### PR TITLE
fix #300596: Highlight Palette-Search text upon issuing keyboard shor…

### DIFF
--- a/mscore/qml/palettes/PalettesWidgetHeader.qml
+++ b/mscore/qml/palettes/PalettesWidgetHeader.qml
@@ -127,6 +127,9 @@ Item {
 
     Connections {
         target: mscore
-        onPaletteSearchRequested: searchTextInput.forceActiveFocus()
+        onPaletteSearchRequested: {
+            searchTextInput.forceActiveFocus()
+            searchTextInput.selectAll()
+        }
     }
 }


### PR DESCRIPTION
Resolves Suggestion: https://musescore.org/en/node/300596

Merely copy/pasting the paragraph in that issue post:

After inquiring as to whether clearing palette search upon [palette search command] invocation seemed appropriate to others, the response lent toward adapting the default application behavior of selecting/highlighting search-text. This would prepare for new search entry, and if by the off-chance the user wanted to continue previous searching key, a right arrow would serve the purpose. It doesn't seem to be normal/default behavior to do this upon clicking.

The purpose therefore is to have a fresh search prepared upon issuing the command without having to press [CTRL+A] first or Backspaces or pressing the [[X] Clear] button on the palette itself. This saves -- albeit not much, but it all adds up -- time when using the palette search function extensively. 

Compiles fine of course, but didn't mtest. Shouldn't be a problem for Travis.

P.S., Selection isn't performed in the [on focus] code area because so far it seemed appropriate to leave the default mouse behavior alone. 