### PR TITLE
Improve Split Staff dialogue

### DIFF
--- a/mscore/splitstaff.ui
+++ b/mscore/splitstaff.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>302</width>
-    <height>152</height>
+    <width>178</width>
+    <height>111</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -53,12 +53,19 @@
                <string>Split point:</string>
               </property>
               <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="Awl::PitchEdit" name="splitPoint"/>
+             <widget class="Awl::PitchEdit" name="splitPoint">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>


### PR DESCRIPTION
Align the text on the left and make the size policy of spin box "Expanding".

Before:
![image](https://user-images.githubusercontent.com/46259489/71885838-24b58800-3176-11ea-9712-b97368d62295.png)

Now:
![image](https://user-images.githubusercontent.com/46259489/71885424-4eba7a80-3175-11ea-82e7-17d74b2ae589.png)
![image](https://user-images.githubusercontent.com/46259489/71885484-6b56b280-3175-11ea-9e7d-bf4d287fe092.png)
