### PR TITLE
Fix telemetry dialog accessibility

### DIFF
--- a/telemetry/qml/TelemetryPermissionDialog.qml
+++ b/telemetry/qml/TelemetryPermissionDialog.qml
@@ -31,10 +31,6 @@ FocusScope {
         root.closeRequested()
     }
 
-    Component.onCompleted: {
-        forceActiveFocus()
-    }
-
     Rectangle {
         anchors.fill: parent
 
@@ -74,8 +70,6 @@ FocusScope {
             font.pixelSize: 28
 
             text: qsTr("Help us improve MuseScore")
-
-            focus: true
         }
 
         Column {

--- a/telemetry/widgets/telemetrypermissiondialog.cpp
+++ b/telemetry/widgets/telemetrypermissiondialog.cpp
@@ -32,7 +32,7 @@ TelemetryPermissionDialog::TelemetryPermissionDialog(QQmlEngine* engine) : QQuic
       setMinimumWidth(500);
       setMinimumHeight(460);
 
-      setFlags(Qt::CustomizeWindowHint); ///@note Hidding a native frame with 'X' close button
+      setFlags(Qt::Dialog | Qt::CustomizeWindowHint); ///@note Hidding a native frame with 'X' close button
 
       QRect desktopRect = QApplication::desktop()->availableGeometry();
       QPoint center = desktopRect.center();
@@ -51,4 +51,14 @@ TelemetryPermissionDialog::TelemetryPermissionDialog(QQmlEngine* engine) : QQuic
 
       connect(rootObject(), SIGNAL(closeRequested()), this, SLOT(close()));
       connect(rootObject(), SIGNAL(closeRequested()), this, SIGNAL(closeRequested()));
+      }
+
+//---------------------------------------------------------
+//   focusInEvent
+//---------------------------------------------------------
+
+void TelemetryPermissionDialog::focusInEvent(QFocusEvent* evt)
+      {
+      QQuickView::focusInEvent(evt);
+      rootObject()->forceActiveFocus();
       }

--- a/telemetry/widgets/telemetrypermissiondialog.h
+++ b/telemetry/widgets/telemetrypermissiondialog.h
@@ -31,6 +31,8 @@
 class TelemetryPermissionDialog : public QQuickView {
       Q_OBJECT
 
+      void focusInEvent(QFocusEvent*) override;
+
    public:
       explicit TelemetryPermissionDialog(QQmlEngine* engine);
 


### PR DESCRIPTION
This PR aims to correct accessibility issues with telemetry permission dialog reported for NVDA screen reader. Addition of `Qt::Dialog` flag make it shown in list of tasks so user can Alt+Tab to it, focus on root object is ensured to make the dialog controllable by keyboard after showing it.