### PR TITLE
Replace MuseScore with Musescore (+ collect_artifacts)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,7 +279,7 @@ set(CMAKE_BUILD_WITH_INSTALL_RPATH ON) # Call CMake with option -DCMAKE_SKIP_RPA
 set(CMAKE_SKIP_RULE_DEPENDENCY TRUE)
 
 # The MuseScore version number.
-SET(MUSESCORE_NAME "MuseScore")
+SET(MUSESCORE_NAME "Musescore")
 SET(MUSESCORE_VERSION_MAJOR  "3")
 SET(MUSESCORE_VERSION_MINOR  "4")
 SET(MUSESCORE_VERSION_PATCH  "0")
@@ -334,7 +334,7 @@ if (DOWNLOAD_SOUNDFONT)
 
     string(COMPARE LESS ${SF_VERSION_LOCAL} ${SF_VERSION_REMOTE} DO_DOWNLOAD)
     if (DO_DOWNLOAD)
-      message("Downloading version ${SF_VERSION_REMOTE} of the MuseScore SoundFont. Version is outdated ${SF_VERSION_LOCAL}.")
+      message("Downloading version ${SF_VERSION_REMOTE} of the Musescore SoundFont. Version is outdated ${SF_VERSION_LOCAL}.")
       # delete soundfont and download new version
       ## TODO check STATUS of downloads
       file (REMOVE ${SOUND_DIRECTORY}/MuseScore_General.sf3
@@ -354,7 +354,7 @@ if (DOWNLOAD_SOUNDFONT)
       file (COPY ${SF_VERSION_REMOTE_FILE} DESTINATION ${SOUND_DIRECTORY})
       file (REMOVE ${SF_VERSION_REMOTE_FILE})
     else(DO_DOWNLOAD)
-      message("MuseScore SoundFont is up to date.")
+      message("Musescore SoundFont is up to date.")
     endif(DO_DOWNLOAD)
   endif()
 endif(DOWNLOAD_SOUNDFONT)
@@ -700,7 +700,7 @@ if (NOT MINGW AND NOT MSVC AND NOT APPLE)
     # Create symlink alias for man pages so `man musescore` = `man mscore`
     find_program( LN_EXECUTABLE ln DOC "A tool for creating symbolic link aliases (optional)." )
     if (LN_EXECUTABLE)
-        message(STATUS "Found 'ln'. Symlink aliases will be created for MuseScore executable and the man pages.")
+        message(STATUS "Found 'ln'. Symlink aliases will be created for Musescore executable and the man pages.")
         add_custom_command(
             TARGET manpages
             COMMAND echo "Creating symlink alias for man pages."
@@ -711,7 +711,7 @@ if (NOT MINGW AND NOT MSVC AND NOT APPLE)
      else (LN_EXECUTABLE)
          message(STATUS "'ln' not found (it is optional). No symlink aliases will be created.")
      endif (LN_EXECUTABLE)
-    # Add .MSCZ and .MSCX to MIME database (informs system that filetypes .MSCZ & .MSCX are MuseScore files)
+    # Add .MSCZ and .MSCX to MIME database (informs system that filetypes .MSCZ & .MSCX are Musescore files)
     configure_file(build/Linux+BSD/musescore.xml.in musescore${MSCORE_INSTALL_SUFFIX}.xml)
     install( FILES ${PROJECT_BINARY_DIR}/musescore${MSCORE_INSTALL_SUFFIX}.xml DESTINATION share/mime/packages COMPONENT doc)
     # Note: Must now run "update-mime-database" to apply changes. This is done in the Makefile.

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ install: release
 #   $  make portable
 # PREFIX sets install location *and* the name of the resulting AppDir.
 # Version is appended to PREFIX in CMakeLists.txt if MSCORE_UNSTABLE=FALSE.
-portable: PREFIX=MuseScore
+portable: PREFIX=Musescore
 portable: SUFFIX=-portable
 portable: LABEL=Portable AppImage
 portable: NO_RPATH=TRUE

--- a/build/Linux+BSD/mscore.1.preview.sh
+++ b/build/Linux+BSD/mscore.1.preview.sh
@@ -15,9 +15,9 @@ sed \
     -e 's!@MAN_MSCORE_UPPER@!MSCORE!g' \
     -e 's!@Variables_substituted_by_CMAKE_on_installation@!!g' \
     -e 's!@MSCORE_INSTALL_SUFFIX@!!g' \
-    -e 's!@MUSESCORE_NAME_VERSION@!MuseScore 3!g' \
+    -e 's!@MUSESCORE_NAME_VERSION@!Musescore 3!g' \
     -e 's!@MAN_PORTABLE@!'"$portable"'!g' \
-    -e 's!@PORTABLE_INSTALL_NAME@!MuseScorePortable!g' \
+    -e 's!@PORTABLE_INSTALL_NAME@!MusescorePortable!g' \
     -e 's!@CMAKE_INSTALL_PREFIX@!/usr!g' \
     -e 's!@Mscore_SHARE_NAME@!share/!g' \
     -e 's!@Mscore_INSTALL_NAME@!mscore-3.0/!g' \

--- a/build/Linux+BSD/mscore.desktop.in
+++ b/build/Linux+BSD/mscore.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=1.0@This_is_version_of_Desktop_Entry_Specification@@It_is_NOT_MuseScore_version@
+Version=1.0@This_is_version_of_Desktop_Entry_Specification@@It_is_NOT_Musescore_version@
 Name=@MUSESCORE_NAME_VERSION@@Variables_substituted_by_CMAKE_on_installation@
 GenericName=Music notation
 GenericName[de]=Notensatz

--- a/build/Linux+BSD/musescore.xml.in
+++ b/build/Linux+BSD/musescore.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
   <mime-type type="application/x-musescore@MSCORE_INSTALL_SUFFIX@">@Variables_substituted_by_CMAKE_on_installation@
-    <comment>MuseScore file</comment>
+    <comment>Musescore file</comment>
     <sub-class-of type="application/zip"/>
     <glob pattern="*.mscz"/>
   </mime-type>
   <mime-type type="application/x-musescore@MSCORE_INSTALL_SUFFIX@+xml">
-    <comment>uncompressed MuseScore file</comment>
+    <comment>uncompressed Musescore file</comment>
     <sub-class-of type="application/xml"/>
     <glob pattern="*.mscx" />
   </mime-type>

--- a/build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in
+++ b/build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in
@@ -3,13 +3,13 @@
 <component type="desktop-application">
   <id>org.musescore.MuseScore@MSCORE_INSTALL_SUFFIX@</id>
   <translation type="qt">mscore</translation>
-  <name>MuseScore</name>
+  <name>Musescore</name>
   <summary>Create, playback, and print sheet music for free</summary>
   <developer_name>MuseScore BVBA</developer_name>
   <description>
-    <p>Create, playback, and print sheet music for free. MuseScore is cross-platform, multi-lingual, open source music notation software. It features an easy to use WYSIWYG editor with audio score playback for results that look and sound beautiful. It supports unlimited staves with up to four voices each, dynamics, articulations, lyrics, chords, lead sheet notation, import/export of MIDI and MusicXML, export to PDF and WAV, plus online score sharing.</p>
-    <p>MuseScore can upload scores directly to the score sharing site musescore.com. Program support is provided on musescore.org.</p>
-    <p>Features supported by MuseScore include:</p>
+    <p>Create, playback, and print sheet music for free. Musescore is cross-platform, multi-lingual, open source music notation software. It features an easy to use WYSIWYG editor with audio score playback for results that look and sound beautiful. It supports unlimited staves with up to four voices each, dynamics, articulations, lyrics, chords, lead sheet notation, import/export of MIDI and MusicXML, export to PDF and WAV, plus online score sharing.</p>
+    <p>Musescore can upload scores directly to the score sharing site musescore.com. Program support is provided on musescore.org.</p>
+    <p>Features supported by Musescore include:</p>
     <ul>
       <li>Unlimited score length</li>
       <li>Unlimited number of staves per system</li>
@@ -32,9 +32,9 @@
       <li>Additive time signatures</li>
       <li>User-defined score styles</li>
     </ul>
-    <p>Most elements in MuseScore are laid out automatically but can also be positioned manually. The capabilities of MuseScore can be extended via plugins, and the growing repository on musescore.org contains many plugins submitted by users.</p>
-    <p>MuseScore includes a set of sounds that reproduce common instruments (as defined by General MIDI) without taking up a lot of disk space or memory, but you can also substitute any SoundFont you prefer for a wider variety of sounds or for more realism.</p>
-    <p>MuseScore can import and export MIDI and MusicXML files, and it can also import from Capella and several other programs. MuseScore can export to PDF, PNG, and other graphic formats, to WAV and other audio formats, or to Lilypond for an alternative layout and print option.</p>
+    <p>Most elements in Musescore are laid out automatically but can also be positioned manually. The capabilities of Musescore can be extended via plugins, and the growing repository on musescore.org contains many plugins submitted by users.</p>
+    <p>Musescore includes a set of sounds that reproduce common instruments (as defined by General MIDI) without taking up a lot of disk space or memory, but you can also substitute any SoundFont you prefer for a wider variety of sounds or for more realism.</p>
+    <p>Musescore can import and export MIDI and MusicXML files, and it can also import from Capella and several other programs. Musescore can export to PDF, PNG, and other graphic formats, to WAV and other audio formats, or to Lilypond for an alternative layout and print option.</p>
   </description>
   <kudos>
     <kudo>ModernToolkit</kudo>
@@ -104,17 +104,17 @@
     </release>
     <release date="2019-05-28" version="3.1">
       <description>
-        <p>MuseScore 3.1, in addition to hundreds of bug fixes, introduces some new features (including single-note dynamics) and significant improvements related to playback, automatic placement and layout, fretboard diagrams, and performance.</p>
+        <p>Musescore 3.1, in addition to hundreds of bug fixes, introduces some new features (including single-note dynamics) and significant improvements related to playback, automatic placement and layout, fretboard diagrams, and performance.</p>
       </description>
     </release>
     <release date="2019-03-12" version="3.0.5">
       <description>
-        <p>The focus of this release was performance and stability. We reached an incredible boost in optimization so MuseScore 3 is now faster than MuseScore 2, but is still powerful with the smart layout feature. The crash reporter facility introduced in MuseScore 3.0.3 lets us concentrate on fixing the most frequent crashes.</p>
+        <p>The focus of this release was performance and stability. We reached an incredible boost in optimization so Musescore 3 is now faster than Musescore 2, but is still powerful with the smart layout feature. The crash reporter facility introduced in Musescore 3.0.3 lets us concentrate on fixing the most frequent crashes.</p>
       </description>
     </release>
     <release date="2019-02-28" version="3.0.4">
       <description>
-        <p>MuseScore 3.0.3 introduced some great improvements as well as unfortunate regressions which were addressed in the MuseScore 3.0.4 release.</p>
+        <p>Musescore 3.0.3 introduced some great improvements as well as unfortunate regressions which were addressed in the Musescore 3.0.4 release.</p>
       </description>
     </release>
     <release date="2019-02-26" version="3.0.3">
@@ -124,7 +124,7 @@
     </release>
     <release date="2019-01-29" version="3.0.2">
       <description>
-        <p>The main change in this release is the reinstatement of the plugin framework, which makes the most popular plugins work in MuseScore 3. Another important improvement is the new login page which appears when you use the Save Online feature. This redesigned page allows you to use Google and Facebook to sign in and to create a new account right in the editor.</p>
+        <p>The main change in this release is the reinstatement of the plugin framework, which makes the most popular plugins work in Musescore 3. Another important improvement is the new login page which appears when you use the Save Online feature. This redesigned page allows you to use Google and Facebook to sign in and to create a new account right in the editor.</p>
       </description>
     </release>
     <release date="2019-01-15" version="3.0.1">
@@ -154,7 +154,7 @@
     </release>
     <release date="2018-12-24" version="3.0">
       <description>
-        <p>MuseScore 3.0 is packed full of new features and improvements.</p>
+        <p>Musescore 3.0 is packed full of new features and improvements.</p>
         <p>Musical notation:</p>
         <ul>
           <li>Automatic placement - potential collisions between elements are detected and resolved automatically, allowing you to easily create great-looking scores with little need for manual adjustment</li>
@@ -187,11 +187,11 @@
     </release>
     <release date="2018-07-31" version="2.3.2">
       <description>
-        <p>After the release of MuseScore 2.3.1 on July 6th 2018, we found a couple of regressions that we addressed in MuseScore 2.3.2, released on July 31st 2018. We also updated all languages to latest translations.</p>
+        <p>After the release of Musescore 2.3.1 on July 6th 2018, we found a couple of regressions that we addressed in Musescore 2.3.2, released on July 31st 2018. We also updated all languages to latest translations.</p>
         <p>Features:</p>
         <ul>
           <li>#208006: Embed MP3 support by default on macOS</li>
-          <li>Add access to MuseScore version and revision used to create a score in plugin framework</li>
+          <li>Add access to Musescore version and revision used to create a score in plugin framework</li>
         </ul>
         <p>Improvements:</p>
         <ul>
@@ -216,7 +216,7 @@
     </release>
     <release date="2018-07-06" version="2.3.1">
       <description>
-        <p>After the release of MuseScore 2.3 on June 29th 2018, we found a couple of regressions that we addressed in MuseScore 2.3.1 released on July 6th 2018. We also updated all languages to latest translations.</p>
+        <p>After the release of Musescore 2.3 on June 29th 2018, we found a couple of regressions that we addressed in Musescore 2.3.1 released on July 6th 2018. We also updated all languages to latest translations.</p>
         <p>Bug Fixes:</p>
         <ul>
           <li>Fix #273921: [Regression] Augm. dot misplaced for low stemless notes</li>
@@ -270,7 +270,7 @@
         </ul>
         <p>Crashes and corruptions fixed:</p>
         <ul>
-          <li>Fix #76751: MuseScore crashes when opening plugin manager after adding new plugin</li>
+          <li>Fix #76751: Musescore crashes when opening plugin manager after adding new plugin</li>
           <li>Fix #270850: Changes to a score cause all fermatas over a barline to be discarded</li>
           <li>Fix #271039: crash when closing score after changing tempo in play panel</li>
           <li>Fix #271161: crashes on certain tuplets due to failure to sanitize</li>
@@ -305,7 +305,7 @@
         <ul>
           <li>Fix #271707: MusicXML export: crash when exporting hairpins</li>
           <li>Fix #271840: MusicXML import: no barlines when using property</li>
-          <li>Fix #272062: Opening of some MusicXML files caused MuseScore to crash</li>
+          <li>Fix #272062: Opening of some MusicXML files caused Musescore to crash</li>
         </ul>
         <p>Miscellaneous:</p>
         <ul>

--- a/build/Linux+BSD/portable/ARM/jessie-crosscompile-armhf.cmake
+++ b/build/Linux+BSD/portable/ARM/jessie-crosscompile-armhf.cmake
@@ -1,4 +1,4 @@
-#Cross toolchain file for building QT project (specifically MuseScore)
+#Cross toolchain file for building QT project (specifically Musescore)
 #For use in Debian x86-64 + armhf with cross compiler
 
 SET(CMAKE_SYSTEM_NAME Linux)

--- a/build/Linux+BSD/portable/AppRun.in
+++ b/build/Linux+BSD/portable/AppRun.in
@@ -44,7 +44,7 @@ done
 libs="${APPDIR}/lib"
 export LD_LIBRARY_PATH="${APPIMAGE_LIBRARY_PATH}:${libs}:${libs}/qt5/lib:${LD_LIBRARY_PATH}${fallback_libs}"
 
-# Launch MuseScore or an accompanying script
+# Launch Musescore or an accompanying script
 case "$1" in
   -h|--help|install|uninstall|remove|man|manual|manpage|check-depends|check-dependencies )
     "${APPDIR}/bin/portable-utils" "$@"

--- a/build/Linux+BSD/portable/RecipeDebian
+++ b/build/Linux+BSD/portable/RecipeDebian
@@ -126,7 +126,7 @@ fetch-package-dependencies() {
 # BUILD MuseScore PORTABLE (Compile, not package)
 ########################################################
 build() {
-  echo "building MuseScore Portable for arch: $ARCH"
+  echo "building Musescore Portable for arch: $ARCH"
 
   cd MuseScore
 

--- a/build/Linux+BSD/portable/portable-utils.in
+++ b/build/Linux+BSD/portable/portable-utils.in
@@ -121,7 +121,7 @@ EOF
   echo "Resources installed to '$PWD'."
 cat <<EOF
 Step 2 of 3.
-MuseScore is at: ${APPIMAGE}
+Musescore is at: ${APPIMAGE}
 EOF
   if [ ! "$interactive" ]; then
     echo "Moving it to 'PREFIX/bin'."
@@ -131,7 +131,7 @@ EOF
   else
 cat <<EOF
 You can leave it there, but it is recommended that you move it to 'PREFIX/bin'.
-Options: move (m) or copy (c) MuseScore, do nothing (n), or show help (h)?
+Options: move (m) or copy (c) Musescore, do nothing (n), or show help (h)?
 EOF
     local answer
     while [ true ]; do
@@ -148,19 +148,19 @@ EOF
           ;;
         H|h )
 less <<EOF
-Moving or copying MuseScore to 'PREFIX/bin' has these benefits:
+Moving or copying Musescore to 'PREFIX/bin' has these benefits:
 
  1) It will have the same permissions as the resources. (I.e. it will be
     available to the same user(s) as the resources were installed for.)
 
  2) If 'PREFIX/bin' is in your PATH environment variable then you can launch
-    MuseScore by typing '$(basename ${APPIMAGE})' instead of the full path.
+    Musescore by typing '$(basename ${APPIMAGE})' instead of the full path.
     The default locations for PREFIX are in PATH on most systems.
 
 You should move rather than copy unless you want to keep another copy at the
-current location. (E.g if you're installing MuseScore from a USB stick.)
+current location. (E.g if you're installing Musescore from a USB stick.)
 
-If you choose not to move or copy MuseScore then you will still be able to
+If you choose not to move or copy Musescore then you will still be able to
 launch it by clicking on its icon or by typing the full path
 
   '${APPIMAGE}'
@@ -173,10 +173,10 @@ EOF
     done
   fi
   sed -ri "s|^Exec=[^#%]*(.*)\$|Exec=${APPIMAGE} \1|" "share/applications/mscore@MSCORE_INSTALL_SUFFIX@.desktop"
-  echo "Finished installing MuseScore to $prefix"
+  echo "Finished installing Musescore to $prefix"
 cat <<EOF
 Step 3 of 3.
-Symlinks can be created to make it easier to launch MuseScore from
+Symlinks can be created to make it easier to launch Musescore from
 the command line. (Symlinks are like shortcuts or aliases.)
 EOF
   [ "$interactive" ] && printf "Create symlinks 'mscore@MSCORE_INSTALL_SUFFIX@' and 'musescore@MSCORE_INSTALL_SUFFIX@' [Y/n]?"
@@ -187,12 +187,12 @@ EOF
   fi
   if [ ! "$(which "$(basename "${APPIMAGE}")")" ]; then
 cat <<EOF
-INFORMATION: MuseScore is not in PATH. If you want to run MuseScore from
+INFORMATION: Musescore is not in PATH. If you want to run Musescore from
 the command line you will have to type the full file path, like this:
 
   ${APPIMAGE}
 
-This does not affect you if you launch MuseScore by clicking on the icon.
+This does not affect you if you launch Musescore by clicking on the icon.
 EOF
   fi
 }
@@ -205,10 +205,10 @@ function removeResources() {
     echo -n "Remove resources from ${prefix} [Y/n]?"
   elif [ "${EUID}" == "0" ]; then
     prefix=/usr/local
-    echo -n "Running as root. Remove MuseScore resources from '$prefix' for all users [Y/n]?"
+    echo -n "Running as root. Remove Musescore resources from '$prefix' for all users [Y/n]?"
   else
     prefix=~/.local
-    echo -n "Not running as root. Remove MuseScore resources from '$prefix' for current user only [Y/n]?"
+    echo -n "Not running as root. Remove Musescore resources from '$prefix' for current user only [Y/n]?"
   fi
   readYes || return 0
   cd "$prefix" && <"${APPDIR}/install_manifest.txt" xargs rm || return 1
@@ -216,9 +216,9 @@ function removeResources() {
   rm "$(dirname "${APPIMAGE}")/musescore@MSCORE_INSTALL_SUFFIX@"
   <"${APPDIR}/install_manifest.txt" xargs "${APPDIR}/bin/rm-empty-dirs"
   updateCache $prefix
-  echo -ne "Resources removed from ${PWD}.\nRemove MuseScore itself (delete ${APPIMAGE}) [Y/n]?"
-  readYes || { echo -e "MuseScore remains at ${APPIMAGE}.\nYou may delete it yourself or install again at any time." && return 0 ; }
-  rm "${APPIMAGE}" && echo "Successfully removed MuseScore from $prefix"
+  echo -ne "Resources removed from ${PWD}.\nRemove Musescore itself (delete ${APPIMAGE}) [Y/n]?"
+  readYes || { echo -e "Musescore remains at ${APPIMAGE}.\nYou may delete it yourself or install again at any time." && return 0 ; }
+  rm "${APPIMAGE}" && echo "Successfully removed Musescore from $prefix"
   rmdir "$(dirname "${APPIMAGE}")"
   return 0
 }

--- a/build/Packaging.cmake
+++ b/build/Packaging.cmake
@@ -4,7 +4,7 @@
 
 include (InstallRequiredSystemLibraries)
 
-SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY "MuseScore is a full featured WYSIWYG score editor")
+SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Musescore is a full featured WYSIWYG score editor")
 SET(CPACK_PACKAGE_VENDOR "Werner Schweer and Others")
 SET(CPACK_PACKAGE_DESCRIPTION_FILE "${PROJECT_SOURCE_DIR}/LICENSE.GPL")
 SET(CPACK_RESOURCE_FILE_LICENSE    "${PROJECT_SOURCE_DIR}/LICENSE.GPL")
@@ -14,7 +14,7 @@ SET(CPACK_PACKAGE_VERSION_MINOR "${MUSESCORE_VERSION_MINOR}")
 SET(CPACK_PACKAGE_VERSION_PATCH "${MUSESCORE_VERSION_PATCH}")
 SET(CPACK_PACKAGE_VERSION_BUILD "${CMAKE_BUILD_NUMBER}")
 SET(CPACK_PACKAGE_VERSION "${MUSESCORE_VERSION_MAJOR}.${MUSESCORE_VERSION_MINOR}.${MUSESCORE_VERSION_PATCH}.${CPACK_PACKAGE_VERSION_BUILD}")
-SET(CPACK_PACKAGE_INSTALL_DIRECTORY "MuseScore ${MUSESCORE_VERSION_MAJOR}.${MUSESCORE_VERSION_MINOR}")
+SET(CPACK_PACKAGE_INSTALL_DIRECTORY "Musescore ${MUSESCORE_VERSION_MAJOR}.${MUSESCORE_VERSION_MINOR}")
 
 set(git_date_string "")
 if (MSCORE_UNSTABLE)
@@ -53,12 +53,12 @@ IF(MINGW OR MSVC)
     SET(CPACK_NSIS_DEFINES "!include ${PROJECT_SOURCE_DIR}/build/packaging\\\\FileAssociation.nsh")
 
     SET(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
-        \\\${registerExtension} \\\"MuseScore File\\\" \\\".mscx\\\" \\\"\\\$INSTDIR\\\\bin\\\\${MSCORE_EXECUTABLE_NAME}.exe\\\"
-        \\\${registerExtension} \\\"Compressed MuseScore File\\\" \\\".mscz\\\" \\\"\\\$INSTDIR\\\\bin\\\\${MSCORE_EXECUTABLE_NAME}.exe\\\"
+        \\\${registerExtension} \\\"Musescore File\\\" \\\".mscx\\\" \\\"\\\$INSTDIR\\\\bin\\\\${MSCORE_EXECUTABLE_NAME}.exe\\\"
+        \\\${registerExtension} \\\"Compressed Musescore File\\\" \\\".mscz\\\" \\\"\\\$INSTDIR\\\\bin\\\\${MSCORE_EXECUTABLE_NAME}.exe\\\"
     ")
     SET(CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS "
-        \\\${unregisterExtension} \\\".mscx\\\" \\\"MuseScore File\\\"
-        \\\${unregisterExtension} \\\".mscz\\\" \\\"Compressed MuseScore File\\\"
+        \\\${unregisterExtension} \\\".mscx\\\" \\\"Musescore File\\\"
+        \\\${unregisterExtension} \\\".mscz\\\" \\\"Compressed Musescore File\\\"
     ")
 
     file(TO_CMAKE_PATH $ENV{PROGRAMFILES} PROGRAMFILES)
@@ -82,7 +82,7 @@ ELSE(MINGW OR MSVC)
     SET(CPACK_PACKAGE_ICON "${PROJECT_SOURCE_DIR}/mscore/data/mscore.bmp")
     SET(CPACK_STRIP_FILES "${MSCORE_OUTPUT_NAME}")
     SET(CPACK_SOURCE_STRIP_FILES "")
-    SET(CPACK_PACKAGE_EXECUTABLES   "mscore" "MuseScore")
+    SET(CPACK_PACKAGE_EXECUTABLES   "mscore" "Musescore")
     SET(CPACK_SOURCE_PACKAGE_FILE_NAME "mscore")
     SET(CPACK_PACKAGE_FILE_NAME     "${CPACK_SOURCE_PACKAGE_FILE_NAME}-${MUSESCORE_VERSION_FULL}${git_date_string}")
 ENDIF(MINGW OR MSVC)

--- a/build/appveyor/after_build.bat
+++ b/build/appveyor/after_build.bat
@@ -15,7 +15,7 @@ SET DEBUG_SYMS_FILE=musescore_win%TARGET_PROCESSOR_BITS%.sym
 C:\MuseScore\breakpad_tools\dump_syms.exe %APPVEYOR_BUILD_FOLDER%\%BUILD_FOLDER%\mscore\RelWithDebInfo\MuseScore3.pdb > %DEBUG_SYMS_FILE%
 @echo off
 
-:: Test MuseScore stability
+:: Test Musescore stability
 IF "%NIGHTLY_BUILD%" == "" (
   goto :STABLE_LABEL
 ) ELSE (
@@ -84,19 +84,19 @@ goto :UPLOAD
 :UNSTABLE_LABEL
 echo "Unstable: build 7z package"
 CD C:\MuseScore
-RENAME C:\MuseScore\msvc.install_%PLATFORM%\bin\MuseScore3.exe nightly.exe
-RENAME C:\MuseScore\msvc.install_%PLATFORM% MuseScoreNightly
-XCOPY C:\MuseScore\build\appveyor\special C:\MuseScore\MuseScoreNightly\special /I /E /Y /Q
-COPY C:\MuseScore\build\appveyor\support\README.txt C:\MuseScore\MuseScoreNightly\README.txt /Y
-COPY C:\MuseScore\build\appveyor\support\nightly.bat C:\MuseScore\MuseScoreNightly\nightly.bat /Y
-COPY C:\MuseScore\mscore\revision.h C:\MuseScore\MuseScoreNightly\revision.h
+RENAME C:\MuseScore\msvc.install_%PLATFORM%\bin\Musescore3.exe nightly.exe
+RENAME C:\MuseScore\msvc.install_%PLATFORM% MusescoreNightly
+XCOPY C:\MuseScore\build\appveyor\special C:\MuseScore\MusescoreNightly\special /I /E /Y /Q
+COPY C:\MuseScore\build\appveyor\support\README.txt C:\MuseScore\MusescoreNightly\README.txt /Y
+COPY C:\MuseScore\build\appveyor\support\nightly.bat C:\MuseScore\MusescoreNightly\nightly.bat /Y
+COPY C:\MuseScore\mscore\revision.h C:\MuseScore\MusescoreNightly\revision.h
 :: get hour with a trailing 0 if necessary (add 100)
 SET hh0=%time:~0,2%
 SET /a hh1=%hh0%+100
 SET hh=%hh1:~1,2%
 SET BUILD_DATE=%Date:~10,4%-%Date:~4,2%-%Date:~7,2%-%hh%%time:~3,2%
-SET ARTIFACT_NAME=MuseScoreNightly-%BUILD_DATE%-%APPVEYOR_REPO_BRANCH%-%MSREVISION%-%TARGET_PROCESSOR_ARCH%.7z
-7z a C:\MuseScore\%ARTIFACT_NAME% C:\MuseScore\MuseScoreNightly
+SET ARTIFACT_NAME=MusescoreNightly-%BUILD_DATE%-%APPVEYOR_REPO_BRANCH%-%MSREVISION%-%TARGET_PROCESSOR_ARCH%.7z
+7z a C:\MuseScore\%ARTIFACT_NAME% C:\MuseScore\MusescoreNightly
 
 :: create update file for S3
 SET SHORT_DATE=%Date:~10,4%-%Date:~4,2%-%Date:~7,2%
@@ -109,7 +109,7 @@ echo ^<version^>%MUSESCORE_VERSION%^</version^>
 echo ^<revision^>%MSREVISION%^</revision^>
 echo ^<releaseType^>nightly^</releaseType^>
 echo ^<date^>%SHORT_DATE%^</date^>
-echo ^<description^>MuseScore %MUSESCORE_VERSION% %MSREVISION%^</description^>
+echo ^<description^>Musescore %MUSESCORE_VERSION% %MSREVISION%^</description^>
 echo ^<downloadUrl^>https://ftp.osuosl.org/pub/musescore-nightlies/windows/%ARTIFACT_NAME%^</downloadUrl^>
 echo ^<infoUrl^>https://ftp.osuosl.org/pub/musescore-nightlies/windows/^</infoUrl^>
 echo ^</update^>
@@ -123,7 +123,7 @@ SET SSH_IDENTITY=C:\MuseScore\build\appveyor\resources\osuosl_nighlies_rsa_nopp
 SET PATH=%OLD_PATH%
 IF DEFINED ENCRYPT_SECRET_SSH (
   scp -oStrictHostKeyChecking=no -C -i %SSH_IDENTITY% %ARTIFACT_NAME% musescore-nightlies@ftp-osl.osuosl.org:~/ftp/windows/
-  ssh -oStrictHostKeyChecking=no -i %SSH_IDENTITY% musescore-nightlies@ftp-osl.osuosl.org "cd ~/ftp/windows; ls MuseScoreNightly* -t | tail -n +41 | xargs rm -f"
+  ssh -oStrictHostKeyChecking=no -i %SSH_IDENTITY% musescore-nightlies@ftp-osl.osuosl.org "cd ~/ftp/windows; ls MusescoreNightly* -t | tail -n +41 | xargs rm -f"
   rem create and upload index.html and RSS
   python build/appveyor/updateHTML.py %SSH_IDENTITY%
   scp -oStrictHostKeyChecking=no -C -i %SSH_IDENTITY% build/appveyor/web/index.html musescore-nightlies@ftp-osl.osuosl.org:ftp/windows

--- a/build/appveyor/before_build.bat
+++ b/build/appveyor/before_build.bat
@@ -46,7 +46,7 @@ IF NOT EXIST %TOOLS_ARCHIVE% ( START " " /wait "C:\cygwin64\bin\wget.exe" --no-c
 START " " /wait "7z" x -y %TOOLS_ARCHIVE% > nul
 CD C:\MuseScore
 
-:: is MuseScore stable? Check here, no grep in PATH later on
+:: is Musescore stable? Check here, no grep in PATH later on
 for /f "delims=" %%i in ('grep "^[[:blank:]]*set( *MSCORE_UNSTABLE \+TRUE *)" C:\MuseScore\CMakeLists.txt') do set NIGHTLY_BUILD=%%i
 
 :: get revision number

--- a/build/appveyor/updateHTML.py
+++ b/build/appveyor/updateHTML.py
@@ -20,7 +20,7 @@ def generateHTML(pathname, lines):
     li = ""
     branches = dict()
     for l in lines:
-        if l and l.startswith("MuseScore"):
+        if l and l.startswith("Musescore"):
             sA = l.split("-")
             if len(sA) > 5:
                 branch = sA[5]
@@ -59,7 +59,7 @@ def generateRSS(pathname, lines):
     li = ""
     baseUrl = 'https://ftp.osuosl.org/pub/musescore-nightlies/' + osName + '/'
     for l in lines:
-        if l and l.startswith("MuseScore"):
+        if l and l.startswith("Musescore"):
             info = l.split("-")
             if len(info) == 4:
                 date = info[1]
@@ -82,7 +82,7 @@ def generateRSS(pathname, lines):
 <title>''' + l + '''</title>
 <link>''' + baseUrl + l + '''</link>
 <pubDate>'''+formatdate(time.mktime(d.timetuple()), usegmt=True)+'''</pubDate>
-<description>Nightly Build of MuseScore, Branch: ''' + branch + ''', Revision: '''+commit + '''</description>
+<description>Nightly Build of Musescore, Branch: ''' + branch + ''', Revision: '''+commit + '''</description>
 </item>'''
 
     rssTplPath = pathname + "/web/nightly.xml.tpl"

--- a/build/appveyor/web/index.html.tpl
+++ b/build/appveyor/web/index.html.tpl
@@ -2,7 +2,7 @@
    "http://www.w3.org/TR/html4/strict.dtd">
 <html>
 <head>
-<title>Development builds for Windows | MuseScore</title>
+<title>Development builds for Windows | Musescore</title>
 <link rel="alternate" type="application/rss+xml" title="Development builds for Windows feed" href="nightly.xml" />
 <style type="text/css">
 #nightly-list li:first-child {font-weight:bold}
@@ -14,14 +14,14 @@
 
 <p>The development builds allow you to test the very latest developments, including new features and bug fixes. The goal is to catch new bugs, crashes, and regressions before they reach the prerelease or stable versions. For more information, see <a href="https://musescore.org/en/developers-handbook/comparison-stable-beta-and-development-versions">Comparison of stable, beta, and nightly versions</a>. You can report any regressions or bugs you find via <code>Help > Report a Bug</code> within the nightly build.</p>
 
-<p>A development build can run side-by-side with other versions of MuseScore on the same computer. If you change preferences in the nightly build, it does not affect your preferences in the prerelease or stable versions of MuseScore. The development builds use a cymbal icon (a play on the fact that nightly builds are likely to suspend and crash) to visually differentiate them from normal versions of MuseScore. If this sounds scary to you, instead use the latest stable version of MuseScore from <a href="https://www.musescore.org/">musescore.org</a>.</p>
+<p>A development build can run side-by-side with other versions of Musescore on the same computer. If you change preferences in the nightly build, it does not affect your preferences in the prerelease or stable versions of Musescore. The development builds use a cymbal icon (a play on the fact that nightly builds are likely to suspend and crash) to visually differentiate them from normal versions of Musescore. If this sounds scary to you, instead use the latest stable version of Musescore from <a href="https://www.musescore.org/">musescore.org</a>.</p>
 
 <h3 id="instructions">Instructions</h3>
 <ol>
-<li>Download one of the "MuseScoreNightly" files from the Download section below. (The first is the most recent.)</li>
+<li>Download one of the "MusescoreNightly" files from the Download section below. (The first is the most recent.)</li>
 <li>After the download finishes, uncompress the file using <a href="http://7-zip.org/">7-Zip</a>. (If you have not used 7-Zip before then you need to download and install it from their website first)</li>
 <li>After the file uncompresses, open the folder you just uncompressed</li>
-<li>Open the "bin" folder and double-click on "nightly.exe" to start MuseScore</li>
+<li>Open the "bin" folder and double-click on "nightly.exe" to start Musescore</li>
 </ol>
 
 <h3 id="download">Download</h3>
@@ -30,7 +30,7 @@
 </div>
 
 
-<p>* <strong>If you experience a crash on startup</strong>, revert to factory settings by running MuseScore with the -F flag (nightly.exe -F) or via the batch file <code>special/revertToFactorySettings.bat</code>.</p>
+<p>* <strong>If you experience a crash on startup</strong>, revert to factory settings by running Musescore with the -F flag (nightly.exe -F) or via the batch file <code>special/revertToFactorySettings.bat</code>.</p>
 
 <p>Follow development builds via <a href="nightly.xml">RSS feed</a></p>
 

--- a/build/appveyor/web/nightly.xml.tpl
+++ b/build/appveyor/web/nightly.xml.tpl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <rss version="2.0">
 <channel>
-<title>Development Builds of MuseScore</title>
+<title>Development Builds of Musescore</title>
 <link>http://ftp.osuosl.org/pub/musescore-nightlies/windows/</link>
-<description>Development Builds of MuseScore for Windows</description>
+<description>Development Builds of Musescore for Windows</description>
 <language>en-us</language>
 ##PLACEHOLDER##
 </channel>

--- a/build/appveyor/winsparkle_appcast_generator.sh
+++ b/build/appveyor/winsparkle_appcast_generator.sh
@@ -1,6 +1,6 @@
 # $1 - artifact name
 # $2 - artifact ftp path
-# $3 - MuseScore version
+# $3 - Musescore version
 # $4 - Revision hash
 
 export MSCORE_RELEASE_CHANNEL=$(grep '^[[:blank:]]*set *( *MSCORE_RELEASE_CHANNEL' CMakeLists.txt | awk -F \" '{print $2}')
@@ -14,14 +14,14 @@ echo ${MSCORE_RELEASE_CHANNEL} >> MSCORE_RELEASE_CHANNEL.txt
 #use dummy values for now
 echo "<rss xmlns:sparkle=\"http://www.andymatuschak.org/xml-namespaces/sparkle\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" version=\"2.0\">
 <channel>
-<title>MuseScore development channel</title>
+<title>Musescore development channel</title>
 <link>
 ${APPCAST_URL}
 </link>
 <description>Most recent changes with links to updates.</description>
 <language>en</language>
 <item>
-<title>MuseScore $3 $4</title>
+<title>Musescore $3 $4</title>
 <description>
 <![CDATA[
 ${GIT_LOG}

--- a/build/mscore.xml
+++ b/build/mscore.xml
@@ -7,8 +7,8 @@
 	<program-info id="@mscore.sourceforge.net/mscore"> 
 
 		<shortname>mscore</shortname>
-		<fullname>MuseScore Score Typesetter</fullname>
-		<desc>MuseScore is a full featured WYSIWYG score editor</desc> 
+		<fullname>Musescore Score Typesetter</fullname>
+		<desc>Musescore is a full featured WYSIWYG score editor</desc> 
 
 	</program-info>
 

--- a/build/package_mac
+++ b/build/package_mac
@@ -1,16 +1,16 @@
 #!/bin/bash
 
 APPNAME=mscore
-LONG_NAME=MuseScore
+LONG_NAME=Musescore
 
 if [[ $1 ]]
 then
-    LONG_NAME=MuseScoreNightly
-    LONGER_NAME=MuseScoreNightly
+    LONG_NAME=MusescoreNightly
+    LONGER_NAME=MusescoreNightly
     VERSION=$1
 else
-    LONG_NAME=MuseScore
-    LONGER_NAME="MuseScore 3"
+    LONG_NAME=Musescore
+    LONGER_NAME="Musescore 3"
     VERSION=3.4.0
 fi
 

--- a/build/packaging/NSIS.template.in
+++ b/build/packaging/NSIS.template.in
@@ -1,4 +1,4 @@
-; MuseScore: For customizing Windows installer
+; Musescore: For customizing Windows installer
 ; CPack install script designed for a nmake build
 
 ;--------------------------------
@@ -151,11 +151,11 @@ Var AR_RegFlags
 ;--- End of Add/Remove macros ---
 
 Function InstallDesktopShortcut
-  CreateShortcut "$DESKTOP\MuseScore 2.lnk" "$INSTDIR\bin\MuseScore.exe"
+  CreateShortcut "$DESKTOP\Musescore 2.lnk" "$INSTDIR\bin\Musescore.exe"
 FunctionEnd
 
 Function un.InstallDesktopShortcut
-  Delete "$DESKTOP\MuseScore 2.lnk"
+  Delete "$DESKTOP\Musescore 2.lnk"
 FunctionEnd
 
 ;--------------------------------
@@ -165,7 +165,7 @@ FunctionEnd
   !define MUI_ABORTWARNING
   !define MUI_FINISHPAGE_LINK "http://musescore.org"
   !define MUI_FINISHPAGE_LINK_LOCATION "http://musescore.org"
-  !define MUI_FINISHPAGE_RUN "$INSTDIR\bin\MuseScore.exe"
+  !define MUI_FINISHPAGE_RUN "$INSTDIR\bin\Musescore.exe"
   !define MUI_FINISHPAGE_SHOWREADME ""
   !define MUI_FINISHPAGE_SHOWREADME_CHECKED
   !define MUI_FINISHPAGE_SHOWREADME_TEXT $(createDesktopShortcut)
@@ -617,8 +617,8 @@ FunctionEnd
   LangString createDesktopShortcut ${LANG_ESTONIAN} "Create desktop shortcut"
   LangString createDesktopShortcut ${LANG_FARSI} "Create desktop shortcut"
   LangString createDesktopShortcut ${LANG_FINNISH} "Create desktop shortcut"
-  LangString createDesktopShortcut ${LANG_FRENCH} "Créer un raccourci sur le bureau"
-  LangString createDesktopShortcut ${LANG_GERMAN} "Desktop-Verknüpfung erstellen"
+  LangString createDesktopShortcut ${LANG_FRENCH} "Crï¿½er un raccourci sur le bureau"
+  LangString createDesktopShortcut ${LANG_GERMAN} "Desktop-Verknï¿½pfung erstellen"
   LangString createDesktopShortcut ${LANG_GREEK} "Create desktop shortcut"
   LangString createDesktopShortcut ${LANG_HEBREW} "Create desktop shortcut"
   LangString createDesktopShortcut ${LANG_HUNGARIAN} "Create desktop shortcut"

--- a/build/packaging/WIX.README
+++ b/build/packaging/WIX.README
@@ -1,6 +1,6 @@
 The Wix.template.in file contains one absolute path to the exe file. It needs to be changed.
 <?define ExeId="CM_FP_bin.$(var.CPACK_PACKAGE_NAME).exe" ?>
 
-To create new version, the 3 digits version of MuseScore needs to be 
+To create new version, the 3 digits version of Musescore needs to be 
 changed and the product ID as well (see Packaging.cmake)
 

--- a/build/packaging/WIX.template.in
+++ b/build/packaging/WIX.template.in
@@ -75,8 +75,8 @@
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities" Name="ApplicationName" Value="$(var.ProdName)" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\DefaultIcon" Value="[INSTALL_ROOT]bin\$(var.ExeName),1" Type="string" />
             
-            <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\FileAssociations" Name=".mscz" Value="MuseScore.mscz" Type="string" />
-            <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\FileAssociations" Name=".mscx" Value="MuseScore.mscx" Type="string" />
+            <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\FileAssociations" Name=".mscz" Value="Musescore.mscz" Type="string" />
+            <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\FileAssociations" Name=".mscx" Value="Musescore.mscx" Type="string" />
             
             <!-- TODO add more types?-->
             

--- a/build/travis/job1_Tests/install.sh
+++ b/build/travis/job1_Tests/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Run this script from MuseScore's root directory
+# Run this script from Musescore's root directory
 
 set -e # exit on error
 set -x # echo commands

--- a/build/travis/job1_Tests/run_tests.sh
+++ b/build/travis/job1_Tests/run_tests.sh
@@ -63,7 +63,7 @@ else
   rm -rf share/sound/README*
   rm -rf share/locale/*.qm
   make zip
-  ./build/travis/job1_Tests/osuosl.sh MuseScore*.zip
+  ./build/travis/job1_Tests/osuosl.sh Musescore*.zip
 fi
 
 

--- a/build/travis/job2_AppImage/bintray.sh
+++ b/build/travis/job2_AppImage/bintray.sh
@@ -80,7 +80,7 @@ echo "$0: Creating package '${BINTRAY_PACKAGE}'..." >&2
 my_curl -X "POST" -d "@-" "${api}/packages/${repo_slug}" <<EOF
 {
   "name": "${BINTRAY_PACKAGE}",
-  "desc": "Unofficial MuseScore builds. Use at your own risk!",
+  "desc": "Unofficial Musescore builds. Use at your own risk!",
   "labels": ["music", "audio", "midi", "musicxml"],
   "licenses": ["GPL-2.0"],
   "vcs_url": "https://github.com/musescore/MuseScore",

--- a/build/travis/job2_AppImage/build.sh
+++ b/build/travis/job2_AppImage/build.sh
@@ -47,7 +47,7 @@ if [ "$(grep '^[[:blank:]]*set( *MSCORE_UNSTABLE \+TRUE *)' CMakeLists.txt)" ]
 then # Build is marked UNSTABLE inside CMakeLists.txt
   if [ "${BINTRAY_REPO_OWNER}" == "musescore" ]
   then # This is a nightly build
-    makefile_overrides="PREFIX='MuseScoreNightly-$date-$branch-$revision' \
+    makefile_overrides="PREFIX='MusescoreNightly-$date-$branch-$revision' \
                         SUFFIX='-portable-nightly' \
                         BUILD_NUMBER='${TRAVIS_BUILD_NUMBER}' \
                         LABEL='Portable Nightly Build'"
@@ -57,19 +57,19 @@ then # Build is marked UNSTABLE inside CMakeLists.txt
   else
     # This is someone developing on their own fork
     export BINTRAY_VERSION="${date}-${branch}-${revision}"
-    makefile_overrides="PREFIX='MuseScoreDev-${BINTRAY_VERSION}' \
+    makefile_overrides="PREFIX='MusescoreDev-${BINTRAY_VERSION}' \
                         SUFFIX='-portable-dev' \
                         LABEL='Unofficial Developer Build'"
     export BINTRAY_USER="${BINTRAY_USER:?${env_error_msg}}" # env, otherwise appimagetool will fail
     export BINTRAY_REPO="${BINTRAY_REPO:-MuseScore}"
     export BINTRAY_REPO_OWNER="${BINTRAY_REPO_OWNER:-${BINTRAY_USER}}" # env, or use $BINTRAY_USER
     export BINTRAY_PACKAGE="${BINTRAY_PACKAGE:-MuseScoreDev-${branch}}"
-    update_info="bintray-zsync|${BINTRAY_REPO_OWNER}|${BINTRAY_REPO}|${BINTRAY_PACKAGE}|MuseScoreDev-_latestVersion-${TARGET_ARCH}.AppImage.zsync"
+    update_info="bintray-zsync|${BINTRAY_REPO_OWNER}|${BINTRAY_REPO}|${BINTRAY_PACKAGE}|MusescoreDev-_latestVersion-${TARGET_ARCH}.AppImage.zsync"
   fi
 else
   # Build is STABLE so create a stable release!
   makefile_overrides="" # use Makefile defaults
-  update_info="gh-releases-zsync|musescore|MuseScore|latest|MuseScore-*x86_64.AppImage.zsync"
+  update_info="gh-releases-zsync|musescore|Musescore|latest|Musescore-*x86_64.AppImage.zsync"
 fi
 
 # Build AppImage depending on arch specified in $1 if cross-compiling, else default build x86_64
@@ -129,14 +129,14 @@ if [ "${upload}" ]; then
   else
     if [[ "${TRAVIS_REPO_SLUG}" == "musescore/MuseScore" ]]; then
       # this is an official build (stable or nightly)
-      ./build/travis/job2_AppImage/osuosl.sh build.release/MuseScore*.AppImage
-      if [[ -f build.release/MuseScore*.AppImage.zsync ]]; then
+      ./build/travis/job2_AppImage/osuosl.sh build.release/Musescore*.AppImage
+      if [[ -f build.release/Musescore*.AppImage.zsync ]]; then
         # upload zsync delta for automatic updates
-        ./build/travis/job2_AppImage/osuosl.sh build.release/MuseScore*.AppImage.zsync
+        ./build/travis/job2_AppImage/osuosl.sh build.release/Musescore*.AppImage.zsync
       fi
     else
       # This is a developer building on their personal fork
-      ./build/travis/job2_AppImage/bintray.sh build.release/MuseScore*.AppImage* # both AppImage and zsync
+      ./build/travis/job2_AppImage/bintray.sh build.release/Musescore*.AppImage* # both AppImage and zsync
     fi
   fi
 else

--- a/build/travis/job2_AppImage/osuosl.sh
+++ b/build/travis/job2_AppImage/osuosl.sh
@@ -61,4 +61,4 @@ esac
 scp -C -i $SSH_INDENTITY $FILE musescore-nightlies@ftp-osl.osuosl.org:ftp/linux/$ARCH_NAME/$FILE_UPLOAD_PATH
 
 # delete old files
-ssh -i $SSH_INDENTITY musescore-nightlies@ftp-osl.osuosl.org "cd ~/ftp/linux/$ARCH_NAME; ls MuseScoreNightly* -t | tail -n +41 | xargs -r rm"
+ssh -i $SSH_INDENTITY musescore-nightlies@ftp-osl.osuosl.org "cd ~/ftp/linux/$ARCH_NAME; ls MusescoreNightly* -t | tail -n +41 | xargs -r rm"

--- a/build/travis/job_macos/script.sh
+++ b/build/travis/job_macos/script.sh
@@ -37,13 +37,13 @@ cp -Rf ~/Library/Frameworks/Sparkle.framework applebuild/mscore.app/Contents/Fra
 if [[ "$NIGHTLY_BUILD" = "TRUE" ]]
 then # Build is marked UNSTABLE inside CMakeLists.txt
 build/package_mac $BRANCH-$REVISION
-PACKAGE_NAME=MuseScoreNightly
+PACKAGE_NAME=MusescoreNightly
 DMGFILE=applebuild/$PACKAGE_NAME-$DATE-$BRANCH-$REVISION.dmg
 DMGFILENAME=$PACKAGE_NAME-$DATE-$BRANCH-$REVISION.dmg
 mv applebuild/$PACKAGE_NAME-$BRANCH-$REVISION.dmg $DMGFILE
 else
 build/package_mac
-PACKAGE_NAME=MuseScore
+PACKAGE_NAME=Musescore
 DMGFILE=applebuild/$PACKAGE_NAME-*.dmg
 fi
 
@@ -53,7 +53,7 @@ SSH_INDENTITY=$HOME/.ssh/osuosl_nighlies_rsa
 scp -C -i $SSH_INDENTITY $DMGFILE musescore-nightlies@ftp-osl.osuosl.org:ftp/macosx
 
 # delete old files
-ssh -i $SSH_INDENTITY musescore-nightlies@ftp-osl.osuosl.org "cd ~/ftp/macosx; ls MuseScoreNightly* -t | tail -n +41 | xargs rm -f"
+ssh -i $SSH_INDENTITY musescore-nightlies@ftp-osl.osuosl.org "cd ~/ftp/macosx; ls MusescoreNightly* -t | tail -n +41 | xargs rm -f"
 
 # create and upload index.html and RSS
 python build/travis/job_macos/updateHTML.py $SSH_INDENTITY
@@ -86,7 +86,7 @@ echo "<update>
 <revision>${REVISION}</revision>
 <releaseType>nightly</releaseType>
 <date>${SHORT_DATE}</date>
-<description>MuseScore ${MUSESCORE_VERSION} ${REVISION}</description>
+<description>Musescore ${MUSESCORE_VERSION} ${REVISION}</description>
 <downloadUrl>https://ftp.osuosl.org/pub/musescore-nightlies/macosx/$DMGFILENAME</downloadUrl>
 <infoUrl>https://ftp.osuosl.org/pub/musescore-nightlies/macosx/</infoUrl>
 </update>" >> update_mac_nightly.xml
@@ -104,14 +104,14 @@ fi
 
 echo "<rss xmlns:sparkle=\"http://www.andymatuschak.org/xml-namespaces/sparkle\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" version=\"2.0\">
 <channel>
-<title>MuseScore development channel</title>
+<title>Musescore development channel</title>
 <link>
 ${APPCAST_URL}
 </link>
 <description>Most recent changes with links to updates.</description>
 <language>en</language>
 <item>
-<title>MuseScore ${MUSESCORE_VERSION} ${REVISION}</title>
+<title>Musescore ${MUSESCORE_VERSION} ${REVISION}</title>
 <description>
 <![CDATA[
 ${GIT_LOG}

--- a/build/travis/job_macos/updateHTML.py
+++ b/build/travis/job_macos/updateHTML.py
@@ -20,7 +20,7 @@ def generateHTML(pathname, lines):
     li = ""
     branches = dict()
     for l in lines:
-        if l and l.startswith("MuseScore"):
+        if l and l.startswith("Musescore"):
             sA = l.split("-")
             if len(sA) > 5:
                 branch = sA[5]
@@ -59,7 +59,7 @@ def generateRSS(pathname, lines):
     li = ""
     baseUrl = 'https://ftp.osuosl.org/pub/musescore-nightlies/' + osName + '/'
     for l in lines:
-        if l and l.startswith("MuseScore"):
+        if l and l.startswith("Musescore"):
             info = l.split("-")
             if len(info) == 4:
                 date = info[1]
@@ -82,7 +82,7 @@ def generateRSS(pathname, lines):
 <title>''' + l + '''</title>
 <link>''' + baseUrl + l + '''</link>
 <pubDate>'''+formatdate(time.mktime(d.timetuple()), usegmt=True)+'''</pubDate>
-<description>Nightly Build of MuseScore, Branch: ''' + branch + ''', Revision: '''+commit + '''</description>
+<description>Nightly Build of Musescore, Branch: ''' + branch + ''', Revision: '''+commit + '''</description>
 </item>'''
 
     rssTplPath = pathname + "/web/nightly.xml.tpl"

--- a/build/travis/job_macos/web/index.html.tpl
+++ b/build/travis/job_macos/web/index.html.tpl
@@ -2,7 +2,7 @@
    "http://www.w3.org/TR/html4/strict.dtd">
 <html>
 <head>
-<title>Development builds for macOS | MuseScore</title>
+<title>Development builds for macOS | Musescore</title>
 <link rel="alternate" type="application/rss+xml" title="Development build for macOS feed" href="nightly.xml" />
 <style type="text/css">
 #nightly-list li:first-child {font-weight:bold}
@@ -14,12 +14,12 @@
 
 <p>The development builds allow you to test the very latest developments, including new features and bug fixes. The goal is to catch new bugs, crashes, and regressions before they reach the prerelease or stable versions. For more information, see <a href="http://www.musescore.org/en/handbook/comparison-stable-prerelease-and-nightly-builds">Comparison of stable, beta, and nightly versions</a>. You can report any regressions or bugs you find via <code>Help > Report a Bug</code> within the development build.</p>
 
-<p>A development build can run side-by-side with other versions of MuseScore on the same computer. If you change preferences in the development build, it does not affect your preferences in the prerelease or stable versions of MuseScore. The development builds use a cymbal icon (a play on the fact that nightly builds are likely to suspend and crash) to visually differentiate them from normal versions of MuseScore. If this sounds scary to you, instead use the latest stable version of MuseScore from <a href="http://www.musescore.org/">musescore.org</a>.</p>
+<p>A development build can run side-by-side with other versions of Musescore on the same computer. If you change preferences in the development build, it does not affect your preferences in the prerelease or stable versions of Musescore. The development builds use a cymbal icon (a play on the fact that nightly builds are likely to suspend and crash) to visually differentiate them from normal versions of Musescore. If this sounds scary to you, instead use the latest stable version of Musescore from <a href="http://www.musescore.org/">musescore.org</a>.</p>
 
 <h3 id="instructions">Instructions</h3>
 <ol>
-<li>Download one of the "MuseScoreNightly" files from the Download section below. (The first is the most recent.)</li>
-<li>Open the DMG file, then drag and drop MuseScoreNightly to your <code>Applications</code> folder.</li>
+<li>Download one of the "MusescoreNightly" files from the Download section below. (The first is the most recent.)</li>
+<li>Open the DMG file, then drag and drop MusescoreNightly to your <code>Applications</code> folder.</li>
 </ol>
 
 <h3 id="download">Download</h3>
@@ -28,7 +28,7 @@
 </div>
 
 
-<p>* <strong>If you experience a crash on startup</strong>, revert to factory settings by running MuseScore with the -F flag.</p>
+<p>* <strong>If you experience a crash on startup</strong>, revert to factory settings by running Musescore with the -F flag.</p>
 
 <p>Follow development builds via <a href="nightly.xml">RSS feed</a></p>
 

--- a/build/travis/job_macos/web/nightly.xml.tpl
+++ b/build/travis/job_macos/web/nightly.xml.tpl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <rss version="2.0">
 <channel>
-<title>Nightly Builds of MuseScore</title>
+<title>Nightly Builds of Musescore</title>
 <link>http://ftp.osuosl.org/pub/musescore-nightlies/macosx/</link>
-<description>Nightly Builds of MuseScore for Mac OS</description>
+<description>Nightly Builds of Musescore for Mac OS</description>
 <language>en-us</language>
 ##PLACEHOLDER##
 </channel>

--- a/msvc_build.bat
+++ b/msvc_build.bat
@@ -4,14 +4,14 @@ REM Default build is 64-bit
 REM 32-bit compilation is available using "32" as a second parameter when you run msvc_build.bat
 REM How to use:
 REM BUILD 64-bit:
-REM    "msvc_build.bat debug" builds 64-bit Debug version of MuseScore without optimizations
-REM    "msvc_build.bat relwithdebinfo" builds optimized 64-bit version of MuseScore with almost all debug symbols
-REM    "msvc_build.bat release" builds fully optimized 64-bit version of MuseScore without command line output
+REM    "msvc_build.bat debug" builds 64-bit Debug version of Musescore without optimizations
+REM    "msvc_build.bat relwithdebinfo" builds optimized 64-bit version of Musescore with almost all debug symbols
+REM    "msvc_build.bat release" builds fully optimized 64-bit version of Musescore without command line output
 REM
 REM BUILD 32-bit:
-REM    "msvc_build.bat debug 32" builds 32-bit Debug version of MuseScore
-REM    "msvc_build.bat relwithdebinfo 32" builds 32-bit RelWithDebInfo version of MuseScore
-REM    "msvc_build.bat release 32" builds 32-bit Release version of MuseScore
+REM    "msvc_build.bat debug 32" builds 32-bit Debug version of Musescore
+REM    "msvc_build.bat relwithdebinfo 32" builds 32-bit RelWithDebInfo version of Musescore
+REM    "msvc_build.bat release 32" builds 32-bit Release version of Musescore
 REM
 REM INSTALL 64-bit:
 REM    "msvc_build.bat install" put all required files of 64-bit Release build to install folder (msvc.install_x64)
@@ -24,8 +24,8 @@ REM    "msvc_build.bat installdebug 32" put all required files of 32-bit Debug b
 REM    "msvc_build.bat installrelwithdebinfo 32" put all required files of 32-bit RelWithDebInfo build to install folder (msvc.install_x86)
 REM
 REM PACKAGE:
-REM    "msvc_build.bat package" pack the installer for already built and installed 64-bit Release build (msvc.build_x64/MuseScore-*.msi)
-REM    "msvc_build.bat package 32" pack the installer for already built and installed 32-bit Release build (msvc.build_x86/MuseScore-*.msi)
+REM    "msvc_build.bat package" pack the installer for already built and installed 64-bit Release build (msvc.build_x64/Musescore-*.msi)
+REM    "msvc_build.bat package 32" pack the installer for already built and installed 32-bit Release build (msvc.build_x86/Musescore-*.msi)
 REM
 REM CLEAN:
 REM    "msvc_build.bat clean" remove all files in msvc.* folders and the folders itself
@@ -130,14 +130,14 @@ IF NOT "%CRASH_LOG_SERVER_URL%" == "" (
 REM -DCMAKE_BUILD_NUMBER=%BUILD_NUMBER% -DCMAKE_BUILD_AUTOUPDATE=%BUILD_AUTOUPDATE% %CRASH_REPORT_URL_OPT% are used for CI only
    cd "%BUILD_FOLDER%" & cmake -G %GENERATOR_NAME% -DCMAKE_INSTALL_PREFIX=../%INSTALL_FOLDER% -DCMAKE_BUILD_TYPE=%CONFIGURATION_STR% -DBUILD_FOR_WINSTORE=%BUILD_FOR_WINSTORE% -DBUILD_64=%BUILD_64% -DCMAKE_BUILD_NUMBER=%BUILD_NUMBER% -DBUILD_AUTOUPDATE=%BUILD_AUTOUPDATE% %CRASH_REPORT_URL_OPT% ..
 
-   echo Building MuseScore...
+   echo Building Musescore...
    cd "%BUILD_FOLDER%" & cmake --build . --config %CONFIGURATION_STR% --target mscore
    GOTO :END
    )
 
 :INSTALL
    cd "%BUILD_FOLDER%"
-   echo Installing MuseScore files...
+   echo Installing Musescore files...
    cmake --build . --config %CONFIGURATION_STR% --target install
    GOTO :END
 


### PR DESCRIPTION
In the packages titles and build docs

MuseScore was decided to be renamed to Musescore everywhere for marketing purposes. Most of the renaming process has been done on other resources, but the software is the most complex one. Let's start with visible packages names.

Next step is to replace MuseScore with Musescore in all visible strings.
