### PR TITLE
fix #298115: Replacing a note with an accidental leaves accidental on new note

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1788,14 +1788,8 @@ void ScoreView::cmd(const char* s)
       if (cmd == "escape")
             escapeCmd();
       else if (cmd == "note-input") {
-            if (state == ViewState::NORMAL) {
+            if (state == ViewState::NORMAL)
                   changeState(ViewState::NOTE_ENTRY);
-                  TDuration td = _score->inputState().duration();
-                  if (!td.isValid() || td.isZero() || td.isMeasure())
-                        _score->inputState().setDuration(TDuration::DurationType::V_QUARTER);
-                  _score->inputState().setAccidentalType(AccidentalType::NONE);
-                  _score->inputState().setRest(false);
-                  }
             else if (state == ViewState::NOTE_ENTRY)
                   changeState(ViewState::NORMAL);
             }
@@ -2688,6 +2682,7 @@ void ScoreView::startNoteEntry()
       TDuration d(is.duration());
       if (!d.isValid() || d.isZero() || d.type() == TDuration::DurationType::V_MEASURE)
             is.setDuration(TDuration(TDuration::DurationType::V_QUARTER));
+      is.setAccidentalType(AccidentalType::NONE);
 
       _score->select(el, SelectType::SINGLE, 0);
       is.setRest(false);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/298115.

This makes sure that ScoreView::startNoteEntry() clears the accidental state. Since this function already properly sets the duration and rest states, none of this needs to happen directly from within ScoreView::cmd().