### PR TITLE
fix #289643: fix crashes if volta anchor is set incorrectly in MSCZ file

### DIFF
--- a/libmscore/volta.cpp
+++ b/libmscore/volta.cpp
@@ -98,7 +98,7 @@ Volta::Volta(Score* s)
       resetProperty(Pid::BEGIN_HOOK_TYPE);
       resetProperty(Pid::END_HOOK_TYPE);
 
-      setAnchor(Anchor::MEASURE);
+      setAnchor(VOLTA_ANCHOR);
       }
 
 //---------------------------------------------------------
@@ -138,9 +138,27 @@ void Volta::read(XmlReader& e)
                         _endings.append(i);
                         }
                   }
-            else if (!TextLineBase::readProperties(e))
+            else if (!readProperties(e))
                   e.unknown();
             }
+      }
+
+//---------------------------------------------------------
+//   readProperties
+//---------------------------------------------------------
+
+bool Volta::readProperties(XmlReader& e)
+      {
+      if (!TextLineBase::readProperties(e))
+            return false;
+
+      if (anchor() != VOLTA_ANCHOR) {
+            // Volta strictly assumes that its anchor is measure, so don't let old scores override this.
+            qWarning("Correcting volta anchor type from %d to %d", int(anchor()), int(VOLTA_ANCHOR));
+            setAnchor(VOLTA_ANCHOR);
+            }
+
+      return true;
       }
 
 //---------------------------------------------------------
@@ -246,7 +264,7 @@ QVariant Volta::propertyDefault(Pid propertyId) const
             case Pid::VOLTA_ENDING:
                   return QVariant::fromValue(QList<int>());
             case Pid::ANCHOR:
-                  return int(Anchor::MEASURE);
+                  return int(VOLTA_ANCHOR);
             case Pid::BEGIN_HOOK_TYPE:
                   return int(HookType::HOOK_90);
             case Pid::END_HOOK_TYPE:

--- a/libmscore/volta.h
+++ b/libmscore/volta.h
@@ -47,6 +47,7 @@ class VoltaSegment final : public TextLineBaseSegment {
 
 class Volta final : public TextLineBase {
       QList<int> _endings;
+      static constexpr Anchor VOLTA_ANCHOR = Anchor::MEASURE;
 
    public:
       enum class Type : char {
@@ -60,6 +61,7 @@ class Volta final : public TextLineBase {
 
       virtual void write(XmlWriter&) const override;
       virtual void read(XmlReader& e) override;
+      bool readProperties(XmlReader&) override;
       virtual SpannerSegment* layoutSystem(System* system) override;
 
       void setVelocity() const;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/289643

Resolves the issue by correcting volta anchor to `Anchor::MEASURE` if it is defined otherwise in MSCZ file.