### PR TITLE
 fix #294834 and #294836: Midi note-off messages not sent during editing, or when stopping playback

### DIFF
--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -1320,11 +1320,18 @@ void Seq::stopNotes(int channel, bool realTime)
                   putEvent(event);
             else
                   sendEvent(event);
-      };
+            };
+      // For VSTs/devices that do not support All Notes Off
+      // CTRL_ALL_NOTES_OFF should still be evoked after calling this function, even if it seems redundant
+      auto turnAllNotesOff = [send](int channel) {
+            for (unsigned note = 0; note < 128; note++)
+                  send(NPlayEvent(ME_NOTEOFF, channel, note, 0));
+            };
       // Stop notes in all channels
       if (channel == -1) {
             for(unsigned ch = 0; ch < cs->midiMapping().size(); ch++) {
                   send(NPlayEvent(ME_CONTROLLER, ch, CTRL_SUSTAIN, 0));
+                  turnAllNotesOff(ch);
                   send(NPlayEvent(ME_CONTROLLER, ch, CTRL_ALL_NOTES_OFF, 0));
                   if (cs->midiChannel(ch) != 9)
                         send(NPlayEvent(ME_PITCHBEND,  ch, 0, 64));
@@ -1332,6 +1339,7 @@ void Seq::stopNotes(int channel, bool realTime)
             }
       else {
             send(NPlayEvent(ME_CONTROLLER, channel, CTRL_SUSTAIN, 0));
+            turnAllNotesOff(channel);
             send(NPlayEvent(ME_CONTROLLER, channel, CTRL_ALL_NOTES_OFF, 0));
             if (cs->midiChannel(channel) != 9)
                   send(NPlayEvent(ME_PITCHBEND,  channel, 0, 64));


### PR DESCRIPTION
Certain applications don't respond to `All Notes Off`, so this change turns off all 128 notes in a channel iteratively. I don't know what the performance impact would be with weaker hardware, if this many messages at once could cause a buffer overflow or mess with the default synthesizer.

If there are problems, this type of solution should still be incorporated in some way, maybe as an toggle in the settings, or a rewrite to how notes are turned off in different contexts, to support as much hardware/software as possible.