### PR TITLE
295020 Range-transpose shortcuts

### DIFF
--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -662,12 +662,9 @@ void Score::transposeSemitone(int step)
 
     const int interval = intervalListArray[keyType][step > 0 ? 0 : 1];
 
-    cmdSelectAll();
     if (!transpose(TransposeMode::BY_INTERVAL, dir, Key::C, interval, true, true, false)) {
         qDebug("Score::transposeSemitone: failed");
         // TODO: set error message
-    } else {
-        deselectAll();
     }
 }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/295020

This changes the semitone transpose up/down shortcuts, provided under the name [transpose up/down], to apply only upon a range selection. Previously, these shortcuts always selected the entire score before performing transposition, and then afterwards it de-selected everything. The change here limits this to be upon a range selection instead, and also maintains that range selection afterwards for further transposition or whatever else the user may have in mind. 

The previous full score transposition as a shortcut is dangerous, and it is already suggested in the handbook: (see handbook: transposition) https://musescore.org/en/handbook/3/transposition
to utilize the dialogue interface for entire score transposition (don't highlight anything and use the dialogue box). There's no mention of these shortcuts in the handbook for entire score transposition, so once this is merged, I or someone with good will/free time will need to add an additional entry letting users know that they may now perform semi-tone transposition with the keyboard upon a range selection. Not having these commands apply to the entire score also follows the general trend of Musescore to have entire-score commands be dialogue-based rather than pure keyboard activity

Aside: To be sure, these functions take into consideration the key signatures, so if any key signature is within the range-selection, it will also be transposed instead of only the notes themselves. Quite useful for sections without having to deal with the dialogue box.