### PR TITLE
Plugin API: merge changes from onScoreStateChanged with user action in undo stack

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -818,7 +818,7 @@ bool Score::dirty() const
 
 ScoreContentState Score::state() const
       {
-      return std::make_pair(this, undoStack()->state());
+      return ScoreContentState(this, undoStack()->state());
       }
 
 //---------------------------------------------------------

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -315,7 +315,18 @@ class UpdateState {
 //   ScoreContentState
 //---------------------------------------------------------
 
-typedef std::pair<const Score*, int> ScoreContentState;
+class ScoreContentState {
+      const Score* score;
+      int num;
+   public:
+      ScoreContentState() : score(nullptr), num(0) {}
+      ScoreContentState(const Score* s, int stateNum) : score(s), num(stateNum) {}
+
+      bool operator==(const ScoreContentState& s2) const { return score == s2.score && num == s2.num; }
+      bool operator!=(const ScoreContentState& s2) const { return !(*this == s2); }
+
+      bool isNewerThan(const ScoreContentState& s2) const { return score == s2.score && num > s2.num; }
+      };
 
 class MasterScore;
 

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4832,7 +4832,7 @@ void MuseScore::undoRedo(bool undo)
             cv->changeState(ViewState::NORMAL);
       cv->startUndoRedo(undo);
       updateInputState(cs);
-      endCmd();
+      endCmd(/* undoRedo */ true);
       if (pianorollEditor)
             pianorollEditor->update();
       }
@@ -5813,10 +5813,10 @@ void MuseScore::cmd(QAction* a)
 //    Updates the UI after a possible score change.
 //---------------------------------------------------------
 
-void MuseScore::endCmd()
+void MuseScore::endCmd(bool undoRedo)
       {
 #ifdef SCRIPT_INTERFACE
-      getPluginEngine()->beginEndCmd(this);
+      getPluginEngine()->beginEndCmd(this, undoRedo);
 #endif
       if (timeline())
             timeline()->updateGrid();

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -697,7 +697,8 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
 
       Q_INVOKABLE void openExternalLink(const QString&);
 
-      virtual void endCmd() override;
+      void endCmd(bool undoRedo);
+      void endCmd() override { endCmd(false); };
       void printFile();
       void exportFile();
       bool exportParts();

--- a/mscore/plugin/api/score.cpp
+++ b/mscore/plugin/api/score.cpp
@@ -18,6 +18,9 @@
 #include "libmscore/segment.h"
 #include "libmscore/text.h"
 
+#include "musescore.h"
+#include "../qmlpluginengine.h"
+
 namespace Ms {
 namespace PluginAPI {
 
@@ -118,5 +121,24 @@ Measure* Score::lastMeasureMM()
       return wrap<Measure>(score()->lastMeasureMM(), Ownership::SCORE);
       }
 
+//---------------------------------------------------------
+//   Score::startCmd
+//---------------------------------------------------------
+
+void Score::startCmd()
+      {
+      // TODO: should better use qmlEngine(this) (need to set context for wrappers then)
+      const QmlPluginEngine* engine = mscore->getPluginEngine();
+      if (engine->inScoreChangeActionHandler()) {
+            // Plugin-originated changes made while handling onScoreStateChanged
+            // should be grouped together with the action which caused this change
+            // (if it was caused by actual score change).
+            if (!score()->undoStack()->active())
+                  score()->undoStack()->reopen();
+            }
+      else {
+            score()->startCmd();
+            }
+      }
 }
 }

--- a/mscore/plugin/api/score.h
+++ b/mscore/plugin/api/score.h
@@ -154,7 +154,7 @@ class Score : public Ms::PluginAPI::ScoreElement {
        * least once by "dock" type plugins in case they
        * modify the score.
        */
-      Q_INVOKABLE void startCmd() { score()->startCmd(); }
+      Q_INVOKABLE void startCmd();
       /**
        * For "dock" type plugins: to be used after score
        * modifications to make them undoable.

--- a/mscore/plugin/qmlpluginengine.h
+++ b/mscore/plugin/qmlpluginengine.h
@@ -21,6 +21,7 @@
 #define __QMLPLUGINENGINE_H__
 
 #include "../qml/msqmlengine.h"
+#include "libmscore/score.h"
 
 namespace Ms {
 
@@ -36,14 +37,20 @@ class QmlPluginEngine : public MsQmlEngine {
       QMap<QString, QVariant> endCmdInfo;
       int cmdCount = 0;
       bool recursion = false;
+      bool undoRedo = false;
+
+      ScoreContentState lastScoreState;
+      ScoreContentState currScoreState;
 
    signals:
       void endCmd(const QMap<QString, QVariant>& changes);
    public:
       QmlPluginEngine(QObject* parent = nullptr);
 
-      void beginEndCmd(MuseScore*);
+      void beginEndCmd(MuseScore*, bool undoRedo);
       void endEndCmd(MuseScore*);
+
+      bool inScoreChangeActionHandler() const;
       };
 
 } // namespace Ms


### PR DESCRIPTION
After having tried some of the suggestions in https://github.com/dmitrio95/fretboard-plugin/pull/1#issuecomment-563007341 it turned out that the experimental [score changes notification API](https://github.com/musescore/MuseScore/commit/db001c2d0afb6438d96cf8adc60eaff39e002ab9) does not play well with the concept of undoable actions. As a part of handling score state change a plugin may want to make some adjustment to a score (for example, update some elements or their properties). In order to make it undoable it must call `startCmd()`/`endCmd()`. However this creates a separate entry in undo stack with the changes made by a plugin. When user tries to undo this action, only plugin-originated action will be undone and not the one made by user. Moreover, as plugin-originated changes are likely to depend on score state it will likely try to redo this change again. In this case his will lead to inability to undo anything at all while such plugin is running.

In order to make this situation better it is proposed to merge plugin-originated changes made in response to user action with the user action itself, so invoking "Undo" command would undo both plugin-originated and user-originated changes. This should enable creating plugins which modify score editing process in certain way. An example of such plugin could be a "Note Names" plugin which updates note names for the relevant range on each score change without requiring explicit invocation by user. It might be useful for plugin developers to have such an example plugin bundled with MuseScore so I will probably create a modified version of this plugin shortly.