### PR TITLE
fix #299351: MIME types are invalid in Linux AppImage

### DIFF
--- a/build/Linux+BSD/mscore.desktop.in
+++ b/build/Linux+BSD/mscore.desktop.in
@@ -15,4 +15,4 @@ Type=Application
 Categories=Qt;Audio;Sequencer;Midi;AudioVideoEditing;Music;AudioVideo;
 Keywords=music;notation;composition;composing;arranging;making;sheet music;music notation software;lead sheet;leadsheet;score;full score;scorewriter;MIDI;musicxml;playback;instrument;
 Keywords[de]=Musik;Noten;Musiknoten;Komposition;Komponieren;Arrangieren;Notenblatt;Notenblätter;Notationsprogramm;Musiknotationsprogramm;Musiknotation;Tabulatur;MIDI;musicxml;Instrument;
-MimeType=application/x-musescore@MSCORE_INSTALL_SUFFIX@;application/x-musescore@MSCORE_INSTALL_SUFFIX@+xml;application/vnd.recordare.musicxml@MSCORE_INSTALL_SUFFIX@;application/vnd.recordare.musicxml@MSCORE_INSTALL_SUFFIX@+xml;
+MimeType=application/x-musescore;application/x-musescore+xml;application/vnd.recordare.musicxml;application/vnd.recordare.musicxml+xml;audio/midi;application/x-bww;application/x-biab;application/x-capella;audio/x-gtp;application/x-musedata;application/x-overture;audio/x-ptb;application/x-sf2;application/x-sf3

--- a/build/Linux+BSD/musescore.xml.in
+++ b/build/Linux+BSD/musescore.xml.in
@@ -1,58 +1,172 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>@Variables_substituted_by_CMAKE_on_installation@
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
-  <mime-type type="application/x-musescore@MSCORE_INSTALL_SUFFIX@">@Variables_substituted_by_CMAKE_on_installation@
-    <comment>MuseScore file</comment>
-    <sub-class-of type="application/zip"/>
-    <glob pattern="*.mscz"/>
-  </mime-type>
-  <mime-type type="application/x-musescore@MSCORE_INSTALL_SUFFIX@+xml">
-    <comment>uncompressed MuseScore file</comment>
-    <sub-class-of type="application/xml"/>
-    <glob pattern="*.mscx" />
-  </mime-type>
-  <mime-type type="application/vnd.recordare.musicxml@MSCORE_INSTALL_SUFFIX@">
-    <!-- http://www.musicxml.com/for-developers/musicxml-dtd/ -->
-    <_comment>compressed MusicXML file</_comment>
-    <sub-class-of type="application/zip"/>
-<!-- Note: a custom icon is used for MusicXML files. You can change this below -->
-<!--  <icon name="application-x-musescore"/> Uncomment to use MuseScore file icon -->
-<!--  <generic-icon name="audio-x-generic"/> Uncomment to use generic audio file icon -->
-    <glob pattern="*.mxl"/>
-  </mime-type>
-  <mime-type type="application/vnd.recordare.musicxml@MSCORE_INSTALL_SUFFIX@+xml">
-    <!-- http://www.musicxml.com/for-developers/musicxml-dtd/ -->
-    <_comment>uncompressed MusicXML file</_comment>
-    <sub-class-of type="application/xml"/>
-<!--  <icon name="application-x-musescore"/> Uncomment to use MuseScore file icon -->
-<!--  <generic-icon name="audio-x-generic"/> Uncomment to use generic audio file icon -->
-    <magic>
-      <match type="string" value="&lt;?xml" offset="0">
-        <match type="string" value="score-partwise" offset="0:128"/>
-        <match type="string" value="score-timewise" offset="0:128"/>
-      </match>
-      <match type="string" value="&lt;!--" offset="0">
-        <match type="string" value="score-partwise" offset="0:128"/>
-        <match type="string" value="score-timewise" offset="0:128"/>
-      </match>
-    </magic>
-    <glob pattern="*.xml" weight="40"/>
-  </mime-type>
-  <mime-type type="application/vnd.recordare.musicxml@MSCORE_INSTALL_SUFFIX@+xml">
-        <!-- http://www.musicxml.com/for-developers/musicxml-dtd/ -->
-        <_comment>uncompressed MusicXML file</_comment>
+
+    <!-- MuseScore documents -->
+
+    <mime-type type="application/x-musescore">
+        <comment>MuseScore compressed score</comment>
+        <glob pattern="*.mscz"/>
+        <sub-class-of type="application/zip"/>
+        <icon name="application-x-musescore@MSCORE_INSTALL_SUFFIX@"/>
+    </mime-type>
+
+    <mime-type type="application/x-musescore+xml">
+        <comment>MuseScore uncompressed score</comment>
+        <glob pattern="*.mscx"/>
         <sub-class-of type="application/xml"/>
-        <!--  <icon name="application-x-musescore"/> Uncomment to use MuseScore file icon -->
-        <!--  <generic-icon name="audio-x-generic"/> Uncomment to use generic audio file icon -->
+        <root-XML namespaceURI="" localName="museScore"/>
+        <icon name="application-x-musescore@MSCORE_INSTALL_SUFFIX@+xml"/>
         <magic>
-              <match type="string" value="&lt;?xml" offset="0">
-                    <match type="string" value="score-partwise" offset="0:128"/>
-                    <match type="string" value="score-timewise" offset="0:128"/>
-              </match>
-              <match type="string" value="&lt;!--" offset="0">
-                    <match type="string" value="score-partwise" offset="0:128"/>
-                    <match type="string" value="score-timewise" offset="0:128"/>
-              </match>
+            <match type="string" value="&lt;?xml" offset="0">
+                <match type="string" value="&lt;museScore" offset="0:128">
+                    <match type="string" value="&lt;Score" offset="0:512"/>
+                </match>
+            </match>
         </magic>
-        <glob pattern="*.musicxml" weight="40"/>
-  </mime-type>
+    </mime-type>
+
+    <!-- MuseScore internal formats -->
+
+    <mime-type type="application/x-musescore.drumset+xml">
+        <comment>MuseScore drumset</comment>
+        <glob pattern="*.drm"/>
+        <sub-class-of type="application/xml"/>
+        <root-XML namespaceURI="" localName="museScore"/>
+        <magic>
+            <match type="string" value="&lt;?xml" offset="0">
+                <match type="string" value="&lt;museScore" offset="0:128">
+                    <match type="string" value="&lt;Drum" offset="0:512"/>
+                </match>
+            </match>
+        </magic>
+    </mime-type>
+
+    <mime-type type="application/x-musescore.palette">
+        <comment>MuseScore palette</comment>
+        <glob pattern="*.mpal"/>
+        <sub-class-of type="application/zip"/>
+    </mime-type>
+
+    <mime-type type="application/x-musescore.style+xml">
+        <comment>MuseScore style</comment>
+        <glob pattern="*.mss"/>
+        <sub-class-of type="application/xml"/>
+        <root-XML namespaceURI="" localName="museScore"/>
+        <magic>
+            <match type="string" value="&lt;?xml" offset="0">
+                <match type="string" value="&lt;museScore" offset="0:128">
+                    <match type="string" value="&lt;Style" offset="0:512"/>
+                </match>
+            </match>
+        </magic>
+    </mime-type>
+
+    <!-- MusicXML documents -->
+
+    <mime-type type="application/vnd.recordare.musicxml">
+        <!-- See "Container file" at http://www.musicxml.com/for-developers/musicxml-dtd/ -->
+        <comment>MusicXML compressed score</comment>
+        <glob pattern="*.mxl"/>
+        <sub-class-of type="application/zip"/>
+        <icon name="application-vnd.recordare.musicxml@MSCORE_INSTALL_SUFFIX@"/>
+    </mime-type>
+
+    <mime-type type="application/vnd.recordare.musicxml+xml">
+        <!-- http://www.musicxml.com/for-developers/musicxml-dtd/ -->
+        <comment>MusicXML uncompressed score</comment>
+        <glob pattern="*.musicxml"/><!-- preferred extension must go first -->
+        <glob pattern="*.xml" weight="40"/><!-- reduced weight (default 50) to avoid matching ordinary XML files -->
+        <sub-class-of type="application/xml"/>
+        <root-XML namespaceURI="" localName="score-partwise"/>
+        <root-XML namespaceURI="" localName="score-timewise"/>
+        <icon name="application-vnd.recordare.musicxml@MSCORE_INSTALL_SUFFIX@+xml"/>
+        <magic>
+            <match type="string" value="&lt;?xml" offset="0">
+                <match type="string" value="score-partwise" offset="0:128"/>
+                <match type="string" value="score-timewise" offset="0:128"/>
+            </match>
+            <match type="string" value="&lt;!--" offset="0">
+                <match type="string" value="score-partwise" offset="0:128"/>
+                <match type="string" value="score-timewise" offset="0:128"/>
+            </match>
+        </magic>
+    </mime-type>
+
+    <!--
+        Specialist file formats that MuseScore can import or export
+
+        If the format doesn't have a MIME type yet then you need to invent
+        one (e.g. "application/x-newtype"). This enables us to reference the
+        MIME type in other places (e.g. the .desktop file).
+
+        Common types like "audio/midi" do not need to be declared here unless
+        you want to provide custom icons for them.
+    -->
+
+    <mime-type type="application/x-bww"><!-- invented -->
+        <comment>Bagpipe Music Writer score</comment>
+        <glob pattern="*.bww"/>
+    </mime-type>
+
+    <mime-type type="application/x-biab"><!-- invented -->
+        <comment>Band-in-a-Box score</comment>
+        <glob pattern="*.mgu"/>
+        <glob pattern="*.sgu"/>
+    </mime-type>
+
+    <mime-type type="application/x-capella"><!-- invented -->
+        <comment>Capella score</comment>
+        <glob pattern="*.cap"/>
+        <glob pattern="*.capx"/>
+    </mime-type>
+
+    <mime-type type="audio/x-gtp"><!-- See https://sourceforge.net/p/tuxguitar/bugs/117/ -->
+        <comment>Guitar Pro tablature</comment>
+        <glob pattern="*.gpx"/><!-- Version 6 -->
+        <glob pattern="*.gp5"/>
+        <glob pattern="*.gp4"/>
+        <glob pattern="*.gp3"/>
+        <glob pattern="*.gtp"/><!-- Versions 1 and 2 -->
+    </mime-type>
+
+    <mime-type type="application/x-musedata"><!-- invented -->
+        <!-- https://wiki.ccarh.org/wiki/MuseData_file_specification -->
+        <comment>MuseData score</comment>
+        <glob pattern="*.md" weight="40"/><!-- Avoid matching Markdown .md files -->
+        <sub-class-of type="text/plain"/>
+        <magic>
+            <match type="string" value="WK#:" offset="0:512">
+                <match type="string" value="Group memberships:" offset="0:1024"/>
+            </match>
+        </magic>
+    </mime-type>
+
+    <mime-type type="application/x-overture"><!-- invented -->
+        <comment>Overture score</comment>
+        <glob pattern="*.ove"/>
+    </mime-type>
+
+    <mime-type type="audio/x-ptb"><!-- See https://sourceforge.net/p/tuxguitar/bugs/117/ -->
+        <comment>Power Tab Editor tablature</comment>
+        <glob pattern="*.ptb"/>
+    </mime-type>
+
+    <mime-type type="application/x-sf2"><!-- invented -->
+        <comment>SoundFont audio bank</comment>
+        <glob pattern="*.sf2"/>
+        <sub-class-of type="application/x-riff"/>
+    </mime-type>
+
+    <mime-type type="application/x-sf3"><!-- invented -->
+        <comment>Vorbis compressed soundfont</comment><!-- NOT SoundFont since that is a trademarked term. -->
+        <glob pattern="*.sf3"/>
+        <sub-class-of type="application/x-riff"/><!-- NOT a subclass of application/x-sf2 (SF3 files are not valid SF2 files). -->
+    </mime-type>
+
+    <mime-type type="application/x-sfz"><!-- invented -->
+        <comment>SFZ soundfont descriptor</comment><!-- NOT SoundFont since that is a trademarked term. -->
+        <glob pattern="*.sfz"/>
+        <sub-class-of type="text/plain"/>
+    </mime-type>
+
 </mime-info>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/299351

MIME types are used to setup file associations (i.e. tell the File Manager
which files MuseScore can open) and to provide icons for those files.

Primary changes:

- Remove MSCORE_INSTALL_SUFFIX from MIME types to ensure they are valid.

- Manually specify icon names so they no longer have to match the MIME type.
  Icon names retain MSCORE_INSTALL_SUFFIX to ensure there are no conflicts
  when the user has multiple copies of MuseScore installed simultaneously.

Additional changes:

- Improve formatting (indent 4 spaces instead of 2).

- Create MIME types for MuseScore Drumsets (.drm), Palettes (.mpal) and
  Styles (.mss).

- Add types for import formats, including Guitar Pro and Overture.

- Add MIDI and new import types to .desktop file so MuseScore will appear in
  the File Manager's "Open with..." list for these types of file.

*Use "x" letter to fill the checkboxes below like [x]*

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
