### PR TITLE
Add more data to Telemetry

### DIFF
--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -348,6 +348,7 @@ add_library(mscoreapp STATIC
       instrdialog.cpp instrwidget.cpp
       debugger/debugger.cpp menus.cpp
       musescore.cpp musescoredialogs.cpp navigator.cpp pagesettings.cpp palette.cpp
+      sessionstatusobserver.cpp
       timeline.cpp
       mixer.cpp mixertrackchannel.cpp mixertrackitem.cpp mixertrackpart.cpp mixerdetails.cpp
       parteditbase.cpp playpanel.cpp selectionwindow.cpp

--- a/mscore/inspector/inspectorBase.cpp
+++ b/mscore/inspector/inspectorBase.cpp
@@ -26,9 +26,12 @@
 #include "scoreview.h"
 #include "script/script.h"
 #include "resetButton.h"
+#include "telemetrymanager.h"
 #include "tourhandler.h"
 
 namespace Ms {
+
+std::unique_ptr<InspectorEventObserver> InspectorEventObserver::i;
 
 //---------------------------------------------------------
 //   InspectorBase
@@ -394,6 +397,7 @@ void InspectorBase::valueChanged(int idx, bool reset)
       if (ScriptRecorder* rec = mscore->getScriptRecorder())
             rec->recordInspectorValueChange(iElement, ii, val2);
 #endif
+      InspectorEventObserver::instance()->event(reset ? InspectorEventObserver::PropertyReset : InspectorEventObserver::PropertyChange, ii, iElement);
 
       if (ii.t == Pid::AUTOPLACE)
             TourHandler::startTour("autoplace-tour");
@@ -467,6 +471,8 @@ void InspectorBase::setStyleClicked(int i)
       if (Element* delegate = e->propertyDelegate(id))
             e = delegate;
       Score* score = e->score();
+
+      InspectorEventObserver::instance()->event(InspectorEventObserver::PropertySetStyle, ii, e);
 
       Sid sidx = e->getPropertyStyle(ii.t);
       if (sidx == Sid::NOSTYLE)
@@ -649,5 +655,38 @@ void InspectorBase::resetToStyle()
       score->endCmd();
       }
 
+void InspectorEventObserver::event(EventType evtType, const InspectorItem& ii, const Element* e)
+      {
+#ifdef BUILD_TELEMETRY_MODULE
+      QString evtCategory;
+      switch (evtType) {
+            case EventType::PropertyChange:
+                  evtCategory = QStringLiteral("inspector-property-change");
+                  break;
+            case EventType::PropertyReset:
+                  evtCategory = QStringLiteral("inspector-property-reset");
+                  break;
+            case EventType::PropertySetStyle:
+                  evtCategory = QStringLiteral("inspector-property-set-style");
+                  break;
+            }
+
+      const QObject* w = ii.w;
+      const QObject* p = w->parent();
+      while (p && !qobject_cast<const InspectorBase*>(p)) {
+            w = p;
+            p = p->parent();
+            }
+      const QString inspectorName = w->objectName();
+
+      const QString evtAction = QStringLiteral("%1/%2").arg(inspectorName).arg(propertyName(ii.t));
+      const QString evtLabel = e ? e->name() : "null";
+      TelemetryManager::telemetryService()->sendEvent(evtCategory, evtAction, evtLabel);
+#else
+      Q_UNUSED(evtType);
+      Q_UNUSED(ii);
+      Q_UNUSED(e);
+#endif
+      }
 }
 

--- a/mscore/inspector/inspectorBase.h
+++ b/mscore/inspector/inspectorBase.h
@@ -87,6 +87,30 @@ class InspectorBase : public QWidget {
       friend class InspectorScriptEntry;
       };
 
+//---------------------------------------------------------
+//   InspectorEventObserver
+//---------------------------------------------------------
+
+class InspectorEventObserver {
+      static std::unique_ptr<InspectorEventObserver> i;
+
+      InspectorEventObserver() = default;
+
+   public:
+      enum EventType {
+            PropertyChange,
+            PropertyReset,
+            PropertySetStyle,
+            };
+      void event(EventType evtType, const InspectorItem& ii, const Element* e);
+
+      static InspectorEventObserver* instance()
+            {
+            if (!i)
+                  i.reset(new InspectorEventObserver());
+            return i.get();
+            }
+      };
 
 } // namespace Ms
 #endif

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7171,6 +7171,21 @@ void MuseScore::updateUiStyleAndTheme()
       }
 
 //---------------------------------------------------------
+//   fullVersion
+///   \return Full version of MuseScore, including version
+///   label (e.g. 3.4.0-Beta).
+//---------------------------------------------------------
+
+QString MuseScore::fullVersion()
+      {
+      QString version(VERSION);
+      const QString versionLabel(VERSION_LABEL);
+      if (!versionLabel.isEmpty())
+            version.append("-").append(versionLabel);
+      return version;
+      }
+
+//---------------------------------------------------------
 //   initApplication
 //---------------------------------------------------------
 
@@ -7197,7 +7212,7 @@ MuseScoreApplication* MuseScoreApplication::initApplication(int& argc, char** ar
 
       QCoreApplication::setOrganizationName("MuseScore");
       QCoreApplication::setOrganizationDomain("musescore.org");
-      QCoreApplication::setApplicationVersion(VERSION);
+      QCoreApplication::setApplicationVersion(MuseScore::fullVersion());
 
 #ifdef BUILD_CRASH_REPORTER
       {

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -164,6 +164,7 @@ extern Ms::Synthesizer* createZerberus();
 #include "actioneventobserver.h"
 #include "widgets/telemetrypermissiondialog.h"
 #endif
+#include "telemetrymanager.h"
 
 namespace Ms {
 
@@ -283,6 +284,9 @@ static constexpr double SCALE_MIN  = 0.05;
 static constexpr double SCALE_STEP = 1.7;
 
 static const char* saveOnlineMenuItem = "file-save-online";
+
+std::unique_ptr<TelemetryManager> TelemetryManager::mgr;
+
 //---------------------------------------------------------
 // cmdInsertMeasure
 //---------------------------------------------------------

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -26,6 +26,7 @@
 #include "updatechecker.h"
 #include "libmscore/musescoreCore.h"
 #include "libmscore/score.h"
+#include "sessionstatusobserver.h"
 
 namespace Ms {
 
@@ -402,6 +403,8 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       bool _lastFocusWindowIsQQuickView { false };
 
       std::unique_ptr<GeneralAutoUpdater> autoUpdater;
+
+      SessionStatusObserver sessionStatusObserver;
 
       //---------------------
 

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -643,6 +643,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void setRevision(QString& r)  {rev = r;}
       Q_INVOKABLE QString revision()            {return rev;}
       Q_INVOKABLE QString version()            {return VERSION;}
+      static QString fullVersion();
       Q_INVOKABLE void newFile();
       MasterScore* getNewFile();
       Q_INVOKABLE void loadFile(const QString& url);

--- a/mscore/sessionstatusobserver.cpp
+++ b/mscore/sessionstatusobserver.cpp
@@ -1,0 +1,54 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#include "sessionstatusobserver.h"
+#include "musescore.h"
+#include "telemetrymanager.h"
+
+namespace Ms {
+
+void SessionStatusObserver::prevSessionStatus(bool sessionFileFound, const QString& sessionFullVersion, bool clean)
+      {
+#ifdef BUILD_TELEMETRY_MODULE
+      QString status;
+      QString label;
+      if (mscoreFirstStart)
+            status = QStringLiteral("first-start");
+      else if (!sessionFileFound)
+            status = QStringLiteral("session-file-not-found");
+      else {
+            const bool versionChanged = MuseScore::fullVersion() != sessionFullVersion;
+            if (versionChanged) {
+                  status = QStringLiteral("version-changed");
+                  label = sessionFullVersion;
+                  }
+            else if (clean)
+                  status = QStringLiteral("clean");
+            else
+                  status = QStringLiteral("dirty");
+            }
+      TelemetryManager::telemetryService()->sendEvent("prev-session-status", status, label);
+#else
+      Q_UNUSED(sessionFileFound);
+      Q_UNUSED(sessionFullVersion);
+      Q_UNUSED(clean);
+#endif
+      }
+
+} // namespace Ms

--- a/mscore/sessionstatusobserver.h
+++ b/mscore/sessionstatusobserver.h
@@ -1,0 +1,36 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef __SESSIONSTATUSOBSERVER_H__
+#define __SESSIONSTATUSOBSERVER_H__
+
+namespace Ms {
+
+//---------------------------------------------------------
+//   SessionStatusObserver
+//---------------------------------------------------------
+
+class SessionStatusObserver {
+   public:
+      void prevSessionStatus(bool sessionFileFound, const QString& sessionFullVersion, bool clean);
+      };
+
+} // namespace Ms
+
+#endif

--- a/mscore/telemetrymanager.h
+++ b/mscore/telemetrymanager.h
@@ -1,0 +1,56 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef __TELEMETRYMANAGER_H__
+#define __TELEMETRYMANAGER_H__
+
+#include "serviceinjector.h"
+#ifdef BUILD_TELEMETRY_MODULE
+#include "interfaces/itelemetryservice.h"
+#else
+class ITelemetryService;
+#endif
+
+namespace Ms {
+
+//---------------------------------------------------------
+//   TelemetryManager
+//---------------------------------------------------------
+
+class TelemetryManager : public ServiceInjector<ITelemetryService> {
+      INJECT(ITelemetryService, _telemetryService)
+      static std::unique_ptr<TelemetryManager> mgr;
+
+      static TelemetryManager* instance()
+            {
+            if (!mgr)
+                  mgr.reset(new TelemetryManager());
+            return mgr.get();
+            }
+
+   public:
+      static ITelemetryService* telemetryService()
+            {
+            return instance()->_telemetryService();
+            }
+      };
+
+} // namespace Ms
+
+#endif


### PR DESCRIPTION
Collect telemetry data on Inspector usage to provide information useful for the upcoming Inspector redesign. This pull request implements collecting data on changing properties, resetting them and updating style values from Inspector. Buttons for element selection at Inspector bottom are not covered by this pull request.