### PR TITLE
Improve autosave performance

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -177,14 +177,18 @@ void ChordRest::writeProperties(XmlWriter& xml) const
 
       for (Lyrics* lyrics : _lyrics)
             lyrics->write(xml);
+
+      const int curTick = xml.curTick().ticks();
+
       if (!isGrace()) {
             Fraction t(globalTicks());
             if (staff())
                   t /= staff()->timeStretch(xml.curTick());
             xml.incCurTick(t);
             }
-      for (auto i : score()->spanner()) {     // TODO: don’t search whole list
-            Spanner* s = i.second;
+
+      for (auto i : score()->spannerMap().findOverlapping(curTick - 1, curTick + 1)) {
+            Spanner* s = i.value;
             if (s->generated() || !s->isSlur() || toSlur(s)->broken() || !xml.canWrite(s))
                   continue;
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -789,7 +789,7 @@ class Score : public QObject, public ScoreElement {
 
       bool saveFile(QFileInfo& info);
       bool saveFile(QIODevice* f, bool msczFormat, bool onlySelection = false);
-      bool saveCompressedFile(QFileInfo&, bool onlySelection);
+      bool saveCompressedFile(QFileInfo&, bool onlySelection, bool createThumbnail = true);
       bool saveCompressedFile(QFileDevice*, QFileInfo&, bool onlySelection, bool createThumbnail = true);
 
       void print(QPainter* printer, int page);

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -486,7 +486,7 @@ bool MasterScore::saveFile()
 //   saveCompressedFile
 //---------------------------------------------------------
 
-bool Score::saveCompressedFile(QFileInfo& info, bool onlySelection)
+bool Score::saveCompressedFile(QFileInfo& info, bool onlySelection, bool createThumbnail)
       {
       if (readOnly() && info == *masterScore()->fileInfo())
             return false;
@@ -495,7 +495,7 @@ bool Score::saveCompressedFile(QFileInfo& info, bool onlySelection)
             MScore::lastError = tr("Open File\n%1\nfailed: %2").arg(info.filePath(), strerror(errno));
             return false;
             }
-      return saveCompressedFile(&fp, info, onlySelection);
+      return saveCompressedFile(&fp, info, onlySelection, createThumbnail);
       }
 
 //---------------------------------------------------------

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5039,7 +5039,7 @@ void MuseScore::autoSaveTimerTimeout()
                   if (!tmp.isEmpty()) {
                         QFileInfo fi(tmp);
                         // TODO: cannot catch exception here:
-                        s->saveCompressedFile(fi, false);
+                        s->saveCompressedFile(fi, false, false); // no thumbnail
                         }
                   else {
                         QDir dir;


### PR DESCRIPTION
It has often been reported that autosaves lead to significant freezes when editing large scores. This PR aims to somewhat mitigate this issue. It contains the following optimizations:
 - Do not generate thumbnail on autosave. Previously thumbnails were previously disabled only for the first score autosave, although complete disabling was probably intended, see 4cd48850a30423dd8b8805123449e37c7132c17b.
 - Optimize slurs saving by avoiding iterating over all spanners in a score for each chord. This led to significant performance penalty on large scores.

On my system on a test score these changes result in autosave time decreasing from ~6.2s (or ~5.4s on the first autosave) to about ~1.6s. The resulting freeze is still noticeable but at least much shorter than before.

Slurs saving optimization will also improve performance of saving large scores in general thus affecting not only autosaves.