### PR TITLE
fix #277800: allow to preserve ties when replacing measures (by removing and inserting them)

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -552,7 +552,7 @@ bool Score::rewriteMeasures(Measure* fm, Measure* lm, const Fraction& ns, int st
                 undo(new RemoveElement(i.value));
             }
         }
-        s->undoRemoveMeasures(m1, m2);
+        s->undoRemoveMeasures(m1, m2, true);
 
         Measure* nfm = 0;
         Measure* nlm = 0;
@@ -2187,7 +2187,7 @@ void Score::deleteItem(Element* el)
 //   deleteMeasures
 //---------------------------------------------------------
 
-void Score::deleteMeasures(MeasureBase* is, MeasureBase* ie)
+void Score::deleteMeasures(MeasureBase* is, MeasureBase* ie, bool preserveTies)
 {
 // qDebug("deleteMeasures %p %p", is, ie);
 
@@ -2271,7 +2271,7 @@ void Score::deleteMeasures(MeasureBase* is, MeasureBase* ie)
         Measure* mis = score->tick2measure(startTick);
         Measure* mie = score->tick2measure(endTick);
 
-        score->undoRemoveMeasures(mis, mie);
+        score->undoRemoveMeasures(mis, mie, preserveTies);
 
         // adjust views
         Measure* focusOn = mis->prevMeasure() ? mis->prevMeasure() : score->firstMeasure();
@@ -5482,7 +5482,7 @@ void Score::undoInsertTime(const Fraction& tick, const Fraction& len)
 //   undoRemoveMeasures
 //---------------------------------------------------------
 
-void Score::undoRemoveMeasures(Measure* m1, Measure* m2)
+void Score::undoRemoveMeasures(Measure* m1, Measure* m2, bool preserveTies)
 {
     Q_ASSERT(m1 && m2);
 
@@ -5507,7 +5507,11 @@ void Score::undoRemoveMeasures(Measure* m1, Measure* m2)
                 // Remove ties crossing measure range boundaries
                 Tie* t = n->tieBack();
                 if (t && (t->startNote()->chord()->tick() < startTick)) {
-                    undoRemoveElement(t);
+                    if (preserveTies) {
+                        t->setEndNote(0);
+                    } else {
+                        undoRemoveElement(t);
+                    }
                 }
                 t = n->tieFor();
                 if (t && (t->endNote()->chord()->tick() >= endTick)) {

--- a/libmscore/joinMeasure.cpp
+++ b/libmscore/joinMeasure.cpp
@@ -58,7 +58,7 @@ void Score::cmdJoinMeasure(Measure* m1, Measure* m2)
         }
     }
 
-    deleteMeasures(m1, m2);
+    deleteMeasures(m1, m2, true);
 
     MeasureBase* next = m2->next();
     const Fraction newTimesig = m1->timesig();

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -707,7 +707,7 @@ public:
     void undoPropertyChanged(ScoreElement*, Pid, const QVariant& v, PropertyFlags ps = PropertyFlags::NOSTYLE);
     inline virtual UndoStack* undoStack() const;
     void undo(UndoCommand*, EditData* = 0) const;
-    void undoRemoveMeasures(Measure*, Measure*);
+    void undoRemoveMeasures(Measure*, Measure*, bool preserveTies = false);
     void undoAddBracket(Staff* staff, int level, BracketType type, int span);
     void undoRemoveBracket(Bracket*);
     void undoInsertTime(const Fraction& tick, const Fraction& len);
@@ -759,7 +759,7 @@ public:
     NoteVal noteValForPosition(Position pos, AccidentalType at, bool& error);
 
     void deleteItem(Element*);
-    void deleteMeasures(MeasureBase* firstMeasure, MeasureBase* lastMeasure);
+    void deleteMeasures(MeasureBase* firstMeasure, MeasureBase* lastMeasure, bool preserveTies = false);
     void cmdDeleteSelection();
     void cmdFullMeasureRest();
 

--- a/libmscore/splitMeasure.cpp
+++ b/libmscore/splitMeasure.cpp
@@ -92,7 +92,7 @@ void Score::splitMeasure(Segment* segment)
 
     MeasureBase* nm = measure->next();
 
-    undoRemoveMeasures(measure, measure);
+    undoRemoveMeasures(measure, measure, true);
     undoInsertTime(measure->tick(), -measure->ticks());
 
     // create empty measures:


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/277800

This bug one of a set of bugs that are caused by a distinction that is not currently made between **"removing"** measures (deleting them and deleting everything connected to them) and **"detaching"** measures from the score (keeping ties and other spanners connected at one end, and only dissociating them from the detached measures). this distinction is important when performing an action like `rewriteMeasures`, which needs to only "detach" the old measures and insert new ones, preserving the outgoing ties and other spanners.

This solution is only for ties and not for other spanners, but it solves similar problems with ties described above (I also tested ties across split/join measures and it worked).

(for CLA, my musescore username is liorkl)

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
