### PR TITLE
Update aeolus to the latest Synthesizer interface

### DIFF
--- a/aeolus/aeolus.cpp
+++ b/aeolus/aeolus.cpp
@@ -52,23 +52,34 @@ Synthesizer* createAeolus()
 //   Aeolus
 //---------------------------------------------------------
 
-Aeolus::Aeolus()
+Aeolus::Aeolus() : Synthesizer()
       {
-      model = 0;
+      model = nullptr;
       patchList.append(new MidiPatch { false, "Aeolus", 0, 0, 0, "Aeolus" });
 
       _sc_cmode = 0;
       _sc_group = 0;
       _running = false;
+      _hold = 0;
       _nplay = 0;
-      _fsamp = 0;
       _nasect = 0;
       _ndivis = 0;
+      _revsize = 0.0f;
+      _revtime = 0.0f;
       nout = 0;
-      _ifc_init = 0;
-      for (int i = 0; i < NGROUP; i++)
-            _ifelms [i] = 0;
-      memset(_keymap, 0, sizeof(_keymap));
+      _fsamp = 0.0f;
+      _fsize = 0;
+      _ifc_init = nullptr;
+      _midimap = { 0 };
+      _asectp = { nullptr };
+      _divisp = { nullptr };
+      _keymap = { 0 };
+      _audiopar = { 0.0f };
+      routb = { 0.0f };
+      loutb = { 0.0f };
+      _asectpar = { nullptr };
+      _ifelms = { 0 };
+      _tempstr = { 0 };
       }
 
 Aeolus::~Aeolus()
@@ -257,10 +268,11 @@ SynthesizerGroup Aeolus::state() const
 //   setState
 //---------------------------------------------------------
 
-void Aeolus::setState(const SynthesizerGroup& g)
+bool Aeolus::setState(const SynthesizerGroup& g)
       {
       for (const IdValue& v : g)
             setValue(v.id, v.data.toDouble());
+      return true;
       }
 
 //---------------------------------------------------------

--- a/aeolus/aeolus.h
+++ b/aeolus/aeolus.h
@@ -109,7 +109,7 @@ class Aeolus : public Synthesizer {
       virtual double masterTuning() const;
 
       virtual bool loadSoundFonts(const QStringList&) { return true; }
-      virtual QStringList soundFonts() const { return QStringList(); }
+      virtual std::vector<Ms::SoundFontInfo> soundFontsInfo() const { std::vector<Ms::SoundFontInfo> sl; return sl; }
 
       virtual void process(unsigned, float*, float*, float*);
       virtual void play(const PlayEvent&);
@@ -118,7 +118,7 @@ class Aeolus : public Synthesizer {
 
       // get/set synthesizer state
       virtual SynthesizerGroup state() const;
-      virtual void setState(const SynthesizerGroup&);
+      virtual bool setState(const SynthesizerGroup&);
 
       virtual void allSoundsOff(int channel) { allNotesOff(channel); }
       virtual void allNotesOff(int /*channel*/);

--- a/aeolus/model.cpp
+++ b/aeolus/model.cpp
@@ -745,7 +745,7 @@ int Model::write_instr()
       Ifelm         *I;
       Addsynth      *A;
 
-    sprintf (buff, "%s/definition", _instr);
+    snprintf (buff, sizeof(buff), "%s/definition", _instr);
     if (! (F = fopen (buff, "w")))
     {
       fprintf (stderr, "Can't open '%s' for writing\n", buff);
@@ -963,7 +963,7 @@ bool Model::writePresets()
       uchar  data [256];
       FILE   *F;
 
-      sprintf (name, "%s/presets", _instr);
+      snprintf (name, sizeof(name), "%s/presets", _instr);
       if (! (F = fopen (name, "w"))) {
             fprintf (stderr, "Can't open '%s' for writing\n", name);
             return 1;

--- a/aeolus/sparm.cpp
+++ b/aeolus/sparm.cpp
@@ -110,12 +110,12 @@ bool SyntiParameterData::operator==(const SyntiParameterData& sp) const
 //   write
 //---------------------------------------------------------
 
-void SyntiParameterData::write(Xml& xml) const
+void SyntiParameterData::write(XmlWriter& xml) const
       {
       if (_type == SP_FLOAT)
             xml.tagE(QString("f name=\"%1\" val=\"%3\"").arg(_name).arg(_fval));
       else if (_type == SP_STRING)
-            xml.tagE(QString("s name=\"%1\" val=\"%3\"").arg(_name).arg(Xml::xmlString(_sval)));
+            xml.tagE(QString("s name=\"%1\" val=\"%3\"").arg(_name).arg(XmlWriter::xmlString(_sval)));
       }
 
 //---------------------------------------------------------
@@ -189,7 +189,7 @@ SyntiParameterType SyntiParameter::type() const
 //   write
 //---------------------------------------------------------
 
-void SyntiParameter::write(Xml& xml) const
+void SyntiParameter::write(XmlWriter& xml) const
       {
       d->write(xml);
       }

--- a/aeolus/sparm.h
+++ b/aeolus/sparm.h
@@ -21,7 +21,7 @@
 #define __SPARM_H__
 
 namespace Ms {
-      class Xml;
+      class XmlWriter;
       class Synth;
       }
 
@@ -54,7 +54,7 @@ class SyntiParameter {
 
       SyntiParameterType type() const;
 
-      void write(Ms::Xml&) const;
+      void write(Ms::XmlWriter&) const;
 
       const QString& name() const;
       void setName(const QString& s);

--- a/aeolus/sparm_p.h
+++ b/aeolus/sparm_p.h
@@ -70,7 +70,7 @@ class SyntiParameterData : public QSharedData {
       SyntiParameterData(int id, const QString& name, const QString& val);
       SyntiParameterData(const SyntiParameterData& pd);
 
-      virtual void write(Ms::Xml&) const;
+      virtual void write(Ms::XmlWriter&) const;
       virtual bool operator==(const SyntiParameterData&) const;
       virtual void print() const;
 


### PR DESCRIPTION
Are you interested in keeping the aeolus code in a buildable state?  I would like to use it, but found that the code no longer implements the current Synthesizer interface.  After fixing that, I experienced crashes in the aeolus destructor, because of uninitialized fields.  This commit fixes all of the above.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
