### PR TITLE
Fix MusicXML header handling as requested by OpenScore Lieder Corpus project

### DIFF
--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -1196,10 +1196,9 @@ void ExportMusicXml::credits(XmlWriter& xml)
       const double bm = getTenthsFromInches(_score->styleD(Sid::pageOddBottomMargin));
       //qDebug("page h=%g w=%g lm=%g rm=%g tm=%g bm=%g", h, w, lm, rm, tm, bm);
 
-      // write the credits
-      const MeasureBase* measure = _score->measures()->first();
-      if (measure) {
-            for (const Element* element : measure->el()) {
+      // write the credits (found in the header, i.e. everything before the first measure)
+      for (auto mb = _score->measures()->first(); mb && !mb->isMeasure(); mb = mb->next()) {
+            for (const Element* element : mb->el()) {
                   if (element->isText()) {
                         const Text* text = toText(element);
                         const double ph = getTenthsFromDots(parentHeight(text));

--- a/mscore/importmxmlpass1.cpp
+++ b/mscore/importmxmlpass1.cpp
@@ -537,24 +537,14 @@ static void addText2(VBox* vbx, Score* s, QString strTxt, Tid stl, Align v, doub
 
 static void doCredits(Score* score, const CreditWordsList& credits, const int pageWidth, const int pageHeight)
       {
-      /*
-      qDebug("MusicXml::doCredits()");
-      qDebug("page format set (inch) w=%g h=%g tm=%g spatium=%g DPMM=%g DPI=%g",
-             pf->width(), pf->height(), pf->oddTopMargin(), score->spatium(), DPMM, DPI);
-      */
       // page width, height and odd top margin in tenths
-      const double ph  = score->styleD(Sid::pageHeight) * 10 * DPI / score->spatium();
+      const int ph  = pageHeight;
       const int pw1 = pageWidth / 3;
       const int pw2 = pageWidth * 2 / 3;
       const int ph2 = pageHeight / 2;
-      /*
-      const double pw  = pf->width() * 10 * DPI / score->spatium();
-      const double tm  = pf->oddTopMargin() * 10 * DPI / score->spatium();
-      const double tov = ph - tm;
-      qDebug("page format set (tenths) w=%g h=%g tm=%g tov=%g", pw, ph, tm, tov);
-      qDebug("page format (xml, tenths) w=%d h=%d", pageWidth, pageHeight);
-      qDebug("page format pw1=%d pw2=%d ph2=%d", pw1, pw2, ph2);
-      */
+      //qDebug("page format (xml, tenths) w=%d h=%d", pageWidth, pageHeight);
+      //qDebug("page format pw1=%d pw2=%d ph=%d ph2=%d", pw1, pw2, ph, ph2);
+
       // dump the credits
       /*
       for (ciCreditWords ci = credits.begin(); ci != credits.end(); ++ci) {

--- a/mscore/importmxmlpass1.cpp
+++ b/mscore/importmxmlpass1.cpp
@@ -630,14 +630,14 @@ static void doCredits(Score* score, const CreditWordsList& credits, const int pa
                         // found composer
                         addText2(vbox, score, w->words,
                                  Tid::COMPOSER, Align::RIGHT | Align::BOTTOM,
-                                 (miny - w->defaultY) * score->spatium() / (10 * DPI));
+                                 (miny - w->defaultY) * score->spatium() / 10);
                         }
                   // poet is in the left column
                   else if (defx < pw1) {
                         // found poet/lyricist
                         addText2(vbox, score, w->words,
                                  Tid::POET, Align::LEFT | Align::BOTTOM,
-                                 (miny - w->defaultY) * score->spatium() / (10 * DPI));
+                                 (miny - w->defaultY) * score->spatium() / 10);
                         }
                   // save others (in the middle column) to be handled later
                   else {
@@ -680,7 +680,7 @@ static void doCredits(Score* score, const CreditWordsList& credits, const int pa
             //qDebug("title='%s'", qPrintable(w->words));
             addText2(vbox, score, w->words,
                      Tid::TITLE, Align::HCENTER | Align::TOP,
-                     (maxy - w->defaultY) * score->spatium() / (10 * DPI));
+                     (maxy - w->defaultY) * score->spatium() / 10);
             }
 
       // add remaining credit-words as subtitles
@@ -689,7 +689,7 @@ static void doCredits(Score* score, const CreditWordsList& credits, const int pa
             //qDebug("subtitle='%s'", qPrintable(w->words));
             addText2(vbox, score, w->words,
                      Tid::SUBTITLE, Align::HCENTER | Align::TOP,
-                     (maxy - w->defaultY) * score->spatium() / (10 * DPI));
+                     (maxy - w->defaultY) * score->spatium() / 10);
             }
 
       // use metadata if no workable credit-words found


### PR DESCRIPTION
Resolves:
- https://musescore.org/en/node/297688
- https://musescore.org/en/node/297893
- obsolete code in mscore/importmxmlpass1.cpp function doCredits()

Description:
- in case the header consists of more than one vbox, export all of them, instead of just the first one. Fixes MusicXML export for score using the OpenScore Lieder Corpus project "two Vertical Frames" format
- fixes the calculation of vertical offsets in the header, preventing title and subtitle being overlaid after MusicXML import
- removed or reworked obsolete code

*Use "x" letter to fill the checkboxes below like [x]*

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n/a] I created the test (mtest, vtest, script test) to verify the changes I made