### PR TITLE
fix #52906, fix #279990, fix #288019: relax restrictions on pasting to tuplets

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -1023,7 +1023,7 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view, Fraction scale)
                   MScore::setError(NO_DEST);
                   return;
                   }
-            else if (cr->tuplet()) {
+            else if (cr->tuplet() && cr->tick() != cr->topTuplet()->tick()) {
                   MScore::setError(DEST_TUPLET);
                   return;
                   }
@@ -1054,10 +1054,6 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view, Fraction scale)
                   }
             if (cr == 0) {
                   MScore::setError(NO_DEST);
-                  return;
-                  }
-            else if (cr->tuplet()) {
-                  MScore::setError(DEST_TUPLET);
                   return;
                   }
             else {


### PR DESCRIPTION
Resolves:
https://musescore.org/en/node/52906
https://musescore.org/en/node/279990
https://musescore.org/en/node/288019

1) Pasting symbol lists (lyrics, dynamics, chord symbols etc.) to
tuplets work correctly so we don't need to impose any restrictions
here.

2) Pasting a staff range to the first chord/rest of a tuplet correctly
replaces the tuplet with the clipboard content. We need to restrict
pasting a range only if trying to paste to the middle of a tuplet.