### PR TITLE
fix #300347: capital "L" cannot be entered in text

### DIFF
--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -919,7 +919,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::SCORE_TAB,
-         STATE_NORMAL | STATE_TEXT_EDIT | STATE_HARMONY_FIGBASS_EDIT,
+         STATE_NORMAL,
          "get-location",
          QT_TRANSLATE_NOOP("action","Get Location"),
          QT_TRANSLATE_NOOP("action","Accessibility: Get location"),


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/300347

When I added the "accessibility: get-location" command,
I made it active during text entry.
Not good if the default shortcut is a simple letter.
This PR sets the context to normal mode only.

Might be possible to create test?  Not really sure, but this is emergency fix...