### PR TITLE
fix #288495: allow user to select flats or sharps for enharmonic key signatures

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2109,7 +2109,7 @@ void Score::deleteMeasures(MeasureBase* is, MeasureBase* ie)
                                     transposeKeySigEvent = true;
                                     Interval v = staff(0)->part()->instrument(m->tick())->transpose();
                                     if (!v.isZero())
-                                          lastDeletedKeySigEvent.setKey(transposeKey(lastDeletedKeySigEvent.key(), v));
+                                          lastDeletedKeySigEvent.setKey(transposeKey(lastDeletedKeySigEvent.key(), v, lastDeletedKeySig->part()->preferSharpFlat()));
                                     }
                               }
                         }
@@ -2172,7 +2172,7 @@ void Score::deleteMeasures(MeasureBase* is, MeasureBase* ie)
                               if (transposeKeySigEvent) {
                                     Interval v = score->staff(staffIdx)->part()->instrument(Fraction(0,1))->transpose();
                                     v.flip();
-                                    nkse.setKey(transposeKey(nkse.key(), v));
+                                    nkse.setKey(transposeKey(nkse.key(), v, lastDeletedKeySig->part()->preferSharpFlat()));
                                     }
                               KeySig* nks = new KeySig(score);
                               nks->setTrack(staffIdx * VOICES);
@@ -3779,7 +3779,7 @@ void Score::undoChangeKeySig(Staff* ostaff, const Fraction& tick, KeySigEvent ke
             bool concertPitch = score->styleB(Sid::concertPitch);
             if (interval.chromatic && !concertPitch && !nkey.custom() && !nkey.isAtonal()) {
                   interval.flip();
-                  nkey.setKey(transposeKey(key.key(), interval));
+                  nkey.setKey(transposeKey(key.key(), interval, staff->part()->preferSharpFlat()));
                   }
             if (ks) {
                   ks->undoChangeProperty(Pid::GENERATED, false);

--- a/libmscore/key.h
+++ b/libmscore/key.h
@@ -145,7 +145,9 @@ class AccidentalState {
       };
 
 struct Interval;
-extern Key transposeKey(Key oldKey, const Interval&);
+
+enum class PreferSharpFlat : char;
+extern Key transposeKey(Key oldKey, const Interval&, PreferSharpFlat prefer = PreferSharpFlat(0));
 
 
 }     // namespace Ms

--- a/libmscore/part.cpp
+++ b/libmscore/part.cpp
@@ -37,6 +37,7 @@ Part::Part(Score* s)
       _color = DEFAULT_COLOR;
       _show  = true;
       _instruments.setInstrument(new Instrument, -1);   // default instrument
+      _preferSharpFlat = PreferSharpFlat::DEFAULT;
       }
 
 //---------------------------------------------------------
@@ -109,7 +110,7 @@ bool Part::readProperties(XmlReader& e)
       else if (tag == "Instrument") {
             Instrument* instr = new Instrument;
             instr->read(e, this);
-            setInstrument(instr, Fraction(-1,1));
+            setInstrument(instr, Fraction(-1, 1));
             }
       else if (tag == "name")
             instrument()->setLongName(e.readElementText());
@@ -121,6 +122,8 @@ bool Part::readProperties(XmlReader& e)
             _partName = e.readElementText();
       else if (tag == "show")
             _show = e.readInt();
+      else if (tag == "preferSharpFlat")
+            _preferSharpFlat = PreferSharpFlat(e.readInt());
       else
             return false;
       return true;
@@ -154,6 +157,8 @@ void Part::write(XmlWriter& xml) const
       xml.tag("trackName", _partName);
       if (_color != DEFAULT_COLOR)
             xml.tag("color", _color);
+      if (_preferSharpFlat != PreferSharpFlat::DEFAULT)
+            xml.tag("preferSharpFlat", int(_preferSharpFlat));
       instrument()->write(xml, this);
       xml.etag();
       }

--- a/libmscore/part.cpp
+++ b/libmscore/part.cpp
@@ -433,6 +433,8 @@ QVariant Part::getProperty(Pid id) const
                   return QVariant(_show);
             case Pid::USE_DRUMSET:
                   return instrument()->useDrumset();
+            case Pid::PREFER_SHARP_FLAT:
+                  return int(preferSharpFlat());
             default:
                   return QVariant();
             }
@@ -451,6 +453,8 @@ bool Part::setProperty(Pid id, const QVariant& property)
             case Pid::USE_DRUMSET:
                   instrument()->setUseDrumset(property.toBool());
                   break;
+            case Pid::PREFER_SHARP_FLAT:
+                  setPreferSharpFlat(PreferSharpFlat(property.toInt()));
             default:
                   qDebug("Part::setProperty: unknown id %d", int(id));
                   break;

--- a/libmscore/part.cpp
+++ b/libmscore/part.cpp
@@ -123,7 +123,8 @@ bool Part::readProperties(XmlReader& e)
       else if (tag == "show")
             _show = e.readInt();
       else if (tag == "preferSharpFlat")
-            _preferSharpFlat = PreferSharpFlat(e.readInt());
+            _preferSharpFlat =
+               e.readElementText() == "sharps" ? PreferSharpFlat::SHARPS : PreferSharpFlat::FLATS;
       else
             return false;
       return true;
@@ -158,7 +159,8 @@ void Part::write(XmlWriter& xml) const
       if (_color != DEFAULT_COLOR)
             xml.tag("color", _color);
       if (_preferSharpFlat != PreferSharpFlat::DEFAULT)
-            xml.tag("preferSharpFlat", int(_preferSharpFlat));
+            xml.tag("preferSharpFlat",
+               _preferSharpFlat == PreferSharpFlat::SHARPS ? "sharps" : "flats");
       instrument()->write(xml, this);
       xml.etag();
       }

--- a/libmscore/part.h
+++ b/libmscore/part.h
@@ -141,7 +141,7 @@ class Part final : public ScoreElement {
       const Part* masterPart() const;
       Part* masterPart();
 
-      PreferSharpFlat preferSharpFlat()           { return _preferSharpFlat; }
+      PreferSharpFlat preferSharpFlat() const     { return _preferSharpFlat; }
       void setPreferSharpFlat(PreferSharpFlat v)  { _preferSharpFlat = v;    }
 
       // Allows not reading the same instrument twice on importing 2.X scores.

--- a/libmscore/part.h
+++ b/libmscore/part.h
@@ -25,6 +25,14 @@ class Score;
 class InstrumentTemplate;
 
 //---------------------------------------------------------
+//   PreferSharpFlat
+//---------------------------------------------------------
+
+enum class PreferSharpFlat : char {
+      DEFAULT, SHARPS, FLATS
+      };
+
+//---------------------------------------------------------
 //   @@ Part
 //   @P endTrack        int         (read only)
 //   @P harmonyCount    int         (read only)
@@ -53,6 +61,8 @@ class Part final : public ScoreElement {
 
       static const int DEFAULT_COLOR = 0x3399ff;
       int _color;                   ///User specified color for helping to label parts
+
+      PreferSharpFlat _preferSharpFlat;
 
    public:
       Part(Score* = 0);
@@ -130,6 +140,9 @@ class Part final : public ScoreElement {
 
       const Part* masterPart() const;
       Part* masterPart();
+
+      PreferSharpFlat preferSharpFlat()           { return _preferSharpFlat; }
+      void setPreferSharpFlat(PreferSharpFlat v)  { _preferSharpFlat = v;    }
 
       // Allows not reading the same instrument twice on importing 2.X scores.
       // TODO: do we need instruments info in parts at all?

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -304,7 +304,7 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::END_HOOK_HEIGHT,         false, "endHookHeight",         P_TYPE::SPATIUM,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "end hook height")  },
       { Pid::END_FONT_FACE,           false, "endFontFace",           P_TYPE::FONT,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "end font face")    },
       { Pid::END_FONT_SIZE,           false, "endFontSize",           P_TYPE::REAL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "end font size")    },
-      { Pid::END_FONT_STYLE,          false, "endFontStyle",          P_TYPE::INT,                DUMMY_QT_TRANSLATE_NOOP("propertyName",  "end font style")    },
+      { Pid::END_FONT_STYLE,          false, "endFontStyle",          P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName",  "end font style")  },
       { Pid::END_TEXT_OFFSET,         false, "endTextOffset",         P_TYPE::POINT_SP,            DUMMY_QT_TRANSLATE_NOOP("propertyName", "end text offset")  },
 
       { Pid::POS_ABOVE,               false, "posAbove",              P_TYPE::SP_REAL,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "position above")   },
@@ -336,6 +336,8 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::START_WITH_MEASURE_ONE,  true,  "startWithMeasureOne",   P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "start with measure one") },
 
       { Pid::PATH,                    false, "path",                  P_TYPE::PATH,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "path") },
+
+      { Pid::PREFER_SHARP_FLAT,       true,  "preferSharpFlat",       P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "prefer sharps or flats") },
 
       { Pid::END, false, "++end++", P_TYPE::INT, DUMMY_QT_TRANSLATE_NOOP("propertyName", "<invalid property>") }
       };

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -345,6 +345,8 @@ enum class Pid {
       START_WITH_MEASURE_ONE,
 
       PATH, // for ChordLine to make its shape changes undoable
+      
+      PREFER_SHARP_FLAT,
 
       END
       };

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2606,7 +2606,7 @@ void Score::adjustKeySigs(int sidx, int eidx, KeyList km)
                   KeySigEvent nKey = oKey;
                   int diff = -staff->part()->instrument(tick)->transpose().chromatic;
                   if (diff != 0 && !styleB(Sid::concertPitch) && !oKey.custom() && !oKey.isAtonal())
-                        nKey.setKey(transposeKey(nKey.key(), diff));
+                        nKey.setKey(transposeKey(nKey.key(), diff, staff->part()->preferSharpFlat()));
                   staff->setKey(tick, nKey);
                   KeySig* keysig = new KeySig(this);
                   keysig->setTrack(staffIdx * VOICES);
@@ -4113,7 +4113,7 @@ int Score::keysig()
             result = key;
             int diff = st->part()->instrument()->transpose().chromatic;
             if (!styleB(Sid::concertPitch) && diff)
-                  result = transposeKey(key, diff);
+                  result = transposeKey(key, diff, st->part()->preferSharpFlat());
             break;
             }
       return int(result);

--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -340,9 +340,9 @@ void EditStaff::apply()
       bool preferSharpFlatChanged = (part->preferSharpFlat() != PreferSharpFlat(preferSharpFlat->currentIndex()));
       // instrument becomes non/octave-transposing, preferSharpFlat isn't useful anymore
       if ((iList->currentIndex() == 0) || (iList->currentIndex() == 25))
-            part->setPreferSharpFlat(PreferSharpFlat::DEFAULT);
+            part->undoChangeProperty(Pid::PREFER_SHARP_FLAT, int(PreferSharpFlat::DEFAULT));
       else
-            part->setPreferSharpFlat(PreferSharpFlat(preferSharpFlat->currentIndex()));
+            part->undoChangeProperty(Pid::PREFER_SHARP_FLAT, int(PreferSharpFlat(preferSharpFlat->currentIndex())));
 
       instrument.setMinPitchA(_minPitchA);
       instrument.setMaxPitchA(_maxPitchA);

--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -368,10 +368,11 @@ void EditStaff::apply()
       if (instrumentFieldChanged && _tickStart == Fraction(-1, 1))
             clefType = instrument.clefType(orgStaff->rstaff());
 
-      if (instrumentFieldChanged || part->partName() != newPartName || preferSharpFlatChanged) {
+      Interval v1 = instrument.transpose();
+      Interval v2 = part->instrument(_tickStart)->transpose();
+
+      if (instrumentFieldChanged || part->partName() != newPartName) {
             // instrument has changed
-            Interval v1 = instrument.transpose();
-            Interval v2 = part->instrument(_tickStart)->transpose();
 
             if (_tickStart == Fraction(-1, 1)) {
                   // change instrument and part name globally
@@ -392,9 +393,13 @@ void EditStaff::apply()
                   }
             emit instrumentChanged();
 
-            if ((v1 != v2) || preferSharpFlatChanged)
+            if (v1 != v2)
                   score->transpositionChanged(part, v2, _tickStart, _tickEnd);
             }
+
+      if (preferSharpFlatChanged)
+            score->transpositionChanged(part, v2, _tickStart, _tickEnd);
+
       orgStaff->undoChangeProperty(Pid::MAG, mag->value() / 100.0);
       orgStaff->undoChangeProperty(Pid::COLOR, color->color());
       orgStaff->undoChangeProperty(Pid::SMALL, small->isChecked());

--- a/mscore/editstaff.h
+++ b/mscore/editstaff.h
@@ -71,6 +71,7 @@ class EditStaff : public QDialog, private Ui::EditStaffBase {
       void showBarlinesChanged();
       void gotoNextStaff();
       void gotoPreviousStaff();
+      void transpositionChanged();
 
    signals:
       void instrumentChanged();

--- a/mscore/editstaff.ui
+++ b/mscore/editstaff.ui
@@ -575,209 +575,273 @@
        </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="hLayout_Transposition">
+       <layout class="QVBoxLayout" name="vLayout_Transposition">
         <item>
-         <widget class="QLabel" name="labelTransp">
-          <property name="toolTip">
-           <string>Interval from written to sounding pitch</string>
-          </property>
-          <property name="text">
-           <string>Transposition:</string>
-          </property>
-          <property name="buddy">
-           <cstring>iList</cstring>
-          </property>
-         </widget>
+         <layout class="QHBoxLayout" name="transp_Main">
+          <item>
+           <widget class="QLabel" name="labelTransp">
+            <property name="toolTip">
+             <string>Interval from written to sounding pitch</string>
+            </property>
+            <property name="text">
+             <string>Transposition:</string>
+            </property>
+            <property name="buddy">
+             <cstring>iList</cstring>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="octave">
+            <property name="accessibleName">
+             <string>Octave</string>
+            </property>
+            <property name="maximum">
+             <number>10</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_11">
+            <property name="text">
+             <string>Octave(s) +</string>
+            </property>
+            <property name="buddy">
+             <cstring>octave</cstring>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="iList">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="accessibleName">
+             <string>Interval</string>
+            </property>
+            <item>
+             <property name="text">
+              <string>0 - Perfect Unison</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>1 - Augmented Unison</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>0 - Diminished Second</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>1 - Minor Second</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>2 - Major Second</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>3 - Augmented Second</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>2 - Diminished Third</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>3 - Minor Third</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>4 - Major Third</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>5 - Augmented Third</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>4 - Diminished Fourth</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>5 - Perfect Fourth</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>6 - Augmented Fourth</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>6 - Diminished Fifth</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>7 - Perfect Fifth</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>8 - Augmented Fifth</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>7 - Diminished Sixth</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>8 - Minor Sixth</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>9 - Major Sixth</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>10 - Augmented Sixth</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>9 - Diminished Seventh</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>10 - Minor Seventh</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>11 - Major Seventh</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>12 - Augmented Seventh</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>11 - Diminished Octave</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>12 - Perfect Octave</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="up">
+            <property name="text">
+             <string>Up</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="down">
+            <property name="text">
+             <string>Down</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_1">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>17</width>
+              <height>18</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
         </item>
         <item>
-         <widget class="QSpinBox" name="octave">
-          <property name="accessibleName">
-           <string>Octave</string>
-          </property>
-          <property name="maximum">
-           <number>10</number>
-          </property>
+         <widget class="QWidget" name="transp_PreferSharpFlat" native="true">
+          <layout class="QHBoxLayout" name="transp_PreferSharpFlat_Layout">
+           <property name="spacing">
+            <number>6</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="labelPreferSharpFlat">
+             <property name="text">
+              <string>Prefer sharps or flats for transposed key signature:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="preferSharpFlat">
+             <item>
+              <property name="text">
+               <string>Default</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Sharps</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Flats</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_7">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
          </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_11">
-          <property name="text">
-           <string>Octave(s) +</string>
-          </property>
-          <property name="buddy">
-           <cstring>octave</cstring>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="iList">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="accessibleName">
-           <string>Interval</string>
-          </property>
-          <item>
-           <property name="text">
-            <string>0 - Perfect Unison</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>1 - Augmented Unison</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>0 - Diminished Second</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>1 - Minor Second</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>2 - Major Second</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>3 - Augmented Second</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>2 - Diminished Third</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>3 - Minor Third</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>4 - Major Third</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>5 - Augmented Third</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>4 - Diminished Fourth</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>5 - Perfect Fourth</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>6 - Augmented Fourth</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>6 - Diminished Fifth</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>7 - Perfect Fifth</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>8 - Augmented Fifth</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>7 - Diminished Sixth</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>8 - Minor Sixth</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>9 - Major Sixth</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>10 - Augmented Sixth</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>9 - Diminished Seventh</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>10 - Minor Seventh</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>11 - Major Seventh</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>12 - Augmented Seventh</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>11 - Diminished Octave</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>12 - Perfect Octave</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="up">
-          <property name="text">
-           <string>Up</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="down">
-          <property name="text">
-           <string>Down</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_1">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>17</width>
-            <height>18</height>
-           </size>
-          </property>
-         </spacer>
         </item>
        </layout>
       </item>
@@ -957,6 +1021,7 @@
   <tabstop>iList</tabstop>
   <tabstop>up</tabstop>
   <tabstop>down</tabstop>
+  <tabstop>preferSharpFlat</tabstop>
   <tabstop>numOfStrings</tabstop>
   <tabstop>editStringData</tabstop>
   <tabstop>singleNoteDynamics</tabstop>

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -632,7 +632,7 @@ MasterScore* MuseScore::getNewFile()
                                     KeySigEvent nKey = ks;
                                     if (!nKey.custom() && !nKey.isAtonal() && part->instrument()->transpose().chromatic && !score->styleB(Sid::concertPitch)) {
                                           int diff = -part->instrument()->transpose().chromatic;
-                                          nKey.setKey(transposeKey(nKey.key(), diff));
+                                          nKey.setKey(transposeKey(nKey.key(), diff, part->preferSharpFlat()));
                                           }
                                     // do not create empty keysig unless custom or atonal
                                     if (nKey.custom() || nKey.isAtonal() || nKey.key() != Key::C) {

--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -198,6 +198,7 @@ void MuseScore::updateInstrumentDialog()
       if (instrList)
             instrList->buildInstrumentsList();
       }
+
 //---------------------------------------------------------
 //   editInstrList
 //---------------------------------------------------------

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5727,7 +5727,7 @@ void MuseScore::transpose()
                   if (!cs->styleB(Sid::concertPitch)) {
                         int diff = staff->part()->instrument(startTick)->transpose().chromatic;
                         if (diff)
-                              key = transposeKey(key, diff);
+                              key = transposeKey(key, diff, staff->part()->preferSharpFlat());
                         }
                   break;
                   }

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -660,7 +660,7 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
                                                 Interval v = staff->part()->instrument(tick1)->transpose();
                                                 if (!v.isZero()) {
                                                       Key k = okeysig->key();
-                                                      okeysig->setKey(transposeKey(k, v));
+                                                      okeysig->setKey(transposeKey(k, v, okeysig->part()->preferSharpFlat()));
                                                       }
                                                 }
                                           oelement = okeysig;

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -1156,7 +1156,7 @@ void Timeline::key_meta(Segment* seg, int* stagger, int pos)
                   global_key = Key::NUM_OF;
             else {
                   const Interval curr_interval = stave->part()->instrument()->transpose();
-                  global_key = transposeKey(global_key, curr_interval);
+                  global_key = transposeKey(global_key, curr_interval, stave->part()->preferSharpFlat());
                   }
 
             std::map<Key, int>::iterator it = key_frequencies.find(global_key);

--- a/mtest/libmscore/keysig/preferSharpFlat-1-ref.mscx
+++ b/mtest/libmscore/keysig/preferSharpFlat-1-ref.mscx
@@ -34,7 +34,7 @@
         <defaultTransposingClef>G</defaultTransposingClef>
         </Staff>
       <trackName>D♭ Piccolo</trackName>
-      <preferSharpFlat>2</preferSharpFlat>
+      <preferSharpFlat>flats</preferSharpFlat>
       <Instrument>
         <longName>D♭ Piccolo</longName>
         <shortName>D♭ Picc.</shortName>

--- a/mtest/libmscore/keysig/preferSharpFlat-1-ref.mscx
+++ b/mtest/libmscore/keysig/preferSharpFlat-1-ref.mscx
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.01">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <pagePrintableWidth>7.4826</pagePrintableWidth>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <defaultConcertClef>G8va</defaultConcertClef>
+        <defaultTransposingClef>G</defaultTransposingClef>
+        </Staff>
+      <trackName>D♭ Piccolo</trackName>
+      <preferSharpFlat>2</preferSharpFlat>
+      <Instrument>
+        <longName>D♭ Piccolo</longName>
+        <shortName>D♭ Picc.</shortName>
+        <trackName>D♭ Piccolo</trackName>
+        <minPitchP>75</minPitchP>
+        <maxPitchP>109</maxPitchP>
+        <minPitchA>75</minPitchA>
+        <maxPitchA>106</maxPitchA>
+        <transposeDiatonic>8</transposeDiatonic>
+        <transposeChromatic>13</transposeChromatic>
+        <instrumentId>wind.flutes.flute.piccolo</instrumentId>
+        <concertClef>G8va</concertClef>
+        <transposingClef>G</transposingClef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="72"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <KeySig>
+            <accidental>-7</accidental>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/keysig/preferSharpFlat-1.mscx
+++ b/mtest/libmscore/keysig/preferSharpFlat-1.mscx
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.01">
+  <programVersion>3.3.3</programVersion>
+  <programRevision>3543170</programRevision>
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <pagePrintableWidth>7.4826</pagePrintableWidth>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2019-11-29</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Microsoft Windows</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <defaultConcertClef>G8va</defaultConcertClef>
+        <defaultTransposingClef>G</defaultTransposingClef>
+        </Staff>
+      <trackName>D♭ Piccolo</trackName>
+      <Instrument>
+        <longName>D♭ Piccolo</longName>
+        <shortName>D♭ Picc.</shortName>
+        <trackName>D♭ Piccolo</trackName>
+        <minPitchP>75</minPitchP>
+        <maxPitchP>109</maxPitchP>
+        <minPitchA>75</minPitchA>
+        <maxPitchA>106</maxPitchA>
+        <transposeDiatonic>8</transposeDiatonic>
+        <transposeChromatic>13</transposeChromatic>
+        <instrumentId>wind.flutes.flute.piccolo</instrumentId>
+        <concertClef>G8va</concertClef>
+        <transposingClef>G</transposingClef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="72"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <KeySig>
+            <accidental>5</accidental>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/keysig/preferSharpFlat-2-ref.mscx
+++ b/mtest/libmscore/keysig/preferSharpFlat-2-ref.mscx
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.01">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <pagePrintableWidth>7.4826</pagePrintableWidth>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Horn in D</trackName>
+      <preferSharpFlat>2</preferSharpFlat>
+      <Instrument>
+        <longName>Horn in D</longName>
+        <shortName>D Hn.</shortName>
+        <trackName>Horn in D</trackName>
+        <minPitchP>32</minPitchP>
+        <maxPitchP>74</maxPitchP>
+        <minPitchA>36</minPitchA>
+        <maxPitchA>69</maxPitchA>
+        <transposeDiatonic>-6</transposeDiatonic>
+        <transposeChromatic>-10</transposeChromatic>
+        <instrumentId>brass.natural-horn</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="60"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <KeySig>
+            <accidental>-7</accidental>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/keysig/preferSharpFlat-2-ref.mscx
+++ b/mtest/libmscore/keysig/preferSharpFlat-2-ref.mscx
@@ -32,7 +32,7 @@
           </StaffType>
         </Staff>
       <trackName>Horn in D</trackName>
-      <preferSharpFlat>2</preferSharpFlat>
+      <preferSharpFlat>flats</preferSharpFlat>
       <Instrument>
         <longName>Horn in D</longName>
         <shortName>D Hn.</shortName>

--- a/mtest/libmscore/keysig/preferSharpFlat-2.mscx
+++ b/mtest/libmscore/keysig/preferSharpFlat-2.mscx
@@ -36,7 +36,7 @@
           </StaffType>
         </Staff>
       <trackName>Horn in D</trackName>
-      <preferSharpFlat>2</preferSharpFlat>
+      <preferSharpFlat>flats</preferSharpFlat>
       <Instrument>
         <longName>Horn in D</longName>
         <shortName>D Hn.</shortName>

--- a/mtest/libmscore/keysig/preferSharpFlat-2.mscx
+++ b/mtest/libmscore/keysig/preferSharpFlat-2.mscx
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.01">
+  <programVersion>3.3.3</programVersion>
+  <programRevision>3543170</programRevision>
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <pagePrintableWidth>7.4826</pagePrintableWidth>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2019-11-29</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Microsoft Windows</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Horn in D</trackName>
+      <preferSharpFlat>2</preferSharpFlat>
+      <Instrument>
+        <longName>Horn in D</longName>
+        <shortName>D Hn.</shortName>
+        <trackName>Horn in D</trackName>
+        <minPitchP>32</minPitchP>
+        <maxPitchP>74</maxPitchP>
+        <minPitchA>36</minPitchA>
+        <maxPitchA>69</maxPitchA>
+        <transposeDiatonic>-6</transposeDiatonic>
+        <transposeChromatic>-10</transposeChromatic>
+        <instrumentId>brass.natural-horn</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="60"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <KeySig>
+            <accidental>-2</accidental>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/keysig/tst_keysig.cpp
+++ b/mtest/libmscore/keysig/tst_keysig.cpp
@@ -16,6 +16,8 @@
 #include "libmscore/measure.h"
 #include "libmscore/keysig.h"
 #include "libmscore/undo.h"
+#include "libmscore/fraction.h"
+#include "libmscore/part.h"
 
 #define DIR QString("libmscore/keysig/")
 
@@ -34,6 +36,7 @@ class TestKeySig : public QObject, public MTest
       void keysig();
       void concertPitch();
       void keysig_78216();
+      void preferSharpFlat();
       };
 
 //---------------------------------------------------------
@@ -127,7 +130,13 @@ void TestKeySig::keysig_78216()
       QVERIFY2(m1->findSegment(SegmentType::KeySig, m1->endTick()) == nullptr, "Should be no keysig at end of measure 1.");
       QVERIFY2(m2->findSegment(SegmentType::KeySig, m2->endTick()) == nullptr, "Should be no keysig at end of measure 2.");
       QVERIFY2(m3->findSegment(SegmentType::KeySig, m3->endTick()) == nullptr, "Should be no keysig at end of measure 3.");
+
+      delete score;
       }
+
+//---------------------------------------------------------
+//   concertPitch
+//---------------------------------------------------------
 
 void TestKeySig::concertPitch()
       {
@@ -136,6 +145,34 @@ void TestKeySig::concertPitch()
       QVERIFY(saveCompareScore(score, "concert-pitch-01-test.mscx", DIR + "concert-pitch-01-ref.mscx"));
       score->cmdConcertPitchChanged(false, true);
       QVERIFY(saveCompareScore(score, "concert-pitch-02-test.mscx", DIR + "concert-pitch-02-ref.mscx"));
+
+      delete score;
+      }
+
+//---------------------------------------------------------
+//   preferSharpFlat
+//---------------------------------------------------------
+
+void TestKeySig::preferSharpFlat()
+      {
+      MasterScore* score1 = readScore(DIR + "preferSharpFlat-1.mscx");
+      auto parts = score1->parts();
+      Part* part1 = parts[0];
+      part1->setPreferSharpFlat(PreferSharpFlat::FLATS);
+      score1->transpositionChanged(part1, part1->instrument(Fraction(0, 1))->transpose(), Fraction(0, 1), Fraction(16, 4));
+      score1->update();
+      score1->doLayout();
+      QVERIFY(saveCompareScore(score1, "preferSharpFlat-1-test.mscx", DIR + "preferSharpFlat-1-ref.mscx"));
+      delete score1;
+
+      MasterScore* score2 = readScore(DIR + "preferSharpFlat-2.mscx");
+      score2->cmdSelectAll();
+      score2->startCmd();
+      // transpose augmented unison up
+      score2->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 1, true, true, true);
+      score2->endCmd();
+      QVERIFY(saveCompareScore(score2, "preferSharpFlat-2-test.mscx", DIR + "preferSharpFlat-2-ref.mscx"));
+      delete score2;
       }
 
 QTEST_MAIN(TestKeySig)


### PR DESCRIPTION
Resolves: https://musescore.org/node/288495.

A new part property `_preferSharpFlat` is added to let the user decide.