### PR TITLE
fix #297040: Palette keyboard navigation

### DIFF
--- a/mscore/palette/palettemodel.cpp
+++ b/mscore/palette/palettemodel.cpp
@@ -253,8 +253,10 @@ QVariant PaletteTreeModel::data(const QModelIndex& index, int role) const
       if (const PalettePanel* pp = findPalettePanel(index)) {
             switch (role) {
                   case Qt::DisplayRole:
-                  case Qt::AccessibleTextRole:
                         return pp->translatedName();
+                  case Qt::ToolTipRole:
+                  case Qt::AccessibleTextRole:
+                        return QString("%1 palette").arg(pp->translatedName());
                   case VisibleRole:
                         return pp->visible();
                   case CustomRole:

--- a/mscore/qml/palettes/PaletteTree.qml
+++ b/mscore/qml/palettes/PaletteTree.qml
@@ -26,10 +26,9 @@ import "utils.js" as Utils
 
 ListView {
     id: paletteTree
-    Accessible.role: Accessible.Tree // makes NVDA say "TreeView"
+    Accessible.name: qsTr("Palettes Tree, contains %n palettes", "", count)
 
-    keyNavigationEnabled: true
-    activeFocusOnTab: true
+    activeFocusOnTab: true // allow focus even when empty
 
     property PaletteWorkspace paletteWorkspace
     property var paletteModel: paletteWorkspace ? paletteWorkspace.mainPaletteModel : null
@@ -54,6 +53,7 @@ ListView {
     }
 
     property bool enableAnimations: true
+    property int expandDuration: enableAnimations ? 150 : 0 // duration of expand / collapse animations
 
     function insertCustomPalette(idx) {
         if (paletteTree.paletteController.insertNewItem(paletteTreeDelegateModel.rootIndex, idx))
@@ -63,6 +63,18 @@ ListView {
     ItemSelectionModel {
         id: paletteSelectionModel
         model: paletteTree.paletteModel
+
+        function selectRange(endIndex) {
+            const firstRow = currentIndex.row;
+            const lastRow = endIndex.row;
+            const parentIndex = endIndex.parent;
+            const step = firstRow < lastRow ? 1 : -1;
+            const endRow = lastRow + step;
+            for (var row = firstRow; row !== endRow; row += step) {
+                const idx = paletteTree.paletteModel.index(row, 0, parentIndex);
+                select(idx, ItemSelectionModel.Select);
+            }
+        }
     }
 
     function applyCurrentElement() {
@@ -102,40 +114,38 @@ ListView {
         Utils.removeSelectedItems(paletteController, paletteSelectionModel, parentIndex);
     }
 
-    Keys.onDeletePressed: {
-        expandedPopupIndex = null;
-        removeSelectedItems();
-    }
     Keys.onPressed: {
-        if (event.key == Qt.Key_Backspace) {
-            expandedPopupIndex = null;
-            removeSelectedItems();
-            event.accepted = true;
-        } else if (event.key == Qt.Key_Home) {
-            positionViewAtBeginning();
-            event.accepted = true;
-        } else if (event.key == Qt.Key_End) {
-            positionViewAtEnd();
-            event.accepted = true;
-        } else if (event.key == Qt.Key_PageUp) {
-            var idx = indexAt(contentX, contentY);
-            if (idx < 0)
-                idx = 0;
-            if (idx > 0 && itemAt(contentX, contentY).height > height)
-                contentY -= height;
-            else
-                positionViewAtIndex(idx, ListView.End);
-            event.accepted = true;
-        } else if (event.key == Qt.Key_PageDown) {
-            var idx = indexAt(contentX, contentY + height);
-            if (idx < 0)
-                idx = count - 1;
-            if (idx < count - 1 && itemAt(contentX, contentY + height).height > height)
-                contentY += height;
-            else
-                positionViewAtIndex(idx, ListView.Beginning);
-            event.accepted = true;
+        switch (event.key) {
+            case Qt.Key_Down:
+                focusNextItem();
+                break;
+            case Qt.Key_Up:
+                focusPreviousItem();
+                break;
+            case Qt.Key_Home:
+                focusFirstItem();
+                break;
+            case Qt.Key_End:
+                focusLastItem();
+                break;
+            case Qt.Key_PageUp:
+                focusPreviousPageItem();
+                break;
+            case Qt.Key_PageDown:
+                focusNextPageItem();
+                break;
+            case Qt.Key_Backspace:
+            case Qt.Key_Delete:
+                expandedPopupIndex = null;
+                removeSelectedItems();
+                break;
+            case Qt.Key_Asterisk:
+                expandCollapseAll(null);
+                break;
+            default:
+                return; // don't accept event
         }
+        event.accepted = true;
     }
 
     displaced: Transition {
@@ -163,20 +173,117 @@ ListView {
         return { display: "", gridSize: Qt.size(1, 1), drawGrid: false, custom: false, editable: false, expanded: false };
     }
 
-    function focusFirstItem() {
-        currentIndex = 0;
-        if (filter.length) // on searching jump directly to the found cells
+    function focusNextItem(includeChildren) {
+        if (includeChildren === undefined) // https://stackoverflow.com/a/44128406
+            includeChildren = true;
+
+        if (includeChildren && currentItem.expanded) {
             currentItem.focusFirstItem();
+            return;
+        }
+
+        if (currentIndex == count - 1)
+            return; // no next item
+
+        incrementCurrentIndex();
+        currentItem.forceActiveFocus();
+        positionViewAtIndex(currentIndex, ListView.Contain);
+    }
+
+    function focusPreviousItem(includeChildren) {
+        if (includeChildren === undefined) // https://stackoverflow.com/a/44128406
+            includeChildren = true;
+
+        if (currentIndex == 0)
+            return; // no previous item
+
+        decrementCurrentIndex();
+
+        if (includeChildren && currentItem.expanded)
+            currentItem.focusLastItem();
         else
             currentItem.forceActiveFocus();
+
+        positionViewAtIndex(currentIndex, ListView.Contain);
+    }
+
+    function focusNextPageItem() {
+        if (currentIndex < count - 1) {
+            currentIndex++; // move by at least one item
+            // try to keep going, but new item must stay entirely in view
+            var distance = currentItem.height;
+            while (currentIndex < count - 1) {
+                currentIndex++; // try another
+                distance += currentItem.height;
+                if (distance > height) {
+                    currentIndex--; // too far, go back one
+                    break;
+                }
+            }
+        }
+        currentItem.forceActiveFocus();
+        positionViewAtIndex(currentIndex, ListView.Contain);
+    }
+
+    function focusPreviousPageItem() {
+        if (currentIndex > 0) {
+            currentIndex--; // move by at least one item
+            // try to keep going, but new item must stay entirely in view
+            var distance = currentItem.height;
+            while (currentIndex > 0) {
+                currentIndex--; // try another
+                distance += currentItem.height;
+                if (distance > height) {
+                    currentIndex++; // too far, go back one
+                    break;
+                }
+            }
+        }
+        currentItem.forceActiveFocus();
+        positionViewAtIndex(currentIndex, ListView.Contain);
+    }
+
+    function focusFirstItem() {
+        currentIndex = 0;
+        currentItem.forceActiveFocus();
+        positionViewAtIndex(currentIndex, ListView.Contain);
     }
 
     function focusLastItem() {
         currentIndex = count - 1;
-        if (filter.length) // on searching jump directly to the found cells
+        if (currentItem.expanded)
             currentItem.focusLastItem();
         else
             currentItem.forceActiveFocus();
+        positionViewAtIndex(currentIndex, ListView.Contain);
+    }
+
+    function focusNextMatchingItem(str) {
+        const nextIndex = (currentIndex < count - 1) ? currentIndex + 1 : 0;
+        const modelIndex = paletteModel.index(nextIndex, 0);
+        const matchedIndexList = paletteModel.match(modelIndex, Qt.DisplayRole, str);
+        if (matchedIndexList.length) {
+            currentIndex = matchedIndexList[0].row;
+            currentItem.forceActiveFocus();
+            positionViewAtIndex(currentIndex, ListView.Contain);
+        }
+    }
+
+    function expandCollapseAll(expand) {
+        console.assert([true, false, null].indexOf(expand) !== -1, "Invalid value for expand: " + expand);
+        // expand = true  - expand all
+        //          false - collapse all
+        //          null  - decide based on current state
+        if (expand === null) {
+            // if any are collapsed then expand all, otherwise collapse all
+            const startIndex = paletteModel.index(0, 0);
+            const collapsedIndexList = paletteModel.match(startIndex, PaletteTreeModel.PaletteExpandedRole, false);
+            expand = !!collapsedIndexList.length;
+        }
+        for (var idx = 0; idx < count; idx++) {
+            const paletteIndex = paletteModel.index(idx, 0);
+            paletteModel.setData(paletteIndex, expand, PaletteTreeModel.PaletteExpandedRole);
+        }
     }
 
     // set highlight color for selected palette depending on using light or dark mode
@@ -204,18 +311,25 @@ ListView {
             }
 
             function focusFirstItem() {
-                mainPalette.currentIndex = 0;
-                mainPalette.currentItem.forceActiveFocus();
+                mainPalette.focusFirstItem();
             }
 
             function focusLastItem() {
-                mainPalette.currentIndex = mainPalette.count - 1;
-                mainPalette.currentItem.forceActiveFocus();
+                mainPalette.focusLastItem();
             }
 
             property bool expanded: filter.length || model.expanded
             function toggleExpand() {
                 model.expanded = !expanded
+            }
+            Timer {
+                id: expandTimer
+                interval: expandDuration + 50 // allow extra grace period
+                onTriggered: paletteTree.positionViewAtIndex(index, ListView.Contain)
+                }
+            onExpandedChanged: {
+                if (ListView.isCurrentItem && !filter.length)
+                    expandTimer.restart();
             }
 
             property bool selected: paletteSelectionModel.hasSelection ? paletteSelectionModel.isSelected(modelIndex) : false
@@ -258,28 +372,42 @@ ListView {
             Keys.onPressed: {
                 switch (event.key) {
                     case Qt.Key_Right:
-                        if (expanded)
-                            mainPalette.focus = true;
-                        else
+                    case Qt.Key_Plus:
+                        if (!expanded)
                             toggleExpand();
+                        else if (event.key === Qt.Key_Right)
+                            focusFirstItem();
                         break;
                     case Qt.Key_Left:
-                        if (expanded && !mainPalette.focus)
+                    case Qt.Key_Minus:
+                        if (expanded)
                             toggleExpand();
-                        focus = true;
                         break;
                     case Qt.Key_Space:
                     case Qt.Key_Enter:
                     case Qt.Key_Return:
                         toggleExpand();
                         break;
+                    case Qt.Key_F10:
+                        if (!(event.modifiers & Qt.ShiftModifier))
+                            return;
+                        // fallthrough
+                    case Qt.Key_Menu:
+                        paletteHeader.showPaletteMenu();
+                        break;
                     default:
-                        return; // don't accept event
+                        if (event.modifiers === Qt.NoModifier && event.text.match(/\w/) !== null)
+                            paletteTree.focusNextMatchingItem(event.text);
+                        else
+                            return; // don't accept event
                 }
                 event.accepted = true;
             }
 
-            text: model.display
+            text: filter.length ? qsTr("%1, contains %n matching elements", "palette", mainPalette.count).arg(model.accessibleText)
+                                : model.expanded ? qsTr("%1 expanded", "tree item not collapsed").arg(model.accessibleText)
+                                                 : model.accessibleText
+            Accessible.role: Accessible.TreeItem
 
             width: parent.width
 
@@ -354,14 +482,14 @@ ListView {
                     Transition {
                         from: "collapsed"; to: "expanded"
                         enabled: paletteTree.enableAnimations
-                        NumberAnimation { target: mainPaletteContainer; property: "height"; from: 0; to: mainPaletteContainer.implicitHeight; easing.type: Easing.OutCubic; duration: 150 }
+                        NumberAnimation { target: mainPaletteContainer; property: "height"; from: 0; to: mainPaletteContainer.implicitHeight; easing.type: Easing.OutCubic; duration: paletteTree.expandDuration }
                     },
                     Transition {
                         from: "expanded"; to: "collapsed"
                         enabled: paletteTree.enableAnimations
                         SequentialAnimation {
                             PropertyAction { target: mainPaletteContainer; property: "visible"; value: true } // temporarily set palette visible to animate it being hidden
-                            NumberAnimation { target: mainPaletteContainer; property: "height"; from: mainPaletteContainer.implicitHeight; to: 0; easing.type: Easing.OutCubic; duration: 150 }
+                            NumberAnimation { target: mainPaletteContainer; property: "height"; from: mainPaletteContainer.implicitHeight; to: 0; easing.type: Easing.OutCubic; duration: paletteTree.expandDuration }
                             PropertyAction { target: mainPaletteContainer; property: "visible"; value: false } // make palette invisible again
                             PropertyAction { target: mainPaletteContainer; property: "height"; value: mainPaletteContainer.implicitHeight } // restore the height binding
                         }
@@ -376,7 +504,7 @@ ListView {
                     opacity: enabled ? 1 : 0.3
                     expanded: control.expanded
                     hovered: control.hovered
-                    text: control.text
+                    text: model.display
                     hidePaletteElementVisible: {
                         return !control.selected && control.expanded
                             && paletteSelectionModel.hasSelection && paletteSelectionModel.columnIntersectsSelection(0, control.modelIndex)
@@ -471,7 +599,7 @@ ListView {
                     cellSize: control.cellSize
                     drawGrid: control.drawGrid
 
-                    paletteName: control.text
+                    paletteName: model.display
                     paletteIsCustom: model.custom
                     paletteEditingEnabled: model.editable
 

--- a/mscore/qml/palettes/PalettesWidget.qml
+++ b/mscore/qml/palettes/PalettesWidget.qml
@@ -42,7 +42,7 @@ Item {
         paletteTree.applyCurrentElement();
     }
 
-    FocusChainBreak {}
+    FocusChainBreak { id: focusBreaker }
 
     PalettesWidgetHeader {
         id: palettesWidgetHeader

--- a/mscore/qml/palettes/PalettesWidgetHeader.qml
+++ b/mscore/qml/palettes/PalettesWidgetHeader.qml
@@ -48,10 +48,21 @@ Item {
         anchors.right: parent.right
 
         placeholderText: qsTr("Search")
-        //TODO: in the future we may wish these values to differ
-        //Accessible.name: qsTr("Search")
-        Accessible.name: placeholderText
         font: globalStyle.font
+
+        onTextChanged: resultsTimer.restart()
+        onActiveFocusChanged: {
+            resultsTimer.stop();
+            Accessible.name = qsTr("Palette Search")
+        }
+
+        Timer {
+            id: resultsTimer
+            interval: 500
+            onTriggered: {
+                parent.Accessible.name = parent.text.length === 0 ? qsTr("Palette Search") : qsTr("%n palettes match", "", paletteTree.count);
+            }
+        }
 
         color: globalStyle.text
 
@@ -61,8 +72,7 @@ Item {
         }
 
         KeyNavigation.tab: paletteTree.currentTreeItem
-        KeyNavigation.up: paletteTree
-        KeyNavigation.down: paletteTree
+
         Keys.onDownPressed: paletteTree.focusFirstItem();
         Keys.onUpPressed: paletteTree.focusLastItem();
 
@@ -78,6 +88,7 @@ Item {
             visible: searchTextInput.text.length && searchTextInput.width > 2 * width
             flat: true
             onClicked: searchTextInput.clear()
+            activeFocusOnTab: false // don't annoy keyboard users tabbing to palette (they can use Ctrl+A, Delete to clear search)
 
             padding: 4
 

--- a/mscore/qml/palettes/TreePaletteHeader.qml
+++ b/mscore/qml/palettes/TreePaletteHeader.qml
@@ -47,6 +47,12 @@ Item {
     implicitHeight: paletteExpandArrow.height
     implicitWidth: paletteExpandArrow.implicitWidth + textItem.implicitWidth + paletteHeaderMenuButton.implicitWidth + 8 // 8 for margins
 
+    function showPaletteMenu() {
+        paletteHeaderMenu.x = paletteHeaderMenuButton.x + paletteHeaderMenuButton.width - paletteHeaderMenu.width;
+        paletteHeaderMenu.y = paletteHeaderMenuButton.y;
+        paletteHeaderMenu.open();
+    }
+
     StyledToolButton {
         id: paletteExpandArrow
         z: 1000
@@ -94,6 +100,10 @@ Item {
 //         icon.source: "icons/delete.png"
         text: qsTr("Remove element")
         visible: paletteHeader.hidePaletteElementVisible && paletteHeader.editingEnabled
+        activeFocusOnTab: mainPalette.currentItem === paletteTree.currentTreeItem
+
+        KeyNavigation.backtab: mainPalette.currentItem
+        KeyNavigation.tab: focusBreaker
 
         onHoveredChanged: {
             if (hovered) {
@@ -130,12 +140,7 @@ Item {
 
         text: qsTr("Palette menu") // used by screen readers (they ignore Accessible.name for buttons)
 
-        onClicked: {
-            paletteHeaderMenu.x = paletteHeaderMenuButton.x + paletteHeaderMenuButton.width - paletteHeaderMenu.width;
-            paletteHeaderMenu.y = paletteHeaderMenuButton.y;
-//             paletteHeaderMenu.y = paletteHeaderMenuButton.y + paletteHeaderMenuButton.height;
-            paletteHeaderMenu.open();
-        }
+        onClicked: showPaletteMenu()
     }
 
     MouseArea {


### PR DESCRIPTION
Implements standard keyboard navigation for an item view / tree view as demonstrated by QAbstractItemView and QTreeView classes. Also changes how elements are displayed as necessary to indicate the different kinds of selection (e.g. when current item is not selected).

Resolves: https://musescore.org/en/node/297040

## Features

- Adds blue outline for current item (selected items have blue fill).
- Changing item also selects it (unless Ctrl is held).
- More button behaves like a normal item for navigation purposes

__New keyboard shortcuts:__

- Asterisk (*) key expands or collapses all items
- Menu key (or [Ctrl+]Shift+F10) opens context menus
- Press any letter key to jump to palette starting with that letter

__Various improvements to screen reader output:__

- Palette names end in "palette" to distinguish from elements
- Says when palettes are expanded
- Says how many elements in palette, and palettes in view
- Says when palette elements are selected

__Selection behavior__

Slightly changes behaviour for __mouse users__ to match that described in [QAbstractItemView::ExtendedSelection](https://doc.qt.io/qt-5/qabstractitemview.html#SelectionMode-enum):

> When the user selects an item in the usual way, the selection is cleared and the new item selected. However, if the user presses the Ctrl key when clicking on an item, the clicked item gets toggled and all other items are left untouched. If the user presses the Shift key while clicking on an item, all items between the current item and the clicked item are selected or unselected, depending on the state of the clicked item. Multiple items can be selected by dragging the mouse over them.

The behaviour for __keyboard users__ is almost the same, with point and click replaced by arrow keys and spacebar. Keyboard users also have the ability to change current item without changing the selection, which is done by holding Ctrl when using the arrow keys, as described [here](https://doc.qt.io/qt-5/qabstractitemview.html#details).

This behaviour for keyboard and mouse matches that of File Explorer in Windows 10.

## Checklist

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made