### PR TITLE
fix #298959: Note changes pitch, but accidental is not changed

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1829,7 +1829,7 @@ void Score::changeAccidental(Note* note, AccidentalType accidental)
       // precautionary or microtonal accidental
       // either way, we display it unconditionally
       // both for this note and for any linked notes
-      else if (acc == acc2 || pitch == note->pitch() || Accidental::isMicrotonal(accidental))
+      else if (acc == acc2 || (pitch == note->pitch() && !Accidental::isMicrotonal(note->accidentalType())) || Accidental::isMicrotonal(accidental))
             forceAdd = true;
 
       for (ScoreElement* se : note->linkList()) {
@@ -1852,6 +1852,9 @@ void Score::changeAccidental(Note* note, AccidentalType accidental)
                   a1->setAccidentalType(accidental);
                   a1->setRole(AccidentalRole::USER);
                   lns->undoAddElement(a1);
+                  }
+            else if (a && Accidental::isMicrotonal(a->accidentalType())) {
+                  lns->undoRemoveElement(a);
                   }
             changeAccidental2(ln, pitch, tpc);
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/298959.

Note: In the following paragraphs, I use the word "microtonal" to refer to all accidentals for which Accidental::isMicrotonal() currently returns true. That is, all proper microtonal accidentals as well as NATURAL_FLAT, NATURAL_SHARP, and SHARP_SHARP.

When force adding or force removing an accidental, Score::changeAccidental() will remove a note's existing accidental (if any) from the score. When not force adding or force removing an accidental, the note's pitch is changed, but the accidental is left alone until Note::updateAccidental() is called. But Note::updateAccidental() does not touch microtonal accidentals, so any existing microtonal accidentals must be removed in Score::changeAccidental().

Also, when changing from a microtonal accidental to a non-microtonal accidental that results in the same change to the pitch of the note, the new accidental's role is currently set to USER every time, when in fact this should only be done if it truly is a courtesy accidental. So when determining whether or not the accidental is being force added, when we are comparing the new pitch to the old pitch, we should also look at whether the old accidental was microtonal or not, to make sure that the accidental's role is not being set incorrectly.