### PR TITLE
fix #295544: fix reverting non-textual changes made in text editing mode

### DIFF
--- a/libmscore/textedit.h
+++ b/libmscore/textedit.h
@@ -34,11 +34,22 @@ struct TextEditData : public ElementEditData {
       };
 
 //---------------------------------------------------------
+//   TextEditUndoCommand
+//---------------------------------------------------------
+
+class TextEditUndoCommand : public UndoCommand {
+   protected:
+      TextCursor c;
+   public:
+      TextEditUndoCommand(const TextCursor& tc) : c(tc) {}
+      bool isFiltered(UndoCommand::Filter f, const Element* target) const override { return f == UndoCommand::Filter::TextEdit && c.text() == target; }
+      };
+
+//---------------------------------------------------------
 //   ChangeText
 //---------------------------------------------------------
 
-class ChangeText : public UndoCommand {
-      TextCursor c;
+class ChangeText : public TextEditUndoCommand {
       QString s;
 
    protected:
@@ -46,7 +57,7 @@ class ChangeText : public UndoCommand {
       void removeText(EditData*);
 
    public:
-      ChangeText(const TextCursor* tc, const QString& t) : c(*tc), s(t) {}
+      ChangeText(const TextCursor* tc, const QString& t) : TextEditUndoCommand(*tc), s(t) {}
       virtual void undo(EditData*) override = 0;
       virtual void redo(EditData*) override = 0;
       const TextCursor& cursor() const { return c; }
@@ -83,14 +94,13 @@ class RemoveText : public ChangeText {
 //   SplitJoinText
 //---------------------------------------------------------
 
-class SplitJoinText : public UndoCommand {
+class SplitJoinText : public TextEditUndoCommand {
    protected:
-      TextCursor c;
       virtual void split(EditData*);
       virtual void join(EditData*);
 
    public:
-      SplitJoinText(const TextCursor* tc) : c(*tc) {}
+      SplitJoinText(const TextCursor* tc) : TextEditUndoCommand(*tc) {}
       };
 
 //---------------------------------------------------------

--- a/mscore/editelement.cpp
+++ b/mscore/editelement.cpp
@@ -92,6 +92,10 @@ void ScoreView::startEditMode(Element* e)
             qDebug("The element cannot be edited");
             return;
             }
+      if (textEditMode()) {
+            // leave text edit mode before starting editing another element
+            changeState(ViewState::NORMAL);
+            }
       if (score()->undoStack()->active())
             score()->endCmd();
       editData.element = e;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/295544

As mentioned in the issue, it is caused by changes made in #4921 to prevent crashes resulting from inaccurate editing of undo stack in `TextBase::endEdit()`. The fix in #4921 avoided unusual editing of undo stack at all but causes an issue with all non-textual changes made in text editing mode being reverted. The proposed patch returns to undo stack editing strategy but tries to do this in a more accurate way to avoid both crashes and undesirable changes reverting.