### PR TITLE
fix #291957: Mixer causes piano to disappear off screen.

### DIFF
--- a/mscore/mixer.ui
+++ b/mscore/mixer.ui
@@ -135,7 +135,7 @@
         <property name="minimumSize">
          <size>
           <width>0</width>
-          <height>370</height>
+          <height>0</height>
          </size>
         </property>
         <property name="widgetResizable">


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/291957.

The mixer needs to be able to shrink in order to accomodate the piano keyboard if it is made visible. Decreasing the minimum height for the QScrollArea that contains the mixer sliders allows this to happen.