### PR TITLE
Allow always using whole rest for measure rests

### DIFF
--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -278,7 +278,7 @@ SymId Rest::getSymbol(TDuration::DurationType type, int line, int lines, int* yo
             case TDuration::DurationType::V_BREVE:
                   return SymId::restDoubleWhole;
             case TDuration::DurationType::V_MEASURE:
-                  if (ticks() >= Fraction(2, 1))
+                  if (ticks() >= Fraction(2, 1) && !score()->styleB(Sid::alwaysUseWholeRest))
                         return SymId::restDoubleWhole;
                   // fall through
             case TDuration::DurationType::V_WHOLE:

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -191,6 +191,7 @@ static const StyleType styleTypes[] {
       { Sid::ledgerLineLength,        "ledgerLineLength",        Spatium(.6)   },     // notehead width + this value
       { Sid::accidentalDistance,      "accidentalDistance",      Spatium(0.22) },
       { Sid::accidentalNoteDistance,  "accidentalNoteDistance",  Spatium(0.22) },
+      { Sid::alwaysUseWholeRest,      "alwaysUseWholeRest",      QVariant(false) },
 
       { Sid::beamWidth,               "beamWidth",               Spatium(0.5)  },     // was 0.48
       { Sid::beamDistance,            "beamDistance",            QVariant(0.5) },     // 0.25sp units

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -165,6 +165,8 @@ enum class Sid {
       ledgerLineLength,
       accidentalDistance,
       accidentalNoteDistance,
+      alwaysUseWholeRest,
+
       beamWidth,
       beamDistance,
       beamMinLen,

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -366,6 +366,8 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
 
       { Sid::bendLineWidth,     false, bendLineWidth,     resetBendLineWidth     },
       { Sid::bendArrowWidth,    false, bendArrowWidth,    resetBendArrowWidth    },
+
+      { Sid::alwaysUseWholeRest,      false, alwaysUseWholeRest,    0 }
       };
 
       for (QComboBox* cb : std::vector<QComboBox*> {

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -108,7 +108,7 @@
       </item>
       <item>
        <property name="text">
-        <string>Notes</string>
+        <string>Notes/Rests</string>
        </property>
       </item>
       <item>
@@ -4234,6 +4234,22 @@
              </property>
              <property name="singleStep">
               <double>0.010000000000000</double>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="groupBox_2">
+          <property name="title">
+           <string>Rests</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_46">
+           <item row="0" column="0">
+            <widget class="QCheckBox" name="alwaysUseWholeRest">
+             <property name="text">
+              <string>Always use whole rest for measure rests</string>
              </property>
             </widget>
            </item>
@@ -9354,7 +9370,7 @@
               <item row="1" column="1">
                <widget class="QDoubleSpinBox" name="extensionAdjust">
                 <property name="minimum">
-                 <double>-99.99</double>
+                 <double>-99.989999999999995</double>
                 </property>
                </widget>
               </item>
@@ -9388,7 +9404,7 @@
               <item row="1" column="4">
                <widget class="QDoubleSpinBox" name="modifierAdjust">
                 <property name="minimum">
-                 <double>-99.99</double>
+                 <double>-99.989999999999995</double>
                 </property>
                </widget>
               </item>
@@ -10201,8 +10217,7 @@
                   <number>0</number>
                  </property>
                  <item row="0" column="1">
-                  <widget class="Awl::ColorLabel" name="textStyleFrameForeground">
-                  </widget>
+                  <widget class="Awl::ColorLabel" name="textStyleFrameForeground"/>
                  </item>
                  <item row="2" column="0">
                   <widget class="QLabel" name="label_205">
@@ -10287,8 +10302,7 @@
                   <widget class="QDoubleSpinBox" name="textStyleFramePadding"/>
                  </item>
                  <item row="1" column="1">
-                  <widget class="Awl::ColorLabel" name="textStyleFrameBackground">
-                  </widget>
+                  <widget class="Awl::ColorLabel" name="textStyleFrameBackground"/>
                  </item>
                  <item row="3" column="2">
                   <widget class="QToolButton" name="resetTextStyleFramePadding">
@@ -10348,8 +10362,7 @@
             </widget>
            </item>
            <item row="6" column="1">
-            <widget class="Awl::ColorLabel" name="textStyleColor">
-            </widget>
+            <widget class="Awl::ColorLabel" name="textStyleColor"/>
            </item>
            <item row="7" column="1">
             <widget class="Ms::OffsetSelect" name="textStyleOffset" native="true"/>


### PR DESCRIPTION
As discussed on Telegram.

Even if the measure duration is no shorter than `Fraction(2, 1)`.