### PR TITLE
fix #298471: strings with no X or O render as ? on Linux

### DIFF
--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -371,6 +371,8 @@ void FretDiagram::draw(QPainter* painter) const
       for (auto const& i : _markers) {
             int string = i.first;
             FretItem::Marker marker = i.second;
+            if (!marker.exists())
+                  continue;
 
             QChar markerChar = FretItem::markerToChar(marker.mtype);
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/298471

Strings in fret diagrams with no X or O have no marker,
but in some Linux systems, we are rendering a "?" character,
as we are actually trying to draw a null character in FreeSans,
and that is the result depending on the specific version
of the font, rendering libraries, etc.

Fix is simplky to skip the draw if the market is null.
This is the approach used in the Inspector,
and is also what was done prior to the big fret diagram refactor,

There is already at least one vtest that covers this (harmony-2), we just never noticed the results were bad on Linux I guess.