### PR TITLE
[MU4] [WIP] [Plugin] Add feature to notify plugins when a score gets saved.

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -77,6 +77,7 @@
 #include "scorecmp/scorecmp.h"
 #include "extension.h"
 #include "tourhandler.h"
+#include "plugin/qmlpluginengine.h"
 
 #ifdef OMR
 #include "omr/omr.h"
@@ -2021,6 +2022,10 @@ bool MuseScore::saveAs(Score* cs_, bool saveCopy, const QString& path, const QSt
             cs_->setLayoutMode(layoutMode);
             cs_->doLayout();
             }
+
+      // Send event to plugins
+      getPluginEngine()->sendScoreSaved(cs_, rv, ext);
+
       return rv;
       }
 

--- a/mscore/plugin/api/qmlpluginapi.cpp
+++ b/mscore/plugin/api/qmlpluginapi.cpp
@@ -384,5 +384,10 @@ void PluginAPI::registerQmlTypes()
       qmlTypesRegistered = true;
       }
 
-}
-}
+void PluginAPI::sendScoreSaved(Ms::Score* s, bool successful, const QString& ext) // WARNING: Ms::Score is not the same as Ms::PluginAPI::Score!
+      {
+      emit scoreSaved(wrap<Score>(s), successful, ext);
+      }
+
+} // namespace PluginAPI
+} // namespace Ms

--- a/mscore/plugin/mscorePlugins.cpp
+++ b/mscore/plugin/mscorePlugins.cpp
@@ -438,7 +438,7 @@ void MuseScore::pluginTriggered(QString pp)
                   }
             }
 
-      connect(engine, &QmlPluginEngine::endCmd, p, &QmlPlugin::endCmd);
+      engine->mapPluginSignals(p);
 
       p->setFilePath(pp.section('/', 0, -2));
 

--- a/mscore/plugin/pluginCreator.cpp
+++ b/mscore/plugin/pluginCreator.cpp
@@ -371,8 +371,9 @@ void PluginCreator::runClicked()
             connect(view, SIGNAL(destroyed()), SLOT(closePlugin()));
             }
 
+      // relatif to the pluginCreator: should not be included in mapSignals
       connect(qml,  SIGNAL(quit()), SLOT(closePlugin()));
-      connect(qml, &QmlPluginEngine::endCmd, item, &QmlPlugin::endCmd);
+      qml->mapPluginSignals(item);
 
       if (mscore->currentScore() && item->pluginType() != "dock")
             mscore->currentScore()->startCmd();

--- a/mscore/plugin/qmlplugin.h
+++ b/mscore/plugin/qmlplugin.h
@@ -63,6 +63,7 @@ class QmlPlugin : public QQuickItem {
 
    public slots:
       virtual void endCmd(const QMap<QString, QVariant>&) = 0;
+      virtual void sendScoreSaved(Score* s, bool successful, const QString& ext) = 0;
 
    public:
       QmlPlugin(QQuickItem* parent = 0);

--- a/mscore/plugin/qmlpluginengine.cpp
+++ b/mscore/plugin/qmlpluginengine.cpp
@@ -73,7 +73,7 @@ void QmlPluginEngine::beginEndCmd(MuseScore* ms, bool inUndoRedo)
 void QmlPluginEngine::endEndCmd(MuseScore*)
       {
       if (cmdCount >= maxCmdCount) {
-            QMessageBox::warning(mscore, tr("Plugin Error"), tr("Score update recursion limit reached (%1)").arg(maxCmdCount));
+            QMessageBox::warning(mscore, tr("Plugin Error"), tr("Score update recursion limit reached (%1) with scoreStateChanged").arg(maxCmdCount));
             recursion = true;
             }
 
@@ -86,6 +86,26 @@ void QmlPluginEngine::endEndCmd(MuseScore*)
             undoRedo = false;
             lastScoreState = currScoreState;
             }
+}
+
+//---------------------------------------------------------
+//   QmlPluginEngine::scoreSaved
+//---------------------------------------------------------
+
+void QmlPluginEngine::sendScoreSaved(Score* s, bool successful, const QString& ext)
+      {
+      emit scoreSaved(s, successful, ext);
+      }
+
+//---------------------------------------------------------
+//   QmlPluginEngine::mapPluginSignals
+///   maps the MuseScore events to the plugins.
+//---------------------------------------------------------
+
+void QmlPluginEngine::mapPluginSignals(QmlPlugin* plugin)
+      {
+      connect(this, &QmlPluginEngine::endCmd, plugin, &QmlPlugin::endCmd);
+      connect(this, &QmlPluginEngine::scoreSaved, plugin, &QmlPlugin::sendScoreSaved);
       }
 
 //---------------------------------------------------------

--- a/mscore/plugin/qmlpluginengine.h
+++ b/mscore/plugin/qmlpluginengine.h
@@ -22,11 +22,11 @@
 
 #include "../qml/msqmlengine.h"
 #include "libmscore/score.h"
+#include "api/qmlpluginapi.h"
 
 namespace Ms {
 
 class MuseScore;
-
 //---------------------------------------------------------
 //   QmlPluginEngine
 //---------------------------------------------------------
@@ -44,11 +44,18 @@ class QmlPluginEngine : public MsQmlEngine {
 
    signals:
       void endCmd(const QMap<QString, QVariant>& changes);
+      void scoreSaved(Score* s, bool successful, const QString& ext);
+
    public:
       QmlPluginEngine(QObject* parent = nullptr);
 
+      void mapPluginSignals(QmlPlugin* item);
+
       void beginEndCmd(MuseScore*, bool undoRedo);
       void endEndCmd(MuseScore*);
+
+      void sendScoreSaved(Score* s, bool successful, const QString& ext);
+
 
       bool inScoreChangeActionHandler() const;
       };


### PR DESCRIPTION
It uses the same method as for scoreStateChanged:
1) When the event happens, it sends it to the plugin engine.
2) The plugin engine emits "scoreSaved" which is connected to the plugin's sendScoreSaved function.
3) This triggers the plugin to call the signal "scoreSaved" that is then retrieved by the plugin.