### PR TITLE
fix AppImage deploy step

### DIFF
--- a/build/Linux+BSD/portable/Recipe
+++ b/build/Linux+BSD/portable/Recipe
@@ -48,6 +48,7 @@ apt_packages_standard=(
 # MuseScore compiles without these but won't run without them
 apt_packages_runtime=(
   # Alphabetical order please!
+  libcups2
   libdbus-1-3
   libegl1-mesa-dev
   libodbc1


### PR DESCRIPTION
Fixes AppImage creation by installing libcups in the docker container.
libcups is identified as a required dependency when printsupport plugin is included in the AppImage.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [N/A] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
