### PR TITLE
fix #284441: implement per-staff alignment of pedal lines

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3230,13 +3230,17 @@ static void processLines(System* system, std::vector<Spanner*> lines, bool align
             }
 
       if (align && segments.size() > 1) {
-            qreal y = segments[0]->rypos();
-            for (unsigned i = 1; i < segments.size(); ++i) {
-                  if (segments[i]->visible())
-                        y = qMax(y, segments[i]->rypos());
+            const int nstaves = system->staves()->size();
+            std::vector<qreal> y(nstaves, -1000000.0);
+
+            for (SpannerSegment* ss : segments) {
+                  if (ss->visible()) {
+                        qreal& staffY = y[ss->staffIdx()];
+                        staffY = qMax(staffY, ss->rypos());
+                        }
                   }
-            for (auto ss : segments)
-                  ss->rypos() = y;
+            for (SpannerSegment* ss : segments)
+                  ss->rypos() = y[ss->staffIdx()];
             }
 
       //


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/284441