### PR TITLE
fix #281503 : enable compilation with make on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,7 +269,11 @@ if (NOT MSVC)
 endif (NOT MSVC)
 
 if (APPLE)
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC -stdlib=libc++ -Wno-inconsistent-missing-override -Wno-deprecated-register")
+   if (XCODE)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC -stdlib=libc++ -Wno-inconsistent-missing-override -Wno-deprecated-register")
+   else (XCODE)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -fPIC -stdlib=libc++ -Wno-inconsistent-missing-override -Wno-deprecated-register")
+   endif (XCODE)
    # This is necessary for genManual to be executed during the build phase,
    # it needs to be able to get the Qt libs.
    # TODO: is it still needed? genManual is removed.
@@ -845,12 +849,12 @@ if (BUILD_CRASH_REPORTER)
 endif (BUILD_CRASH_REPORTER)
 
 string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE)
-if (APPLE AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
+if (XCODE AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
 # With xcode, we need to have all the targets in the same project
 add_subdirectory(mtest)
-else(APPLE AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
+else(XCODE AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
 add_subdirectory(mtest EXCLUDE_FROM_ALL)
-endif(APPLE AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
+endif(XCODE AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
 
 add_subdirectory(rdoc EXCLUDE_FROM_ALL)
 add_subdirectory(miditools EXCLUDE_FROM_ALL)

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -23,7 +23,7 @@ PREFIX=../applebuild
 TELEMETRY_TRACK_ID=""
 MUSESCORE_BUILD_CONFIG="dev"
 MUSESCORE_REVISION=""
-
+CPUS = `sysctl -n hw.logicalcpu`
 XCODEPROJ = mscore.xcodeproj
 
 # Use xcpretty if installed
@@ -105,3 +105,38 @@ clean:
 	-rm -rf build.release build.debug build.xcode
 	-rm -rf applebuild
 
+release-cl:
+	@echo "Make release"; \
+    mkdir build.release; \
+    cd build.release; \
+    cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+          -DCMAKE_BUILD_TYPE=RELEASE \
+          -DCMAKE_BUILD_NUMBER="${BUILD_NUMBER}" \
+          -DMUSESCORE_BUILD_CONFIG="${MUSESCORE_BUILD_CONFIG}" \
+          -DMUSESCORE_REVISION="${MUSESCORE_REVISION}" \
+          -DTELEMETRY_TRACK_ID="${TELEMETRY_TRACK_ID}" \
+          -DBUILD_PCH="ON"  \
+          .. -G "Unix Makefiles"; \
+    make lrelease; \
+    $(FORMATTER_START) make -j ${CPUS} $(FORMATTER_END); \
+
+debug-cl:
+	mkdir build.debug; \
+    cd build.debug; \
+    cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+          -DCMAKE_BUILD_TYPE=DEBUG \
+          -DCMAKE_BUILD_NUMBER="${BUILD_NUMBER}" \
+          -DMUSESCORE_BUILD_CONFIG="${MUSESCORE_BUILD_CONFIG}" \
+          -DMUSESCORE_REVISION="${MUSESCORE_REVISION}" \
+          -DBUILD_PCH="ON" \
+          .. -G "Unix Makefiles"; \
+    make lrelease; \
+    $(FORMATTER_START) make -j ${CPUS} $(FORMATTER_END); \
+
+install-cl:
+	cd build.release;   \
+	$(FORMATTER_START) make install $(FORMATTER_END);
+
+installdebug-cl:
+	cd build.debug; \
+	$(FORMATTER_START) make install $(FORMATTER_END);

--- a/build/CreatePrecompiledHeader.cmake
+++ b/build/CreatePrecompiledHeader.cmake
@@ -5,10 +5,21 @@ macro( precompiled_header includes header_name build_pch)
         string( TOUPPER "CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}" flags_for_build_name )
         set( compile_flags "${CMAKE_CXX_FLAGS} ${${flags_for_build_name}}" )
 
-        # Add all the Qt include directories
-        foreach( item ${${includes}} )
-            list( APPEND compile_flags "-I${item}" )
-        endforeach()
+        if (APPLE)
+            # Add the Qt lib folder to the search path for framework include files
+            list( APPEND compile_flags "-F${QT_INSTALL_LIBS}" )
+            # Add only the right directories to the include search path
+            foreach( item ${${includes}} )
+                if (NOT "${item}" MATCHES "framework$")
+                    list( APPEND compile_flags "-I${item}" )
+                endif (NOT "${item}" MATCHES "framework$")
+            endforeach()
+        else (APPLE)
+            # Add all the Qt include directories
+            foreach( item ${${includes}} )
+                list( APPEND compile_flags "-I${item}" )
+            endforeach()
+        endif (APPLE)
 
         # Get the list of all build-independent preprocessor definitions
         get_directory_property( defines_global COMPILE_DEFINITIONS )
@@ -25,6 +36,10 @@ macro( precompiled_header includes header_name build_pch)
         endforeach()
 
         list( APPEND compile_flags ${all_define_flags} )
+
+        if (APPLE)
+            list( APPEND compile_flags "-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+        endif (APPLE)
 
         # Prepare the compile flags var for passing to GCC
         separate_arguments( compile_flags )

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -133,10 +133,19 @@ endif (OMR)
 
 if (APPLE)
       file(GLOB_RECURSE INCS "*.h")
-      set(COCOABRIDGE "macos/cocoabridge.mm")
+      set(COCOABRIDGE "cocoabridge")
       if (SPARKLE_FOUND)
             set(MAC_SPARKLE_FILES "macos/SparkleAutoUpdater.mm")
       endif(SPARKLE_FOUND)
+      add_library (
+         cocoabridge STATIC
+         macos/cocoabridge.mm
+         )
+      set_target_properties (
+         cocoabridge
+         PROPERTIES
+         COMPILE_FLAGS "-g -Wall -Wextra -Winvalid-pch  -include ${PROJECT_SOURCE_DIR}/all.h"
+         )
 else (APPLE)
       set(INCS "")
       set(COCOABRIDGE "")
@@ -261,7 +270,6 @@ add_library(mscoreapp STATIC
       ${MSCORE_MIXER_SRC}
       ${PIANOROLL_SRC}
       ${WIDGETS_SOURCE_FILES}
-      ${COCOABRIDGE}
       ${OMR_FILES}
       ${PLUGIN_SRC}
       ${MAC_SPARKLE_FILES}
@@ -284,6 +292,7 @@ target_link_libraries(mscoreapp
       libmscore
       qzip
       importexport
+      ${COCOABRIDGE}
       )
 
 if (BUILD_CRASH_REPORTER)


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/281503
This PR enables compilation of MuseScore under MacOS without installing the full XCode IDE, but only the command line tools.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ N/A ] I created the test (mtest, vtest, script test) to verify the changes I made
