### PR TITLE
fix #298703: edit drumset button is too small for some translations

### DIFF
--- a/mscore/drumtools.cpp
+++ b/mscore/drumtools.cpp
@@ -60,11 +60,12 @@ DrumTools::DrumTools(QWidget* parent)
       pitchName->setWordWrap(true);
       pitchName->setContentsMargins(25, 0, 25, 0);
       layout1->addWidget(pitchName);
+
       QHBoxLayout* buttonLayout = new QHBoxLayout;
-      buttonLayout->setContentsMargins(25, 10, 25, 10);
+      buttonLayout->setContentsMargins(5, 5, 5, 5);
       editButton = new QToolButton;
-      editButton->setMinimumWidth(100);
-      editButton->setSizePolicy(QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed));
+      editButton->setMinimumWidth(175);
+      editButton->setSizePolicy(QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding));
       buttonLayout->addWidget(editButton);
       layout1->addLayout(buttonLayout);
       layout->addLayout(layout1);
@@ -148,7 +149,7 @@ void DrumTools::updateDrumset(const Drumset* ds)
                   noteheadSym = drumset->noteHeads(pitch, NoteHead::Type::HEAD_QUARTER);
             else
                   noteheadSym = note->noteHead(true, noteHead, NoteHead::Type::HEAD_QUARTER);
-            
+
             note->setCachedNoteheadSym(noteheadSym); // we use the cached notehead so we don't recompute it at each layout
             chord->add(note);
             int sc = drumset->shortcut(pitch);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/298703

This just allows it too expand vertically, and increases the minimum width, and decreases the margins around it.

New:

![Screenshot from 2019-12-31 18-54-55](https://user-images.githubusercontent.com/8274049/71631265-a6019d80-2bff-11ea-99d3-f48b4e4b1454.png)
