### PR TITLE
Plugin API: alter Cursor API for better usage in interactive plugins

### DIFF
--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -716,7 +716,7 @@ class Score : public QObject, public ScoreElement {
       void addElement(Element*);
       void removeElement(Element*);
 
-      Note* addPitch(NoteVal&, bool addFlag);
+      Note* addPitch(NoteVal&, bool addFlag, InputState* externalInputState = nullptr);
       void addPitch(int pitch, bool addFlag, bool insert);
       Note* addTiedMidiPitch(int pitch, bool addFlag, Chord* prevChord);
       Note* addMidiPitch(int pitch, bool addFlag);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5914,7 +5914,7 @@ void MuseScore::cmd(QAction* a)
       cmd(a, cmdn);
       if (lastShortcut->isCmd())
             cs->endCmd();
-      else
+      else if (!lastShortcut->isUndoRedo()) // undoRedo() calls endCmd() itself
             endCmd();
       TourHandler::startTour(cmdn);
       }

--- a/mscore/plugin/api/cursor.cpp
+++ b/mscore/plugin/api/cursor.cpp
@@ -54,11 +54,18 @@ Score* Cursor::score() const
 
 void Cursor::setScore(Ms::Score* s)
       {
+      if (_score == s)
+            return;
+
       _score = s;
-      if (_score) {
-            _score->inputState().setTrack(_track);
-            _score->inputState().setSegment(_segment);
-            }
+
+      switch (_inputStateMode) {
+            case INPUT_STATE_INDEPENDENT:
+                  is.reset(new InputState);
+                  break;
+            case INPUT_STATE_SYNC_WITH_SCORE:
+                  break;
+            };
       }
 
 //---------------------------------------------------------
@@ -68,6 +75,29 @@ void Cursor::setScore(Ms::Score* s)
 void Cursor::setScore(Score* s)
       {
       setScore(s ? s->score() : nullptr);
+      }
+
+//---------------------------------------------------------
+//   inputState
+//---------------------------------------------------------
+
+InputState& Cursor::inputState()
+      {
+      return is ? *is.get() : _score->inputState();
+      }
+
+//---------------------------------------------------------
+//   setInputStateMode
+//---------------------------------------------------------
+
+void Cursor::setInputStateMode(InputStateMode val)
+      {
+      if (val == INPUT_STATE_SYNC_WITH_SCORE)
+            is.reset();
+      else
+            is.reset(new InputState);
+
+      _inputStateMode = val;
       }
 
 //---------------------------------------------------------
@@ -88,11 +118,13 @@ void Cursor::rewind(RewindMode mode)
       // rewind to start of score
       //
       if (mode == SCORE_START) {
-            _segment = nullptr;
             Ms::Measure* m = _score->firstMeasure();
             if (m) {
-                  _segment = m->first(_filter);
+                  setSegment(m->first(_filter));
                   nextInTrack();
+                  }
+            else {
+                  setSegment(nullptr);
                   }
             }
       //
@@ -101,8 +133,8 @@ void Cursor::rewind(RewindMode mode)
       else if (mode == SELECTION_START) {
             if (!_score->selection().isRange())
                   return;
-            _segment  = _score->selection().startSegment();
-            _track    = _score->selection().staffStart() * VOICES;
+            setSegment(_score->selection().startSegment());
+            setTrack(_score->selection().staffStart() * VOICES);
             nextInTrack();
             }
       //
@@ -111,11 +143,9 @@ void Cursor::rewind(RewindMode mode)
       else if (mode == SELECTION_END) {
             if (!_score->selection().isRange())
                   return;
-            _segment  = _score->selection().endSegment();
-            _track    = (_score->selection().staffEnd() * VOICES) - 1;  // be sure _track exists
+            setSegment(_score->selection().endSegment());
+            setTrack((_score->selection().staffEnd() * VOICES) - 1);  // be sure _track exists
             }
-      _score->inputState().setTrack(_track);
-      _score->inputState().setSegment(_segment);
       }
 
 //---------------------------------------------------------
@@ -128,12 +158,10 @@ void Cursor::rewind(RewindMode mode)
 
 bool Cursor::prev()
       {
-      if (!_segment)
+      if (!segment())
             return false;
       prevInTrack();
-      _score->inputState().setTrack(_track);
-      _score->inputState().setSegment(_segment);
-      return _segment != 0;
+      return segment();
       }
 
 //---------------------------------------------------------
@@ -145,13 +173,11 @@ bool Cursor::prev()
 
 bool Cursor::next()
       {
-      if (!_segment)
+      if (!segment())
             return false;
-      _segment = _segment->next1(_filter);
+      setSegment(segment()->next1(_filter));
       nextInTrack();
-      _score->inputState().setTrack(_track);
-      _score->inputState().setSegment(_segment);
-      return _segment != 0;
+      return segment();
       }
 
 //---------------------------------------------------------
@@ -164,16 +190,16 @@ bool Cursor::next()
 
 bool Cursor::nextMeasure()
       {
-      if (_segment == 0)
+      if (!segment())
             return false;
-      Ms::Measure* m = _segment->measure()->nextMeasure();
+      Ms::Measure* m = segment()->measure()->nextMeasure();
       if (m == 0) {
-            _segment = 0;
+            setSegment(nullptr);
             return false;
             }
-      _segment = m->first(_filter);
+      setSegment(m->first(_filter));
       nextInTrack();
-      return _segment != 0;
+      return segment();
       }
 
 //---------------------------------------------------------
@@ -185,7 +211,7 @@ bool Cursor::nextMeasure()
 void Cursor::add(Element* wrapped)
       {
       Ms::Element* s = wrapped ? wrapped->element() : nullptr;
-      if (!_segment || !s)
+      if (!segment() || !s)
             return;
 
       // Ensure that the object has the expected ownership
@@ -193,6 +219,9 @@ void Cursor::add(Element* wrapped)
             qWarning("Cursor::add: Cannot add this element. The element is already part of the score.");
             return;        // Don't allow operation.
             }
+
+      const int _track = track();
+      Ms::Segment* _segment = segment();
 
       wrapped->setOwnership(Ownership::SCORE);
       s->setScore(_score);
@@ -325,11 +354,10 @@ void Cursor::addNote(int pitch, bool addToChord)
             qWarning("Cursor::addNote: invalid pitch: %d", pitch);
             return;
             }
-      if (!_score->inputState().duration().isValid())
+      if (!inputState().duration().isValid())
             setDuration(1, 4);
       NoteVal nval(pitch);
-      _score->addPitch(nval, addToChord);
-      _segment = _score->inputState().segment();
+      _score->addPitch(nval, addToChord, is.get());
       }
 
 //---------------------------------------------------------
@@ -346,7 +374,7 @@ void Cursor::setDuration(int z, int n)
       TDuration d(Fraction(z, n));
       if (!d.isValid())
             d = TDuration(TDuration::DurationType::V_QUARTER);
-      _score->inputState().setDuration(d);
+      inputState().setDuration(d);
       }
 
 //---------------------------------------------------------
@@ -355,7 +383,8 @@ void Cursor::setDuration(int z, int n)
 
 int Cursor::tick()
       {
-      return (_segment) ? _segment->tick().ticks() : 0;
+      const Ms::Segment* seg = segment();
+      return seg ? seg->tick().ticks() : 0;
       }
 
 //---------------------------------------------------------
@@ -382,16 +411,19 @@ qreal Cursor::tempo()
 
 Ms::Element* Cursor::currentElement() const
       {
-      return _segment && _segment->element(_track) ? _segment->element(_track) : nullptr;
+      const int t = track();
+      Ms::Segment* seg = segment();
+      return seg && seg->element(t) ? seg->element(t) : nullptr;
       }
 
 //---------------------------------------------------------
 //   segment
 //---------------------------------------------------------
 
-Segment* Cursor::segment() const
+Segment* Cursor::qmlSegment() const
       {
-      return _segment ? wrap<Segment>(_segment, Ownership::SCORE) : nullptr;
+      Ms::Segment* seg = segment();
+      return seg ? wrap<Segment>(seg, Ownership::SCORE) : nullptr;
       }
 
 //---------------------------------------------------------
@@ -412,22 +444,31 @@ Element* Cursor::element() const
 
 Measure* Cursor::measure() const
       {
-      return _segment ? wrap<Measure>(_segment->measure(), Ownership::SCORE) : nullptr;
+      Ms::Segment* seg = segment();
+      return seg ? wrap<Measure>(seg->measure(), Ownership::SCORE) : nullptr;
+      }
+
+//---------------------------------------------------------
+//   track
+//---------------------------------------------------------
+
+int Cursor::track() const
+      {
+      return inputState().track();
       }
 
 //---------------------------------------------------------
 //   setTrack
 //---------------------------------------------------------
 
-void Cursor::setTrack(int v)
+void Cursor::setTrack(int _track)
       {
-      _track = v;
       int tracks = _score->nstaves() * VOICES;
       if (_track < 0)
             _track = 0;
       else if (_track >= tracks)
             _track = tracks - 1;
-      _score->inputState().setTrack(_track);
+      inputState().setTrack(_track);
       }
 
 //---------------------------------------------------------
@@ -436,13 +477,13 @@ void Cursor::setTrack(int v)
 
 void Cursor::setStaffIdx(int v)
       {
-      _track = v * VOICES + _track % VOICES;
+      int _track = v * VOICES + track() % VOICES;
       int tracks = _score->nstaves() * VOICES;
       if (_track < 0)
             _track = 0;
       else if (_track >= tracks)
             _track = tracks - 1;
-      _score->inputState().setTrack(_track);
+      inputState().setTrack(_track);
       }
 
 //---------------------------------------------------------
@@ -451,13 +492,31 @@ void Cursor::setStaffIdx(int v)
 
 void Cursor::setVoice(int v)
       {
-      _track = (_track / VOICES) * VOICES + v;
+      int _track = (track() / VOICES) * VOICES + v;
       int tracks = _score->nstaves() * VOICES;
       if (_track < 0)
             _track = 0;
       else if (_track >= tracks)
             _track = tracks - 1;
-      _score->inputState().setTrack(_track);
+      inputState().setTrack(_track);
+      }
+
+//---------------------------------------------------------
+//   segment
+//---------------------------------------------------------
+
+Ms::Segment* Cursor::segment() const
+      {
+      return inputState().segment();
+      }
+
+//---------------------------------------------------------
+//   setSegment
+//---------------------------------------------------------
+
+void Cursor::setSegment(Ms::Segment* seg)
+      {
+      inputState().setSegment(seg);
       }
 
 //---------------------------------------------------------
@@ -466,7 +525,7 @@ void Cursor::setVoice(int v)
 
 int Cursor::staffIdx() const
       {
-      return _track / VOICES;
+      return track() / VOICES;
       }
 
 //---------------------------------------------------------
@@ -475,7 +534,7 @@ int Cursor::staffIdx() const
 
 int Cursor::voice() const
       {
-      return _track % VOICES;
+      return track() % VOICES;
       }
 
 //---------------------------------------------------------
@@ -485,10 +544,13 @@ int Cursor::voice() const
 
 void Cursor::prevInTrack()
       {
-      if (_segment)
-            _segment = _segment->prev1(_filter);
-      while (_segment && !_segment->element(_track))
-            _segment = _segment->prev1(_filter);
+      const int t = track();
+      Ms::Segment* seg = segment();
+      if (seg)
+            seg = seg->prev1(_filter);
+      while (seg && !seg->element(t))
+            seg = seg->prev1(_filter);
+      setSegment(seg);
       }
 
 //---------------------------------------------------------
@@ -498,8 +560,11 @@ void Cursor::prevInTrack()
 
 void Cursor::nextInTrack()
       {
-      while (_segment && _segment->element(_track) == 0)
-            _segment = _segment->next1(_filter);
+      const int t = track();
+      Ms::Segment* seg = segment();
+      while (seg && seg->element(t) == 0)
+            seg = seg->next1(_filter);
+      setSegment(seg);
       }
 
 //---------------------------------------------------------

--- a/mscore/plugin/api/cursor.cpp
+++ b/mscore/plugin/api/cursor.cpp
@@ -602,5 +602,22 @@ int Cursor::qmlKeySignature()
       Staff* staff = _score->staves()[staffIdx()];
       return static_cast<int>(staff->key(Fraction::fromTicks(tick())));
       }
+
+//---------------------------------------------------------
+//   inputStateString
+//---------------------------------------------------------
+
+int Cursor::inputStateString() const
+      {
+      const InputState& istate = inputState();
+      return _score->staff(staffIdx())->staffType(istate.tick())->visualStringToPhys(istate.string());
+      }
+
+void Cursor::setInputStateString(int string)
+      {
+      InputState& istate = inputState();
+      const int visString = _score->staff(staffIdx())->staffType(istate.tick())->visualStringToPhys(string);
+      istate.setString(visString);
+      }
 }
 }

--- a/mscore/plugin/api/cursor.cpp
+++ b/mscore/plugin/api/cursor.cpp
@@ -149,6 +149,30 @@ void Cursor::rewind(RewindMode mode)
       }
 
 //---------------------------------------------------------
+//   rewindToTick
+///   Rewind cursor to a position defined by tick.
+///   \param tick Determines the position where to move
+///   this cursor.
+///   \see \ref Ms::PluginAPI::Segment::tick "Segment.tick"
+///   \since MuseScore 3.5
+//---------------------------------------------------------
+
+void Cursor::rewindToTick(int tick)
+      {
+      // integer ticks may contain numeric errors so it is
+      // better to search not precisely if possible
+      Ms::Fraction fTick = Ms::Fraction::fromTicks(tick + 1);
+      Ms::Segment* seg = _score->tick2leftSegment(fTick);
+      if (!(seg->segmentType() & _filter)) {
+            // we need another segment type, search by known tick
+            seg = _score->tick2segment(seg->tick(), /* first */ true, _filter);
+            }
+
+      setSegment(seg);
+      nextInTrack();
+      }
+
+//---------------------------------------------------------
 //   prev
 ///   Move the cursor to the previous segment.
 ///   \return \p false if the beginning of the score is

--- a/mscore/plugin/api/cursor.h
+++ b/mscore/plugin/api/cursor.h
@@ -16,6 +16,7 @@
 namespace Ms {
 
 class Element;
+class InputState;
 class Score;
 class Chord;
 class Rest;
@@ -74,7 +75,7 @@ class Cursor : public QObject {
       /** Current element at track, read only */
       Q_PROPERTY(Ms::PluginAPI::Element* element READ element)
       /** Current segment, read only */
-      Q_PROPERTY(Ms::PluginAPI::Segment*  segment READ segment)
+      Q_PROPERTY(Ms::PluginAPI::Segment*  segment READ qmlSegment)
       /** Current measure, read only */
       Q_PROPERTY(Ms::PluginAPI::Measure*  measure READ measure)
 
@@ -86,20 +87,39 @@ class Cursor : public QObject {
             };
       Q_ENUM(RewindMode);
 
-   private:
-      Ms::Score* _score = nullptr;
-      int _track = 0;
-//       bool _expandRepeats; // used?
+      /** \since MuseScore 3.5 */
+      enum InputStateMode {
+            INPUT_STATE_INDEPENDENT, ///< Input state of cursor is independent of score input state (default)
+            INPUT_STATE_SYNC_WITH_SCORE ///< Input state of cursor is synchronized with score input state
+            };
+      Q_ENUM(InputStateMode);
 
-      //state
-      Ms::Segment* _segment = nullptr;
+   private:
+      /**
+       * Behavior of input state (position, notes duration etc.) of this cursor
+       * with respect to input state of the score. By default any changes in
+       * score and in this Cursor are not synchronized.
+       * \since MuseScore 3.5
+       */
+      Q_PROPERTY(InputStateMode inputStateMode READ inputStateMode WRITE setInputStateMode)
+
+      Ms::Score* _score = nullptr;
+//       bool _expandRepeats; // used?
       SegmentType _filter;
+      std::unique_ptr<InputState> is;
+      InputStateMode _inputStateMode = INPUT_STATE_INDEPENDENT;
 
       // utility methods
       void prevInTrack();
       void nextInTrack();
       void setScore(Ms::Score* s);
       Ms::Element* currentElement() const;
+
+      InputState& inputState();
+      const InputState& inputState() const { return const_cast<Cursor*>(this)->inputState(); }
+
+      Ms::Segment* segment() const;
+      void setSegment(Ms::Segment* seg);
 
    public:
       /// \cond MS_INTERNAL
@@ -109,7 +129,7 @@ class Cursor : public QObject {
       Score* score() const;
       void setScore(Score* s);
 
-      int track() const             { return _track;    }
+      int track() const;
       void setTrack(int v);
 
       int staffIdx() const;
@@ -121,8 +141,11 @@ class Cursor : public QObject {
       int filter() const            { return int(_filter); }
       void setFilter(int f)         { _filter = SegmentType(f); }
 
+      InputStateMode inputStateMode() const { return _inputStateMode; }
+      void setInputStateMode(InputStateMode val);
+
       Element* element() const;
-      Segment* segment() const;
+      Segment* qmlSegment() const;
       Measure* measure() const;
 
       int tick();

--- a/mscore/plugin/api/cursor.h
+++ b/mscore/plugin/api/cursor.h
@@ -78,6 +78,13 @@ class Cursor : public QObject {
       Q_PROPERTY(Ms::PluginAPI::Segment*  segment READ qmlSegment)
       /** Current measure, read only */
       Q_PROPERTY(Ms::PluginAPI::Measure*  measure READ measure)
+      /**
+       * A physical string number where this cursor currently at. This is useful
+       * in conjunction with \ref InputStateMode.INPUT_STATE_SYNC_WITH_SCORE
+       * cursor mode.
+       * \since MuseScore 3.5
+       */
+      Q_PROPERTY(int stringNumber READ inputStateString WRITE setInputStateString)
 
    public:
       enum RewindMode {
@@ -120,6 +127,9 @@ class Cursor : public QObject {
 
       Ms::Segment* segment() const;
       void setSegment(Ms::Segment* seg);
+
+      int inputStateString() const;
+      void setInputStateString(int);
 
    public:
       /// \cond MS_INTERNAL

--- a/mscore/plugin/api/cursor.h
+++ b/mscore/plugin/api/cursor.h
@@ -156,6 +156,7 @@ class Cursor : public QObject {
       /// \endcond
 
       Q_INVOKABLE void rewind(RewindMode mode);
+      Q_INVOKABLE void rewindToTick(int tick);
 
       Q_INVOKABLE bool next();
       Q_INVOKABLE bool nextMeasure();

--- a/mscore/plugin/api/qmlpluginapi.h
+++ b/mscore/plugin/api/qmlpluginapi.h
@@ -173,6 +173,9 @@ class PluginAPI : public Ms::QmlPlugin {
        * - \p instrumentsChanged
        * - \p startLayoutTick
        * - \p endLayoutTick
+       * - \p undoRedo - whether this onScoreStateChanged invokation results
+       *   from user undo/redo action. It is usualy not recommended to modify
+       *   score from plugins in this case. Available since MuseScore 3.5.
        *
        * If a plugin modifies score in this handler, then it should:
        * 1. enclose all modifications within Score::startCmd() / Score::endCmd()

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -170,7 +170,8 @@ Shortcut Shortcut::_sc[] = {
          QT_TRANSLATE_NOOP("action","Undo"),
          QT_TRANSLATE_NOOP("action","Undo last change"),
          Icons::undo_ICON,
-         Qt::ApplicationShortcut
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_UNDO_REDO
          },
       {
          MsWidget::MAIN_WINDOW,
@@ -180,7 +181,8 @@ Shortcut Shortcut::_sc[] = {
          QT_TRANSLATE_NOOP("action","Redo"),
          QT_TRANSLATE_NOOP("action","Redo last undo"),
          Icons::redo_ICON,
-         Qt::ApplicationShortcut
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_UNDO_REDO
          },
       {
          MsWidget::SCORE_TAB,

--- a/mscore/shortcut.h
+++ b/mscore/shortcut.h
@@ -77,7 +77,8 @@ enum class ShortcutFlags : char {
       A_SCORE     = 1,
       A_CMD       = 1 << 1,
       A_CHECKABLE = 1 << 2,
-      A_CHECKED   = 1 << 3
+      A_CHECKED   = 1 << 3,
+      A_UNDO_REDO = 1 << 4,
       };
 
 constexpr ShortcutFlags operator| (ShortcutFlags t1, ShortcutFlags t2) {
@@ -150,6 +151,7 @@ class Shortcut {
       void setState(int v)                      { _state = v;     }
       bool needsScore() const                  { return _flags & ShortcutFlags::A_SCORE; }
       bool isCmd() const                       { return _flags & ShortcutFlags::A_CMD; }
+      bool isUndoRedo() const                  { return _flags & ShortcutFlags::A_UNDO_REDO; }
       bool isCheckable() const                 { return _flags & ShortcutFlags::A_CHECKABLE; }
       bool isChecked() const                   { return _flags & ShortcutFlags::A_CHECKED; }
       Icons icon() const                       { return _icon;  }

--- a/share/plugins/notenames-interactive.qml
+++ b/share/plugins/notenames-interactive.qml
@@ -1,0 +1,370 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Note Names Plugin
+//
+//  Copyright (C) 2012 Werner Schweer
+//  Copyright (C) 2013 - 2019 Joachim Schmitz
+//  Copyright (C) 2014 Jörn Eichler
+//  Copyright (C) 2020 MuseScore BVBA
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+import QtQuick 2.2
+import QtQuick.Controls 2.0
+import MuseScore 3.0
+
+MuseScore {
+    version: "3.4"
+    description: qsTr("This plugin names notes as per your language setting")
+    menuPath: "Plugins.Notes." + qsTr("Note Names (Interactive)")
+    pluginType: "dock"
+
+    implicitHeight: controls.implicitHeight * 1.5
+    implicitWidth: controls.implicitWidth
+
+    // Small note name size is fraction of the full font size.
+    property var defaultFontSize
+    property var fontSizeMini: 0.7;
+
+    property int nstaves: 0 // for validators in staff number inputs
+
+    property bool inCmd: false
+
+    function ensureCmdStarted() {
+        if (!inCmd) {
+            curScore.startCmd();
+            inCmd = true;
+        }
+    }
+
+    function ensureCmdEnded() {
+        if (inCmd) {
+            curScore.endCmd();
+            inCmd = false;
+        }
+    }
+
+    function findSegment(el) {
+        while (el && el.type != Element.SEGMENT)
+            el = el.parent;
+        return el;
+    }
+
+    function getChordName(chord) {
+        var text = "";
+        var notes = chord.notes;
+        for (var i = 0; i < notes.length; i++) {
+            var sep = "\n";   // change to "," if you want them horizontally (anybody?)
+            if ( i > 0 )
+                text = sep + text; // any but top note
+            if (typeof notes[i].tpc === "undefined") // like for grace notes ?!?
+                return;
+            switch (notes[i].tpc) {
+                case -1: text = qsTranslate("InspectorAmbitus", "F♭♭") + text; break;
+                case  0: text = qsTranslate("InspectorAmbitus", "C♭♭") + text; break;
+                case  1: text = qsTranslate("InspectorAmbitus", "G♭♭") + text; break;
+                case  2: text = qsTranslate("InspectorAmbitus", "D♭♭") + text; break;
+                case  3: text = qsTranslate("InspectorAmbitus", "A♭♭") + text; break;
+                case  4: text = qsTranslate("InspectorAmbitus", "E♭♭") + text; break;
+                case  5: text = qsTranslate("InspectorAmbitus", "B♭♭") + text; break;
+                case  6: text = qsTranslate("InspectorAmbitus", "F♭")  + text; break;
+                case  7: text = qsTranslate("InspectorAmbitus", "C♭")  + text; break;
+
+                case  8: text = qsTranslate("InspectorAmbitus", "G♭")  + text; break;
+                case  9: text = qsTranslate("InspectorAmbitus", "D♭")  + text; break;
+                case 10: text = qsTranslate("InspectorAmbitus", "A♭")  + text; break;
+                case 11: text = qsTranslate("InspectorAmbitus", "E♭")  + text; break;
+                case 12: text = qsTranslate("InspectorAmbitus", "B♭")  + text; break;
+                case 13: text = qsTranslate("InspectorAmbitus", "F")   + text; break;
+                case 14: text = qsTranslate("InspectorAmbitus", "C")   + text; break;
+                case 15: text = qsTranslate("InspectorAmbitus", "G")   + text; break;
+                case 16: text = qsTranslate("InspectorAmbitus", "D")   + text; break;
+                case 17: text = qsTranslate("InspectorAmbitus", "A")   + text; break;
+                case 18: text = qsTranslate("InspectorAmbitus", "E")   + text; break;
+                case 19: text = qsTranslate("InspectorAmbitus", "B")   + text; break;
+
+                case 20: text = qsTranslate("InspectorAmbitus", "F♯")  + text; break;
+                case 21: text = qsTranslate("InspectorAmbitus", "C♯")  + text; break;
+                case 22: text = qsTranslate("InspectorAmbitus", "G♯")  + text; break;
+                case 23: text = qsTranslate("InspectorAmbitus", "D♯")  + text; break;
+                case 24: text = qsTranslate("InspectorAmbitus", "A♯")  + text; break;
+                case 25: text = qsTranslate("InspectorAmbitus", "E♯")  + text; break;
+                case 26: text = qsTranslate("InspectorAmbitus", "B♯")  + text; break;
+                case 27: text = qsTranslate("InspectorAmbitus", "F♯♯") + text; break;
+                case 28: text = qsTranslate("InspectorAmbitus", "C♯♯") + text; break;
+                case 29: text = qsTranslate("InspectorAmbitus", "G♯♯") + text; break;
+                case 30: text = qsTranslate("InspectorAmbitus", "D♯♯") + text; break;
+                case 31: text = qsTranslate("InspectorAmbitus", "A♯♯") + text; break;
+                case 32: text = qsTranslate("InspectorAmbitus", "E♯♯") + text; break;
+                case 33: text = qsTranslate("InspectorAmbitus", "B♯♯") + text; break;
+                default: text = qsTr("?")   + text; break;
+            } // end switch tpc
+
+            // octave, middle C being C4
+            //text += (Math.floor(notes[i].pitch / 12) - 1)
+            // or
+            //text += (Math.floor(notes[i].ppitch / 12) - 1)
+
+            // change below false to true for courtesy- and microtonal accidentals
+            // you might need to come up with suitable translations
+            // only #, b, natural and possibly also ## seem to be available in UNICODE
+            if (false) {
+                switch (notes[i].userAccidental) {
+                    case  0: break;
+                    case  1: text = qsTranslate("accidental", "Sharp") + text; break;
+                    case  2: text = qsTranslate("accidental", "Flat") + text; break;
+                    case  3: text = qsTranslate("accidental", "Double sharp") + text; break;
+                    case  4: text = qsTranslate("accidental", "Double flat") + text; break;
+                    case  5: text = qsTranslate("accidental", "Natural") + text; break;
+                    case  6: text = qsTranslate("accidental", "Flat-slash") + text; break;
+                    case  7: text = qsTranslate("accidental", "Flat-slash2") + text; break;
+                    case  8: text = qsTranslate("accidental", "Mirrored-flat2") + text; break;
+                    case  9: text = qsTranslate("accidental", "Mirrored-flat") + text; break;
+                    case 10: text = qsTranslate("accidental", "Mirrored-flat-slash") + text; break;
+                    case 11: text = qsTranslate("accidental", "Flat-flat-slash") + text; break;
+                    case 12: text = qsTranslate("accidental", "Sharp-slash") + text; break;
+                    case 13: text = qsTranslate("accidental", "Sharp-slash2") + text; break;
+                    case 14: text = qsTranslate("accidental", "Sharp-slash3") + text; break;
+                    case 15: text = qsTranslate("accidental", "Sharp-slash4") + text; break;
+                    case 16: text = qsTranslate("accidental", "Sharp arrow up") + text; break;
+                    case 17: text = qsTranslate("accidental", "Sharp arrow down") + text; break;
+                    case 18: text = qsTranslate("accidental", "Sharp arrow both") + text; break;
+                    case 19: text = qsTranslate("accidental", "Flat arrow up") + text; break;
+                    case 20: text = qsTranslate("accidental", "Flat arrow down") + text; break;
+                    case 21: text = qsTranslate("accidental", "Flat arrow both") + text; break;
+                    case 22: text = qsTranslate("accidental", "Natural arrow down") + text; break;
+                    case 23: text = qsTranslate("accidental", "Natural arrow up") + text; break;
+                    case 24: text = qsTranslate("accidental", "Natural arrow both") + text; break;
+                    case 25: text = qsTranslate("accidental", "Sori") + text; break;
+                    case 26: text = qsTranslate("accidental", "Koron") + text; break;
+                    default: text = qsTr("?") + text; break;
+                }  // end switch userAccidental
+            }  // end if courtesy- and microtonal accidentals
+        }  // end for note
+
+        return text;
+    }
+
+    function getGraceNoteNames(graceChordsList) {
+        var names = [];
+        // iterate through all grace chords
+        for (var chordNum = 0; chordNum < graceChordsList.length; chordNum++) {
+            var chord = graceChordsList[chordNum];
+            var chordName = getChordName(chord);
+            // append the name to the list of names
+            names.push(chordName);
+
+        }
+        return names;
+    }
+
+    function getAllChords(el) {
+        // List chords in the following order:
+        // 1) Leading grace notes;
+        // 2) Chord itself;
+        // 3) Trailing grace notes.
+
+        if (!el || el.type != Element.CHORD)
+            return [];
+
+        var chord = el;
+        var allChords = [ chord ];
+
+        // Search for grace notes
+        var graceChords = chord.graceNotes;
+        for (var chordNum = 0; chordNum < graceChords.length; chordNum++) {
+            var graceChord = graceChords[chordNum];
+            var noteType = graceChord.noteType;
+
+            switch (noteType) {
+                case NoteType.GRACE8_AFTER:
+                case NoteType.GRACE16_AFTER:
+                case NoteType.GRACE32_AFTER:
+                    leadingLifo.push(graceChord); // append trailing grace chord to list
+                    break;
+                default:
+                    allChords.unshift(graceChord); // prepend leading grace chord to list
+                    break;
+            }
+        }
+
+        return allChords;
+    }
+
+    function isNoteName(el) {
+        return el.type == Element.STAFF_TEXT; // TODO: how to distinguish note names from all staff texts?
+    }
+
+    function getExistingNoteNames(segment, track) {
+        var annotations = segment.annotations;
+        var noteNames = [];
+
+        for (var i = 0; i < annotations.length; ++i) {
+            var a = annotations[i];
+            if (a.track != track)
+                continue;
+            if (isNoteName(a))
+                noteNames.push(a);
+        }
+
+        return noteNames;
+    }
+
+    function handleChordAtCursor(cursor) {
+        var allNoteNames = getExistingNoteNames(cursor.segment, cursor.track);
+        var allChords = getAllChords(cursor.element);
+        var chordIdx = 0;
+
+        for (; chordIdx < allChords.length; ++chordIdx) {
+            var chord = allChords[chordIdx];
+            var noteName = allNoteNames[chordIdx];
+
+            var chordProperties = {
+                "offsetX": chord.posX,
+                "fontSize" : chord.noteType == NoteType.NORMAL ? defaultFontSize : (defaultFontSize * fontSizeMini),
+                "placement": (chord.voice & 1) ? Placement.BELOW : Placement.ABOVE, // place below for voice 1 and voice 3 (numbered as 2 and 4 in user interface)
+                "text": getChordName(chord)
+            }
+
+            if (!noteName) {
+                // Note name does not exist, add a new one
+                ensureCmdStarted();
+                var nameText = newElement(Element.STAFF_TEXT);
+                for (var prop in chordProperties) {
+                    if (nameText[prop] != chordProperties[prop])
+                        nameText[prop] = chordProperties[prop];
+                }
+                cursor.add(nameText);
+            } else {
+                // Note name exists, ensure it is up to date
+                for (var prop in chordProperties) {
+                    if (noteName[prop] != chordProperties[prop]) {
+                        ensureCmdStarted();
+                        noteName[prop] = chordProperties[prop];
+                    }
+                }
+            } // end if/else noteName
+        } // end for allChords
+
+        // Remove the remaining redundant note names, if any
+        for (; chordIdx < allNoteNames.length; ++chordIdx) {
+            ensureCmdStarted();
+            var noteName = allNoteNames[chordIdx];
+            removeElement(noteName);
+        }
+    } // end handleChordAtCursor()
+
+    function processRange(startTick, endTick, firstStaff, lastStaff) {
+        if (startTick < 0)
+            startTick = 0;
+        if (endTick < 0)
+            endTick = Infinity; // process the entire score
+
+        var cursor = curScore.newCursor();
+
+        for (var staff = firstStaff; staff <= lastStaff; staff++) {
+            for (var voice = 0; voice < 4; voice++) {
+                cursor.voice    = voice;
+                cursor.staffIdx = staff;
+                cursor.rewindToTick(startTick);
+
+                while (cursor.segment && cursor.tick <= endTick) {
+                    handleChordAtCursor(cursor);
+                    cursor.next();
+                } // end while segment
+
+            } // end for voice
+        } // end for staff
+
+        ensureCmdEnded();
+    }
+
+    function getStavesRange() {
+        if (allStavesCheckBox.checked)
+            return [0, curScore.nstaves];
+
+        var firstStaff = firstStaffInput.acceptableInput ? +firstStaffInput.text : curScore.nstaves;
+        var lastStaff = lastStaffInput.acceptableInput ? +lastStaffInput.text : -1;
+
+        return [firstStaff, lastStaff];
+    }
+
+    onScoreStateChanged: {
+        if (inCmd) // prevent recursion from own changes
+            return;
+        if (state.undoRedo) // try not to interfere with undo/redo commands
+            return;
+
+        nstaves = curScore.nstaves; // needed for validators in staff number inputs
+
+        if (!noteNamesEnabledCheckBox.checked)
+            return;
+        if (!curScore || state.startLayoutTick < 0) // nothing to process?
+            return;
+
+        var stavesRange = getStavesRange();
+
+        processRange(state.startLayoutTick, state.endLayoutTick, stavesRange[0], stavesRange[1]);
+    }
+
+    onRun: {
+        defaultFontSize = newElement(Element.STAFF_TEXT).fontSize;
+    }
+
+    Column {
+        id: controls
+
+        CheckBox {
+            id: noteNamesEnabledCheckBox
+            text: "Enable notes naming"
+        }
+        CheckBox {
+            id: allStavesCheckBox
+            checked: true
+            text: "All staves"
+        }
+
+        Grid {
+            id: staffRangeControls
+            columns: 2
+            spacing: 4
+            enabled: !allStavesCheckBox.checked
+
+            Text {
+                height: firstStaffInput.height
+                verticalAlignment: Text.AlignVCenter
+                text: "first staff:"
+            }
+            TextField {
+                id: firstStaffInput
+                text: "0"
+                validator: IntValidator { bottom: 0; top: nstaves - 1 }
+                onTextChanged: {
+                    if (+lastStaffInput.text < +text)
+                        lastStaffInput.text = text
+                }
+            }
+
+            Text {
+                height: lastStaffInput.height
+                verticalAlignment: Text.AlignVCenter
+                text: "last staff:"
+            }
+            TextField {
+                id: lastStaffInput
+                text: "0"
+                validator: IntValidator { bottom: 0; top: nstaves - 1 }
+                onTextChanged: {
+                    if (text !== "" && (+firstStaffInput.text > +text))
+                        firstStaffInput.text = text
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR implements changes in Cursor API which could be useful for interactive plugins functioning. The most important of the proposed changes is to allow plugins explicitly choose whether Cursor actions (changing its position, adding notes) should influence score input state. It is proposed to make it independent of score input state by default while still offering an option of full synchronization of Cursor state with score input state (which hasn't been possible before). This should allow plugins to make use of `onScoreStateChanged` handler to modify score editing process while not breaking note input cursor behavior and even potentially co-existing with other plugins which might use Cursor in either mode as well (see this discussion for a possible example: https://github.com/dmitrio95/fretboard-plugin/pull/1).

Other changes are less important but could still be useful:
- include convenience API for rewinding cursor to a particular tick (otherwise plugins would just implement the logic similar to `Score::tick2segment()`);
- ensure that `endCmd()` does always get called once on undo/redo actions to make sure that plugins are always properly notified of undo/redo changes. This may be useful to prevent unwanted plugin-originated changes on undo/redo actions.
- add `Cursor.stringNumber` property for better integration with tablature note input.

This PR also contains an interactive version of Note Names plugin to demonstrate some basic usage of this framework. I planned to create it after #5626, but it turned out to be problematic to create something fully usable before decoupling Cursor state from input state in Score. Other changes in this PR also make implementation of this plugin simpler. 