### PR TITLE
[Inspector] make the appearance of layout break inspector consistent with other inspectors

### DIFF
--- a/mscore/inspector/inspector_break.ui
+++ b/mscore/inspector/inspector_break.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>86</width>
-    <height>29</height>
+    <width>148</width>
+    <height>34</height>
    </rect>
   </property>
   <property name="accessibleName">
@@ -16,9 +16,6 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
     <number>0</number>
-   </property>
-   <property name="sizeConstraint">
-    <enum>QLayout::SetNoConstraint</enum>
    </property>
    <property name="leftMargin">
     <number>0</number>
@@ -43,7 +40,13 @@
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="elementName">
+    <widget class="QToolButton" name="title">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="font">
       <font>
        <weight>75</weight>
@@ -53,24 +56,27 @@
      <property name="text">
       <string>Layout Break</string>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
     </widget>
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetDefaultConstraint</enum>
+     </property>
      <property name="leftMargin">
+      <number>3</number>
+     </property>
+     <property name="topMargin">
       <number>3</number>
      </property>
      <property name="rightMargin">
       <number>3</number>
      </property>
-     <property name="horizontalSpacing">
+     <property name="bottomMargin">
       <number>3</number>
      </property>
-     <property name="verticalSpacing">
-      <number>0</number>
+     <property name="spacing">
+      <number>3</number>
      </property>
     </layout>
    </item>


### PR DESCRIPTION
Right now if you switch the inspector from a section break inspector to layout break inspector, you'll notice the top margin of layout break inspector is thinner, that's because the title is a `QLabel` instead of a `QToolButton` like every other inspector. This patch makes the appearance consistent by changing that `QLabel` to a `QToolButton`.