### PR TITLE
fix #293363: apply master palette elements with Enter

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -781,6 +781,7 @@ void PaletteScrollArea::keyPressEvent(QKeyEvent* event)
                   else if (idx >= p->size())
                         idx = 0;
                   p->setSelected(idx);
+                  p->setCurrentIdx(idx);
                   // set widget name to name of selected element
                   // we could set the description, but some screen readers ignore it
                   QString name = p->cellAt(idx)->translatedName();
@@ -791,6 +792,11 @@ void PaletteScrollArea::keyPressEvent(QKeyEvent* event)
                   p->update();
                   break;
                   }
+            case Qt::Key_Enter:
+            case Qt::Key_Return:
+                  if (!p->disableElementsApply())
+                        p->applyPaletteElement();
+                  break;
             default:
                   break;
             }

--- a/mscore/palette.h
+++ b/mscore/palette.h
@@ -154,6 +154,7 @@ class Palette : public QWidget {
       void setSelected(int idx)      { selectedIdx = idx;  }
       bool readOnly() const          { return _readOnly;   }
       void setReadOnly(bool val);
+      bool disableElementsApply() const      { return _disableElementsApply; }
       void setDisableElementsApply(bool val) { _disableElementsApply = val; }
 
       bool systemPalette() const     { return _systemPalette; }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/293363

Enter works to apply the current palette element for the main palette,
but not for the master palette.
It turns out this is mostly just because there is no handler for Enter.
Also, we aren't managing curretnIdx, just selectedIdx.
Those two simple changes make this work.

I don't believe that it's possible to create an automated test for this.