### PR TITLE
fix #297326: Crash on opening Musescore 2.x file that uses leading space setting on the initial clef

### DIFF
--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -3330,8 +3330,10 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                   beam->setParent(0);
                   e.addBeam(beam);
                   }
-            else if (tag == "Segment")
-                  segment->read(e);
+            else if (tag == "Segment") {
+                  if (segment) segment->read(e);
+                  else e.unknown();
+                  }
             else if (tag == "MeasureNumber") {
                   MeasureNumber* noText = new MeasureNumber(score);
                   readText206(e, noText, m);


### PR DESCRIPTION
which seems to not belong to any segment, so dereferences a NULL pointer leading to a segment violation (pun intended).
The fix simply ignores this, and this avoids the crash, but also looses the 'visible' property of that clef for some yet unknown but unrelated reason.

Solves https://musescore.org/en/node/297310 / https://musescore.org/en/node/297326