### PR TITLE
fix #104731 - Text lost when musicXML file imported

### DIFF
--- a/mscore/importmxmlpass1.h
+++ b/mscore/importmxmlpass1.h
@@ -121,15 +121,16 @@ public:
       void scorePartwise();
       void identification();
       void credit(CreditWordsList& credits);
-      void defaults(int& pageWidth, int& pageHeight);
-      void pageLayout(PageFormat& pf, const qreal conversion, int& pageWidth, int& pageHeight);
+      void defaults();
+      void pageLayout(PageFormat& pf, const qreal conversion);
       void partList(MusicXmlPartGroupList& partGroupList);
       void partGroup(const int scoreParts, MusicXmlPartGroupList& partGroupList, MusicXmlPartGroupMap& partGroups);
       void scorePart();
       void scoreInstrument(const QString& partId);
       void midiInstrument(const QString& partId);
       void part();
-      void measure(const QString& partId, const Fraction cTime, Fraction& mdur, VoiceOverlapDetector& vod);
+      void measure(const QString& partId, const Fraction cTime, Fraction& mdur, VoiceOverlapDetector& vod, const int measureNr);
+      void print(const int measureNr);
       void attributes(const QString& partId, const Fraction cTime);
       void clef(const QString& partId);
       void time(const Fraction cTime);
@@ -161,6 +162,7 @@ public:
       MusicXmlInstrList getInstrList(const QString id) const;
       Fraction getMeasureStart(const int i) const;
       int octaveShift(const QString& id, const int staff, const Fraction f) const;
+      const CreditWordsList& credits() const { return _credits; }
 
 private:
       // functions
@@ -170,8 +172,11 @@ private:
       QXmlStreamReader _e;
       int _divs;                                ///< Current MusicXML divisions value
       QMap<QString, MusicXmlPart> _parts;       ///< Parts data, mapped on part id
+      std::set<int> _systemStartMeasureNrs;     ///< Measure numbers of measures starting a page
+      std::set<int> _pageStartMeasureNrs;       ///< Measure numbers of measures starting a page
       QVector<Fraction> _measureLength;         ///< Length of each measure
       QVector<Fraction> _measureStart;          ///< Start time of each measure
+      CreditWordsList _credits;                 ///< All credits collected
       PartMap _partMap;                         ///< TODO merge into MusicXmlPart ??
       QMap<QString, MusicXMLDrumset> _drumsets; ///< Drumset for each part, mapped on part id
       Score* _score;                            ///< MuseScore score
@@ -182,6 +187,7 @@ private:
       QMap<int, MxmlOctaveShiftDesc> _octaveShifts; ///< Pending octave-shifts
       Fraction _firstInstrSTime;                ///< First instrument start time
       QString _firstInstrId;                    ///< First instrument id
+      QSize _pageSize;                          ///< Page width read from defaults
       };
 
 } // namespace Ms

--- a/mscore/importmxmlpass2.cpp
+++ b/mscore/importmxmlpass2.cpp
@@ -2002,7 +2002,7 @@ void MusicXMLParserPass2::measure(const QString& partId,
             else if (_e.name() == "barline")
                   barline(partId, measure, time + mTime);
             else if (_e.name() == "print")
-                  print(measure);
+                  _e.skipCurrentElement();
             else
                   skipLogCurrElem();
 
@@ -2252,51 +2252,6 @@ void MusicXMLParserPass2::measureStyle(Measure* measure)
                   }
             else
                   skipLogCurrElem();
-            }
-      }
-
-
-//---------------------------------------------------------
-//   print
-//---------------------------------------------------------
-
-/**
- Parse the /score-partwise/part/measure/print node.
- */
-
-void MusicXMLParserPass2::print(Measure* measure)
-      {
-      Q_ASSERT(_e.isStartElement() && _e.name() == "print");
-
-      bool newSystem = _e.attributes().value("new-system") == "yes";
-      bool newPage   = _e.attributes().value("new-page") == "yes";
-      int blankPage = _e.attributes().value("blank-page").toInt();
-      //
-      // in MScore the break happens _after_ the marked measure:
-      //
-      MeasureBase* pm = measure->prevMeasure();        // We insert VBox only for title, no HBox for the moment
-      if (pm == 0) {
-            _logger->logDebugInfo("break on first measure", &_e);
-            if (blankPage == 1) {       // blank title page, insert a VBOX if needed
-                  pm = measure->prev();
-                  if (pm == 0) {
-                        _score->insertMeasure(ElementType::VBOX, measure);
-                        pm = measure->prev();
-                        }
-                  }
-            }
-      if (pm) {
-            if (preferences.getBool(PREF_IMPORT_MUSICXML_IMPORTBREAKS) && (newSystem || newPage)) {
-                  if (!pm->lineBreak() && !pm->pageBreak()) {
-                        LayoutBreak* lb = new LayoutBreak(_score);
-                        lb->setLayoutBreakType(newSystem ? LayoutBreak::Type::LINE : LayoutBreak::Type::PAGE);
-                        pm->add(lb);
-                        }
-                  }
-            }
-
-      while (_e.readNextStartElement()) {
-            skipLogCurrElem();
             }
       }
 

--- a/mscore/importmxmlpass2.h
+++ b/mscore/importmxmlpass2.h
@@ -251,7 +251,6 @@ private:
       void measure(const QString& partId, const Fraction time);
       void attributes(const QString& partId, Measure* measure, const Fraction& tick);
       void measureStyle(Measure* measure);
-      void print(Measure* measure);
       void barline(const QString& partId, Measure* measure, const Fraction& tick);
       void key(const QString& partId, Measure* measure, const Fraction& tick);
       void clef(const QString& partId, Measure* measure, const Fraction& tick);

--- a/mscore/musicxml.h
+++ b/mscore/musicxml.h
@@ -55,14 +55,16 @@ const int MAX_NUMBER_LEVEL = 6; // maximum number of overlapping MusicXML object
 //---------------------------------------------------------
 
 struct CreditWords {
+      int page;
       double defaultX;
       double defaultY;
       QString justify;
       QString hAlign;
       QString vAlign;
       QString words;
-      CreditWords(double a, double b, QString c, QString d, QString e, QString f)
+      CreditWords(int p, double a, double b, QString c, QString d, QString e, QString f)
             {
+            page = p;
             defaultX = a;
             defaultY = b;
             justify  = c;

--- a/mtest/musicxml/io/Page_break_in_vbox.xml
+++ b/mtest/musicxml/io/Page_break_in_vbox.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>Title</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Composer</creator>
+    <creator type="lyricist">Lyricist</creator>
+    <rights>Copyright</rights>
+    <encoding>
+      <software>MuseScore 3.4.0</software>
+      <encoding-date>2020-01-24</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.05556</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1683.36</page-height>
+      <page-width>1190.88</page-width>
+      <page-margins type="even">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <word-font font-family="FreeSerif" font-size="10"/>
+    <lyric-font font-family="FreeSerif" font-size="11"/>
+    </defaults>
+  <credit page="1">
+    <credit-words default-x="595.44" default-y="1626.67" justify="center" valign="top" font-size="24">Title</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="595.44" default-y="1569.97" justify="center" valign="top" font-size="14">Subtitle</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="1134.19" default-y="1526.67" justify="right" valign="bottom" font-size="12">Composer</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="56.6929" default-y="1526.67" justify="left" valign="bottom" font-size="12">Lyricist</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="59" default-y="67" valign="top" font-size="12">Bottom vbox page 1</credit-words>
+    </credit>
+  <credit page="2">
+    <credit-words default-x="59" default-y="1626" valign="top" font-size="12">Top vbox page 2</credit-words>
+    </credit>
+  <credit page="2">
+    <credit-words default-x="59" default-y="67" valign="top" font-size="12">Bottom vbox page 2</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Voice</part-name>
+      <part-abbreviation>Vo.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Voice</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>53</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="1077.49">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>0.00</left-margin>
+            <right-margin>0.00</right-margin>
+            </system-margins>
+          <top-system-distance>170.00</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2" width="1077.49">
+      <print new-system="yes"/>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="3" width="1077.49">
+      <print new-page="yes"/>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="4" width="1077.49">
+      <print new-system="yes"/>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/mtest/musicxml/io/TODO
+++ b/mtest/musicxml/io/TODO
@@ -1,3 +1,6 @@
+2.2.2020 lv
+      Convert files Page*.xml and Title*.xml into regular testfiles.
+      Note: depends on fixing MusicXML export for the fetaures tested.
 6.2.2015 ws
       Test Wedge2 needs checking.
       A Hairpin() changes its tick length in checkSpanners().

--- a/mtest/musicxml/io/Title_page_double_at_start.xml
+++ b/mtest/musicxml/io/Title_page_double_at_start.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>Title page</work-title>
+    </work>
+  <identification>
+    <encoding>
+      <software>MuseScore 3.4.0</software>
+      <encoding-date>2020-02-02</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.05556</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1683.36</page-height>
+      <page-width>1190.88</page-width>
+      <page-margins type="even">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <word-font font-family="FreeSerif" font-size="10"/>
+    <lyric-font font-family="FreeSerif" font-size="11"/>
+    </defaults>
+  <credit page="1">
+    <credit-words default-x="595.44" default-y="1626.67" justify="center" valign="top" font-size="24">Title (double at start) page 1</credit-words>
+    </credit>
+  <credit page="2">
+    <credit-words default-x="595.44" default-y="1626.67" justify="center" valign="top" font-size="24">Title (double at start) page 2</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Voice</part-name>
+      <part-abbreviation>Vo.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Voice</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>53</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="239.74">
+      <print blank-page="2" new-page="yes">
+        <system-layout>
+          <system-margins>
+            <left-margin>0.00</left-margin>
+            <right-margin>837.76</right-margin>
+            </system-margins>
+          <top-system-distance>70.00</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/mtest/musicxml/io/Title_page_single_at_start.xml
+++ b/mtest/musicxml/io/Title_page_single_at_start.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>Title page</work-title>
+    </work>
+  <identification>
+    <encoding>
+      <software>MuseScore 3.4.0</software>
+      <encoding-date>2020-02-02</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.05556</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1683.36</page-height>
+      <page-width>1190.88</page-width>
+      <page-margins type="even">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <word-font font-family="FreeSerif" font-size="10"/>
+    <lyric-font font-family="FreeSerif" font-size="11"/>
+    </defaults>
+  <credit page="1">
+    <credit-words default-x="595.44" default-y="1626.67" justify="center" valign="top" font-size="24">Title page (single at start)</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Voice</part-name>
+      <part-abbreviation>Vo.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Voice</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>53</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="239.74">
+      <print blank-page="1" new-page="yes">
+        <system-layout>
+          <system-margins>
+            <left-margin>0.00</left-margin>
+            <right-margin>837.76</right-margin>
+            </system-margins>
+          <top-system-distance>70.00</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/mtest/musicxml/io/Title_page_single_in_between.xml
+++ b/mtest/musicxml/io/Title_page_single_in_between.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>Title page</work-title>
+    </work>
+  <identification>
+    <encoding>
+      <software>MuseScore 3.4.0</software>
+      <encoding-date>2020-02-02</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.05556</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1683.36</page-height>
+      <page-width>1190.88</page-width>
+      <page-margins type="even">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <word-font font-family="FreeSerif" font-size="10"/>
+    <lyric-font font-family="FreeSerif" font-size="11"/>
+    </defaults>
+  <credit page="1">
+    <credit-words default-x="595.44" default-y="1626.67" justify="center" valign="top" font-size="24">Title (in between) page 1</credit-words>
+    </credit>
+  <credit page="2">
+    <credit-words default-x="595.44" default-y="1626.67" justify="center" valign="top" font-size="24">Title page (in between) page 2</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Voice</part-name>
+      <part-abbreviation>Vo.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Voice</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>53</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="1077.49">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>0.00</left-margin>
+            <right-margin>0.00</right-margin>
+            </system-margins>
+          <top-system-distance>170.00</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2" width="197.55">
+      <print blank-page="1" new-page="yes"/>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/mtest/musicxml/io/iotest.mxmltomscx
+++ b/mtest/musicxml/io/iotest.mxmltomscx
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# simple standalone iotest for MusicXML import
+# run in mtest/musicxml/io directory as "./iotest.mscxtomxml"
+#
+# read a list of MusicXML files
+# one by one convert to MuseScore format and compare with reference
+
+# Linux
+#MSCORE=../../../build.debug/mscore/mscore
+# OS X terminal build
+#MSCORE=../../../applebuild/mscore.app/Contents/MacOS/mscore
+# OS X Xcode build
+#MSCORE=../../../build.xcode/mscore/Debug/mscore.app/Contents/MacOS/mscore
+# OS X Xcode build (since early 2020)
+MSCORE=../../../build.xcode/main/Debug/mscore.app/Contents/MacOS/mscore
+
+echo "----------------------------------------------"
+echo "Regression Tests for MuseScore MusicXML import"
+echo "----------------------------------------------"
+echo
+$MSCORE -v
+echo
+
+musicxml_files=`cat tst_mxml_to_mscx.txt`
+testcount=0
+failures=0
+
+rwtestXmlRef() {
+      echo -n "testing load/save $1";
+      REF=`basename $1 .xml`_ref.mscx
+      $MSCORE $1 -d -o mops.mscx &> /dev/null
+      if diff -q $REF mops.mscx &> /dev/null; then
+            echo -e "\r\t\t\t\t\t\t...OK";
+      else
+            echo -e "\r\t\t\t\t\t\t...FAILED";
+            failures=$(($failures+1));
+            echo "+++++++++DIFF++++++++++++++"
+            diff $REF mops.mscx
+            echo "+++++++++++++++++++++++++++"
+      fi
+      rm mops.mscx
+      testcount=$(($testcount+1))
+      }
+
+rwtestAllXml() {
+      for f in $musicxml_files; do
+            rwtestXmlRef ${f}.xml
+      done
+      }
+
+usage() {
+      echo "usage: $0"
+      echo
+      exit 1
+      }
+
+if [ $# -eq 0 ]; then
+      rwtestAllXml
+else
+      usage
+fi
+
+echo
+echo "$testcount test(s), $failures failure(s)"

--- a/mtest/musicxml/io/tst_mxml_to_mscx.txt
+++ b/mtest/musicxml/io/tst_mxml_to_mscx.txt
@@ -1,0 +1,4 @@
+Page_break_in_vbox
+Title_page_double_at_start
+Title_page_single_at_start
+Title_page_single_in_between


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/104731

Before this change, the MusicXML importer only tried to create a MuseScore style header from the credit-words found on the first page top half. Other credit-words were ignored, leading to information loss. This was especially obvious for imports from Sibelius (which tends to create a title footer instead of header, which was ignored) and for MusicXML files containing lyrics or other significant chunks of texts as credit-words.

After this change, all credit-words are imported from MusicMXL and placed in vertical frames at the top and bottom of the correct page.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made