### PR TITLE
fix #291699 - Stems and beams for small chords don't align correctly

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -1780,7 +1780,7 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
                               crBase[i1] = bl;
                         }
 
-                  qreal stemWidth  = score()->styleP(Sid::stemWidth);
+                  qreal stemWidth  = toChord(cr1)->stem()->lineWidthMag();
                   qreal x2         = cr1->stemPosX() + cr1->pageX() - _pagePos.x();
                   qreal x3;
 
@@ -1797,7 +1797,7 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
                               if (cr1->up())
                                     x2 -= stemWidth;
                               if (!chordRest2->up())
-                                    x3 += stemWidth;
+                                    x3 += toChord(chordRest2)->stem()->lineWidthMag();
                               }
                         }
                   else {
@@ -1975,7 +1975,7 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
             Stem* stem = c->stem();
             if (stem) {
                   bool useTablature = staff() && staff()->isTabStaff(cr->tick());
-                  qreal sw2  = useTablature ? 0.f : stem->lineWidth() * .5;
+                  qreal sw2  = useTablature ? 0.f : stem->lineWidthMag() * .5;
                   if (c->up())
                         sw2 = -sw2;
                   stem->rxpos() = c->stemPosX() + sw2;

--- a/libmscore/stem.cpp
+++ b/libmscore/stem.cpp
@@ -112,7 +112,7 @@ void Stem::layout()
                   }
             }
 
-      qreal lw5 = _lineWidth * .5 * mag();
+      qreal lw5 = 0.5 * lineWidthMag();
 
       line.setLine(0.0, y1, 0.0, l);
 
@@ -155,7 +155,7 @@ void Stem::draw(QPainter* painter) const
       const StaffType* stt = st ? st->staffType(chord()->tick()) : 0;
       bool useTab          = stt && stt->isTabStaff();
 
-      painter->setPen(QPen(curColor(), _lineWidth * mag(), Qt::SolidLine, Qt::RoundCap));
+      painter->setPen(QPen(curColor(), lineWidthMag(), Qt::SolidLine, Qt::RoundCap));
       painter->drawLine(line);
 
       if (!(useTab && chord()))
@@ -397,7 +397,7 @@ QPointF Stem::hookPos() const
       {
       QPointF p(pos() + line.p2());
 
-      qreal xoff = _lineWidth * .5 * mag();
+      qreal xoff = 0.5 * lineWidthMag();
       p.rx() += xoff;
       return p;
       }

--- a/libmscore/stem.h
+++ b/libmscore/stem.h
@@ -63,6 +63,7 @@ class Stem final : public Element {
       void setUserLen(qreal l)        { _userLen = l; }
 
       qreal lineWidth() const         { return _lineWidth; }
+      qreal lineWidthMag() const      { return _lineWidth * mag(); }
       void setLineWidth(qreal w)      { _lineWidth = w; }
 
       void setLen(qreal l);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/291699

When calculating the length of the beams the width of the stems was neglected.
To support this calculation, a new method lineWidthMag() is the class Stem was
created, returning the scaled width of the stem.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n.a.] I created the test (mtest, vtest, script test) to verify the changes I made
