### PR TITLE
Fix #299539  (Plugins are not run correctly when running musescore in converter mode.)

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -3651,7 +3651,14 @@ static bool convert(const QString& inFile, const QJsonArray& outFiles, const QSt
       MasterScore* score = mscore->readScore(inFile);
       if (!score)
             return false;
-      mscore->setCurrentScore(score);
+      if (processJob)
+            mscore->setCurrentScore(score);
+      else {
+            mscore->appendScore(score);
+            mscore->setCurrentScore(score);
+            mscore->setCurrentView(0, 0);
+            mscore->setCurrentView(1, 0);
+            }
       bool success = doConvert(score, outFiles, plugin);
       fprintf(stderr, success ? "... success!\n" : "... failed!\n");
       mscore->setCurrentScore(nullptr);
@@ -3661,7 +3668,10 @@ static bool convert(const QString& inFile, const QJsonArray& outFiles, const QSt
 
 static bool convert(const QString& inFile, const QString& outFile)
       {
-      return convert(inFile, QJsonArray{ outFile });
+      if (pluginMode)
+            return convert(inFile, QJsonArray{ outFile }, pluginName);
+      else
+            return convert(inFile, QJsonArray{ outFile });
       }
 
 //---------------------------------------------------------
@@ -3734,8 +3744,8 @@ static bool processNonGui(const QStringList& argv)
             return mscore->exportPartsPdfsToJSON(argv[0]);
       else if (exportTransposedScore)
             return mscore->exportTransposedScoreToJSON(argv[0], transposeExportOptions);
-
-      if (pluginMode) {
+      
+      if (pluginMode && !converterMode) {
             loadScores(argv);
             QString pn(pluginName);
             bool res = false;
@@ -3758,9 +3768,9 @@ static bool processNonGui(const QStringList& argv)
                         }
                   res = true;
                   }
-            if (!converterMode)
-                  return res;
+            return res;
             }
+
       if (converterMode) {
             if (processJob)
                   return doProcessJob(jsonFileName);


### PR DESCRIPTION
Resolves: [Issue  #299539](https://musescore.org/en/node/299539)

This PR fixes a set of related logical bugs in the command line interface handling logic. Essentially, in master as it stands right now, two options are somewhat intertwined, but break each other in subtle ways, which leads to plugins being entirely broken when run in command line mode: 

- Plugin mode does nothing when enabled by itself, and after making changes to a score, simply discards them. 
- Converter mode (which should then save changes), instead re-loads score files, discarding changes made by the plugin mode. 
- Finally converter mode *also* attempts to run plugins but, however, it doesn't run the plugin specified by the user - said plugin name is replaced with the empty string, so no plugins are actually run. 

The overall effect is that plugins (when specified at the command line) either a) do something, and then discard their work, or b) are ignored. This PR fixes this issue in the following way: 

- Firstly, "standalone" plugin mode has been removed, with plugins instead being run during converter mode. 
- Converter mode now correctly runs the user-specified plugin when invoked with plugin mode. 
- Converter mode also has a small number of fixes to correctly load a score in order to allow plugins to run correctly. 

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
