### PR TITLE
Use separate version number to decide whether to show telemetry dialog

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7114,6 +7114,12 @@ void tryToRequestTelemetryPermission()
       if (accessRequestedAtVersion == telemetryVersion)
             return;
 
+      // Disable telemetry until the permission is explicitly confirmed by user
+      preferences.setPreference(PREF_APP_TELEMETRY_ALLOWED, false);
+
+      if (MScore::noGui)
+            return;
+
       QEventLoop eventLoop;
 
       TelemetryPermissionDialog *requestDialog = new TelemetryPermissionDialog(mscore->getQmlUiEngine());

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7108,9 +7108,10 @@ bool MuseScore::saveMp3(Score* score, QIODevice* device, bool& wasCanceled)
 
 void tryToRequestTelemetryPermission()
       {
+      static const QString telemetryVersion = "3.4.1";
       QString accessRequestedAtVersion = preferences.getString(PREF_APP_STARTUP_TELEMETRY_ACCESS_REQUESTED);
 
-      if (accessRequestedAtVersion == VERSION)
+      if (accessRequestedAtVersion == telemetryVersion)
             return;
 
       QEventLoop eventLoop;
@@ -7124,7 +7125,7 @@ void tryToRequestTelemetryPermission()
       eventLoop.exec();
       requestDialog->deleteLater();
 
-      preferences.setPreference(PREF_APP_STARTUP_TELEMETRY_ACCESS_REQUESTED, VERSION);
+      preferences.setPreference(PREF_APP_STARTUP_TELEMETRY_ACCESS_REQUESTED, telemetryVersion);
       }
 #endif
 


### PR DESCRIPTION
Extracted from #5610 (see https://github.com/musescore/MuseScore/pull/5610#discussion_r367874461) to allow more discussion for this particular change.