### PR TITLE
[TEST] fix #296682: force ANGLE OpenGL implementation on Windows 7

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ cache:
 # build platform, i.e. x86, x64, Any CPU. This setting is optional.
 platform:
 #use for releases only
-#  - x86
+  - x86
   - x64
 
 #environment:

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -689,6 +689,7 @@ if (MINGW)
       ${QT_INSTALL_BINS}/libEGL.dll
       ${QT_INSTALL_BINS}/libGLESv2.dll
       ${QT_INSTALL_BINS}/opengl32sw.dll
+      ${QT_INSTALL_BINS}/d3dcompiler_47.dll
       ${QtInstallLibraries}
       ${PROJECT_SOURCE_DIR}/build/qt.conf
       DESTINATION bin)
@@ -930,6 +931,7 @@ else (MINGW)
                   "${QT_INSTALL_BINS}/Qt5WebChannel.dll"
                   "${QT_INSTALL_BINS}/Qt5QuickWidgets.dll" "${QT_INSTALL_BINS}/Qt5Positioning.dll"
                   "${QT_INSTALL_BINS}/libEGL.dll" "${QT_INSTALL_BINS}/libGLESv2.dll" "${QT_INSTALL_BINS}/opengl32sw.dll"
+                  "${QT_INSTALL_BINS}/d3dcompiler_47.dll"
                   )
       if (USE_WEBENGINE)
          list(APPEND dlls_to_copy "${QT_INSTALL_BINS}/Qt5WebEngineWidgets.dll" "${QT_INSTALL_BINS}/Qt5WebEngineCore.dll")
@@ -998,6 +1000,7 @@ else (MINGW)
             ${QT_INSTALL_BINS}/libEGL.dll
             ${QT_INSTALL_BINS}/libGLESv2.dll
             ${QT_INSTALL_BINS}/opengl32sw.dll
+            ${QT_INSTALL_BINS}/d3dcompiler_47.dll
             ${QT_INSTALL_BINS}/Qt5Positioning.dll
             ${QT_INSTALL_BINS}/Qt5WebChannel.dll
             ${QT_INSTALL_BINS}/Qt5QuickTemplates2.dll

--- a/mscore/data/win_opengl_buglist.json
+++ b/mscore/data/win_opengl_buglist.json
@@ -1,5 +1,5 @@
 {
-    "name": "MuseScore GPU driver blacklist - based on Qt built-in GPU driver blacklist for Qt 5.12.5",
+    "name": "MuseScore GPU driver blacklist - based on Qt built-in GPU driver blacklist for Qt 5.12.6",
     "version": "5.6",
     "entries": [
         {
@@ -159,10 +159,7 @@
             "description": "Desktop OpenGL on Windows 7 often leads to bad QtQuick rendering (MuseScore issue #296682)",
             "os": {
                 "type": "win",
-                "release": {
-                    "op": "=",
-                    "value": "7"
-                }
+                "release": [ "7" ]
             },
             "features": [
                 "disable_desktopgl"

--- a/mscore/data/win_opengl_buglist.json
+++ b/mscore/data/win_opengl_buglist.json
@@ -1,0 +1,172 @@
+{
+    "name": "MuseScore GPU driver blacklist - based on Qt built-in GPU driver blacklist for Qt 5.12.5",
+    "version": "5.6",
+    "entries": [
+        {
+            "id": 1,
+            "description": "Desktop OpenGL is unreliable on some Intel HD laptops (QTBUG-43263)",
+            "vendor_id": "0x8086",
+            "device_id": [ "0x0A16" ],
+            "os": {
+                "type": "win"
+            },
+            "driver_version": {
+                "op": "<=",
+                "value": "10.18.10.3277"
+            },
+            "features": [
+                "disable_desktopgl"
+            ]
+        },
+        {
+            "id": 2,
+            "description": "Intel Q965/Q963 - GMA 3000 has insufficient support of opengl and directx",
+            "vendor_id": "0x8086",
+            "device_id": [ "0x2992" ],
+            "os": {
+                "type": "win"
+            },
+            "features": [
+                "disable_desktopgl",
+                "disable_angle"
+            ]
+       },
+       {
+           "id": 3,
+           "description": "No OpenGL on Intel G33/G31 (QTBUG-47522)",
+           "vendor_id": "0x8086",
+           "device_id": [ "0x29C2" ],
+           "os": {
+               "type": "win"
+           },
+           "features": [
+               "disable_desktopgl"
+           ]
+       },
+       {
+           "id": 4,
+          "description": "Intel HD Graphics 3000 crashes when initializing the OpenGL driver (QTBUG-42240)",
+          "vendor_id": "0x8086",
+          "device_id": [ "0x0102", "0x0106", "0x010A", "0x0112", "0x0116", "0x0122", "0x0126" ],
+          "os": {
+              "type": "win"
+          },
+          "features": [
+              "disable_desktopgl"
+          ]
+       },
+       {
+           "id": 5,
+           "description": "Intel GMA 3150 (QTBUG-43243), Mobile Intel 945GM (QTBUG-47435) crash",
+           "vendor_id": "0x8086",
+           "device_id": [ "0xA001", "0xA011", "0x27A0" ],
+           "os": {
+               "type": "win"
+           },
+           "features": [
+               "disable_desktopgl", "disable_angle"
+           ]
+        },
+        {
+           "id": 6,
+           "description": "Intel(R) HD Graphics 4000 / 5500 cause crashes on orientation changes in fullscreen mode (QTBUG-49541)",
+           "vendor_id": "0x8086",
+           "device_id": [ "0x0166", "0x1616" ],
+           "os": {
+               "type": "win"
+           },
+           "features": [
+               "disable_rotation"
+           ]
+        },
+        {
+           "id": 7,
+           "description": "AMD FirePro V5900 driver causes crashes in Direct3D on Windows.",
+           "vendor_id": "0x1002",
+           "device_id": ["0x6707"],
+           "os": {
+               "type": "win"
+           },
+           "features": [
+               "disable_angle"
+           ]
+        },
+        {
+           "id": 8,
+           "description": "Standard VGA: Insufficent support for OpenGL, D3D9 and D3D11",
+           "vendor_id": "0x0000",
+           "device_id": ["0x0000"],
+           "os": {
+               "type": "win"
+           },
+           "features": [
+               "disable_desktopgl", "disable_d3d11", "disable_d3d9"
+           ]
+        },
+        {
+           "id": 9,
+           "description": "Intel 945 crash (QTBUG-40991)",
+           "vendor_id": "0x8086",
+           "device_id": [ "0x27A2" ],
+           "os": {
+               "type": "win"
+           },
+           "features": [
+               "disable_desktopgl"
+           ]
+        },
+        {
+          "id": 10,
+          "description": "Intel(R) HD Graphics IronLake (Arrandale) crashes on makeCurrent QTBUG-53888",
+          "vendor_id": "0x8086",
+          "device_id": [ "0x0046" ],
+          "os": {
+              "type": "win"
+          },
+          "features": [
+              "disable_desktopgl"
+          ]
+        },
+        {
+          "id": 11,
+          "description": "Intel driver version 8.15.10.1749 causes GPU process hangs (QTBUG-56360)",
+          "vendor_id": "0x8086",
+          "os": {
+            "type": "win"
+          },
+          "driver_version": {
+            "op": "=",
+            "value": "8.15.10.1749"
+          },
+          "features": [
+            "disable_desktopgl", "disable_d3d11", "disable_d3d9"
+          ]
+        },
+        {
+           "id": 12,
+           "description": "Intel HD Graphics crash in conjunction with shader caches (QTBUG-64697) - disable for all Intel GPUs",
+           "vendor_id": "0x8086",
+           "os": {
+               "type": "win"
+           },
+           "features": [
+               "disable_program_cache"
+           ]
+        },
+
+        {
+            "id": 13,
+            "description": "Desktop OpenGL on Windows 7 often leads to bad QtQuick rendering (MuseScore issue #296682)",
+            "os": {
+                "type": "win",
+                "release": {
+                    "op": "=",
+                    "value": "7"
+                }
+            },
+            "features": [
+                "disable_desktopgl"
+            ]
+        }
+    ]
+}

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7268,7 +7268,12 @@ int main(int argc, char* av[])
 #endif
 
 #ifdef Q_OS_WIN
-      qputenv("QT_OPENGL_BUGLIST", ":/data/win_opengl_buglist.json");
+      if (!qEnvironmentVariableIsSet("QT_OPENGL_BUGLIST")) {
+            // Set custom OpenGL buglist to work around rendering issues
+            // on Windows 7 (#296682). This should also prevent crashes
+            // happening for some Intel GPUs due to outdated buglist in Qt 5.9.
+            qputenv("QT_OPENGL_BUGLIST", ":/data/win_opengl_buglist.json");
+            }
 #endif
 
       qRegisterMetaTypeStreamOperators<SessionStart>("SessionStart");

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7268,12 +7268,7 @@ int main(int argc, char* av[])
 #endif
 
 #ifdef Q_OS_WIN
-      if (QSysInfo::WindowsVersion <= QSysInfo::WV_WINDOWS7) {
-            // Force using ANGLE OpenGL implementation unless user didn't
-            // request otherwise. See issue #296682.
-            if (!qEnvironmentVariableIsSet("QT_OPENGL"))
-                  QApplication::setAttribute(Qt::AA_UseOpenGLES);
-            }
+      qputenv("QT_OPENGL_BUGLIST", ":/data/win_opengl_buglist.json");
 #endif
 
       qRegisterMetaTypeStreamOperators<SessionStart>("SessionStart");

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7267,6 +7267,15 @@ int main(int argc, char* av[])
       qInstallMessageHandler(mscoreMessageHandler);
 #endif
 
+#ifdef Q_OS_WIN
+      if (QSysInfo::WindowsVersion <= QSysInfo::WV_WINDOWS7) {
+            // Force using ANGLE OpenGL implementation unless user didn't
+            // request otherwise. See issue #296682.
+            if (!qEnvironmentVariableIsSet("QT_OPENGL"))
+                  QApplication::setAttribute(Qt::AA_UseOpenGLES);
+            }
+#endif
+
       qRegisterMetaTypeStreamOperators<SessionStart>("SessionStart");
       qRegisterMetaTypeStreamOperators<MusicxmlExportBreaks>("MusicxmlExportBreaks");
       qRegisterMetaTypeStreamOperators<MuseScoreStyleType>("MuseScoreStyleType");

--- a/mscore/musescore.qrc
+++ b/mscore/musescore.qrc
@@ -184,5 +184,6 @@
         <file>data/icons/triangleDown.svg</file>
         <file>data/icons/triangleUp.svg</file>
         <file>data/icons/arrowsMoveToTop.svg</file>
+        <file>data/win_opengl_buglist.json</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/296682 (at least if this solution happens to work)

Native OpenGL implementation often leads to QtQuick-based views (such as QML-based Palettes) render incorrectly.