### PR TITLE
fix #299727: Change Transpose "By Key" to "To Key"

### DIFF
--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -129,7 +129,7 @@ enum class TransposeDirection : char {
 //---------------------------------------------------------
 
 enum class TransposeMode : char {
-      BY_KEY, BY_INTERVAL, DIATONICALLY
+      TO_KEY, BY_INTERVAL, DIATONICALLY
       };
 
 //---------------------------------------------------------

--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -253,8 +253,8 @@ bool Score::transpose(TransposeMode mode, TransposeDirection direction, Key trKe
 
       Interval interval;
       if (mode != TransposeMode::DIATONICALLY) {
-            if (mode == TransposeMode::BY_KEY) {
-                  // calculate interval from "transpose by key"
+            if (mode == TransposeMode::TO_KEY) {
+                  // calculate interval from "transpose to key"
                   // find the key of the first pitched staff
                   Key key = Key::C;
                   for (int i = startStaffIdx; i < endStaffIdx; ++i) {
@@ -293,7 +293,7 @@ bool Score::transpose(TransposeMode mode, TransposeDirection direction, Key trKe
                   trKeys = false;
                   }
             bool fullOctave = (interval.chromatic % 12) == 0;
-            if (fullOctave && (mode != TransposeMode::BY_KEY)) {
+            if (fullOctave && (mode != TransposeMode::TO_KEY)) {
                   trKeys = false;
                   transposeChordNames = false;
                   }

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -3422,8 +3422,8 @@ bool MuseScore::exportTransposedScoreToJSON(const QString& inFilePath, const QSt
 
       TransposeMode mode;
       const QString modeName = options["mode"].toString();
-      if (modeName == "by_key")
-            mode = TransposeMode::BY_KEY;
+      if (modeName == "by_key" || modeName == "to_key") // "by_key" for backwards compatibility
+            mode = TransposeMode::TO_KEY;
       else if (modeName == "by_interval")
             mode = TransposeMode::BY_INTERVAL;
       else if (modeName == "diatonically")
@@ -3448,7 +3448,7 @@ bool MuseScore::exportTransposedScoreToJSON(const QString& inFilePath, const QSt
 
       constexpr int defaultKey = int(Key::INVALID);
       const Key targetKey = Key(options["targetKey"].toInt(defaultKey));
-      if (mode == TransposeMode::BY_KEY) {
+      if (mode == TransposeMode::TO_KEY) {
             const bool targetKeyValid = int(Key::MIN) <= int(targetKey) && int(targetKey) <= int(Key::MAX);
             if (!targetKeyValid) {
                   qCritical("Transpose: invalid targetKey: %d", int(targetKey));
@@ -3457,7 +3457,7 @@ bool MuseScore::exportTransposedScoreToJSON(const QString& inFilePath, const QSt
             }
 
       const int transposeInterval = options["transposeInterval"].toInt(-1);
-      if (mode != TransposeMode::BY_KEY) {
+      if (mode != TransposeMode::TO_KEY) {
             const bool transposeIntervalValid = -1 < transposeInterval && transposeInterval < intervalListSize;
             if (!transposeIntervalValid) {
                   qCritical("Transpose: invalid transposeInterval: %d", transposeInterval);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5704,9 +5704,9 @@ void MuseScore::transpose()
       bool rangeSelection = cs->selection().isRange();
       TransposeDialog td;
 
-      // TRANSPOSE_BY_KEY and "transpose keys" is only possible if selection state is SelState::RANGE
+      // TRANSPOSE_TO_KEY and "transpose keys" is only possible if selection state is SelState::RANGE
       td.enableTransposeKeys(rangeSelection);
-      td.enableTransposeByKey(rangeSelection);
+      td.enableTransposeToKey(rangeSelection);
       td.enableTransposeChordNames(rangeSelection);
 
       int startStaffIdx = 0;

--- a/mscore/transposedialog.cpp
+++ b/mscore/transposedialog.cpp
@@ -87,7 +87,7 @@ void TransposeDialog::diatonicBoxToggled(bool val)
 TransposeMode TransposeDialog::mode() const
       {
       return chromaticBox->isChecked()
-         ? (transposeByKey->isChecked() ? TransposeMode::BY_KEY : TransposeMode::BY_INTERVAL)
+         ? (transposeByKey->isChecked() ? TransposeMode::TO_KEY : TransposeMode::BY_INTERVAL)
          : TransposeMode::DIATONICALLY;
       }
 
@@ -95,7 +95,7 @@ TransposeMode TransposeDialog::mode() const
 //   enableTransposeByKey
 //---------------------------------------------------------
 
-void TransposeDialog::enableTransposeByKey(bool val)
+void TransposeDialog::enableTransposeToKey(bool val)
       {
       transposeByKey->setEnabled(val);
       transposeByInterval->setChecked(!val);
@@ -120,7 +120,7 @@ TransposeDirection TransposeDialog::direction() const
       {
       switch (mode())
             {
-            case TransposeMode::BY_KEY:
+            case TransposeMode::TO_KEY:
                   if (closestKey->isChecked())
                         return TransposeDirection::CLOSEST;
                   return upKey->isChecked() ? TransposeDirection::UP : TransposeDirection::DOWN;

--- a/mscore/transposedialog.h
+++ b/mscore/transposedialog.h
@@ -45,7 +45,7 @@ class TransposeDialog : public QDialog, Ui::TransposeDialogBase {
    public:
       TransposeDialog(QWidget* parent = 0);
       void enableTransposeKeys(bool val)  { transposeKeys->setEnabled(val);       }
-      void enableTransposeByKey(bool val);
+      void enableTransposeToKey(bool val);
       void enableTransposeChordNames(bool val);
       bool getTransposeKeys() const       { return chromaticBox->isChecked()
                                                 ? transposeKeys->isChecked()

--- a/mscore/transposedialog.ui
+++ b/mscore/transposedialog.ui
@@ -28,8 +28,11 @@
         <layout class="QVBoxLayout" name="verticalLayout_3">
          <item>
           <widget class="QGroupBox" name="transposeByKey">
+           <property name="toolTip">
+            <string>Transpose to key (specified at concert pitch)</string>
+           </property>
            <property name="title">
-            <string>By Key</string>
+            <string>To Key</string>
            </property>
            <property name="checkable">
             <bool>true</bool>


### PR DESCRIPTION
and add a tooltip mentioning that the key is specified at concert pitch

![image](https://user-images.githubusercontent.com/1786669/72608110-47882f00-3922-11ea-9e05-5141a5343065.png)

Resolves https://musescore.org/en/node/299727 and stems from a discussion in https://musescore.org/en/node/299670#comment-972012