### PR TITLE
[MU4] fix #299191: Provide a pair of diatonic transpose up/down (keeping al…

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -4368,6 +4368,8 @@ void Score::cmd(const QAction* a, EditData& ed)
         { "add-audio",                  [](Score* cs, EditData&) { cs->addAudioTrack(); } },
         { "transpose-up",               [](Score* cs, EditData&) { cs->transposeSemitone(1); } },
         { "transpose-down",             [](Score* cs, EditData&) { cs->transposeSemitone(-1); } },
+        { "pitch-up-diatonic-alterations",   [](Score* cs, EditData&) { cs->transposeDiatonicAlterations(TransposeDirection::UP); } },
+        { "pitch-down-diatonic-alterations", [](Score* cs, EditData&) { cs->transposeDiatonicAlterations(TransposeDirection::DOWN); } },
         { "delete",                     [](Score* cs, EditData&) { cs->cmdDeleteSelection(); } },
         { "full-measure-rest",          [](Score* cs, EditData&) { cs->cmdFullMeasureRest(); } },
         { "toggle-insert-mode",         [](Score* cs, EditData&) { cs->_is.setInsertMode(!cs->_is.insertMode()); } },

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -1149,6 +1149,7 @@ public:
     void cmdSelectSection();
     void respace(std::vector<ChordRest*>* elements);
     void transposeSemitone(int semitone);
+    void transposeDiatonicAlterations(TransposeDirection direction);
     void insertMeasure(ElementType type, MeasureBase*, bool createEmptyMeasures = false,bool moveSignaturesClef = true);
     Audio* audio() const { return _audio; }
     void setAudio(Audio* a) { _audio = a; }

--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -748,6 +748,19 @@ void Note::transposeDiatonic(int interval, bool keepAlterations, bool useDoubleA
 }
 
 //---------------------------------------------------------
+//   transposeDiatonicAlterations
+//---------------------------------------------------------
+
+void Score::transposeDiatonicAlterations(TransposeDirection direction)
+{
+    // Transpose current selection diatonically (up/down) while keeping degree alterations
+    // Note: Score::transpose() absolutely requires valid selection before invocation.
+    if (!selection().isNone()) {
+        transpose(TransposeMode::DIATONICALLY, direction, Key::C, 1, true, true, true);
+    }
+}
+
+//---------------------------------------------------------
 //   transpositionChanged
 //---------------------------------------------------------
 

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -792,6 +792,17 @@ Shortcut Shortcut::_sc[] = {
     {
         MsWidget::SCORE_TAB,
         STATE_NORMAL | STATE_NOTE_ENTRY,
+        "pitch-up-diatonic-alterations",
+        QT_TRANSLATE_NOOP("action","Diatonic Up (Keep Degree Alterations)"),
+        QT_TRANSLATE_NOOP("action","Diatonic pitch up (Keep degree alterations)"),
+        0,
+        Icons::Invalid_ICON,
+        Qt::WindowShortcut,
+        ShortcutFlags::A_CMD
+    },
+    {
+        MsWidget::SCORE_TAB,
+        STATE_NORMAL | STATE_NOTE_ENTRY,
         "pitch-up-octave",
         QT_TRANSLATE_NOOP("action","Up Octave"),
         QT_TRANSLATE_NOOP("action","Pitch up octave"),
@@ -846,6 +857,17 @@ Shortcut Shortcut::_sc[] = {
         "pitch-down-diatonic",
         QT_TRANSLATE_NOOP("action","Diatonic Down"),
         QT_TRANSLATE_NOOP("action","Diatonic pitch down"),
+        0,
+        Icons::Invalid_ICON,
+        Qt::WindowShortcut,
+        ShortcutFlags::A_CMD
+    },
+    {
+        MsWidget::SCORE_TAB,
+        STATE_NORMAL | STATE_NOTE_ENTRY,
+        "pitch-down-diatonic-alterations",
+        QT_TRANSLATE_NOOP("action","Diatonic Down (Keep Degree Alterations)"),
+        QT_TRANSLATE_NOOP("action","Diatonic pitch down (Keep degree alterations)"),
         0,
         Icons::Invalid_ICON,
         Qt::WindowShortcut,


### PR DESCRIPTION
…terations) shortcuts

Resolves: https://musescore.org/en/node/299191

These shortcuts provide what is already provisioned through the transpose dialogue box of diatonic transposition by one semi-tone (up/down) with the check-box of "Keep degree alterations". The pair already implemented do not keep degree alterations. With these, the user can move a tone+accidental around without losing or altering the accidental sign, like moving C# to D#, to E# without the chromatic activity of semitone up, and it wouldn't lose the accidental applied to it like with the regular diatonic pitch up/down shortcuts. They may also be useful to help someone experiment with composition. 