### PR TITLE
enhance text tab command to preserve placement

### DIFF
--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -208,7 +208,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void realtimeAdvance(bool allowRests);
       void cmdAddFret(int fret);
       void cmdAddChordName(HarmonyType ht);
-      void cmdAddText(Tid tid, Tid customTid = Tid::DEFAULT);
+      void cmdAddText(Tid tid, Tid customTid = Tid::DEFAULT, PropertyFlags pf = PropertyFlags::STYLED, Placement p = Placement::ABOVE);
       void cmdEnterRest(const TDuration&);
       void cmdEnterRest();
       void cmdTuplet(int n, ChordRest*);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/297092#comment-958921.

If current text (staff text/system text/fingering) is `UNSTYLED` or `NOSTYLE`, the next text created using text tab command inherits the same `PropertyFlags` and `Placement`, making it much easier to put all texts above/below staves.