### PR TITLE
fix appstream validator warning

### DIFF
--- a/build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in
+++ b/build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in
@@ -311,9 +311,9 @@
         <ul>
           <li>Fix #270496: Add missing elements to incomplete tuplets when reading from a file</li>
           <li>Fix #272042: Saved preferences override command line options</li>
-          <li>Debian fix: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=898757. Fix crash when starting with piano open.</li>
+          <li>Fix Debian#898757: Fix crash when starting with piano open.</li>
           <li>Allow path to be relative to stored album file</li>
-          <li>Fix #273660 : MIDI Keyboard Not Responded when Pressed Before Opening a Score</li>
+          <li>Fix #273660: MIDI Keyboard Not Responded when Pressed Before Opening a Score</li>
         </ul>
       </description>
     </release>


### PR DESCRIPTION
Resolves: https://appstream.debian.org/sid/main/issues/musescore3.html

fix appstream validator warning (no URLs allowed inside text); also, fix a space before colon to look consistent

*Use "x" letter to fill the checkboxes below like [x]*

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made

Note: releases 3.3 and newer are missing from the file… the release manager should add them ☻