### PR TITLE
Telemetry dialog accessibility for the blind

### DIFF
--- a/telemetry/qml/DialogButton.qml
+++ b/telemetry/qml/DialogButton.qml
@@ -40,6 +40,16 @@ Rectangle {
         GradientStop { position: 1.0; color: "#C4C9CD" }
     }
 
+    Keys.onPressed: {
+        if (event.key === Qt.Key_Return ||
+            event.key === Qt.Key_Enter) {
+
+            root.clicked()
+
+            event.accepted = true
+        }
+    }
+
     Text {
         id: buttonLabel
 

--- a/telemetry/qml/DialogButton.qml
+++ b/telemetry/qml/DialogButton.qml
@@ -2,7 +2,7 @@
 //  MuseScore
 //  Music Composition & Notation
 //
-//  Copyright (C) 2019 MuseScore BVBA and others
+//  Copyright (C) 2020 MuseScore BVBA and others
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2.
@@ -19,34 +19,48 @@
 
 import QtQuick 2.0
 
-Rectangle {
+FocusableItem {
     id: root
 
     property alias text: buttonLabel.text
     property alias pressed: clickableArea.pressed
 
-    signal clicked()
+    signal clicked
 
     height: 24
     width: 252
 
-    border.color: "#a2a2a2"
-    border.width: 1
-
-    radius: 3
-
-    gradient: Gradient {
-        GradientStop { position: 0.0; color: "#E5E9EF" }
-        GradientStop { position: 1.0; color: "#C4C9CD" }
-    }
-
     Keys.onPressed: {
-        if (event.key === Qt.Key_Return ||
-            event.key === Qt.Key_Enter) {
+        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
 
             root.clicked()
 
             event.accepted = true
+        }
+    }
+
+    Accessible.role: Accessible.Button
+    Accessible.name: root.text
+
+    Rectangle {
+        id: backgroundRect
+
+        anchors.fill: parent
+
+        border.color: "#a2a2a2"
+        border.width: 1
+
+        radius: 3
+
+        gradient: Gradient {
+            GradientStop {
+                position: 0.0
+                color: "#E5E9EF"
+            }
+            GradientStop {
+                position: 1.0
+                color: "#C4C9CD"
+            }
         }
     }
 
@@ -76,7 +90,7 @@ Rectangle {
             when: root.pressed
 
             PropertyChanges {
-                target: root
+                target: backgroundRect
 
                 color: "#C4C9CD"
                 gradient: undefined

--- a/telemetry/qml/FocusableItem.qml
+++ b/telemetry/qml/FocusableItem.qml
@@ -8,10 +8,10 @@ FocusScope {
     MouseArea {
         anchors.fill: parent
 
-        hoverEnabled: true
+        preventStealing: true
 
-        onContainsMouseChanged: {
-            if (containsMouse) {
+        onClicked: {
+            if (!activeFocus) {
                 root.forceActiveFocus()
             }
         }

--- a/telemetry/qml/FocusableItem.qml
+++ b/telemetry/qml/FocusableItem.qml
@@ -1,0 +1,19 @@
+import QtQuick 2.5
+
+FocusScope {
+    id: root
+
+    activeFocusOnTab: true
+
+    MouseArea {
+        anchors.fill: parent
+
+        hoverEnabled: true
+
+        onContainsMouseChanged: {
+            if (containsMouse) {
+                root.forceActiveFocus()
+            }
+        }
+    }
+}

--- a/telemetry/qml/TelemetryPermissionDialog.qml
+++ b/telemetry/qml/TelemetryPermissionDialog.qml
@@ -20,14 +20,26 @@
 import QtQuick 2.0
 import MuseScore.Telemetry 3.3
 
-Rectangle {
+FocusScope {
     id: root
 
-    signal closeRequested()
+    signal closeRequested
 
     height: childrenRect.height
 
-    color: globalStyle.window
+    Keys.onEscapePressed: {
+        root.closeRequested()
+    }
+
+    Component.onCompleted: {
+        forceActiveFocus()
+    }
+
+    Rectangle {
+        anchors.fill: parent
+
+        color: globalStyle.window
+    }
 
     TelemetryPermissionModel {
         id: permissionModel
@@ -47,7 +59,7 @@ Rectangle {
             width: parent.width
         }
 
-        Text {
+        TextLabel {
             id: titleLabel
 
             anchors {
@@ -62,6 +74,8 @@ Rectangle {
             font.pixelSize: 28
 
             text: qsTr("Help us improve MuseScore")
+
+            focus: true
         }
 
         Column {
@@ -116,21 +130,11 @@ Rectangle {
 
             spacing: 24
 
-            focus: true
-            Keys.forwardTo: [positiveButton, negativeButton]
-
-            Keys.onEscapePressed: {
-                root.closeRequested()
-            }
-
             Column {
 
                 width: parent.width
 
                 spacing: 10
-
-                KeyNavigation.down: negativeButton
-                KeyNavigation.tab: negativeButton
 
                 DialogButton {
                     id: positiveButton
@@ -161,9 +165,6 @@ Rectangle {
                 width: parent.width
 
                 spacing: 10
-
-                KeyNavigation.up: positiveButton
-                KeyNavigation.tab: positiveButton
 
                 DialogButton {
                     id: negativeButton
@@ -202,4 +203,3 @@ Rectangle {
         }
     }
 }
-

--- a/telemetry/qml/TelemetryPermissionDialog.qml
+++ b/telemetry/qml/TelemetryPermissionDialog.qml
@@ -116,11 +116,21 @@ Rectangle {
 
             spacing: 24
 
+            focus: true
+            Keys.forwardTo: [positiveButton, negativeButton]
+
+            Keys.onEscapePressed: {
+                root.closeRequested()
+            }
+
             Column {
 
                 width: parent.width
 
                 spacing: 10
+
+                KeyNavigation.down: negativeButton
+                KeyNavigation.tab: negativeButton
 
                 DialogButton {
                     id: positiveButton
@@ -151,6 +161,9 @@ Rectangle {
                 width: parent.width
 
                 spacing: 10
+
+                KeyNavigation.up: positiveButton
+                KeyNavigation.tab: positiveButton
 
                 DialogButton {
                     id: negativeButton

--- a/telemetry/qml/TextLabel.qml
+++ b/telemetry/qml/TextLabel.qml
@@ -2,7 +2,7 @@
 //  MuseScore
 //  Music Composition & Notation
 //
-//  Copyright (C) 2019 MuseScore BVBA and others
+//  Copyright (C) 2020 MuseScore BVBA and others
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2.
@@ -17,18 +17,42 @@
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
 
-import QtQuick 2.0
+import QtQuick 2.5
 
-Text {
+FocusableItem {
     id: root
 
-    height: implicitHeight
+    property alias color: textLabel.color
+    property alias lineHeight: textLabel.lineHeight
+    property alias wrapMode: textLabel.wrapMode
+    property alias text: textLabel.text
+    property alias horizontalAlignment: textLabel.horizontalAlignment
+    property alias verticalAlignment: textLabel.verticalAlignment
+    property alias font: textLabel.font
+
+    signal linkActivated(var link)
+
+    height: textLabel.height
     width: parent.width
 
-    font.pixelSize: 12
-    horizontalAlignment: Text.AlignHCenter
+    Accessible.role: Accessible.StaticText
+    Accessible.name: textLabel.text
 
-    wrapMode: Text.WordWrap
+    Text {
+        id: textLabel
 
-    color: "#373737"
+        height: implicitHeight
+        width: parent.width
+
+        font.pixelSize: 12
+        horizontalAlignment: Text.AlignHCenter
+
+        wrapMode: Text.WordWrap
+
+        color: "#373737"
+
+        onLinkActivated: {
+            root.linkActivated()
+        }
+    }
 }

--- a/telemetry/telemetry_resources.qrc
+++ b/telemetry/telemetry_resources.qrc
@@ -3,5 +3,6 @@
         <file>qml/TelemetryPermissionDialog.qml</file>
         <file>qml/DialogButton.qml</file>
         <file>qml/TextLabel.qml</file>
+        <file>qml/FocusableItem.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Now users can iterate through the dialogue elements, and the screen reader will pronounce the contents of the selected element.

The first in the order, by default, dialog title ("Help us...")

When the button is selected by the tab key it's able to process enter key to confirm the choice.

At any time user can press 'Esc' button and dialog will just close itself.

Tested with Orca