### PR TITLE
fix #298362: pressing number after mouse click works for a different line in "Italian" styled tablature staff

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3687,7 +3687,7 @@ void Score::cmdAddFret(int fret)
       Position pos;
       pos.segment   = is.segment();
       pos.staffIdx  = is.track() / VOICES;
-      pos.line      = is.string();
+      pos.line      = is.cr()->staff()->staffType(is.tick())->physStringToVisual(is.string());
       pos.fret      = fret;
       putNote(pos, false);
       }


### PR DESCRIPTION
Resolves: https://musescore.org/node/298362.

This is because the string number is reversed for number pressing (for upside-down tablature staves) while in fact it isn't needed. So a `physStringToVisual()` is called in this patch to eliminate the effect. See https://musescore.org/en/node/298362#comment-965223.