### PR TITLE
fix #297514: Cannot copy and paste stickings

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -535,6 +535,7 @@ Element* ChordRest::drop(EditData& data)
             case ElementType::TEXT:
             case ElementType::STAFF_TEXT:
             case ElementType::SYSTEM_TEXT:
+            case ElementType::STICKING:
             case ElementType::STAFF_STATE:
             case ElementType::INSTRUMENT_CHANGE:
                   if (e->isInstrumentChange() && part()->instruments()->find(tick().ticks()) != part()->instruments()->end()) {

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1629,6 +1629,7 @@ bool Note::acceptDrop(EditData& data) const
          || (type == ElementType::HAIRPIN)
          || (type == ElementType::STAFF_TEXT)
          || (type == ElementType::SYSTEM_TEXT)
+         || (type == ElementType::STICKING)
          || (type == ElementType::TEMPO_TEXT)
          || (type == ElementType::BEND)
          || (type == ElementType::TREMOLOBAR)


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/297514

The problem as I saw it was that the relevant code for pasting stickings on a note did not exist.
I simply made sure that pasting a sticking is the same as pasting other text-like elements (hope I'm not wrong here, this is my first contribution).

I did not create tests for this fix because I couldn't find other pasting tests. Tell me if I missed something like that.

*Use "x" letter to fill the checkboxes below like [x]*

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
