### PR TITLE
fix #293593 - Issues with ottavas

### DIFF
--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -330,6 +330,7 @@ public:
       void setPitch(int val);
       void setPitch(int pitch, int tpc1, int tpc2);
       int pitch() const                   { return _pitch;    }
+      int ottaveCapoFret() const;
       int ppitch() const;           ///< playback pitch
       int epitch() const;           ///< effective pitch
       qreal tuning() const                { return _tuning;   }


### PR DESCRIPTION
Resolves: #293593 - Issues with ottavas
Corrects first problem: Status doesn't display the pitch of note that have an
ottave line. This is solved in Note::tpcUserName().

Solves the second problem in issue 293593: Accidentals do apply if 8va sign is added.
This is solved in Note::updateAccidental(). All calculations are based on the
effective pitch of the a note rather than the actual pitch. The solution now
takes to ottava signs into account by using the actual pitch.

For easily find out wheather an ottava is applied, a new method ottavaCapoFret()
is added which returns the pitch offset by an ottava (or capo fret). To prevent
code duplication, ppitch() also use this new ottavaCapoFret() method.

This pull request replaces #5587 which was based on a messed up database :-(.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
