### PR TITLE
fix #297329: add Straight (tempo) text to master palette

### DIFF
--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -1592,6 +1592,13 @@ PalettePanel* MuseScore::newTextPalettePanel(bool defaultPalettePanel)
       stxt->setSwing(true);
       sp->append(stxt, QT_TRANSLATE_NOOP("Palette", "Swing"))->setElementTranslated(true);
 
+      stxt = new SystemText(gscore, Tid::TEMPO);
+      /*: System text to switch from swing rhythm back to straight rhythm */
+      stxt->setXmlText(QT_TRANSLATE_NOOP("Palette", "Straight"));
+      stxt->setSwing(false); // redundant, being the default anyhow, but for documentation
+      /*: System text to switch from swing rhythm back to straight rhythm */
+      sp->append(stxt, QT_TRANSLATE_NOOP("Palette", "Straight"))->setElementTranslated(true);
+
       stxt = new SystemText(gscore);
       stxt->setXmlText(QT_TRANSLATE_NOOP("Palette", "System Text"));
       sp->append(stxt, QT_TRANSLATE_NOOP("Palette", "System text"))->setElementTranslated(true);


### PR DESCRIPTION
Solves https://musescore.org/en/node/297329 and https://musescore.org/en/node/75631#comment-959954 ff.