### PR TITLE
fix #300738: Ottava (8va/8vb) number is too big

### DIFF
--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -498,7 +498,7 @@ static const StyleType styleTypes[] {
       { Sid::ottavaLineStyle,         "ottavaLineStyle",         QVariant(int(Qt::DashLine)) },
       { Sid::ottavaNumbersOnly,       "ottavaNumbersOnly",       true },
       { Sid::ottavaFontFace,          "ottavaFontFace",          "FreeSerif" },
-      { Sid::ottavaFontSize,          "ottavaFontSize",          12.0 },
+      { Sid::ottavaFontSize,          "ottavaFontSize",          10.0 },
       { Sid::ottavaFontSpatiumDependent, "ottavaFontSpatiumDependent", true },
       { Sid::ottavaFontStyle,         "ottavaFontStyle",         int(FontStyle::Normal) },
       { Sid::ottavaColor,             "ottavaColor",             QColor(0, 0, 0, 255) },


### PR DESCRIPTION
Resolves https://musescore.org/node/300738