### PR TITLE
fix #298552 - [MusicXML] use offset for non-spanning directions

### DIFF
--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -99,6 +99,7 @@
 #include "libmscore/textline.h"
 #include "libmscore/fermata.h"
 #include "musicxmlfonthandler.h"
+#include "libmscore/textframe.h"
 
 namespace Ms {
 
@@ -334,6 +335,7 @@ public:
       Score* score() const { return _score; };
       double getTenthsFromInches(double) const;
       double getTenthsFromDots(double) const;
+      Fraction tick() const { return _tick; }
       };
 
 //---------------------------------------------------------
@@ -1624,19 +1626,28 @@ void ExportMusicXml::barlineRight(Measure* m)
       }
 
 //---------------------------------------------------------
+//   calculateTimeDeltaInDivisions
+//---------------------------------------------------------
+
+static int calculateTimeDeltaInDivisions(const Fraction& t1, const Fraction& t2, const int divisions)
+      {
+      return (t1 - t2).ticks() / divisions;
+      }
+
+//---------------------------------------------------------
 //   moveToTick
 //---------------------------------------------------------
 
 void ExportMusicXml::moveToTick(const Fraction& t)
       {
-      // qDebug("ExportMusicXml::moveToTick(t=%d) tick=%d", t, tick);
+      //qDebug("ExportMusicXml::moveToTick(t=%s) _tick=%s", qPrintable(t.print()), qPrintable(_tick.print()));
       if (t < _tick) {
 #ifdef DEBUG_TICK
             qDebug(" -> backup");
 #endif
             _attr.doAttr(_xml, false);
             _xml.stag("backup");
-            _xml.tag("duration", (_tick - t).ticks() / div);
+            _xml.tag("duration", calculateTimeDeltaInDivisions(_tick, t, div));
             _xml.etag();
             }
       else if (t > _tick) {
@@ -1645,7 +1656,7 @@ void ExportMusicXml::moveToTick(const Fraction& t)
 #endif
             _attr.doAttr(_xml, false);
             _xml.stag("forward");
-            _xml.tag("duration", (t - _tick).ticks() / div);
+            _xml.tag("duration", calculateTimeDeltaInDivisions(t, _tick, div));
             _xml.etag();
             }
       _tick = t;
@@ -3373,7 +3384,7 @@ static void beatUnit(XmlWriter& xml, const TDuration dur)
             }
       }
 
-static void wordsMetrome(XmlWriter& xml, Score* s, TextBase const* const text)
+static void wordsMetrome(XmlWriter& xml, Score* s, TextBase const* const text, const int offset)
       {
       //qDebug("wordsMetrome('%s')", qPrintable(text->xmlText()));
       const QList<TextFragment> list = text->fragmentList();
@@ -3441,21 +3452,24 @@ static void wordsMetrome(XmlWriter& xml, Score* s, TextBase const* const text)
             mttm.writeTextFragments(text->fragmentList(), xml);
             xml.etag();
             }
+
+      if (offset)
+            xml.tag("offset", offset);
       }
 
 void ExportMusicXml::tempoText(TempoText const* const text, int staff)
       {
+      const auto offset = calculateTimeDeltaInDivisions(text->tick(), tick(), div);
       /*
-      qDebug("ExportMusicXml::tempoText(TempoText='%s')", qPrintable(text->xmlText()));
+      qDebug("tick %s text->tick %s offset %d xmlText='%s')",
+             qPrintable(tick().print()),
+             qPrintable(text->tick().print()),
+             offset,
+             qPrintable(text->xmlText()));
       */
       _attr.doAttr(_xml, false);
       _xml.stag(QString("direction placement=\"%1\"").arg((text->placement() ==Placement::BELOW ) ? "below" : "above"));
-      wordsMetrome(_xml, _score, text);
-      /*
-      int offs = text->mxmlOff();
-      if (offs)
-            xml.tag("offset", offs);
-      */
+      wordsMetrome(_xml, _score, text, offset);
       if (staff)
             _xml.tag("staff", staff);
       _xml.tagE(QString("sound tempo=\"%1\"").arg(QString::number(text->tempo()*60.0)));
@@ -3468,8 +3482,12 @@ void ExportMusicXml::tempoText(TempoText const* const text, int staff)
 
 void ExportMusicXml::words(TextBase const* const text, int staff)
       {
+      const auto offset = calculateTimeDeltaInDivisions(text->tick(), tick(), div);
       /*
-      qDebug("ExportMusicXml::words userOff.x=%f userOff.y=%f xmlText='%s' plainText='%s'",
+      qDebug("tick %s text->tick %s offset %d userOff.x=%f userOff.y=%f xmlText='%s' plainText='%s'",
+             qPrintable(tick().print()),
+             qPrintable(text->tick().print()),
+             offset,
              text->offset().x(), text->offset().y(),
              qPrintable(text->xmlText()),
              qPrintable(text->plainText()));
@@ -3482,7 +3500,7 @@ void ExportMusicXml::words(TextBase const* const text, int staff)
             }
 
       directionTag(_xml, _attr, text);
-      wordsMetrome(_xml, _score, text);
+      wordsMetrome(_xml, _score, text, offset);
       directionETag(_xml, staff);
       }
 
@@ -3512,6 +3530,9 @@ void ExportMusicXml::rehearsal(RehearsalMark const* const rmk, int staff)
       MScoreTextToMXML mttm("rehearsal", attr, defFmt, mtf);
       mttm.writeTextFragments(rmk->fragmentList(), _xml);
       _xml.etag();
+      const auto offset = calculateTimeDeltaInDivisions(rmk->tick(), tick(), div);
+      if (offset)
+            _xml.tag("offset", offset);
       directionETag(_xml, staff);
       }
 
@@ -3965,11 +3986,10 @@ void ExportMusicXml::dynamic(Dynamic const* const dyn, int staff)
 
       _xml.etag();
 
-      /*
-      int offs = dyn->mxmlOff();
-      if (offs)
-            xml.tag("offset", offs);
-      */
+      const auto offset = calculateTimeDeltaInDivisions(dyn->tick(), tick(), div);
+      if (offset)
+            _xml.tag("offset", offset);
+
       if (staff)
             _xml.tag("staff", staff);
 
@@ -4003,6 +4023,9 @@ void ExportMusicXml::symbol(Symbol const* const sym, int staff)
       _xml.stag("direction-type");
       _xml.tagE(mxmlName);
       _xml.etag();
+      const auto offset = calculateTimeDeltaInDivisions(sym->tick(), tick(), div);
+      if (offset)
+            _xml.tag("offset", offset);
       directionETag(_xml, staff);
       }
 
@@ -4397,6 +4420,10 @@ static bool commonAnnotations(ExportMusicXml* exp, const Element* e, int sstaff)
 //---------------------------------------------------------
 //  annotations
 //---------------------------------------------------------
+
+/*
+ * Write annotations that are attached to chords or rests
+ */
 
 // In MuseScore, Element::FRET_DIAGRAM and Element::HARMONY are separate annotations,
 // in MusicXML they are combined in the harmony element. This means they have to be matched.
@@ -5438,10 +5465,8 @@ static void annotationsWithoutNote(ExportMusicXml* exp, const int strack, const 
                   for (const auto element : segment->annotations()) {
                         if (!element->isFiguredBass() && !element->isHarmony()) {       // handled elsewhere
                               const auto wtrack = findTrackForAnnotations(element->track(), segment); // track to write annotation
-                              if (strack <= element->track() && element->track() < (strack + VOICES * staves) && wtrack < 0) {
-                                    exp->moveToTick(element->tick());
+                              if (strack <= element->track() && element->track() < (strack + VOICES * staves) && wtrack < 0)
                                     commonAnnotations(exp, element, staves > 1 ? 1 : 0);
-                                    }
                               }
                         }
                   }

--- a/mscore/importmxmlpass2.h
+++ b/mscore/importmxmlpass2.h
@@ -328,7 +328,7 @@ private:
 class MusicXMLParserDirection {
 public:
       MusicXMLParserDirection(QXmlStreamReader& e, Score* score, const MusicXMLParserPass1& pass1, MusicXMLParserPass2& pass2, MxmlLogger* logger);
-      void direction(const QString& partId, Measure* measure, const Fraction& tick, MusicXmlSpannerMap& spanners);
+      void direction(const QString& partId, Measure* measure, const Fraction& tick, const int divisions, MusicXmlSpannerMap& spanners);
 
 private:
       QXmlStreamReader& _e;
@@ -357,6 +357,7 @@ private:
       double _tpoMetro;                 // tempo according to metronome
       double _tpoSound;                 // tempo according to sound
       QList<Element*> _elems;
+      Fraction _offset;
 
       void directionType(QList<MusicXmlSpannerDesc>& starts, QList<MusicXmlSpannerDesc>& stops);
       void bracket(const QString& type, const int number, QList<MusicXmlSpannerDesc>& starts, QList<MusicXmlSpannerDesc>& stops);

--- a/mtest/musicxml/io/testDirections2.xml
+++ b/mtest/musicxml/io/testDirections2.xml
@@ -95,18 +95,13 @@
         <duration>4</duration>
         <voice>1</voice>
         </note>
-      <backup>
-        <duration>3</duration>
-        </backup>
       <direction placement="above">
         <direction-type>
           <words font-weight="bold" font-size="12">Andante</words>
           </direction-type>
+        <offset>-3</offset>
         <sound tempo="91.9998"/>
         </direction>
-      <forward>
-        <duration>3</duration>
-        </forward>
       </measure>
     <measure number="3">
       <note>
@@ -114,17 +109,12 @@
         <duration>4</duration>
         <voice>1</voice>
         </note>
-      <backup>
-        <duration>2</duration>
-        </backup>
       <direction placement="above">
         <direction-type>
           <rehearsal font-weight="bold" font-size="14">A</rehearsal>
           </direction-type>
+        <offset>-2</offset>
         </direction>
-      <forward>
-        <duration>2</duration>
-        </forward>
       <barline location="right">
         <bar-style>light-heavy</bar-style>
         </barline>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/298552

See https://musescore.org/en/node/282185 for the discussion and justification. This issues replaces backup/forward by offset for non-spanning directions only, to improve braille translation.

*Use "x" letter to fill the checkboxes below like [x]*

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made