### PR TITLE
fix #299883: allow using Ctrl+arrow on grips in normal mode

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -75,7 +75,9 @@ bool ScoreView::event(QEvent* event)
                               // KeypadModifier is necessary on MacOS as arrow keys seem to always
                               // trigger that modifier there. However it would probably be appropriate
                               // to allow it on other systems too.
-                              constexpr auto allowedModifiers = Qt::ShiftModifier | Qt::KeypadModifier;
+                              const auto allowedModifiers = (editData.curGrip == Grip::NO_GRIP)
+                                 ? (Qt::KeypadModifier | Qt::ShiftModifier)
+                                 : (Qt::KeypadModifier | Qt::ShiftModifier | Qt::ControlModifier);
                               if ((m & ~allowedModifiers) == 0) {
                                     ke->accept();
                                     return true;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/299883

Allows using Ctrl+arrow on grips in normal mode if grip is selected.