### PR TITLE
fix #299179: for single stave key sig, courtesy key sig is shown in all staves

### DIFF
--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -341,7 +341,7 @@ Element* KeySig::drop(EditData& data)
             }
       else {
             // apply to all staves:
-            foreach(Staff* s, score()->masterScore()->staves())
+            for (Staff* s : score()->masterScore()->staves())
                   score()->undoChangeKeySig(s, tick(), k);
             }
       return this;

--- a/libmscore/measurebase.cpp
+++ b/libmscore/measurebase.cpp
@@ -614,5 +614,37 @@ LayoutBreak* MeasureBase::sectionBreakElement() const
             }
       return 0;
       }
+
+//---------------------------------------------------------
+//   addCourtesyKeySigStaff
+//---------------------------------------------------------
+
+void MeasureBase::addCourtesyKeySigStaff(int idx)
+      {
+      setHasCourtesyKeySig(true);
+      _courtesyKeySigStaves.insert(idx);
+      }
+
+//---------------------------------------------------------
+//   clearCourtesyKeySigStaves
+//---------------------------------------------------------
+
+void MeasureBase::clearCourtesyKeySigStaves()
+      {
+      setHasCourtesyKeySig(false);
+      _courtesyKeySigStaves.clear();
+      }
+
+//---------------------------------------------------------
+//   requiresCourtesyKeySig
+//---------------------------------------------------------
+
+bool MeasureBase::requiresCourtesyKeySig(int idx) const
+      {
+      if (!hasCourtesyKeySig())
+            return false;
+      return std::find(_courtesyKeySigStaves.cbegin(), _courtesyKeySigStaves.cend(), idx) != _courtesyKeySigStaves.cend();
+      }
+
 }
 

--- a/libmscore/measurebase.h
+++ b/libmscore/measurebase.h
@@ -68,6 +68,8 @@ class MeasureBase : public Element {
       int _no                { 0 };       ///< Measure number, counting from zero
       int _noOffset          { 0 };       ///< Offset to measure number
 
+      std::set<int> _courtesyKeySigStaves;  ///< Staves which require a courtesy key sig when this is an end measure
+
    protected:
       Fraction _len  { Fraction(0, 1) };  ///< actual length of measure
       void cleanupLayoutBreaks(bool undo);
@@ -169,6 +171,10 @@ class MeasureBase : public Element {
 
       bool hasCourtesyKeySig() const   { return flag(ElementFlag::KEYSIG);        }
       void setHasCourtesyKeySig(int v) { setFlag(ElementFlag::KEYSIG, v);         }
+
+      void clearCourtesyKeySigStaves();
+      void addCourtesyKeySigStaff(int idx);
+      bool requiresCourtesyKeySig(int idx) const;
 
       virtual void computeMinWidth() { };
 


### PR DESCRIPTION
resolves https://musescore.org/en/node/299179

Shows the courtesy key sig now only in staves where it has changed. This is done by storing the staves in which key sigs have changed instead of just setting a flag for the entire measure, so that when the measure generates courtesy key sigs, it only does it where necessary.

Looks like this now: 

![image](https://user-images.githubusercontent.com/8274049/71680834-15ec6100-2d83-11ea-9469-9cd34e93c218.png)

Note the 'empty' space for staves where no key sig has changed. This isn't great, but is very hard to get rid of. Besides, courtesy time sigs also leave this empty space, so it should be fine.