### PR TITLE
Add reveal in finder (show in explorer) option in metaedit dialog.

### DIFF
--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -173,6 +173,7 @@ add_library(mscoreapp STATIC
       musescore.h navigator.h newwizard.h noteGroups.h
       omrpanel.h pagesettings.h palette.h partedit.h parteditbase.h
       pathlistdialog.h piano.h  pianotools.h
+      openfilelocation.h
       playpanel.h preferences.h preferenceslistwidget.h prefsdialog.h
       recordbutton.h resourceManager.h revision.h ruler.h scoreaccessibility.h
       scoreBrowser.h scoreInfo.h scorePreview.h scoretab.h scoreview.h searchComboBox.h
@@ -198,6 +199,7 @@ add_library(mscoreapp STATIC
       seq.cpp textpalette.cpp
       timedialog.cpp symboldialog.cpp shortcutcapturedialog.cpp
       simplebutton.cpp
+      openfilelocation.cpp
       editdrumset.cpp editstaff.cpp
       timesigproperties.cpp newwizard.cpp transposedialog.cpp
       excerptsdialog.cpp metaedit.cpp magbox.cpp realizeharmonydialog.cpp

--- a/mscore/metaedit.cpp
+++ b/mscore/metaedit.cpp
@@ -23,6 +23,7 @@
 #include "musescore.h"
 #include "preferences.h"
 #include "icons.h"
+#include "openfilelocation.h"
 
 namespace Ms {
 
@@ -69,8 +70,15 @@ MetaEditDialog::MetaEditDialog(Score* score, QWidget* parent)
 
       scrollAreaLayout->setColumnStretch(1, 1); // The 'value' column should be expanding
 
-      connect(newButton,  &QPushButton::clicked, this, [this]() { newClicked(); });
+      connect(newButton,  &QPushButton::clicked, this, &MetaEditDialog::newClicked);
       connect(saveButton, &QPushButton::clicked, this, &MetaEditDialog::save);
+      if (!QFileInfo::exists(score->importedFilePath()))
+            revealButton->setEnabled(false);
+
+      revealButton->setIcon(*icons[int(Icons::fileOpen_ICON)]);
+      revealButton->setToolTip(OpenFileLocation::platformText());
+
+      connect(revealButton, &QPushButton::clicked, this, &MetaEditDialog::openFileLocation);
       MuseScore::restoreGeometry(this);
       }
 
@@ -174,6 +182,18 @@ void MetaEditDialog::setDirty(const bool dirty)
       }
 
 //---------------------------------------------------------
+//   setDirty
+///    Opens the file location with a QMessageBox::warning on failure
+//---------------------------------------------------------
+
+void MetaEditDialog::openFileLocation()
+      {
+      if (!OpenFileLocation::openFileLocation(filePath->text()))
+          QMessageBox::warning(this, QString(QT_TR_NOOP("Open Containing Folder Error")),
+                                     QString(QT_TR_NOOP("Could not open containing folder")));
+      }
+
+//---------------------------------------------------------
 //   save
 ///   Save the currently displayed metatags
 //---------------------------------------------------------
@@ -265,4 +285,3 @@ void MetaEditDialog::closeEvent(QCloseEvent* event)
       }
 
 } // namespace Ms
-

--- a/mscore/metaedit.h
+++ b/mscore/metaedit.h
@@ -50,6 +50,7 @@ class MetaEditDialog : public QDialog, public Ui::MetaEditDialog {
       bool save();
       void newClicked();
       void setDirty(const bool dirty = true);
+      void openFileLocation();
 
    public:
       MetaEditDialog(Score* score, QWidget* parent = nullptr);

--- a/mscore/metaedit.ui
+++ b/mscore/metaedit.ui
@@ -22,7 +22,7 @@
      <property name="topMargin">
       <number>0</number>
      </property>
-     <item row="1" column="4">
+     <item row="3" column="4">
       <widget class="QLabel" name="labelLevel">
        <property name="text">
         <string>API-Level:</string>
@@ -32,8 +32,59 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1" colspan="6">
-      <widget class="QLabel" name="filePath">
+     <item row="3" column="0">
+      <widget class="QLabel" name="labelVersion">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>MuseScore Version:</string>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::NoTextInteraction</set>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="3">
+      <widget class="QLabel" name="revision">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::Panel</enum>
+       </property>
+       <property name="text">
+        <string>No revision</string>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="labelFilePath">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>File Path:</string>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::NoTextInteraction</set>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLabel" name="version">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -41,23 +92,33 @@
         </sizepolicy>
        </property>
        <property name="toolTip">
-        <string>Where this score is saved on your computer.</string>
+        <string>The MuseScore version with which this score was last saved.</string>
        </property>
        <property name="accessibleDescription">
-        <string>Where this score is saved on your computer.</string>
+        <string>The MuseScore version with which this score was last saved.</string>
        </property>
        <property name="frameShape">
         <enum>QFrame::Panel</enum>
        </property>
        <property name="text">
-        <string>The score has not been saved yet.</string>
+        <string>No version</string>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::TextSelectableByMouse</set>
        </property>
       </widget>
      </item>
-     <item row="1" column="5">
+     <item row="3" column="2">
+      <widget class="QLabel" name="labelRevision">
+       <property name="text">
+        <string>Revision:</string>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::NoTextInteraction</set>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="5">
       <widget class="QLabel" name="level">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -85,8 +146,8 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QLabel" name="version">
+     <item row="2" column="1" colspan="5">
+      <widget class="QLabel" name="filePath">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -94,82 +155,24 @@
         </sizepolicy>
        </property>
        <property name="toolTip">
-        <string>The MuseScore version with which this score was last saved.</string>
+        <string>Where this score is saved on your computer.</string>
        </property>
        <property name="accessibleDescription">
-        <string>The MuseScore version with which this score was last saved.</string>
+        <string>Where this score is saved on your computer.</string>
        </property>
        <property name="frameShape">
         <enum>QFrame::Panel</enum>
        </property>
        <property name="text">
-        <string>No version</string>
+        <string>The score has not been saved yet.</string>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::TextSelectableByMouse</set>
        </property>
       </widget>
      </item>
-     <item row="1" column="2">
-      <widget class="QLabel" name="labelRevision">
-       <property name="text">
-        <string>Revision:</string>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::NoTextInteraction</set>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="labelVersion">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>20</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>MuseScore Version:</string>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::NoTextInteraction</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="labelFilePath">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>20</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>File Path:</string>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::NoTextInteraction</set>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="3">
-      <widget class="QLabel" name="revision">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::Panel</enum>
-       </property>
-       <property name="text">
-        <string>No revision</string>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::TextSelectableByMouse</set>
-       </property>
-      </widget>
+     <item row="2" column="6">
+      <widget class="QToolButton" name="revealButton"/>
      </item>
     </layout>
    </item>
@@ -184,7 +187,7 @@
         <x>0</x>
         <y>0</y>
         <width>662</width>
-        <height>302</height>
+        <height>300</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="scrollAreaLayout">

--- a/mscore/openfilelocation.cpp
+++ b/mscore/openfilelocation.cpp
@@ -1,0 +1,73 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#include "openfilelocation.h"
+
+namespace Ms {
+
+//---------------------------------------------------------
+//   platformText
+///   Returns the platform specific text for opening the file.
+///   There is no official standard, but there seems to be a general agreement
+///
+///   Windows: "Show in Explorer"
+///   MacOs:   "Reveal in Finder"
+///   Else:    "Open Containing Folder"
+//---------------------------------------------------------
+
+const QString OpenFileLocation::platformText() {
+#if defined(Q_OS_WIN)
+      return QT_TR_NOOP("Show in Explorer");
+#elif defined(Q_OS_MAC)
+      return QT_TR_NOOP("Reveal in Finder");
+#else
+      return QT_TR_NOOP("Open Containing Folder");
+#endif
+      }
+
+//---------------------------------------------------------
+//   openFileLocation
+///   reveals the file in explorer (Windows) / finder (MacOs) or the default file manager in other cases.
+///   Note that opening the default file manager doesn't show the file, but simply opens the containing folder.
+///   Note also that all platforms will fallback to opening the containing folder if they can't show the file.
+///
+///   Returns true on success, false on failure.
+///   See MetaEditDialog::openFileLocation example usage
+//---------------------------------------------------------
+
+bool OpenFileLocation::openFileLocation(const QString& path)
+      {
+      const QFileInfo fileInfo(path);
+      if (!fileInfo.exists())
+            return false;
+      QStringList args;
+#if defined(Q_OS_WIN)
+      if (!fileInfo.isDir())
+            args += QLatin1String("/select,");
+      args += QDir::toNativeSeparators(fileInfo.canonicalFilePath());
+      if(QProcess::startDetached("explorer.exe", args))
+            return true;
+#elif defined(Q_OS_MAC)
+      args << QLatin1String("-e")
+             << QString::fromLatin1("tell application \"Finder\" to reveal POSIX file \"%1\"")
+                                   .arg(fileInfo.canonicalFilePath());
+      QProcess::execute(QLatin1String("/usr/bin/osascript"), args);
+      args.clear();
+      args << QLatin1String("-e")
+             << QLatin1String("tell application \"Finder\" to activate");
+      if (!QProcess::execute("/usr/bin/osascript", args))
+            return true;
+#endif // not #else so that the following can be used as a fallback.
+      return QDesktopServices::openUrl(QUrl::fromLocalFile(fileInfo.isDir()? path : fileInfo.path()));
+      }
+
+} // namespace Ms

--- a/mscore/openfilelocation.h
+++ b/mscore/openfilelocation.h
@@ -1,0 +1,28 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#ifndef OPENFILELOCATION_H
+#define OPENFILELOCATION_H
+
+namespace Ms {
+
+/// A class with static functions to open a file location
+class OpenFileLocation
+      {
+   public:
+      static bool openFileLocation(const QString& path);
+      static const QString platformText();
+      };
+
+} // namespace Ms
+
+#endif // OPENFILELOCATION_H


### PR DESCRIPTION
Previously, the path shown in metaedit dialog had been set as selectable by mouse. I guess this was to be able to copy it into explorer or wherever needed. This is even faster.

It works on my machine, windows 10. However, it would be really appreciated if someone could test it under Macos and Linux.
