### PR TITLE
fix #297719 : [Linux AppImage] System printers not available in print…

### DIFF
--- a/build/Linux+BSD/portable/Recipe
+++ b/build/Linux+BSD/portable/Recipe
@@ -225,6 +225,10 @@ mv "${qt_sql_drivers_tmp}/libqsqlpsql.so" "${qt_sql_drivers_path}/libqsqlpsql.so
 # BUNDLE REMAINING DEPENDENCIES MANUALLY
 ##########################################################################
 
+# Manually bundle printsupport plugin, see issue #297719
+mkdir -p "${appdir}/plugins/printsupport/"
+cp -L "${QT_PLUGIN_PATH}/printsupport/libcupsprintersupport.so" "${appdir}/plugins/printsupport/libcupsprintersupport.so"
+
 function find_library()
 {
   # Print full path to a library or return exit status 1 if not found


### PR DESCRIPTION
… dialogue

Resolves: https://musescore.org/en/node/297719

Linuxdeploy, with qt-plugin, used to deploy the AppImage, does not include at the moment the library libcupsprintersupport.so which is needed for printing support, so we should manually include it.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n/a] I created the test (mtest, vtest, script test) to verify the changes I made
