### PR TITLE
fix #297738: "generate key signatures" in staff type change does not work

### DIFF
--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -101,7 +101,7 @@ void KeySig::layout()
             }
 
       _sig.keySymbols().clear();
-      if (staff() && !staff()->genKeySig())     // no key sigs on TAB staves
+      if (staff() && !staff()->staffType(tick())->genKeysig())
             return;
 
       // determine current clef for this staff

--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -87,6 +87,7 @@ StaffType::StaffType(StaffGroup sg, const QString& xml, const QString& name, int
       setShowBarlines(showBarLines);
       setStemless(stemless);
       setGenTimesig(genTimesig);
+      setGenKeysig(sg != StaffGroup::TAB);
       setDurationFontName(durFontName);
       setDurationFontSize(durFontSize);
       setDurationFontUserY(durFontUserY);
@@ -273,6 +274,9 @@ void StaffType::read(XmlReader& e)
             _group = StaffGroup::STANDARD;
             }
 
+      if (_group == StaffGroup::TAB)
+            setGenKeysig(false);
+
       while (e.readNextStartElement()) {
             const QStringRef& tag(e.name());
             if (tag == "name")
@@ -314,7 +318,7 @@ void StaffType::read(XmlReader& e)
                   setDurationFontSize(e.readDouble());
             else if (tag == "durationFontY")
                   setDurationFontUserY(e.readDouble());
-           else if (tag == "fretFontName")
+            else if (tag == "fretFontName")
                   setFretFontName(e.readElementText());
             else if (tag == "fretFontSize")
                   setFretFontSize(e.readDouble());

--- a/mscore/editstafftype.cpp
+++ b/mscore/editstafftype.cpp
@@ -412,6 +412,7 @@ void EditStaffType::setFromDlg()
       staffType.setStemsDown(stemBelowRadio->isChecked());
       staffType.setStemsThrough(stemThroughRadio->isChecked());
       if (staffType.group() == StaffGroup::TAB) {
+            staffType.setGenKeysig(false);
             staffType.setStemless(true);                   // assume no note values
             staffType.setGenDurations(false);              //    "     "
             if (noteValuesSymb->isChecked())

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -72,6 +72,8 @@
 #include "libmscore/accidental.h"
 #include "libmscore/articulation.h"
 #include "libmscore/fermata.h"
+#include "libmscore/stafftypechange.h"
+#include "libmscore/mscore.h"
 #include "libmscore/stafftextbase.h"
 
 namespace Ms {
@@ -500,6 +502,31 @@ InspectorStaffTypeChange::InspectorStaffTypeChange(QWidget* parent)
             sl.noteheadScheme->addItem(StaffType::scheme2userName(i), int(i));
             }
       mapSignals();
+      }
+
+//---------------------------------------------------------
+//   setElement
+//---------------------------------------------------------
+
+void InspectorStaffTypeChange::setElement()
+      {
+      InspectorBase::setElement();
+      bool hasTabStaff = false;
+      bool hasNonTabStaff = false;
+      for (Element* el : *(inspector->el())) {
+            StaffTypeChange* stc = toStaffTypeChange(el);
+            // tab staff shouldn't have key signature
+            if (stc->staffType()->group() == StaffGroup::TAB) {
+                  hasTabStaff = true;
+                  sl.genKeysig->setEnabled(false);
+                  sl.resetGenKeysig->setEnabled(false);
+                  }
+            else {
+                  hasNonTabStaff = true;
+                  }
+            }
+      if (hasTabStaff && !hasNonTabStaff)
+            sl.genKeysig->setChecked(false);
       }
 
 //---------------------------------------------------------

--- a/mscore/inspector/inspector.h
+++ b/mscore/inspector/inspector.h
@@ -104,6 +104,7 @@ class InspectorStaffTypeChange : public InspectorBase {
 
    public:
       InspectorStaffTypeChange(QWidget* parent);
+      virtual void setElement() override;
       };
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/node/297738.

`staff()->genKeySig()` always checks for `Fraction(0, 1)` while `staff()->staffType(tick())->genKeysig()` checks for the property at the exact tick.

The patch also fixes the `StaffType` generation of tablature staves, making `genKeysig` default to false.