### PR TITLE
fix #297176: prevent scrolling on non-focussed spinboxes and comboboxes

### DIFF
--- a/mscore/inspector/inspectorBase.h
+++ b/mscore/inspector/inspectorBase.h
@@ -20,6 +20,7 @@ namespace Ms {
 
 class Inspector;
 class Element;
+class InspectorScrollPreventer;
 
 //---------------------------------------------------------
 //   InspectorPanel
@@ -53,6 +54,7 @@ class InspectorBase : public QWidget {
       void checkDifferentValues(const InspectorItem&);
       bool compareValues(const InspectorItem& ii, QVariant a, QVariant b);
       Element* effectiveElement(const InspectorItem&) const;
+      InspectorScrollPreventer* scrollPreventer;
 
    signals:
       void elementChanged();
@@ -85,6 +87,20 @@ class InspectorBase : public QWidget {
       QWidget* addWidget();
 
       friend class InspectorScriptEntry;
+      };
+
+//---------------------------------------------------------
+//   InspectorScrollPreventer
+//---------------------------------------------------------
+
+class InspectorScrollPreventer : public QObject {
+      Q_OBJECT
+
+   protected:
+      bool eventFilter(QObject* watched, QEvent* event) override;
+
+   public:
+      InspectorScrollPreventer(QObject* parent) : QObject(parent) {};
       };
 
 //---------------------------------------------------------

--- a/mscore/inspector/offsetSelect.cpp
+++ b/mscore/inspector/offsetSelect.cpp
@@ -14,6 +14,7 @@
 #include "libmscore/types.h"
 #include "icons.h"
 #include "musescore.h"
+#include "inspectorBase.h"
 
 namespace Ms {
 
@@ -102,6 +103,12 @@ void OffsetSelect::setOffset(const QPointF& o)
       xVal->setValue(o.x());
       yVal->setValue(o.y());
       blockOffset(false);
+      }
+
+void OffsetSelect::installScrollPreventer(InspectorScrollPreventer* sp)
+      {
+      xVal->installEventFilter(sp);
+      yVal->installEventFilter(sp);
       }
 
 }

--- a/mscore/inspector/offsetSelect.h
+++ b/mscore/inspector/offsetSelect.h
@@ -17,6 +17,8 @@
 
 namespace Ms {
 
+class InspectorScrollPreventer;
+
 //---------------------------------------------------------
 //   OffsetSelect
 //---------------------------------------------------------
@@ -38,6 +40,7 @@ class OffsetSelect : public QWidget, public Ui::OffsetSelect {
       QPointF offset() const;
       void setOffset(const QPointF&);
       void showRaster(bool);
+      void installScrollPreventer(InspectorScrollPreventer* sp);
       };
 
 }

--- a/mscore/inspector/offset_select.ui
+++ b/mscore/inspector/offset_select.ui
@@ -33,6 +33,9 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
      <property name="accessibleName">
       <string>Horizontal offset</string>
      </property>
@@ -74,6 +77,9 @@
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
      </property>
      <property name="accessibleName">
       <string>Vertical offset</string>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/297176

This adds an event filter to all spinboxes and comboboxes in the inspector, which catches scroll events when not focussed, and prevents them from being passed further along. This requires setting the Qt::StrongFocus policy on each of these widgets.