### PR TITLE
fix Linux build (remove sectionbreak.ui)

### DIFF
--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -91,7 +91,7 @@ QT5_WRAP_UI (ui_headers
       transposedialog.ui excerptsdialog.ui  stafftext.ui tupletdialog.ui
       articulation.ui metaedit.ui paletteProperties.ui paletteCellProperties.ui selectdialog.ui selectnotedialog.ui
       synthcontrol.ui splitstaff.ui keyedit.ui selectinstr.ui
-      fretdprops.ui editstafftype.ui sectionbreak.ui  bend.ui tremolobar.ui
+      fretdprops.ui editstafftype.ui bend.ui tremolobar.ui
       editpitch.ui editstringdata.ui editraster.ui mediadialog.ui albummanager.ui layer.ui
       omrpanel.ui masterpalette.ui harmonyedit.ui pathlistdialog.ui
       note_groups.ui resourceManager.ui stafftypetemplates.ui


### PR DESCRIPTION
Build is broken on Linux, at least for me, due to sectionbreak.ui not having been removed from mscore/CMakeLists.txt.  No idea if this is the right thing for everyone, but it fixes it for me.