### PR TITLE
fix #299246 and #284434 : Issues with hiding courtesy time/key signatures

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -20,6 +20,7 @@
 #include "scoreaccessibility.h"
 #include "libmscore/score.h"
 #include "libmscore/keysig.h"
+#include "libmscore/timesig.h"
 #include "libmscore/segment.h"
 #include "libmscore/utils.h"
 #include "libmscore/text.h"
@@ -375,6 +376,18 @@ void ScoreView::mousePressEventNormal(QMouseEvent* ev)
             if (e->isKeySig() && (keyState != Qt::ControlModifier) && st == SelectType::SINGLE) {
                   // special case: select for all staves
                   Segment* s = toKeySig(e)->segment();
+                  bool first = true;
+                  for (int staffIdx = 0; staffIdx < _score->nstaves(); ++staffIdx) {
+                        Element* ee = s->element(staffIdx * VOICES);
+                        if (ee) {
+                              ee->score()->select(ee, first ? SelectType::SINGLE : SelectType::ADD);
+                              first = false;
+                              }
+                        }
+                  }
+            else if (e->isTimeSig() && !toTimeSig(e)->isLocal() && (keyState != Qt::ControlModifier) && st == SelectType::SINGLE) {
+                  // special case: select for all staves except when TimeSig is local.
+                  Segment* s = toTimeSig(e)->segment();
                   bool first = true;
                   for (int staffIdx = 0; staffIdx < _score->nstaves(); ++staffIdx) {
                         Element* ee = s->element(staffIdx * VOICES);


### PR DESCRIPTION
fix #299246 : Hiding courtesy time signature only works for the first staff

Resolves: https://musescore.org/en/node/299246
Resolves: https://musescore.org/en/node/284434

When selecting a time signature, it now shows the same behavior as selecting a key signature which solves
Key Signature had exactly the same problem as Show/Hid Courtesy Time Signature. This is solved
similar for both key and time signature.

Also, in propertymenu.cpp all static_cast<Xxx*>() replaced by toXx(), according the coding rules.

Since these change are related to the GUI there is *no* test created to verify the changes.

*Use "x" letter to fill the checkboxes below like [x]*

- [x ] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
