### PR TITLE
fix #298490: Musescore crashes when trying to open a specific score

### DIFF
--- a/libmscore/lyricsline.cpp
+++ b/libmscore/lyricsline.cpp
@@ -153,7 +153,8 @@ void LyricsLine::layout()
                   }
             // Spanner::computeEndElement() will actually ignore this value and use the (earlier) lyrics()->endTick() instead
             // still, for consistency with other lines, we should set the ticks for this to the computed (later) value
-            setTicks(s->tick() - lyricsStartTick);
+            if (s)
+                  setTicks(s->tick() - lyricsStartTick);
             }
       else {                                    // dash(es)
             _nextLyrics = searchNextLyrics(lyrics()->segment(), staffIdx(), lyrics()->no(), lyrics()->placement());


### PR DESCRIPTION
Fixes the crash on loading the score from https://musescore.org/en/node/298490

Does not fix the crash on (auto)save for that same score, which seems due to a corrupt part.