### PR TITLE
fix #298564: shift of manually adjusted slur on small staff

### DIFF
--- a/libmscore/slurtie.cpp
+++ b/libmscore/slurtie.cpp
@@ -311,7 +311,7 @@ void SlurTieSegment::writeSlur(XmlWriter& xml, int no) const
 
       xml.stag(this, QString("no=\"%1\"").arg(no));
 
-      qreal _spatium = spatium();
+      qreal _spatium = score()->spatium();
       if (!ups(Grip::START).off.isNull())
             xml.tag("o1", ups(Grip::START).off / _spatium);
       if (!ups(Grip::BEZIER1).off.isNull())
@@ -330,7 +330,7 @@ void SlurTieSegment::writeSlur(XmlWriter& xml, int no) const
 
 void SlurTieSegment::read(XmlReader& e)
       {
-      qreal _spatium = spatium();
+      qreal _spatium = score()->spatium();
       while (e.readNextStartElement()) {
             const QStringRef& tag(e.name());
             if (tag == "o1")

--- a/mtest/libmscore/spanners/smallstaff01-ref.mscx
+++ b/mtest/libmscore/spanners/smallstaff01-ref.mscx
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.01">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <pagePrintableWidth>7.4826</pagePrintableWidth>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          <small>1</small>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument>
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Spanner type="Pedal">
+            <Pedal>
+              <endHookType>1</endHookType>
+              <beginHookType>1</beginHookType>
+              <Segment>
+                <subtype>0</subtype>
+                <offset x="0" y="2.8"/>
+                <off2 x="-10.5" y="0"/>
+                </Segment>
+              </Pedal>
+            <next>
+              <location>
+                <fractions>1/1</fractions>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Spanner type="Slur">
+              <Slur>
+                <SlurSegment no="0">
+                  <o2 x="0" y="-2.8"/>
+                  <o3 x="0" y="-2.8"/>
+                  </SlurSegment>
+                </Slur>
+              <next>
+                <location>
+                  <fractions>3/4</fractions>
+                  </location>
+                </next>
+              </Spanner>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <pitch>74</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <pitch>76</pitch>
+              <tpc>18</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Spanner type="Slur">
+              <prev>
+                <location>
+                  <fractions>-3/4</fractions>
+                  </location>
+                </prev>
+              </Spanner>
+            <Note>
+              <pitch>77</pitch>
+              <tpc>13</tpc>
+              </Note>
+            </Chord>
+          <Spanner type="Pedal">
+            <prev>
+              <location>
+                <fractions>-1/1</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/spanners/smallstaff01.mscx
+++ b/mtest/libmscore/spanners/smallstaff01.mscx
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.01">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <pagePrintableWidth>7.4826</pagePrintableWidth>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          <small>1</small>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument>
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Spanner type="Pedal">
+            <Pedal>
+              <endHookType>1</endHookType>
+              <beginHookType>1</beginHookType>
+              <Segment>
+                <subtype>0</subtype>
+                <offset x="0" y="2.8"/>
+                <off2 x="-10.5" y="0"/>
+                </Segment>
+              </Pedal>
+            <next>
+              <location>
+                <fractions>1/1</fractions>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Spanner type="Slur">
+              <Slur>
+                <SlurSegment no="0">
+                  <o2 x="0" y="-2.8"/>
+                  <o3 x="0" y="-2.8"/>
+                  </SlurSegment>
+                </Slur>
+              <next>
+                <location>
+                  <fractions>3/4</fractions>
+                  </location>
+                </next>
+              </Spanner>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <pitch>74</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <pitch>76</pitch>
+              <tpc>18</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Spanner type="Slur">
+              <prev>
+                <location>
+                  <fractions>-3/4</fractions>
+                  </location>
+                </prev>
+              </Spanner>
+            <Note>
+              <pitch>77</pitch>
+              <tpc>13</tpc>
+              </Note>
+            </Chord>
+          <Spanner type="Pedal">
+            <prev>
+              <location>
+                <fractions>-1/1</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/spanners/tst_spanners.cpp
+++ b/mtest/libmscore/spanners/tst_spanners.cpp
@@ -54,6 +54,7 @@ class TestSpanners : public QObject, public MTest
 //      void spanners13();            // drop a line break at the middle of a LyricsLine and check LyricsLineSegments
       void spanners14();            // creating part from an existing grand staff containing a cross staff glissando
       void spanners15();            // change the color & min distance of a line and save it
+      void spanners16();            // read lines with manual adjustments on a small staff and save
       };
 
 //---------------------------------------------------------
@@ -644,6 +645,20 @@ void TestSpanners::spanners15()
             }
 
       QVERIFY(saveCompareScore(score, "linecolor01.mscx", DIR + "linecolor01-ref.mscx"));
+      delete score;
+      }
+
+//---------------------------------------------------------
+///  spanners16
+///   read manually adjusted lines on a small staff and save
+//---------------------------------------------------------
+
+void TestSpanners::spanners16()
+      {
+      MasterScore* score = readScore(DIR + "smallstaff01.mscx");
+      QVERIFY(score);
+
+      QVERIFY(saveCompareScore(score, "smallstaff01.mscx", DIR + "smallstaff01-ref.mscx"));
       delete score;
       }
 

--- a/mtest/libmscore/spanners/updateReference
+++ b/mtest/libmscore/spanners/updateReference
@@ -7,9 +7,11 @@ cp ../../../build.debug/mtest/libmscore/spanners/glissando-cloning02.mscx    gli
 cp ../../../build.debug/mtest/libmscore/spanners/glissando-cloning03.mscx    glissando-cloning03-ref.mscx
 cp ../../../build.debug/mtest/libmscore/spanners/glissando-cloning04.mscx    glissando-cloning04-ref.mscx
 cp ../../../build.debug/mtest/libmscore/spanners/glissando-cloning05.mscx    glissando-cloning05-ref.mscx
-cp ../../../build.debug/mtest/libmscore/spanners/glissando-crsossstaff01.mscx glissando-crossstaff01-ref.mscx
+cp ../../../build.debug/mtest/libmscore/spanners/glissando-crossstaff01.mscx glissando-crossstaff01-ref.mscx
 cp ../../../build.debug/mtest/libmscore/spanners/glissando-graces01.mscx     glissando-graces01-ref.mscx
 cp ../../../build.debug/mtest/libmscore/spanners/lyricsline02.mscx           lyricsline02-ref.mscx
 cp ../../../build.debug/mtest/libmscore/spanners/lyricsline03.mscx           lyricsline03-ref.mscx
 cp ../../../build.debug/mtest/libmscore/spanners/lyricsline04.mscx           lyricsline04-ref.mscx
 cp ../../../build.debug/mtest/libmscore/spanners/lyricsline05.mscx           lyricsline05-ref.mscx
+cp ../../../build.debug/mtest/libmscore/spanners/linecolor01.mscx            linecolor01-ref.mscx
+cp ../../../build.debug/mtest/libmscore/spanners/smallstaff01.mscx           smallstaff01-ref.mscx


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/298564

We currently write the offsets for slur grips
scaled according to the staff, but we read them
scaled according to the score.  That's because
on read, the slur hasn't been added yet, so the track is not set.
I fixed the exact same issue for other lines in
https://github.com/musescore/MuseScore/commit/812a2811b9754e8c327e491c722ea4b6202670a4
but slurs have their own read/write and I neglected
to make the corresponding change for them.
This fixes the issue by explicitly scaling according to score.
Note there are other reasons why this makes sense,
see other comments in https://github.com/musescore/MuseScore/pull/4827
for more information on the scaling of offsets and other properties.

I couldn't see a good way to create an automated test for this, as it relies on manual adjustment via editDrag().  Perhaps the recent enhancements to mtest make this more feasible?