### PR TITLE
[MU4] fix #295235: Same Beat and Measure (Select All Similar Filter)

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -35,6 +35,7 @@
 #include "figuredbass.h"
 #include "fingering.h"
 #include "fret.h"
+#include "fraction.h"
 #include "glissando.h"
 #include "hairpin.h"
 #include "harmony.h"
@@ -347,6 +348,21 @@ Fraction Element::playTick() const
 {
     // Play from the element's tick position by default.
     return tick();
+}
+
+
+//---------------------------------------------------------
+//   beat
+//---------------------------------------------------------
+
+Fraction Element::beat() const
+{
+    int bar, beat, ticks;
+    TimeSigMap* tsm = score()->sigmap();
+    tsm->tickValues(tick().ticks(), &bar, &beat, &ticks);
+    int ticksB = ticks_beat(tsm->timesig(tick().ticks()).timesig().denominator());
+
+    return Fraction((beat + 1 + ticks), ticksB);
 }
 
 //---------------------------------------------------------

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -18,6 +18,7 @@
 #include "fraction.h"
 #include "scoreElement.h"
 #include "shape.h"
+#include "sig.h"
 
 namespace Ms {
 #ifdef Q_OS_MAC
@@ -288,6 +289,8 @@ public:
     virtual Fraction tick() const;
     virtual Fraction rtick() const;
     virtual Fraction playTick() const;   ///< Returns the tick at which playback should begin when this element is selected. Defaults to the element's own tick position.
+
+    Fraction beat() const;
 
     bool isNudged() const { return !_offset.isNull(); }
 

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3354,6 +3354,14 @@ void Score::collectMatch(void* data, Element* e)
         }
     }
 
+    if (p->measure && (p->measure != e->findMeasure())) {
+        return;
+    }
+
+    if ((p->beat.isValid()) && (p->beat != e->beat())) {
+        return;
+    }
+
     p->el.append(e);
 }
 
@@ -3400,6 +3408,13 @@ void Score::collectNoteMatch(void* data, Element* e)
     if (p->system && (p->system != n->chord()->segment()->system())) {
         return;
     }
+    if (p->measure && (p->measure != n->findMeasure())) {
+        return;
+    }
+    if ((p->beat.isValid()) && (p->beat != n->beat())) {
+        return;
+    }
+
     p->el.append(n);
 }
 

--- a/libmscore/select.h
+++ b/libmscore/select.h
@@ -39,9 +39,11 @@ struct ElementPattern {
     int staffStart;
     int staffEnd;   // exclusive
     int voice;
-    const System* system;
     bool subtypeValid;
     Fraction durationTicks;
+    Fraction beat {0,0};
+    const Measure* measure = nullptr;
+    const System* system = nullptr;
 };
 
 //---------------------------------------------------------
@@ -60,7 +62,9 @@ struct NotePattern {
     int staffStart;
     int staffEnd;   // exclusive
     int voice;
-    const System* system;
+    Fraction beat {0,0};
+    const Measure* measure = nullptr;
+    const System* system = nullptr;
 };
 
 //---------------------------------------------------------

--- a/mscore/selectdialog.cpp
+++ b/mscore/selectdialog.cpp
@@ -101,6 +101,18 @@ void SelectDialog::setPattern(ElementPattern* p)
         p->durationTicks = Fraction(-1,1);
     }
 
+    if (sameBeat->isChecked()) {
+        p->beat = e->beat();
+    } else {
+        p->beat = Fraction(0,0);
+    }
+
+    if (sameMeasure->isChecked()) {
+        p->measure = e->findMeasure();
+    } else {
+        p->measure = nullptr;
+    }
+
     p->voice   = sameVoice->isChecked() ? e->voice() : -1;
     p->subtypeValid = sameSubtype->isChecked();
     p->system  = 0;

--- a/mscore/selectdialog.ui
+++ b/mscore/selectdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>395</width>
-    <height>300</height>
+    <height>364</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -34,17 +34,24 @@
         <string>Select</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_2">
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="sameSubtype">
+          <property name="text">
+           <string>Same subtype:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QCheckBox" name="sameBeat">
+          <property name="text">
+           <string>Same beat</string>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="0">
          <widget class="QLabel" name="label">
           <property name="text">
            <string>Element type:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QCheckBox" name="sameStaff">
-          <property name="text">
-           <string>Same staff</string>
           </property>
          </widget>
         </item>
@@ -62,10 +69,24 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QCheckBox" name="sameSubtype">
+        <item row="2" column="0">
+         <widget class="QCheckBox" name="sameStaff">
           <property name="text">
-           <string>Same subtype:</string>
+           <string>Same staff</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1" colspan="2">
+         <widget class="QCheckBox" name="sameSystem">
+          <property name="text">
+           <string>Same system</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QCheckBox" name="inSelection">
+          <property name="text">
+           <string>In selection</string>
           </property>
          </widget>
         </item>
@@ -83,17 +104,10 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="1" colspan="2">
-         <widget class="QCheckBox" name="sameSystem">
+        <item row="5" column="0">
+         <widget class="QCheckBox" name="sameMeasure">
           <property name="text">
-           <string>Same system</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QCheckBox" name="inSelection">
-          <property name="text">
-           <string>In selection</string>
+           <string>Same measure</string>
           </property>
          </widget>
         </item>
@@ -172,6 +186,8 @@
   <tabstop>sameVoice</tabstop>
   <tabstop>sameSystem</tabstop>
   <tabstop>sameDuration</tabstop>
+  <tabstop>sameBeat</tabstop>
+  <tabstop>sameMeasure</tabstop>
   <tabstop>replace</tabstop>
   <tabstop>add</tabstop>
   <tabstop>fromSelection</tabstop>

--- a/mscore/selectnotedialog.cpp
+++ b/mscore/selectnotedialog.cpp
@@ -86,6 +86,18 @@ void SelectNoteDialog::setPattern(NotePattern* p)
         p->durationTicks = Fraction(-1,1);
     }
 
+    if (sameBeat->isChecked()) {
+        p->beat = n->beat();
+    } else {
+        p->beat = Fraction(0,0);
+    }
+
+    if (sameMeasure->isChecked()) {
+        p->measure = n->findMeasure();
+    } else {
+        p->measure = nullptr;
+    }
+
     if (sameStaff->isChecked()) {
         p->staffStart = n->staffIdx();
         p->staffEnd = n->staffIdx() + 1;

--- a/mscore/selectnotedialog.ui
+++ b/mscore/selectnotedialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>403</width>
-    <height>439</height>
+    <height>468</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -34,66 +34,17 @@
         <string>Select</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_2">
-        <item row="0" column="1">
-         <widget class="QLabel" name="notehead">
+        <item row="5" column="0">
+         <widget class="QCheckBox" name="sameDurationTicks">
           <property name="text">
-           <string/>
+           <string>Same duration:</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="0">
-         <widget class="QCheckBox" name="sameNotehead">
-          <property name="text">
-           <string>Same notehead:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="1" colspan="2">
+        <item row="8" column="1">
          <widget class="QCheckBox" name="sameSystem">
           <property name="text">
            <string>Same system</string>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="0">
-         <widget class="QCheckBox" name="sameVoice">
-          <property name="text">
-           <string>Same voice</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QLabel" name="durationType">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QCheckBox" name="sameDurationType">
-          <property name="text">
-           <string>Same note type:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="QLabel" name="durationTicks">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-          <widget class="QCheckBox" name="sameDurationTicks">
-            <property name="text">
-              <string>Same duration:</string>
-            </property>
-          </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QCheckBox" name="samePitch">
-          <property name="text">
-           <string>Same pitch:</string>
           </property>
          </widget>
         </item>
@@ -104,17 +55,10 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
-         <widget class="QLabel" name="pitch">
+        <item row="6" column="1">
+         <widget class="QLabel" name="name">
           <property name="text">
            <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
-         <widget class="QCheckBox" name="sameStaff">
-          <property name="text">
-           <string>Same staff</string>
           </property>
          </widget>
         </item>
@@ -125,22 +69,15 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
-         <widget class="QLabel" name="type">
+        <item row="4" column="1">
+         <widget class="QLabel" name="durationType">
           <property name="text">
            <string/>
           </property>
          </widget>
         </item>
-        <item row="6" column="0">
-         <widget class="QCheckBox" name="sameName">
-          <property name="text">
-           <string>Same note name:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="QLabel" name="name">
+        <item row="5" column="1">
+         <widget class="QLabel" name="durationTicks">
           <property name="text">
            <string/>
           </property>
@@ -153,10 +90,87 @@
           </property>
          </widget>
         </item>
+        <item row="1" column="1">
+         <widget class="QLabel" name="pitch">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QCheckBox" name="sameNotehead">
+          <property name="text">
+           <string>Same notehead:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="0">
+         <widget class="QCheckBox" name="sameVoice">
+          <property name="text">
+           <string>Same voice</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLabel" name="notehead">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QLabel" name="type">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="0">
+         <widget class="QCheckBox" name="sameStaff">
+          <property name="text">
+           <string>Same staff</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QCheckBox" name="sameDurationType">
+          <property name="text">
+           <string>Same note type:</string>
+          </property>
+         </widget>
+        </item>
         <item row="2" column="1">
          <widget class="QLabel" name="string">
           <property name="text">
            <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="0">
+         <widget class="QCheckBox" name="sameName">
+          <property name="text">
+           <string>Same note name:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="samePitch">
+          <property name="text">
+           <string>Same pitch:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="0">
+         <widget class="QCheckBox" name="sameBeat">
+          <property name="text">
+           <string>Same beat</string>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="1">
+         <widget class="QCheckBox" name="sameMeasure">
+          <property name="text">
+           <string>Same measure</string>
           </property>
          </widget>
         </item>
@@ -169,16 +183,6 @@
         <string>Action</string>
        </property>
        <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QRadioButton" name="replace">
-          <property name="text">
-           <string>Replace selection</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="1">
          <widget class="QRadioButton" name="add">
           <property name="text">
@@ -200,6 +204,16 @@
          <widget class="QRadioButton" name="subtract">
           <property name="text">
            <string>Subtract from selection</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QRadioButton" name="replace">
+          <property name="text">
+           <string>Replace selection</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -238,6 +252,8 @@
   <tabstop>inSelection</tabstop>
   <tabstop>sameVoice</tabstop>
   <tabstop>sameSystem</tabstop>
+  <tabstop>sameBeat</tabstop>
+  <tabstop>sameMeasure</tabstop>
   <tabstop>replace</tabstop>
   <tabstop>add</tabstop>
   <tabstop>fromSelection</tabstop>


### PR DESCRIPTION
Resolves: Select Similar Elements: Same Beat (#295235) + Same Measure Options

The use case is simply to allow for selecting all notes/elements of the same beat number position, and its uses are multiple. Especially useful are note articulations, dynamics, or velocity programming, etc. There are many ways to use it. I've provided a .gif file on the issue @ musescore.org: https://musescore.org/en/node/295235#comment-973622 

At first, the idea was merely for Similar Beat, but as I started to play around with it, I realized that to select the [_Same beat + Same measure_] as a filter works really well for larger scores when a whole vertical process is desired and figured [_Select All Similar→Same Measure_] should also be included as an option to whomever might find reasons for its use. Of course, a range selection with a mouse works also when dealing with a vertical range, but to be able to do that with the keyboard - especially if the entire system is larger than the current view area -  is nice to have as an option. 

So far, no bugs have been found, and it compiles fine. The only thing that isn't cool right now is that MuseScore still applies multiple dynamic marks on chords of more than one notehead (p-f markings). It looks like there's a Pull Request or two open right now trying to fix this, so I didn't attempt to do anything about that with this pull request. For reference: https://musescore.org/en/node/298955 
 + https://github.com/musescore/MuseScore/pull/5560 + https://musescore.org/en/node/292475


Update: It looks like the previously mentioned issue (https://musescore.org/en/node/298955) has been fixed since this PR began (multiple dynamic markings don't apply to a chord now, so that seems to be non-issue!)

The dialogues look as follows: 

![selectdialogue](https://user-images.githubusercontent.com/7139517/73048755-0a92cf80-3e2f-11ea-8c66-61e186680fe3.png)

![selectnotes](https://user-images.githubusercontent.com/7139517/73048766-0e265680-3e2f-11ea-9b17-084eb1887de9.png)

Passes the mtests, but also contains strings for translation in the .ui addition