### PR TITLE
fix #287998 and #102676 : Courtesy time signature not removed when subsequent measures are deleted

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3306,9 +3306,7 @@ System* Score::collectSystem(LayoutContext& lc)
                         }
 
                   m->createEndBarLines(true);
-                  Measure* nm = m->nextMeasure();
-                  if (nm)
-                        m->addSystemTrailer(nm);
+                  m->addSystemTrailer(m->nextMeasure());
                   m->computeMinWidth();
                   ww = m->width();
                   }

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3967,7 +3967,7 @@ void Measure::addSystemTrailer(Measure* nm)
       TimeSig* ts = nullptr;
       bool showCourtesySig = false;
       Segment* s = findSegmentR(SegmentType::TimeSigAnnounce, _rtick);
-      if (score()->genCourtesyTimesig() && !isFinalMeasure && !score()->floatMode()) {
+      if (nm && score()->genCourtesyTimesig() && !isFinalMeasure && !score()->floatMode()) {
             Segment* tss = nm->findSegmentR(SegmentType::TimeSig, Fraction(0,1));
             if (tss) {
                   int nstaves = score()->nstaves();
@@ -4055,7 +4055,7 @@ void Measure::addSystemTrailer(Measure* nm)
                   Clef* clef = toClef(clefSegment->element(track));
                   if (clef) {
                         clef->setSmall(true);
-                        if (!score()->genCourtesyClef() || isFinalMeasure || !clef->showCourtesy())
+                        if (!nm || !score()->genCourtesyClef() || isFinalMeasure || !clef->showCourtesy())
                               clef->clear();          // make invisible
                         }
                   }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/287998
Resolves: https://musescore.org/en/node/102676

When a measure contains a line or page break **and** the next measure contains a key/time
signature or clef change, a courtesy element is drawn at the end of the measure.
However, if all measures **after** the line or page break are deleted, these courtesy
elements are not removed because Measure::addSystemTrailer(Measure*) is never called
in Score::collectSystem(LayoutContext&) since there is no next measure. As a result
these courtesy elements are not disabled by Measure::addSystemTrailer(Measure*).
The solution is to call Measure::addSystemTrailer(Measure*) even when nm equals 0 and
Measure::addSystemTrailer(Measure*) will disable all courtesy elements in case nm equals 0.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
