### PR TITLE
Notify PR authors when merge conflicts arise

### DIFF
--- a/.github/workflows/label_merge_conflicts.yml
+++ b/.github/workflows/label_merge_conflicts.yml
@@ -1,0 +1,16 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Marr11317/ConflictAdviser@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          conflict_label: "merge conflicts"
+          comment: 'Rebase needed'


### PR DESCRIPTION
Edit:
The bot does three things: 
1. When merge conflicts appear, it adds the 'merge conflicts' label if it wasn't there before.
2. The same way, it adds a comment:  'Rebase needed'
3. It checks if PRs with the 'merge conflict' are now mergeable. If so, it removes the label.

Limitations:
- There seems to be no way to subscribe to force-push events, which means that when someone rebases and force pushes, this PR will still have the 'merge conflicts' label until the bot is run. The bot runs whenever: 
    - a PR is opened, re-opened, or new commits are added, 
    - new commits are pushed to the master branch.

Maintainers: when merging this commit to master, the label "Merge conflict" has to be added or the action will fail.

Source: https://github.com/marketplace/actions/auto-label-merge-conflicts