### PR TITLE
fix #278169: images attached to rests not imported from MuseScore 2

### DIFF
--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -2064,6 +2064,16 @@ bool readChordRestProperties206(XmlReader& e, ChordRest* ch)
             QPointF pt = e.readPoint();
             ch->setOffset(pt * ch->spatium());
             }
+      else if (ch->isRest() && tag == "Image"){
+            if (MScore::noImages)
+                  e.skipCurrentElement();
+            else {
+                  Image *image = new Image(ch->score());
+                  image->setTrack(e.track());
+                  image->read(e);
+                  ch->add(image);
+                  }
+            }
       else if (!readDurationProperties206(e, ch))
             return false;
       return true;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/278169

The code to read an Image tag attached to a note was present in read206.cpp
but the analogous code for a rest was missing. The same has been added.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
