### PR TITLE
fix #300718: Cannot increase the duration of a chord/rest within a nested tuplet.

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1194,8 +1194,6 @@ QList<Fraction> Score::splitGapToMeasureBoundaries(ChordRest* cr, Fraction gap)
 
       Tuplet* tuplet = cr->tuplet();
       if (tuplet) {
-            if (tuplet->tuplet())
-                  return flist; // do no deal with nested tuplets
             Fraction rest = tuplet->elementsDuration();
             for (DurationElement* de : tuplet->elements()) {
                   if (de == cr)


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/300718.

From [my comment](https://musescore.org/en/node/300718#comment-976683) on the issue:

> This limitation was introduced with commit https://github.com/musescore/MuseScore/commit/c1b55b0, presumably because [this calculation](https://github.com/musescore/MuseScore/blob/c1b55b06e572f199e5d49ef82676427676c6962a/libmscore/cmd.cpp#L936) would fail in the case of nested tuplets. That calculation has since been replaced with a [more general solution](https://github.com/musescore/MuseScore/blob/master/libmscore/cmd.cpp#L1199-L1204), so it should be safe to remove the two lines that cause the function to return early in the case of nested tuplets, which is what prevents the operation from doing anything.