### PR TITLE
[MU4] [Plugin Creator] Dock the log output in the plugin creator.

### DIFF
--- a/mscore/plugin/pluginCreator.cpp
+++ b/mscore/plugin/pluginCreator.cpp
@@ -42,11 +42,18 @@ PluginCreator::PluginCreator(QWidget* parent)
       dock        = 0;
       manualDock  = 0;
       helpBrowser = 0;
+      logDock     = new QDockWidget(tr("Log"), this);
+      log         = new QPlainTextEdit;
+
+      logDock->setWidget(log);
 
       setObjectName("PluginCreator");
       setIconSize(QSize(preferences.getInt(PREF_UI_THEME_ICONWIDTH) * guiScaling, preferences.getInt(PREF_UI_THEME_ICONHEIGHT) * guiScaling));
 
       setupUi(this);
+
+      menuHelp->addAction(logDock->toggleViewAction());
+      addDockWidget(Qt::BottomDockWidgetArea, logDock);
 
       QToolBar* fileTools = addToolBar(tr("File Operations"));
       fileTools->setObjectName("FileOperations");
@@ -213,7 +220,6 @@ void PluginCreator::writeSettings()
       QSettings settings;
       settings.beginGroup(objectName());
       settings.setValue("windowState", saveState());
-      settings.setValue("splitter", splitter->saveState());
       settings.endGroup();
 
       MuseScore::saveGeometry(this);
@@ -228,7 +234,6 @@ void PluginCreator::readSettings()
       if (!useFactorySettings) {
             QSettings settings;
             settings.beginGroup(objectName());
-            splitter->restoreState(settings.value("splitter").toByteArray());
             restoreState(settings.value("windowState").toByteArray());
             settings.endGroup();
             }
@@ -455,7 +460,6 @@ void PluginCreator::load()
       created = false;
       setState(PCState::CLEAN);
       setTitle( fi.completeBaseName() );
-      setToolTip(path);
       raise();
       }
 
@@ -485,7 +489,6 @@ void PluginCreator::doSavePlugin(bool saveas)
             created = false;
             setState(PCState::CLEAN);
             setTitle( fi.completeBaseName() );
-            setToolTip(path);
             }
       else {
             // TODO
@@ -538,7 +541,6 @@ void PluginCreator::newPlugin()
       textEdit->setPlainText(s);
       setState(PCState::CLEAN);
       setTitle(path);
-      setToolTip(path);
       raise();
       }
 

--- a/mscore/plugin/pluginCreator.h
+++ b/mscore/plugin/pluginCreator.h
@@ -37,6 +37,8 @@ class PluginCreator : public QMainWindow, public Ui::PluginCreatorBase {
       QDockWidget* manualDock;
       QPointer<QQuickView> view;
       QPointer<QDockWidget> dock;
+      QDockWidget* logDock;
+      QPlainTextEdit* log;
 
       void setState(PCState newState);
       virtual void closeEvent(QCloseEvent*);

--- a/mscore/plugin/pluginCreator.ui
+++ b/mscore/plugin/pluginCreator.ui
@@ -14,8 +14,8 @@
    <string/>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QGridLayout" name="gridLayout">
-    <item row="0" column="0">
+   <layout class="QHBoxLayout" name="horizontalLayout">
+    <item>
      <widget class="QWidget" name="widget" native="true">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -66,14 +66,8 @@
       </layout>
      </widget>
     </item>
-    <item row="0" column="1">
-     <widget class="QSplitter" name="splitter">
-      <property name="orientation">
-       <enum>Qt::Vertical</enum>
-      </property>
-      <widget class="Ms::QmlEdit" name="textEdit"/>
-      <widget class="QPlainTextEdit" name="log"/>
-     </widget>
+    <item>
+     <widget class="Ms::QmlEdit" name="textEdit"/>
     </item>
    </layout>
   </widget>
@@ -114,7 +108,6 @@
    <addaction name="menuEdit"/>
    <addaction name="menuHelp"/>
   </widget>
-  <widget class="QStatusBar" name="statusbar"/>
   <action name="actionNew">
    <property name="text">
     <string>New</string>


### PR DESCRIPTION
There was a splitter between the textedit area and the log, but a dockwidget allows more flexibility. It also means you can put the plugin creator aside so it doesn't take space on screen, but keep the log visible.