### PR TITLE
fix #298141: crash on deleting an element being dragged

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -2004,6 +2004,8 @@ void Element::endDrag(EditData& ed)
       if (!isMovable())
             return;
       ElementEditData* eed = ed.getData(this);
+      if (!eed)
+            return;
       for (PropertyData pd : eed->propertyData) {
             PropertyFlags f = propertyFlags(pd.id);
             if (f == PropertyFlags::STYLED)


### PR DESCRIPTION
Resolves: https://musescore.org/node/298141.

When the element is being dragged, it is selected, but if it's deleted, then the selection changes. This causes `this` in `endDrag()` to change to the parent element, but since the `EditData` parameter (`ed`) is still that of the deleted element, `ed.getData(this)` returns a `nullptr` which directly leads to a crash.