### PR TITLE
fix #297549: Selecting notes by duration matches notes with different duration

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3273,7 +3273,9 @@ void Score::collectNoteMatch(void* data, Element* e)
             return;
       if (p->notehead != NoteHead::Group::HEAD_INVALID && p->notehead != n->headGroup())
             return;
-      if (p->duration.type() != TDuration::DurationType::V_INVALID && p->duration != n->chord()->actualDurationType())
+      if (p->durationType.type() != TDuration::DurationType::V_INVALID && p->durationType != n->chord()->actualDurationType())
+            return;
+      if (p->durationTicks != Fraction(-1,1) && p->durationTicks != n->chord()->actualTicks())
             return;
       if ((p->staffStart != -1)
          && ((p->staffStart > e->staffIdx()) || (p->staffEnd <= e->staffIdx())))

--- a/libmscore/select.h
+++ b/libmscore/select.h
@@ -55,7 +55,8 @@ struct NotePattern {
       int string = STRING_NONE;
       int tpc = Tpc::TPC_INVALID;;
       NoteHead::Group notehead = NoteHead::Group::HEAD_INVALID;
-      TDuration duration = TDuration();
+      TDuration durationType = TDuration();
+      Fraction durationTicks;
       NoteType type = NoteType::INVALID;
       int staffStart;
       int staffEnd; // exclusive

--- a/mscore/selectnotedialog.cpp
+++ b/mscore/selectnotedialog.cpp
@@ -49,7 +49,8 @@ SelectNoteDialog::SelectNoteDialog(const Note* _n, QWidget* parent)
       pitch->setText(n->tpcUserName());
       string->setText(QString::number(n->string()+1));
       type->setText(n->noteTypeUserName());
-      duration->setText(n->chord()->durationUserName());
+      durationType->setText(tr("%1 Note").arg(n->chord()->durationType().durationTypeUserName()));
+      durationTicks->setText(n->chord()->durationUserName());
       name->setText(tpc2name(n->tpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, false));
       inSelection->setEnabled(n->score()->selection().isRange());
       MuseScore::restoreGeometry(this);
@@ -71,8 +72,13 @@ void SelectNoteDialog::setPattern(NotePattern* p)
             p->tpc = n->tpc();
       if (sameType->isChecked())
             p->type = n->noteType();
-      if (sameDuration->isChecked())
-            p->duration = n->chord()->actualDurationType();
+      if (sameDurationType->isChecked())
+            p->durationType = n->chord()->actualDurationType();
+
+      if (sameDurationTicks->isChecked())
+            p->durationTicks = n->chord()->actualTicks();
+      else
+            p->durationTicks = Fraction(-1,1);
 
       if (sameStaff->isChecked()) {
             p->staffStart = n->staffIdx();

--- a/mscore/selectnotedialog.ui
+++ b/mscore/selectnotedialog.ui
@@ -48,14 +48,14 @@
           </property>
          </widget>
         </item>
-        <item row="7" column="1" colspan="2">
+        <item row="8" column="1" colspan="2">
          <widget class="QCheckBox" name="sameSystem">
           <property name="text">
            <string>Same system</string>
           </property>
          </widget>
         </item>
-        <item row="7" column="0">
+        <item row="8" column="0">
          <widget class="QCheckBox" name="sameVoice">
           <property name="text">
            <string>Same voice</string>
@@ -63,18 +63,32 @@
          </widget>
         </item>
         <item row="4" column="1">
-         <widget class="QLabel" name="duration">
+         <widget class="QLabel" name="durationType">
           <property name="text">
            <string/>
           </property>
          </widget>
         </item>
         <item row="4" column="0">
-         <widget class="QCheckBox" name="sameDuration">
+         <widget class="QCheckBox" name="sameDurationType">
           <property name="text">
-           <string>Same duration:</string>
+           <string>Same note type:</string>
           </property>
          </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QLabel" name="durationTicks">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+          <widget class="QCheckBox" name="sameDurationTicks">
+            <property name="text">
+              <string>Same duration:</string>
+            </property>
+          </widget>
         </item>
         <item row="1" column="0">
          <widget class="QCheckBox" name="samePitch">
@@ -83,7 +97,7 @@
           </property>
          </widget>
         </item>
-        <item row="6" column="1">
+        <item row="7" column="1">
          <widget class="QCheckBox" name="inSelection">
           <property name="text">
            <string>In selection</string>
@@ -97,7 +111,7 @@
           </property>
          </widget>
         </item>
-        <item row="6" column="0">
+        <item row="7" column="0">
          <widget class="QCheckBox" name="sameStaff">
           <property name="text">
            <string>Same staff</string>
@@ -118,14 +132,14 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="0">
+        <item row="6" column="0">
          <widget class="QCheckBox" name="sameName">
           <property name="text">
            <string>Same note name:</string>
           </property>
          </widget>
         </item>
-        <item row="5" column="1">
+        <item row="6" column="1">
          <widget class="QLabel" name="name">
           <property name="text">
            <string/>
@@ -217,7 +231,8 @@
   <tabstop>samePitch</tabstop>
   <tabstop>sameString</tabstop>
   <tabstop>sameType</tabstop>
-  <tabstop>sameDuration</tabstop>
+  <tabstop>sameDurationType</tabstop>
+  <tabstop>sameDurationTicks</tabstop>
   <tabstop>sameName</tabstop>
   <tabstop>sameStaff</tabstop>
   <tabstop>inSelection</tabstop>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/297549

The main issue in that thread was the `SelectNoteDialog` bug: select by duration matched notes with same note type (e.g. 16th notes) but different durations (16th Triplet and normal 16th).
The solution for that is straightforward: compare note duration by `actualTicks()` attribute instead of `duration.type()`.

But, the option for selecting notes by same note type (i.e. all notes that look the same regardless of tuplets) was still needed as expressed in the thread. So I created another option for selecting a note - selecting by note type (Eighth Note, 16th Note etc.).

I hope that the two options are discernible for the user, and if not tell me what can be improved.

examples:

![image](https://user-images.githubusercontent.com/22118580/69859369-b17a4580-129c-11ea-895a-055d8b97796e.png)

![image](https://user-images.githubusercontent.com/22118580/69859431-d66eb880-129c-11ea-846d-5d9471bba9ee.png)

(for the CLA, my musescore username is liorkl)

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
