### PR TITLE
fix #297468: fix a crash on reading a corrupted score with linear layout mode in part

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -4369,7 +4369,7 @@ void Score::doLayoutRange(const Fraction& st, const Fraction& et)
             }
 //      if (!_systems.isEmpty())
 //            return;
-      bool layoutAll = stick <= Fraction(0,1) && (etick < Fraction(0,1) || etick >= last()->endTick());
+      bool layoutAll = stick <= Fraction(0,1) && (etick < Fraction(0,1) || etick >= masterScore()->last()->endTick());
       if (stick < Fraction(0,1))
             stick = Fraction(0,1);
       if (etick < Fraction(0,1))


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/297468

In a corrupted score tick values may sometimes be not synchronized between master score and parts. This may lead to incorrect setting of layoutAll flag as ticks from different scores are compared. Ensuring that only master score ticks are compared fixes layoutAll flag for scores corrupted that way and prevents a crash due to not making a full layout on score loading. This change makes no difference for correctly saved scores.