### PR TITLE
fix #297287: scale palettes with monitor resolution +collect_artifacts

### DIFF
--- a/mscore/drumtools.cpp
+++ b/mscore/drumtools.cpp
@@ -49,7 +49,7 @@ DrumTools::DrumTools(QWidget* parent)
 
       QWidget* w = new QWidget(this);
       w->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed));
-      w->setMaximumHeight(100);
+      w->setMaximumHeight(100 * Palette::guiMag());
       QHBoxLayout* layout = new QHBoxLayout;
       w->setLayout(layout);
 

--- a/mscore/editstafftype.cpp
+++ b/mscore/editstafftype.cpp
@@ -106,6 +106,7 @@ EditStaffType::EditStaffType(QWidget* parent, Staff* st)
       else {
             Q_ASSERT_X(false, "EditStaffType::EditStaffType", "Error in opening sample tab file for preview");
             }
+      tabPreview->adjustSize();
 
       setValues();
 

--- a/mscore/keyedit.cpp
+++ b/mscore/keyedit.cpp
@@ -34,6 +34,8 @@ extern bool useFactorySettings;
 extern Palette* newAccidentalsPalette();
 extern Palette* newKeySigPalette();
 
+static const qreal editScale = 1.0;
+
 //---------------------------------------------------------
 //   KeyCanvas
 //---------------------------------------------------------
@@ -42,7 +44,7 @@ KeyCanvas::KeyCanvas(QWidget* parent)
    : QFrame(parent)
       {
       setAcceptDrops(true);
-      extraMag   = 2.0;
+      extraMag   = editScale * guiScaling;
       qreal mag  = PALETTE_SPATIUM * extraMag / gscore->spatium();
       _matrix    = QTransform(mag, 0.0, 0.0, mag, 0.0, 0.0);
       imatrix    = _matrix.inverted();
@@ -290,6 +292,9 @@ KeyEditor::KeyEditor(QWidget* parent)
       l->setContentsMargins(0, 0, 0, 0);
       frame_3->setLayout(l);
       sp1 = MuseScore::newAccidentalsPalette();
+      qreal adj = sp1->mag();
+      sp1->setGrid(sp1->gridWidth() * editScale / adj, sp1->gridHeight() * editScale / adj);
+      sp1->setMag(editScale);
       PaletteScrollArea* accPalette = new PaletteScrollArea(sp1);
       QSizePolicy policy1(QSizePolicy::Expanding, QSizePolicy::Expanding);
       accPalette->setSizePolicy(policy1);

--- a/mscore/noteGroups.cpp
+++ b/mscore/noteGroups.cpp
@@ -87,14 +87,30 @@ NoteGroups::NoteGroups(QWidget* parent)
             };
 
       iconPalette->setName(QT_TRANSLATE_NOOP("Palette", "Beam Properties"));
+      iconPalette->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+      //iconPalette->setMag(.5);
       iconPalette->setGrid(27, 40);
-      iconPalette->setMag(.5);
+      iconPalette->setMinimumWidth(27 * 4 * Palette::guiMag() + 1);     // enough room for all icons, with roundoff
       iconPalette->setDrawGrid(true);
       populateIconPalette(iconPalette, bpa);
       iconPalette->setReadOnly(true);
-      //iconPalette->adjustSize();
+      iconPalette->setFixedHeight(iconPalette->heightForWidth(iconPalette->width()));
+      iconPalette->updateGeometry();
       //groupBox->adjustSize();
-
+      //adjustSize();
+#if 0
+      iconPalette->adjustSize();
+      groupBox->adjustSize();
+      //adjustSize();
+      iconPalette->setFixedHeight(heightForWidth(iconPalette->width()));
+      iconPalette->updateGeometry();
+      iconPalette->emitChanged();
+      //iconPalette->adjustSize();
+      groupBox->adjustSize();
+      groupBox->updateGeometry();
+      adjustSize();
+      updateGeometry();
+#endif
       connect(resetGroups, SIGNAL(clicked()), SLOT(resetClicked()));
       connect(view8,  SIGNAL(noteClicked(Note*)), SLOT(noteClicked(Note*)));
       connect(view16, SIGNAL(noteClicked(Note*)), SLOT(noteClicked(Note*)));

--- a/mscore/noteGroups.cpp
+++ b/mscore/noteGroups.cpp
@@ -96,21 +96,7 @@ NoteGroups::NoteGroups(QWidget* parent)
       iconPalette->setReadOnly(true);
       iconPalette->setFixedHeight(iconPalette->heightForWidth(iconPalette->width()));
       iconPalette->updateGeometry();
-      //groupBox->adjustSize();
-      //adjustSize();
-#if 0
-      iconPalette->adjustSize();
-      groupBox->adjustSize();
-      //adjustSize();
-      iconPalette->setFixedHeight(heightForWidth(iconPalette->width()));
-      iconPalette->updateGeometry();
-      iconPalette->emitChanged();
-      //iconPalette->adjustSize();
-      groupBox->adjustSize();
-      groupBox->updateGeometry();
-      adjustSize();
-      updateGeometry();
-#endif
+
       connect(resetGroups, SIGNAL(clicked()), SLOT(resetClicked()));
       connect(view8,  SIGNAL(noteClicked(Note*)), SLOT(noteClicked(Note*)));
       connect(view16, SIGNAL(noteClicked(Note*)), SLOT(noteClicked(Note*)));

--- a/mscore/noteGroups.cpp
+++ b/mscore/noteGroups.cpp
@@ -53,7 +53,7 @@ Score* NoteGroups::createScore(int n, TDuration::DurationType t, std::vector<Cho
             chord->setStemDirection(Direction::UP);
             chords->push_back(chord);
             }
-      c.score()->style().set(Sid::pageOddTopMargin, 16.0/INCH);
+      //c.score()->style().set(Sid::pageOddTopMargin, 16.0/INCH);
       c.score()->style().set(Sid::pageOddLeftMargin, 0.0);
 
       c.score()->parts().front()->setLongName("");
@@ -92,6 +92,8 @@ NoteGroups::NoteGroups(QWidget* parent)
       iconPalette->setDrawGrid(true);
       populateIconPalette(iconPalette, bpa);
       iconPalette->setReadOnly(true);
+      //iconPalette->adjustSize();
+      //groupBox->adjustSize();
 
       connect(resetGroups, SIGNAL(clicked()), SLOT(resetClicked()));
       connect(view8,  SIGNAL(noteClicked(Note*)), SLOT(noteClicked(Note*)));

--- a/mscore/note_groups.ui
+++ b/mscore/note_groups.ui
@@ -158,16 +158,10 @@
      <item>
       <widget class="QGroupBox" name="groupBox">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>134</width>
-         <height>80</height>
-        </size>
        </property>
        <property name="baseSize">
         <size>
@@ -178,28 +172,18 @@
        <property name="title">
         <string>Beam Properties</string>
        </property>
-       <widget class="Ms::Palette" name="iconPalette" native="true">
-        <property name="geometry">
-         <rect>
-          <x>10</x>
-          <y>30</y>
-          <width>114</width>
-          <height>40</height>
-         </rect>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="Ms::Palette" name="iconPalette" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </item>
     </layout>

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -243,7 +243,13 @@ void Palette::setMag(qreal val)
 
 qreal Palette::guiMag()
       {
-      return guiScaling * preferences.getDouble(PREF_APP_PALETTESCALE);
+      qreal pref = preferences.getDouble(PREF_APP_PALETTESCALE);
+      if (guiScaling <= 1.0)                    // low DPI: target is 100% life size
+            return pref * guiScaling;
+      else if (guiScaling > 1.33)               // high DPI: target is 75% life size
+            return pref * guiScaling * 0.75;
+      else                                      // medium high DPI: no target, scaling dependent on resolution
+            return pref;                        // (will be 75-100% range)
       }
 
 //---------------------------------------------------------

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -81,7 +81,7 @@ static bool needsStaff(Element* e)
 Palette::Palette(QWidget* parent)
    : QWidget(parent)
       {
-      extraMag      = 1.0;
+      extraMag      = 1.0 * guiScaling;
       currentIdx    = -1;
       dragIdx       = -1;
       selectedIdx   = -1;
@@ -234,7 +234,7 @@ void Palette::setReadOnly(bool val)
 
 void Palette::setMag(qreal val)
       {
-      extraMag = val;
+      extraMag = val * guiScaling;
       }
 
 //---------------------------------------------------------
@@ -323,8 +323,8 @@ void Palette::contextMenuEvent(QContextMenuEvent* event)
 
 void Palette::setGrid(int hh, int vv)
       {
-      hgrid = hh;
-      vgrid = vv;
+      hgrid = hh * guiScaling;
+      vgrid = vv * guiScaling;
       QSize s(hgrid, vgrid);
       setSizeIncrement(s);
       setBaseSize(s);
@@ -1271,9 +1271,9 @@ bool Palette::event(QEvent* ev)
 void Palette::write(XmlWriter& xml) const
       {
       xml.stag(QString("Palette name=\"%1\"").arg(XmlWriter::xmlString(_name)));
-      xml.tag("gridWidth", hgrid);
-      xml.tag("gridHeight", vgrid);
-      xml.tag("mag", extraMag);
+      xml.tag("gridWidth", hgrid / guiScaling);
+      xml.tag("gridHeight", vgrid / guiScaling);
+      xml.tag("mag", extraMag / guiScaling);
       if (_drawGrid)
             xml.tag("grid", _drawGrid);
 
@@ -1485,11 +1485,11 @@ void Palette::read(XmlReader& e)
       while (e.readNextStartElement()) {
             const QStringRef& t(e.name());
             if (t == "gridWidth")
-                  hgrid = e.readDouble();
+                  hgrid = e.readDouble() * guiScaling;
             else if (t == "gridHeight")
-                  vgrid = e.readDouble();
+                  vgrid = e.readDouble() * guiScaling;
             else if (t == "mag")
-                  extraMag = e.readDouble();
+                  extraMag = e.readDouble() * guiScaling;
             else if (t == "grid")
                   _drawGrid = e.readInt();
             else if (t == "moreElements")
@@ -1640,11 +1640,11 @@ PaletteProperties::PaletteProperties(Palette* p, QWidget* parent)
       palette = p;
 
       name->setText(palette->name());
-      cellWidth->setValue(palette->gridWidth());
-      cellHeight->setValue(palette->gridHeight());
+      cellWidth->setValue(palette->gridWidth() / guiScaling);
+      cellHeight->setValue(palette->gridHeight() / guiScaling);
       showGrid->setChecked(palette->drawGrid());
       elementOffset->setValue(palette->yOffset());
-      mag->setValue(palette->mag());
+      mag->setValue(palette->mag() / guiScaling);
 
       MuseScore::restoreGeometry(this);
       }

--- a/mscore/palette.h
+++ b/mscore/palette.h
@@ -161,8 +161,8 @@ class Palette : public QWidget {
       void setMag(qreal val);
       qreal mag() const              { return extraMag;    }
       void setYOffset(qreal val)     { _yOffset = val;     }
-      qreal yOffset() const          { return _yOffset;        }
-      int columns() const            { return width() / hgrid; }
+      qreal yOffset() const          { return _yOffset;    }
+      int columns() const;
       int rows() const;
       int size() const               { return filterActive ? dragCells.size() : cells.size(); }
       PaletteCell* cellAt(int index) const { return ccp()->value(index); }
@@ -175,6 +175,10 @@ class Palette : public QWidget {
       void setMoreElements(bool val);
       bool filter(const QString& text);
       void setShowContextMenu(bool val) { _showContextMenu = val; }
+
+      static qreal guiMag();
+      int gridWidthM() const  { return hgrid * guiMag(); }
+      int gridHeightM() const { return vgrid * guiMag(); }
 
       int getCurrentIdx() { return currentIdx; }
       void setCurrentIdx(int i) { currentIdx = i; }

--- a/mscore/palette/palettemodel.cpp
+++ b/mscore/palette/palettemodel.cpp
@@ -261,7 +261,7 @@ QVariant PaletteTreeModel::data(const QModelIndex& index, int role) const
                   case EditableRole:
                         return pp->editable();
                   case GridSizeRole:
-                        return pp->gridSize();
+                        return pp->gridSize() * guiScaling * preferences.getDouble(PREF_APP_PALETTESCALE);
                   case DrawGridRole:
                         return pp->drawGrid();
                   case PaletteExpandedRole:
@@ -289,7 +289,7 @@ QVariant PaletteTreeModel::data(const QModelIndex& index, int role) const
                         qreal extraMag = 1.0;
                         if (const PalettePanel* pp = iptrToPalettePanel(index.internalPointer()))
                               extraMag = pp->mag();
-                        return QIcon(new PaletteCellIconEngine(cell, extraMag));
+                        return QIcon(new PaletteCellIconEngine(cell, extraMag * guiScaling * preferences.getDouble(PREF_APP_PALETTESCALE)));
                         }
                   case PaletteCellRole:
                         return QVariant::fromValue(cell.get());

--- a/mscore/palette/palettemodel.cpp
+++ b/mscore/palette/palettemodel.cpp
@@ -24,6 +24,7 @@
 #include "libmscore/icon.h"
 #include "libmscore/select.h"
 #include "palettetree.h"
+#include "palette.h"
 #include "preferences.h"
 #include "scoreaccessibility.h"
 
@@ -261,7 +262,7 @@ QVariant PaletteTreeModel::data(const QModelIndex& index, int role) const
                   case EditableRole:
                         return pp->editable();
                   case GridSizeRole:
-                        return pp->gridSize() * guiScaling * preferences.getDouble(PREF_APP_PALETTESCALE);
+                        return pp->gridSize() * Palette::guiMag();
                   case DrawGridRole:
                         return pp->drawGrid();
                   case PaletteExpandedRole:
@@ -289,7 +290,7 @@ QVariant PaletteTreeModel::data(const QModelIndex& index, int role) const
                         qreal extraMag = 1.0;
                         if (const PalettePanel* pp = iptrToPalettePanel(index.internalPointer()))
                               extraMag = pp->mag();
-                        return QIcon(new PaletteCellIconEngine(cell, extraMag * guiScaling * preferences.getDouble(PREF_APP_PALETTESCALE)));
+                        return QIcon(new PaletteCellIconEngine(cell, extraMag * Palette::guiMag()));
                         }
                   case PaletteCellRole:
                         return QVariant::fromValue(cell.get());

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -99,7 +99,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_APP_PLAYBACK_PLAYREPEATS,                        new BoolPreference(true)},
             {PREF_APP_PLAYBACK_LOOPTOSELECTIONONPLAY,              new BoolPreference(true)},
             {PREF_APP_USESINGLEPALETTE,                            new BoolPreference(false)},
-            {PREF_APP_PALETTESCALE,                                new DoublePreference(1.0)},
+            {PREF_APP_PALETTESCALE,                                new DoublePreference(0.8)},
             {PREF_APP_STARTUP_FIRSTSTART,                          new BoolPreference(true)},
             {PREF_APP_STARTUP_SESSIONSTART,                        new EnumPreference(QVariant::fromValue(SessionStart::SCORE), false)},
             {PREF_APP_STARTUP_STARTSCORE,                          new StringPreference(":/data/My_First_Score.mscx", false)},

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -99,7 +99,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_APP_PLAYBACK_PLAYREPEATS,                        new BoolPreference(true)},
             {PREF_APP_PLAYBACK_LOOPTOSELECTIONONPLAY,              new BoolPreference(true)},
             {PREF_APP_USESINGLEPALETTE,                            new BoolPreference(false)},
-            {PREF_APP_PALETTESCALE,                                new DoublePreference(0.8)},
+            {PREF_APP_PALETTESCALE,                                new DoublePreference(1.0)},
             {PREF_APP_STARTUP_FIRSTSTART,                          new BoolPreference(true)},
             {PREF_APP_STARTUP_SESSIONSTART,                        new EnumPreference(QVariant::fromValue(SessionStart::SCORE), false)},
             {PREF_APP_STARTUP_STARTSCORE,                          new StringPreference(":/data/My_First_Score.mscx", false)},

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -99,6 +99,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_APP_PLAYBACK_PLAYREPEATS,                        new BoolPreference(true)},
             {PREF_APP_PLAYBACK_LOOPTOSELECTIONONPLAY,              new BoolPreference(true)},
             {PREF_APP_USESINGLEPALETTE,                            new BoolPreference(false)},
+            {PREF_APP_PALETTESCALE,                                new DoublePreference(1.0)},
             {PREF_APP_STARTUP_FIRSTSTART,                          new BoolPreference(true)},
             {PREF_APP_STARTUP_SESSIONSTART,                        new EnumPreference(QVariant::fromValue(SessionStart::SCORE), false)},
             {PREF_APP_STARTUP_STARTSCORE,                          new StringPreference(":/data/My_First_Score.mscx", false)},

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -96,6 +96,7 @@ enum class MusicxmlExportBreaks : char {
 #define PREF_APP_PLAYBACK_PLAYREPEATS                       "application/playback/playRepeats"
 #define PREF_APP_PLAYBACK_LOOPTOSELECTIONONPLAY             "application/playback/setLoopToSelectionOnPlay"
 #define PREF_APP_USESINGLEPALETTE                           "application/useSinglePalette"
+#define PREF_APP_PALETTESCALE                               "application/paletteScale"
 #define PREF_APP_STARTUP_FIRSTSTART                         "application/startup/firstStart"
 #define PREF_APP_STARTUP_SESSIONSTART                       "application/startup/sessionStart"
 #define PREF_APP_STARTUP_STARTSCORE                         "application/startup/startScore"

--- a/mscore/preferenceslistwidget.cpp
+++ b/mscore/preferenceslistwidget.cpp
@@ -214,6 +214,8 @@ DoublePreferenceItem::DoublePreferenceItem(QString name)
       _editor->setMaximum(DBL_MAX);
       _editor->setMinimum(DBL_MIN);
       _editor->setValue(_initialValue);
+      if (qAbs(_initialValue) < 2.0)
+          _editor->setSingleStep(0.1);
       }
 
 void DoublePreferenceItem::save()


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/297287

MuseScore 2 used to scale the palettes according to screen resolution,
so they were the same physical size on all systems.
This was broken in MuseScore 3 development, so palettes are too small
on high DPI systems and too large on low DPI systems.
This fixes the issue by reinstating the code in palette.cpp
that scales the grid and mag by the global guiScaling setting
(same setting used to scale the score view itself).
That only affects places in the code where the "old" palettes
are still used - keysig and timesig dialogs, etc.
Similar but simple code accomplishes the same in palettemodel.cpp
for the "new" palettes.

In addition, because users may *prefer* larger or smaller palettes,
I added an advanced preference to specify global palette scaling
(applied on top of the automatic DPI scaling).
This value is factored in to the main palette scaling.

This is an onscreen issue only, no way to test automatically.