### PR TITLE
telemetry_dialog_content_height

### DIFF
--- a/telemetry/qml/TelemetryPermissionDialog.qml
+++ b/telemetry/qml/TelemetryPermissionDialog.qml
@@ -25,6 +25,8 @@ Rectangle {
 
     signal closeRequested()
 
+    height: childrenRect.height
+
     color: globalStyle.window
 
     TelemetryPermissionModel {
@@ -34,16 +36,16 @@ Rectangle {
     Column {
         id: contentWrapper
 
-        anchors {
-            top: root.top
-            topMargin: 36
-            bottom: root.bottom
-            bottomMargin: 0
-        }
-
         width: root.width
 
         spacing: 36
+
+        Item {
+            id: topSpacer
+
+            height: 1
+            width: parent.width
+        }
 
         Text {
             id: titleLabel
@@ -173,6 +175,13 @@ Rectangle {
                     }
                 }
             }
+        }
+
+        Item {
+            id: bottomSpacer
+
+            height: 1
+            width: parent.width
         }
     }
 }

--- a/telemetry/widgets/telemetrypermissiondialog.cpp
+++ b/telemetry/widgets/telemetrypermissiondialog.cpp
@@ -34,10 +34,11 @@ TelemetryPermissionDialog::TelemetryPermissionDialog(QWidget* parentWidget) : QQ
       setSource(url);
 
       setModality(Qt::ApplicationModal);
-      setResizeMode(QQuickView::SizeRootObjectToView);
+      setResizeMode(QQuickView::SizeViewToRootObject);
       setTitle("");
 
       QObject* rootItem = qobject_cast<QObject*>(rootObject());
+      rootObject()->setWidth(minimumWidth());
 
       connect(rootItem, SIGNAL(closeRequested()), this, SLOT(close()));
       }


### PR DESCRIPTION
Changed resize policy for the dialog view. Now it depends on the size of the content and should look nicer with all languages.