### PR TITLE
fix #279877: Continuous view: white block appears when wallpaper chan…

### DIFF
--- a/mscore/continuouspanel.cpp
+++ b/mscore/continuouspanel.cpp
@@ -279,12 +279,9 @@ void ContinuousPanel::paint(const QRect&, QPainter& painter)
       QPixmap* fgPixmap = _sv->fgPixmap();
       if (fgPixmap == 0 || fgPixmap->isNull())
             painter.fillRect(bg, preferences.getColor(PREF_UI_CANVAS_FG_COLOR));
-      else {
-            painter.setMatrixEnabled(false);
+      else
             painter.drawTiledPixmap(bg, *fgPixmap, bg.topLeft()
                - QPoint(lrint(_sv->matrix().dx()), lrint(_sv->matrix().dy())));
-            painter.setMatrixEnabled(true);
-            }
 
       painter.setClipRect(_rect);
       painter.setClipping(true);

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1331,7 +1331,7 @@ void ScoreView::paint(const QRect& r, QPainter& p)
       if (lassoToDraw)
             lassoToDraw->drawEditMode(&p, editData);
 
-      p.setMatrixEnabled(false);
+      p.setWorldMatrixEnabled(false);
       if (_score->layoutMode() != LayoutMode::LINE && _score->layoutMode() != LayoutMode::SYSTEM && !r1.isEmpty()) {
             p.setClipRegion(r1);  // only background
             if (_bgPixmap == 0 || _bgPixmap->isNull())


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/279877

In mscore/continouspanel.cpp the transformation matrix was disabled for pixmaps, causing the issues as reported in the ticket.
Now there is no difference when color or a wallpaper is used for the canvas paper:

*Use "x" letter to fill the checkboxes below like [x]*

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n.a.] I created the test (mtest, vtest, script test) to verify the changes I made
