### PR TITLE
fix #299829: Implement extra navigation shortcuts (Top/Trailing/Next-Prev System)

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -4065,6 +4065,39 @@ ChordRest* Score::findCRinStaff(const Fraction& tick, int staffIdx) const
 }
 
 //---------------------------------------------------------
+//   cmdNextPrevSystem
+//---------------------------------------------------------
+
+ChordRest* Score::cmdNextPrevSystem(ChordRest* cr, bool next)
+{
+    auto currentMeasure       = cr->measure();
+    auto currentSystem        = currentMeasure->system();
+    auto destinationMeasure   = currentSystem->firstMeasure();
+    auto firstSegmentOfSystem = destinationMeasure->first();
+
+    if (next) {
+        // [go to next system]
+        if ((destinationMeasure = currentSystem->lastMeasure()->nextMeasure())) {
+            firstSegmentOfSystem = destinationMeasure->first();
+            cr = firstSegmentOfSystem->nextChordRest(trackZeroVoice(cr->track()), false);
+        } else if (currentMeasure != lastMeasure()) {
+            cr = lastMeasure()->first()->nextChordRest(trackZeroVoice(cr->track()), false);
+        } else {
+            // [go to previous system]
+            auto currentSegment = cr->segment();
+            auto segmentOfFirstCR = firstSegmentOfSystem->nextChordRest(trackZeroVoice(cr->track()), false)->segment();
+            if (destinationMeasure != firstMeasure() && currentSegment == segmentOfFirstCR) {
+                destinationMeasure = destinationMeasure->prevMeasure()->system()->firstMeasure();
+            }
+            if (destinationMeasure) {
+                cr = destinationMeasure->first()->nextChordRest(trackZeroVoice(cr->track()), false);
+            }
+        }
+        return cr;
+    }
+}
+
+//---------------------------------------------------------
 //   setSoloMute
 //   called once at opening file, adds soloMute marks
 //---------------------------------------------------------
@@ -4106,6 +4139,44 @@ int Score::nmeasures() const
         n++;
     }
     return n;
+}
+
+//---------------------------------------------------------
+//   firstTrailingMeasure
+//---------------------------------------------------------
+
+Measure* Score::firstTrailingMeasure(ChordRest** cr)
+{
+    Measure* firstMeasure = nullptr;
+    auto m = lastMeasure();
+
+    if (!cr) {
+        // No active selection: prepare first empty trailing measure of entire score
+        for (; m && m->isFullMeasureRest(); firstMeasure = m, m = m->prevMeasure());
+    } else {
+        // Active selection: select full measure rest of active staff's empty trailing measure
+        ChordRest* tempCR = nullptr;
+        while (m && (tempCR = m->first()->nextChordRest(trackZeroVoice((*cr)->track()), false))->isFullMeasureRest()) {
+            *cr = tempCR;
+            m = m->prevMeasure();
+        }
+    }
+    return firstMeasure;
+}
+
+//---------------------------------------------------------
+//   cmdTopStaff
+//---------------------------------------------------------
+
+ChordRest* Score::cmdTopStaff(ChordRest* cr)
+{
+    // Go to top-most staff of current or first measure depending upon active selection
+    if (!cr) {
+        cr = firstMeasure()->first()->nextChordRest(0, false);
+    } else {
+        cr = cr->measure()->first()->nextChordRest(0, false);
+    }
+    return cr;
 }
 
 //---------------------------------------------------------

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -859,6 +859,7 @@ public:
     void rebuildTempoAndTimeSigMaps(Measure* m);
     Element* nextElement();
     Element* prevElement();
+    ChordRest* cmdNextPrevSystem(ChordRest*, bool);
 
     void cmd(const QAction*, EditData&);
     int fileDivision(int t) const { return ((qint64)t * MScore::division + _fileDivision / 2) / _fileDivision; }
@@ -1224,13 +1225,15 @@ public:
     void cmdRemoveEmptyTrailingMeasures();
     void cmdRealizeChordSymbols(bool lit = true, Voicing v = Voicing(-1), HDuration durationType = HDuration(-1));
 
+    Measure* firstTrailingMeasure(ChordRest** cr = nullptr);
+    ChordRest* cmdTopStaff(ChordRest* cr = nullptr);
+
     void setAccessibleInfo(QString s) { accInfo = s.remove(":").remove(";"); }
     QString accessibleInfo() const { return accInfo; }
 
     QImage createThumbnail();
     QString createRehearsalMarkText(RehearsalMark* current) const;
     QString nextRehearsalMarkText(RehearsalMark* previous, RehearsalMark* current) const;
-
     //@ ??
 //      Q_INVOKABLE void cropPage(qreal margins);
     bool sanityCheck(const QString& name = QString());

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2250,7 +2250,11 @@ void ScoreView::cmd(const char* s)
             "next-track",
             "prev-track",
             "next-measure",
-            "prev-measure" }, [](ScoreView* cv, const QByteArray& cmd) {
+            "prev-measure",
+            "next-system",
+            "prev-system",
+            "empty-trailing-measure",
+            "top-staff"}, [](ScoreView* cv, const QByteArray& cmd) {
                 if (cv->score()->selection().isLocked()) {
                     LOGW() << "unable exec cmd: " << cmd << ", selection locked, reason: "
                            << cv->score()->selection().lockReason();
@@ -2277,6 +2281,9 @@ void ScoreView::cmd(const char* s)
                     cv->score()->endCmd();
                 } else {
                     Element* ele = cv->score()->move(cmd);
+                    if (cmd == "empty-trailing-measure") {
+                        cv->changeState(ViewState::NOTE_ENTRY);
+                    }
                     if (ele) {
                         cv->adjustCanvasPosition(ele, false);
                     }

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1011,6 +1011,13 @@ Shortcut Shortcut::_sc[] = {
     {
         MsWidget::SCORE_TAB,
         STATE_NORMAL | STATE_NOTE_ENTRY,
+        "prev-system",
+        QT_TRANSLATE_NOOP("action","Previous System"),
+        QT_TRANSLATE_NOOP("action","Go to previous system")
+    },
+    {
+        MsWidget::SCORE_TAB,
+        STATE_NORMAL | STATE_NOTE_ENTRY,
         "prev-track",
         QT_TRANSLATE_NOOP("action","Previous Staff or Voice"),
         QT_TRANSLATE_NOOP("action","Previous staff or voice")
@@ -1028,6 +1035,27 @@ Shortcut Shortcut::_sc[] = {
         "next-measure",
         QT_TRANSLATE_NOOP("action","Next Measure"),
         QT_TRANSLATE_NOOP("action","Go to next measure or move text right")
+    },
+    {
+        MsWidget::SCORE_TAB,
+        STATE_NORMAL | STATE_NOTE_ENTRY,
+        "next-system",
+        QT_TRANSLATE_NOOP("action","Next System"),
+        QT_TRANSLATE_NOOP("action","Go to next system")
+    },
+    {
+        MsWidget::SCORE_TAB,
+        STATE_NORMAL | STATE_NOTE_ENTRY,
+        "top-staff",
+        QT_TRANSLATE_NOOP("action","Top Staff"),
+        QT_TRANSLATE_NOOP("action","Go to top staff")
+    },
+    {
+        MsWidget::SCORE_TAB,
+        STATE_NORMAL | STATE_NOTE_ENTRY,
+        "empty-trailing-measure",
+        QT_TRANSLATE_NOOP("action","First Empty Trailing Measure"),
+        QT_TRANSLATE_NOOP("action","Go to first empty trailing measure")
     },
     {
         MsWidget::SCORE_TAB,


### PR DESCRIPTION
Resolves: The suggestion to implement extra navigation shortcuts: https://musescore.org/en/node/299829

Originally, this was for [_go to next/previous system_] (https://github.com/musescore/MuseScore/pull/5596) which brought the selection cursor to the top-left of the next/previous system. After the hint that this was too specialized and that other commands should be provided instead/additionally, here is a group of four commands and a description of their behavior. I will cancel the previous pull request since this supersedes it. 

**[Go to top staff]** - Goes to current measure's top staff. If there is no selection at all, this will go to the top staff at measure one 

**[Go to empty trailing measure]** - This is a little more interesting. If there is no active selection, the result will be to take the user to the first staff at the first empty trailing measure of the entire score, practically the same position where the **Tools**->**Remove Empty Trailing Measures** begins deleting. This will give the exact same desired activity i wanted in the old proposed [next system] behavior, under the assumption that the user is working per-system and that the next system starts at the empty trailing measure. 

To give this command a double-edged sword, this will also go to _an individual staff's_ empty trailing measure which may or may not be equivalent to the entire score's empty trailing measure. This can be also useful at times, and at first it was thought that only one or the other would be able to be implemented as a trade off, but after testing, I think having both function and contingent upon whether or not there's a selection makes the most sense with the only trade off being that if the user mainly wants the entire score's trailing measure instead of an individual staff's trailing measure, an [Escape] or clicking off of any elements would be required first. P.S. Since this is dealing explicitly with going to an empty measure, it seemed most logical to enter into Note-Entry Mode automatically after issuing this command. Not so with the other ones. 

Finally, although falling into the background, I didn't want to completely banish having a pair of:

**[Go to next/previous system]** commands to have available if a user should so happen to find it useful (I still do at times even with the above two other functions) depending on their workflow (Especially for score traversal in larger scores). However, this time, the selection will continue on the current working staff as would be expected for default behavior. So here the user can traverse per system forward, or backward. Backward will also take the user to the beginning of the current system before going to previous system. These are moreso 'helper' functions like with the [_go to top staff_] in that if set up by a user, they can aid in speed (instead of doing ctrl+left/right multiple times or alt+up multiple times, these could be used).

+ These compiled locally, passed the mtest ($make in mtest directory is really slow for me unfortunately), and have no bugs as far as I've tested them extensively. 