### PR TITLE
Add .jsc (compiled JavaScript) to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ mscore/revision.h
 .DS_Store
 CMakeLists.txt.user.*
 *.qmlc
+*.jsc
 vtest/html
 thirdparty/mupdf-qt
 vtest/LOG


### PR DESCRIPTION
JSC files are generated when a JavaScript library is included in QML.