### PR TITLE
Add "Brass Band" and "Brass Quintet" instrument genres

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -15,9 +15,6 @@
       <Genre id="orchestra">
             <name>Orchestra</name>
       </Genre>
-      <Genre id="brassquintet">
-            <name>Brass Quintet</name>
-      </Genre>
       <Genre id="brassband">
             <name>Brass Band</name>
       </Genre>
@@ -2881,7 +2878,6 @@
                   </Channel>
                   <genre>common</genre>
                   <genre>orchestra</genre>
-                  <genre>brassquintet</genre>
                   <genre>concertband</genre>
                   <genre>marching</genre>
             </Instrument>
@@ -2987,7 +2983,6 @@
                   <Channel>
                         <program value="60"/> <!--French Horn-->
                   </Channel>
-                  <genre>brassquintet</genre>
                   <genre>brassband</genre>
             </Instrument>
             <Instrument id="d-horn">
@@ -3217,7 +3212,6 @@
                   <Channel>
                         <program value="60"/> <!--French Horn-->
                   </Channel>
-                  <genre>brassquintet</genre>
                   <genre>concertband</genre>
             </Instrument>
             <Instrument id="bb-baritone-horn-treble">
@@ -3427,7 +3421,6 @@
                         <program value="59"/> <!--Muted Trumpet-->
                   </Channel>
                   <genre>orchestra</genre>
-                  <genre>brassquintet</genre>
             </Instrument>
             <Instrument id="bb-trumpet">
                   <longName>B♭ Trumpet</longName>
@@ -3450,7 +3443,6 @@
                   <genre>jazz</genre>
                   <genre>popular</genre>
                   <genre>orchestra</genre>
-                  <genre>brassquintet</genre>
                   <genre>concertband</genre>
                   <genre>marching</genre>
             </Instrument>
@@ -4130,7 +4122,6 @@
                   <genre>jazz</genre>
                   <genre>orchestra</genre>
                   <genre>popular</genre>
-                  <genre>brassquintet</genre>
                   <genre>concertband</genre>
                   <genre>marching</genre>
             </Instrument>
@@ -4150,7 +4141,6 @@
                   <Channel>
                         <program value="57"/> <!--Trombone-->
                   </Channel>
-                  <genre>brassquintet</genre>
                   <genre>brassband</genre>
             </Instrument>
             <Instrument id="soprano-trombone">
@@ -4288,7 +4278,6 @@
                   <genre>common</genre>
                   <genre>jazz</genre>
                   <genre>orchestra</genre>
-                  <genre>brassquintet</genre>
                   <genre>concertband</genre>
                   <genre>marching</genre>
             </Instrument>
@@ -4335,7 +4324,6 @@
                   <Channel>
                         <program value="58"/> <!--Tuba-->
                   </Channel>
-                  <genre>brassquintet</genre>
                   <genre>brassband</genre>
             </Instrument>
             <Instrument id="c-tuba">
@@ -4381,7 +4369,6 @@
                   <Channel>
                         <program value="58"/> <!--Tuba-->
                   </Channel>
-                  <genre>brassquintet</genre>
                   <genre>brassband</genre>
             </Instrument>
             <Instrument id="bass-f-tuba">

--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -15,6 +15,12 @@
       <Genre id="orchestra">
             <name>Orchestra</name>
       </Genre>
+      <Genre id="brassquintet">
+            <name>Brass Quintet</name>
+      </Genre>
+      <Genre id="brassband">
+            <name>Brass Band</name>
+      </Genre>
       <Genre id="concertband">
             <name>Concert Band</name>
       </Genre>
@@ -2875,6 +2881,7 @@
                   </Channel>
                   <genre>common</genre>
                   <genre>orchestra</genre>
+                  <genre>brassquintet</genre>
                   <genre>concertband</genre>
                   <genre>marching</genre>
             </Instrument>
@@ -2980,6 +2987,8 @@
                   <Channel>
                         <program value="60"/> <!--French Horn-->
                   </Channel>
+                  <genre>brassquintet</genre>
+                  <genre>brassband</genre>
             </Instrument>
             <Instrument id="d-horn">
                   <longName>Horn in D</longName>
@@ -3073,6 +3082,7 @@
                   <Channel name="mute">
                         <program value="59"/> <!--Muted Trumpet-->
                   </Channel>
+                  <genre>brassband</genre>
                   <genre>concertband</genre>
             </Instrument>
             <Instrument id="c-cornet">
@@ -3110,6 +3120,7 @@
                   </Channel>
                   <genre>common</genre>
                   <genre>jazz</genre>
+                  <genre>brassband</genre>
                   <genre>concertband</genre>
             </Instrument>
             <Instrument id="a-cornet">
@@ -3206,7 +3217,27 @@
                   <Channel>
                         <program value="60"/> <!--French Horn-->
                   </Channel>
+                  <genre>brassquintet</genre>
                   <genre>concertband</genre>
+            </Instrument>
+            <Instrument id="bb-baritone-horn-treble">
+                  <!-- same as baritone-horn-treble but with "brass band" name -->
+                  <trackName>B♭ Baritone (Treble Clef)</trackName>
+                  <longName>B♭ Baritone</longName>
+                  <shortName>B♭ Bar.</shortName>
+                  <description>B♭ Baritone</description>
+                  <musicXMLid>brass.baritone-horn</musicXMLid>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>F</concertClef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>40-67</aPitchRange>
+                  <pPitchRange>40-70</pPitchRange>
+                  <transposeDiatonic>-8</transposeDiatonic>
+                  <transposeChromatic>-14</transposeChromatic>
+                  <Channel>
+                        <program value="60"/> <!--French Horn-->
+                  </Channel>
+                  <genre>brassband</genre>
             </Instrument>
             <Instrument id="posthorn">
                   <longName>Posthorn</longName>
@@ -3287,6 +3318,8 @@
                   <Channel name="mute">
                         <program value="59"/> <!--Muted Trumpet-->
                   </Channel>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
             </Instrument>
             <Instrument id="a-piccolo-trumpet">
                   <longName>Piccolo Trumpet in A</longName>
@@ -3394,6 +3427,7 @@
                         <program value="59"/> <!--Muted Trumpet-->
                   </Channel>
                   <genre>orchestra</genre>
+                  <genre>brassquintet</genre>
             </Instrument>
             <Instrument id="bb-trumpet">
                   <longName>B♭ Trumpet</longName>
@@ -3416,6 +3450,7 @@
                   <genre>jazz</genre>
                   <genre>popular</genre>
                   <genre>orchestra</genre>
+                  <genre>brassquintet</genre>
                   <genre>concertband</genre>
                   <genre>marching</genre>
             </Instrument>
@@ -3772,6 +3807,7 @@
                         <program value="59"/>
                   </Channel>
                   <genre>jazz</genre>
+                  <genre>brassband</genre>
                   <genre>concertband</genre>
                   <genre>marching</genre>
             </Instrument>
@@ -4094,6 +4130,7 @@
                   <genre>jazz</genre>
                   <genre>orchestra</genre>
                   <genre>popular</genre>
+                  <genre>brassquintet</genre>
                   <genre>concertband</genre>
                   <genre>marching</genre>
             </Instrument>
@@ -4113,6 +4150,8 @@
                   <Channel>
                         <program value="57"/> <!--Trombone-->
                   </Channel>
+                  <genre>brassquintet</genre>
+                  <genre>brassband</genre>
             </Instrument>
             <Instrument id="soprano-trombone">
                   <longName>Soprano Trombone</longName>
@@ -4168,6 +4207,7 @@
                   </Channel>
                   <genre>jazz</genre>
                   <genre>orchestra</genre>
+                  <genre>brassband</genre>
                   <genre>concertband</genre>
                   <genre>marching</genre>
             </Instrument>
@@ -4229,6 +4269,7 @@
                   <Channel>
                         <program value="58"/> <!--Tuba-->
                   </Channel>
+                  <genre>brassband</genre>
                   <genre>concertband</genre>
                   <genre>marching</genre>
             </Instrument>
@@ -4247,6 +4288,7 @@
                   <genre>common</genre>
                   <genre>jazz</genre>
                   <genre>orchestra</genre>
+                  <genre>brassquintet</genre>
                   <genre>concertband</genre>
                   <genre>marching</genre>
             </Instrument>
@@ -4293,6 +4335,8 @@
                   <Channel>
                         <program value="58"/> <!--Tuba-->
                   </Channel>
+                  <genre>brassquintet</genre>
+                  <genre>brassband</genre>
             </Instrument>
             <Instrument id="c-tuba">
                   <longName>C Tuba</longName>
@@ -4337,6 +4381,8 @@
                   <Channel>
                         <program value="58"/> <!--Tuba-->
                   </Channel>
+                  <genre>brassquintet</genre>
+                  <genre>brassband</genre>
             </Instrument>
             <Instrument id="bass-f-tuba">
                   <longName>Bass Tuba in F</longName>


### PR DESCRIPTION
Make life easier for finding brass band and brass quintet instruments by adding genres underneath "Brass".
Also create a "Bb Baritone" instrument because that's what brass bands call the "baritone horn" - I should know, I play one!

Resolves: *(direct link to the issue)* There is no issue, just a straight change

I play in a brass band and a brass quintet.  It irks me that there's no easy way to select the instruments that make up these groups. So I created genres for them. Enjoy!

*Use "x" letter to fill the checkboxes below like [x]*

- [x ] I signed [CLA](https://musescore.org/en/cla)
- [ x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [ x] I made sure the code compiles on my machine
- [ x] I made sure there are no unnecessary changes in the code
- [ x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made - nope, but is there one?
