### PR TITLE
fix #298121: Adding Intervals (above/below) should take into consideration the accidental toggle state

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -376,7 +376,7 @@ Note* Score::addNote(Chord* chord, NoteVal& noteVal, bool forceAccidental)
       note->setNval(noteVal);
       undoAddElement(note);
       if (forceAccidental) {
-            int tpc = styleB(Sid::concertPitch) ? noteVal.tpc2 : noteVal.tpc1;
+            int tpc = styleB(Sid::concertPitch) ? noteVal.tpc1 : noteVal.tpc2;
             AccidentalVal alter = tpc2alter(tpc);
             AccidentalType at = Accidental::value2subtype(alter);
             Accidental* a = new Accidental(this);

--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -511,7 +511,7 @@ void Score::repitchNote(const Position& p, bool replace)
             forceAccidental = (nval.pitch == nval2.pitch);
             }
       if (forceAccidental) {
-            int tpc = styleB(Sid::concertPitch) ? nval.tpc2 : nval.tpc1;
+            int tpc = styleB(Sid::concertPitch) ? nval.tpc1 : nval.tpc2;
             AccidentalVal alter = tpc2alter(tpc);
             at = Accidental::value2subtype(alter);
             Accidental* a = new Accidental(this);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/298121.

In addition to making the "Add Interval" commands apply the highlighted accidental when in note input mode, I have corrected a few cases where I had chosen the wrong tpc to use to calculate the AccidentalType for a user accidental, given the current value of styleB(Sid::concertPitch).