### PR TITLE
[Inspector] fix #298272, fix #298363: inspector title issues

### DIFF
--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -171,6 +171,7 @@ void Inspector::update(Score* s)
             return;
       _score = s;
       bool sameTypes = true;
+      bool sameSubtypes = true;
       if (el()) {
             for (Element* ee : *el()) {
                   if (((element()->type() != ee->type()) && // different and
@@ -184,9 +185,19 @@ void Inspector::update(Score* s)
                         sameTypes = false;
                         break;
                         }
+                      // an articulation and an ornament
+                  if ((ee->isArticulation() && toArticulation(ee)->isOrnament() != toArticulation(element())->isOrnament()) ||
+                      // a slur and a tie
+                      (ee->isSlurTieSegment() && toSlurTieSegment(ee)->accessibleInfo() != toSlurTieSegment(element())->accessibleInfo()) ||
+                      // a breath and a caesura (or different breaths)
+                      (ee->isBreath() && toBreath(ee)->accessibleInfo() != toBreath(element())->accessibleInfo()) ||
+                      // a staff text and a system text
+                      ((ee->isStaffText() || ee->isSystemText())
+                          && (ee->type() != element()->type()) || (ee->isSystemText() != element()->isSystemText())))
+                        sameSubtypes = false;
                   }
             }
-      if (oe != element() || oSameTypes != sameTypes) {
+      if (oe != element() || oSameTypes != sameTypes || (sameTypes && !sameSubtypes)) {
             delete ie;
             ie  = 0;
             oe  = element();
@@ -196,7 +207,7 @@ void Inspector::update(Score* s)
             else if (!sameTypes)
                   ie = new InspectorGroupElement(this);
             else {
-                  switch(element()->type()) {
+                  switch (element()->type()) {
                         case ElementType::FBOX:
                         case ElementType::VBOX:
                               ie = new InspectorVBox(this);
@@ -1178,7 +1189,7 @@ InspectorSlurTie::InspectorSlurTie(QWidget* parent)
 //---------------------------------------------------------
 
 InspectorEmpty::InspectorEmpty(QWidget* parent)
-      :InspectorBase(parent)
+   : InspectorBase(parent)
       {
       e.setupUi(addWidget());
       }
@@ -1196,7 +1207,8 @@ QSize InspectorEmpty::sizeHint() const
 //   InspectorCaesura
 //---------------------------------------------------------
 
-InspectorCaesura::InspectorCaesura(QWidget* parent) : InspectorElementBase(parent)
+InspectorCaesura::InspectorCaesura(QWidget* parent)
+   : InspectorElementBase(parent)
       {
       c.setupUi(addWidget());
 
@@ -1222,7 +1234,8 @@ InspectorCaesura::InspectorCaesura(QWidget* parent) : InspectorElementBase(paren
 //   InspectorBracket
 //---------------------------------------------------------
 
-InspectorBracket::InspectorBracket(QWidget* parent) : InspectorBase(parent)
+InspectorBracket::InspectorBracket(QWidget* parent)
+   : InspectorBase(parent)
       {
       b.setupUi(addWidget());
 
@@ -1237,7 +1250,8 @@ InspectorBracket::InspectorBracket(QWidget* parent) : InspectorBase(parent)
 //   InspectorIname
 //---------------------------------------------------------
 
-InspectorIname::InspectorIname(QWidget* parent) : InspectorTextBase(parent)
+InspectorIname::InspectorIname(QWidget* parent)
+   : InspectorTextBase(parent)
       {
       i.setupUi(addWidget());
 

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -189,8 +189,8 @@ void Inspector::update(Score* s)
                   if ((ee->isArticulation() && toArticulation(ee)->isOrnament() != toArticulation(element())->isOrnament()) ||
                       // a slur and a tie
                       (ee->isSlurTieSegment() && toSlurTieSegment(ee)->accessibleInfo() != toSlurTieSegment(element())->accessibleInfo()) ||
-                      // a breath and a caesura (or different breaths)
-                      (ee->isBreath() && toBreath(ee)->accessibleInfo() != toBreath(element())->accessibleInfo()) ||
+                      // a breath and a caesura
+                      (ee->isBreath() && toBreath(ee)->isCaesura() != toBreath(element())->isCaesura()) ||
                       // a staff text and a system text
                       ((ee->isStaffText() || ee->isSystemText())
                           && (ee->type() != element()->type()) || (ee->isSystemText() != element()->isSystemText())))
@@ -1215,13 +1215,13 @@ InspectorCaesura::InspectorCaesura(QWidget* parent)
       Breath* b = toBreath(inspector->element());
       bool sameTypes = true;
       for (const auto& ee : *inspector->el()) {
-            if (ee->accessibleInfo() != b->accessibleInfo()) {
+            if (toBreath(ee)->isCaesura() != b->isCaesura()) {
                   sameTypes = false;
                   break;
                   }
             }
       if (sameTypes)
-            c.title->setText(b->accessibleInfo());
+            c.title->setText(b->isCaesura() ? tr("Caesura") : tr("Breath"));
 
       const std::vector<InspectorItem> il = {
             { Pid::PAUSE,  0, c.pause,         c.resetPause         }

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -569,6 +569,18 @@ InspectorArticulation::InspectorArticulation(QWidget* parent)
       {
       ar.setupUi(addWidget());
 
+      Articulation* el = toArticulation(inspector->element());
+      bool sameTypes = true;
+
+      for (const auto& ee : *inspector->el()) {
+            if (toArticulation(ee)->isOrnament() != el->isOrnament()) {
+                  sameTypes = false;
+                  break;
+                  }
+            }
+      if (sameTypes)
+            ar.title->setText(el->isOrnament() ? tr("Ornament") : tr("Articulation"));
+
       const std::vector<InspectorItem> iiList = {
             { Pid::ARTICULATION_ANCHOR, 0, ar.anchor,           ar.resetAnchor           },
             { Pid::DIRECTION,           0, ar.direction,        ar.resetDirection        },

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -188,7 +188,7 @@ void Inspector::update(Score* s)
                       // an articulation and an ornament
                   if ((ee->isArticulation() && toArticulation(ee)->isOrnament() != toArticulation(element())->isOrnament()) ||
                       // a slur and a tie
-                      (ee->isSlurTieSegment() && toSlurTieSegment(ee)->accessibleInfo() != toSlurTieSegment(element())->accessibleInfo()) ||
+                      (ee->isSlurTieSegment() && toSlurTieSegment(ee)->isSlurSegment() != toSlurTieSegment(element())->isSlurSegment()) ||
                       // a breath and a caesura
                       (ee->isBreath() && toBreath(ee)->isCaesura() != toBreath(element())->isCaesura()) ||
                       // a staff text and a system text
@@ -1168,13 +1168,13 @@ InspectorSlurTie::InspectorSlurTie(QWidget* parent)
       bool sameTypes = true;
 
       for (const auto& ee : *inspector->el()) {
-            if (ee->accessibleInfo() != el->accessibleInfo()) {
+            if (ee->isSlurSegment() != el->isSlurSegment()) {
                   sameTypes = false;
                   break;
                   }
             }
       if (sameTypes)
-            s.title->setText(el->accessibleInfo());
+            s.title->setText(el->isSlurSegment() ? tr("Slur") : tr("Tie"));
 
       const std::vector<InspectorItem> iiList = {
             { Pid::LINE_TYPE,       0, s.lineType,      s.resetLineType      },

--- a/mscore/inspector/inspector_articulation.ui
+++ b/mscore/inspector/inspector_articulation.ui
@@ -54,7 +54,7 @@
       </font>
      </property>
      <property name="text">
-      <string>Articulation</string>
+      <string>Articulation/Ornament</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Resolves: https://musescore.org/node/298272.

&&

Resolves: https://musescore.org/node/298363.

From 2.x to 3.x, a change was made which leaded to the issue: if `oSameTypes != sameTypes`, inspectors will not be updated. Even if slur and tie/breath and caesura/articulation and ornament are both selected, for each group `sameType` will continue to give `true`, and so the inspector is not updated.

This patch adds another field: `sameSubtypes`. If `sameTypes` is `true` but the subtypes are different, the inspector will be updated too.