### PR TITLE
fix #297614: fix moving viewport to irrelevant position when editing spanner segment

### DIFF
--- a/libmscore/scoreElement.h
+++ b/libmscore/scoreElement.h
@@ -472,6 +472,10 @@ static inline SpannerSegment* toSpannerSegment(ScoreElement* e) {
       Q_ASSERT(e == 0 || e->isSpannerSegment());
       return (SpannerSegment*)e;
       }
+static inline const SpannerSegment* toSpannerSegment(const ScoreElement* e) {
+      Q_ASSERT(e == 0 || e->isSpannerSegment());
+      return (const SpannerSegment*)e;
+      }
 static inline BSymbol* toBSymbol(ScoreElement* e) {
       Q_ASSERT(e == 0 || e->isBSymbol());
       return (BSymbol*)e;

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4906,8 +4906,21 @@ void ScoreView::moveViewportToLastEdit()
       const Element* editElement = visibleElementInScore(st.element(), sc);
 
       const MeasureBase* mb = nullptr;
-      if (editElement)
-            mb = editElement->findMeasureBase();
+      if (editElement) {
+            if (editElement->isSpannerSegment()) {
+                  const SpannerSegment* s = toSpannerSegment(editElement);
+                  Fraction tick = s->tick();
+                  if (System* sys = s->system()) {
+                        Measure* fm = sys->firstMeasure();
+                        if (fm)
+                              tick = std::max(tick, fm->tick());
+                        }
+                  mb = sc->tick2measureMM(tick);
+                  }
+            else {
+                  mb = editElement->findMeasureBase();
+                  }
+            }
       if (!mb)
             mb = sc->tick2measureMM(st.startTick());
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/297614