### PR TITLE
fix #297957: Ties extended in region after time signature change

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -3127,10 +3127,7 @@ std::vector<Note*> Note::tiedNotes() const
 int Note::unisonIndex() const
       {
       int index = 0;
-      auto notes = chord()->notes();
-      size_t ns = notes.size();
-      for (size_t i = 0; i < ns; ++i) {
-            Note* n = notes.at(i);
+      for (Note* n : chord()->notes()) {
             if (n->pitch() == pitch()) {
                   if (n == this)
                         return index;

--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -823,6 +823,7 @@ Note* searchTieNote(Note* note)
       // but err on the safe side in case there is roundoff in tick count
       Fraction endTick = chord->tick() + chord->actualTicks() - Fraction(1, 4 * 480);
 
+      int idx1 = note->unisonIndex();
       while ((seg = seg->next1(SegmentType::ChordRest))) {
             // skip ahead to end of current note duration as calculated above
             // but just in case, stop if we find element in current track
@@ -846,12 +847,17 @@ Note* searchTieNote(Note* note)
                         if (gn2)
                               return gn2;
                         }
+                  int idx2 = 0;
                   for (Note* n : c->notes()) {
-                        if (n->pitch() == note->pitch() && !n->tieBack()) {
-                              if (note2 == 0 || c->track() == chord->track()) {
-                                    note2 = n;
-                                    break;
+                        if (n->pitch() == note->pitch()) {
+                              if (idx1 == idx2) {
+                                    if (note2 == 0 || c->track() == chord->track()) {
+                                          note2 = n;
+                                          break;
+                                          }
                                     }
+                              else
+                                    ++idx2;
                               }
                         }
                   }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/297957.

When searching for a note to complete a tie, what matters is not so much that the note doesn't already have a tieBack(), but rather that the two notes have the same unisonIndex().