### PR TITLE
fix #281957, fix #297425: Display of beam properties and Dragging multiple selected elements

### DIFF
--- a/mscore/editelement.cpp
+++ b/mscore/editelement.cpp
@@ -86,6 +86,8 @@ void ScoreView::updateGrips()
 
 void ScoreView::startEditMode(Element* e)
       {
+      if (score()->selection().elements().size() != 1)
+            score()->select(e);
       if (!e || !e->isEditable()) {
             qDebug("The element cannot be edited");
             return;

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2336,10 +2336,10 @@ void MuseScore::selectionChanged(SelState selectionState)
 //   chord rest
 //---------------------------------------------------------
 
-void MuseScore::updatePaletteBeamMode(bool unselect)
+void MuseScore::updatePaletteBeamMode()
       {
       if (paletteWorkspace)
-            paletteWorkspace->updateCellsState(cs->selection(), unselect);
+            paletteWorkspace->updateCellsState(cs->selection());
       }
 
 //---------------------------------------------------------
@@ -5968,8 +5968,7 @@ void MuseScore::endCmd()
             selectionChanged(SelState::NONE);
             }
       updateInspector();
-      if (cv)
-            updatePaletteBeamMode(cv->clickOffElement);
+      updatePaletteBeamMode();
 #ifdef SCRIPT_INTERFACE
       getPluginEngine()->endEndCmd(this);
 #endif

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -644,7 +644,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void showPluginManager();
 
 //      void updateTabNames();
-      void updatePaletteBeamMode(bool unselect = false);
+      void updatePaletteBeamMode();
       QProgressBar* showProgressBar();
       void hideProgressBar();
       void addRecentScore(Score*);

--- a/mscore/palette/palettemodel.cpp
+++ b/mscore/palette/palettemodel.cpp
@@ -789,13 +789,21 @@ bool PaletteTreeModel::insertPalettePanel(std::unique_ptr<PalettePanel> pp, int 
 //   PaletteTreeModel::updateCellsState
 //---------------------------------------------------------
 
-void PaletteTreeModel::updateCellsState(const Selection& sel, bool deactivateAll)
+void PaletteTreeModel::updateCellsState(const Selection& sel)
       {
-      const ChordRest* cr = sel.cr();
-      const IconType beamIconType = cr ? Beam::iconType(cr->beamMode()) : IconType::NONE;
+      const ChordRest* cr = sel.firstChordRest();
+      const Beam::Mode bm = cr ? cr->beamMode() : Beam::Mode::NONE;
+      const IconType beamIconType = Beam::iconType(bm);
+      bool deactivateAll = !cr;
 
-      if (!sel.isSingle() || !cr)
-            deactivateAll = true;
+      for (Element* e : sel.elements()) {
+            if (e->isNote())
+                  e = e->parent();
+            if (e->isChordRest()) {
+                  if (toChordRest(e)->beamMode() != bm)
+                        deactivateAll = true;
+                  }
+            }
 
       const size_t npalettes = palettes().size();
       for (size_t row = 0; row < npalettes; ++row) {

--- a/mscore/palette/palettemodel.h
+++ b/mscore/palette/palettemodel.h
@@ -170,7 +170,7 @@ class PaletteTreeModel : public QAbstractItemModel {
       PaletteCellPtr findCell(const QModelIndex& index);
       bool insertPalettePanel(std::unique_ptr<PalettePanel> pp, int row, const QModelIndex& parent = QModelIndex());
 
-      void updateCellsState(const Selection&, bool deactivateAll);
+      void updateCellsState(const Selection&);
       void retranslate();
       };
 

--- a/mscore/palette/paletteworkspace.h
+++ b/mscore/palette/paletteworkspace.h
@@ -226,7 +226,7 @@ class PaletteWorkspace : public QObject {
       void write(XmlWriter&) const;
       bool read(XmlReader&);
 
-      void updateCellsState(const Selection& sel, bool deactivateAll) { userPalette->updateCellsState(sel, deactivateAll); }
+      void updateCellsState(const Selection& sel) { userPalette->updateCellsState(sel); }
       void retranslate() { userPalette->retranslate(); masterPalette->retranslate(); defaultPalette->retranslate(); }
       };
 

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -123,6 +123,8 @@ class ScoreView : public QWidget, public MuseScoreView {
 
       bool tripleClickPending = false;
       bool popupActive = false;
+      bool modifySelection = false;
+      Element* elementToSelect = nullptr;
 
       // Loop In/Out marks in the score
       PositionCursor* _curLoopIn;
@@ -422,7 +424,6 @@ class ScoreView : public QWidget, public MuseScoreView {
 
       virtual const QRect geometry() const override { return QWidget::geometry(); }
 
-      bool clickOffElement;
       void updateGrips();
       bool moveWhenInactive() const { return _moveWhenInactive; }
       bool moveWhenInactive(bool move) { bool m = _moveWhenInactive; _moveWhenInactive = move; return m; }


### PR DESCRIPTION
This PR addresses two issues that are mostly unrelated, but they both involve the `clickOffElement` variable which I have renamed to `modifySelection`.

First issue: https://musescore.org/en/node/281957#comment-961204
Second issue: https://musescore.org/en/node/297425
