### PR TITLE
Revert to double-click to apply elements from drum input palette

### DIFF
--- a/mscore/drumtools.cpp
+++ b/mscore/drumtools.cpp
@@ -72,6 +72,7 @@ DrumTools::DrumTools(QWidget* parent)
       drumPalette = new Palette;
       drumPalette->setMag(0.8);
       drumPalette->setSelectable(true);
+      drumPalette->setUseDoubleClickToActivate(true);
       drumPalette->setGrid(28, 60);
       PaletteScrollArea* sa = new PaletteScrollArea(drumPalette);
       sa->setFocusPolicy(Qt::NoFocus);

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -804,19 +804,35 @@ void PaletteScrollArea::keyPressEvent(QKeyEvent* event)
       }
 
 //---------------------------------------------------------
+//   mouseDoubleClickEvent
+//---------------------------------------------------------
+
+void Palette::mouseDoubleClickEvent(QMouseEvent* event)
+      {
+      if (_useDoubleClickToActivate)
+            applyElementAtPosition(event->pos(), event->modifiers());
+      }
+
+//---------------------------------------------------------
 //   mouseReleaseEvent
 //---------------------------------------------------------
 
-void Palette::mouseReleaseEvent(QMouseEvent *event)
+void Palette::mouseReleaseEvent(QMouseEvent* event)
       {
       pressedIndex = -1;
 
       update();
 
+      if (!_useDoubleClickToActivate)
+            applyElementAtPosition(event->pos(), event->modifiers());
+      }
+
+void Palette::applyElementAtPosition(QPoint pos, Qt::KeyboardModifiers modifiers)
+      {
       if (_disableElementsApply)
             return;
 
-      int index = idx(event->pos());
+      const int index = idx(pos);
 
       if (index == -1)
             return;
@@ -831,7 +847,7 @@ void Palette::mouseReleaseEvent(QMouseEvent *event)
       if (!cell)
             return;
 
-      applyPaletteElement(cell->element.get(), event->modifiers());
+      applyPaletteElement(cell->element.get(), modifiers);
       }
 
 //---------------------------------------------------------

--- a/mscore/palette.h
+++ b/mscore/palette.h
@@ -88,6 +88,7 @@ class Palette : public QWidget {
       bool _drawGrid;
       bool _selectable;
       bool _disableElementsApply { false };
+      bool _useDoubleClickToActivate { false };
       bool _readOnly;
       bool _systemPalette;
       qreal _yOffset;                // in spatium units of "gscore"
@@ -99,6 +100,7 @@ class Palette : public QWidget {
       virtual void paintEvent(QPaintEvent*) override;
       virtual void mousePressEvent(QMouseEvent*) override;
       void mouseReleaseEvent(QMouseEvent* event) override;
+      void mouseDoubleClickEvent(QMouseEvent*) override;
       virtual void mouseMoveEvent(QMouseEvent*) override;
       virtual void leaveEvent(QEvent*) override;
       virtual bool event(QEvent*) override;
@@ -115,6 +117,7 @@ class Palette : public QWidget {
       const QList<PaletteCell*>* ccp() const { return filterActive ? &dragCells : &cells; }
       QPixmap pixmap(int cellIdx) const;
 
+      void applyElementAtPosition(QPoint pos, Qt::KeyboardModifiers modifiers);
 
    private slots:
       void actionToggled(bool val);
@@ -156,6 +159,9 @@ class Palette : public QWidget {
       void setReadOnly(bool val);
       bool disableElementsApply() const      { return _disableElementsApply; }
       void setDisableElementsApply(bool val) { _disableElementsApply = val; }
+
+      bool useDoubleClickToActivate() const { return _useDoubleClickToActivate; }
+      void setUseDoubleClickToActivate(bool val) { _useDoubleClickToActivate = val; }
 
       bool systemPalette() const     { return _systemPalette; }
       void setSystemPalette(bool val);


### PR DESCRIPTION
Addresses the widely reported regression of 3.4 version regarding drum input by reverting to the previous behavior. Not sure whether there is an issue tracker entry for this.