### PR TITLE
fix #280343 - Repeat measure signs: not vertically-centred in tablature

### DIFF
--- a/libmscore/repeat.cpp
+++ b/libmscore/repeat.cpp
@@ -16,6 +16,7 @@
 #include "system.h"
 #include "measure.h"
 #include "mscore.h"
+#include "staff.h"
 
 namespace Ms {
 
@@ -48,14 +49,17 @@ void RepeatMeasure::layout()
       for (Element* e : el())
             e->layout();
 
-      rxpos() = 0.0;
+      Staff* st = staff();
+      qreal ld = st ? st->lineDistance(tick()) : 1.0;
       qreal sp  = spatium();
 
-      qreal y   = sp;
-      qreal w   = sp * 2.4;
-      qreal h   = sp * 2.0;
-      qreal lw  = sp * .50;  // line width
-      qreal r   = sp * .20;  // dot radius
+      qreal y   = sp * 1.0 * ld;
+      qreal w   = sp * 2.4 * ld;
+      qreal h   = sp * 2.0 * ld;
+      qreal lw  = sp * .50 * ld;  // line width
+      qreal r   = sp * .20 * ld;  // dot radius
+
+      setPos(0.0, (st ? (st->height() - h) / 2.0 : y) - y);
 
       path      = QPainterPath();
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/280343

Measure rest was drawn on fix y coordinate. Now the y coordinate is calculated
taking the staff height into account so it is always vertically centered.
Also the size of the symbol is sized depending on the staff line distance.

*Use "x" letter to fill the checkboxes below like [x]*

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n.a.] I created the test (mtest, vtest, script test) to verify the changes I made
