### PR TITLE
fix #291758 - [Musicxml Export] - Tbox and Vbox after measure 1 don't export

### DIFF
--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -2,7 +2,7 @@
 //  MusE Score
 //  Linux Music Score Editor
 //
-//  Copyright (C) 2002-2013 Werner Schweer and others
+//  Copyright (C) 2002-2020 Werner Schweer and others
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2.
@@ -324,6 +324,7 @@ public:
       void credits(XmlWriter& xml);
       void moveToTick(const Fraction& t);
       void words(TextBase const* const text, int staff);
+      void tboxTextAsWords(TextBase const* const text, int staff, QPointF position);
       void rehearsal(RehearsalMark const* const rmk, int staff);
       void hairpin(Hairpin const* const hp, int staff, const Fraction& tick);
       void ottava(Ottava const* const ot, int staff, const Fraction& tick);
@@ -341,12 +342,41 @@ public:
       };
 
 //---------------------------------------------------------
-//   addPositioningAttributes
+//   positionToQString
+//---------------------------------------------------------
+
+static QString positionToQString(const QPointF def, const QPointF rel, const float spatium)
+      {
+      // minimum value to export
+      const float positionElipson = 0.1f;
+
+      // convert into tenths for MusicXML
+      const float defaultX =  10 * def.x() / spatium;
+      const float defaultY =  -10 * def.y()  / spatium;
+      const float relativeX =  10 * rel.x() / spatium;
+      const float relativeY =  -10 * rel.y() / spatium;
+
+      // generate string representation
+      QString res;
+      if (fabsf(defaultX) > positionElipson)
+            res += QString(" default-x=\"%1\"").arg(QString::number(defaultX, 'f', 2));
+      if (fabsf(defaultY) > positionElipson)
+            res += QString(" default-y=\"%1\"").arg(QString::number(defaultY, 'f', 2));
+      if (fabsf(relativeX) > positionElipson)
+            res += QString(" relative-x=\"%1\"").arg(QString::number(relativeX, 'f', 2));
+      if (fabsf(relativeY) > positionElipson)
+            res += QString(" relative-y=\"%1\"").arg(QString::number(relativeY, 'f', 2));
+
+      return res;
+      }
+
+//---------------------------------------------------------
+//   positioningAttributes
 //   According to the specs (common.dtd), all direction-type and note elements must be relative to the measure
 //   while all other elements are relative to their position or the nearest note.
 //---------------------------------------------------------
 
-static QString addPositioningAttributes(Element const* const el, bool isSpanStart = true)
+static QString positioningAttributes(Element const* const el, bool isSpanStart = true)
       {
       if (!preferences.getBool(PREF_EXPORT_MUSICXML_EXPORTLAYOUT))
             return "";
@@ -354,11 +384,8 @@ static QString addPositioningAttributes(Element const* const el, bool isSpanStar
       //qDebug("single el %p _pos x,y %f %f _userOff x,y %f %f spatium %f",
       //       el, el->ipos().x(), el->ipos().y(), el->offset().x(), el->offset().y(), el->spatium());
 
-      const float positionElipson = 0.1f;
-      float defaultX = 0;
-      float defaultY = 0;
-      float relativeX = 0;
-      float relativeY = 0;
+      QPointF def;
+      QPointF rel;
       float spatium = el->spatium();
 
       const SLine* span = nullptr;
@@ -370,8 +397,8 @@ static QString addPositioningAttributes(Element const* const el, bool isSpanStar
                   const auto seg = span->frontSegment();
                   const auto offset = seg->offset();
                   const auto p = seg->pos();
-                  relativeX = offset.x();
-                  defaultY = p.y();
+                  rel.setX(offset.x());
+                  def.setY(p.y());
 
                   //qDebug("sline start seg %p seg->pos x,y %f %f seg->userOff x,y %f %f spatium %f",
                   //       seg, p.x(), p.y(), seg->offset().x(), seg->offset().y(), seg->spatium());
@@ -389,36 +416,18 @@ static QString addPositioningAttributes(Element const* const el, bool isSpanStar
 
                   // For an SLine, the actual offset equals the sum of userOff and userOff2,
                   // as userOff moves the SLine as a whole
-                  relativeX = userOff.x() + userOff2.x();
+                  rel.setX(userOff.x() + userOff2.x());
 
                   // Following would probably required for non-horizontal SLines:
                   //defaultY = pos.y() + pos2.y();
                   }
             }
       else {
-            defaultX = el->ipos().x();   // Note: for some elements, Finale Notepad seems to work slightly better w/o default-x
-            defaultY = el->ipos().y();
-            relativeX = el->offset().x();
-            relativeY = el->offset().y();
+            def = el->ipos();   // Note: for some elements, Finale Notepad seems to work slightly better w/o default-x
+            rel = el->offset();
             }
 
-      // convert into spatium tenths for MusicXML
-      defaultX *=  10 / spatium;
-      defaultY *=  -10 / spatium;
-      relativeX *=  10 / spatium;
-      relativeY *=  -10 / spatium;
-
-      QString res;
-      if (fabsf(defaultX) > positionElipson)
-            res += QString(" default-x=\"%1\"").arg(QString::number(defaultX, 'f', 2));
-      if (fabsf(defaultY) > positionElipson)
-            res += QString(" default-y=\"%1\"").arg(QString::number(defaultY, 'f', 2));
-      if (fabsf(relativeX) > positionElipson)
-            res += QString(" relative-x=\"%1\"").arg(QString::number(relativeX, 'f', 2));
-      if (fabsf(relativeY) > positionElipson)
-            res += QString(" relative-y=\"%1\"").arg(QString::number(relativeY, 'f', 2));
-
-      return res;
+      return positionToQString(def, rel, spatium);
       }
 
 //---------------------------------------------------------
@@ -672,7 +681,7 @@ void SlurHandler::doSlurStart(const Slur* s, Notations& notations, XmlWriter& xm
       tagName += color2xml(s);
       tagName += QString(" type=\"start\" placement=\"%1\"")
             .arg(s->up() ? "above" : "below");
-      tagName += addPositioningAttributes(s, true);
+      tagName += positioningAttributes(s, true);
 
       if (i >= 0) {
             // remove from list and print start
@@ -719,7 +728,7 @@ void SlurHandler::doSlurStop(const Slur* s, Notations& notations, XmlWriter& xml
                   started[i] = false;
                   notations.tag(xml);
                   QString tagName = QString("slur type=\"stop\" number=\"%1\"").arg(i + 1);
-                  tagName += addPositioningAttributes(s, false);
+                  tagName += positioningAttributes(s, false);
                   xml.tagE(tagName);
                   }
             else
@@ -731,7 +740,7 @@ void SlurHandler::doSlurStop(const Slur* s, Notations& notations, XmlWriter& xml
             started[i] = false;
             notations.tag(xml);
             QString tagName = QString("slur type=\"stop\" number=\"%1\"").arg(i + 1);
-            tagName += addPositioningAttributes(s, false);
+            tagName += positioningAttributes(s, false);
             xml.tagE(tagName);
             }
       }
@@ -766,7 +775,7 @@ static void glissando(const Glissando* gli, int number, bool start, Notations& n
             }
       tagName += QString(" number=\"%1\" type=\"%2\"").arg(number).arg(start ? "start" : "stop");
       tagName += color2xml(gli);
-      tagName += addPositioningAttributes(gli, start);
+      tagName += positioningAttributes(gli, start);
       notations.tag(xml);
       if (start && gli->showText() && gli->text() != "")
             xml.tag(tagName, gli->text());
@@ -1140,24 +1149,35 @@ static void defaults(XmlWriter& xml, const Score* const s, double& millimeters, 
       xml.etag();
       }
 
+//---------------------------------------------------------
+//   formatForWords
+//---------------------------------------------------------
+
+static CharFormat formatForWords(const Score* const s)
+      {
+      CharFormat defFmt;
+      defFmt.setFontFamily(s->styleSt(Sid::staffTextFontFace));
+      defFmt.setFontSize(s->styleD(Sid::staffTextFontSize));
+      return defFmt;
+      }
 
 //---------------------------------------------------------
 //   creditWords
 //---------------------------------------------------------
 
-static void creditWords(XmlWriter& xml, Score* s, double x, double y, QString just, QString val, const QList<TextFragment>& words)
+static void creditWords(XmlWriter& xml, const Score* const s, const int pageNr,
+                        const double x, const double y, const QString& just, const QString& val,
+                        const QList<TextFragment>& words)
       {
       // prevent incorrect MusicXML for empty text
       if (words.isEmpty())
             return;
 
       const QString mtf = s->styleSt(Sid::MusicalTextFont);
-      CharFormat defFmt;
-      defFmt.setFontFamily(s->styleSt(Sid::staffTextFontFace));
-      defFmt.setFontSize(s->styleD(Sid::staffTextFontSize));
+      const CharFormat defFmt = formatForWords(s);
 
       // export formatted
-      xml.stag("credit page=\"1\"");
+      xml.stag(QString("credit page=\"%1\"").arg(pageNr));
       QString attr = QString(" default-x=\"%1\"").arg(x);
       attr += QString(" default-y=\"%1\"").arg(y);
       attr += " justify=\"" + just + "\"";
@@ -1186,79 +1206,104 @@ static double parentHeight(const Element* element)
       }
 
 //---------------------------------------------------------
+//   textAsCreditWords
+//---------------------------------------------------------
+
+// Refactor suggestion: make getTenthsFromInches static instead of ExportMusicXml member function
+
+static void textAsCreditWords(const ExportMusicXml* const expMxml, XmlWriter& xml, const Score* const s, const int pageNr, const Text* const text)
+      {
+      // determine page formatting
+      const double h  = expMxml->getTenthsFromInches(s->styleD(Sid::pageHeight));
+      const double w  = expMxml->getTenthsFromInches(s->styleD(Sid::pageWidth));
+      const double lm = expMxml->getTenthsFromInches(s->styleD(Sid::pageOddLeftMargin));
+      const double rm = expMxml->getTenthsFromInches(s->styleD(Sid::pageEvenLeftMargin));
+      const double ph = expMxml->getTenthsFromDots(parentHeight(text));
+
+      double tx = w / 2;
+      double ty = h - expMxml->getTenthsFromDots(text->pagePos().y());
+
+      Align al = text->align();
+      QString just;
+      QString val;
+
+      if (al & Align::RIGHT) {
+            just = "right";
+            tx   = w - rm;
+            }
+      else if (al & Align::HCENTER) {
+            just = "center";
+            // tx already set correctly
+            }
+      else {
+            just = "left";
+            tx   = lm;
+            }
+
+      if (al & Align::BOTTOM) {
+            val = "bottom";
+            ty -= ph;
+            }
+      else if (al & Align::VCENTER) {
+            val = "middle";
+            ty -= ph / 2;
+            }
+      else if (al & Align::BASELINE) {
+            val = "baseline";
+            ty -= ph / 2;
+            }
+      else {
+            val = "top";
+            // ty already set correctly
+            }
+
+      creditWords(xml, s, pageNr, tx, ty, just, val, text->fragmentList());
+      }
+
+//---------------------------------------------------------
 //   credits
 //---------------------------------------------------------
 
 void ExportMusicXml::credits(XmlWriter& xml)
       {
-      // determine page formatting
-      const double h  = getTenthsFromInches(_score->styleD(Sid::pageHeight));
-      const double w  = getTenthsFromInches(_score->styleD(Sid::pageWidth));
-      const double lm = getTenthsFromInches(_score->styleD(Sid::pageOddLeftMargin));
-      const double rm = getTenthsFromInches(_score->styleD(Sid::pageEvenLeftMargin));
-      //const double tm = getTenthsFromInches(_score->styleD(Sid::pageOddTopMargin));
-      const double bm = getTenthsFromInches(_score->styleD(Sid::pageOddBottomMargin));
-      //qDebug("page h=%g w=%g lm=%g rm=%g tm=%g bm=%g", h, w, lm, rm, tm, bm);
-
-      // write the credits (found in the header, i.e. everything before the first measure)
-      for (auto mb = _score->measures()->first(); mb && !mb->isMeasure(); mb = mb->next()) {
-            for (const Element* element : mb->el()) {
-                  if (element->isText()) {
-                        const Text* text = toText(element);
-                        const double ph = getTenthsFromDots(parentHeight(text));
-
-                        double tx = w / 2;
-                        double ty = h - getTenthsFromDots(text->pagePos().y());
-
-                        Align al = text->align();
-                        QString just;
-                        QString val;
-
-                        if (al & Align::RIGHT) {
-                              just = "right";
-                              tx   = w - rm;
+      // find the vboxes in every page and write their elements as credit-words
+      for (const auto page : _score->pages()) {
+            const auto pageIdx = _score->pageIdx(page);
+            for (const auto system : page->systems()) {
+                  for (const auto mb : system->measures()) {
+                        if (mb->isVBox()) {
+                              for (const Element* element : mb->el()) {
+                                    if (element->isText()) {
+                                          const Text* text = toText(element);
+                                          textAsCreditWords(this, xml, _score, pageIdx + 1, text);
+                                          }
+                                    }
                               }
-                        else if (al & Align::HCENTER) {
-                              just = "center";
-                              // tx already set correctly
-                              }
-                        else {
-                              just = "left";
-                              tx   = lm;
-                              }
-
-                        if (al & Align::BOTTOM) {
-                              val = "bottom";
-                              ty -= ph;
-                              }
-                        else if (al & Align::VCENTER) {
-                              val = "middle";
-                              ty -= ph / 2;
-                              }
-                        else if (al & Align::BASELINE) {
-                              val = "baseline";
-                              ty -= ph / 2;
-                              }
-                        else {
-                              val = "top";
-                              // ty already set correctly
-                              }
-
-                        creditWords(xml, _score, tx, ty, just, val, text->fragmentList());
                         }
                   }
             }
 
+      // put copyright at the bottom center of every page
+      // note: as the copyright metatag contains plain text, special XML characters must be escaped
+      // determine page formatting
       const QString rights = _score->metaTag("copyright");
       if (!rights.isEmpty()) {
-            // put copyright at the bottom center of the page
-            // note: as the copyright metatag contains plain text, special XML characters must be escaped
+            const double bm = getTenthsFromInches(_score->styleD(Sid::pageOddBottomMargin));
+            const double w  = getTenthsFromInches(_score->styleD(Sid::pageWidth));
+            /*
+            const double h  = getTenthsFromInches(_score->styleD(Sid::pageHeight));
+            const double lm = getTenthsFromInches(_score->styleD(Sid::pageOddLeftMargin));
+            const double rm = getTenthsFromInches(_score->styleD(Sid::pageEvenLeftMargin));
+            const double tm = getTenthsFromInches(_score->styleD(Sid::pageOddTopMargin));
+            qDebug("page h=%g w=%g lm=%g rm=%g tm=%g bm=%g", h, w, lm, rm, tm, bm);
+            */
             TextFragment f(XmlWriter::xmlString(rights));
             f.changeFormat(FormatId::FontFamily, _score->styleSt(Sid::footerFontFace));
             f.changeFormat(FormatId::FontSize, _score->styleD(Sid::footerFontSize));
             QList<TextFragment> list;
             list.append(f);
-            creditWords(xml, _score, w / 2, bm, "center", "bottom", list);
+            for (int pageIdx = 0; pageIdx < _score->npages(); ++pageIdx)
+                  creditWords(xml, _score, pageIdx + 1, w / 2, bm, "center", "bottom", list);
             }
       }
 
@@ -1449,7 +1494,7 @@ static void ending(XmlWriter& xml, Volta* v, bool left)
                   }
             }
       QString voltaXml = QString("ending number=\"%1\" type=\"%2\"").arg(number).arg(type);
-      voltaXml += addPositioningAttributes(v, left);
+      voltaXml += positioningAttributes(v, left);
       xml.tagE(voltaXml);
       }
 
@@ -1883,7 +1928,7 @@ static void wavyLineStart(const Trill* tr, const int number, Notations& notation
       QString tagName = "wavy-line type=\"start\"";
       tagName += QString(" number=\"%1\"").arg(number + 1);
       tagName += color2xml(tr);
-      tagName += addPositioningAttributes(tr, true);
+      tagName += positioningAttributes(tr, true);
       xml.tagE(tagName);
       }
 
@@ -1896,7 +1941,7 @@ static void wavyLineStop(const Trill* tr, const int number, Notations& notations
       notations.tag(xml);
       ornaments.tag(xml);
       QString trillXml = QString("wavy-line type=\"stop\" number=\"%1\"").arg(number + 1);
-      trillXml += addPositioningAttributes(tr, false);
+      trillXml += positioningAttributes(tr, false);
       xml.tagE(trillXml);
       }
 
@@ -2385,7 +2430,7 @@ static void arpeggiate(Arpeggio* arp, bool front, bool back, XmlWriter& xml, Not
             }
 
       if (tagName != "") {
-            tagName += addPositioningAttributes(arp);
+            tagName += positioningAttributes(arp);
             xml.tagE(tagName);
             }
       }
@@ -3250,7 +3295,7 @@ static void partGroupStart(XmlWriter& xml, int number, BracketType bracket)
       }
 
 //---------------------------------------------------------
-//   words
+//   findUnit
 //---------------------------------------------------------
 
 static bool findUnit(TDuration::DurationType val, QString& unit)
@@ -3264,6 +3309,10 @@ static bool findUnit(TDuration::DurationType val, QString& unit)
             }
       return true;
       }
+
+//---------------------------------------------------------
+//   findMetronome
+//---------------------------------------------------------
 
 static bool findMetronome(const QList<TextFragment>& list,
                           QList<TextFragment>& wordsLeft,  // words left of metronome
@@ -3373,6 +3422,10 @@ static bool findMetronome(const QList<TextFragment>& list,
       return false;
       }
 
+//---------------------------------------------------------
+//   beatUnit
+//---------------------------------------------------------
+
 static void beatUnit(XmlWriter& xml, const TDuration dur)
       {
       int dots = dur.dots();
@@ -3384,6 +3437,10 @@ static void beatUnit(XmlWriter& xml, const TDuration dur)
             --dots;
             }
       }
+
+//---------------------------------------------------------
+//   wordsMetrome
+//---------------------------------------------------------
 
 static void wordsMetrome(XmlWriter& xml, Score* s, TextBase const* const text, const int offset)
       {
@@ -3397,15 +3454,12 @@ static void wordsMetrome(XmlWriter& xml, Score* s, TextBase const* const text, c
 
       // set the default words format
       const QString mtf = s->styleSt(Sid::MusicalTextFont);
-      CharFormat defFmt;
-      defFmt.setFontFamily(s->styleSt(Sid::staffTextFontFace));
-      defFmt.setFontSize(s->styleD(Sid::staffTextFontSize));
+      const CharFormat defFmt = formatForWords(s);
 
       if (findMetronome(list, wordsLeft, hasParen, metroLeft, metroRight, wordsRight)) {
             if (wordsLeft.size() > 0) {
                   xml.stag("direction-type");
-                  QString attr; // TODO TBD
-                  attr += addPositioningAttributes(text);
+                  QString attr = positioningAttributes(text);
                   MScoreTextToMXML mttm("words", attr, defFmt, mtf);
                   mttm.writeTextFragments(wordsLeft, xml);
                   xml.etag();
@@ -3413,7 +3467,7 @@ static void wordsMetrome(XmlWriter& xml, Score* s, TextBase const* const text, c
 
             xml.stag("direction-type");
             QString tagName = QString("metronome parentheses=\"%1\"").arg(hasParen ? "yes" : "no");
-            tagName += addPositioningAttributes(text);
+            tagName += positioningAttributes(text);
             xml.stag(tagName);
             int len1 = 0;
             TDuration dur;
@@ -3430,8 +3484,7 @@ static void wordsMetrome(XmlWriter& xml, Score* s, TextBase const* const text, c
 
             if (wordsRight.size() > 0) {
                   xml.stag("direction-type");
-                  QString attr; // TODO TBD
-                  attr += addPositioningAttributes(text);
+                  QString attr = positioningAttributes(text);
                   MScoreTextToMXML mttm("words", attr, defFmt, mtf);
                   mttm.writeTextFragments(wordsRight, xml);
                   xml.etag();
@@ -3447,7 +3500,7 @@ static void wordsMetrome(XmlWriter& xml, Score* s, TextBase const* const text, c
                   else
                         attr = " enclosure=\"rectangle\"";
                   }
-            attr += addPositioningAttributes(text);
+            attr += positioningAttributes(text);
             MScoreTextToMXML mttm("words", attr, defFmt, mtf);
             //qDebug("words('%s')", qPrintable(text->text()));
             mttm.writeTextFragments(text->fragmentList(), xml);
@@ -3457,6 +3510,10 @@ static void wordsMetrome(XmlWriter& xml, Score* s, TextBase const* const text, c
       if (offset)
             xml.tag("offset", offset);
       }
+
+//---------------------------------------------------------
+//   tempoText
+//---------------------------------------------------------
 
 void ExportMusicXml::tempoText(TempoText const* const text, int staff)
       {
@@ -3471,6 +3528,7 @@ void ExportMusicXml::tempoText(TempoText const* const text, int staff)
       _attr.doAttr(_xml, false);
       _xml.stag(QString("direction placement=\"%1\"").arg((text->placement() ==Placement::BELOW ) ? "below" : "above"));
       wordsMetrome(_xml, _score, text, offset);
+
       if (staff)
             _xml.tag("staff", staff);
       _xml.tagE(QString("sound tempo=\"%1\"").arg(QString::number(text->tempo()*60.0)));
@@ -3506,6 +3564,55 @@ void ExportMusicXml::words(TextBase const* const text, int staff)
       }
 
 //---------------------------------------------------------
+//   positioningAttributesForTboxText
+//---------------------------------------------------------
+
+static QString positioningAttributesForTboxText(const QPointF position, float spatium)
+      {
+      if (!preferences.getBool(PREF_EXPORT_MUSICXML_EXPORTLAYOUT))
+            return "";
+
+      QPointF relative;       // use zero relative position
+      return positionToQString(position, relative, spatium);
+      }
+
+//---------------------------------------------------------
+//   tboxTextAsWords
+//---------------------------------------------------------
+
+void ExportMusicXml::tboxTextAsWords(TextBase const* const text, const int staff, const QPointF relativePosition)
+      {
+      if (text->plainText() == "") {
+            // sometimes empty Texts are present, exporting would result
+            // in invalid MusicXML (as an empty direction-type would be created)
+            return;
+            }
+
+      // set the default words format
+      const QString mtf = _score->styleSt(Sid::MusicalTextFont);
+      const CharFormat defFmt = formatForWords(_score);
+
+      QString tagname { "direction" };
+      tagname += " placement=";
+      tagname += (relativePosition.y() < 0) ? "\"above\"" : "\"below\"";
+      _xml.stag(tagname);
+      _xml.stag("direction-type");
+      QString attr;
+      if (text->hasFrame()) {
+            if (text->circle())
+                  attr = " enclosure=\"circle\"";
+            else
+                  attr = " enclosure=\"rectangle\"";
+            }
+      attr += positioningAttributesForTboxText(relativePosition, text->spatium());
+      attr += " valign=\"top\"";
+      MScoreTextToMXML mttm("words", attr, defFmt, mtf);
+      mttm.writeTextFragments(text->fragmentList(), _xml);
+      _xml.etag();
+      directionETag(_xml, staff);
+      }
+
+//---------------------------------------------------------
 //   rehearsal
 //---------------------------------------------------------
 
@@ -3519,14 +3626,11 @@ void ExportMusicXml::rehearsal(RehearsalMark const* const rmk, int staff)
 
       directionTag(_xml, _attr, rmk);
       _xml.stag("direction-type");
-      QString attr;
-      attr += addPositioningAttributes(rmk);
+      QString attr = positioningAttributes(rmk);
       if (!rmk->hasFrame()) attr = " enclosure=\"none\"";
       // set the default words format
       const QString mtf = _score->styleSt(Sid::MusicalTextFont);
-      CharFormat defFmt;
-      defFmt.setFontFamily(_score->styleSt(Sid::staffTextFontFace));
-      defFmt.setFontSize(_score->styleD(Sid::staffTextFontSize));
+      const CharFormat defFmt = formatForWords(_score);
       // write formatted
       MScoreTextToMXML mttm("rehearsal", attr, defFmt, mtf);
       mttm.writeTextFragments(rmk->fragmentList(), _xml);
@@ -3622,14 +3726,14 @@ void ExportMusicXml::hairpin(Hairpin const* const hp, int staff, const Fraction&
                   tag += QString(" font-family=\"%1\"").arg(hp->getProperty(Pid::BEGIN_FONT_FACE).toString());
                   tag += QString(" font-size=\"%1\"").arg(hp->getProperty(Pid::BEGIN_FONT_SIZE).toReal());
                   tag += fontSyleToXML(static_cast<FontStyle>(hp->getProperty(Pid::BEGIN_FONT_STYLE).toInt()));
-                  tag += addPositioningAttributes(hp, hp->tick() == tick);
+                  tag += positioningAttributes(hp, hp->tick() == tick);
                   _xml.tag(tag, hp->getProperty(Pid::BEGIN_TEXT));
                   _xml.etag();
 
                   _xml.stag("direction-type");
                   tag = "dashes type=\"start\"";
                   tag += QString(" number=\"%1\"").arg(n + 1);
-                  tag += addPositioningAttributes(hp, hp->tick() == tick);
+                  tag += positioningAttributes(hp, hp->tick() == tick);
                   _xml.tagE(tag);
                   _xml.etag();
                   }
@@ -3660,7 +3764,7 @@ void ExportMusicXml::hairpin(Hairpin const* const hp, int staff, const Fraction&
                         }
                   }
             tag += QString(" number=\"%1\"").arg(n + 1);
-            tag += addPositioningAttributes(hp, hp->tick() == tick);
+            tag += positioningAttributes(hp, hp->tick() == tick);
             _xml.tagE(tag);
             _xml.etag();
             }
@@ -3740,7 +3844,7 @@ void ExportMusicXml::ottava(Ottava const* const ot, int staff, const Fraction& t
       if (octaveShiftXml != "") {
             directionTag(_xml, _attr, ot);
             _xml.stag("direction-type");
-            octaveShiftXml += addPositioningAttributes(ot, ot->tick() == tick);
+            octaveShiftXml += positioningAttributes(ot, ot->tick() == tick);
             _xml.tagE(octaveShiftXml);
             _xml.etag();
             directionETag(_xml, staff);
@@ -3760,7 +3864,7 @@ void ExportMusicXml::pedal(Pedal const* const pd, int staff, const Fraction& tic
             pedalXml = "pedal type=\"start\" line=\"yes\"";
       else
             pedalXml = "pedal type=\"stop\" line=\"yes\"";
-      pedalXml += addPositioningAttributes(pd, pd->tick() == tick);
+      pedalXml += positioningAttributes(pd, pd->tick() == tick);
       _xml.tagE(pedalXml);
       _xml.etag();
       directionETag(_xml, staff);
@@ -3868,7 +3972,7 @@ void ExportMusicXml::textLine(TextLine const* const tl, int staff, const Fractio
             rest += QString(" end-length=\"%1\"").arg(hookHeight * 10);
             }
 
-      rest += addPositioningAttributes(tl, tl->tick() == tick);
+      rest += positioningAttributes(tl, tl->tick() == tick);
 
       directionTag(_xml, _attr, tl);
 
@@ -3922,7 +4026,7 @@ void ExportMusicXml::dynamic(Dynamic const* const dyn, int staff)
       _xml.stag("direction-type");
 
       QString tagName = "dynamics";
-      tagName += addPositioningAttributes(dyn);
+      tagName += positioningAttributes(dyn);
       _xml.stag(tagName);
       const QString dynTypeName = dyn->dynamicTypeName();
 
@@ -4020,7 +4124,7 @@ void ExportMusicXml::symbol(Symbol const* const sym, int staff)
             return;
             }
       directionTag(_xml, _attr, sym);
-      mxmlName += addPositioningAttributes(sym);
+      mxmlName += positioningAttributes(sym);
       _xml.stag("direction-type");
       _xml.tagE(mxmlName);
       _xml.etag();
@@ -4041,7 +4145,7 @@ void ExportMusicXml::lyrics(const std::vector<Lyrics*>* ll, const int trk)
                   if ((l)->track() == trk) {
                         QString lyricXml = QString("lyric number=\"%1\"").arg((l)->no() + 1);
                         lyricXml += color2xml(l);
-                        lyricXml += addPositioningAttributes(l);
+                        lyricXml += positioningAttributes(l);
                         _xml.stag(lyricXml);
                         Lyrics::Syllabic syl = (l)->syllabic();
                         QString s = "";
@@ -4146,8 +4250,7 @@ static void directionJump(XmlWriter& xml, const Jump* const jp)
       if (sound != "") {
             xml.stag(QString("direction placement=\"%1\"").arg((jp->placement() == Placement::BELOW ) ? "below" : "above"));
             xml.stag("direction-type");
-            QString positioning = "";
-            positioning += addPositioningAttributes(jp);
+            QString positioning = positioningAttributes(jp);
             if (type != "") xml.tagE(type + positioning);
             if (words != "") xml.tag("words" + positioning, words);
             xml.etag();
@@ -4202,8 +4305,7 @@ static void directionMarker(XmlWriter& xml, const Marker* const m)
       if (sound != "") {
             xml.stag(QString("direction placement=\"%1\"").arg((m->placement() == Placement::BELOW ) ? "below" : "above"));
             xml.stag("direction-type");
-            QString positioning = "";
-            positioning += addPositioningAttributes(m);
+            QString positioning = positioningAttributes(m);
             if (type != "") xml.tagE(type + positioning);
             if (words != "") xml.tag("words" + positioning, words);
             xml.etag();
@@ -5553,6 +5655,115 @@ bool MeasureNumberStateHandler::isFirstActualMeasure() const
       }
 
 //---------------------------------------------------------
+//  findLastSystemWithMeasures
+//---------------------------------------------------------
+
+static System* findLastSystemWithMeasures(const Page* const page)
+      {
+      for (int i = page->systems().size() - 1; i >= 0; --i) {
+            const auto s = page->systems().at(i);
+            const auto m = s->firstMeasure();
+            if (m)
+                  return s;
+            }
+      return nullptr;
+      }
+
+//---------------------------------------------------------
+//  isFirstMeasureInSystem
+//---------------------------------------------------------
+
+static bool isFirstMeasureInSystem(const Measure* const measure)
+      {
+      const auto system = measure->mmRest1()->system();
+      const auto firstMeasureInSystem = system->firstMeasure();
+      const auto realFirstMeasureInSystem = firstMeasureInSystem->isMMRest() ? firstMeasureInSystem->mmRestFirst() : firstMeasureInSystem;
+      return measure == realFirstMeasureInSystem;
+      }
+//---------------------------------------------------------
+//  isFirstMeasureInLastSystem
+//---------------------------------------------------------
+
+static bool isFirstMeasureInLastSystem(const Measure* const measure)
+      {
+      const auto system = measure->mmRest1()->system();
+      const auto page = system->page();
+
+      /*
+       Notes on multi-measure rest handling:
+       Function mmRest1() returns either the measure itself (if not part of multi-measure rest)
+       or the replacing multi-measure rest measure.
+       Using this is required as a measure that is covered by a multi-measure rest has no system.
+       Furthermore, the first measure in a system starting with a multi-measure rest is the a multi-
+       measure rest itself instead of the first covered measure.
+       */
+
+      const auto lastSystem = findLastSystemWithMeasures(page);
+      if (!lastSystem)
+            return false;       // degenerate case: no system with measures found
+      const auto firstMeasureInLastSystem = lastSystem->firstMeasure();
+      const auto realFirstMeasureInLastSystem = firstMeasureInLastSystem->isMMRest() ? firstMeasureInLastSystem->mmRestFirst() : firstMeasureInLastSystem;
+      return measure == realFirstMeasureInLastSystem;
+      }
+
+//---------------------------------------------------------
+//  systemHasMeasures
+//---------------------------------------------------------
+
+static bool systemHasMeasures(const System* const system)
+      {
+      return system->firstMeasure();
+      }
+
+//---------------------------------------------------------
+//  findTextFramesToWriteAsWordsAbove
+//---------------------------------------------------------
+
+static std::vector<TBox*> findTextFramesToWriteAsWordsAbove(const Measure* const measure)
+      {
+      const auto system = measure->mmRest1()->system();
+      const auto page = system->page();
+      const auto systemIndex = page->systems().indexOf(system);
+      std::vector<TBox*> tboxes;
+      if (isFirstMeasureInSystem(measure)) {
+            for (auto idx = systemIndex - 1; idx >= 0 && !systemHasMeasures(page->system(idx)); --idx) {
+                  const auto sys = page->system(idx);
+                  for (const auto mb : sys->measures()) {
+                        if (mb->isTBox()) {
+                              auto tbox = toTBox(mb);
+                              tboxes.insert(tboxes.begin(), tbox);
+                              }
+                        }
+                  }
+            }
+      return tboxes;
+      }
+
+//---------------------------------------------------------
+//  findTextFramesToWriteAsWordsBelow
+//---------------------------------------------------------
+
+static std::vector<TBox*> findTextFramesToWriteAsWordsBelow(const Measure* const measure)
+      {
+      const auto system = measure->mmRest1()->system();
+      const auto page = system->page();
+      const auto systemIndex = page->systems().indexOf(system);
+      std::vector<TBox*> tboxes;
+      if (isFirstMeasureInLastSystem(measure)) {
+            for (auto idx = systemIndex + 1; idx < page->systems().size() /* && !systemHasMeasures(page->system(idx))*/; ++idx) {
+                  const auto sys = page->system(idx);
+                  for (const auto mb : sys->measures()) {
+                        if (mb->isTBox()) {
+                              auto tbox = toTBox(mb);
+                              tboxes.insert(tboxes.begin(), tbox);
+                              }
+                        }
+                  }
+            }
+      return tboxes;
+      }
+
+//---------------------------------------------------------
 //  write
 //---------------------------------------------------------
 
@@ -5605,6 +5816,8 @@ void ExportMusicXml::write(QIODevice* dev)
 
       for (int idx = 0; idx < il.size(); ++idx) {
             const auto part = il.at(idx);
+            const bool isFirstPart = (idx == 0);
+            const bool isLastPart = (idx == (il.size() - 1));
             _tick = { 0,1 };
             _xml.stag(QString("part id=\"P%1\"").arg(idx+1));
 
@@ -5621,6 +5834,7 @@ void ExportMusicXml::write(QIODevice* dev)
             FigBassMap fbMap;           // pending figured bass extends
 
             for (auto mb = _score->measures()->first(); mb; mb = mb->next()) {
+
                   if (!mb->isMeasure())
                         continue;
                   const auto m = toMeasure(mb);
@@ -5686,6 +5900,12 @@ void ExportMusicXml::write(QIODevice* dev)
                   if (idx == 0)
                         repeatAtMeasureStart(_xml, _attr, m, strack, etrack, strack);
 
+                  bool tboxesAboveWritten = false;
+                  const auto tboxesAbove = findTextFramesToWriteAsWordsAbove(m);
+
+                  bool tboxesBelowWritten = false;
+                  const auto tboxesBelow = findTextFramesToWriteAsWordsBelow(m);
+
                   for (int st = strack; st < etrack; ++st) {
                         // sstaff - xml staff number, counting from 1 for this
                         // instrument
@@ -5712,6 +5932,27 @@ void ExportMusicXml::write(QIODevice* dev)
                               // handle annotations and spanners (directions attached to this note or rest)
                               if (el->isChordRest()) {
                                     _attr.doAttr(_xml, false);
+                                    if (!tboxesAboveWritten && isFirstPart) {
+                                          for (const auto tbox : tboxesAbove) {
+                                                // note: use mmRest1() to get at a possible multi-measure rest,
+                                                // as the covered measure would be positioned at 0,0.
+                                                tboxTextAsWords(tbox->text(), 0, tbox->text()->canvasPos() - m->mmRest1()->canvasPos());
+                                                }
+                                          tboxesAboveWritten = true;
+                                          }
+                                    if (!tboxesBelowWritten && isLastPart && (etrack - VOICES) <= st) {
+                                          for (const auto tbox : tboxesBelow) {
+                                                const auto lastStaffNr = st / VOICES;
+                                                const auto sys = m->mmRest1()->system();
+                                                auto textPos = tbox->text()->canvasPos() - m->mmRest1()->canvasPos();
+                                                if (lastStaffNr < sys->staves()->size()) {
+                                                      // convert to position relative to last staff of system
+                                                      textPos.setY(textPos.y() - (sys->staffCanvasYpage(lastStaffNr) - sys->staffCanvasYpage(0)));
+                                                      }
+                                                tboxTextAsWords(tbox->text(), sstaff, textPos);
+                                                }
+                                          tboxesBelowWritten = true;
+                                          }
                                     annotations(this, strack, etrack, st, sstaff, seg);
                                     // look for more harmony
                                     for (auto seg1 = seg->next(); seg1; seg1 = seg1->next()) {

--- a/mtest/musicxml/io/iotest.mscxtomxml
+++ b/mtest/musicxml/io/iotest.mscxtomxml
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# simple standalone iotest for MusicXML import
+# run in mtest/musicxml/io directory as "./iotest.mscxtomxml"
+
+# Linux
+#MSCORE=../../../build.debug/mscore/mscore
+# OS X terminal build
+#MSCORE=../../../applebuild/mscore.app/Contents/MacOS/mscore
+# OS X Xcode build
+#MSCORE=../../../build.xcode/mscore/Debug/mscore.app/Contents/MacOS/mscore
+# OS X Xcode build (since early 2020)
+MSCORE=../../../build.xcode/main/Debug/mscore.app/Contents/MacOS/mscore
+
+echo "----------------------------------------------"
+echo "Regression Tests for MuseScore MusicXML import"
+echo "----------------------------------------------"
+echo
+$MSCORE -v
+echo
+
+musicxml_files=`cat tst_mxml_io.cpp | grep "{ mxmlMscxExportTestRef" | awk -F\" '{print $2}' | sort`
+testcount=0
+failures=0
+
+rwtestXmlRef() {
+      echo -n "testing load/save $1";
+      REF=`basename $1 .mscx`_ref.xml
+      $MSCORE $1 -d -o mops.xml &> /dev/null
+      if diff -q $REF mops.xml &> /dev/null; then
+            echo -e "\r\t\t\t\t\t\t...OK";
+      else
+            echo -e "\r\t\t\t\t\t\t...FAILED";
+            failures=$(($failures+1));
+            echo "+++++++++DIFF++++++++++++++"
+            diff $REF mops.xml
+            echo "+++++++++++++++++++++++++++"
+      fi
+      rm mops.xml
+      testcount=$(($testcount+1))
+      }
+
+rwtestAllXml() {
+      for f in $musicxml_files; do
+            rwtestXmlRef ${f}.mscx
+      done
+      }
+
+usage() {
+      echo "usage: $0"
+      echo
+      exit 1
+      }
+
+if [ $# -eq 0 ]; then
+      rwtestAllXml
+else
+      usage
+fi
+
+echo
+echo "$testcount test(s), $failures failure(s)"

--- a/mtest/musicxml/io/testTboxAboveBelow1.mscx
+++ b/mtest/musicxml/io/testTboxAboveBelow1.mscx
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.01">
+  <programVersion>3.4.0</programVersion>
+  <programRevision>3543170</programRevision>
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <pagePrintableWidth>7.4826</pagePrintableWidth>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2019-12-21</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Voice</trackName>
+      <Instrument>
+        <longName>Voice</longName>
+        <shortName>Vo.</shortName>
+        <trackName>Voice</trackName>
+        <minPitchP>36</minPitchP>
+        <maxPitchP>94</maxPitchP>
+        <minPitchA>40</minPitchA>
+        <maxPitchA>79</maxPitchA>
+        <instrumentId>voice.vocals</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <controller ctrl="32" value="17"/>
+          <program value="52"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <TBox>
+        <height>1</height>
+        <Text>
+          <style>Frame</style>
+          <text>Above</text>
+          </Text>
+        </TBox>
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <TBox>
+        <height>1</height>
+        <Text>
+          <style>Frame</style>
+          <text>Below</text>
+          </Text>
+        </TBox>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/musicxml/io/testTboxAboveBelow1_ref.xml
+++ b/mtest/musicxml/io/testTboxAboveBelow1_ref.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <identification>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Voice</part-name>
+      <part-abbreviation>Vo.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Voice</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>53</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <direction placement="above">
+        <direction-type>
+          <words valign="top" font-size="12">Above</words>
+          </direction-type>
+        </direction>
+      <direction placement="below">
+        <direction-type>
+          <words valign="top" font-size="12">Below</words>
+          </direction-type>
+        </direction>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/mtest/musicxml/io/testTboxAboveBelow2.mscx
+++ b/mtest/musicxml/io/testTboxAboveBelow2.mscx
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.01">
+  <programVersion>3.4.0</programVersion>
+  <programRevision>3543170</programRevision>
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <pagePrintableWidth>7.4826</pagePrintableWidth>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2019-12-21</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <defaultClef>G8vbp</defaultClef>
+        </Staff>
+      <trackName>Voice</trackName>
+      <Instrument>
+        <trackName>Voice</trackName>
+        <minPitchP>36</minPitchP>
+        <maxPitchP>94</maxPitchP>
+        <minPitchA>40</minPitchA>
+        <maxPitchA>79</maxPitchA>
+        <instrumentId>voice.vocals</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <controller ctrl="0" value="0"/>
+          <controller ctrl="32" value="17"/>
+          <program value="52"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part>
+      <Staff id="2">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <bracket type="1" span="2" col="0"/>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <Staff id="3">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <defaultClef>F</defaultClef>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <TBox>
+        <height>1</height>
+        <Text>
+          <style>Frame</style>
+          <text>Above</text>
+          </Text>
+        </TBox>
+      <!-- Measure 1 -->
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <TBox>
+        <height>1</height>
+        <Text>
+          <style>Frame</style>
+          <text>Below</text>
+          </Text>
+        </TBox>
+      </Staff>
+    <Staff id="2">
+      <!-- Measure 1 -->
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="3">
+      <!-- Measure 1 -->
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/musicxml/io/testTboxAboveBelow2_ref.xml
+++ b/mtest/musicxml/io/testTboxAboveBelow2_ref.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <identification>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name print-object="no">Voice</part-name>
+      <score-instrument id="P1-I1">
+        <instrument-name>Voice</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>53</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P2">
+      <part-name print-object="no">Piano</part-name>
+      <score-instrument id="P2-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-instrument id="P2-I1">
+        <midi-channel>2</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <direction placement="above">
+        <direction-type>
+          <words valign="top" font-size="12">Above</words>
+          </direction-type>
+        </direction>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P2">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <direction placement="below">
+        <direction-type>
+          <words valign="top" font-size="12">Below</words>
+          </direction-type>
+        <staff>2</staff>
+        </direction>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/mtest/musicxml/io/testTboxAboveBelow3.mscx
+++ b/mtest/musicxml/io/testTboxAboveBelow3.mscx
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.01">
+  <programVersion>3.4.0</programVersion>
+  <programRevision>3543170</programRevision>
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <pagePrintableWidth>7.4826</pagePrintableWidth>
+      <createMultiMeasureRests>1</createMultiMeasureRests>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2019-12-21</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Voice</trackName>
+      <Instrument>
+        <longName>Voice</longName>
+        <shortName>Vo.</shortName>
+        <trackName>Voice</trackName>
+        <minPitchP>36</minPitchP>
+        <maxPitchP>94</maxPitchP>
+        <minPitchA>40</minPitchA>
+        <maxPitchA>79</maxPitchA>
+        <instrumentId>voice.vocals</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <controller ctrl="0" value="0"/>
+          <controller ctrl="32" value="17"/>
+          <program value="52"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <TBox>
+        <height>1</height>
+        <Text>
+          <style>Frame</style>
+          <text>Above</text>
+          </Text>
+        </TBox>
+      <Measure>
+        <voice>
+          <TimeSig>
+            <linkedMain/>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure len="8/4">
+        <multiMeasureRest>2</multiMeasureRest>
+        <voice>
+          <TimeSig>
+            <linked>
+              <indexDiff>-1</indexDiff>
+              </linked>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>8/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <breakMultiMeasureRest>1</breakMultiMeasureRest>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <breakMultiMeasureRest>1</breakMultiMeasureRest>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure len="8/4">
+        <multiMeasureRest>2</multiMeasureRest>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>8/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <TBox>
+        <height>1</height>
+        <Text>
+          <style>Frame</style>
+          <text>Below</text>
+          </Text>
+        </TBox>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/musicxml/io/testTboxAboveBelow3_ref.xml
+++ b/mtest/musicxml/io/testTboxAboveBelow3_ref.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <identification>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Voice</part-name>
+      <part-abbreviation>Vo.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Voice</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>53</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <measure-style>
+          <multiple-rest>2</multiple-rest>
+          </measure-style>
+        </attributes>
+      <direction placement="above">
+        <direction-type>
+          <words valign="top" font-size="12">Above</words>
+          </direction-type>
+        </direction>
+      <direction placement="below">
+        <direction-type>
+          <words valign="top" font-size="12">Below</words>
+          </direction-type>
+        </direction>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="3">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="4">
+      <attributes>
+        <measure-style>
+          <multiple-rest>2</multiple-rest>
+          </measure-style>
+        </attributes>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="5">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/mtest/musicxml/io/testTboxMultiPage1.mscx
+++ b/mtest/musicxml/io/testTboxMultiPage1.mscx
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.01">
+  <programVersion>3.4.0</programVersion>
+  <programRevision>3543170</programRevision>
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <pagePrintableWidth>7.4826</pagePrintableWidth>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2019-12-21</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Voice</trackName>
+      <Instrument>
+        <longName>Voice</longName>
+        <shortName>Vo.</shortName>
+        <trackName>Voice</trackName>
+        <minPitchP>36</minPitchP>
+        <maxPitchP>94</maxPitchP>
+        <minPitchA>40</minPitchA>
+        <maxPitchA>79</maxPitchA>
+        <instrumentId>voice.vocals</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <controller ctrl="0" value="0"/>
+          <controller ctrl="32" value="17"/>
+          <program value="52"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>Title</style>
+          <text>Title</text>
+          </Text>
+        </VBox>
+      <TBox>
+        <height>1</height>
+        <Text>
+          <style>Frame</style>
+          <text>Tbox 1</text>
+          </Text>
+        </TBox>
+      <!-- Measure 1 -->
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <!-- Measure 2 -->
+      <Measure>
+        <LayoutBreak>
+          <subtype>line</subtype>
+          </LayoutBreak>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <TBox>
+        <height>1</height>
+        <Text>
+          <style>Frame</style>
+          <text>Tbox 2</text>
+          </Text>
+        </TBox>
+      <!-- Measure 3 -->
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <!-- Measure 4 -->
+      <Measure>
+        <LayoutBreak>
+          <subtype>line</subtype>
+          </LayoutBreak>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <TBox>
+        <height>1</height>
+        <Text>
+          <style>Frame</style>
+          <text>Tbox 3</text>
+          </Text>
+        </TBox>
+      <!-- Measure 5 -->
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <!-- Measure 6 -->
+      <Measure>
+        <LayoutBreak>
+          <subtype>line</subtype>
+          </LayoutBreak>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <TBox>
+        <height>1</height>
+        <LayoutBreak>
+          <subtype>page</subtype>
+          </LayoutBreak>
+        <Text>
+          <style>Frame</style>
+          <text>Tbox 4</text>
+          </Text>
+        </TBox>
+      <TBox>
+        <height>1</height>
+        <Text>
+          <style>Frame</style>
+          <text>Tbox 5</text>
+          </Text>
+        </TBox>
+      <!-- Measure 7 -->
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <!-- Measure 8 -->
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <TBox>
+        <height>1</height>
+        <Text>
+          <style>Frame</style>
+          <text>Tbox 6</text>
+          </Text>
+        </TBox>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/musicxml/io/testTboxMultiPage1_ref.xml
+++ b/mtest/musicxml/io/testTboxMultiPage1_ref.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <identification>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Voice</part-name>
+      <part-abbreviation>Vo.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Voice</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>53</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <direction placement="above">
+        <direction-type>
+          <words valign="top" font-size="12">Tbox 1</words>
+          </direction-type>
+        </direction>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="3">
+      <print new-system="yes"/>
+      <direction placement="above">
+        <direction-type>
+          <words valign="top" font-size="12">Tbox 2</words>
+          </direction-type>
+        </direction>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="4">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="5">
+      <print new-system="yes"/>
+      <direction placement="above">
+        <direction-type>
+          <words valign="top" font-size="12">Tbox 3</words>
+          </direction-type>
+        </direction>
+      <direction placement="below">
+        <direction-type>
+          <words valign="top" font-size="12">Tbox 4</words>
+          </direction-type>
+        </direction>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="6">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="7">
+      <direction placement="above">
+        <direction-type>
+          <words valign="top" font-size="12">Tbox 5</words>
+          </direction-type>
+        </direction>
+      <direction placement="below">
+        <direction-type>
+          <words valign="top" font-size="12">Tbox 6</words>
+          </direction-type>
+        </direction>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="8">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/mtest/musicxml/io/testTboxVbox1.mscx
+++ b/mtest/musicxml/io/testTboxVbox1.mscx
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.01">
+  <programVersion>3.4.0</programVersion>
+  <programRevision>3543170</programRevision>
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <pagePrintableWidth>7.4826</pagePrintableWidth>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2019-12-16</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Voice</trackName>
+      <Instrument>
+        <longName>Voice</longName>
+        <shortName>Vo.</shortName>
+        <trackName>Voice</trackName>
+        <minPitchP>36</minPitchP>
+        <maxPitchP>94</maxPitchP>
+        <minPitchA>40</minPitchA>
+        <maxPitchA>79</maxPitchA>
+        <instrumentId>voice.vocals</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <controller ctrl="32" value="17"/>
+          <program value="52"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>Title</style>
+          <text>Vbox 1</text>
+          </Text>
+        </VBox>
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>Title</style>
+          <text>Vbox 2</text>
+          </Text>
+        </VBox>
+      <TBox>
+        <height>1</height>
+        <Text>
+          <style>Frame</style>
+          <text>Tbox 1</text>
+          </Text>
+        </TBox>
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <LayoutBreak>
+          <subtype>line</subtype>
+          </LayoutBreak>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>Title</style>
+          <text>Vbox 3</text>
+          </Text>
+        </VBox>
+      <TBox>
+        <height>1</height>
+        <Text>
+          <style>Frame</style>
+          <text>Tbox 2</text>
+          </Text>
+        </TBox>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>Title</style>
+          <text>Vbox 4</text>
+          </Text>
+        </VBox>
+      <TBox>
+        <height>1</height>
+        <Text>
+          <style>Frame</style>
+          <text>Tbox 3</text>
+          </Text>
+        </TBox>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/musicxml/io/testTboxVbox1_ref.xml
+++ b/mtest/musicxml/io/testTboxVbox1_ref.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <identification>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Voice</part-name>
+      <part-abbreviation>Vo.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Voice</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>53</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <direction placement="above">
+        <direction-type>
+          <words valign="top" font-size="12">Tbox 1</words>
+          </direction-type>
+        </direction>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="3">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="4">
+      <print new-system="yes"/>
+      <direction placement="above">
+        <direction-type>
+          <words valign="top" font-size="12">Tbox 2</words>
+          </direction-type>
+        </direction>
+      <direction placement="below">
+        <direction-type>
+          <words valign="top" font-size="12">Tbox 3</words>
+          </direction-type>
+        </direction>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="5">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="6">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/mtest/musicxml/io/testTboxWords1.mscx
+++ b/mtest/musicxml/io/testTboxWords1.mscx
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.01">
+  <programVersion>3.4.0</programVersion>
+  <programRevision>3543170</programRevision>
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <pagePrintableWidth>7.4826</pagePrintableWidth>
+      <createMultiMeasureRests>1</createMultiMeasureRests>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright">Copyright</metaTag>
+    <metaTag name="creationDate">2019-12-26</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Title</metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Voice</trackName>
+      <Instrument>
+        <longName>Voice</longName>
+        <shortName>Vo.</shortName>
+        <trackName>Voice</trackName>
+        <minPitchP>36</minPitchP>
+        <maxPitchP>94</maxPitchP>
+        <minPitchA>40</minPitchA>
+        <maxPitchA>79</maxPitchA>
+        <instrumentId>voice.vocals</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <controller ctrl="0" value="0"/>
+          <controller ctrl="32" value="17"/>
+          <program value="52"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>Title</style>
+          <text>Title on page 1</text>
+          </Text>
+        <Text>
+          <style>Composer</style>
+          <text>Composer on page 1</text>
+          </Text>
+        <Text>
+          <style>Lyricist</style>
+          <text>Lyricist on page 1</text>
+          </Text>
+        </VBox>
+      <TBox>
+        <height>1</height>
+        <Text>
+          <style>Frame</style>
+          <text>Above</text>
+          </Text>
+        </TBox>
+      <!-- Measure 1 -->
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <TBox>
+        <height>1</height>
+        <LayoutBreak>
+          <subtype>page</subtype>
+          </LayoutBreak>
+        <Text>
+          <style>Frame</style>
+          <text>Below</text>
+          </Text>
+        </TBox>
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>Title</style>
+          <text>Title in vbox on page 2</text>
+          </Text>
+        <Text>
+          <style>Frame</style>
+          <text>Text on page 2</text>
+          </Text>
+        </VBox>
+      <TBox>
+        <height>1</height>
+        <Text>
+          <style>Frame</style>
+          <text>Above 2</text>
+          </Text>
+        </TBox>
+      <!-- Measure 2 -->
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <!-- Measure 2 -->
+      <Measure len="8/4">
+        <multiMeasureRest>2</multiMeasureRest>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>8/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <!-- Measure 3 -->
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <TBox>
+        <height>1</height>
+        <LayoutBreak>
+          <subtype>page</subtype>
+          </LayoutBreak>
+        <Text>
+          <style>Frame</style>
+          <text>Below 2</text>
+          </Text>
+        </TBox>
+      <VBox>
+        <height>10</height>
+        <bottomGap>22.5</bottomGap>
+        <Text>
+          <style>Title</style>
+          <text>Title in vbox on page 3</text>
+          </Text>
+        <Text>
+          <style>Instrument Name (Part)</style>
+          <text>Part name on page 3</text>
+          </Text>
+        </VBox>
+      <!-- Measure 4 -->
+      <Measure>
+        <voice>
+          <StaffText>
+            <offset x="0" y="-7.59223"/>
+            <text>Staff Text</text>
+            </StaffText>
+          <StaffText>
+            <placement>below</placement>
+            <offset x="0.139806" y="8.46416"/>
+            <text>Staff Text</text>
+            </StaffText>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <!-- Measure 5 -->
+      <Measure>
+        <voice>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/musicxml/io/testTboxWords1_ref.xml
+++ b/mtest/musicxml/io/testTboxWords1_ref.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>Title</work-title>
+    </work>
+  <identification>
+    <rights>Copyright</rights>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Voice</part-name>
+      <part-abbreviation>Vo.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Voice</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>53</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <direction placement="above">
+        <direction-type>
+          <words valign="top" font-size="12">Above</words>
+          </direction-type>
+        </direction>
+      <direction placement="below">
+        <direction-type>
+          <words valign="top" font-size="12">Below</words>
+          </direction-type>
+        </direction>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2">
+      <attributes>
+        <measure-style>
+          <multiple-rest>2</multiple-rest>
+          </measure-style>
+        </attributes>
+      <direction placement="above">
+        <direction-type>
+          <words valign="top" font-size="12">Above 2</words>
+          </direction-type>
+        </direction>
+      <direction placement="below">
+        <direction-type>
+          <words valign="top" font-size="12">Below 2</words>
+          </direction-type>
+        </direction>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="3">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="4">
+      <direction placement="above">
+        <direction-type>
+          <words>Staff Text</words>
+          </direction-type>
+        </direction>
+      <direction placement="below">
+        <direction-type>
+          <words>Staff Text</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      </measure>
+    <measure number="5">
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/mtest/musicxml/io/tst_mxml_io.cpp
+++ b/mtest/musicxml/io/tst_mxml_io.cpp
@@ -149,6 +149,8 @@ private slots:
       void slurTieLineStyle() { mxmlIoTest("testSlurTieLineStyle"); }
       void slurs() { mxmlIoTest("testSlurs"); }
       void slurs2() { mxmlIoTest("testSlurs2"); }
+      void sound1() { mxmlIoTestRef("testSound1"); }
+      void sound2() { mxmlIoTestRef("testSound2"); }
       void specialCharacters() { mxmlIoTest("testSpecialCharacters"); }
       void staffTwoKeySigs() { mxmlIoTest("testStaffTwoKeySigs"); }
       void stringVoiceName() { mxmlIoTestRef("testStringVoiceName"); }
@@ -159,6 +161,12 @@ private slots:
       void tablature3() { mxmlIoTest("testTablature3"); }
       void tablature4() { mxmlIoTest("testTablature4"); }
       void tablature5() { mxmlIoTestRef("testTablature5"); }
+      void tboxAboveBelow1() { mxmlMscxExportTestRef("testTboxAboveBelow1"); }
+      void tboxAboveBelow2() { mxmlMscxExportTestRef("testTboxAboveBelow2"); }
+      void tboxAboveBelow3() { mxmlMscxExportTestRef("testTboxAboveBelow3"); }
+      void tboxMultiPage1() { mxmlMscxExportTestRef("testTboxMultiPage1"); }
+      void tboxVbox1() { mxmlMscxExportTestRef("testTboxVbox1"); }
+      void tboxWords1() { mxmlMscxExportTestRef("testTboxWords1"); }
       void tempo1() { mxmlIoTest("testTempo1"); }
       void tempo2() { mxmlIoTestRef("testTempo2"); }
       void tempo3() { mxmlIoTestRef("testTempo3"); }
@@ -187,8 +195,6 @@ private slots:
       void wedge3() { mxmlIoTest("testWedge3"); }
       void words1() { mxmlIoTest("testWords1"); }
       void words2() { mxmlIoTest("testWords2"); }
-      void sound1() { mxmlIoTestRef("testSound1"); }
-      void sound2() { mxmlIoTestRef("testSound2"); }
       };
 
 //---------------------------------------------------------

--- a/mtest/musicxml/io/tst_mxml_io.cpp
+++ b/mtest/musicxml/io/tst_mxml_io.cpp
@@ -75,7 +75,7 @@ private slots:
       void divisionsDefinedTooLate2() { mxmlIoTestRef("testDivsDefinedTooLate2"); }
       void doubleClefError() { mxmlIoTestRef("testDoubleClefError"); }
       void drumset1() { mxmlIoTest("testDrumset1"); }
-//ws: fails      void drumset2() { mxmlIoTest("testDrumset2"); }
+      void drumset2() { mxmlIoTest("testDrumset2"); }
       void durationRoundingError() { mxmlIoTestRef("testDurationRoundingError"); }
       void dynamics1() { mxmlIoTest("testDynamics1"); }
       void dynamics2() { mxmlIoTest("testDynamics2"); }
@@ -126,8 +126,8 @@ private slots:
       void multiMeasureRest4() { mxmlIoTestRef("testMultiMeasureRest4"); }
       void multipleNotations() { mxmlIoTestRef("testMultipleNotations"); }
       void nonStandardKeySig1() { mxmlIoTest("testNonStandardKeySig1"); }
-      //void nonStandardKeySig2() { mxmlIoTest("testNonStandardKeySig2"); } //problem with cautionary measure 8 and 9
-      void nonStandardKeySig2() { mxmlIoTest("testNonStandardKeySig3"); }
+      void nonStandardKeySig2() { mxmlIoTest("testNonStandardKeySig2"); }
+      void nonStandardKeySig3() { mxmlIoTest("testNonStandardKeySig3"); }
       void nonUniqueThings() { mxmlIoTestRef("testNonUniqueThings"); }
       void noteAttributes1() { mxmlIoTest("testNoteAttributes1"); }
       void noteAttributes2() { mxmlIoTestRef("testNoteAttributes2"); }
@@ -209,50 +209,14 @@ void TestMxmlIO::initTestCase()
 //---------------------------------------------------------
 //   fixupScore -- do required fixups after MusicXML import
 //   see mscore/file.cpp MuseScore::readScore(Score* score, QString name)
-//   TODO: remove duplication of code
 //---------------------------------------------------------
 
 static void fixupScore(Score* score)
       {
-//      score->syntiState().append(SyntiParameter("soundfont", MScore::soundFont));
       score->connectTies();
       score->masterScore()->rebuildMidiMapping();
       score->setCreated(false);
       score->setSaved(false);
-
-#if 0
-      int staffIdx = 0;
-      foreach(Staff* st, score->staves()) {
-            if (st->updateKeymap())
-                  st->clearKeys();
-            int track = staffIdx * VOICES;
-            KeySig* key1 = 0;
-            for (Measure* m = score->firstMeasure(); m; m = m->nextMeasure()) {
-                  for (Segment* s = m->first(); s; s = s->next()) {
-                        if (!s->element(track))
-                              continue;
-                        Element* e = s->element(track);
-                        if (e->generated())
-                              continue;
-                        //if ((s->subtype() == SegClef) && st->updateClefList()) {
-                        //      Clef* clef = static_cast<Clef*>(e);
-                        //      st->setClef(s->tick(), clef->clefTypeList());
-                        //      }
-                        if ((s->segmentType() == Segment::Type::KeySig) && st->updateKeymap()) {
-                              KeySig* ks = static_cast<KeySig*>(e);
-                              int naturals = key1 ? key1->keySigEvent().accidentalType() : 0;
-                              ks->setOldSig(naturals);
-                              st->setKey(s->tick(), ks->key());
-                              key1 = ks;
-                              }
-                        }
-                  if (m->sectionBreak())
-                        key1 = 0;
-                  }
-            st->setUpdateKeymap(false);
-            ++staffIdx;
-            }
-#endif
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
… export

Resolves: https://musescore.org/en/node/291758

Export text frames as MusicXML words and all vertical frames as MusicXML credit-words. Popular request, also required to better support Braille transcriptions.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made