### PR TITLE
Fix Deprecation warnings with Qt 5.15 (and 5.14)

### DIFF
--- a/audio/midi/fluid/sfont.cpp
+++ b/audio/midi/fluid/sfont.cpp
@@ -824,7 +824,7 @@ bool SFont::load()
     }
     f.close();
     /* sort preset list by bank, preset # */
-    qSort(presets.begin(), presets.end(), preset_compare);
+    std::sort(presets.begin(), presets.end(), preset_compare);
     return true;
 }
 

--- a/audio/midi/midifile.cpp
+++ b/audio/midi/midifile.cpp
@@ -914,7 +914,7 @@ void MidiFile::separateChannel()
         if (nn <= 1) {
             continue;
         }
-        qSort(channel);
+        std::sort(channel.begin(), channel.end());
         // -- split --
         // insert additional tracks, assign to them found channels
         for (int ii = 1; ii < nn; ++ii) {

--- a/avsomr/ui/recognitionproccessdialog.h
+++ b/avsomr/ui/recognitionproccessdialog.h
@@ -53,7 +53,7 @@ private:
     IAvsOmrRecognizer::Step _lastStep;
 
     QTimer _updater;
-    QTime _time;
+    QElapsedTimer _time;
     QPushButton* _closeBtn{ nullptr };
     TaskbarProgress* _taskbarProgress{ nullptr };
 };

--- a/awl/aslider.cpp
+++ b/awl/aslider.cpp
@@ -128,7 +128,7 @@ void AbstractSlider::wheelEvent(QWheelEvent* ev)
     if (ev->modifiers() & Qt::ShiftModifier) {
         div = 15;
     }
-    _value += (ev->delta() * lineStep()) / div;
+    _value += (ev->angleDelta().y() * lineStep()) / div;
     if (_value < _minValue) {
         _value = _minValue;
     } else if (_value > _maxValue) {

--- a/awl/pitchlabel.cpp
+++ b/awl/pitchlabel.cpp
@@ -57,8 +57,13 @@ QSize PitchLabel::sizeHint() const
     QFontMetrics fm(font());
     int fw = style()->pixelMetric(QStyle::PM_DefaultFrameWidth);
     int h  = fm.height() + fw * 2;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+//      int w = 2 + fm.horizontalAdvance(QString("A#8")) +  fw * 4;
+    int w = 2 + fm.horizontalAdvance(QString("-9999")) + fw * 4;       // must display 14Bit controller values
+#else
 //      int w = 2 + fm.width(QString("A#8")) +  fw * 4;
     int w = 2 + fm.width(QString("-9999")) + fw * 4;       // must display 14Bit controller values
+#endif
     return QSize(w, h).expandedTo(QApplication::globalStrut());
 }
 
@@ -76,7 +81,7 @@ void PitchLabel::setValue(int val)
     if (_pitchMode) {
         s = pitch2string(_value);
     } else {
-        s.sprintf("%d", _value);
+        s = QString::asprintf("%d", _value);
     }
     setText(s);
 }

--- a/awl/poslabel.cpp
+++ b/awl/poslabel.cpp
@@ -68,11 +68,19 @@ QSize PosLabel::sizeHint() const
     int fw = style()->pixelMetric(QStyle::PM_DefaultFrameWidth);
     int h  = fm.height() + fw * 2;
     int w;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+    if (_smpte) {
+        w = 2 + fm.horizontalAdvance('9') * 9 + fm.horizontalAdvance(':') * 3 + fw * 4;
+    } else {
+        w = 2 + fm.horizontalAdvance('9') * 9 + fm.horizontalAdvance('.') * 2 + fw * 4;
+    }
+#else
     if (_smpte) {
         w  = 2 + fm.width('9') * 9 + fm.width(':') * 3 + fw * 4;
     } else {
         w  = 2 + fm.width('9') * 9 + fm.width('.') * 2 + fw * 4;
     }
+#endif
     return QSize(w, h).expandedTo(QApplication::globalStrut());
 }
 
@@ -89,11 +97,11 @@ void PosLabel::updateValue()
     if (_smpte) {
         int min, sec, frame, subframe;
         pos.msf(&min, &sec, &frame, &subframe);
-        s.sprintf("%03d:%02d:%02d:%02d", min, sec, frame, subframe);
+        s = QString::asprintf("%03d:%02d:%02d:%02d", min, sec, frame, subframe);
     } else {
         int measure, beat, tick;
         pos.mbt(&measure, &beat, &tick);
-        s.sprintf("%04d.%02d.%03u", measure + 1, beat + 1, tick);
+        s = QString::asprintf("%04d.%02d.%03u", measure + 1, beat + 1, tick);
     }
     setText(s);
 }

--- a/awl/utils.cpp
+++ b/awl/utils.cpp
@@ -60,7 +60,7 @@ QString pitch2string(int v)
     }
     int octave = (v / 12) - 1;
     QString o;
-    o.sprintf("%d", octave);
+    o = QString::asprintf("%d", octave);
     int i = v % 12;
     return qApp->translate("awlutils", octave < 0 ? valu[i] : vall[i]) + o;
 }

--- a/framework/telemetry/CMakeLists.txt
+++ b/framework/telemetry/CMakeLists.txt
@@ -43,6 +43,6 @@ target_link_libraries(${MODULE} global google_analytics)
 
 if (MSVC)
   set_target_properties (${MODULE} PROPERTIES
-    COMPILE_FLAGS "/wd4127"
+    COMPILE_FLAGS "/wd4127 /wd26439 /wd5999" # ToDo for Qt 5.15: "... /wd26444 /wd26451 /wd26495 /wd26498 /wd26812" ??
   )
 endif (MSVC)

--- a/framework/telemetry/widgets/telemetrypermissiondialog.cpp
+++ b/framework/telemetry/widgets/telemetrypermissiondialog.cpp
@@ -35,6 +35,7 @@ TelemetryPermissionDialog::TelemetryPermissionDialog(QQmlEngine* engine)
 
     setFlags(Qt::Dialog | Qt::CustomizeWindowHint);   ///@note Hidding a native frame with 'X' close button
 
+    // ToDo for Qt 5.15: QDesktopWidget::availableGeometry() vs. QGuiApplication::screens() ??
     QRect desktopRect = QApplication::desktop()->availableGeometry();
     QPoint center = desktopRect.center();
 

--- a/global/gui/miconengine.cpp
+++ b/global/gui/miconengine.cpp
@@ -221,7 +221,7 @@ QPixmap MIconEngine::pixmap(const QSize& size, QIcon::Mode mode, QIcon::State st
     QString pmckey(d->pmcKey(size, mode, state));
     pmckey.prepend("Ms");
 
-    if (QPixmapCache::find(pmckey, pm)) {
+    if (QPixmapCache::find(pmckey, &pm)) {
         return pm;
     }
 

--- a/importexport/bww/parser.cpp
+++ b/importexport/bww/parser.cpp
@@ -215,7 +215,7 @@ static void determineTimesig(QList<Bww::MeasureDescription> const& measures, int
     QMap<int, int>::const_iterator i = map.constBegin();
     while (i != map.constEnd())
     {
-        qDebug() << "measureDurations:" << i.key() << i.value() << endl;
+        qDebug() << "measureDurations:" << i.key() << i.value();
         if (i.value() > max) {
             commonDur = i.key();
             max = i.value();

--- a/importexport/guitarpro/importgtp-gp6.cpp
+++ b/importexport/guitarpro/importgtp-gp6.cpp
@@ -2378,7 +2378,11 @@ void GuitarPro6::readMasterBars(GPPartInfo* partInfo)
                         currentFermata = currentFermata.nextSibling();
 
                         // get the fermata information and construct a gpFermata from them
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+                        QStringList fermataComponents = fermata.split("/", Qt::SkipEmptyParts);
+#else
                         QStringList fermataComponents = fermata.split("/", QString::SkipEmptyParts);
+#endif
                         GPFermata gpFermata;
                         gpFermata.index        = fermataComponents.at(0).toInt();
                         gpFermata.timeDivision = fermataComponents.at(1).toInt();

--- a/importexport/guitarpro/importgtp.cpp
+++ b/importexport/guitarpro/importgtp.cpp
@@ -876,8 +876,13 @@ void GuitarPro::readLyrics()
     QString lyrics = readWordPascalString();
     lyrics.replace(QRegExp("\n"), " ");
     lyrics.replace(QRegExp("\r"), " ");
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    auto sl = lyrics.split(" ", Qt::KeepEmptyParts);
+    //gpLyrics.lyrics = lyrics.split(" ", Qt::KeepEmptyParts);
+#else
     auto sl = lyrics.split(" ", QString::KeepEmptyParts);
     //gpLyrics.lyrics = lyrics.split(" ", QString::KeepEmptyParts);
+#endif
     for (auto& str : sl) {
         /*while (str[0] == '-')
     {

--- a/importexport/midiimport/importmidi_chord.cpp
+++ b/importexport/midiimport/importmidi_chord.cpp
@@ -108,9 +108,9 @@ ReducedFraction maxNoteLen(const std::pair<const ReducedFraction, MidiChord>& ch
 
 void removeOverlappingNotes(QList<MidiNote>& notes)
 {
-    QLinkedList<MidiNote> tempNotes;
+    std::list<MidiNote> tempNotes;
     for (const auto& note: notes) {
-        tempNotes.append(note);
+        tempNotes.push_back(note);
     }
 
     for (auto noteIt1 = tempNotes.begin(); noteIt1 != tempNotes.end(); ++noteIt1) {
@@ -430,7 +430,7 @@ void sortNotesByPitch(std::multimap<ReducedFraction, MidiChord>& chords)
     for (auto& chordEvent: chords) {
         // in each chord sort notes by pitches
         auto& notes = chordEvent.second.notes;
-        qSort(notes.begin(), notes.end(), pitchSort);
+        std::sort(notes.begin(), notes.end(), pitchSort);
     }
 }
 
@@ -446,7 +446,7 @@ void sortNotesByLength(std::multimap<ReducedFraction, MidiChord>& chords)
     for (auto& chordEvent: chords) {
         // in each chord sort notes by lengths
         auto& notes = chordEvent.second.notes;
-        qSort(notes.begin(), notes.end(), lenSort);
+        std::sort(notes.begin(), notes.end(), lenSort);
     }
 }
 

--- a/importexport/midiimport/importmidi_model.cpp
+++ b/importexport/midiimport/importmidi_model.cpp
@@ -1124,7 +1124,7 @@ Qt::ItemFlags TracksModel::editableFlags(int row, int col) const
 Qt::ItemFlags TracksModel::flags(const QModelIndex& index) const
 {
     if (!index.isValid()) {
-        return 0;
+        return {};
     }
 
     Qt::ItemFlags flags = Qt::ItemFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);

--- a/importexport/musedata/musedata.cpp
+++ b/importexport/musedata/musedata.cpp
@@ -47,7 +47,11 @@ namespace Ms {
 
 void MuseData::musicalAttribute(QString s, Part* part)
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QStringList al = s.mid(3).split(" ", Qt::SkipEmptyParts);
+#else
     QStringList al = s.mid(3).split(" ", QString::SkipEmptyParts);
+#endif
     foreach (QString item, al) {
         if (item.startsWith("K:")) {
             int key = item.mid(2).toInt();

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -932,7 +932,7 @@ static void handleTupletStop(Tuplet*& tuplet, const int normalNotes)
 //---------------------------------------------------------
 
 static void setElementPropertyFlags(ScoreElement* element, const Pid propertyId,
-                                    const QString value1, const QString value2 = QString::null)
+                                    const QString value1, const QString value2 = QString())
 {
     if (value1.isEmpty()) { // Set as an implicit value
         element->setPropertyFlags(propertyId, PropertyFlags::STYLED);
@@ -3389,7 +3389,11 @@ void MusicXMLParserPass2::doEnding(const QString& partId, Measure* measure,
         } else if (type.isEmpty()) {
             _logger->logError("empty ending type", &_e);
         } else {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+            QStringList sl = number.split(",", Qt::SkipEmptyParts);
+#else
             QStringList sl = number.split(",", QString::SkipEmptyParts);
+#endif
             QList<int> iEndingNumbers;
             bool unsupported = false;
             foreach (const QString& s, sl) {

--- a/importexport/musicxml/importxml.cpp
+++ b/importexport/musicxml/importxml.cpp
@@ -183,8 +183,8 @@ static bool extractRootfile(QFile* qf, QByteArray& data)
 
 static Score::FileError doValidate(const QString& name, QIODevice* dev)
 {
-    QTime t;
-    t.start();
+    //QElapsedTimer t;
+    //t.start();
 
     // initialize the schema
     ValidatorMessageHandler messageHandler;

--- a/importexport/ove/ove.cpp
+++ b/importexport/ove/ove.cpp
@@ -3589,7 +3589,11 @@ QString NumericEnding::getText() const
 QList<int> NumericEnding::getNumbers() const
 {
     int i;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QStringList strs = text_.split(",", Qt::SkipEmptyParts);
+#else
     QStringList strs = text_.split(",", QString::SkipEmptyParts);
+#endif
     QList<int> endings;
 
     for (i = 0; i < strs.size(); ++i) {
@@ -9487,7 +9491,11 @@ void LyricChunkParse::processLyricInfo(const LyricInfo& info)
     bool changeMeasure = true;
     MeasureData* measureData = 0;
     int trackMeasureCount = ove_->getTrackBarCount();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QStringList words = info.lyric_.split(" ", Qt::SkipEmptyParts);
+#else
     QStringList words = info.lyric_.split(" ", QString::SkipEmptyParts);
+#endif
 
     while (index < words.size() && measureId + 1 < trackMeasureCount) {
         if (changeMeasure) {
@@ -9881,7 +9889,7 @@ void OveOrganizer::organizeContainers(int /*part*/, int /*track*/,
     }
 
     // shift voices
-    qSort(voices.begin(), voices.end());
+    std::sort(voices.begin(), voices.end());
 
     for (i = 0; i < voices.size(); ++i) {
         int voice = voices[i];

--- a/inspectors/models/inspectorlistmodel.cpp
+++ b/inspectors/models/inspectorlistmodel.cpp
@@ -119,6 +119,7 @@ void InspectorListModel::removeUnusedModels(const QSet<Ms::ElementType>& newElem
             continue;
         }
 
+        // ToDo for Qt 5.15: QListMs::ElementType::toSet vs. QSet(list.begin(), list.end()) 
         QSet<Ms::ElementType> supportedElementTypes = AbstractInspectorModel::supportedElementTypesBySectionType(model->sectionType()).toSet();
 
         supportedElementTypes.intersect(newElementTypeSet);

--- a/inspectors/utils/doubleinputvalidator.cpp
+++ b/inspectors/utils/doubleinputvalidator.cpp
@@ -22,7 +22,11 @@ void DoubleInputValidator::fixup(QString& string) const
     if (string.endsWith("."))
         string.append(zeros(m_decimal));
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QStringList strList = string.split(".", Qt::SkipEmptyParts);
+#else
     QStringList strList = string.split(".", QString::SkipEmptyParts);
+#endif
 
     QString intPart = strList.at(0);
     QString floatPart = strList.at(1);

--- a/inspectors/view/ui/inspectorBase.cpp
+++ b/inspectors/view/ui/inspectorBase.cpp
@@ -124,7 +124,11 @@ QVariant InspectorBase::getValue(const InspectorItem& ii) const
                   v = QVariant::fromValue<Direction>(Direction(v.toInt()));
                   break;
             case P_TYPE::INT_LIST: {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+                  QStringList sl = v.toString().split(",", Qt::SkipEmptyParts);
+#else
                   QStringList sl = v.toString().split(",", QString::SkipEmptyParts);
+#endif
                   QList<int> il;
                   for (const QString& l : sl) {
                         int i = l.simplified().toInt();

--- a/inspectors/view/ui/inspector_ambitus.ui
+++ b/inspectors/view/ui/inspector_ambitus.ui
@@ -881,22 +881,6 @@
   <connection>
    <sender>hasLine</sender>
    <signal>toggled(bool)</signal>
-   <receiver>label_10</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>44</x>
-     <y>137</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>50</x>
-     <y>149</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>hasLine</sender>
-   <signal>toggled(bool)</signal>
    <receiver>lineWidth</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
@@ -907,22 +891,6 @@
     <hint type="destinationlabel">
      <x>129</x>
      <y>156</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>hasLine</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>resetLineWidth</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>163</x>
-     <y>134</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>242</x>
-     <y>152</y>
     </hint>
    </hints>
   </connection>

--- a/inspectors/view/ui/inspector_fermata.ui
+++ b/inspectors/view/ui/inspector_fermata.ui
@@ -211,22 +211,6 @@
   <connection>
    <sender>playArticulation</sender>
    <signal>toggled(bool)</signal>
-   <receiver>label_2</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>40</x>
-     <y>91</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>44</x>
-     <y>108</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>playArticulation</sender>
-   <signal>toggled(bool)</signal>
    <receiver>timeStretch</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
@@ -237,22 +221,6 @@
     <hint type="destinationlabel">
      <x>112</x>
      <y>114</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>playArticulation</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>resetTimeStretch</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>157</x>
-     <y>89</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>178</x>
-     <y>106</y>
     </hint>
    </hints>
   </connection>

--- a/inspectors/view/ui/inspector_glissando.ui
+++ b/inspectors/view/ui/inspector_glissando.ui
@@ -420,22 +420,6 @@
   <connection>
    <sender>playGlissando</sender>
    <signal>toggled(bool)</signal>
-   <receiver>label_2</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>33</x>
-     <y>268</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>35</x>
-     <y>292</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>playGlissando</sender>
-   <signal>toggled(bool)</signal>
    <receiver>glissandoStyle</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
@@ -446,22 +430,6 @@
     <hint type="destinationlabel">
      <x>114</x>
      <y>291</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>playGlissando</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>resetGlissandoStyle</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>234</x>
-     <y>267</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>352</x>
-     <y>296</y>
     </hint>
    </hints>
   </connection>

--- a/inspectors/view/ui/inspector_hairpin.ui
+++ b/inspectors/view/ui/inspector_hairpin.ui
@@ -511,22 +511,6 @@
   <connection>
    <sender>singleNoteDynamics</sender>
    <signal>toggled(bool)</signal>
-   <receiver>label_7</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>83</x>
-     <y>325</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>83</x>
-     <y>346</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>singleNoteDynamics</sender>
-   <signal>toggled(bool)</signal>
    <receiver>veloChangeMethod</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
@@ -537,22 +521,6 @@
     <hint type="destinationlabel">
      <x>176</x>
      <y>336</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>singleNoteDynamics</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>resetVeloChangeMethod</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>335</x>
-     <y>321</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>377</x>
-     <y>358</y>
     </hint>
    </hints>
   </connection>

--- a/inspectors/view/ui/inspector_trill.ui
+++ b/inspectors/view/ui/inspector_trill.ui
@@ -278,22 +278,6 @@
   <connection>
    <sender>playArticulation</sender>
    <signal>toggled(bool)</signal>
-   <receiver>label_3</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>42</x>
-     <y>147</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>49</x>
-     <y>164</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>playArticulation</sender>
-   <signal>toggled(bool)</signal>
    <receiver>ornamentStyle</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
@@ -304,22 +288,6 @@
     <hint type="destinationlabel">
      <x>151</x>
      <y>156</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>playArticulation</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>resetOrnamentStyle</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>224</x>
-     <y>138</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>333</x>
-     <y>159</y>
     </hint>
    </hints>
   </connection>

--- a/libmscore/chordlist.cpp
+++ b/libmscore/chordlist.cpp
@@ -29,7 +29,11 @@ HChord::HChord(const QString& str)
         { "C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B" }
     };
     keys = 0;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QStringList sl = str.split(" ", Qt::SkipEmptyParts);
+#else
     QStringList sl = str.split(" ", QString::SkipEmptyParts);
+#endif
     for (const QString& s : sl) {
         for (int i = 0; i < 12; ++i) {
             if (s == scaleNames[0][i] || s == scaleNames[1][i]) {
@@ -316,10 +320,18 @@ void HChord::add(const QList<HDegree>& degreeList)
 static void readRenderList(QString val, QList<RenderAction>& renderList)
 {
     renderList.clear();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QStringList sl = val.split(" ", Qt::SkipEmptyParts);
+#else
     QStringList sl = val.split(" ", QString::SkipEmptyParts);
+#endif
     for (const QString& s : sl) {
         if (s.startsWith("m:")) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+            QStringList ssl = s.split(":", Qt::SkipEmptyParts);
+#else
             QStringList ssl = s.split(":", QString::SkipEmptyParts);
+#endif
             if (ssl.size() == 3) {
                 // m:x:y
                 RenderAction a;

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -131,7 +131,7 @@ public:
     bool vRaster                     { false };
 
     int key                          { 0 };
-    Qt::KeyboardModifiers modifiers  { 0 };
+    Qt::KeyboardModifiers modifiers  { /*0*/ };   // '0' initialized via default constructor, doing it here too results in compiler warning with Qt 5.15
     QString s;
 
     Qt::MouseButtons buttons         { Qt::NoButton };

--- a/libmscore/figuredbass.cpp
+++ b/libmscore/figuredbass.cpp
@@ -1389,7 +1389,11 @@ void FiguredBass::endEdit(EditData& ed)
     }
 
     // split text into lines and create an item for each line
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QStringList list = txt.split("\n", Qt::SkipEmptyParts);
+#else
     QStringList list = txt.split('\n', QString::SkipEmptyParts);
+#endif
     qDeleteAll(items);
     items.clear();
     QString normalizedText = QString();

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -2094,7 +2094,11 @@ QString Harmony::generateScreenReaderInfo() const
         aux = aux.replace("#", QObject::tr("♯")).replace("<", "");
         QString extension = "";
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        for (QString s : aux.split(">", Qt::SkipEmptyParts)) {
+#else
         for (QString s : aux.split(">", QString::SkipEmptyParts)) {
+#endif
             if (!s.contains("blues")) {
                 s.replace("b", QObject::tr("♭"));
             }

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -229,8 +229,8 @@ void Score::layoutChords1(Segment* segment, int staffIdx)
 
         // layout upstem noteheads
         if (upVoices > 1) {
-            qSort(upStemNotes.begin(), upStemNotes.end(),
-                  [](Note* n1, const Note* n2) ->bool { return n1->line() > n2->line(); });
+            std::sort(upStemNotes.begin(), upStemNotes.end(),
+                      [](Note* n1, const Note* n2) ->bool { return n1->line() > n2->line(); });
         }
         if (upVoices) {
             qreal hw = layoutChords2(upStemNotes, true);
@@ -239,8 +239,8 @@ void Score::layoutChords1(Segment* segment, int staffIdx)
 
         // layout downstem noteheads
         if (downVoices > 1) {
-            qSort(downStemNotes.begin(), downStemNotes.end(),
-                  [](Note* n1, const Note* n2) ->bool { return n1->line() > n2->line(); });
+            std::sort(downStemNotes.begin(), downStemNotes.end(),
+                      [](Note* n1, const Note* n2) ->bool { return n1->line() > n2->line(); });
         }
         if (downVoices) {
             qreal hw = layoutChords2(downStemNotes, false);
@@ -355,8 +355,8 @@ void Score::layoutChords1(Segment* segment, int staffIdx)
                         break;
                     }
                 }
-                qSort(overlapNotes.begin(), overlapNotes.end(),
-                      [](Note* n1, const Note* n2) ->bool { return n1->line() > n2->line(); });
+                std::sort(overlapNotes.begin(), overlapNotes.end(),
+                          [](Note* n1, const Note* n2) ->bool { return n1->line() > n2->line(); });
 
                 // determine nature of overlap
                 bool shareHeads = true;               // can all overlapping notes share heads?
@@ -587,8 +587,8 @@ void Score::layoutChords1(Segment* segment, int staffIdx)
             notes.insert(notes.end(), downStemNotes.begin(), downStemNotes.end());
         }
         if (upVoices + downVoices > 1) {
-            qSort(notes.begin(), notes.end(),
-                  [](Note* n1, const Note* n2) ->bool { return n1->line() > n2->line(); });
+            std::sort(notes.begin(), notes.end(),
+                      [](Note* n1, const Note* n2) ->bool { return n1->line() > n2->line(); });
         }
         layoutChords3(notes, staff, segment);
     }
@@ -1131,7 +1131,7 @@ void Score::layoutChords3(std::vector<Note*>& notes, const Staff* staff, Segment
         }
         nAcc = umi.size();
         if (nAcc > 1) {
-            qSort(umi);
+            std::sort(umi.begin(), umi.end());
         }
 
         // lay out columns

--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -386,7 +386,11 @@ void Lyrics::paste(EditData& ed)
 #endif
     QString txt = QApplication::clipboard()->text(mode);
     QString regex = QString("[^\\S") + QChar(0xa0) + QChar(0x202F) + "]+";
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QStringList sl = txt.split(QRegExp(regex), Qt::SkipEmptyParts);
+#else
     QStringList sl = txt.split(QRegExp(regex), QString::SkipEmptyParts);
+#endif
     if (sl.empty()) {
         return;
     }

--- a/libmscore/mscoreview.cpp
+++ b/libmscore/mscoreview.cpp
@@ -79,7 +79,7 @@ const QList<Element*> MuseScoreView::elementsAt(const QPointF& p)
     Page* page = point2page(p);
     if (page) {
         el = page->items(p - page->pos());
-        qSort(el.begin(), el.end(), elementLower);
+        std::sort(el.begin(), el.end(), elementLower);
     }
     return el;
 }

--- a/libmscore/page.cpp
+++ b/libmscore/page.cpp
@@ -343,21 +343,30 @@ QString Page::replaceTextMacros(const QString& s) const
                 d += masterScore()->fileInfo()->absoluteFilePath().toHtmlEscaped();
                 break;
             case 'd':
+                // ToDo for Qt 5.15: Qt::DefaultLocaleShortDate vs. QLocale ??
                 d += QDate::currentDate().toString(Qt::DefaultLocaleShortDate);
                 break;
             case 'D':
                 {
                 QString creationDate = score()->metaTag("creationDate");
                 if (creationDate.isNull())
-                      d += masterScore()->fileInfo()->created().date().toString(Qt::DefaultLocaleShortDate);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+                    // ToDo for Qt 5.15: Qt::DefaultLocaleShortDate vs. QLocale ??
+                    d += masterScore()->fileInfo()->birthTime().date().toString(Qt::DefaultLocaleShortDate);
+#else
+                    d += masterScore()->fileInfo()->created().date().toString(Qt::DefaultLocaleShortDate);
+#endif
                 else
-                      d += QDate::fromString(creationDate, Qt::ISODate).toString(Qt::DefaultLocaleShortDate);
+                    // ToDo for Qt 5.15: Qt::DefaultLocaleShortDate vs. QLocale ??
+                    d += QDate::fromString(creationDate, Qt::ISODate).toString(Qt::DefaultLocaleShortDate);
                 }
                 break;
             case 'm':
                 if ( score()->dirty() )
+                      // ToDo for Qt 5.15: Qt::DefaultLocaleShortDate vs. QLocale ??
                       d += QTime::currentTime().toString(Qt::DefaultLocaleShortDate);
                 else
+                      // ToDo for Qt 5.15: Qt::DefaultLocaleShortDate vs. QLocale ??
                       d += masterScore()->fileInfo()->lastModified().time().toString(Qt::DefaultLocaleShortDate);
                 break;
             case 'M':

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -1302,7 +1302,11 @@ static void readVolta114(XmlReader& e, Volta* volta)
         const QStringRef& tag(e.name());
         if (tag == "endings") {
             QString s = e.readElementText();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+            QStringList sl = s.split(",", Qt::SkipEmptyParts);
+#else
             QStringList sl = s.split(",", QString::SkipEmptyParts);
+#endif
             volta->endings().clear();
             for (const QString& l : sl) {
                 int i = l.simplified().toInt();

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -2434,7 +2434,11 @@ static void readVolta206(XmlReader& e, Volta* volta)
         const QStringRef& tag(e.name());
         if (tag == "endings") {
             QString s = e.readElementText();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+            QStringList sl = s.split(",", Qt::SkipEmptyParts);
+#else
             QStringList sl = s.split(",", QString::SkipEmptyParts);
+#endif
             volta->endings().clear();
             for (const QString& l : sl) {
                 int i = l.simplified().toInt();

--- a/libmscore/realizedharmony.cpp
+++ b/libmscore/realizedharmony.cpp
@@ -532,7 +532,7 @@ RealizedHarmony::PitchMap RealizedHarmony::normalizeNoteMap(const PitchMap& inte
     //redo insertions if we must have a specific number of notes with insertMulti
     if (enforceMaxAsGoal) {
         while (ret.size() < max) {
-            ret.insertMulti(rootPitch, rootTpc);       //duplicate root
+            ret.insert(rootPitch, rootTpc);       //duplicate root
 
             int size = max - ret.size();
             itr = PitchMapIterator(intervals);       //reset iterator
@@ -541,11 +541,11 @@ RealizedHarmony::PitchMap RealizedHarmony::normalizeNoteMap(const PitchMap& inte
                     break;
                 }
                 itr.next();
-                ret.insertMulti((itr.key() % 128 + rootPitch) % PITCH_DELTA_OCTAVE, itr.value());
+                ret.insert((itr.key() % 128 + rootPitch) % PITCH_DELTA_OCTAVE, itr.value());
             }
         }
     } else if (ret.size() < max) { //insert another root if we have room in general
-        ret.insertMulti(rootPitch, rootTpc);
+        ret.insert(rootPitch, rootTpc);
     }
     return ret;
 }

--- a/libmscore/realizedharmony.h
+++ b/libmscore/realizedharmony.h
@@ -57,7 +57,7 @@ enum class HDuration : signed char {
 class RealizedHarmony
 {
 public:
-    using PitchMap = QMap<int, int>;   //map from pitch to tpc
+    using PitchMap = QMultiMap<int, int>;   //map from pitch to tpc
     using PitchMapIterator = QMapIterator<int, int>;
 
 private:

--- a/libmscore/scorediff.cpp
+++ b/libmscore/scorediff.cpp
@@ -127,10 +127,17 @@ std::vector<TextDiff> MscxModeDiff::lineModeDiff(const QString& s1, const QStrin
     typedef std::pair<elem, dtl::elemInfo> sesElem;
     typedef std::vector<sesElem> sesElemVec;
 
+# if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    const QVector<QStringRef> linesVec1 = s1.splitRef('\n');
+    std::vector<QStringRef> lines1(linesVec1.begin(), linesVec1.end());
+    const QVector<QStringRef> linesVec2 = s2.splitRef('\n');
+    std::vector<QStringRef> lines2(linesVec2.begin(), linesVec2.end());
+#else
     // QVector does not contain range constructor used inside dtl
     // so we have to convert to std::vector.
     std::vector<QStringRef> lines1 = s1.splitRef('\n').toStdVector();
     std::vector<QStringRef> lines2 = s2.splitRef('\n').toStdVector();
+#endif
     dtl::Diff<QStringRef, std::vector<QStringRef> > diff(lines1, lines2);
 
     diff.compose();

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -1043,7 +1043,7 @@ void Score::print(QPainter* painter, int pageNo)
     QRectF fr  = page->abbox();
 
     QList<Element*> ell = page->items(fr);
-    qStableSort(ell.begin(), ell.end(), elementLessThan);
+    std::stable_sort(ell.begin(), ell.end(), elementLessThan);
     for (const Element* e : ell) {
         if (!e->visible()) {
             continue;

--- a/libmscore/skyline.cpp
+++ b/libmscore/skyline.cpp
@@ -255,7 +255,7 @@ void Skyline::paint(QPainter& p) const
     p.save();
 
     p.setBrush(Qt::NoBrush);
-    QMatrix matrix = p.matrix();
+    QMatrix matrix = p.worldTransform().toAffine();
     p.setPen(QPen(QBrush(Qt::darkYellow), 2.0 / matrix.m11()));
     _north.paint(p);
     p.setPen(QPen(QBrush(Qt::green), 2.0 / matrix.m11()));

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -157,7 +157,11 @@ void Staff::swapBracket(int oldIdx, int newIdx)
     fillBrackets(idx);
     _brackets[oldIdx]->setColumn(newIdx);
     _brackets[newIdx]->setColumn(oldIdx);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    _brackets.swapItemsAt(oldIdx, newIdx);
+#else
     _brackets.swap(oldIdx, newIdx);
+#endif
     cleanBrackets();
 }
 
@@ -175,7 +179,11 @@ void Staff::changeBracketColumn(int oldColumn, int newColumn)
         int newIdx = i + step;
         _brackets[oldIdx]->setColumn(newIdx);
         _brackets[newIdx]->setColumn(oldIdx);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        _brackets.swapItemsAt(oldIdx, newIdx);
+#else
         _brackets.swap(oldIdx, newIdx);
+#endif
     }
     cleanBrackets();
 }

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -2986,7 +2986,7 @@ void TextBase::drawEditMode(QPainter* p, EditData& ed)
         p->drawRect(_cursor->cursorRect());
     }
 
-    QMatrix matrix = p->matrix();
+    QMatrix matrix = p->worldTransform().toAffine();
     p->translate(-pos);
     p->setPen(QPen(QBrush(Qt::lightGray), 4.0 / matrix.m11()));    // 4 pixel pen size
     p->setBrush(Qt::NoBrush);

--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -392,7 +392,7 @@ bool TextBase::edit(EditData& ed)
 
         case Qt::Key_Tab:
             s = " ";
-            ed.modifiers = 0;
+            ed.modifiers = {};
             break;
 
         case Qt::Key_Space:
@@ -406,7 +406,7 @@ bool TextBase::edit(EditData& ed)
                 }
                 s = " ";
             }
-            ed.modifiers = 0;
+            ed.modifiers = {};
             break;
 
         case Qt::Key_Minus:

--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -1040,7 +1040,7 @@ static bool tickGreater(const DurationElement* a, const DurationElement* b)
 
 void Tuplet::sortElements()
 {
-    qSort(_elements.begin(), _elements.end(), tickGreater);
+    std::sort(_elements.begin(), _elements.end(), tickGreater);
 }
 
 //---------------------------------------------------------

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -2055,7 +2055,11 @@ void RemoveExcerpt::redo(EditData*)
 
 void SwapExcerpt::flip(EditData*)
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    score->excerpts().swapItemsAt(pos1, pos2);
+#else
     score->excerpts().swap(pos1, pos2);
+#endif
     score->setExcerptsChanged(true);
 }
 

--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -512,7 +512,7 @@ QString pitch2string(int v)
     }
     int octave = (v / 12) - 1;
     QString o;
-    o.sprintf("%d", octave);
+    o = QString::asprintf("%d", octave);
     int i = v % 12;
     return qApp->translate("utils", octave < 0 ? valu[i] : vall[i]) + o;
 }

--- a/libmscore/volta.cpp
+++ b/libmscore/volta.cpp
@@ -134,7 +134,11 @@ void Volta::read(XmlReader& e)
         const QStringRef& tag(e.name());
         if (tag == "endings") {
             QString s = e.readElementText();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+            QStringList sl = s.split(",", Qt::SkipEmptyParts);
+#else
             QStringList sl = s.split(",", QString::SkipEmptyParts);
+#endif
             _endings.clear();
             for (const QString& l : sl) {
                 int i = l.simplified().toInt();

--- a/libmscore/xmlwriter.cpp
+++ b/libmscore/xmlwriter.cpp
@@ -14,6 +14,11 @@
 #include "property.h"
 #include "scoreElement.h"
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)) //???
+#define endl Qt::endl
+#define dec Qt::dec
+#endif
+
 namespace Ms {
 //---------------------------------------------------------
 //   Xml

--- a/mscore/abstractdialog.h
+++ b/mscore/abstractdialog.h
@@ -30,7 +30,7 @@ class AbstractDialog : public QDialog
     Q_OBJECT
 
 public:
-    AbstractDialog(QWidget* parent = 0, Qt::WindowFlags f = 0);
+    AbstractDialog(QWidget* parent = 0, Qt::WindowFlags f = {});
     virtual ~AbstractDialog();
 
 protected:

--- a/mscore/chordview.cpp
+++ b/mscore/chordview.cpp
@@ -345,7 +345,7 @@ void ChordView::moveLocator()
 
 void ChordView::wheelEvent(QWheelEvent* event)
 {
-    int step    = event->delta() / 120;
+    int step    = event->angleDelta().y() / 120;
     double xmag = transform().m11();
     double ymag = transform().m22();
 
@@ -415,7 +415,17 @@ void ChordView::wheelEvent(QWheelEvent* event)
             emit xposChanged(xpos);
         }
     } else if (event->modifiers() == Qt::ShiftModifier) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
+# if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 1)) //???
+        QWheelEvent we(event->position(), event->globalPosition(), event->pixelDelta(), event->angleDelta(),
+                       event->buttons(), event->modifiers(), event->phase(), event->inverted(), event->source());
+# else
+        QWheelEvent we(event->pos(), event->globalPos(), event->pixelDelta(), event->angleDelta(), event->buttons(),
+                       event->modifiers(), event->phase(), event->inverted(), event->source());
+# endif
+#else
         QWheelEvent we(event->pos(), event->delta(), event->buttons(), 0, Qt::Horizontal);
+#endif
         QGraphicsView::wheelEvent(&we);
     } else if (event->modifiers() == 0) {
         QGraphicsView::wheelEvent(event);

--- a/mscore/cloud/loginmanager.cpp
+++ b/mscore/cloud/loginmanager.cpp
@@ -20,6 +20,10 @@
 #include <QWebEngineCookieStore>
 #endif
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+#define qrand() QRandomGenerator::global()->generate()
+#endif
+
 namespace Ms {
 extern QString dataPath;
 
@@ -74,6 +78,7 @@ void ApiInfo::createInstance()
     QByteArray clientId;
     if (f.open(QIODevice::ReadOnly)) {
         const QByteArray saveData = f.readAll();
+        // ToDo for Qt 5.15: QJsonDocument::fromBinaryDatsa vs. CBOR format ??
         const QJsonDocument d(QJsonDocument::fromBinaryData(saveData));
         QJsonObject saveObject = d.object();
         clientId = saveObject["clientId"].toString().toLatin1();
@@ -85,6 +90,7 @@ void ApiInfo::createInstance()
             QJsonObject saveObject;
             saveObject["clientId"] = QString(clientId);
             QJsonDocument saveDoc(saveObject);
+            // ToDo for Qt 5.15: QJsonDocument::toBinaryDatsa vs. CBOR format ??
             f.write(saveDoc.toBinaryData());
             f.close();
         }
@@ -180,6 +186,7 @@ bool LoginManager::save()
     saveObject["accessToken"] = _accessToken;
     saveObject["refreshToken"] = _refreshToken;
     QJsonDocument saveDoc(saveObject);
+    // ToDo for Qt 5.15: QJsonDocument::toBinaryDatsa vs. CBOR format ??
     saveFile.write(saveDoc.toBinaryData());
     saveFile.close();
     return true;
@@ -196,6 +203,7 @@ bool LoginManager::load()
         return false;
     }
     QByteArray saveData = loadFile.readAll();
+    // ToDo for Qt 5.15: QJsonDocument::fromBinaryDatsa vs. CBOR format ??
     QJsonDocument loadDoc(QJsonDocument::fromBinaryData(saveData));
     QJsonObject saveObject = loadDoc.object();
     _accessToken = saveObject["accessToken"].toString();

--- a/mscore/cloud/uploadscoredialog.cpp
+++ b/mscore/cloud/uploadscoredialog.cpp
@@ -101,12 +101,11 @@ void UploadScoreDialog::upload(int nid)
 {
     Score* score = mscore->currentScore()->masterScore();
     const QString scoreTitle = title->text().trimmed().isEmpty() ? score->title() : title->text();
-    //revert changes partially made in c8278789267ab6d1c6fcf1cd2b39a2495862255c
-    /*QString path = QDir::tempPath() + "/" + mscore->currentScore()->masterScore()->fileInfo()->fileName();
-    if (QFile::exists(path))
-          path = QDir::tempPath() + QString("/%1-").arg(qrand() % 100000) + mscore->currentScore()->masterScore()->fileInfo()->fileName();
-    if (mscore->saveAs(score, true, path, "mscz")) {*/
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+    QString path = QDir::tempPath() + QString("/temp_%1.mscz").arg(QRandomGenerator::global()->generate() % 100000);
+#else
     QString path = QDir::tempPath() + QString("/temp_%1.mscz").arg(qrand() % 100000);
+#endif
     if (mscore->saveAs(score, true, path, "mscz")) {
         _nid = nid;
         _loginManager->upload(path, nid, scoreTitle);

--- a/mscore/continuouspanel.cpp
+++ b/mscore/continuouspanel.cpp
@@ -107,7 +107,7 @@ void ContinuousPanel::paint(const QRect&, QPainter& painter)
         _visible = false;
         return;
     }
-    qStableSort(el.begin(), el.end(), elementLessThan);
+    std::stable_sort(el.begin(), el.end(), elementLessThan);
 
     const Measure* _currentMeasure = 0;
     for (const Element* e : el) {

--- a/mscore/debugger/debugger.cpp
+++ b/mscore/debugger/debugger.cpp
@@ -568,13 +568,13 @@ bool Debugger::searchElement(QTreeWidgetItem* pi, Element* el)
         ElementItem* ei = (ElementItem*)item;
         if (ei->element() == el) {
             QTreeWidget* tw = pi->treeWidget();
-            tw->setItemExpanded(item, true);
+            item->setExpanded(true);
             tw->setCurrentItem(item);
             tw->scrollToItem(item);
             return true;
         }
         if (searchElement(item, el)) {
-            pi->treeWidget()->setItemExpanded(item, true);
+            item->setExpanded(true);
             return true;
         }
     }
@@ -648,7 +648,7 @@ void Debugger::updateElement(Element* el)
         }
         ElementItem* ei = static_cast<ElementItem*>(item);
         if (ei->element() == el) {
-            list->setItemExpanded(item, true);
+            item->setExpanded(true);
             list->setCurrentItem(item);
             list->scrollToItem(item);
             found = true;
@@ -1874,7 +1874,11 @@ QSize DoubleLabel::sizeHint() const
     QFontMetrics fm = fontMetrics();
     int h           = fm.height() + 4;
     int n           = 3 + 3;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+    int w = fm.horizontalAdvance(QString("-0.")) + fm.horizontalAdvance('0') * n + 6;
+#else
     int w = fm.width(QString("-0.")) + fm.width('0') * n + 6;
+#endif
     return QSize(w, h);
 }
 

--- a/mscore/drumview.cpp
+++ b/mscore/drumview.cpp
@@ -347,7 +347,7 @@ void DrumView::moveLocator(int i)
 
 void DrumView::wheelEvent(QWheelEvent* event)
 {
-    int step = event->delta() / 120;
+    int step = event->angleDelta().y() / 120;
     double xmag = transform().m11();
     double ymag = transform().m22();
 
@@ -417,7 +417,17 @@ void DrumView::wheelEvent(QWheelEvent* event)
             emit xposChanged(xpos);
         }
     } else if (event->modifiers() == Qt::ShiftModifier) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
+# if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 1)) //???
+        QWheelEvent we(event->position(), event->globalPosition(), event->pixelDelta(), event->angleDelta(),
+                       event->buttons(), event->modifiers(), event->phase(), event->inverted(), event->source());
+# else
+        QWheelEvent we(event->pos(), event->globalPos(), event->pixelDelta(), event->angleDelta(), event->buttons(),
+                       event->modifiers(), event->phase(), event->inverted(), event->source());
+# endif
+#else
         QWheelEvent we(event->pos(), event->delta(), event->buttons(), 0, Qt::Horizontal);
+#endif
         QGraphicsView::wheelEvent(&we);
     } else if (event->modifiers() == 0) {
         QGraphicsView::wheelEvent(event);

--- a/mscore/editdrumset.cpp
+++ b/mscore/editdrumset.cpp
@@ -70,7 +70,7 @@ NoteHead::Group noteHeadNames[] = {
 bool EditDrumsetTreeWidgetItem::operator<(const QTreeWidgetItem& other) const
 {
     if (treeWidget()->sortColumn() == Column::PITCH) {
-        return data(Column::PITCH, Qt::UserRole) < other.data(Column::PITCH, Qt::UserRole);
+        return data(Column::PITCH, Qt::UserRole).toInt() < other.data(Column::PITCH, Qt::UserRole).toInt();
     } else {
         return QTreeWidgetItem::operator<(other);
     }

--- a/mscore/editlyrics.cpp
+++ b/mscore/editlyrics.cpp
@@ -78,7 +78,7 @@ bool ScoreView::editKeyLyrics()
     case Qt::Key_Underscore:
         if (editData.control(textEditing)) {
             // change into normal underscore
-            editData.modifiers = 0;             // &= ~CONTROL_MODIFIER;
+            editData.modifiers = {};             // &= ~CONTROL_MODIFIER;
             return false;
         } else {
             lyricsUnderscore();

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -179,7 +179,11 @@ void ScoreView::wheelEvent(QWheelEvent* event)
 
     if (event->modifiers() & Qt::ControlModifier) {   // Windows touch pad pinches also execute this
         QApplication::sendPostedEvents(this, 0);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 1)) //???
+        zoomStep(nReal, event->position().toPoint());
+#else
         zoomStep(nReal, event->pos());
+#endif
         return;
     }
 

--- a/mscore/exampleview.cpp
+++ b/mscore/exampleview.cpp
@@ -197,7 +197,7 @@ void ExampleView::paintEvent(QPaintEvent* ev)
         QRegion r1(r);
         Page* page = _score->pages().front();
         QList<Element*> ell = page->items(fr);
-        qStableSort(ell.begin(), ell.end(), elementLessThan);
+        std::stable_sort(ell.begin(), ell.end(), elementLessThan);
         drawElements(p, ell);
     }
     QFrame::paintEvent(ev);

--- a/mscore/excerptsdialog.cpp
+++ b/mscore/excerptsdialog.cpp
@@ -353,7 +353,7 @@ void ExcerptsDialog::excerptChanged(QListWidgetItem* cur, QListWidgetItem*)
                 sli->setDisabled(!b);
             }
             pi->setText(0, p->partName());
-            partList->setItemExpanded(pi, false);
+            pi->setExpanded(false);
         }
         assignTracks(tracks);
     } else {

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -1080,7 +1080,7 @@ QString MuseScore::getSaveScoreName(const QString& title, QString& name, const Q
 
     if (preferences.getBool(PREF_UI_APP_USENATIVEDIALOGS)) {
         QString s;
-        QFileDialog::Options options = selectFolder ? QFileDialog::ShowDirsOnly : QFileDialog::Options(0);
+        QFileDialog::Options options = selectFolder ? QFileDialog::ShowDirsOnly : QFileDialog::Options();
         return QFileDialog::getSaveFileName(this, title, name, filter, &s, options);
     }
 
@@ -1863,7 +1863,7 @@ void MuseScore::exportFile()
 
     QString name;
 #ifdef Q_OS_WIN
-    if (QSysInfo::WindowsVersion == QSysInfo::WV_XP) {
+    if (QOperatingSystemVersion::current() <= QOperatingSystemVersion(QOperatingSystemVersion::Windows, 5, 1)) {   //XP
         if (!cs->isMaster()) {
             name = QString("%1/%2-%3").arg(saveDirectory).arg(cs->masterScore()->fileInfo()->completeBaseName()).arg(createDefaultFileName(
                                                                                                                          cs
@@ -1963,7 +1963,7 @@ bool MuseScore::exportParts()
     QString scoreName = cs->isMaster() ? cs->masterScore()->fileInfo()->completeBaseName() : cs->title();
     QString name;
 #ifdef Q_OS_WIN
-    if (QSysInfo::WindowsVersion == QSysInfo::WV_XP) {
+    if (QOperatingSystemVersion::current() <= QOperatingSystemVersion(QOperatingSystemVersion::Windows, 5, 1)) { //XP
         name = QString("%1/%2").arg(saveDirectory).arg(scoreName);
     } else
 #endif
@@ -2639,7 +2639,7 @@ bool MuseScore::saveAs(Score* cs_, bool saveCopy)
     }
     QString name;
 #ifdef Q_OS_WIN
-    if (QSysInfo::WindowsVersion == QSysInfo::WV_XP) {
+    if (QOperatingSystemVersion::current() <= QOperatingSystemVersion(QOperatingSystemVersion::Windows, 5, 1)) {  //XP
         if (!cs_->isMaster()) {
             name = QString("%1/%2-%3").arg(saveDirectory).arg(fileBaseName).arg(createDefaultFileName(cs->title()));
         } else {
@@ -2924,7 +2924,7 @@ bool MuseScore::savePng(Score* score, QIODevice* device, int pageNumber, bool dr
     }
 
     QList< Element*> pel = page->elements();
-    qStableSort(pel.begin(), pel.end(), elementLessThan);
+    std::stable_sort(pel.begin(), pel.end(), elementLessThan);
     paintElements(p, pel);
     if (format == QImage::Format_Indexed8) {
         //convert to grayscale & respect alpha
@@ -3209,7 +3209,7 @@ bool MuseScore::saveSvg(Score* score, QIODevice* device, int pageNumber, bool dr
     }
     // 2nd pass: the rest of the elements
     QList<Element*> pel = page->elements();
-    qStableSort(pel.begin(), pel.end(), elementLessThan);
+    std::stable_sort(pel.begin(), pel.end(), elementLessThan);
     ElementType eType;
     for (const Element* e : pel) {
         // Always exclude invisible elements

--- a/mscore/fotomode.cpp
+++ b/mscore/fotomode.cpp
@@ -379,6 +379,9 @@ void ScoreView::fotoContextPopup(QContextMenuEvent* ev)
                                                     preferences.getDouble(PREF_EXPORT_PNG_RESOLUTION),
                                                     16.0, 2400.0, 1,
                                                     &ok
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)) //???
+                                                    , {}, 1.0
+#endif
                                                     );
         if (ok) {
             preferences.setPreference(PREF_EXPORT_PNG_RESOLUTION, resolution);
@@ -656,6 +659,6 @@ void ScoreView::fotoDragDrop(QMouseEvent*)
     mimeData->setUrls(ul);
 
     drag->setMimeData(mimeData);
-    drag->start(Qt::CopyAction);
+    drag->exec(Qt::CopyAction);
 }
 }

--- a/mscore/help.cpp
+++ b/mscore/help.cpp
@@ -97,6 +97,7 @@ void HelpQuery::textChanged(const QString& ss)
     if (!mscore->helpEngine()) {
         return;
     }
+    // ToDo for Qt 5.15: QHelpEngineCore::linksForIdentifier vs. documentsForIdentifier ??
     QMap<QString,QUrl> list = mscore->helpEngine()->linksForIdentifier(s);
 //      QMap<QString,QUrl>list = mscore->helpEngine()->indexModel()->linksForKeyword(s);
     int k = 0;
@@ -142,6 +143,7 @@ void HelpQuery::returnPressed()
     if (!he) {
         return;
     }
+    // ToDo for Qt 5.15: QHelpEngineCore::linksForIdentifier vs. documentsForIdentifier ??
     QMap<QString,QUrl> list = he->linksForIdentifier(entry->text().toLower());
     if (!list.isEmpty()) {
         mscore->showHelp(list.begin().value());

--- a/mscore/importmidi_ui/importmidi_delegate.cpp
+++ b/mscore/importmidi_ui/importmidi_delegate.cpp
@@ -298,7 +298,11 @@ void OperationsDelegate::drawArrow(
     const int height = 4;
     const int width = 8;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+    const int textWidth = fm.horizontalAdvance(index.data(Qt::DisplayRole).toString());
+#else
     const int textWidth = fm.width(index.data(Qt::DisplayRole).toString());
+#endif
     const int x = rightArrowAlign
                   ? option.rect.right() - width - gap
                   : option.rect.left() + textWidth + gap;

--- a/mscore/importmidi_ui/importmidi_panel.cpp
+++ b/mscore/importmidi_ui/importmidi_panel.cpp
@@ -148,7 +148,7 @@ void ImportMidiPanel::fillCharsetList()
 
     _ui->comboBoxCharset->clear();
     QList<QByteArray> charsets = QTextCodec::availableCodecs();
-    qSort(charsets.begin(), charsets.end());
+    std::sort(charsets.begin(), charsets.end());
     int idx = 0;
     int maxWidth = 0;
     for (const auto& charset: charsets) {
@@ -156,7 +156,11 @@ void ImportMidiPanel::fillCharsetList()
         if (charset == MidiCharset::defaultCharset()) {
             _ui->comboBoxCharset->setCurrentIndex(idx);
         }
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+        int newWidth = fm.horizontalAdvance(charset);
+#else
         int newWidth = fm.width(charset);
+#endif
         if (newWidth > maxWidth) {
             maxWidth = newWidth;
         }

--- a/mscore/importmidi_ui/importmidi_view.cpp
+++ b/mscore/importmidi_ui/importmidi_view.cpp
@@ -384,7 +384,7 @@ bool TracksView::viewportEvent(QEvent* event)
 
 void TracksView::wheelEvent(QWheelEvent* event)
 {
-    const int degrees = event->delta() / 8;
+    const int degrees = event->angleDelta().y() / 8;
     const int steps = degrees / 15;
 
     if ((event->modifiers() & Qt::ShiftModifier) || (event->modifiers() & Qt::ControlModifier)) {

--- a/mscore/importmidi_ui/importmidi_view.h
+++ b/mscore/importmidi_ui/importmidi_view.h
@@ -28,13 +28,13 @@ public:
 
         if (index.row() == _frozenRowIndex) {
             painter->save();
-            painter->setPen(option.palette.foreground().color());
+            painter->setPen(option.palette.windowText().color());
             painter->drawLine(option.rect.bottomLeft(), option.rect.bottomRight());
             painter->restore();
         }
         if (index.column() == _frozenColIndex) {
             painter->save();
-            painter->setPen(option.palette.foreground().color());
+            painter->setPen(option.palette.windowText().color());
             // use -1 padding to create double-line effect
             const int x = option.rect.right() - 1;
             painter->drawLine(x, option.rect.top(), x, option.rect.bottom());

--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -498,7 +498,7 @@ void InstrumentsWidget::genPartList(Score* cs)
             sli->setStaffType(s->staffType(Fraction(0,1)));          // TODO
         }
         pli->updateClefs();
-        partiturList->setItemExpanded(pli, true);
+        pli->setExpanded(true);
     }
     partiturList->resizeColumnToContents(2);    // adjust width of "Clef " and "Staff type" columns
     partiturList->resizeColumnToContents(4);
@@ -627,7 +627,7 @@ void InstrumentsWidget::on_addButton_clicked()
             sli->setStaffType(it->staffTypePreset);
         }
         pli->updateClefs();
-        partiturList->setItemExpanded(pli, true);
+        pli->setExpanded(true);
         partiturList->clearSelection();         // should not be necessary
         partiturList->setCurrentItem(pli);
     }
@@ -733,7 +733,7 @@ void InstrumentsWidget::on_upButton_clicked()
     QTreeWidgetItem* item = wi.front();
 
     if (item->type() == PART_LIST_ITEM) {
-        bool isExpanded = partiturList->isItemExpanded(item);
+        bool isExpanded = item->isExpanded();
         int idx = partiturList->indexOfTopLevelItem(item);
         // if part item not first, move one slot up
         if (idx) {
@@ -766,7 +766,7 @@ void InstrumentsWidget::on_upButton_clicked()
                 staffItem->initStaffTypeCombo(true);
                 staffItem->setStaffType(staffIdx[itemIdx]);
             }
-            partiturList->setItemExpanded(item1, isExpanded);
+            item1->setExpanded(isExpanded);
             partiturList->setCurrentItem(item1);
         }
     } else {
@@ -822,7 +822,7 @@ void InstrumentsWidget::on_downButton_clicked()
     }
     QTreeWidgetItem* item = wi.front();
     if (item->type() == PART_LIST_ITEM) {
-        bool isExpanded = partiturList->isItemExpanded(item);
+        bool isExpanded = item->isExpanded();
         int idx = partiturList->indexOfTopLevelItem(item);
         int n = partiturList->topLevelItemCount();
         // if part not last, move one slot down
@@ -857,7 +857,7 @@ void InstrumentsWidget::on_downButton_clicked()
                 staffItem->initStaffTypeCombo(true);
                 staffItem->setStaffType(staffIdx[itemIdx]);
             }
-            partiturList->setItemExpanded(item1, isExpanded);
+            item1->setExpanded(isExpanded);
             partiturList->setCurrentItem(item1);
         }
     } else {

--- a/mscore/magbox.cpp
+++ b/mscore/magbox.cpp
@@ -66,7 +66,7 @@ MagBox::MagBox(QWidget* parent)
     setToolTip(tr("Zoom"));
     setWhatsThis(tr("Zoom"));
     setValidator(new MagValidator(this));
-    setAutoCompletion(false);
+    setCompleter(nullptr);
 
     int i = 0;
     for (const MagEntry& e : magTable) {

--- a/mscore/mixer/mixer.cpp
+++ b/mscore/mixer/mixer.cpp
@@ -52,6 +52,7 @@ namespace Ms {
     __x->setChecked(__y); \
     __x->blockSignals(false);
 
+#if 0
 double volumeToUserRange(char v) { return v * 100.0 / 128.0; }
 double panToUserRange(char v) { return (v / 128.0) * 360.0; }
 double chorusToUserRange(char v) { return v * 100.0 / 128.0; }
@@ -65,6 +66,7 @@ char userRangeToPan(double v) { return (char)qBound(0, static_cast<int>((v / 360
 char userRangeToChorus(double v) { return (char)qBound(0, static_cast<int>(v / 100.0 * 128.0), 127); }
 //0 to 100
 char userRangeToReverb(double v) { return (char)qBound(0, static_cast<int>(v / 100.0 * 128.0), 127); }
+#endif
 
 //---------------------------------------------------------
 //   Mixer

--- a/mscore/mixer/mixer.h
+++ b/mscore/mixer/mixer.h
@@ -40,6 +40,7 @@ class MixerDetails;
 class MixerTrack;
 class MidiMapping;
 
+#if 0
 double volumeToUserRange(char v);
 double panToUserRange(char v);
 double chorusToUserRange(char v);
@@ -53,6 +54,7 @@ char userRangeToPan(double v);
 char userRangeToChorus(double v);
 //0 to 100
 char userRangeToReverb(double v);
+#endif
 
 //---------------------------------------------------------
 //   Mixer

--- a/mscore/mixer/mixer.ui
+++ b/mscore/mixer/mixer.ui
@@ -9,7 +9,7 @@
    <bool>false</bool>
   </property>
   <property name="features">
-   <set>QDockWidget::AllDockWidgetFeatures</set>
+   <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable</set>
   </property>
   <property name="geometry">
    <rect>

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -179,6 +179,10 @@ Q_LOGGING_CATEGORY(undoRedo, "undoRedo", QtCriticalMsg);
 #include "telemetrymanager.h"
 #include "global/context/scorestateobserver.h"
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)) //???
+# define endl Qt::endl
+#endif
+
 namespace Ms {
 MuseScore* mscore;
 MasterSynthesizer* synti;
@@ -760,7 +764,7 @@ bool MuseScore::importExtension(QString path)
     infoMsgBox->setTextFormat(Qt::RichText);
     infoMsgBox->setMinimumSize(300, 100);
     infoMsgBox->setMaximumSize(300, 100);
-    infoMsgBox->setStandardButtons(0);
+    infoMsgBox->setStandardButtons({});
     infoMsgBox->setText(QString("<p align='center'>") + tr("Please wait; unpacking extension…") + QString("</p>"));
 
     //setup async run of long operations
@@ -1064,7 +1068,7 @@ MuseScore::MuseScore()
     QScreen* screen = QGuiApplication::primaryScreen();
     if (userDPI == 0.0) {
 #if defined(Q_OS_WIN)
-        if (QSysInfo::WindowsVersion <= QSysInfo::WV_WINDOWS7) {
+        if (QOperatingSystemVersion::current() <= QOperatingSystemVersion(QOperatingSystemVersion::Windows, 7)) {
             _physicalDotsPerInch = screen->logicalDotsPerInch() * screen->devicePixelRatio();
         } else {
             _physicalDotsPerInch = screen->physicalDotsPerInch();  // physical resolution
@@ -4383,10 +4387,12 @@ bool MuseScore::readLanguages(const QString& path)
         int line, column;
         QString err;
         if (!doc.setContent(&qf, false, &err, &line, &column)) {
+            QString error;
+            error = QString::asprintf(qPrintable(tr("Error reading language file %s at line %d column %d: %s\n")),
+                                      qPrintable(qf.fileName()), line, column, qPrintable(err));
             QMessageBox::warning(0,
                                  QWidget::tr("Load Languages Failed:"),
-                                 tr("Error reading language file %1 at line %2 column %3: %4")
-                                 .arg(qf.fileName()).arg(line).arg(column).arg(err),
+                                 error,
                                  QString(), QWidget::tr("Quit"), QString(), 0, 1);
             return false;
         }
@@ -6096,14 +6102,14 @@ GreendotButton::GreendotButton(QWidget* parent)
 QRectF drawHandle(QPainter& p, const QPointF& pos, bool active)
 {
     p.save();
-    p.setPen(QPen(QColor(MScore::selectColor[0]), 2.0 / p.matrix().m11()));
+    p.setPen(QPen(QColor(MScore::selectColor[0]), 2.0 / p.worldTransform().toAffine().m11()));
     if (active) {
         p.setBrush(MScore::selectColor[0]);
     } else {
         p.setBrush(Qt::NoBrush);
     }
-    qreal w = 8.0 / p.matrix().m11();
-    qreal h = 8.0 / p.matrix().m22();
+    qreal w = 8.0 / p.worldTransform().toAffine().m11();
+    qreal h = 8.0 / p.worldTransform().toAffine().m22();
 
     QRectF r(-w / 2, -h / 2, w, h);
     r.translate(pos);

--- a/mscore/navigator.cpp
+++ b/mscore/navigator.cpp
@@ -115,7 +115,7 @@ Navigator::Navigator(NScrollArea* sa, QWidget* parent)
     : QWidget(parent)
 {
     setObjectName("Navigator");
-    setAttribute(Qt::WA_NoBackground);
+    setAttribute(Qt::WA_OpaquePaintEvent);
     _score         = 0;
     scrollArea     = sa;
     scrollArea->setWidgetResizable(true);
@@ -365,7 +365,11 @@ void Navigator::paintEvent(QPaintEvent* ev)
     QFont font("FreeSans", 4000);
     QFontMetrics fm(font);
     Page* firstPage = _score->pages()[0];
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+    qreal factor = (firstPage->width() * 0.5) / fm.horizontalAdvance(QString::number(_score->pages().size()));
+#else
     qreal factor = (firstPage->width() * 0.5) / fm.width(QString::number(_score->pages().size()));
+#endif
     font.setPointSizeF(font.pointSizeF() * factor);
 
     p.setTransform(matrix);

--- a/mscore/palette.h
+++ b/mscore/palette.h
@@ -137,7 +137,7 @@ public:
     void nextPaletteElement();
     void prevPaletteElement();
     void applyPaletteElement();
-    static bool applyPaletteElement(Element* element, Qt::KeyboardModifiers modifiers = 0);
+    static bool applyPaletteElement(Element* element, Qt::KeyboardModifiers modifiers = {});
     PaletteCell* append(Element*, const QString& name, QString tag = QString(),qreal mag = 1.0);
     PaletteCell* add(int idx, Element*, const QString& name,const QString tag = QString(), qreal mag = 1.0);
 

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -571,21 +571,39 @@ void PianoView::zoomView(int step, bool horizontal, int centerX, int centerY)
 
 void PianoView::wheelEvent(QWheelEvent* event)
 {
-    int step = event->delta() / 120;
+    int step = event->angleDelta().y() / 120;
 
     if (event->modifiers() == 0) {
         //Vertical scroll
         QGraphicsView::wheelEvent(event);
     } else if (event->modifiers() == Qt::ShiftModifier) {
         //Horizontal scroll
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
+# if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 1)) //???
+        QWheelEvent we(event->position(), event->globalPosition(), event->pixelDelta(), event->angleDelta(),
+                       event->buttons(), event->modifiers(), event->phase(), event->inverted(), event->source());
+# else
+        QWheelEvent we(event->pos(), event->globalPos(), event->pixelDelta(), event->angleDelta(), event->buttons(),
+                       event->modifiers(), event->phase(), event->inverted(), event->source());
+# endif
+#else
         QWheelEvent we(event->pos(), event->delta(), event->buttons(), 0, Qt::Horizontal);
+#endif
         QGraphicsView::wheelEvent(&we);
     } else if (event->modifiers() == Qt::ControlModifier) {
         //Vertical zoom
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 1)) //???
+        zoomView(step, false, event->position().x(), event->position().y());
+#else
         zoomView(step, false, event->x(), event->y());
+#endif
     } else if (event->modifiers() == (Qt::ShiftModifier | Qt::ControlModifier)) {
         //Horizontal zoom
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 1)) //???
+        zoomView(step, true, event->position().x(), event->position().y());
+#else
         zoomView(step, true, event->x(), event->y());
+#endif
     }
 }
 

--- a/mscore/pianotools.cpp
+++ b/mscore/pianotools.cpp
@@ -478,7 +478,7 @@ void PianoTools::changeEvent(QEvent* event)
 void HPiano::wheelEvent(QWheelEvent* event)
 {
     static int deltaSum = 0;
-    deltaSum += event->delta();
+    deltaSum += event->angleDelta().y();
     int step = deltaSum / 120;
     deltaSum %= 120;
     qreal mag = scaleVal;

--- a/mscore/playpanel.ui
+++ b/mscore/playpanel.ui
@@ -20,7 +20,7 @@
    <bool>true</bool>
   </property>
   <property name="features">
-   <set>QDockWidget::AllDockWidgetFeatures</set>
+   <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable</set>
   </property>
   <property name="windowTitle">
    <string>Play Panel</string>

--- a/mscore/plugin/api/qmlpluginapi.cpp
+++ b/mscore/plugin/api/qmlpluginapi.cpp
@@ -347,6 +347,23 @@ void PluginAPI::registerQmlTypes()
     qmlRegisterType<ScoreView>("MuseScore", 3, 0, "ScoreView");
 
     qmlRegisterType<Cursor>("MuseScore", 3, 0, "Cursor");
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    qmlRegisterAnonymousType<ScoreElement>("MuseScore", 3);
+    qmlRegisterAnonymousType<Score>("MuseScore", 3);
+    qmlRegisterAnonymousType<Element>("MuseScore", 3);
+    qmlRegisterAnonymousType<Chord>("MuseScore", 3);
+    qmlRegisterAnonymousType<Note>("MuseScore", 3);
+    qmlRegisterAnonymousType<Segment>("MuseScore", 3);
+    qmlRegisterAnonymousType<Measure>("MuseScore", 3);
+    qmlRegisterAnonymousType<Part>("MuseScore", 3);
+    qmlRegisterAnonymousType<Excerpt>("MuseScore", 3);
+    qmlRegisterAnonymousType<Selection>("MuseScore", 3);
+    qmlRegisterAnonymousType<Tie>("MuseScore", 3);
+    //qmlRegisterAnonymousType<Hook>("MuseScore", 3);
+    //qmlRegisterAnonymousType<Stem>("MuseScore", 3);
+    //qmlRegisterAnonymousType<StemSlash>("MuseScore", 3);
+    //qmlRegisterAnonymousType<Beam>("MuseScore", 3);
+#else
     qmlRegisterType<ScoreElement>();
     qmlRegisterType<Score>();
     qmlRegisterType<Element>();
@@ -358,11 +375,12 @@ void PluginAPI::registerQmlTypes()
     qmlRegisterType<Excerpt>();
     qmlRegisterType<Selection>();
     qmlRegisterType<Tie>();
-    qmlRegisterType<PlayEvent>("MuseScore", 3, 0, "PlayEvent");
     //qmlRegisterType<Hook>();
     //qmlRegisterType<Stem>();
     //qmlRegisterType<StemSlash>();
     //qmlRegisterType<Beam>();
+#endif
+    qmlRegisterType<PlayEvent>("MuseScore", 3, 0, "PlayEvent");
 
 #if 0
     qmlRegisterType<NoteHead>("MuseScore", 1, 0, "NoteHead");
@@ -393,7 +411,11 @@ void PluginAPI::registerQmlTypes()
     qmlRegisterType<SlurTie>();
     qmlRegisterType<Spanner>();
 #endif
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    qmlRegisterAnonymousType<FractionWrapper>("MuseScore", 3);
+#else
     qmlRegisterType<FractionWrapper>();
+#endif
     qRegisterMetaType<FractionWrapper*>("FractionWrapper*");
 
     qmlTypesRegistered = true;

--- a/mscore/plugin/api/util.h
+++ b/mscore/plugin/api/util.h
@@ -123,7 +123,11 @@ public:
 
 public slots:
     //@ --
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)) //???
+    Q_INVOKABLE void start(const QString& program) { QProcess::start(program, {}, ReadWrite); }
+#else
     Q_INVOKABLE void start(const QString& program) { QProcess::start(program); }
+#endif
     //@ --
     Q_INVOKABLE bool waitForFinished(int msecs = 30000) { return QProcess::waitForFinished(msecs); }
     //@ --

--- a/mscore/plugin/qmledit.cpp
+++ b/mscore/plugin/qmledit.cpp
@@ -274,7 +274,7 @@ void JSHighlighter::mark(const QString& str, Qt::CaseSensitivity caseSensitivity
 
 QStringList JSHighlighter::keywords() const
 {
-    return m_keywords.toList();
+    return m_keywords.values();
 }
 
 //---------------------------------------------------------
@@ -283,7 +283,11 @@ QStringList JSHighlighter::keywords() const
 
 void JSHighlighter::setKeywords(const QStringList& keywords)
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    m_keywords = QSet<QString>(keywords.begin(), keywords.end());
+#else
     m_keywords = QSet<QString>::fromList(keywords);
+#endif
     rehighlight();
 }
 

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -218,6 +218,7 @@ PreferenceDialog::PreferenceDialog(QWidget* parent)
     recordButtons->addButton(recordEditMode, RMIDI_NOTE_EDIT_MODE);
     recordButtons->addButton(recordRealtimeAdvance, RMIDI_REALTIME_ADVANCE);
 
+    // ToDo for Qt 5.15: QButtonGroup::buttonClicked vs. QButtonGroup::idClicked(int) ??
     connect(recordButtons,              QOverload<int>::of(
                 &QButtonGroup::buttonClicked), this, &PreferenceDialog::recordButtonClicked);
     connect(midiRemoteControlClear,     &QToolButton::clicked, this, &PreferenceDialog::midiRemoteControlClearClicked);

--- a/mscore/qml/nativemenu.h
+++ b/mscore/qml/nativemenu.h
@@ -42,7 +42,11 @@ class QmlNativeMenu : public QQuickItem
 
     Q_PROPERTY(bool visible READ visible WRITE setVisible NOTIFY visibleChanged)
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)) //???
+    QQmlListProperty<QObject> contentData() { return QQmlListProperty<QObject>(this, &_contentData); }   // TODO: use different QQmlListProperty constructor?
+#else
     QQmlListProperty<QObject> contentData() { return QQmlListProperty<QObject>(this, _contentData); }   // TODO: use different QQmlListProperty constructor?
+#endif
 
     QMenu* createMenu() const;
     void showMenu(QPoint p);

--- a/mscore/qml/palettes/Palette.qml
+++ b/mscore/qml/palettes/Palette.qml
@@ -767,7 +767,7 @@ GridView {
                 // force not hiding palette cell if it is being dragged to a score
                 enabled: paletteCell.paletteDrag
                 target: mscore
-                onElementDraggedToScoreView: paletteCell.paletteDrag = false
+                function onElementDraggedToScoreView() { paletteCell.paletteDrag = false; }
             }
         } // end ItemDelegate
     } // end DelegateModel

--- a/mscore/qml/palettes/PaletteTree.qml
+++ b/mscore/qml/palettes/PaletteTree.qml
@@ -763,7 +763,7 @@ ListView {
 
     Connections {
         target: palettesWidget
-        onHasFocusChanged: {
+        function onHasFocusChanged() {
             if (!palettesWidget.hasFocus) {
                 paletteSelectionModel.clearSelection();
                 expandedPopupIndex = null;

--- a/mscore/qml/palettes/PalettesWidgetHeader.qml
+++ b/mscore/qml/palettes/PalettesWidgetHeader.qml
@@ -130,7 +130,7 @@ Item {
 
     Connections {
         target: palettesWidget
-        onHasFocusChanged: {
+        function onHasFocusChanged() {
             if (!palettesWidget.hasFocus && !palettePopup.inMenuAction)
                 palettePopup.visible = false;
         }
@@ -138,7 +138,7 @@ Item {
 
     Connections {
         target: mscore
-        onPaletteSearchRequested: {
+        function onPaletteSearchRequested() {
             searchTextInput.forceActiveFocus()
             searchTextInput.selectAll()
         }

--- a/mscore/scorePreview.cpp
+++ b/mscore/scorePreview.cpp
@@ -52,7 +52,11 @@ void ScorePreview::setScore(const ScoreInfo& si)
 {
     scoreInfo = si;
     name->setText(si.completeBaseName());
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+    creationDate->setText(si.birthTime().toString());
+#else
     creationDate->setText(si.created().toString());
+#endif
     fileSize->setText(QString("%1 KiB").arg(si.size() / 1024));
     name->setEnabled(true);
     creationDate->setEnabled(true);

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1163,7 +1163,7 @@ static void drawDebugInfo(QPainter& p, const Element* _e)
     e->shape().paint(p);
 
     p.setPen(QPen(Qt::red, 0.0));               // red x at 0,0 of bbox
-    qreal w = 5.0 / p.matrix().m11();
+    qreal w = 5.0 / p.worldTransform().toAffine().m11();
     qreal h = w;
     qreal x = 0;   // e->bbox().x();
     qreal y = 0;   // e->bbox().y();
@@ -1200,7 +1200,7 @@ static void drawDebugInfo(QPainter& p, const Element* _e)
 
 void ScoreView::drawElements(QPainter& painter, QList<Element*>& el, Element* editElement)
 {
-    qStableSort(el.begin(), el.end(), elementLessThan);
+    std::stable_sort(el.begin(), el.end(), elementLessThan);
     for (const Element* e : el) {
         e->itemDiscovered = 0;
 
@@ -1457,7 +1457,7 @@ void ScoreView::paint(const QRect& r, QPainter& p)
 
         QPen pen;
         pen.setColor(MScore::selectColor[0]);
-        pen.setWidthF(2.0 / p.matrix().m11());
+        pen.setWidthF(2.0 / p.worldTransform().toAffine().m11());
 
         pen.setStyle(Qt::SolidLine);
 
@@ -5173,7 +5173,7 @@ QList<Element*> ScoreView::elementsNear(QPointF p)
         }
     }
     if (!ll.empty()) {
-        qSort(ll.begin(), ll.end(), elementLower);
+        std::sort(ll.begin(), ll.end(), elementLower);
     }
     return ll;
 }

--- a/mscore/script/script.cpp
+++ b/mscore/script/script.cpp
@@ -19,6 +19,10 @@
 
 #include "libmscore/score.h"
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)) //???
+#define endl Qt::endl
+#endif
+
 namespace Ms {
 //---------------------------------------------------------
 //   ScriptContext

--- a/mscore/script/testscript.cpp
+++ b/mscore/script/testscript.cpp
@@ -17,6 +17,10 @@
 
 #include "libmscore/scorediff.h"
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)) //???
+#define endl Qt::endl
+#endif
+
 namespace Ms {
 //---------------------------------------------------------
 //   TestScriptEntry::deserialize

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -4645,7 +4645,11 @@ QKeySequence Shortcut::keySeqFromString(const QString& str, QKeySequence::Sequen
         code[i] = 0;
     }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QStringList strList = str.split(QRegularExpression("(?<!\\\\),|(?<=\\\\\\\\),"), Qt::SkipEmptyParts);
+#else
     QStringList strList = str.split(QRegularExpression("(?<!\\\\),|(?<=\\\\\\\\),"), QString::SkipEmptyParts);
+#endif
     //split based on commas that are not preceded by a single slash; two is okay
     //original regex: (?<!\\),|(?<=\\\\),
 

--- a/mscore/svggenerator.cpp
+++ b/mscore/svggenerator.cpp
@@ -45,6 +45,10 @@
 #include "libmscore/imageStore.h"
 #include "libmscore/mscore.h"
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)) //???
+#define endl Qt::endl
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////
 // FOR GRADIENT FUNCTIONALITY THAT IS NOT IMPLEMENTED (YET):
 //

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -736,7 +736,7 @@ Timeline::Timeline(TDockWidget* dockWidget, QWidget* parent)
 {
     setFocusPolicy(Qt::NoFocus);
     setAlignment(Qt::Alignment((Qt::AlignLeft | Qt::AlignTop)));
-    setAttribute(Qt::WA_NoBackground);
+    setAttribute(Qt::WA_OpaquePaintEvent);
 
     // theming
     _lightTheme.backgroundColor      = QColor(192, 192, 192);

--- a/thirdparty/google_analytics/CMakeLists.txt
+++ b/thirdparty/google_analytics/CMakeLists.txt
@@ -27,6 +27,12 @@ target_link_libraries(google_analytics Qt5::Core Qt5::Network)
 
 if (MSVC)
   set_target_properties( google_analytics PROPERTIES
-    COMPILE_FLAGS "/wd4458 /wd4127"
+    COMPILE_FLAGS "/wd4127 /wd4458 /wd4996"
   )
+else (MSVC)
+    if (MINGW)
+        set_target_properties( google_analytics PROPERTIES
+          COMPILE_FLAGS "-Wno-deprecated-declarations"
+        )
+    endif (MINGW)
 endif (MSVC)


### PR DESCRIPTION
at least those that are backwards compatible to at least Qt 5.9.
There are several hundred such (MSVC) warnings (557 C4996 in MSVC 2017, 680 in MSVC 2019, plus 5 'empty' ones) resp. 716 warnings (-Wdeprecated-declarations in MinGW, more than MSVC, due to being build in DEBUG mode), this PR fixes all but 5 (MSVC 2017), 16 (MSVC 2019), 17 (MinGW) of those.
The remaining few seem to require the use of replacements that are not properly documented,  possibly due to a Qt 5.15 documentation not being available yet (and/or don't work with Qt 5.9), at least I'm at a loss about what to do with them.

Here are the remaining ones (marked with ToDo comments for now):

Description |  File | Line 
 -- | -- | --
'QDesktopWidget::availableGeometry': Use QGuiApplication::screens() | framework\telemetry\widgets\telemetrypermissiondialog.cpp | 38 
'QJsonDocument::fromBinaryData': Use CBOR format instead | mscore\cloud\loginmanager.cpp | 83, 202 
'QJsonDocument::toBinaryData': Use CBOR format instead | mscore\cloud\loginmanager.cpp | 95, 187
'Qt::DefaultLocaleShortDate': Use QLocale | libmscore\page.cpp | 334, 342, 348, 354, 357, 362, 365
'QHelpEngineCore::linksForIdentifier': Use documentsForIdentifier() instead | mscore\help.cpp | 97, 143
'QButtonGroup::butonClicked': Use QButtonGroup::idClicked(int) instead | mscore\prefsdialog.cpp | 223
'QList<Ms::ElementType>::toSet': Use QSet<T>(list.begin(), list.end()) instead. | inspectors\models\inspectorlistmodel.cpp | 122
<!--'QString::null': use QString() | importexport\musicxml\importmxmlpass2.cpp | 916-->

Hints how/whether to deal with those would be very welcome...