### PR TITLE
fix MinGW build and simplify resfile.o generation

### DIFF
--- a/build/wine.bat
+++ b/build/wine.bat
@@ -1,2 +1,0 @@
-@echo off
-windres %2 %3 %4 %5 %6 %7 %8 %9

--- a/build/wrc.bat
+++ b/build/wrc.bat
@@ -1,2 +1,0 @@
-@echo off
-windres %*

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -84,12 +84,9 @@ endif (APPLE)
 
 
 if (MINGW)
-   set (QT_WRC_EXECUTABLE        ${PROJECT_SOURCE_DIR}/build/wrc.bat)
-   set (QT_WINE_EXECUTABLE       ${PROJECT_SOURCE_DIR}/build/wine.bat)
    add_custom_command(
       OUTPUT ${PROJECT_BINARY_DIR}/resfile.o
-      COMMAND ${QT_WRC_EXECUTABLE} -i mscore.rc -o ${PROJECT_BINARY_DIR}/mscore.res
-      COMMAND ${QT_WINE_EXECUTABLE} /home/ws/.wine/drive_c/MingW/bin/windres.exe ${PROJECT_BINARY_DIR}/mscore.res -o ${PROJECT_BINARY_DIR}/resfile.o
+      COMMAND ${CMAKE_RC_COMPILER} -i mscore.rc -o ${PROJECT_BINARY_DIR}/resfile.o
       DEPENDS ${PROJECT_SOURCE_DIR}/mscore/data/mscore.rc
       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/mscore/data
       )
@@ -128,7 +125,7 @@ if (MINGW)
    endforeach (QtLibrary ${QT_LIBRARIES})
    list(REMOVE_DUPLICATES QtInstallLibraries)
 
-   target_link_libraries(mscore ${QT_LIBRARIES})
+   # target_link_libraries(mscore ${QT_LIBRARIES})
 
    install( TARGETS mscore RUNTIME DESTINATION bin )
 


### PR DESCRIPTION
The MinGW build was not linking because of the order in which the Qt libraries were appearing at link time.
The simplification of resfile.o generation cleans up some very old code and should also allow cross-compilation for Windows under Linux (e.g. with MXE).

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [N/A] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
