### PR TITLE
Telemetry build configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ option(BUILD_64 "Build 64 bit version of editor" ON)
 option(BUILD_AUTOUPDATE "Build with autoupdate support" OFF)
 option(BUILD_CRASH_REPORTER "Build with crash reporter" OFF)
 set(CRASH_REPORT_URL "http://127.0.0.1:1127/post" CACHE STRING "URL where to send crash reports (valid if BUILD_CRASH_REPORTER is set to ON)")
-option(BUILD_TELEMETRY_MODULE "Build with telemetry module" OFF)
+option(BUILD_TELEMETRY_MODULE "Build with telemetry module" ON)
 set(TELEMETRY_TRACK_ID "" CACHE STRING "Telemetry track id")
 
 if (BUILD_CRASH_REPORTER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,10 @@ set(CRASH_REPORT_URL "http://127.0.0.1:1127/post" CACHE STRING "URL where to sen
 option(BUILD_TELEMETRY_MODULE "Build with telemetry module" ON)
 set(TELEMETRY_TRACK_ID "" CACHE STRING "Telemetry track id")
 
+if (MSCORE_UNSTABLE OR TELEMETRY_TRACK_ID STREQUAL "")
+    add_definitions(-DTELEMETRY_DISABLED)
+endif(MSCORE_UNSTABLE OR TELEMETRY_TRACK_ID STREQUAL "")
+
 if (BUILD_CRASH_REPORTER)
       message("Crash reporter enabled")
 endif(BUILD_CRASH_REPORTER)

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -160,7 +160,7 @@ extern Ms::Synthesizer* createZerberus();
 #include "thirdparty/libcrashreporter-qt/src/libcrashreporter-handler/Handler.h"
 #endif
 
-#ifdef BUILD_TELEMETRY_MODULE
+#ifndef TELEMETRY_DISABLED
 #include "actioneventobserver.h"
 #include "widgets/telemetrypermissiondialog.h"
 #endif
@@ -7048,7 +7048,7 @@ bool MuseScore::saveMp3(Score* score, QIODevice* device, bool& wasCanceled)
 #endif
       }
 
-#ifdef BUILD_TELEMETRY_MODULE
+#ifndef TELEMETRY_DISABLED
 
 void tryToRequestTelemetryPermission()
       {
@@ -7501,7 +7501,7 @@ int runApplication(int& argc, char** av)
             return ok ? EXIT_SUCCESS : EXIT_FAILURE;
             }
 
-#ifdef BUILD_TELEMETRY_MODULE
+#ifndef TELEMETRY_DISABLED
       tryToRequestTelemetryPermission();
 #endif
 
@@ -7727,7 +7727,7 @@ void MuseScore::init(QStringList& argv)
 
       QApplication::instance()->installEventFilter(mscore);
 
-#ifdef BUILD_TELEMETRY_MODULE
+#ifndef TELEMETRY_DISABLED
       QApplication::instance()->installEventFilter(ActionEventObserver::instance());
 #endif
 

--- a/telemetry/services/telemetryservice.cpp
+++ b/telemetry/services/telemetryservice.cpp
@@ -60,9 +60,9 @@ void TelemetryService::endSession()
 
 bool TelemetryService::isTelemetryAllowed() const
       {
-#ifdef MSCORE_UNSTABLE
-      return false;
-#else
+#ifndef TELEMETRY_DISABLED
       return m_settings.value(PREF_APP_TELEMETRY_ALLOWED, false).toBool();
+#else
+      return false;
 #endif
       }


### PR DESCRIPTION
Disabled explicitly sending telemetry data in unstable builds or when trackid is empty

