### PR TITLE
fix #291177: Parts dialog, problem with "Generate" and related strings

### DIFF
--- a/mscore/excerptsdialog.cpp
+++ b/mscore/excerptsdialog.cpp
@@ -117,8 +117,8 @@ ExcerptsDialog::ExcerptsDialog(MasterScore* s, QWidget* parent)
             instrumentList->addItem(item);
             }
 
-      connect(newButton, SIGNAL(clicked()), SLOT(newClicked()));
-      connect(newAllButton, SIGNAL(clicked()), SLOT(newAllClicked()));
+      connect(singlePartButton, SIGNAL(clicked()), SLOT(singlePartClicked()));
+      connect(allPartsButton, SIGNAL(clicked()), SLOT(allPartsClicked()));
       connect(deleteButton, SIGNAL(clicked()), SLOT(deleteClicked()));
       connect(moveUpButton, SIGNAL(clicked()), SLOT(moveUpClicked()));
       connect(moveDownButton, SIGNAL(clicked()), SLOT(moveDownClicked()));
@@ -168,10 +168,10 @@ void MuseScore::startExcerptsDialog()
       }
 
 //---------------------------------------------------------
-//   newClicked
+//   singlePartClicked
 //---------------------------------------------------------
 
-void ExcerptsDialog::newClicked()
+void ExcerptsDialog::singlePartClicked()
       {
       QString name = createName("Part");
       Excerpt* e   = new Excerpt(score);
@@ -194,10 +194,10 @@ void ExcerptsDialog::newClicked()
       }
 
 //---------------------------------------------------------
-//   newAllClicked
+//   allPartsClicked
 //---------------------------------------------------------
 
-void ExcerptsDialog::newAllClicked()
+void ExcerptsDialog::allPartsClicked()
       {
       QList<Excerpt*> excerpts = Excerpt::createAllExcerpt(score);
       ExcerptItem* ei = 0;

--- a/mscore/excerptsdialog.h
+++ b/mscore/excerptsdialog.h
@@ -96,8 +96,8 @@ class ExcerptsDialog : public QDialog, private Ui::ExcerptsDialog {
 
    private slots:
       void deleteClicked();
-      void newClicked();
-      void newAllClicked();
+      void singlePartClicked();
+      void allPartsClicked();
       void moveUpClicked();
       void moveDownClicked();
       void excerptChanged(QListWidgetItem* cur, QListWidgetItem* prev);

--- a/mscore/excerptsdialog.ui
+++ b/mscore/excerptsdialog.ui
@@ -149,12 +149,12 @@
        <item>
         <layout class="QVBoxLayout" name="buttons">
          <item>
-          <widget class="QPushButton" name="newAllButton">
+          <widget class="QPushButton" name="allPartsButton">
            <property name="toolTip">
-            <string>Generate new part for each instrument</string>
+            <string>New part for each instrument</string>
            </property>
            <property name="text">
-            <string>Generate</string>
+            <string>All Parts</string>
            </property>
           </widget>
          </item>
@@ -172,9 +172,12 @@
           </spacer>
          </item>
          <item>
-          <widget class="QPushButton" name="newButton">
+          <widget class="QPushButton" name="singlePartButton">
+           <property name="toolTip">
+            <string>New part for single instrument</string>
+           </property>
            <property name="text">
-            <string>New</string>
+            <string>Single Part</string>
            </property>
           </widget>
          </item>
@@ -389,8 +392,8 @@
   <tabstop>excerptList</tabstop>
   <tabstop>moveUpButton</tabstop>
   <tabstop>moveDownButton</tabstop>
-  <tabstop>newAllButton</tabstop>
-  <tabstop>newButton</tabstop>
+  <tabstop>allPartsButton</tabstop>
+  <tabstop>singlePartButton</tabstop>
   <tabstop>deleteButton</tabstop>
   <tabstop>title</tabstop>
   <tabstop>instrumentList</tabstop>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/291177

Short description: 
Generate replaces New All but is still problematic and inconsistent (as per the issue discussion). This PR makes the two strings consistent, leaves room for a future "Generate" heading, fixes the current Genrate button's tool tip (too long, gets truncated), and adds a missing tooltip. 

<s>Notes:
a) Once we agree on the new string names, I will add a separate commit to fix the button labels, which still reference the original strings: newAllButton newAllClicked newButton newClicked in excerptsdialog.{cpp,ui,h}. or do another commit as part of this PR (whichever you recommend)</s>
I have updated these strings as well

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n/a ] I created the test (mtest, vtest, script test) to verify the changes I made