### PR TITLE
fix #293732: Go to next/previous system command

### DIFF
--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -816,6 +816,7 @@ class Score : public QObject, public ScoreElement {
       void rebuildTempoAndTimeSigMaps(Measure* m);
       Element* nextElement();
       Element* prevElement();
+      void cmdNextPrevSystem(ChordRest*, bool);
 
       void cmd(const QAction*, EditData&);
       int fileDivision(int t) const { return ((qint64)t * MScore::division + _fileDivision/2) / _fileDivision; }

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -22,7 +22,7 @@
 
 #include "config.h"
 #include "globals.h"
-#include "singleapp/src/QtSingleApplication"
+#include "thirdparty/singleapp/src/QtSingleApplication"
 #include "updatechecker.h"
 #include "libmscore/musescoreCore.h"
 #include "libmscore/score.h"

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1973,7 +1973,9 @@ void ScoreView::cmd(const char* s)
          || cmd == "next-track"
          || cmd == "prev-track"
          || cmd == "next-measure"
-         || cmd == "prev-measure") {
+         || cmd == "prev-measure"
+         || cmd == "next-system"
+         || cmd == "prev-system") {
             Element* el = score()->selection().element();
             if (el && (el->isTextBase())) {
                   score()->startCmd();

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1011,6 +1011,13 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
+         "prev-system",
+         QT_TRANSLATE_NOOP("action","Previous System"),
+         QT_TRANSLATE_NOOP("action","Go to previous system")
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
          "prev-track",
          QT_TRANSLATE_NOOP("action","Previous Staff or Voice"),
          QT_TRANSLATE_NOOP("action","Previous staff or voice")
@@ -1028,6 +1035,13 @@ Shortcut Shortcut::_sc[] = {
          "next-measure",
          QT_TRANSLATE_NOOP("action","Next Measure"),
          QT_TRANSLATE_NOOP("action","Go to next measure or move text right")
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
+         "next-system",
+         QT_TRANSLATE_NOOP("action","Next System"),
+         QT_TRANSLATE_NOOP("action","Go to next system")
          },
       {
          MsWidget::SCORE_TAB,


### PR DESCRIPTION
Resolves: Suggestion #293732 - Implement next/previous system commands

Here is an implementation of the suggestion to implement a pair of next/previous system commands which act similar to next/previous measure. 

How it acts is a little different in that instead of keeping track of the current staff/instrument while moving forward and backward as with next/previous measure, the position will move to the first measure of the first instrument of the previous/next system (top-left position). I deemed this more useful than keeping the staff-number, since moving per measure provides that functionality already, albeit in measure jumps rather than system jumps. 

This then becomes useful while copying scores per system. Once at the bottom-right of a system, instead of having to manually get to the beginning top of the next system, this shortcut [next] will do that quickly. Also, for visual traversing per-system, these also are useful without having to press next measure over and over. Then again, the user is sort of crammed for a decent keyboard combination, so this is undefined by default. I'd use Meta+Left/Right more than likely. Also, when "within" a system, a previous system command won't go to the previous system but rather take the user to the beginning top-most of the current system, and then afterwards will take the user to the previous system.

Finally, it should be mentioned that Continuous View doesn't have a system concept, so for instance when doing Select all Similar in same system, it will actually act as if the whole score is one big system. So, these will act like "go to beginning/end of the entire score" while in continuous mode. 