### PR TITLE
[MU4] proposed fix #297458: implement "apply input state" command

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3710,6 +3710,47 @@ void Score::cmdToggleAutoplace(bool all)
       }
 
 //---------------------------------------------------------
+//   cmdApplyInputState
+//---------------------------------------------------------
+
+void Score::cmdApplyInputState()
+      {
+      if (!noteEntryMode())
+            return;
+
+      // get current note/rest
+      Element* e = selection().element();
+      if (!e)
+            return;
+      Note* n = nullptr;
+      ChordRest* cr = nullptr;
+      if (e->isNote()) {
+            n = toNote(e);
+            cr = n->chord();
+            }
+      else if (e->isRest()) {
+            cr = toRest(e);
+            }
+      if (!cr)
+            return;
+
+      // apply accidental state
+      AccidentalType acc = _is.accidentalType();
+      if (acc != AccidentalType::NONE && e->isNote()) {
+            Note* n = toNote(e);
+            n->setAccidentalType(acc);
+            _is.setAccidentalType(AccidentalType::NONE);
+            }
+
+      // apply duration
+      TDuration d = _is.duration();
+      if (cr->durationType() != d) {
+            changeCRlen(cr, d);
+            _is.moveToNextInputPos();
+            }
+      }
+
+//---------------------------------------------------------
 //   cmd
 //---------------------------------------------------------
 
@@ -3869,6 +3910,7 @@ void Score::cmd(const QAction* a, EditData& ed)
             { "relayout",                   [this]{ cmdRelayout();                                              }},
             { "toggle-autoplace",           [this]{ cmdToggleAutoplace(false);                                  }},
             { "autoplace-enabled",          [this]{ cmdToggleAutoplace(true);                                   }},
+            { "apply-input-state",          [this]{ cmdApplyInputState();                                       }},
             };
 
       for (const auto& c : cmdList) {

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -738,6 +738,7 @@ class Score : public QObject, public ScoreElement {
 
       void cmdRelayout();
       void cmdToggleAutoplace(bool all);
+      void cmdApplyInputState();
 
       bool playNote() const                 { return _updateState._playNote; }
       void setPlayNote(bool v)              { _updateState._playNote = v;    }

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -3711,6 +3711,13 @@ Shortcut Shortcut::_sc[] = {
          Qt::ApplicationShortcut
          },
       {
+         MsWidget::SCORE_TAB,
+         STATE_NOTE_ENTRY,
+         "apply-input-state",
+         QT_TRANSLATE_NOOP("action","Apply Input State"),
+         QT_TRANSLATE_NOOP("action","Apply input state")
+         },
+      {
          MsWidget::MAIN_WINDOW,
          STATE_ALL,
          "leave-feedback",


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/297458

The new behavior of the accidental commands in note input mode
is mostly an improvement, but sometimes one needs to apply an accidental
to a note that is already entered (eg, the most recent note).
While you can use the arrow keys to change pitch, they cannot be used
to enter courtesy accidentals.

This commit adds a new command, "apply input state",
that looks at the accidental state and applies it to the current note.
Because it is easy and also useful, it does the same for duration.
Normally after entering a note, the duration state matches the note,
and the accidental state is cleared (NONE), so this command does nothing
unless you explicitly press the accidental or duration button first.

The intended use is, a user enters a note, realizes too late it has
the wrong duration or is missing an accidental,
so he changes the duration and/or accidental using the toolbar commands
but this of course doesn't affect the current note, just the next one.
The new command simply applies his change retroactively.
It does it by checking the InputState.
If the accidental state is not none, it is applied to the current note.
If the duration is not the same as that of the current note,
it is applied as well.

The code works well enough as is, but I putting this forth as a proposal to see if people like it.