### PR TITLE
[Regression] fix #299369: crash when pressing numbers/letters in a different voice

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3708,7 +3708,7 @@ void Score::cmdAddFret(int fret)
       Position pos;
       pos.segment   = is.segment();
       pos.staffIdx  = is.track() / VOICES;
-      pos.line      = is.cr()->staff()->staffType(is.tick())->physStringToVisual(is.string());
+      pos.line      = staff(pos.staffIdx)->staffType(is.tick())->physStringToVisual(is.string());
       pos.fret      = fret;
       putNote(pos, false);
       }


### PR DESCRIPTION
Resolves: https://musescore.org/node/299369.

Use `staff(pos.staffIdx)->staffType(is.tick())` to make sure `nullptr` won't emerge.