### PR TITLE
[Inspector/Regression] fix #299072: style setting for fingering in Inspector has no items

### DIFF
--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -1222,7 +1222,7 @@ void InspectorStaffText::propertiesClicked()
 
 void InspectorStaffText::setElement()
       {
-      InspectorElementBase::setElement();
+      InspectorTextBase::setElement();
       s.properties->setVisible(inspector->element()->isStaffText());
       }
 


### PR DESCRIPTION
Resolves: https://musescore.org/node/299072.