### PR TITLE
fix #297428: crash on copying measure with slur and pasting it to TAB staff

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -118,6 +118,7 @@ void CmdState::setTick(const Fraction& t)
 
 void CmdState::setStaff(int st)
       {
+      Q_ASSERT(st > -2);
       if (_locked || st == -1)
             return;
 

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4523,9 +4523,10 @@ void Score::undoAddElement(Element* element)
                         Spanner* sp   = toSpanner(element);
                         Spanner* nsp  = toSpanner(ne);
                         int staffIdx1 = sp->track() / VOICES;
-                        int staffIdx2 = sp->track2() / VOICES;
+                        int tr2 = sp->effectiveTrack2();
+                        int staffIdx2 = tr2 / VOICES;
                         int diff      = staffIdx2 - staffIdx1;
-                        nsp->setTrack2((staffIdx + diff) * VOICES + (sp->track2() % VOICES));
+                        nsp->setTrack2((staffIdx + diff) * VOICES + (tr2 % VOICES));
                         nsp->setTrack(ntrack);
 
 #if 0 //whatdoesitdo?

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -1231,7 +1231,7 @@ void Score::writeSegments(XmlWriter& xml, int strack, int etrack,
                                     }
                               if ((s->tick2() == segment->tick())
                                  && !s->isSlur()
-                                 && (s->track2() == track || (s->track2() == -1 && s->track() == track))
+                                 && (s->effectiveTrack2() == track)
                                  && (!clip || s->tick() >= sseg->tick())
                                  ) {
                                     if (needMove) {

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -797,7 +797,7 @@ ChordRest* Spanner::endCR()
       Q_ASSERT(_anchor == Anchor::SEGMENT || _anchor == Anchor::CHORD);
       if ((!_endElement || _endElement->score() != score())) {
             Segment* s  = score()->tick2segmentMM(tick2(), false, SegmentType::ChordRest);
-            const int tr2 = (track2() == -1) ? track() : track2();
+            const int tr2 = effectiveTrack2();
             _endElement = s ? toChordRest(s->element(tr2)) : nullptr;
             }
       return toChordRest(_endElement);
@@ -1034,7 +1034,7 @@ void Spanner::setTicks(const Fraction& f)
 void Spanner::triggerLayout() const
       {
       // Spanners do not have parent even when added to a score, so can't check parent here
-      const int tr2 = track2() == -1 ? track() : track2();
+      const int tr2 = effectiveTrack2();
       score()->setLayout(_tick, _tick + _ticks, staffIdx(), track2staff(tr2), this);
       }
 

--- a/libmscore/spanner.h
+++ b/libmscore/spanner.h
@@ -195,6 +195,7 @@ class Spanner : public Element {
 
       int track2() const       { return _track2;   }
       void setTrack2(int v)    { _track2 = v;      }
+      int effectiveTrack2() const { return _track2 == -1 ? track() : _track2; }
 
       bool broken() const      { return _broken;   }
       void setBroken(bool v)   { _broken = v;      }

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4859,8 +4859,8 @@ static bool needViewportMove(Score* cs, ScoreView* cv)
       mEnd = mEnd ? mEnd->nextMeasureMM() : nullptr;
 
       const bool isExcerpt = !cs->isMaster();
-      const int startStaff = (isExcerpt || state.startStaff() == -1) ? 0 : state.startStaff();
-      const int endStaff = (isExcerpt || state.endStaff() == -1) ? (cs->nstaves() - 1) : state.endStaff();
+      const int startStaff = (isExcerpt || state.startStaff() < 0) ? 0 : state.startStaff();
+      const int endStaff = (isExcerpt || state.endStaff() < 0) ? (cs->nstaves() - 1) : state.endStaff();
 
       for (Measure* m = mStart; m && m != mEnd; m = m->nextMeasureMM()) {
             for (int st = startStaff; st <= endStaff; ++st) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/297428

1) Fix incorrect track2 assignment to spanners on pasting in some
situations due to not handling the case of track2 == -1.
2) Fix staff index checks in ScoreView code to avoid a crash if
incorrect staff index gets recorded to CmdState.
3) Add an assertion to catch invalid negative staff indices recorded
to CmdState.
