### PR TITLE
[MU4] fix #68431: Extra Default Zoom Preferences

### DIFF
--- a/framework/preferencekeys.h
+++ b/framework/preferencekeys.h
@@ -104,6 +104,7 @@
 #define PREF_SCORE_HARMONY_PLAY                             "score/harmony/play"
 #define PREF_SCORE_HARMONY_PLAY_ONEDIT                      "score/harmony/play/onedit"
 #define PREF_SCORE_MAGNIFICATION                            "score/magnification"
+#define PREF_SCORE_ZOOM_TYPE                                "score/zoomType"
 #define PREF_SCORE_NOTE_PLAYONCLICK                         "score/note/playOnClick"
 #define PREF_SCORE_NOTE_DEFAULTPLAYDURATION                 "score/note/defaultPlayDuration"
 #define PREF_SCORE_NOTE_WARNPITCHRANGE                      "score/note/warnPitchRange"

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -201,6 +201,7 @@ void Preferences::init(bool storeInMemoryOnly)
             { PREF_SCORE_HARMONY_PLAY,                              new BoolPreference(false, false) },
             { PREF_SCORE_HARMONY_PLAY_ONEDIT,                       new BoolPreference(true, false) },
             { PREF_SCORE_MAGNIFICATION,                             new DoublePreference(1.0, false) },
+            { PREF_SCORE_ZOOM_TYPE,                                 new IntPreference(0, false) },
             { PREF_SCORE_NOTE_PLAYONCLICK,                          new BoolPreference(true, false) },
             { PREF_SCORE_NOTE_DEFAULTPLAYDURATION,                  new IntPreference(300 /* ms */, false) },
             { PREF_SCORE_NOTE_WARNPITCHRANGE,                       new BoolPreference(true, false) },

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -73,6 +73,14 @@ enum class MusicxmlExportBreaks : char {
     ALL, MANUAL, NO
 };
 
+// Default zoom options in score preferences
+enum class ZoomType : int {
+    PAGE_WIDTH = 0,
+    WHOLE_PAGE,
+    DOUBLE_PAGE,
+    PERCENTAGE
+};
+
 class PreferenceVisitor;
 
 //---------------------------------------------------------

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -196,6 +196,7 @@ PreferenceDialog::PreferenceDialog(QWidget* parent)
     connect(resetToDefault, &QToolButton::clicked, this, &PreferenceDialog::resetAllValues);
     connect(filterShortcuts, &QLineEdit::textChanged, this, &PreferenceDialog::filterShortcutsTextChanged);
     connect(printShortcuts, &QToolButton::clicked, this, &PreferenceDialog::printShortcutsClicked);
+    connect(zoomType, &QComboBox::currentTextChanged, this, &PreferenceDialog::selectZoomType);
 
     recordButtons = new QButtonGroup(this);
     recordButtons->setExclusive(false);
@@ -557,6 +558,7 @@ void PreferenceDialog::updateValues(bool useDefaultValues)
     // score settings
     //
     scale->setValue(preferences.getDouble(PREF_SCORE_MAGNIFICATION) * 100.0);
+    zoomType->setCurrentIndex(preferences.getInt(PREF_SCORE_ZOOM_TYPE));
     showMidiControls->setChecked(preferences.getBool(PREF_IO_MIDI_SHOWCONTROLSINMIXER));
 
     defaultPlayDuration->setValue(preferences.getInt(PREF_SCORE_NOTE_DEFAULTPLAYDURATION));
@@ -920,6 +922,16 @@ void PreferenceDialog::selectInstrumentList2()
 }
 
 //---------------------------------------------------------
+//   selectZoomType
+//---------------------------------------------------------
+
+void PreferenceDialog::selectZoomType()
+{
+    // Only enable editing of [zoom-percentage spinner widget] if [Percentage] is selected
+    static_cast<ZoomType>(zoomType->currentIndex()) != ZoomType::PERCENTAGE ? scale->setEnabled(false) : scale->setEnabled(true);
+}
+
+//---------------------------------------------------------
 //   selectStartWith
 //---------------------------------------------------------
 
@@ -1204,6 +1216,7 @@ void PreferenceDialog::apply()
     preferences.setPreference(PREF_UI_APP_LANGUAGE, l);
 
     preferences.setPreference(PREF_SCORE_MAGNIFICATION, scale->value() / 100.0);
+    preferences.setPreference(PREF_SCORE_ZOOM_TYPE, zoomType->currentIndex());
 
     if (showMidiControls->isChecked() != preferences.getBool(PREF_IO_MIDI_SHOWCONTROLSINMIXER)) {
         preferences.setPreference(PREF_IO_MIDI_SHOWCONTROLSINMIXER, showMidiControls->isChecked());

--- a/mscore/prefsdialog.h
+++ b/mscore/prefsdialog.h
@@ -76,6 +76,7 @@ private slots:
     void selectPluginsDirectory();
     void selectImagesDirectory();
     void selectExtensionsDirectory();
+    void selectZoomType();
     void printShortcutsClicked();
     void filterShortcutsTextChanged(const QString&);
     void filterAdvancedPreferences(const QString&);

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -2429,8 +2429,24 @@
           <string>View</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_7">
-          <item row="0" column="1">
+          <item row="0" column="3">
+           <spacer name="horizontalSpacer_17">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="0" column="2">
            <widget class="QDoubleSpinBox" name="scale">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
             <property name="toolTip">
              <string>Default scale for new score views</string>
             </property>
@@ -2460,6 +2476,13 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="showMidiControls">
+            <property name="text">
+             <string>Show MIDI controls in mixer</string>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="label_48">
             <property name="text">
@@ -2467,24 +2490,37 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="2">
-           <spacer name="horizontalSpacer_17">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="zoomType">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
+            <property name="currentIndex">
+             <number>3</number>
             </property>
-           </spacer>
-          </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="showMidiControls">
-            <property name="text">
-             <string>Show MIDI controls in mixer</string>
-            </property>
+            <item>
+             <property name="text">
+              <string>Page Width</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Whole Page</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Two Pages</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Percentage</string>
+             </property>
+            </item>
            </widget>
           </item>
          </layout>
@@ -4455,7 +4491,6 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources>
-  <include location="musescore.qrc"/>
   <include location="musescore.qrc"/>
  </resources>
  <connections>

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -140,7 +140,26 @@ ScoreView::ScoreView(QWidget* parent)
     double mag  = preferences.getDouble(PREF_SCORE_MAGNIFICATION) * (mscore->physicalDotsPerInch() / DPI);
     _matrix     = QTransform(mag, 0.0, 0.0, mag, 0.0, 0.0);
     imatrix     = _matrix.inverted();
-    _magIdx     = preferences.getDouble(PREF_SCORE_MAGNIFICATION) == 1.0 ? MagIdx::MAG_100 : MagIdx::MAG_FREE;
+
+    switch (static_cast<ZoomType>(preferences.getInt(PREF_SCORE_ZOOM_TYPE))) {
+    // The following cases correspond to zoomType's index value within prefsdialog.ui,
+    // wherein lies zoomType's translatable strings
+    case ZoomType::WHOLE_PAGE:
+        _magIdx = MagIdx::MAG_PAGE;
+        break;
+    case ZoomType::DOUBLE_PAGE:
+        _magIdx = MagIdx::MAG_DBL_PAGE;
+        break;
+    case ZoomType::PERCENTAGE:
+        _magIdx = preferences.getDouble(PREF_SCORE_MAGNIFICATION) == 1.0 ? MagIdx::MAG_100 : MagIdx::MAG_FREE;
+        break;
+    case ZoomType::PAGE_WIDTH:
+        Q_FALLTHROUGH();
+    default:
+        _magIdx = MagIdx::MAG_PAGE_WIDTH;
+        break;
+    }
+
     focusFrame  = 0;
     _bgColor    = Qt::darkBlue;
     _fgColor    = Qt::white;

--- a/mtest/testscript/scripts/ux_replace_slurs_on_copy.script
+++ b/mtest/testscript/scripts/ux_replace_slurs_on_copy.script
@@ -14,6 +14,9 @@ cmd note-c
 cmd note-d
 cmd escape
 cmd del-empty-measures
+cmd note-input
+cmd escape
+cmd prev-measure
 cmd prev-measure
 cmd note-input
 cmd escape


### PR DESCRIPTION
Resolves, partially: https://musescore.org/en/node/68431 (partially in the sense that there's no saving zoom level to score involved, and the shortcut for page width is another pull request active on my account)

This provides the ability to set default zoom-level to Page Width/Whole Page/Two Pages/Percentage instead of only percentage values. The original spinner box of Zoom % still functions as usual, but it is only enabled when "Percentage" is selected in the included new QComboBox.

Here is a .gif for demonstration purposes: 
![zoom-settings](https://user-images.githubusercontent.com/7139517/72709011-ce9ef800-3b18-11ea-8f94-7531bbcd5396.gif)

Updated 2020-05-06 to include adding back the .qrc file tags automatically removed by Qt Designer, defaulted once again to [Page-Width] after realizing the issue with the unit tests, updated that test based on @AntonioBL's assistance, and made use of a simple enumerator rather than using integer constants. Thanks again to all the participants.