### PR TITLE
[MU4] fix #295257: Page-Width shortcut with previous zoom-level toggle

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6585,6 +6585,23 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             cv->setMag(MagIdx::MAG_100, 1.0);
         }
         setMag(1.0);
+    } else if (cmd == "zoom-page-width") {
+        if (cv) {
+            MagIdx currentMagIdx = cv->magIdx();
+            if (currentMagIdx != MagIdx::MAG_PAGE_WIDTH) {
+                // Save current zoom state for toggle
+                cv->previousMagIdx(currentMagIdx);
+                // Update zoom drop-down list
+                mag->setMagIdx(MagIdx::MAG_PAGE_WIDTH);
+                // Update the score's actual zoom-level
+                mag->magChanged(MagIdx::MAG_PAGE_WIDTH);
+            } else {
+                // If current zoom-level is page-width,
+                // switch to previous zoom-level
+                mag->setMagIdx(cv->previousMagIdx());
+                mag->magChanged(cv->previousMagIdx());
+            }
+        }
     } else if (cmd == "midi-on") {
         midiinToggled(a->isChecked());
     } else if (cmd == "undo") {

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -21,6 +21,7 @@
 #include "libmscore/mscoreview.h"
 #include "libmscore/pos.h"
 #include "libmscore/harmony.h"
+#include "mscore/magbox.h"
 
 namespace Ms {
 class ChordRest;
@@ -148,6 +149,8 @@ class ScoreView : public QWidget, public MuseScoreView
 
     QTransform _matrix, imatrix;
     MagIdx _magIdx;
+    // for magnification zoom-level toggling:
+    MagIdx _previousMagIdx { MagIdx::MAG_PAGE_WIDTH };
 
     QFocusFrame* focusFrame;
 
@@ -474,6 +477,9 @@ public:
     FotoLasso* fotoLasso() const { return _foto; }
     Element* getEditElement();
     void onElementDestruction(Element*) override;
+
+    MagIdx previousMagIdx() const { return _previousMagIdx; }
+    void previousMagIdx(MagIdx id) { _previousMagIdx = id; }
 
     virtual Element* elementNear(QPointF);
     QList<Element*> elementsNear(QPointF);

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2647,6 +2647,13 @@ Shortcut Shortcut::_sc[] = {
         QT_TRANSLATE_NOOP("action","Zoom to 100%")
     },
     {
+        MsWidget::MAIN_WINDOW,
+        STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_PLAY,
+        "zoom-page-width",
+        QT_TRANSLATE_NOOP("action","Zoom to Page Width or Previous Magnification Level"),
+        QT_TRANSLATE_NOOP("action","Zoom to page-width / previous magnification level")
+    },
+    {
         MsWidget::SCORE_TAB,
         STATE_NORMAL | STATE_NOTE_ENTRY,
         "mirror-note",


### PR DESCRIPTION
Feature Request: #295257 - Implement Page-Width Shortcut.

This provides the user a shortcut entitled: "Zoom to page-width / previous magnification level" which serves mainly as Page-Width shortcut, but with the additional feature to toggle between it and any previous zoom level. A simple screen-cast is given at https://musescore.org/en/node/298839

There's also a desire shown for making Page-Width the default zoom level, and I also support it. I figured if I do that  { if no one beats me to it >:o }, I'll make a separate pull request rather than have it also be part of this as a shortcut. One thing at a time. It's been a while since I've done GIT requests, so excuse the mis-match of the # or whatever else. 