### PR TITLE
[Inspector] [Regression] fix #298913: new section break inspector lose data

### DIFF
--- a/libmscore/layoutbreak.cpp
+++ b/libmscore/layoutbreak.cpp
@@ -32,12 +32,14 @@ static const ElementStyle sectionBreakStyle {
 LayoutBreak::LayoutBreak(Score* score)
    : Element(score, ElementFlag::SYSTEM | ElementFlag::HAS_TAG)
       {
-      _layoutBreakType     = Type(propertyDefault(Pid::LAYOUT_BREAK).toInt());
-      _pause               = score->styleD(Sid::SectionPause);
-      _startWithLongNames  = true;
-      _startWithMeasureOne = true;
-      lw                   = spatium() * 0.3;
+      _layoutBreakType = Type(propertyDefault(Pid::LAYOUT_BREAK).toInt());
+
       initElementStyle(&sectionBreakStyle);
+
+      resetProperty(Pid::PAUSE);
+      resetProperty(Pid::START_WITH_LONG_NAMES);
+      resetProperty(Pid::START_WITH_MEASURE_ONE);
+      lw = spatium() * 0.3;
       }
 
 LayoutBreak::LayoutBreak(const LayoutBreak& lb)
@@ -60,13 +62,9 @@ void LayoutBreak::write(XmlWriter& xml) const
       xml.stag(this);
       Element::writeProperties(xml);
 
-      writeProperty(xml, Pid::LAYOUT_BREAK);
-      writeProperty(xml, Pid::PAUSE);
+      for (auto id : { Pid::LAYOUT_BREAK, Pid::PAUSE, Pid::START_WITH_LONG_NAMES, Pid::START_WITH_MEASURE_ONE })
+            writeProperty(xml, id);
 
-      if (!_startWithLongNames)
-            xml.tag("startWithLongNames", _startWithLongNames);
-      if (!_startWithMeasureOne)
-            xml.tag("startWithMeasureOne", _startWithMeasureOne);
       xml.etag();
       }
 
@@ -81,11 +79,11 @@ void LayoutBreak::read(XmlReader& e)
             if (tag == "subtype")
                   readProperty(e, Pid::LAYOUT_BREAK);
             else if (tag == "pause")
-                  _pause = e.readDouble();
+                  readProperty(e, Pid::PAUSE);
             else if (tag == "startWithLongNames")
-                  _startWithLongNames = e.readInt();
+                  readProperty(e, Pid::START_WITH_LONG_NAMES);
             else if (tag == "startWithMeasureOne")
-                  _startWithMeasureOne = e.readInt();
+                  readProperty(e, Pid::START_WITH_MEASURE_ONE);
             else if (!Element::readProperties(e))
                   e.unknown();
             }


### PR DESCRIPTION
Resolves: https://musescore.org/node/298913.

This is because `read()` and `write()` aren't updated to "inspector style" (which deals with `Pid` instead of variables in class).