### PR TITLE
fix #44796: enable ptb import

### DIFF
--- a/build/packaging/WIX.template.in
+++ b/build/packaging/WIX.template.in
@@ -110,6 +110,7 @@
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".gp4" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".gp5" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".gpx" Value="" Type="string" />
+            <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".ptb" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".sf2" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".sf3" Value="" Type="string" />
             

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -283,7 +283,7 @@ void MuseScore::loadFiles(bool switchTab, bool singleFile)
 #ifdef OMR
          tr("All Supported Files") + " (*.mscz *.mscx *.mxl *.musicxml *.xml *.mid *.midi *.kar *.md *.mgu *.sgu *.cap *.capx *.pdf *.ove *.scw *.bww *.gtp *.gp3 *.gp4 *.gp5 *.gpx);;" +
 #else
-         tr("All Supported Files") + " (*.mscz *.mscx *.mxl *.musicxml *.xml *.mid *.midi *.kar *.md *.mgu *.sgu *.cap *.capx *.ove *.scw *.bww *.gtp *.gp3 *.gp4 *.gp5 *.gpx);;" +
+         tr("All Supported Files") + " (*.mscz *.mscx *.mxl *.musicxml *.xml *.mid *.midi *.kar *.md *.mgu *.sgu *.cap *.capx *.ove *.scw *.bww *.gtp *.gp3 *.gp4 *.gp5 *.gpx *.ptb);;" +
 #endif
          tr("MuseScore Files") + " (*.mscz *.mscx);;" +
          tr("MusicXML Files") + " (*.mxl *.musicxml *.xml);;" +
@@ -296,7 +296,8 @@ void MuseScore::loadFiles(bool switchTab, bool singleFile)
 #endif
          tr("Overture / Score Writer Files (experimental)") + " (*.ove *.scw);;" +
          tr("Bagpipe Music Writer Files (experimental)") + " (*.bww);;" +
-         tr("Guitar Pro") + " (*.gtp *.gp3 *.gp4 *.gp5 *.gpx)",
+         tr("Guitar Pro Files") + " (*.gtp *.gp3 *.gp4 *.gp5 *.gpx);;" +
+         tr("Power Tab Editor Files (experimental)") + " (*.ptb)",
          tr("Load Score"),
          singleFile
          );

--- a/mtest/testutils.cpp
+++ b/mtest/testutils.cpp
@@ -125,7 +125,7 @@ MasterScore* MTest::readCreatedScore(const QString& name)
 #endif
       else if (csl == "xml" || csl == "musicxml")
             rv = importMusicXml(score, name);
-      else if (csl == "gp3" || csl == "gp4" || csl == "gp5" || csl == "gpx")
+      else if (csl == "gp3" || csl == "gp4" || csl == "gp5" || csl == "gpx" || csl == "ptb")
             rv = importGTP(score, name);
       else
             rv = Score::FileError::FILE_UNKNOWN_TYPE;


### PR DESCRIPTION
Solves the `.ptb` part of https://musescore.org/en/node/44796, for which code already exists (since 2017, in 45c2d91), but not the `.tef` part.
Marking it as experimental (in the import dialog), as it apparently hasn't been tested much, if at all.