### PR TITLE
fix #297626: 2/2, 3/2 and 4/2 have gotten lost from master timesig palette

### DIFF
--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -1656,7 +1656,10 @@ PalettePanel* MuseScore::newTimePalettePanel()
             { 9,  8, TimeSigType::NORMAL, "9/8" },
             { 12, 8, TimeSigType::NORMAL, "12/8" },
             { 4,  4, TimeSigType::FOUR_FOUR,  QT_TRANSLATE_NOOP("Palette", "4/4 common time") },
-            { 2,  2, TimeSigType::ALLA_BREVE, QT_TRANSLATE_NOOP("Palette", "2/2 alla breve") }
+            { 2,  2, TimeSigType::ALLA_BREVE, QT_TRANSLATE_NOOP("Palette", "2/2 alla breve") },
+            { 2,  2, TimeSigType::NORMAL, "2/2" },
+            { 3,  2, TimeSigType::NORMAL, "3/2" },
+            { 4,  2, TimeSigType::NORMAL, "4/2" },
             };
 
       PalettePanel* sp = new PalettePanel(PalettePanel::Type::TimeSig);


### PR DESCRIPTION
Resolves https://musescore.org/en/node/297626
See also #5166 which added this earlier