### PR TITLE
make extension file size suffixes translatable

### DIFF
--- a/mscore/resourceManager.cpp
+++ b/mscore/resourceManager.cpp
@@ -50,41 +50,19 @@ ResourceManager::ResourceManager(QWidget *parent) :
 //---------------------------------------------------------
 
 ExtensionFileSize::ExtensionFileSize(const int i)
-      : QTableWidgetItem(stringutils::convertFileSizeToHumanReadable(i))
-      , _size(i)
+   : QTableWidgetItem(stringutils::convertFileSizeToHumanReadable(i), QTableWidgetItem::UserType)
+     , _size(i)
       {}
+
+//---------------------------------------------------------
+//   operator<
+//---------------------------------------------------------
 
 bool ExtensionFileSize::operator<(const QTableWidgetItem& nextItem) const
       {
-      QString currentText = text();
-      QString nextText = nextItem.text();
-
-      QChar currentSizeType = currentText[currentText.size() - 2];
-      QChar nextSizeType = nextText[currentText.size() - 2];
-
-      // the integer before unit
-      int currentInt = currentText.split(QRegularExpression("\\s+"))[0].toInt();
-      int nextInt = nextText.split(QRegularExpression("\\s+"))[0].toInt();
-
-      return int2size(currentSizeType, currentInt) < int2size(nextSizeType, nextInt);
-      }
-
-//---------------------------------------------------------
-//   int2size
-//---------------------------------------------------------
-
-int ExtensionFileSize::int2size(QChar sizeType, int i)
-      {
-      if (sizeType == QChar('K')) // the size is written as kilobytes, and so on
-            return i * 0x400;
-      else if (sizeType == QChar('M'))
-            return i * 0x100000;
-      else if (sizeType == QChar('G'))
-            return i * 0x40000000;
-      else if (sizeType == QChar('T'))
-            return i * 0x10000000000;
-      //else if (sizeType == QChar(' ')) // the size is written as bytes
-      return i;
+      if (nextItem.type() != type())
+            return false;
+      return getSize() < static_cast<const ExtensionFileSize&>(nextItem).getSize();
       }
 
 //---------------------------------------------------------
@@ -92,15 +70,19 @@ int ExtensionFileSize::int2size(QChar sizeType, int i)
 //---------------------------------------------------------
 
 LanguageFileSize::LanguageFileSize(const double d)
-      : QTableWidgetItem(ResourceManager::tr("%1 KB").arg(d))
-      , _size(d)
+   : QTableWidgetItem(ResourceManager::tr("%1 KB").arg(d), QTableWidgetItem::UserType)
+     , _size(d)
       {}
+
+//---------------------------------------------------------
+//   operator<
+//---------------------------------------------------------
 
 bool LanguageFileSize::operator<(const QTableWidgetItem& nextItem) const
       {
-      QString nextText = nextItem.text();
-      double nextSize = nextText.remove(QChar(' ')).remove(QChar('K')).remove(QChar('B')).toDouble();
-      return getSize() < nextSize;
+      if (nextItem.type() != type())
+            return false;
+      return getSize() < static_cast<const LanguageFileSize&>(nextItem).getSize();
       }
 
 //---------------------------------------------------------

--- a/mscore/resourceManager.h
+++ b/mscore/resourceManager.h
@@ -19,47 +19,46 @@
 namespace Ms {
 
 class ResourceManager : public QDialog, public Ui::Resource
-   {
-    Q_OBJECT
+      {
+      Q_OBJECT
 
-    virtual void hideEvent(QHideEvent*);
-    QByteArray txt;
-    void displayLanguages();
-    void displayExtensions();
-    bool verifyFile(QString path, QString hash);
-    bool verifyLanguageFile(QString filename, QString hash);
+      virtual void hideEvent(QHideEvent*);
+      QByteArray txt;
+      void displayLanguages();
+      void displayExtensions();
+      bool verifyFile(QString path, QString hash);
+      bool verifyLanguageFile(QString filename, QString hash);
+      
+   public:
+      explicit ResourceManager(QWidget *parent = 0);
+      void selectLanguagesTab();
+      void selectExtensionsTab();
+      
+      static inline QString baseAddr() { return "http://extensions.musescore.org/3.4/"; }
 
-public:
-    explicit ResourceManager(QWidget *parent = 0);
-    void selectLanguagesTab();
-    void selectExtensionsTab();
+   private:
+      QMap <QPushButton *, QString> languageButtonMap; 	// QPushButton -> filename
+      QMap <QPushButton *, QString> languageButtonHashMap;// QPushButton -> hash of the file
 
-    static inline QString baseAddr() { return "http://extensions.musescore.org/3.4/"; }
-
-private:
-    QMap <QPushButton *, QString> languageButtonMap; 	// QPushButton -> filename
-    QMap <QPushButton *, QString> languageButtonHashMap;// QPushButton -> hash of the file
-
-private slots:
-    void downloadLanguage();
-    void downloadExtension();
-    void uninstallExtension();
-   };
+   private slots:
+      void downloadLanguage();
+      void downloadExtension();
+      void uninstallExtension();
+      };
 
 class ExtensionFileSize : public QTableWidgetItem
-   {
+      {
       int _size;
 
    public:
       ExtensionFileSize(const int i);
       int getSize() const { return _size; }
       bool operator<(const QTableWidgetItem& nextItem) const;
-      static int int2size(QChar sizeType, int i);
 
-   };
+      };
 
 class LanguageFileSize : public QTableWidgetItem
-   {
+      {
       double _size;
 
    public:
@@ -67,7 +66,7 @@ class LanguageFileSize : public QTableWidgetItem
       double getSize() const { return _size; }
       bool operator<(const QTableWidgetItem& nextItem) const;
 
-   };
+      };
 
 }
 #endif // RESOURCE_H

--- a/mscore/stringutils.cpp
+++ b/mscore/stringutils.cpp
@@ -101,65 +101,47 @@ QString stringutils::removeDiacritics(const QString& pre)
 
 QString stringutils::convertFileSizeToHumanReadable(const qlonglong& bytes)
       {
-      QString number;
-      if (bytes < 0x400) { // If less than 1 KB, report in B
-            number = QLocale::system().toString(bytes);
-            number.append(" B");
-            return number;
+      // If less than 1 KB, report in B
+      if (bytes < 0x400) {
+            return tr("%1 B").arg(bytes);
             }
-      else {
-            if (bytes >= 0x400 && bytes < 0x100000) { // If less than 1 MB, report in KB, unless rounded result is 1024 KB, then report in MB
-                  qlonglong result = (bytes + (0x400 / 2)) / 0x400;
-                  if (result < 0x400) {
-                        number = QLocale::system().toString(result);
-                        number.append(" KB");
-                        return number;
-                        }
-                  else {
-                        result = (bytes + (0x100000 / 2)) / 0x100000;
-                        number = QLocale::system().toString(result);
-                        number.append(" MB");
-                        return number;
-                        }
+      // If less than 1 MB, report in KB, unless rounded result is 1024 KB, then report in MB
+      else if (bytes >= 0x400 && bytes < 0x100000) {
+            qlonglong result = (bytes + (0x400 / 2)) / 0x400;
+            if (result < 0x400) {
+                  return tr("%1 KB").arg(result);
                   }
             else {
-                  if (bytes >= 0x100000 && bytes < 0x40000000) { // If less than 1 GB, report in MB, unless rounded result is 1024 MB, then report in GB
-                        qlonglong result = (bytes + (0x100000 / 2)) / 0x100000;
-                        if (result < 0x100000) {
-                              number = QLocale::system().toString(result);
-                              number.append(" MB");
-                              return number;
-                              }
-                        else {
-                              result = (bytes + (0x40000000 / 2)) / 0x40000000;
-                              number = QLocale::system().toString(result);
-                              number.append(" GB");
-                              return number;
-                              }
-                        }
-                  else {
-                        if (bytes >= 0x40000000 && bytes < 0x10000000000) { // If less than 1 TB, report in GB, unless rounded result is 1024 GB, then report in TB
-                              qlonglong result = (bytes + (0x40000000 / 2)) / 0x40000000;
-                              if (result < 0x40000000) {
-                                    number = QLocale::system().toString(result);
-                                    number.append(" GB");
-                                    return number;
-                                    }
-                              else {
-                                    result = (bytes + (0x10000000000 / 2)) / 0x10000000000;
-                                    number = QLocale::system().toString(result);
-                                    number.append(" TB");
-                                    return number;
-                                    }
-                            }
-                        else {
-                              qlonglong result = (bytes + (0x10000000000 / 2)) / 0x10000000000; // If more than 1 TB, report in TB
-                              number = QLocale::system().toString(result);
-                              number.append(" TB");
-                              return number;
-                              }
-                        }
+                  result = (bytes + (0x100000 / 2)) / 0x100000;
+                  return tr("%1 MB").arg(result);
                   }
+            }
+      // If less than 1 GB, report in MB, unless rounded result is 1024 MB, then report in GB
+      else if (bytes >= 0x100000 && bytes < 0x40000000) {
+            qlonglong result = (bytes + (0x100000 / 2)) / 0x100000;
+            if (result < 0x100000) {
+                  return tr("%1 MB").arg(result);
+                  }
+            else {
+                  result = (bytes + (0x40000000 / 2)) / 0x40000000;
+                  return tr("%1 GB").arg(result);
+                  }
+            }
+      // If less than 1 TB, report in GB, unless rounded result is 1024 GB, then report in TB
+      else if (bytes >= 0x40000000 && bytes < 0x10000000000) {
+            qlonglong result = (bytes + (0x40000000 / 2)) / 0x40000000;
+            if (result < 0x40000000) {
+                  return tr("%1 GB").arg(result);
+                  }
+            else {
+                  result = (bytes + (0x10000000000 / 2)) / 0x10000000000;
+                  return tr("%1 TB").arg(result);
+                  }
+            }
+      // If more than 1 TB, report in TB
+      else {
+            qlonglong result = (bytes + (0x10000000000 / 2)) / 0x10000000000;
+            return tr("%1 TB").arg(result);
             }
       }
 


### PR DESCRIPTION
Kind of a follow-up for #5405, but not really, it's a bug existing before. First brought up in #5513.