### PR TITLE
fix #299807: fix a crash on undoing "Beam middle" setting on single note

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -779,9 +779,9 @@ void ChordRest::remove(Element* e)
 
 //---------------------------------------------------------
 //   removeDeleteBeam
-//      beamed - the chordrest is beamed (will get a (new) beam)
-//          remove ChordRest from beam
-//          delete beam if empty
+///   Remove ChordRest from beam, delete beam if empty.
+///   \param beamed - if the chordrest is beamed (will get
+///                   a (new) beam)
 //---------------------------------------------------------
 
 void ChordRest::removeDeleteBeam(bool beamed)
@@ -796,6 +796,18 @@ void ChordRest::removeDeleteBeam(bool beamed)
             }
       if (!beamed && isChord())
             toChord(this)->layoutStem();
+      }
+
+//---------------------------------------------------------
+//   replaceBeam
+//---------------------------------------------------------
+
+void ChordRest::replaceBeam(Beam* newBeam)
+      {
+      if (_beam == newBeam)
+            return;
+      removeDeleteBeam(true);
+      newBeam->add(this);
       }
 
 //---------------------------------------------------------

--- a/libmscore/chordrest.h
+++ b/libmscore/chordrest.h
@@ -139,6 +139,7 @@ class ChordRest : public DurationElement {
       virtual void add(Element*);
       virtual void remove(Element*);
       void removeDeleteBeam(bool beamed);
+      void replaceBeam(Beam* newBeam);
 
       ElementList& el()                            { return _el; }
       const ElementList& el() const                { return _el; }

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1196,8 +1196,7 @@ void Score::beamGraceNotes(Chord* mainNote, bool after)
             if (beam) {
                   bool beamEnd = bm == Beam::Mode::BEGIN;
                   if (!beamEnd) {
-                        cr->removeDeleteBeam(true);
-                        beam->add(cr);
+                        cr->replaceBeam(beam);
                         cr = 0;
                         beamEnd = (bm == Beam::Mode::END);
                         }
@@ -1221,11 +1220,9 @@ void Score::beamGraceNotes(Chord* mainNote, bool after)
                               beam = new Beam(this);
                               beam->setGenerated(true);
                               beam->setTrack(mainNote->track());
-                              a1->removeDeleteBeam(true);
-                              beam->add(a1);
+                              a1->replaceBeam(beam);
                               }
-                        cr->removeDeleteBeam(true);
-                        beam->add(cr);
+                        cr->replaceBeam(beam);
                         a1 = 0;
                         }
                   }
@@ -2400,8 +2397,7 @@ void Score::createBeams(Measure* measure)
                   if (beam) {
                         bool beamEnd = (bm == Beam::Mode::BEGIN);
                         if (!beamEnd) {
-                              cr->removeDeleteBeam(true);
-                              beam->add(cr);
+                              cr->replaceBeam(beam);
                               cr = 0;
                               beamEnd = (bm == Beam::Mode::END);
                               }
@@ -2433,11 +2429,9 @@ void Score::createBeams(Measure* measure)
                                     beam = new Beam(this);
                                     beam->setGenerated(true);
                                     beam->setTrack(track);
-                                    a1->removeDeleteBeam(true);
-                                    beam->add(a1);
+                                    a1->replaceBeam(beam);
                                     }
-                              cr->removeDeleteBeam(true);
-                              beam->add(cr);
+                              cr->replaceBeam(beam);
                               a1 = 0;
                               }
                         }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/299807

Prevents a crash by avoiding removing a beam from a score (and recording this to undo stack) if not really necessary.