### PR TITLE
fix #281112: enable time stretch customization for articulations [WIP]

### DIFF
--- a/libmscore/articulation.h
+++ b/libmscore/articulation.h
@@ -57,6 +57,8 @@ constexpr bool operator& (ArticulationShowIn a1, ArticulationShowIn a2) {
 class Articulation final : public Element {
       SymId _symId;
       Direction _direction;
+      qreal _gateTime;
+      bool _gateTimeInitialized;
       QString _channelName;
 
       ArticulationAnchor _anchor;
@@ -118,6 +120,12 @@ class Articulation final : public Element {
       Measure* measure() const;
       System* system() const;
       Page* page() const;
+
+      qreal gateTime() const      { return _gateTime; }
+      void setGateTime(qreal ts)  { _gateTime = ts;   }
+      qreal defaultGateTime() const;
+      bool gateTimeInitialized() const       { return _gateTimeInitialized; }
+      void setGateTimeInitialized(bool val)  { _gateTimeInitialized = val;  }
 
       ArticulationAnchor anchor() const     { return _anchor;      }
       void setAnchor(ArticulationAnchor v)  { _anchor = v;         }

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -337,6 +337,8 @@ static constexpr PropertyMetaData propertyList[] = {
 
       { Pid::PATH,                    false, "path",                  P_TYPE::PATH,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "path") },
 
+      { Pid::ARTICULATION_GATE_TIME,  true,  "gateTime",              P_TYPE::REAL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "articulation gate time") },
+
       { Pid::END, false, "++end++", P_TYPE::INT, DUMMY_QT_TRANSLATE_NOOP("propertyName", "<invalid property>") }
       };
 

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -346,6 +346,8 @@ enum class Pid {
 
       PATH, // for ChordLine to make its shape changes undoable
 
+      ARTICULATION_GATE_TIME,
+
       END
       };
 

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -2157,8 +2157,10 @@ void renderChordArticulation(Chord* chord, QList<NoteEventList> & ell, int & gat
                   for (Articulation* a : chord->articulations()) {
                         if (!a->playArticulation())
                               continue;
-                        if (!renderNoteArticulation(events, note, false, a->symId(), a->ornamentStyle()))
-                              instr->updateGateTime(&gateTime, channel, a->articulationName());
+                        if (!renderNoteArticulation(events, note, false, a->symId(), a->ornamentStyle())) {
+                              // instr->updateGateTime(&gateTime, channel, a->articulationName());
+                              gateTime = a->gateTime() * 100;
+                              }
                         }
                   }
             }

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -454,7 +454,7 @@ void Score::fixTicks()
       }
 
 //---------------------------------------------------------
-//    fixTicks
+//    rebuildTempoAndTimeSigMaps
 ///    updates tempomap and time sig map for a measure
 //---------------------------------------------------------
 

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -75,6 +75,7 @@
 #include "libmscore/stafftypechange.h"
 #include "libmscore/mscore.h"
 #include "libmscore/stafftextbase.h"
+#include "libmscore/property.h"
 
 namespace Ms {
 
@@ -599,11 +600,11 @@ InspectorArticulation::InspectorArticulation(QWidget* parent)
       ar.setupUi(addWidget());
 
       const std::vector<InspectorItem> iiList = {
-            { Pid::ARTICULATION_ANCHOR, 0, ar.anchor,           ar.resetAnchor           },
-            { Pid::DIRECTION,           0, ar.direction,        ar.resetDirection        },
-            { Pid::TIME_STRETCH,        0, ar.timeStretch,      ar.resetTimeStretch      },
-            { Pid::ORNAMENT_STYLE,      0, ar.ornamentStyle,    ar.resetOrnamentStyle    },
-            { Pid::PLAY,                0, ar.playArticulation, ar.resetPlayArticulation }
+            { Pid::ARTICULATION_ANCHOR,    0, ar.anchor,           ar.resetAnchor           },
+            { Pid::DIRECTION,              0, ar.direction,        ar.resetDirection        },
+            { Pid::ARTICULATION_GATE_TIME, 0, ar.timeStretch,      ar.resetTimeStretch      },
+            { Pid::ORNAMENT_STYLE,         0, ar.ornamentStyle,    ar.resetOrnamentStyle    },
+            { Pid::PLAY,                   0, ar.playArticulation, ar.resetPlayArticulation }
             };
       const std::vector<InspectorPanel> ppList = { { ar.title, ar.panel } };
       mapSignals(iiList, ppList);
@@ -631,6 +632,13 @@ void InspectorArticulation::propertiesClicked()
 void InspectorArticulation::setElement()
       {
       InspectorElementBase::setElement();
+
+      Articulation* a = toArticulation(inspector->element());
+      if (!a->gateTimeInitialized()) {
+            ar.timeStretch->setValue(a->defaultGateTime());
+            a->setGateTimeInitialized(true);
+            a->setPropertyFlags(Pid::ARTICULATION_GATE_TIME, PropertyFlags::STYLED);
+            }
       if (!ar.playArticulation->isChecked()) {
             ar.gridWidget->setEnabled(false);
             }

--- a/mscore/inspector/inspector_articulation.ui
+++ b/mscore/inspector/inspector_articulation.ui
@@ -269,6 +269,15 @@
            <property name="minimum">
             <double>0.100000000000000</double>
            </property>
+           <property name="maximum">
+            <double>1.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="value">
+            <double>1.000000000000000</double>
+           </property>
           </widget>
          </item>
          <item row="1" column="1">


### PR DESCRIPTION
Resolves: https://musescore.org/node/281112.

A new in-class valuable `_gateTime` to store the customized value.

The tricky part is the addition of `_gateTimeInitialized`. `propertyDefault()` needs a value based on the instrument in instruments.xml, so `this->part()` should be called. This is done in `defaultGateTime()`, but the first call of `propertyDefault()` is before `part()` exists, which means `defaultGateTime()` cannot be called. So a temporary value 1.0 is assigned, but it's subsequently overwritten by `InspectorArticulation::setElement()`, which assigns the correct default value if `_gateTimeInitialized` is `false`, meanwhile setting it to `true`.