### PR TITLE
Improvements for post Qt 5.11 builds

### DIFF
--- a/effects/CMakeLists.txt
+++ b/effects/CMakeLists.txt
@@ -18,18 +18,25 @@ else (APPLE)
       set(INCS "")
 endif (APPLE)
 
-QT5_ADD_RESOURCES (qrc_effects_files
-     zita1/zita.qrc
-     )
+if (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.11.0")
+      find_package(Qt5QuickCompiler)
+      qtquick_compiler_add_resources (qrc_effects_files
+            zita1/zita.qrc
+            )
+else (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.11.0")
+      QT5_ADD_RESOURCES (qrc_effects_files
+            zita1/zita.qrc
+            )
+endif (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.11.0")
 
 QT5_WRAP_UI (ui_headers
       compressor/compressor_gui.ui
       )
 
 if (NOT MSVC)
-   set(_all_h_file "${PROJECT_BINARY_DIR}/all.h")
+      set(_all_h_file "${PROJECT_BINARY_DIR}/all.h")
 else (NOT MSVC)
-   set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
+      set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
 endif (NOT MSVC)
 
 add_library (effects STATIC
@@ -49,17 +56,17 @@ add_library (effects STATIC
       )
 
 if (NOT MSVC)
-   set_target_properties (
-      effects
-      PROPERTIES
-         COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
-      )
+      set_target_properties (
+            effects
+            PROPERTIES
+            COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
+            )
 else (NOT MSVC)
-   set_target_properties (
-      effects
-      PROPERTIES
-         COMPILE_FLAGS "${PCH_INCLUDE}"
-      )
+      set_target_properties (
+            effects
+            PROPERTIES
+            COMPILE_FLAGS "${PCH_INCLUDE}"
+            )
 endif (NOT MSVC)   
 
 xcode_pch(effects all)
@@ -69,7 +76,7 @@ vstudio_pch( effects )
 
 # MSVC does not depend on mops1 & mops2 for PCH
 if (NOT MSVC)
-   ADD_DEPENDENCIES(effects mops1)
-   ADD_DEPENDENCIES(effects mops2)
+      ADD_DEPENDENCIES(effects mops1)
+      ADD_DEPENDENCIES(effects mops2)
 endif (NOT MSVC)   
 

--- a/framework/telemetry/CMakeLists.txt
+++ b/framework/telemetry/CMakeLists.txt
@@ -31,7 +31,13 @@ include_directories(
 file(GLOB_RECURSE telemetry_SOURCES RELATIVE ${CMAKE_CURRENT_LIST_DIR} *.cpp)
 file(GLOB_RECURSE telemetry_HEADERS RELATIVE ${CMAKE_CURRENT_LIST_DIR} *.h)
 
-qt5_add_resources(RCC_SOURCES telemetry_resources.qrc)
+if (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.11.0")
+      find_package(Qt5QuickCompiler)
+      qtquick_compiler_add_resources(RCC_SOURCES telemetry_resources.qrc)
+else (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.11.0")
+      QT5_ADD_RESOURCES(RCC_SOURCES telemetry_resources.qrc)
+endif (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.11.0")
+
 
 add_library(${MODULE} ${LIBRARY_TYPE}
     ${telemetry_SOURCES}

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -99,21 +99,43 @@ QT5_WRAP_UI (ui_headers
       )
 
 if (APPLE)
-      QT5_ADD_RESOURCES (qrc_files musescore.qrc
-            qml.qrc # TODO: replace with qtquick_compiler_add_resources on Qt >= 5.11
-            musescorefonts-Mac.qrc shortcut-Mac.qrc
-            )
+      if (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.11.0")
+            find_package(Qt5QuickCompiler)
+            qtquick_compiler_add_resources (qrc_files musescore.qrc
+                  qml.qrc
+                  musescorefonts-Mac.qrc shortcut-Mac.qrc
+                  )
+      else (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.11.0")
+            QT5_ADD_RESOURCES (qrc_files musescore.qrc
+                 qml.qrc
+                 musescorefonts-Mac.qrc shortcut-Mac.qrc
+                 )
+      endif (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.11.0")
 else (APPLE)
-      QT5_ADD_RESOURCES (qrc_files musescore.qrc
-            qml.qrc # TODO: replace with qtquick_compiler_add_resources on Qt >= 5.11
-            musescorefonts-MScore.qrc
-            musescorefonts-Gootville.qrc
-            musescorefonts-Bravura.qrc
-            musescorefonts-MuseJazz.qrc
-            musescorefonts-Campania.qrc
-            musescorefonts-FreeSerif.qrc
-            musescorefonts-Free.qrc
-            shortcut.qrc)
+      if (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.11.0")
+            find_package(Qt5QuickCompiler)
+            qtquick_compiler_add_resources (qrc_files musescore.qrc
+                  qml.qrc
+                  musescorefonts-MScore.qrc
+                  musescorefonts-Gootville.qrc
+                  musescorefonts-Bravura.qrc
+                  musescorefonts-MuseJazz.qrc
+                  musescorefonts-Campania.qrc
+                  musescorefonts-FreeSerif.qrc
+                  musescorefonts-Free.qrc
+                  shortcut.qrc)
+      else (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.11.0")
+            QT5_ADD_RESOURCES (qrc_files musescore.qrc
+                  qml.qrc
+                  musescorefonts-MScore.qrc
+                  musescorefonts-Gootville.qrc
+                  musescorefonts-Bravura.qrc
+                  musescorefonts-MuseJazz.qrc
+                  musescorefonts-Campania.qrc
+                  musescorefonts-FreeSerif.qrc
+                  musescorefonts-Free.qrc
+                  shortcut.qrc)
+      endif (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.11.0")
 endif (APPLE)
 
 if (${CMAKE_SYSTEM} MATCHES "GNU-0.3")

--- a/mtest/CMakeLists.txt
+++ b/mtest/CMakeLists.txt
@@ -32,14 +32,16 @@ else (USE_SYSTEM_FREETYPE)
 endif (USE_SYSTEM_FREETYPE)
 
 if (OMR)
-set(OMR_SRC ${PROJECT_SOURCE_DIR}/omr/importpdf.cpp)
+      set(OMR_SRC ${PROJECT_SOURCE_DIR}/omr/importpdf.cpp)
 endif (OMR)
 
 if (MSVC)
-   set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
+      set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
 endif (MSVC)
 
-QT5_ADD_RESOURCES(qrc_files ${PROJECT_SOURCE_DIR}/mtest/mtest.qrc
+if (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.11.0")
+      find_package(Qt5QuickCompiler)
+      qtquick_compiler_add_resources(qrc_files ${PROJECT_SOURCE_DIR}/mtest/mtest.qrc
             ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-MScore.qrc
             ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-Gootville.qrc
             ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-Bravura.qrc
@@ -47,6 +49,16 @@ QT5_ADD_RESOURCES(qrc_files ${PROJECT_SOURCE_DIR}/mtest/mtest.qrc
             ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-Free.qrc
             ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-FreeSerif.qrc
       )
+else (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.11.0")
+      QT5_ADD_RESOURCES(qrc_files ${PROJECT_SOURCE_DIR}/mtest/mtest.qrc
+            ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-MScore.qrc
+            ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-Gootville.qrc
+            ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-Bravura.qrc
+            ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-MuseJazz.qrc
+            ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-Free.qrc
+            ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-FreeSerif.qrc
+      )
+endif (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.11.0")
 
 add_library (testResources STATIC
       ${qrc_files}
@@ -248,5 +260,5 @@ install(FILES
 endif (NOT MSVC)
 
 if (OMR)
-subdirs(omr)
+      subdirs(omr)
 endif (OMR)


### PR DESCRIPTION
Tried building MuseScore with a Qt 5.12.7 snapshot, which failed. During investigating that failure I  came up with these changes, which still don't build in Qt 5.12.7 snapshot nor with the final version, but do with Qt 5.15.0 (snapshot too) and with Qt 5.12.6 and lower though (at least down to Qt 5.9, but probably much lower too) and do seem to be doing the RightThing (tm) ;-)