### PR TITLE
Fix a crash on MSCZ reading, add a way of handling such errors

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1956,6 +1956,10 @@ void Measure::read(XmlReader& e, int staffIdx)
             else
                   qDebug("illegal measure size <%s>", qPrintable(e.attribute("len")));
             irregular = true;
+            if (_len.numerator() <= 0 || _len.denominator() <= 0) {
+                  e.raiseError(QObject::tr("MSCX error at line %1: invalid measure length: %2").arg(e.lineNumber()).arg(_len.toString()));
+                  return;
+                  }
             score()->sigmap()->add(tick().ticks(), SigEvent(_len, _timesig));
             score()->sigmap()->add((tick() + ticks()).ticks(), SigEvent(_timesig));
             }

--- a/libmscore/read301.cpp
+++ b/libmscore/read301.cpp
@@ -200,7 +200,10 @@ bool Score::read(XmlReader& e)
             qDebug("%s: xml read error at line %lld col %lld: %s",
                qPrintable(e.getDocName()), e.lineNumber(), e.columnNumber(),
                e.name().toUtf8().data());
-            MScore::lastError = QObject::tr("XML read error at line %1, column %2: %3").arg(e.lineNumber()).arg(e.columnNumber()).arg(e.name().toString());
+            if (e.error() == QXmlStreamReader::CustomError)
+                  MScore::lastError = e.errorString();
+            else
+                  MScore::lastError = QObject::tr("XML read error at line %1, column %2: %3").arg(e.lineNumber()).arg(e.columnNumber()).arg(e.name().toString());
             return false;
             }
 
@@ -326,8 +329,11 @@ Score::FileError MasterScore::read301(XmlReader& e)
                         score->setMscVersion(mscVersion());
                         addMovement(score);
                         }
-                  if (!score->read(e))
+                  if (!score->read(e)) {
+                        if (e.error() == QXmlStreamReader::CustomError)
+                              return FileError::FILE_CRITICALLY_CORRUPTED;
                         return FileError::FILE_BAD_FORMAT;
+                        }
                   }
             else if (tag == "Revision") {
                   Revision* revision = new Revision;

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -404,6 +404,7 @@ class Score : public QObject, public ScoreElement {
             FILE_TOO_NEW,
             FILE_OLD_300_FORMAT,
             FILE_CORRUPTED,
+            FILE_CRITICALLY_CORRUPTED,
             FILE_USER_ABORT,
             FILE_IGNORE_ERROR
             };

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -196,6 +196,10 @@ static bool readScoreError(const QString& name, Score::FileError error, bool ask
                   detailedMsg = MScore::lastError;
                   canIgnore = true;
                   break;
+            case Score::FileError::FILE_CRITICALLY_CORRUPTED:
+                  msg = QObject::tr("File \"%1\" is critically corrupted and cannot be processed.").arg(name);
+                  detailedMsg = MScore::lastError;
+                  break;
             case Score::FileError::FILE_OLD_300_FORMAT:
                   msg += QObject::tr("It was last saved with a developer version of 3.0.\n");
                   canIgnore = true;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/282492

In this PR it is proposed to add a way of handling errors in score data read from a file which are too problematic or impossible to recover from. The proposal is to:
1) Raise MSCX reading errors with [`QXmlStreamReader::raiseError()`](https://doc.qt.io/qt-5/qxmlstreamreader.html#raiseError) function. The other alternative could be returning a boolean flag from `read()` functions and using `MScore::lastError` for error message, but the `raiseError()` approach might help to avoid using global variables in errors handling in MuseScore in future.
2) Adding `FILE_CRITICALLY_CORRUPTED` error category since the file does not actually have "bad format" as it is suggested by the error message emitted otherwise on XML reader errors. It might make sense to raise errors in case of actual format errors so it might make sense to consider implementing this distinction somehow differently.

This approach is applied to prevent crash on reading a file with invalid measure length (`0/1`, as reported in the issue) and show a warning stating that the file is critically corrupted instead.