### PR TITLE
add accessible names & labels

### DIFF
--- a/mscore/inspector/inspector_element.ui
+++ b/mscore/inspector/inspector_element.ui
@@ -132,6 +132,9 @@
         <property name="text">
          <string>Minimum distance:</string>
         </property>
+        <property name="buddy">
+         <cstring>minDistance</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="0" colspan="3">
@@ -294,6 +297,9 @@
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Minimum distance</string>
         </property>
         <property name="suffix">
          <string>sp</string>

--- a/mscore/inspector/inspector_note.ui
+++ b/mscore/inspector/inspector_note.ui
@@ -555,6 +555,9 @@
            <property name="alignment">
             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
            </property>
+           <property name="buddy">
+            <cstring>velocity</cstring>
+           </property>
           </widget>
          </item>
          <item row="1" column="0">
@@ -564,6 +567,9 @@
            </property>
            <property name="alignment">
             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+           <property name="buddy">
+            <cstring>tuning</cstring>
            </property>
           </widget>
          </item>

--- a/mscore/inspector/offset_select.ui
+++ b/mscore/inspector/offset_select.ui
@@ -23,6 +23,9 @@
      <property name="text">
       <string>X:</string>
      </property>
+     <property name="buddy">
+      <cstring>xVal</cstring>
+     </property>
     </widget>
    </item>
    <item row="0" column="1">
@@ -96,6 +99,9 @@
     <widget class="QLabel" name="label_2">
      <property name="text">
       <string>Y:</string>
+     </property>
+     <property name="buddy">
+      <cstring>yVal</cstring>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
There are some fields in the Inspector (and probably elsewhere) that are missing either accessible names or "buddy" properties on their labels, resulting in screen readers not reading the name of the control.  This PR adds the missing properties.  I'm calling it WIP because I expect to add to it as we discover more, but it should be mergeable at any point along the way if anyone is so inclined.  Since strings will be added, though, probably best to them together before the next appropriate release.