### PR TITLE
fix #297544: Nested beams created

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2446,7 +2446,8 @@ void Score::createBeams(Measure* measure)
                   Fraction nextTick = a1->tick() + a1->actualTicks();
                   Measure* m = (nextTick >= measure->endTick() ? measure->nextMeasure() : measure);
                   ChordRest* nextCR = (m ? m->findChordRest(nextTick, track) : nullptr);
-                  if (!nextCR || !beamModeMid(nextCR->beamMode()))
+                  Beam* b = a1->beam();
+                  if (!(b && b->elements().startsWith(a1) && nextCR && beamModeMid(nextCR->beamMode())))
                         a1->removeDeleteBeam(false);
                   }
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/297544.

Commit https://github.com/musescore/musescore/commit/74421ac inadvertantly removed an important case for when a ChordRest should be detached from its former beam. This commit adds that case back.