### PR TITLE
fix #297719: AppImage: add more libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -641,6 +641,7 @@ if (NOT MINGW AND NOT MSVC AND NOT APPLE)
     string(TOUPPER "mscore${MSCORE_INSTALL_SUFFIX}" MAN_MSCORE_UPPER) # Command name shown in uppercase in man pages by convention
     if (${MSCORE_INSTALL_SUFFIX} MATCHES "portable") # Note: "-portable-anything" would match
       # Build portable AppImage as per https://github.com/probonopd/AppImageKit
+      add_subdirectory(build/Linux+BSD/portable)
       if (NOT DEFINED ARCH)
         execute_process(COMMAND arch OUTPUT_VARIABLE ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)# Get architecture (strip trailing newline)
       endif (NOT DEFINED ARCH)

--- a/build/Linux+BSD/portable/AppRun.in
+++ b/build/Linux+BSD/portable/AppRun.in
@@ -6,43 +6,21 @@
 [[  "${APPDIR}"  ]] || export APPDIR="$(dirname "$(readlink -f "${0}")")"
 [[ "${APPIMAGE}" ]] || export APPIMAGE="${APPDIR}/AppRun"
 
-function find_library()
-{
-  # Print full path to a library or return exit status 1 if not found
-  local library="$1" # take library name as input (e.g. "libfoo.so")
-  # Look for the library in $LD_LIBRARY_PATH
-  local dir IFS=':' # split path into array on this separator
-  for dir in "${LD_LIBRARY_PATH[@]}"; do
-    if [[ -e "${dir}/${library}" ]]; then
-      echo "${dir}/${library}"
-      return # Library found
-    fi
-  done
-  # Not found yet so check system cache
-  ldconfig -p | awk -v lib="${library}" -v arch="${HOSTTYPE}" \
-'
-BEGIN {status=1}
-($1 == lib && index($0, arch)) {print $NF; status=0; exit}
-END {exit status}
-'
-}
-
 # Check system libraries and load a fallback if necessary
 fallback_libs="" # start empty
 for fb_dir in "${APPDIR}/fallback"/*; do
   if [[ -d "${fb_dir}" ]]; then
     library="${fb_dir##*/}" # library named like directory
-    if ! find_library "${library}"; then
+    if ! "${APPDIR}/bin/findlib" "${library}" >&2; then
       echo "${APPIMAGE}: Using fallback for library '${library}'" >&2
       fallback_libs="${fallback_libs}:${fb_dir}" # append path
     fi
   fi
 done
 
-# Setting LD_LIBRARY_PATH won't override AppImage libraries, but advanced users
-# can do that with APPIMAGE_LIBRARY_PATH if they really want to.
-libs="${APPDIR}/lib"
-export LD_LIBRARY_PATH="${APPIMAGE_LIBRARY_PATH}:${libs}:${libs}/qt5/lib:${LD_LIBRARY_PATH}${fallback_libs}"
+# Add fallback directories to LD_LIBRARY_PATH. Don't add the main lib
+# directory because linuxdeploy sets RUNPATH to point to it anyway.
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${fallback_libs}"
 
 # Launch MuseScore or an accompanying script
 case "$1" in

--- a/build/Linux+BSD/portable/CMakeLists.txt
+++ b/build/Linux+BSD/portable/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+
+add_executable(findlib findlib.c)
+
+target_link_libraries(findlib ${CMAKE_DL_LIBS})
+
+install(TARGETS findlib DESTINATION bin)

--- a/build/Linux+BSD/portable/Recipe
+++ b/build/Linux+BSD/portable/Recipe
@@ -198,6 +198,9 @@ prefix="$(cat build.release/PREFIX.txt)" # MuseScore was installed here
 cd "$(dirname "${prefix}")"
 appdir="$(basename "${prefix}")" # directory that will become the AppImage
 
+# Prevent linuxdeploy setting RUNPATH in binaries that shouldn't have it
+mv "${appdir}/bin/findlib" "${appdir}/../findlib"
+
 # Remove Qt plugins for MySQL and PostgreSQL to prevent
 # linuxdeploy-plugin-qt from failing due to missing dependencies.
 # SQLite plugin alone should be enough for our AppImage.
@@ -221,6 +224,9 @@ unset QML_SOURCES_PATHS
 mv "${qt_sql_drivers_tmp}/libqsqlmysql.so" "${qt_sql_drivers_path}/libqsqlmysql.so"
 mv "${qt_sql_drivers_tmp}/libqsqlpsql.so" "${qt_sql_drivers_path}/libqsqlpsql.so"
 
+# Put the non-RUNPATH binaries back
+mv "${appdir}/../findlib" "${appdir}/bin/findlib"
+
 ##########################################################################
 # BUNDLE REMAINING DEPENDENCIES MANUALLY
 ##########################################################################
@@ -228,22 +234,7 @@ mv "${qt_sql_drivers_tmp}/libqsqlpsql.so" "${qt_sql_drivers_path}/libqsqlpsql.so
 function find_library()
 {
   # Print full path to a library or return exit status 1 if not found
-  local library="$1" # take library name as input (e.g. "libfoo.so")
-  # Look for the library in $LD_LIBRARY_PATH
-  local dir IFS=':' # split path into array on this separator
-  for dir in "${LD_LIBRARY_PATH[@]}"; do
-    if [[ -e "${dir}/${library}" ]]; then
-      echo "${dir}/${library}"
-      return # Library found
-    fi
-  done
-  # Not found yet so check system cache
-  ldconfig -p | awk -v lib="${library}" -v arch="x86_64" \
-'
-BEGIN {status=1}
-($1 == lib && index($0, arch)) {print $NF; status=0; exit}
-END {exit status}
-'
+  "${appdir}/bin/findlib" "$@"
 }
 
 function fallback_library()
@@ -261,19 +252,28 @@ function fallback_library()
 }
 
 # UNWANTED FILES
-# linuxdeploy may have added some files or directories that we don't want
-unwanted_files=(
-  "lib/libnss3.so" # see https://github.com/probonopd/linuxdeployqt/issues/35#issuecomment-382994446
-  "lib/libnssutil3.so"
-)
+# linuxdeploy or linuxdeploy-plugin-qt may have added some files or folders
+# that we don't want. List them here using paths relative to AppDir root.
 # Report new additions at https://github.com/linuxdeploy/linuxdeploy/issues
+# or https://github.com/linuxdeploy/linuxdeploy-plugin-qt/issues for Qt libs.
+unwanted_files=(
+  # none
+)
+
+# ADDITIONAL QT COMPONENTS
+# linuxdeploy-plugin-qt may have missed some Qt files or folders that we need.
+# List them here using paths relative to the Qt root directory. Report new
+# additions at https://github.com/linuxdeploy/linuxdeploy-plugin-qt/issues
+additional_qt_components=(
+  /plugins/printsupport/libcupsprintersupport.so
+)
 
 # ADDITIONAL LIBRARIES
-# Linuxdeploy may have missed some libraries that we need
+# linuxdeploy may have missed some libraries that we need
+# Report new additions at https://github.com/linuxdeploy/linuxdeploy/issues
 additional_libraries=(
   # none
 )
-# Report new additions at https://github.com/linuxdeploy/linuxdeploy/issues
 
 # FALLBACK LIBRARIES
 # These get bundled in the AppImage, but are only loaded if the user does not
@@ -282,13 +282,18 @@ additional_libraries=(
 # a particular feature to work properly, but where the program would crash at
 # startup if the library was not found. The fallback library may not provide
 # the full functionality of the system version, but it does avoid the crash.
-fallback_libraries=(
-  "libjack.so.0" # https://github.com/LMMS/lmms/pull/3958
-)
 # Report new additions at https://github.com/linuxdeploy/linuxdeploy/issues
+fallback_libraries=(
+  libjack.so.0 # https://github.com/LMMS/lmms/pull/3958
+)
 
 for file in "${unwanted_files[@]}"; do
   rm -rf "${appdir}/${file}"
+done
+
+for file in "${additional_qt_components[@]}"; do
+  mkdir -p "${appdir}/$(dirname "${file}")"
+  cp -L "${qt_path}/${file}" "${appdir}/${file}"
 done
 
 for lib in "${additional_libraries[@]}"; do
@@ -298,6 +303,38 @@ done
 
 for fb_lib in "${fallback_libraries[@]}"; do
   fallback_library "${fb_lib}"
+done
+
+# METHOD OF LAST RESORT
+# Special treatment for some dependencies when all other methods fail
+
+# Bundle libnss3 and friends as fallback libraries. Needed on Chromebook.
+# See discussion at https://github.com/probonopd/linuxdeployqt/issues/35
+libnss3_files=(
+  # https://packages.ubuntu.com/xenial/amd64/libnss3/filelist
+  libnss3.so
+  libnssutil3.so
+  libsmime3.so
+  libssl3.so
+  nss/libfreebl3.chk
+  nss/libfreebl3.so
+  nss/libfreeblpriv3.chk
+  nss/libfreeblpriv3.so
+  nss/libnssckbi.so
+  nss/libnssdbm3.chk
+  nss/libnssdbm3.so
+  nss/libsoftokn3.chk
+  nss/libsoftokn3.so
+)
+
+libnss3_system_path="$(dirname "$(find_library libnss3.so)")"
+libnss3_appdir_path="${appdir}/fallback/libnss3.so" # directory named like library
+
+mkdir -p "${libnss3_appdir_path}/nss"
+
+for file in "${libnss3_files[@]}"; do
+  cp -L "${libnss3_system_path}/${file}" "${libnss3_appdir_path}/${file}"
+  rm -f "${appdir}/lib/$(basename "${file}")" # in case it was already packaged by linuxdeploy
 done
 
 ##########################################################################

--- a/build/Linux+BSD/portable/findlib.c
+++ b/build/Linux+BSD/portable/findlib.c
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+/* findlib.c
+* Dynamically load a shared object file and print its full path.
+* Part of library-utls - https://github.com/shoogle/library-utils
+* Copyright (c) 2020 Peter Jonas
+*/
+#define _GNU_SOURCE
+#include <link.h>
+#include <dlfcn.h>
+#include <libgen.h>
+#include <string.h>
+#include <stdio.h>
+
+char *help =
+"Usage: %s LIBRARY\n"
+"Print the full path to LIBRARY if it is dynamically loadable by this program.\n"
+"\n"
+"Exit status codes:\n"
+"  0 - Success!\n"
+"  1 - Failed to load LIBRARY (or one of its dependencies).\n"
+"  2 - Other error(s) occurred.\n"
+"\n"
+"LIBRARY will fail to load if any of the following are true:\n"
+"  - The file is corrupt.\n"
+"  - It is not found in any of the library search paths (see `man ld.so`).\n"
+"  - It was compiled for a different architecture to that of this program.\n"
+"  - It depends (via DT_NEEDED) on another library that fails to load.\n"
+"\n"
+"Hint: You can use the `file` command to show the processor architecture that\n"
+"any ELF library or executable (including this program) was compiled for.\n";
+
+int main(int argc, char *argv[])
+{
+    if (argc != 2) {
+        fprintf(stderr, help, basename(argv[0]));
+        return 2;
+    }
+
+    if ((strcmp(argv[1], "-h") == 0) || (strcmp(argv[1], "--help") == 0)) {
+        printf(help, basename(argv[0]));
+        return 0;
+    }
+
+    // dlopen enables us to load shared objects during execution
+    void *lib = dlopen(argv[1], RTLD_LAZY);
+
+    if (lib == NULL) {
+        fprintf(stderr, "%s: %s\n", basename(argv[0]), dlerror());
+        return 1;
+    }
+
+    struct link_map * map;
+
+    // dlinfo can return information about objects loaded with dlopen
+    if (dlinfo(lib, RTLD_DI_LINKMAP, &map) == -1) {
+        fprintf(lib, "%s: %s\n", basename(argv[0]), dlerror());
+        return 2;
+    }
+
+    printf("%s\n", map->l_name);
+    return 0;
+}


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/297719

Supersedes: PR #5559.

New files bundled in AppImage:

- libcupsprintersupport.so - Qt printsupport plugin
- libnss3.so - a fallback for Chromebook devices
- findlib - tiny C program to check system libraries

The [findlib program](https://github.com/shoogle/library-utils/tree/master/findlib) should work to detect system libraries across all Linux distributions and processor architectures, unlike the lddconfig + awk solution used previously which only really worked on x86_64 devices running a Debian-based distro.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- N/A I created the test (mtest, vtest, script test) to verify the changes I made
