### PR TITLE
Reorganize ove.h, ove.cpp and importove.cpp

### DIFF
--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -317,9 +317,10 @@ add_library(mscoreapp STATIC
       editstafftype.h editstringdata.h editstyle.h enableplayforwidget.h
       exampleview.h excerptsdialog.h exportmidi.h exportmp3.h extension.h
       file.h fotomode.h fretcanvas.h globals.h greendotbutton.h
-      harmonycanvas.h harmonyedit.h help.h helpBrowser.h icons.h importgtp.h importmxml.h
-      importmxmllogger.h importmxmlnoteduration.h importmxmlnotepitch.h importmxmlpass1.h
-      importmxmlpass2.h importptb.h importxmlfirstpass.h instrdialog.h instrwidget.h jackaudio.h
+      harmonycanvas.h harmonyedit.h help.h helpBrowser.h icons.h
+      importgtp.h importove.h importmxml.h importmxmllogger.h importmxmlnoteduration.h importmxmlnotepitch.h
+      importmxmlpass1.h importmxmlpass2.h importptb.h importxmlfirstpass.h
+      instrdialog.h instrwidget.h jackaudio.h
       keycanvas.h keyedit.h layer.h licence.h
       logindialog.h network/loginmanager.h network/loginmanager_p.h
       magbox.h masterpalette.h

--- a/mscore/importove.h
+++ b/mscore/importove.h
@@ -1,0 +1,115 @@
+//=============================================================================
+//  MusE Score
+//  Linux Music Score Editor
+//
+//  Copyright (C) 2002-2009 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef __IMPORTOVE_H__
+#define __IMPORTOVE_H__
+
+#include "ove.h"
+
+#include "libmscore/chord.h"
+#include "libmscore/measure.h"
+#include "libmscore/part.h"
+#include "libmscore/pedal.h"
+#include "libmscore/score.h"
+
+using namespace Ms;
+
+//---------------------------------------------------------
+//   MeasureToTick
+//---------------------------------------------------------
+
+class MeasureToTick {
+      int _quarter;
+      Ove::OveSong* _ove;
+
+   public:
+      MeasureToTick();
+      ~MeasureToTick() {}
+
+      void build(Ove::OveSong* ove, int quarter);
+
+      int tick(int measure, int tick_pos);
+      static int unitToTick(int unit, int quarter);
+
+      struct TimeTick {
+            int _numerator;
+            int _denominator;
+            int _measure;
+            int _tick;
+            bool _isSymbol;
+
+            TimeTick() :
+                  _numerator(4), _denominator(4), _measure(0), _tick(0), _isSymbol(false) {}
+            };
+      QList<TimeTick> timeTicks() const { return _tts; }
+
+   private:
+      QList<TimeTick> _tts;
+      };
+
+//---------------------------------------------------------
+//   OveToMScore
+//---------------------------------------------------------
+
+class OveToMScore {
+      Ove::OveSong* _ove;
+      Score* _score;
+      MeasureToTick* _mtt;
+
+      Pedal* _pedal;
+
+   public:
+      OveToMScore();
+      ~OveToMScore();
+
+      void convert(Ove::OveSong* oveData, Score* score);
+
+   private:
+      void createStructure();
+      void convertHeader();
+      void convertGroups();
+      void convertTrackHeader(Ove::Track* track, Part* part);
+      void convertTrackElements(int track);
+      void convertLineBreak();
+      void convertSignature();
+      void convertMeasures();
+      void convertMeasure(Measure* measure);
+      void convertMeasureMisc(Measure* measure, int part, int staff, int track);
+      void convertNote(Measure* measure, int part, int staff, int track);
+      void convertArticulation(Measure* measure, ChordRest* cr, int track, int absTick, Ove::Articulation* art);
+      void convertLyric(Measure* measure, int part, int staff, int track);
+      void convertHarmony(Measure* measure, int part, int staff, int track);
+      void convertRepeat(Measure* measure, int part, int staff, int track);
+      void convertDynamic(Measure* measure, int part, int staff, int track);
+      void convertExpression(Measure* measure, int part, int staff, int track);
+      void convertLine(Measure* measure);
+      void convertSlur(Measure* measure, int part, int staff, int track);
+      void convertGlissando(Measure* measure, int part, int staff, int track);
+      void convertWedge(Measure* measure, int part, int staff, int track);
+      // void convertOctaveShift(Measure* measure, int part, int staff, int track);
+
+      Ove::NoteContainer* containerByPos(int part, int staff, const Ove::MeasurePos& pos);
+      // Ove::MusicData* musicDataByUnit(int part, int staff, int measure, int unit, Ove::MusicDataType type);
+      Ove::MusicData* crossMeasureElementByPos(int part, int staff, const Ove::MeasurePos& pos, int voice, Ove::MusicDataType type);
+      // ChordRest* findChordRestByPos(int absTick, int track);
+
+      void clearUp();
+      };
+
+#endif

--- a/mscore/ove.cpp
+++ b/mscore/ove.cpp
@@ -19,1612 +19,749 @@
 
 #include "ove.h"
 
-namespace OVE {
+namespace Ove {
 
-/*template <class T>
-inline void deleteVector(QList<T*>& vec) {
-   for (int i=0; i<vec.size(); ++i)
-      delete vec[i];
-   }
-   //vec.clear();
-}*/
+#if 0
+template <class T>
+inline void deleteVector(QList<T*>& vec)
+      {
+      for (int i = 0; i < vec.size(); ++i)
+            delete vec[i];
+      }
+      // vec.clear();
+#endif
 
-///////////////////////////////////////////////////////////////////////////////
-TickElement::TickElement() {
-      tick_ = 0;
+//---------------------------------------------------------
+//   TickElement
+//---------------------------------------------------------
+
+TickElement::TickElement()
+      {
+      _tick = 0;
       }
 
-void TickElement::setTick(int tick) {
-      tick_ = tick;
+//---------------------------------------------------------
+//   MeasurePos
+//---------------------------------------------------------
+
+MeasurePos::MeasurePos()
+      {
+      _measure = 0;
+      _offset = 0;
       }
 
-int TickElement::getTick(void) const {
-      return tick_;
-      }
+//---------------------------------------------------------
+//   MeasurePos::shiftMeasure/Offset
+//---------------------------------------------------------
 
-///////////////////////////////////////////////////////////////////////////////
-MeasurePos::MeasurePos() {
-      measure_ = 0;
-      offset_ = 0;
-      }
-
-void MeasurePos::setMeasure(int measure) {
-      measure_ = measure;
-      }
-
-int MeasurePos::getMeasure() const {
-      return measure_;
-      }
-
-void MeasurePos::setOffset(int offset) {
-      offset_ = offset;
-      }
-
-int MeasurePos::getOffset() const {
-      return offset_;
-      }
-
-MeasurePos MeasurePos::shiftMeasure(int measure) const {
+MeasurePos MeasurePos::shiftMeasure(int m) const
+      {
       MeasurePos mp;
-      mp.setMeasure(getMeasure() + measure);
-      mp.setOffset(getOffset());
+      mp.setMeasure(measure() + m);
+      mp.setOffset(offset());
 
       return mp;
       }
 
-MeasurePos MeasurePos::shiftOffset(int offset) const {
+MeasurePos MeasurePos::shiftOffset(int off) const
+      {
       MeasurePos mp;
-      mp.setMeasure(getMeasure());
-      mp.setOffset(getOffset() + offset);
+      mp.setMeasure(measure());
+      mp.setOffset(offset() + off);
 
       return mp;
       }
 
-bool MeasurePos::operator ==(const MeasurePos& mp) const {
-      return getMeasure() == mp.getMeasure() && getOffset() == mp.getOffset();
+//---------------------------------------------------------
+//   MeasurePos operators
+//---------------------------------------------------------
+
+bool MeasurePos::operator==(const MeasurePos& mp) const
+      {
+      return measure() == mp.measure() && offset() == mp.offset();
       }
 
-bool MeasurePos::operator !=(const MeasurePos& mp) const {
+bool MeasurePos::operator!=(const MeasurePos& mp) const
+      {
       return !(*this == mp);
       }
 
-bool MeasurePos::operator <(const MeasurePos& mp) const {
-      if (getMeasure() != mp.getMeasure()) {
-            return getMeasure() < mp.getMeasure();
-            }
+bool MeasurePos::operator<(const MeasurePos& mp) const
+      {
+      if (measure() != mp.measure())
+            return measure() < mp.measure();
 
-      return getOffset() < mp.getOffset();
+      return offset() < mp.offset();
       }
 
-bool MeasurePos::operator <=(const MeasurePos& mp) const {
-      if (getMeasure() != mp.getMeasure()) {
-            return getMeasure() <= mp.getMeasure();
-            }
+bool MeasurePos::operator<=(const MeasurePos& mp) const
+      {
+      if (measure() != mp.measure())
+            return measure() <= mp.measure();
 
-      return getOffset() <= mp.getOffset();
+      return offset() <= mp.offset();
       }
 
-bool MeasurePos::operator >(const MeasurePos& mp) const {
+bool MeasurePos::operator>(const MeasurePos& mp) const
+      {
       return !(*this <= mp);
       }
 
-bool MeasurePos::operator >=(const MeasurePos& mp) const {
+bool MeasurePos::operator>=(const MeasurePos& mp) const
+      {
       return !(*this < mp);
       }
 
-///////////////////////////////////////////////////////////////////////////////
-PairElement::PairElement() {
-      start_ = new MeasurePos();
-      stop_ = new MeasurePos();
+//---------------------------------------------------------
+//   PairElement
+//---------------------------------------------------------
+
+PairElement::PairElement()
+      {
+      _start = new MeasurePos();
+      _stop  = new MeasurePos();
       }
 
-PairElement::~PairElement(){
-      delete start_;
-      delete stop_;
+PairElement::~PairElement()
+      {
+      delete _start;
+      delete _stop;
       }
 
-MeasurePos* PairElement::start() const {
-      return start_;
+//---------------------------------------------------------
+//   PairEnds
+//---------------------------------------------------------
+
+PairEnds::PairEnds()
+      {
+      _leftLine      = new LineElement();
+      _rightLine     = new LineElement();
+      _leftShoulder  = new OffsetElement();
+      _rightShoulder = new OffsetElement();
       }
 
-MeasurePos* PairElement::stop() const {
-      return stop_;
+PairEnds::~PairEnds()
+      {
+      delete _leftLine;
+      delete _rightLine;
+      delete _leftShoulder;
+      delete _rightShoulder;
       }
 
-///////////////////////////////////////////////////////////////////////////////
-PairEnds::PairEnds() {
-      leftLine_ = new LineElement();
-      rightLine_ = new LineElement();
-      leftShoulder_ = new OffsetElement();
-      rightShoulder_ = new OffsetElement();
+//---------------------------------------------------------
+//   LineElement
+//---------------------------------------------------------
+
+LineElement::LineElement()
+      {
+      _line = 0;
       }
 
-PairEnds::~PairEnds(){
-      delete leftLine_;
-      delete rightLine_;
-      delete leftShoulder_;
-      delete rightShoulder_;
+//---------------------------------------------------------
+//   OffsetElement
+//---------------------------------------------------------
+
+OffsetElement::OffsetElement()
+      {
+      _xOffset = 0;
+      _yOffset = 0;
       }
 
-LineElement* PairEnds::getLeftLine() const {
-      return leftLine_;
+//---------------------------------------------------------
+//   LengthElement
+//---------------------------------------------------------
+
+LengthElement::LengthElement()
+      {
+      _length = 0;
       }
 
-LineElement* PairEnds::getRightLine() const {
-      return rightLine_;
+//---------------------------------------------------------
+//   MusicData
+//---------------------------------------------------------
+
+MusicData::MusicData()
+      {
+      _musicDataType = MusicDataType::None;
+      _show          = true;
+      _color         = 0;
+      _voice         = 0;
       }
 
-OffsetElement* PairEnds::getLeftShoulder() const {
-      return leftShoulder_;
-      }
+//---------------------------------------------------------
+//   MusicData::xmlDataType
+//---------------------------------------------------------
 
-OffsetElement* PairEnds::getRightShoulder() const {
-      return rightShoulder_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-LineElement::LineElement() {
-      line_ = 0;
-      }
-
-void LineElement::setLine(int line) {
-      line_ = line;
-      }
-
-int LineElement::getLine(void) const {
-      return line_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-OffsetElement::OffsetElement() {
-      xOffset_ = 0;
-      yOffset_ = 0;
-      }
-
-void OffsetElement::setXOffset(int offset) {
-      xOffset_ = offset;
-      }
-
-int OffsetElement::getXOffset() const {
-      return xOffset_;
-      }
-
-void OffsetElement::setYOffset(int offset) {
-      yOffset_ = offset;
-      }
-
-int OffsetElement::getYOffset() const {
-      return yOffset_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-LengthElement::LengthElement() {
-      length_ = 0;
-      }
-
-void LengthElement::setLength(int length) {
-      length_ = length;
-      }
-
-int LengthElement::getLength() const {
-      return length_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-MusicData::MusicData() {
-      musicDataType_ = MusicDataType::None;
-      show_ = true;
-      color_ = 0;
-      voice_ = 0;
-      }
-
-MusicDataType MusicData::getMusicDataType() const {
-      return musicDataType_;
-      }
-
-MusicData::XmlDataType MusicData::getXmlDataType(MusicDataType type) {
+MusicData::XmlDataType MusicData::xmlDataType(MusicDataType type)
+      {
       XmlDataType xmlType = XmlDataType::None;
 
       switch (type) {
-            case MusicDataType::Measure_Repeat: {
+            case MusicDataType::Measure_Repeat:
                   xmlType = XmlDataType::Attributes;
                   break;
-                  }
-            case MusicDataType::Beam: {
+            case MusicDataType::Beam:
                   xmlType = XmlDataType::NoteBeam;
                   break;
-                  }
             case MusicDataType::Slur:
             case MusicDataType::Glissando:
             case MusicDataType::Tuplet:
-            case MusicDataType::Tie: {
+            case MusicDataType::Tie:
                   xmlType = XmlDataType::Notations;
                   break;
-                  }
             case MusicDataType::Text:
             case MusicDataType::Repeat:
             case MusicDataType::Wedge:
-            case MusicDataType::Dynamics:
+            case MusicDataType::Dynamic:
             case MusicDataType::Pedal:
-            case MusicDataType::OctaveShift_EndPoint: {
+            case MusicDataType::OctaveShift_EndPoint:
                   xmlType = XmlDataType::Direction;
                   break;
-                  }
-            default: {
+            default:
                   xmlType = XmlDataType::None;
                   break;
-                  }
             }
 
       return xmlType;
       }
 
-/*bool MusicData::get_is_pair_element(MusicDataType type)
- {
- bool pair = false;
+#if 0
+//---------------------------------------------------------
+//   MusicData::isPairElement
+//---------------------------------------------------------
 
- switch ( type )
- {
- case MusicDataType::Numeric_Ending :
- case MusicDataType::Measure_Repeat :
- case MusicDataType::Wedge :
- case MusicDataType::OctaveShift :
- //case MusicDataType::OctaveShift_EndPoint :
- case MusicDataType::Pedal :
- case MusicDataType::Beam :
- case MusicDataType::Glissando :
- case MusicDataType::Slur :
- case MusicDataType::Tie :
- case MusicDataType::Tuplet :
- {
- pair = true;
- break;
- }
- default:
- break;
- }
+bool MusicData::isPairElement(MusicDataType type)
+      {
+      bool pair = false;
+      
+      switch (type) {
+            case MusicDataType::Numeric_Ending:
+            case MusicDataType::Measure_Repeat:
+            case MusicDataType::Wedge:
+            case MusicDataType::OctaveShift:
+            // case MusicDataType::OctaveShift_EndPoint:
+            case MusicDataType::Pedal:
+            case MusicDataType::Beam:
+            case MusicDataType::Glissando:
+            case MusicDataType::Slur:
+            case MusicDataType::Tie:
+            case MusicDataType::Tuplet:
+                  pair = true;
+                  break;
+            default:
+                  break;
+            }
 
- return pair;
- }*/
+      return pair;
+      }
+#endif
 
-void MusicData::setShow(bool show) {
-      show_ = show;
+//---------------------------------------------------------
+//   MusicData::copyCommonBlock
+//---------------------------------------------------------
+
+void MusicData::copyCommonBlock(const MusicData& source)
+      {
+      setTick(source.tick());
+      start()->setOffset(source.start()->offset());
+      setColor(source.color());
       }
 
-bool MusicData::getShow() const {
-      return show_;
+//---------------------------------------------------------
+//   MidiData
+//---------------------------------------------------------
+
+MidiData::MidiData()
+      {
+      _midiType = MidiType::None;
       }
 
-void MusicData::setColor(unsigned int color) {
-      color_ = color;
-      }
+//---------------------------------------------------------
+//   OveSong
+//---------------------------------------------------------
 
-unsigned int MusicData::getColor() const {
-      return color_;
-      }
+OveSong::OveSong()
+      {
+      _codec = nullptr;
 
-void MusicData::setVoice(unsigned int voice) {
-      voice_ = voice;
-      }
-
-unsigned int MusicData::getVoice() const {
-      return voice_;
-      }
-
-void MusicData::copyCommonBlock(const MusicData& source) {
-      setTick(source.getTick());
-      start()->setOffset(source.start()->getOffset());
-      setColor(source.getColor());
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-MidiData::MidiData() {
-      midiType_ = MidiType::None;
-      }
-
-MidiType MidiData::getMidiType() const {
-      return midiType_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-OveSong::OveSong() :
-      codec_(0) {
       clear();
       }
 
-OveSong::~OveSong() {
+OveSong::~OveSong()
+      {
       clear();
       }
 
-void OveSong::setIsVersion4(bool version4){
-      version4_ = version4;
-      }
+//---------------------------------------------------------
+//   OveSong::track
+//---------------------------------------------------------
 
-bool OveSong::getIsVersion4() const {
-      return version4_;
-      }
-
-void OveSong::setQuarter(int tick) {
-      quarter_ = tick;
-      }
-
-int OveSong::getQuarter(void) const {
-      return quarter_;
-      }
-
-void OveSong::setShowPageMargin(bool show){
-      showPageMargin_ = show;
-      }
-
-bool OveSong::getShowPageMargin() const {
-      return showPageMargin_;
-      }
-
-void OveSong::setShowTransposeTrack(bool show) {
-      showTransposeTrack = show;
-      }
-
-bool OveSong::getShowTransposeTrack() const {
-      return showTransposeTrack;
-      }
-
-void OveSong::setShowLineBreak(bool show) {
-      showLineBreak_ = show;
-      }
-
-bool OveSong::getShowLineBreak() const {
-      return showLineBreak_;
-      }
-
-void OveSong::setShowRuler(bool show) {
-      showRuler_ = show;
-      }
-
-bool OveSong::getShowRuler() const {
-      return showRuler_;
-      }
-
-void OveSong::setShowColor(bool show) {
-      showColor_ = show;
-      }
-
-bool OveSong::getShowColor() const {
-      return showColor_;
-      }
-
-void OveSong::setPlayRepeat(bool play) {
-      playRepeat_ = play;
-      }
-
-bool OveSong::getPlayRepeat() const {
-      return playRepeat_;
-      }
-
-void OveSong::setPlayStyle(PlayStyle style) {
-      playStyle_ = style;
-      }
-
-OveSong::PlayStyle OveSong::getPlayStyle() const {
-      return playStyle_;
-      }
-
-void OveSong::addTitle(const QString& str) {
-      titles_.push_back(str);
-      }
-
-QList<QString> OveSong::getTitles(void) const {
-      return titles_;
-      }
-
-void OveSong::addAnnotate(const QString& str) {
-      annotates_.push_back(str);
-      }
-
-QList<QString> OveSong::getAnnotates(void) const {
-      return annotates_;
-      }
-
-void OveSong::addWriter(const QString& str) {
-      writers_.push_back(str);
-      }
-
-QList<QString> OveSong::getWriters(void) const {
-      return writers_;
-      }
-
-void OveSong::addCopyright(const QString& str) {
-      copyrights_.push_back(str);
-      }
-
-QList<QString> OveSong::getCopyrights(void) const {
-      return copyrights_;
-      }
-
-void OveSong::addHeader(const QString& str) {
-      headers_.push_back(str);
-      }
-
-QList<QString> OveSong::getHeaders(void) const {
-      return headers_;
-      }
-
-void OveSong::addFooter(const QString& str) {
-      footers_.push_back(str);
-      }
-
-QList<QString> OveSong::getFooters(void) const {
-      return footers_;
-      }
-
-void OveSong::addTrack(Track* ptr) {
-      tracks_.push_back(ptr);
-      }
-
-int OveSong::getTrackCount(void) const {
-      return tracks_.size();
-      }
-
-QList<Track*> OveSong::getTracks() const {
-      return tracks_;
-      }
-
-void OveSong::setTrackBarCount(int count) {
-      trackBarCount_ = count;
-      }
-
-int OveSong::getTrackBarCount() const {
-      return trackBarCount_;
-      }
-
-Track* OveSong::getTrack(int part, int staff) const {
+Track* OveSong::track(int part, int staff) const
+      {
       int trackId = partStaffToTrack(part, staff);
 
-      if( trackId >=0 && trackId < (int)tracks_.size() ) {
-            return tracks_[trackId];
-            }
+      if (trackId >= 0 && trackId < trackCount())
+            return _tracks[trackId];
 
-      return 0;
+      return nullptr;
       }
 
-bool OveSong::addPage(Page* page) {
-      pages_.push_back(page);
-      return true;
+//---------------------------------------------------------
+//   OveSong::page
+//---------------------------------------------------------
+
+Page* OveSong::page(int idx) const
+      {
+      if (idx >= 0 && idx < pageCount())
+            return _pages[idx];
+
+      return nullptr;
       }
 
-int OveSong::getPageCount() const {
-      return pages_.size();
+//---------------------------------------------------------
+//   OveSong::line
+//---------------------------------------------------------
+
+Line* OveSong::line(int idx) const
+      {
+      if (idx >= 0 && idx < lineCount())
+            return _lines[idx];
+
+      return nullptr;
       }
 
-Page* OveSong::getPage(int idx) {
-      if( idx>=0 && idx<(int)pages_.size() ) {
-            return pages_[idx];
-            }
+//---------------------------------------------------------
+//   OveSong::measure
+//---------------------------------------------------------
 
-      return 0;
+Measure* OveSong::measure(int m) const
+      {
+      if (m >= 0 && m < measureCount())
+            return _measures[m];
+
+      return nullptr;
       }
 
-void OveSong::addLine(Line* ptr) {
-      lines_.push_back(ptr);
-      }
+//---------------------------------------------------------
+//   OveSong::measureData
+//---------------------------------------------------------
 
-int OveSong::getLineCount() const {
-      return lines_.size();
-      }
-
-Line* OveSong::getLine(int idx) const {
-      if( idx >=0 && idx<(int)lines_.size() ) {
-            return lines_[idx];
-            }
-
-      return 0;
-      }
-
-void OveSong::addMeasure(Measure* ptr) {
-      measures_.push_back(ptr);
-      }
-
-int OveSong::getMeasureCount(void) const {
-      return measures_.size();
-      }
-
-Measure* OveSong::getMeasure(int bar) const {
-      if( bar >= 0 && bar < (int)measures_.size() ) {
-            return measures_[bar];
-            }
-
-      return 0;
-      }
-
-void OveSong::addMeasureData(MeasureData* ptr) {
-      measureDatas_.push_back(ptr);
-      }
-
-int OveSong::getMeasureDataCount(void) const {
-      return measureDatas_.size();
-      }
-
-MeasureData* OveSong::getMeasureData(int part, int staff/*=0*/, int bar) const {
+MeasureData* OveSong::measureData(int part, int staff/*= 0*/, int bar) const
+      {
       int trackId = partStaffToTrack(part, staff);
-      int trackBarCount = getTrackBarCount();
+      int count   = _trackBarCount;
 
-      if( bar >= 0 && bar < trackBarCount ) {
-            int measureId = trackBarCount * trackId + bar;
+      if (bar >= 0 && bar < count) {
+            int measureId = count * trackId + bar;
 
-            if( measureId >=0 && measureId < (int)measureDatas_.size() ) {
-                  return measureDatas_[measureId];
-                  }
+            if (measureId >= 0 && measureId < measureDataCount())
+                  return _measureDatas[measureId];
             }
+
+      return nullptr;
+      }
+
+MeasureData* OveSong::measureData(int track, int bar) const
+      {
+      int count = _trackBarCount;
+      int id    = count * track + bar;
+
+      if (id >= 0 && id < measureDataCount())
+            return _measureDatas[id];
+
+      return nullptr;
+      }
+
+//---------------------------------------------------------
+//   OveSong::addPartStaffCounts
+//---------------------------------------------------------
+
+void OveSong::addPartStaffCounts(const QList<int>& partStaffCounts)
+      {
+      for (int i = 0; i < partStaffCounts.size(); ++i)
+            _partStaffCounts.push_back(partStaffCounts[i]);
+      }
+
+//---------------------------------------------------------
+//   OveSong::staffCount
+//---------------------------------------------------------
+
+int OveSong::staffCount(int part) const
+      {
+      if (part >= 0 && part < partCount())
+            return _partStaffCounts[part];
 
       return 0;
       }
 
-MeasureData* OveSong::getMeasureData(int track, int bar) const {
-      int id = trackBarCount_*track + bar;
+//---------------------------------------------------------
+//   OveSong::trackToPartStaff
+//---------------------------------------------------------
 
-      if( id >=0 && id < (int)measureDatas_.size() ) {
-            return measureDatas_[id];
-            }
-
-      return 0;
-      }
-
-void OveSong::setPartStaffCounts(const QList<int>& partStaffCounts) {
-      //partStaffCounts_.assign(partStaffCounts.begin(), partStaffCounts.end());
-      for(int i=0; i<partStaffCounts.size(); ++i) {
-            partStaffCounts_.push_back(partStaffCounts[i]);
-            }
-      }
-
-int OveSong::getPartCount() const {
-      return partStaffCounts_.size();
-      }
-
-int OveSong::getStaffCount(int part) const {
-      if( part>=0 && part<(int)partStaffCounts_.size() ) {
-            return partStaffCounts_[part];
-            }
-
-      return 0;
-      }
-
-int OveSong::getPartBarCount() const {
-      return measureDatas_.size() / tracks_.size();
-      }
-
-QPair<int, int> OveSong::trackToPartStaff(int track) const {
-      int i;
+QPair<int, int> OveSong::trackToPartStaff(int track) const
+      {
       int staffCount = 0;
 
-      for( i=0; i<partStaffCounts_.size(); ++i ) {
-            if( staffCount + partStaffCounts_[i] > track ) {
-                  return qMakePair((int)i, track-staffCount);
-                  }
+      for (int i = 0; i < partCount(); ++i) {
+            if (staffCount + _partStaffCounts[i] > track)
+                  return qMakePair(i, track - staffCount);
 
-            staffCount += partStaffCounts_[i];
+            staffCount += _partStaffCounts[i];
             }
 
-      return qMakePair((int)partStaffCounts_.size(), 0);
+      return qMakePair(partCount(), 0);
       }
 
-int OveSong::partStaffToTrack(int part, int staff) const {
-      int i;
-      unsigned int staffCount = 0;
+//---------------------------------------------------------
+//   OveSong::partStaffToTrack
+//---------------------------------------------------------
 
-      for( i=0; i<partStaffCounts_.size(); ++i ) {
-            if( part == (int)i && staff>=0 && staff<(int)partStaffCounts_[i] ) {
+int OveSong::partStaffToTrack(int part, int staff) const
+      {
+      int i;
+      unsigned staffCount = 0;
+
+      for (i = 0; i < partCount(); ++i) {
+            if (part == i && staff >= 0 && staff < _partStaffCounts[i]) {
                   int trackId = staffCount + staff;
 
-                  if( trackId >=0 && trackId < (int)tracks_.size() ) {
+                  if (trackId >= 0 && trackId < trackCount())
                         return trackId;
-                        }
                   }
 
-            staffCount += partStaffCounts_[i];
+            staffCount += _partStaffCounts[i];
             }
 
-      return tracks_.size();
+      return trackCount();
       }
 
-void OveSong::setTextCodecName(const QString& codecName) {
-      codec_ = QTextCodec::codecForName(codecName.toLatin1());
-      }
+//---------------------------------------------------------
+//   OveSong::codecString
+//---------------------------------------------------------
 
-QString OveSong::getCodecString(const QByteArray& text) {
+QString OveSong::codecString(const QByteArray& text)
+      {
       QString s;
-      if (codec_ == NULL)
+      if (!_codec)
             s = QString(text);
       else
-            s = codec_->toUnicode(text);
+            s = _codec->toUnicode(text);
 
       s = s.trimmed();
       return s;
       }
 
-void OveSong::clear(void)
+//---------------------------------------------------------
+//   OveSong::clear
+//---------------------------------------------------------
+
+void OveSong::clear()
       {
-      version4_ = true;
-      quarter_ = 480;
-      showPageMargin_ = false;
-      showTransposeTrack = false;
-      showLineBreak_ = false;
-      showRuler_ = false;
-      showColor_ = true;
-      playRepeat_ = true;
-      playStyle_ = PlayStyle::Record;
+      _version4           = true;
+      _quarter            = 480;
+      _showPageMargin     = false;
+      _showTransposeTrack = false;
+      _showLineBreak      = false;
+      _showRuler          = false;
+      _showColor          = true;
+      _playRepeat         = true;
+      _playStyle          = PlayStyle::Record;
 
-      annotates_.clear();
-      copyrights_.clear();
-      footers_.clear();
-      headers_.clear();
-      titles_.clear();
-      writers_.clear();
+      _annotates.clear();
+      _copyrights.clear();
+      _footers.clear();
+      _headers.clear();
+      _titles.clear();
+      _writers.clear();
 
-      // deleteVector(tracks_);
-      for(int i=0; i<tracks_.size(); ++i){
-            delete tracks_[i];
-            }
-      for(int i=0; i<pages_.size(); ++i){
-            delete pages_[i];
-            }
-      for(int i=0; i<lines_.size(); ++i){
-            delete lines_[i];
-            }
-      for(int i=0; i<measures_.size(); ++i){
-            delete measures_[i];
-            }
-      for(int i=0; i<measureDatas_.size(); ++i){
-            delete measureDatas_[i];
-            }
-      tracks_.clear();
-      pages_.clear();
-      lines_.clear();
-      measures_.clear();
-      measureDatas_.clear();
-      trackBarCount_ = 0;
-      partStaffCounts_.clear();
+      for (int i = 0; i < trackCount(); ++i) 
+            delete _tracks[i];
+      for (int i = 0; i < pageCount(); ++i) 
+            delete _pages[i];
+      for (int i = 0; i < lineCount(); ++i) 
+            delete _lines[i];
+      for (int i = 0; i < measureCount(); ++i) 
+            delete _measures[i];
+      for (int i = 0; i < measureDataCount(); ++i) 
+            delete _measureDatas[i];
+
+      _tracks.clear();
+      _pages.clear();
+      _lines.clear();
+      _measures.clear();
+      _measureDatas.clear();
+      _trackBarCount = 0;
+      _partStaffCounts.clear();
       }
 
-///////////////////////////////////////////////////////////////////////////////
-Voice::Voice() {
-      channel_ = 0;
-      volume_ = -1;
-      pitchShift_ = 0;
-      pan_ = 0;
-      patch_ = 0;
-      stemType_ = 0;
+//---------------------------------------------------------
+//   Voice
+//---------------------------------------------------------
+
+Voice::Voice()
+      {
+      _channel    = 0;
+      _volume     = -1;
+      _pitchShift = 0;
+      _pan        = 0;
+      _patch      = 0;
+      _stemType   = 0;
       }
 
-void Voice::setChannel(int channel) {
-      channel_ = channel;
-      }
+//---------------------------------------------------------
+//   Track
+//---------------------------------------------------------
 
-int Voice::getChannel() const {
-      return channel_;
-      }
-
-void Voice::setVolume(int volume) {
-      volume_ = volume;
-      }
-
-int Voice::getVolume() const {
-      return volume_;
-      }
-
-void Voice::setPitchShift(int pitchShift) {
-      pitchShift_ = pitchShift;
-      }
-
-int Voice::getPitchShift() const {
-      return pitchShift_;
-      }
-
-void Voice::setPan(int pan) {
-      pan_ = pan;
-      }
-
-int Voice::getPan() const {
-      return pan_;
-      }
-
-void Voice::setPatch(int patch) {
-      patch_ = patch;
-      }
-
-int Voice::getPatch() const {
-      return patch_;
-      }
-
-void Voice::setStemType(int stemType) {
-      stemType_ = stemType;
-      }
-
-int Voice::getStemType() const {
-      return stemType_;
-      }
-
-int Voice::getDefaultPatch() {
-      return -1;
-      }
-
-int Voice::getDefaultVolume() {
-      return -1;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-Track::Track() {
+Track::Track()
+      {
       clear();
       }
 
-Track::~Track() {
+Track::~Track()
+      {
       clear();
       }
 
-void Track::setName(const QString& str) {
-      name_ = str;
-      }
-
-QString Track::getName(void) const {
-      return name_;
-      }
-
-void Track::setBriefName(const QString& str) {
-      briefName_ = str;
-      }
-
-QString Track::getBriefName(void) const {
-      return briefName_;
-      }
-
-void Track::setPatch(unsigned int patch) {
-      patch_ = patch;
-      }
-
-unsigned int Track::getPatch() const {
-      return patch_;
-      }
-
-void Track::setChannel(int channel) {
-      channel_ = channel;
-      }
-
-int Track::getChannel() const {
-      return channel_;
-      }
-
-void Track::setShowName(bool show) {
-      showName_ = show;
-      }
-
-bool Track::getShowName() const {
-      return showName_;
-      }
-
-void Track::setShowBriefName(bool show) {
-      showBriefName_ = show;
-      }
-
-bool Track::getShowBriefName() const {
-      return showBriefName_;
-      }
-
-void Track::setMute(bool mute) {
-      mute_ = mute;
-      }
-
-bool Track::getMute() const {
-      return mute_;
-      }
-
-void Track::setSolo(bool solo) {
-      solo_ = solo;
-      }
-
-bool Track::getSolo() const {
-      return solo_;
-      }
-
-void Track::setShowKeyEachLine(bool show) {
-      showKeyEachLine_ = show;
-      }
-
-bool Track::getShowKeyEachLine() const {
-      return showKeyEachLine_;
-      }
-
-void Track::setVoiceCount(int voices) {
-      voiceCount_ = voices;
-      }
-
-int Track::getVoiceCount() const {
-      return voiceCount_;
-      }
-
-void Track::addVoice(Voice* voice) {
-      voices_.push_back(voice);
-      }
-
-QList<Voice*> Track::getVoices() const {
-      return voices_;
-      }
-
-void Track::setShowTranspose(bool show) {
-      showTranspose_ = show;
-      }
-
-bool Track::getShowTranspose() const {
-      return showTranspose_;
-      }
-
-void Track::setTranspose(int transpose) {
-      transpose_ = transpose;
-      }
-
-int Track::getTranspose() const {
-      return transpose_;
-      }
-
-void Track::setNoteShift(int shift) {
-      noteShift_ = shift;
-      }
-
-int Track::getNoteShift() const {
-      return noteShift_;
-      }
-
-void Track::setStartClef(int clef/*in Clef*/) {
-      startClef_ = ClefType(clef);
-      }
-
-ClefType Track::getStartClef() const {
-      return startClef_;
-      }
-
-void Track::setTransposeClef(int clef) {
-      transposeClef_ = ClefType(clef);
-      }
-
-ClefType Track::getTansposeClef() const {
-      return transposeClef_;
-      }
-
-void Track::setStartKey(int key) {
-      startKey_ = key;
-      }
-
-int Track::getStartKey() const {
-      return startKey_;
-      }
-
-void Track::setDisplayPercent(unsigned int percent/*25~100?*/) {
-      displayPercent_ = percent;
-      }
-
-unsigned int Track::getDisplayPercent() const {
-      return displayPercent_;
-      }
-
-void Track::setShowLegerLine(bool show) {
-      showLegerLine_ = show;
-      }
-
-bool Track::getShowLegerLine() const {
-      return showLegerLine_;
-      }
-
-void Track::setShowClef(bool show) {
-      showClef_ = show;
-      }
-
-bool Track::getShowClef() const {
-      return showClef_;
-      }
-
-void Track::setShowTimeSignature(bool show) {
-      showTimeSignature_ = show;
-      }
-
-bool Track::getShowTimeSignature() const {
-      return showTimeSignature_;
-      }
-
-void Track::setShowKeySignature(bool show) {
-      showKeySignature_ = show;
-      }
-
-bool Track::getShowKeySignature() const {
-      return showKeySignature_;
-      }
+//---------------------------------------------------------
+//   Track::clear
+//---------------------------------------------------------
 
-void Track::setShowBarline(bool show) {
-      showBarline_ = show;
-      }
-
-bool Track::getShowBarline() const {
-      return showBarline_;
-      }
-
-void Track::setFillWithRest(bool fill) {
-      fillWithRest_ = fill;
-      }
-
-bool Track::getFillWithRest() const {
-      return fillWithRest_;
-      }
-
-void Track::setFlatTail(bool flat) {
-      flatTail_ = flat;
-      }
-
-bool Track::getFlatTail() const {
-      return flatTail_;
-      }
-
-void Track::setShowClefEachLine(bool show) {
-      showClefEachLine_ = show;
-      }
-
-bool Track::getShowClefEachLine() const {
-      return showClefEachLine_;
-      }
-
-void Track::addDrum(const DrumNode& node) {
-      /*DrumNode node;
-   node.line_ = line;
-   node.headType_ = headType;
-   node.pitch_ = pitch;
-   node.voice_ = voice;*/
-      drumKit_.push_back(node);
-      }
-
-QList<Track::DrumNode> Track::getDrumKit() const {
-      return drumKit_;
-      }
-
-void Track::setPart(int part) {
-      part_ = part;
-      }
-
-int Track::getPart() const {
-      return part_;
-      }
-
-void Track::clear(void) {
-      number_ = 0;
-
-      name_ = QString();
-
-      patch_ = 0;
-      channel_ = 0;
-      transpose_ = 0;
-      showTranspose_ = false;
-      noteShift_ = 0;
-      startClef_ = ClefType::Treble;
-      transposeClef_ = ClefType::Treble;
-      displayPercent_ = 100;
-      startKey_ = 0;
-      voiceCount_ = 8;
-
-      showName_ = true;
-      showBriefName_ = false;
-      showKeyEachLine_ = false;
-      showLegerLine_ = true;
-      showClef_ = true;
-      showTimeSignature_ = true;
-      showKeySignature_ = true;
-      showBarline_ = true;
-      showClefEachLine_ = false;
-
-      fillWithRest_ = true;
-      flatTail_ = false;
-
-      mute_ = false;
-      solo_ = false;
-
-      drumKit_.clear();
-
-      part_ = 0;
-
-      for(int i=0; i<voices_.size(); ++i){
-            delete voices_[i];
-            }
-      voices_.clear();
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-Page::Page() {
-      beginLine_ = 0;
-      lineCount_ = 0;
-
-      lineInterval_ = 9;
-      staffInterval_ = 7;
-      staffInlineInterval_ = 6;
-
-      lineBarCount_ = 4;
-      pageLineCount_ = 5;
-
-      leftMargin_ = 0xA8;
-      topMargin_ = 0xA8;
-      rightMargin_ = 0xA8;
-      bottomMargin_ = 0xA8;
-
-      pageWidth_ = 0x0B40;
-      pageHeight_ = 0x0E90;
-      }
-
-void Page::setBeginLine(int line) {
-      beginLine_ = line;
-      }
-
-int Page::getBeginLine() const {
-      return beginLine_;
-      }
-
-void Page::setLineCount(int count) {
-      lineCount_ = count;
-      }
-
-int Page::getLineCount() const {
-      return lineCount_;
-      }
-
-void Page::setLineInterval(int interval) {
-      lineInterval_ = interval;
-      }
-
-int Page::getLineInterval() const {
-      return lineInterval_;
-      }
-
-void Page::setStaffInterval(int interval) {
-      staffInterval_ = interval;
-      }
-
-int Page::getStaffInterval() const {
-      return staffInterval_;
-      }
-
-void Page::setStaffInlineInterval(int interval) {
-      staffInlineInterval_ = interval;
-      }
-
-int Page::getStaffInlineInterval() const {
-      return staffInlineInterval_;
-      }
-
-void Page::setLineBarCount(int count) {
-      lineBarCount_ = count;
-      }
-
-int Page::getLineBarCount() const {
-      return lineBarCount_;
-      }
-
-void Page::setPageLineCount(int count) {
-      pageLineCount_ = count;
-      }
-
-int Page::getPageLineCount() const {
-      return pageLineCount_;
-      }
-
-void Page::setLeftMargin(int margin) {
-      leftMargin_ = margin;
-      }
-
-int Page::getLeftMargin() const {
-      return leftMargin_;
-      }
-
-void Page::setTopMargin(int margin) {
-      topMargin_ = margin;
-      }
-
-int Page::getTopMargin() const {
-      return topMargin_;
-      }
-
-void Page::setRightMargin(int margin) {
-      rightMargin_ = margin;
-      }
-
-int Page::getRightMargin() const {
-      return rightMargin_;
-      }
+void Track::clear() {
+      _number = 0;
 
-void Page::setBottomMargin(int margin) {
-      bottomMargin_ = margin;
-      }
-
-int Page::getBottomMargin() const {
-      return bottomMargin_;
-      }
+      _name = QString();
 
-void Page::setPageWidth(int width) {
-      pageWidth_ = width;
-      }
+      _patch          = 0;
+      _channel        = 0;
+      _transpose      = 0;
+      _showTranspose  = false;
+      _noteShift      = 0;
+      _startClef      = ClefType::Treble;
+      _transposeClef  = ClefType::Treble;
+      _displayPercent = 100;
+      _startKey       = KeyType::Key_C;
+      _voiceCount     = 8;
 
-int Page::getPageWidth() const {
-      return pageWidth_;
-      }
+      _showName          = true;
+      _showBriefName     = false;
+      _showKeyEachLine   = false;
+      _showLegerLine     = true;
+      _showClef          = true;
+      _showTimeSignature = true;
+      _showKeySignature  = true;
+      _showBarline       = true;
+      _showClefEachLine  = false;
 
-void Page::setPageHeight(int height) {
-      pageHeight_ = height;
-      }
+      _fillWithRest = true;
+      _flatTail     = false;
 
-int Page::getPageHeight() const {
-      return pageHeight_;
-      }
+      _mute = false;
+      _solo = false;
 
-///////////////////////////////////////////////////////////////////////////////
-Line::Line() {
-      beginBar_ = 0;
-      barCount_ = 0;
-      yOffset_ = 0;
-      leftXOffset_ = 0;
-      rightXOffset_ = 0;
-      }
+      _drumKit.clear();
 
-Line::~Line() {
-      for(int i=0; i<staffs_.size(); ++i){
-            delete staffs_[i];
-            }
-      staffs_.clear();
-      }
+      _part = 0;
 
-void Line::addStaff(Staff* staff) {
-      staffs_.push_back(staff);
+      for (int i = 0; i < _voices.size(); ++i)
+            delete _voices[i];
+      _voices.clear();
       }
 
-int Line::getStaffCount() const {
-      return staffs_.size();
-      }
+//---------------------------------------------------------
+//   Page
+//---------------------------------------------------------
 
-Staff* Line::getStaff(int idx) const {
-      if (idx >= 0 && idx < static_cast<int>(staffs_.size())) {
-            return staffs_[idx];
-            }
+Page::Page()
+      {
+      _beginLine = 0;
+      _lineCount = 0;
 
-      return 0;
-      }
+      _lineInterval        = 9;
+      _staffInterval       = 7;
+      _staffInlineInterval = 6;
 
-void Line::setBeginBar(unsigned int bar) {
-      beginBar_ = bar;
-      }
+      _lineBarCount  = 4;
+      _pageLineCount = 5;
 
-unsigned int Line::getBeginBar() const {
-      return beginBar_;
-      }
+      _leftMargin   = 0xA8;
+      _topMargin    = 0xA8;
+      _rightMargin  = 0xA8;
+      _bottomMargin = 0xA8;
 
-void Line::setBarCount(unsigned int count) {
-      barCount_ = count;
+      _pageWidth  = 0x0B40;
+      _pageHeight = 0x0E90;
       }
 
-unsigned int Line::getBarCount() const {
-      return barCount_;
-      }
+//---------------------------------------------------------
+//   Line
+//---------------------------------------------------------
 
-void Line::setYOffset(int offset) {
-      yOffset_ = offset;
+Line::Line()
+      {
+      _beginBar     = 0;
+      _barCount     = 0;
+      _yOffset      = 0;
+      _leftXOffset  = 0;
+      _rightXOffset = 0;
       }
 
-int Line::getYOffset() const {
-      return yOffset_;
+Line::~Line()
+      {
+      for (int i = 0; i < _staffs.size(); ++i)
+            delete _staffs[i];
+      _staffs.clear();
       }
 
-void Line::setLeftXOffset(int offset) {
-      leftXOffset_ = offset;
-      }
+//---------------------------------------------------------
+//   Line::staff
+//---------------------------------------------------------
 
-int Line::getLeftXOffset() const {
-      return leftXOffset_;
-      }
+Staff* Line::staff(int idx) const
+      {
+      if (idx >= 0 && idx < static_cast<int>(_staffs.size()))
+            return _staffs[idx];
 
-void Line::setRightXOffset(int offset) {
-      rightXOffset_ = offset;
+      return nullptr;
       }
 
-int Line::getRightXOffset() const {
-      return rightXOffset_;
-      }
+//---------------------------------------------------------
+//   Staff
+//---------------------------------------------------------
 
-///////////////////////////////////////////////////////////////////////////////
 Staff::Staff() {
-      clef_ = ClefType::Treble;
-      key_ = 0;
-      visible_ = true;
-      groupType_ = GroupType::None;
-      groupStaffCount_ = 0;
-      }
-
-void Staff::setClefType(int clef) {
-      clef_ = (ClefType) clef;
-      }
-
-ClefType Staff::getClefType() const {
-      return clef_;
-      }
-
-void Staff::setKeyType(int key) {
-      key_ = key;
-      }
-
-int Staff::getKeyType() const {
-      return key_;
-      }
-
-void Staff::setVisible(bool visible) {
-      visible_ = visible;
-      }
-
-bool Staff::setVisible() const {
-      return visible_;
-      }
-
-void Staff::setGroupType(GroupType type){
-      groupType_ = type;
-      }
-
-GroupType Staff::getGroupType() const {
-      return groupType_;
-      }
-
-void Staff::setGroupStaffCount(int count) {
-      groupStaffCount_ = count;
-      }
-
-int Staff::getGroupStaffCount() const {
-      return groupStaffCount_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-Note::Note() {
-      rest_ = false;
-      note_ = 60;
-      accidental_ = AccidentalType::Normal;
-      showAccidental_ = false;
-      offVelocity_ = 0x40;
-      onVelocity_ = 0x50;
-      headType_ = NoteHeadType::Standard;
-      tiePos_ = TiePos::None;
-      offsetStaff_ = 0;
-      show_ = true;
-      offsetTick_ = 0;
-      }
-
-void Note::setIsRest(bool rest) {
-      rest_ = rest;
-      }
-
-bool Note::getIsRest() const {
-      return rest_;
-      }
-
-void Note::setNote(unsigned int note) {
-      note_ = note;
-      }
-
-unsigned int Note::getNote() const {
-      return note_;
-      }
-
-void Note::setAccidental(int type) {
-      accidental_ = (AccidentalType) type;
-      }
-
-AccidentalType Note::getAccidental() const {
-      return accidental_;
-      }
-
-void Note::setShowAccidental(bool show) {
-      showAccidental_ = show;
-      }
-
-bool Note::getShowAccidental() const {
-      return showAccidental_;
-      }
-
-void Note::setOnVelocity(unsigned int velocity) {
-      onVelocity_ = velocity;
-      }
-
-unsigned int Note::getOnVelocity() const {
-      return onVelocity_;
-      }
-
-void Note::setOffVelocity(unsigned int velocity) {
-      offVelocity_ = velocity;
-      }
-
-unsigned int Note::getOffVelocity() const {
-      return offVelocity_;
-      }
-
-void Note::setHeadType(int type) {
-      headType_ = (NoteHeadType) type;
-      }
-
-NoteHeadType Note::getHeadType() const {
-      return headType_;
-      }
-
-void Note::setTiePos(int tiePos) {
-      tiePos_ = (TiePos) tiePos;
-      }
-
-TiePos Note::getTiePos() const {
-      return tiePos_;
-      }
-
-void Note::setOffsetStaff(int offset) {
-      offsetStaff_ = offset;
-      }
-
-int Note::getOffsetStaff() const {
-      return offsetStaff_;
-      }
-
-void Note::setShow(bool show) {
-      show_ = show;
-      }
-
-bool Note::getShow() const {
-      return show_;
-      }
-
-void Note::setOffsetTick(int offset) {
-      offsetTick_ = offset;
-      }
-
-int Note::getOffsetTick() const {
-      return offsetTick_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-Articulation::Articulation() {
-      type_ = ArticulationType::Marcato;
-      above_ = true;
-
-      changeSoundEffect_ = false;
-      changeLength_ = false;
-      changeVelocity_ = false;
-      changeExtraLength_ = false;
-
-      soundEffect_ = qMakePair(0, 0);
-      lengthPercentage_ = 100;
-      velocityType_ = VelocityType::Offset;
-      velocityValue_ = 0;
-      extraLength_ = 0;
-
-      trillNoteLength_ = 60;
-      trillRate_ = NoteType::Note_Sixteen;
-      accelerateType_ = AccelerateType::None;
-      auxiliaryFirst_ = false;
-      trillInterval_ = TrillInterval::Chromatic;
-      }
-
-void Articulation::setArtType(int type) {
-      type_ = (ArticulationType) type;
-      }
-
-ArticulationType Articulation::getArtType() const {
-      return type_;
-      }
-
-void Articulation::setPlacementAbove(bool above) {
-      above_ = above;
-      }
-
-bool Articulation::getPlacementAbove() const {
-      return above_;
-      }
-
-bool Articulation::getChangeSoundEffect() const {
-      return changeSoundEffect_;
-      }
-
-void Articulation::setSoundEffect(int soundFrom, int soundTo) {
-      soundEffect_ = qMakePair(soundFrom, soundTo);
-      changeSoundEffect_ = true;
-      }
-
-QPair<int, int> Articulation::getSoundEffect() const {
-      return soundEffect_;
-      }
-
-bool Articulation::getChangeLength() const {
-      return changeLength_;
-      }
-
-void Articulation::setLengthPercentage(int percentage) {
-      lengthPercentage_ = percentage;
-      changeLength_ = true;
-      }
-
-int Articulation::getLengthPercentage() const {
-      return lengthPercentage_;
-      }
-
-bool Articulation::getChangeVelocity() const {
-      return changeVelocity_;
-      }
-
-void Articulation::setVelocityType(VelocityType type) {
-      velocityType_ = type;
-      changeVelocity_ = true;
-      }
-
-Articulation::VelocityType Articulation::getVelocityType() const {
-      return velocityType_;
-      }
-
-void Articulation::setVelocityValue(int value) {
-      velocityValue_ = value;
-      }
-
-int Articulation::getVelocityValue() const {
-      return velocityValue_;
-      }
-
-bool Articulation::getChangeExtraLength() const {
-      return changeExtraLength_;
-      }
-
-void Articulation::setExtraLength(int length) {
-      extraLength_ = length;
-      changeExtraLength_ = true;
-      }
-
-int Articulation::getExtraLength() const {
-      return extraLength_;
-      }
-
-void Articulation::setTrillNoteLength(int length) {
-      trillNoteLength_ = length;
-      }
-
-int Articulation::getTrillNoteLength() const {
-      return trillNoteLength_;
-      }
-
-void Articulation::setTrillRate(NoteType rate) {
-      trillRate_ = rate;
-      }
-
-NoteType Articulation::getTrillRate() const {
-      return trillRate_;
-      }
-
-void Articulation::setAccelerateType(int type) {
-      accelerateType_ = (AccelerateType) type;
-      }
-
-Articulation::AccelerateType Articulation::getAccelerateType() const {
-      return accelerateType_;
-      }
-
-void Articulation::setAuxiliaryFirst(bool first) {
-      auxiliaryFirst_ = first;
-      }
-
-bool Articulation::getAuxiliaryFirst() const {
-      return auxiliaryFirst_;
-      }
-
-void Articulation::setTrillInterval(int interval) {
-      trillInterval_ = (TrillInterval) interval;
-      }
-
-Articulation::TrillInterval Articulation::getTrillInterval() const {
-      return trillInterval_;
-      }
-
-bool Articulation::willAffectNotes() const {
-      bool affect = false;
-
-      switch (getArtType()) {
-            case ArticulationType::Major_Trill:
-            case ArticulationType::Minor_Trill:
-            case ArticulationType::Trill_Section:
-            case ArticulationType::Inverted_Short_Mordent:
-            case ArticulationType::Inverted_Long_Mordent:
-            case ArticulationType::Short_Mordent:
-            case ArticulationType::Turn:
-
-            case ArticulationType::Arpeggio:
-            case ArticulationType::Tremolo_Eighth:
-            case ArticulationType::Tremolo_Sixteenth:
-            case ArticulationType::Tremolo_Thirty_Second:
-            case ArticulationType::Tremolo_Sixty_Fourth: {
-                  affect = true;
-                  break;
-                  }
-            case ArticulationType::Finger_1:
-            case ArticulationType::Finger_2:
-            case ArticulationType::Finger_3:
-            case ArticulationType::Finger_4:
-            case ArticulationType::Finger_5:
-            case ArticulationType::Flat_Accidental_For_Trill:
-            case ArticulationType::Sharp_Accidental_For_Trill:
-            case ArticulationType::Natural_Accidental_For_Trill:
-            case ArticulationType::Marcato:
-            case ArticulationType::Marcato_Dot:
-            case ArticulationType::Heavy_Attack:
-            case ArticulationType::SForzando:
-            case ArticulationType::SForzando_Dot:
-            case ArticulationType::Heavier_Attack:
-            case ArticulationType::SForzando_Inverted:
-            case ArticulationType::SForzando_Dot_Inverted:
-            case ArticulationType::Staccatissimo:
-            case ArticulationType::Staccato:
-            case ArticulationType::Tenuto:
-            case ArticulationType::Up_Bow:
-            case ArticulationType::Down_Bow:
-            case ArticulationType::Up_Bow_Inverted:
-            case ArticulationType::Down_Bow_Inverted:
-            case ArticulationType::Natural_Harmonic:
-            case ArticulationType::Artificial_Harmonic:
-            case ArticulationType::Plus_Sign:
-            case ArticulationType::Fermata:
-            case ArticulationType::Fermata_Inverted:
-            case ArticulationType::Pedal_Down:
-            case ArticulationType::Pedal_Up:
-            case ArticulationType::Pause:
-            case ArticulationType::Grand_Pause:
-            case ArticulationType::Toe_Pedal:
-            case ArticulationType::Heel_Pedal:
-            case ArticulationType::Toe_To_Heel_Pedal:
-            case ArticulationType::Heel_To_Toe_Pedal:
-            case ArticulationType::Open_String:
-            case ArticulationType::Guitar_Lift:
-            case ArticulationType::Guitar_Slide_Up:
-            case ArticulationType::Guitar_Rip:
-            case ArticulationType::Guitar_Fall_Off:
-            case ArticulationType::Guitar_Slide_Down:
-            case ArticulationType::Guitar_Spill:
-            case ArticulationType::Guitar_Flip:
-            case ArticulationType::Guitar_Smear:
-            case ArticulationType::Guitar_Bend:
-            case ArticulationType::Guitar_Doit:
-            case ArticulationType::Guitar_Plop:
-            case ArticulationType::Guitar_Wow_Wow:
-            case ArticulationType::Guitar_Thumb:
-            case ArticulationType::Guitar_Index_Finger:
-            case ArticulationType::Guitar_Middle_Finger:
-            case ArticulationType::Guitar_Ring_Finger:
-            case ArticulationType::Guitar_Pinky_Finger:
-            case ArticulationType::Guitar_Tap:
-            case ArticulationType::Guitar_Hammer:
-            case ArticulationType::Guitar_Pluck: {
-                  break;
-                  }
-            default:
-                  break;
-            }
-
-      return affect;
-      }
-
-bool Articulation::isTrill(ArticulationType type) {
-      bool isTrill = false;
-
-      switch (type) {
-            case ArticulationType::Major_Trill:
-            case ArticulationType::Minor_Trill:
-            case ArticulationType::Trill_Section: {
-                  isTrill = true;
-                  break;
-                  }
-            default:
-                  break;
-            }
-
-      return isTrill;
-      }
-
-Articulation::XmlType Articulation::getXmlType() const {
+      _clef            = ClefType::Treble;
+      _keyType         = 0;
+      _visible         = true;
+      _groupType       = GroupType::None;
+      _groupStaffCount = 0;
+      }
+
+//---------------------------------------------------------
+//   Note
+//---------------------------------------------------------
+
+Note::Note()
+      {
+      _isRest         = false;
+      _note           = 60;
+      _accidental     = AccidentalType::Normal;
+      _showAccidental = false;
+      _offVelocity    = 0x40;
+      _onVelocity     = 0x50;
+      _headType       = NoteHeadType::Standard;
+      _tiePos         = TiePos::None;
+      _offsetStaff    = 0;
+      _show           = true;
+      _offsetTick     = 0;
+      }
+
+//---------------------------------------------------------
+//   Articulation
+//---------------------------------------------------------
+
+Articulation::Articulation()
+      {
+      _type  = ArticulationType::Marcato;
+      _above = true;
+
+      _changeSoundEffect = false;
+      _changeLength      = false;
+      _changeVelocity    = false;
+      _changeExtraLength = false;
+
+      _soundEffect      = qMakePair(0, 0);
+      _lengthPercentage = 100;
+      _velocityType     = VelocityType::Offset;
+      _velocity         = 0;
+      _extraLength      = 0;
+
+      _trillNoteLength = 60;
+      _trillRate       = NoteType::Note_Sixteen;
+      _accelerateType  = AccelerateType::None;
+      _auxiliaryFirst  = false;
+      _trillInterval   = TrillInterval::Chromatic;
+      }
+
+//---------------------------------------------------------
+//   Articulation::setSoundEffect
+//---------------------------------------------------------
+
+void Articulation::setSoundEffect(int soundFrom, int soundTo)
+      {
+      _soundEffect       = qMakePair(soundFrom, soundTo);
+      _changeSoundEffect = true;
+      }
+
+//---------------------------------------------------------
+//   Articulation::setLengthPercentage
+//---------------------------------------------------------
+
+void Articulation::setLengthPercentage(int percentage)
+      {
+      _lengthPercentage = percentage;
+      _changeLength     = true;
+      }
+
+//---------------------------------------------------------
+//   Articulation::setVelocityType
+//---------------------------------------------------------
+
+void Articulation::setVelocityType(VelocityType type)
+      {
+      _velocityType   = type;
+      _changeVelocity = true;
+      }
+
+//---------------------------------------------------------
+//   Articulation::setExtraLength
+//---------------------------------------------------------
+
+void Articulation::setExtraLength(int length)
+      {
+      _extraLength       = length;
+      _changeExtraLength = true;
+      }
+
+//---------------------------------------------------------
+//   Articulation::willAffectNotes
+//---------------------------------------------------------
+
+bool Articulation::willAffectNotes() const
+      {
+      return (articulationType() == ArticulationType::Major_Trill) ||
+         (articulationType() == ArticulationType::Minor_Trill) ||
+         (articulationType() == ArticulationType::Trill_Section) ||
+         (articulationType() == ArticulationType::Inverted_Short_Mordent) || 
+         (articulationType() == ArticulationType::Inverted_Long_Mordent) || 
+         (articulationType() == ArticulationType::Short_Mordent) ||
+         (articulationType() == ArticulationType::Turn) ||
+         (articulationType() == ArticulationType::Arpeggio) || 
+         (articulationType() == ArticulationType::Tremolo_Eighth) || 
+         (articulationType() == ArticulationType::Tremolo_Sixteenth) ||
+         (articulationType() == ArticulationType::Tremolo_Thirty_Second) || 
+         (articulationType() == ArticulationType::Tremolo_Sixty_Fourth);
+      }
+
+//---------------------------------------------------------
+//   Articulation::isTrill
+//---------------------------------------------------------
+
+bool Articulation::isTrill() const
+      {
+      return (articulationType() == ArticulationType::Major_Trill) ||
+         (articulationType() == ArticulationType::Minor_Trill) ||
+         (articulationType() == ArticulationType::Trill_Section);
+      }
+
+//---------------------------------------------------------
+//   Articulation::xmlType
+//---------------------------------------------------------
+
+Articulation::XmlType Articulation::xmlType() const
+      {
       XmlType xmlType = XmlType::Unknown;
 
-      switch (type_) {
+      switch (_type) {
             case ArticulationType::Major_Trill:
             case ArticulationType::Minor_Trill:
             case ArticulationType::Trill_Section:
@@ -1632,16 +769,15 @@ Articulation::XmlType Articulation::getXmlType() const {
             case ArticulationType::Inverted_Long_Mordent:
             case ArticulationType::Short_Mordent:
             case ArticulationType::Turn:
-                  // case ArticulationType::Flat_Accidental_For_Trill :
-                  // case ArticulationType::Sharp_Accidental_For_Trill :
-                  // case ArticulationType::Natural_Accidental_For_Trill :
+            // case ArticulationType::Flat_Accidental_For_Trill:
+            // case ArticulationType::Sharp_Accidental_For_Trill:
+            // case ArticulationType::Natural_Accidental_For_Trill:
             case ArticulationType::Tremolo_Eighth:
             case ArticulationType::Tremolo_Sixteenth:
             case ArticulationType::Tremolo_Thirty_Second:
-            case ArticulationType::Tremolo_Sixty_Fourth: {
+            case ArticulationType::Tremolo_Sixty_Fourth:
                   xmlType = XmlType::Ornament;
                   break;
-                  }
             case ArticulationType::Marcato:
             case ArticulationType::Marcato_Dot:
             case ArticulationType::Heavy_Attack:
@@ -1654,10 +790,9 @@ Articulation::XmlType Articulation::getXmlType() const {
             case ArticulationType::Staccato:
             case ArticulationType::Tenuto:
             case ArticulationType::Pause:
-            case ArticulationType::Grand_Pause: {
+            case ArticulationType::Grand_Pause:
                   xmlType = XmlType::Articulation;
                   break;
-                  }
             case ArticulationType::Up_Bow:
             case ArticulationType::Down_Bow:
             case ArticulationType::Up_Bow_Inverted:
@@ -1669,29 +804,25 @@ Articulation::XmlType Articulation::getXmlType() const {
             case ArticulationType::Finger_3:
             case ArticulationType::Finger_4:
             case ArticulationType::Finger_5:
-            case ArticulationType::Plus_Sign: {
+            case ArticulationType::Plus_Sign:
                   xmlType = XmlType::Technical;
                   break;
-                  }
-            case ArticulationType::Arpeggio: {
+            case ArticulationType::Arpeggio: 
                   xmlType = XmlType::Arpeggiate;
                   break;
-                  }
             case ArticulationType::Fermata:
-            case ArticulationType::Fermata_Inverted: {
+            case ArticulationType::Fermata_Inverted:
                   xmlType = XmlType::Fermata;
                   break;
-                  }
             case ArticulationType::Pedal_Down:
-            case ArticulationType::Pedal_Up: {
+            case ArticulationType::Pedal_Up:
                   xmlType = XmlType::Direction;
                   break;
-                  }
-                  // case ArticulationType::Toe_Pedal :
-                  // case ArticulationType::Heel_Pedal :
-                  // case ArticulationType::Toe_To_Heel_Pedal :
-                  // case ArticulationType::Heel_To_Toe_Pedal :
-                  // case ArticulationType::Open_String :
+            // case ArticulationType::Toe_Pedal:
+            // case ArticulationType::Heel_Pedal:
+            // case ArticulationType::Toe_To_Heel_Pedal:
+            // case ArticulationType::Heel_To_Toe_Pedal:
+            // case ArticulationType::Open_String:
             default:
                   break;
             }
@@ -1699,251 +830,118 @@ Articulation::XmlType Articulation::getXmlType() const {
       return xmlType;
       }
 
-///////////////////////////////////////////////////////////////////////////////
-NoteContainer::NoteContainer() {
-      musicDataType_ = MusicDataType::Note_Container;
+//---------------------------------------------------------
+//   NoteContainer
+//---------------------------------------------------------
 
-      grace_ = false;
-      cue_ = false;
-      rest_ = false;
-      raw_ = false;
-      noteType_ = NoteType::Note_Quarter;
-      dot_ = 0;
-      graceNoteType_ = NoteType::Note_Eight;
-      stemUp_ = true;
-      showStem_ = true;
-      stemLength_ = 7;
-      inBeam_ = false;
-      tuplet_ = 0;
-      space_ = 2;//div by 0
-      noteShift_ = 0;
+NoteContainer::NoteContainer()
+      {
+      _musicDataType = MusicDataType::Note_Container;
+
+      _isGrace       = false;
+      _isCue         = false;
+      _isRest        = false;
+      _isRaw         = false;
+      _noteType      = NoteType::Note_Quarter;
+      _dot           = 0;
+      _graceNoteType = NoteType::Note_Eight;
+      _up            = true;
+      _showStem      = true;
+      _stemLength    = 7;
+      _inBeam        = false;
+      _tuplet        = 0;
+      _space         = 2; // div by 0
+      _noteShift     = 0;
       }
 
-NoteContainer::~NoteContainer(){
-      for(int i=0; i<notes_.size(); ++i){
-            delete notes_[i];
-            }
-      for(int i=0; i<articulations_.size(); ++i){
-            delete articulations_[i];
-            }
-      notes_.clear();
-      articulations_.clear();
+NoteContainer::~NoteContainer()
+      {
+      for (int i = 0; i < _notes.size(); ++i)
+            delete _notes[i];
+      _notes.clear();
+      for (int i = 0; i < _articulations.size(); ++i)
+            delete _articulations[i];
+      _articulations.clear();
       }
 
-void NoteContainer::setIsGrace(bool grace) {
-      grace_ = grace;
+//---------------------------------------------------------
+//   NoteContainer::setNoteType
+//---------------------------------------------------------
+
+void NoteContainer::setNoteType(NoteType type)
+      {
+      if (type != NoteType::Note_None)
+            _noteType = type;
+      else
+            _noteType = NoteType::Note_Quarter;
       }
 
-bool NoteContainer::getIsGrace() const {
-      return grace_;
-      }
+//---------------------------------------------------------
+//   NoteContainer::offsetStaff
+//---------------------------------------------------------
 
-void NoteContainer::setIsCue(bool cue) {
-      cue_ = cue;
-      }
-
-bool NoteContainer::getIsCue() const {
-      return cue_;
-      }
-
-void NoteContainer::setIsRest(bool rest) {
-      rest_ = rest;
-      }
-
-bool NoteContainer::getIsRest() const {
-      return rest_;
-      }
-
-void NoteContainer::setIsRaw(bool raw) {
-      raw_ = raw;
-      }
-
-bool NoteContainer::getIsRaw() const {
-      return raw_;
-      }
-
-void NoteContainer::setNoteType(NoteType type) {
-      noteType_ = NoteType::Note_Quarter;
-
-      switch (type) {
-            case NoteType::Note_DoubleWhole:
-            case NoteType::Note_Whole:
-            case NoteType::Note_Half:
-            case NoteType::Note_Quarter:
-            case NoteType::Note_Eight:
-            case NoteType::Note_Sixteen:
-            case NoteType::Note_32:
-            case NoteType::Note_64:
-            case NoteType::Note_128:
-            case NoteType::Note_256: {
-                  noteType_ = type;
-                  break;
-                  }
-            default: {
-                  break;
-                  }
-            }
-      }
-
-NoteType NoteContainer::getNoteType() const {
-      return noteType_;
-      }
-
-void NoteContainer::setDot(int dot) {
-      dot_ = dot;
-      }
-
-int NoteContainer::getDot() const {
-      return dot_;
-      }
-
-void NoteContainer::setGraceNoteType(NoteType type) {
-      graceNoteType_ = type;
-      }
-
-NoteType NoteContainer::getGraceNoteType() const {
-      return graceNoteType_;
-      }
-
-void NoteContainer::setInBeam(bool in) {
-      inBeam_ = in;
-      }
-
-bool NoteContainer::getInBeam() const {
-      return inBeam_;
-      }
-
-void NoteContainer::setStemUp(bool up) {
-      stemUp_ = up;
-      }
-
-bool NoteContainer::getStemUp(void) const {
-      return stemUp_;
-      }
-
-void NoteContainer::setShowStem(bool show) {
-      showStem_ = show;
-      }
-
-bool NoteContainer::getShowStem() const {
-      return showStem_;
-      }
-
-void NoteContainer::setStemLength(int line) {
-      stemLength_ = line;
-      }
-
-int NoteContainer::getStemLength() const {
-      return stemLength_;
-      }
-
-void NoteContainer::setTuplet(int tuplet) {
-      tuplet_ = tuplet;
-      }
-
-int NoteContainer::getTuplet() const {
-      return tuplet_;
-      }
-
-void NoteContainer::setSpace(int space) {
-      space_ = space;
-      }
-
-int NoteContainer::getSpace() const {
-      return space_;
-      }
-
-void NoteContainer::addNoteRest(Note* note) {
-      notes_.push_back(note);
-      }
-
-QList<Note*> NoteContainer::getNotesRests() const {
-      return notes_;
-      }
-
-void NoteContainer::addArticulation(Articulation* art) {
-      articulations_.push_back(art);
-      }
-
-QList<Articulation*> NoteContainer::getArticulations() const {
-      return articulations_;
-      }
-
-void NoteContainer::setNoteShift(int octave) {
-      noteShift_ = octave;
-      }
-
-int NoteContainer::getNoteShift() const {
-      return noteShift_;
-      }
-
-int NoteContainer::getOffsetStaff() const {
-      if(getIsRest())
+int NoteContainer::offsetStaff() const
+      {
+      if (isRest())
             return 0;
 
       int staffMove = 0;
-      QList<OVE::Note*> notes = getNotesRests();
+      QList<Ove::Note*> notes = notesRests();
       for (int i = 0; i < notes.size(); ++i) {
-            OVE::Note* notePtr = notes[i];
-            staffMove = notePtr->getOffsetStaff();
+            Ove::Note* notePtr = notes[i];
+            staffMove = notePtr->offsetStaff();
             }
 
       return staffMove;
       }
 
-int NoteContainer::getDuration() const {
+//---------------------------------------------------------
+//   NoteContainer::duration
+//---------------------------------------------------------
+
+int NoteContainer::duration() const
+      {
       int duration = static_cast<int>(NoteDuration::D_4);
 
-      switch (noteType_) {
-            case NoteType::Note_DoubleWhole: {
+      switch (_noteType) {
+            case NoteType::Note_DoubleWhole:
                   duration = static_cast<int>(NoteDuration::D_Double_Whole);
                   break;
-                  }
-            case NoteType::Note_Whole: {
+            case NoteType::Note_Whole:
                   duration = static_cast<int>(NoteDuration::D_Whole);
                   break;
-                  }
-            case NoteType::Note_Half: {
+            case NoteType::Note_Half:
                   duration = static_cast<int>(NoteDuration::D_2);
                   break;
-                  }
-            case NoteType::Note_Quarter: {
+            case NoteType::Note_Quarter:
                   duration = static_cast<int>(NoteDuration::D_4);
                   break;
-                  }
-            case NoteType::Note_Eight: {
+            case NoteType::Note_Eight:
                   duration = static_cast<int>(NoteDuration::D_8);
                   break;
-                  }
-            case NoteType::Note_Sixteen: {
+            case NoteType::Note_Sixteen:
                   duration = static_cast<int>(NoteDuration::D_16);
                   break;
-                  }
-            case NoteType::Note_32: {
+            case NoteType::Note_32:
                   duration = static_cast<int>(NoteDuration::D_32);
                   break;
-                  }
-            case NoteType::Note_64: {
+            case NoteType::Note_64:
                   duration = static_cast<int>(NoteDuration::D_64);
                   break;
-                  }
-            case NoteType::Note_128: {
+            case NoteType::Note_128:
                   duration = static_cast<int>(NoteDuration::D_128);
                   break;
-                  }
-            case NoteType::Note_256: {
+            case NoteType::Note_256:
                   duration = static_cast<int>(NoteDuration::D_256);
                   break;
-                  }
             default:
                   break;
             }
 
       int dotLength = duration;
 
-      for (int i = 0; i < dot_; ++i) {
+      for (int i = 0; i < _dot; ++i)
             dotLength /= 2;
-            }
 
       dotLength = duration - dotLength;
 
@@ -1952,125 +950,73 @@ int NoteContainer::getDuration() const {
       return duration;
       }
 
-///////////////////////////////////////////////////////////////////////////////
-Beam::Beam() {
-      musicDataType_ = MusicDataType::Beam;
-      grace_ = false;
+//---------------------------------------------------------
+//   Beam
+//---------------------------------------------------------
+
+Beam::Beam()
+      {
+      _musicDataType = MusicDataType::Beam;
+
+      _isGrace       = false;
       }
 
-void Beam::setIsGrace(bool grace) {
-      grace_ = grace;
+//---------------------------------------------------------
+//   Tie
+//---------------------------------------------------------
+
+Tie::Tie()
+      {
+      _musicDataType = MusicDataType::Tie;
+
+      _showOnTop     = true;
+      _note          = 72;
+      _height        = 24;
       }
 
-bool Beam::getIsGrace() const {
-      return grace_;
+//---------------------------------------------------------
+//   Glissando
+//---------------------------------------------------------
+
+Glissando::Glissando()
+      {
+      _musicDataType = MusicDataType::Glissando;
+
+      _straight      = true;
+      _text          = "gliss.";
+      _lineThick     = 8;
       }
 
-void Beam::addLine(const MeasurePos& startMp, const MeasurePos& endMp) {
-      lines_.push_back(qMakePair(startMp, endMp));
+//---------------------------------------------------------
+//   Decorator
+//---------------------------------------------------------
+
+Decorator::Decorator()
+      {
+      _musicDataType    = MusicDataType::Decorator;
+
+      _decoratorType    = DecoratorType::Articulation;
+      _articulationType = ArticulationType::Marcato;
       }
 
-const QList<QPair<MeasurePos, MeasurePos> > Beam::getLines() const {
-      return lines_;
+//---------------------------------------------------------
+//   MeasureRepeat
+//---------------------------------------------------------
+
+MeasureRepeat::MeasureRepeat()
+      {
+      _musicDataType = MusicDataType::Measure_Repeat;
+
+      _singleRepeat  = true;
       }
 
-///////////////////////////////////////////////////////////////////////////////
-Tie::Tie() {
-      musicDataType_ = MusicDataType::Tie;
+//---------------------------------------------------------
+//   MeasureRepeat::setSingleRepeat
+//---------------------------------------------------------
 
-      showOnTop_ = true;
-      note_ = 72;
-      height_ = 24;
-      }
-
-void Tie::setShowOnTop(bool top) {
-      showOnTop_ = top;
-      }
-
-bool Tie::getShowOnTop() const {
-      return showOnTop_;
-      }
-
-void Tie::setNote(int note) {
-      note_ = note;
-      }
-
-int Tie::getNote() const {
-      return note_;
-      }
-
-void Tie::setHeight(int height) {
-      height_ = height;
-      }
-
-int Tie::getHeight() const {
-      return height_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-Glissando::Glissando() {
-      musicDataType_ = MusicDataType::Glissando;
-
-      straight_ = true;
-      text_ = "gliss.";
-      lineThick_ = 8;
-      }
-
-void Glissando::setStraightWavy(bool straight) {
-      straight_ = straight;
-      }
-
-bool Glissando::getStraightWavy() const {
-      return straight_;
-      }
-
-void Glissando::setText(const QString& text) {
-      text_ = text;
-      }
-
-QString Glissando::getText() const {
-      return text_;
-      }
-
-void Glissando::setLineThick(int thick) {
-      lineThick_ = thick;
-      }
-
-int Glissando::getLineThick() const {
-      return lineThick_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-Decorator::Decorator() :
-      decoratorType_(Type::Articulation),
-      artType_(ArticulationType::Marcato) {
-      musicDataType_ = MusicDataType::Decorator;
-      }
-
-void Decorator::setDecoratorType(Type type) {
-      decoratorType_ = type;
-      }
-
-Decorator::Type Decorator::getDecoratorType() const {
-      return decoratorType_;
-      }
-
-void Decorator::setArticulationType(ArticulationType type) {
-      artType_ = type;
-      }
-
-ArticulationType Decorator::getArticulationType() const {
-      return artType_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-MeasureRepeat::MeasureRepeat() {
-      musicDataType_ = MusicDataType::Measure_Repeat;
-      singleRepeat_ = true;
-      }
-
-void MeasureRepeat::setSingleRepeat(bool single) {
-      singleRepeat_ = single;
+void MeasureRepeat::setSingleRepeat(bool single)
+      {
+      _singleRepeat = single;
 
       start()->setMeasure(0);
       start()->setOffset(0);
@@ -2078,445 +1024,213 @@ void MeasureRepeat::setSingleRepeat(bool single) {
       stop()->setOffset(0);
       }
 
-bool MeasureRepeat::getSingleRepeat() const {
-      return singleRepeat_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-Tuplet::Tuplet() :
-      tuplet_(3), space_(2), height_(0), noteType_(NoteType::Note_Quarter){
-      musicDataType_ = MusicDataType::Tuplet;
-      mark_ = new OffsetElement();
-      }
-
-Tuplet::~Tuplet(){
-      delete mark_;
-      }
-
-void Tuplet::setTuplet(int tuplet) {
-      tuplet_ = tuplet;
-      }
-
-int Tuplet::getTuplet() const {
-      return tuplet_;
-      }
-
-void Tuplet::setSpace(int space) {
-      space_ = space;
-      }
-
-int Tuplet::getSpace() const {
-      return space_;
-      }
-
-OffsetElement* Tuplet::getMarkHandle() const {
-      return mark_;
-      }
-
-void Tuplet::setHeight(int height) {
-      height_ = height;
-      }
-
-int Tuplet::getHeight() const {
-      return height_;
-      }
-
-void Tuplet::setNoteType(NoteType type) {
-      noteType_ = type;
-      }
-
-NoteType Tuplet::getNoteType() const {
-      return noteType_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-Harmony::Harmony() {
-      musicDataType_ = MusicDataType::Harmony;
-
-      harmonyType_ = "";
-      root_ = 0;
-      bass_ = -1; //0xff
-      alterRoot_ = 0;
-      alterBass_ = 0;
-      bassOnBottom_ = false;
-      angle_ = 0;
-      }
-
-void Harmony::setHarmonyType(QString type) {
-      harmonyType_ = type;
-      }
-
-QString Harmony::getHarmonyType() const {
-      return harmonyType_;
-      }
-
-void Harmony::setRoot(int root) {
-      root_ = root;
-      }
-
-int Harmony::getRoot() const {
-      return root_;
-      }
-
-void Harmony::setAlterRoot(int val) {
-      alterRoot_ = val;
-      }
-
-int Harmony::getAlterRoot() const {
-      return alterRoot_;
-      }
-
-void Harmony::setBass(int bass) {
-      bass_ = bass;
-      }
-
-int Harmony::getBass() const {
-      return bass_;
-      }
-
-void Harmony::setAlterBass(int val) {
-      alterBass_ = val;
-      }
-
-int Harmony::getAlterBass() const {
-      return alterBass_;
-      }
-
-void Harmony::setBassOnBottom(bool on) {
-      bassOnBottom_ = on;
-      }
-
-bool Harmony::getBassOnBottom() const {
-      return bassOnBottom_;
-      }
-
-void Harmony::setAngle(int angle) {
-      angle_ = angle;
-      }
-
-int Harmony::getAngle() const {
-      return angle_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-Clef::Clef() {
-      musicDataType_ = MusicDataType::Clef;
-
-      clefType_ = ClefType::Treble;
-      }
-
-void Clef::setClefType(int type) {
-      clefType_ = (ClefType) type;
-      }
-
-ClefType Clef::getClefType() const {
-      return clefType_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-Lyric::Lyric() {
-      musicDataType_ = MusicDataType::Lyric;
-
-      lyric_ = QString();
-      verse_ = 0;
-      }
-
-void Lyric::setLyric(const QString& lyricText) {
-      lyric_ = lyricText;
-      }
-
-QString Lyric::getLyric() const {
-      return lyric_;
-      }
-
-void Lyric::setVerse(int verse) {
-      verse_ = verse;
-      }
-
-int Lyric::getVerse() const {
-      return verse_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-Slur::Slur() {
-      musicDataType_ = MusicDataType::Slur;
-
-      containerCount_ = 1;
-      showOnTop_ = true;
-      noteTimePercent_ = 100;
-
-      handle_2_ = new OffsetElement();
-      handle_3_ = new OffsetElement();
-      }
-
-Slur::~Slur() {
-      delete handle_2_;
-      delete handle_3_;
-      }
-
-void Slur::setContainerCount(int count) {
-      containerCount_ = count;
-      }
-
-int Slur::getContainerCount() const {
-      return containerCount_;
-      }
-
-void Slur::setShowOnTop(bool top) {
-      showOnTop_ = top;
-      }
-
-bool Slur::getShowOnTop() const {
-      return showOnTop_;
-      }
-
-OffsetElement* Slur::getHandle2() const {
-      return handle_2_;
-      }
-
-OffsetElement* Slur::getHandle3() const {
-      return handle_3_;
-      }
-
-void Slur::setNoteTimePercent(int percent) {
-      noteTimePercent_ = percent;
-      }
-
-int Slur::getNoteTimePercent() const {
-      return noteTimePercent_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-Dynamics::Dynamics() {
-      musicDataType_ = MusicDataType::Dynamics;
-
-      dynamicsType_ = DynamicsType::PPPP;
-      playback_ = true;
-      velocity_ = 30;
-      }
+//---------------------------------------------------------
+//   Tuplet
+//---------------------------------------------------------
 
-void Dynamics::setDynamicsType(int type) {
-      dynamicsType_ = DynamicsType(type);
-      }
-
-DynamicsType Dynamics::getDynamicsType() const {
-      return dynamicsType_;
-      }
-
-void Dynamics::setIsPlayback(bool play) {
-      playback_ = play;
-      }
+Tuplet::Tuplet()
+      {
+      _musicDataType = MusicDataType::Tuplet;
 
-bool Dynamics::getIsPlayback() const {
-      return playback_;
+      _tuplet        = 3;
+      _space         = 2;
+      _height        = 0;
+      _noteType      = NoteType::Note_Quarter;
+      _mark          = new OffsetElement();
       }
 
-void Dynamics::setVelocity(int vel) {
-      velocity_ = vel;
+Tuplet::~Tuplet()
+      {
+      delete _mark;
       }
 
-int Dynamics::getVelocity() const {
-      return velocity_;
-      }
+//---------------------------------------------------------
+//   Harmony
+//---------------------------------------------------------
 
-///////////////////////////////////////////////////////////////////////////////
-WedgeEndPoint::WedgeEndPoint() {
-      musicDataType_ = MusicDataType::Wedge_EndPoint;
+Harmony::Harmony()
+      {
+      _musicDataType = MusicDataType::Harmony;
 
-      wedgeType_ = WedgeType::Cres;
-      height_ = 24;
-      wedgeStart_ = true;
+      _harmonyType   = "";
+      _root          = 0;
+      _bass          = -1; // 0xff
+      _alterRoot     = 0;
+      _alterBass     = 0;
+      _bassOnBottom  = false;
+      _angle         = 0;
       }
 
-void WedgeEndPoint::setWedgeType(WedgeType type) {
-      wedgeType_ = type;
-      }
+//---------------------------------------------------------
+//   Clef
+//---------------------------------------------------------
 
-WedgeType WedgeEndPoint::getWedgeType() const {
-      return wedgeType_;
-      }
+Clef::Clef()
+      {
+      _musicDataType = MusicDataType::Clef;
 
-void WedgeEndPoint::setHeight(int height) {
-      height_ = height;
+      _clefType      = ClefType::Treble;
       }
 
-int WedgeEndPoint::getHeight() const {
-      return height_;
-      }
+//---------------------------------------------------------
+//   Lyric
+//---------------------------------------------------------
 
-void WedgeEndPoint::setWedgeStart(bool wedgeStart) {
-      wedgeStart_ = wedgeStart;
-      }
+Lyric::Lyric()
+      {
+      _musicDataType = MusicDataType::Lyric;
 
-bool WedgeEndPoint::getWedgeStart() const {
-      return wedgeStart_;
+      _lyric         = QString();
+      _verse         = 0;
       }
 
-///////////////////////////////////////////////////////////////////////////////
-Wedge::Wedge() {
-      musicDataType_ = MusicDataType::Wedge;
-
-      wedgeType_ = WedgeType::Cres;
-      height_ = 24;
-      }
+//---------------------------------------------------------
+//   Slur
+//---------------------------------------------------------
 
-void Wedge::setWedgeType(WedgeType type) {
-      wedgeType_ = type;
-      }
+Slur::Slur()
+      {
+      _musicDataType   = MusicDataType::Slur;
 
-WedgeType Wedge::getWedgeType() const {
-      return wedgeType_;
-      }
+      _containerCount  = 1;
+      _showOnTop       = true;
+      _noteTimePercent = 100;
 
-void Wedge::setHeight(int height) {
-      height_ = height;
+      _handle2         = new OffsetElement();
+      _handle3         = new OffsetElement();
       }
 
-int Wedge::getHeight() const {
-      return height_;
+Slur::~Slur()
+      {
+      delete _handle2;
+      delete _handle3;
       }
-
-///////////////////////////////////////////////////////////////////////////////
-Pedal::Pedal() {
-      musicDataType_ = MusicDataType::Pedal;
-
-      half_ = false;
-      playback_ = false;
-      playOffset_ = 0;
 
-      pedalHandle_ = new OffsetElement();
-      }
+//---------------------------------------------------------
+//   Dynamic
+//---------------------------------------------------------
 
-Pedal::~Pedal() {
-      delete pedalHandle_;
-      }
+Dynamic::Dynamic()
+      {
+      _musicDataType = MusicDataType::Dynamic;
 
-void Pedal::setHalf(bool half) {
-      half_ = half;
+      _dynamicType   = DynamicType::PPPP;
+      _play          = true;
+      _velocity      = 30;
       }
 
-bool Pedal::getHalf() const {
-      return half_;
-      }
+//---------------------------------------------------------
+//   WedgeEndPoint
+//---------------------------------------------------------
 
-OffsetElement* Pedal::getPedalHandle() const {
-      return pedalHandle_;
-      }
+WedgeEndPoint::WedgeEndPoint()
+      {
+      _musicDataType = MusicDataType::Wedge_EndPoint;
 
-void Pedal::setIsPlayback(bool playback) {
-      playback_ = playback;
+      _wedgeType     = WedgeType::Crescendo;
+      _height        = 24;
+      _wedgeStart    = true;
       }
 
-bool Pedal::getIsPlayback() const {
-      return playback_;
-      }
+//---------------------------------------------------------
+//   Wedge
+//---------------------------------------------------------
 
-void Pedal::setPlayOffset(int offset) {
-      playOffset_ = offset;
-      }
+Wedge::Wedge()
+      {
+      _musicDataType = MusicDataType::Wedge;
 
-int Pedal::getPlayOffset() const {
-      return playOffset_;
+      _wedgeType     = WedgeType::Crescendo;
+      _height        = 24;
       }
 
-///////////////////////////////////////////////////////////////////////////////
-KuoHao::KuoHao() {
-      musicDataType_ = MusicDataType::KuoHao;
-
-      kuohaoType_ = KuoHaoType::Parentheses;
-      height_ = 0;
-      }
+//---------------------------------------------------------
+//   Pedal
+//---------------------------------------------------------
 
-void KuoHao::setHeight(int height) {
-      height_ = height;
-      }
+Pedal::Pedal()
+      {
+      _musicDataType = MusicDataType::Pedal;
 
-int KuoHao::getHeight() const {
-      return height_;
-      }
+      _half        = false;
+      _play        = false;
+      _playOffset  = 0;
 
-void KuoHao::setKuohaoType(int type) {
-      kuohaoType_ = (KuoHaoType) type;
+      _pedalHandle = new OffsetElement();
       }
 
-KuoHaoType KuoHao::getKuohaoType() const {
-      return kuohaoType_;
+Pedal::~Pedal()
+      {
+      delete _pedalHandle;
       }
 
-///////////////////////////////////////////////////////////////////////////////
-Expressions::Expressions() {
-      musicDataType_ = MusicDataType::Expressions;
+//---------------------------------------------------------
+//   Bracket
+//---------------------------------------------------------
 
-      text_ = QString();
-      }
+Bracket::Bracket()
+      {
+      _musicDataType = MusicDataType::Bracket;
 
-void Expressions::setText(const QString& str) {
-      text_ = str;
+      _bracketType   = BracketType::Parentheses;
+      _height        = 0;
       }
 
-QString Expressions::getText() const {
-      return text_;
-      }
+//---------------------------------------------------------
+//   Expression
+//---------------------------------------------------------
 
-///////////////////////////////////////////////////////////////////////////////
-HarpPedal::HarpPedal() :
-      showType_(0),
-      showCharFlag_(0) {
-      musicDataType_ = MusicDataType::Harp_Pedal;
-      }
+Expression::Expression()
+      {
+      _musicDataType = MusicDataType::Expression;
 
-void HarpPedal::setShowType(int type) {
-      showType_ = type;
+      _text          = QString();
       }
 
-int HarpPedal::getShowType() const {
-      return showType_;
-      }
+//---------------------------------------------------------
+//   HarpPedal
+//---------------------------------------------------------
 
-void HarpPedal::setShowCharFlag(int flag) {
-      showCharFlag_ = flag;
+HarpPedal::HarpPedal()
+      {
+      _type          = HarpPedalType::Graph;
+      _showCharFlag  = 0;
+      _musicDataType = MusicDataType::Harp_Pedal;
       }
 
-int HarpPedal::getShowCharFlag() const {
-      return showCharFlag_;
-      }
+//---------------------------------------------------------
+//   OctaveShift
+//---------------------------------------------------------
 
-///////////////////////////////////////////////////////////////////////////////
-OctaveShift::OctaveShift() :
-      octaveShiftType_(OctaveShiftType::OS_8),
-      octaveShiftPosition_(OctaveShiftPosition::Start),
-      endTick_(0) {
-      musicDataType_ = MusicDataType::OctaveShift;
-      }
+OctaveShift::OctaveShift()
+      {
+      _musicDataType       = MusicDataType::OctaveShift;
 
-void OctaveShift::setOctaveShiftType(OctaveShiftType type) {
-      octaveShiftType_ = type;
+      _octaveShiftType     = OctaveShiftType::OS_8;
+      _octaveShiftPosition = OctaveShiftPosition::Start;
+      _endTick             = 0;
       }
 
-OctaveShiftType OctaveShift::getOctaveShiftType() const {
-      return octaveShiftType_;
-      }
+//---------------------------------------------------------
+//   OctaveShift::noteShift
+//---------------------------------------------------------
 
-int OctaveShift::getNoteShift() const {
+int OctaveShift::noteShift() const
+      {
       int shift = 12;
 
-      switch (getOctaveShiftType()) {
-            case OctaveShiftType::OS_8: {
-                  shift = 12;
+      switch (octaveShiftType()) {
+            case OctaveShiftType::OS_8:
                   break;
-                  }
-            case OctaveShiftType::OS_Minus_8: {
+            case OctaveShiftType::OS_Minus_8:
                   shift = -12;
                   break;
-                  }
-            case OctaveShiftType::OS_15: {
+            case OctaveShiftType::OS_15:
                   shift = 24;
                   break;
-                  }
-            case OctaveShiftType::OS_Minus_15: {
+            case OctaveShiftType::OS_Minus_15:
                   shift = -24;
                   break;
-                  }
             default:
                   break;
             }
@@ -2524,512 +1238,211 @@ int OctaveShift::getNoteShift() const {
       return shift;
       }
 
-void OctaveShift::setEndTick(int tick) {
-      endTick_ = tick;
+//---------------------------------------------------------
+//   OctaveShiftEndPoint
+//---------------------------------------------------------
+
+OctaveShiftEndPoint::OctaveShiftEndPoint()
+      {
+      _musicDataType       = MusicDataType::OctaveShift_EndPoint;
+
+      _octaveShiftType     = OctaveShiftType::OS_8;
+      _octaveShiftPosition = OctaveShiftPosition::Start;
+      _endTick             = 0;
       }
 
-int OctaveShift::getEndTick() const {
-      return endTick_;
+//---------------------------------------------------------
+//   MultiMeasureRest
+//---------------------------------------------------------
+
+MultiMeasureRest::MultiMeasureRest()
+      {
+      _musicDataType = MusicDataType::Multi_Measure_Rest;
+      _measureCount  = 0;
       }
 
-void OctaveShift::setOctaveShiftPosition(OctaveShiftPosition position) {
-      octaveShiftPosition_ = position;
+//---------------------------------------------------------
+//   Tempo
+//---------------------------------------------------------
+
+Tempo::Tempo()
+      {
+      _musicDataType   = MusicDataType::Tempo;
+
+      _leftNoteType    = NoteType::Note_Quarter;
+      _showMark        = false;
+      _showBeforeText  = false;
+      _showParentheses = false;
+      _typeTempo       = 96;
+      _leftText        = QString();
+      _rightText       = QString();
+      _swingEighth     = false;
+      _rightNoteType   = NoteType::Note_Quarter;
+      _leftNoteDot     = false;
+      _rightNoteDot    = false;
+      _rightSideType   = 0;
       }
 
-OctaveShiftPosition OctaveShift::getOctaveShiftPosition() const {
-      return octaveShiftPosition_;
-      }
+//---------------------------------------------------------
+//   Tempo::quarterTempo
+//---------------------------------------------------------
 
-///////////////////////////////////////////////////////////////////////////////
-OctaveShiftEndPoint::OctaveShiftEndPoint() {
-      musicDataType_ = MusicDataType::OctaveShift_EndPoint;
-
-      octaveShiftType_ = OctaveShiftType::OS_8;
-      octaveShiftPosition_ = OctaveShiftPosition::Start;
-      endTick_ = 0;
-      }
-
-void OctaveShiftEndPoint::setOctaveShiftType(OctaveShiftType type) {
-      octaveShiftType_ = type;
-      }
-
-OctaveShiftType OctaveShiftEndPoint::getOctaveShiftType() const {
-      return octaveShiftType_;
-      }
-
-void OctaveShiftEndPoint::setOctaveShiftPosition(OctaveShiftPosition position) {
-      octaveShiftPosition_ = position;
-      }
-
-OctaveShiftPosition OctaveShiftEndPoint::getOctaveShiftPosition() const {
-      return octaveShiftPosition_;
-      }
-
-void OctaveShiftEndPoint::setEndTick(int tick) {
-      endTick_ = tick;
-      }
-
-int OctaveShiftEndPoint::getEndTick() const {
-      return endTick_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-MultiMeasureRest::MultiMeasureRest() {
-      musicDataType_ = MusicDataType::Multi_Measure_Rest;
-      measureCount_ = 0;
-      }
-
-void MultiMeasureRest::setMeasureCount(int count) {
-      measureCount_ = count;
-      }
-
-int MultiMeasureRest::getMeasureCount() const {
-      return measureCount_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-Tempo::Tempo() {
-      musicDataType_ = MusicDataType::Tempo;
-
-      leftNoteType_ = 3;
-      showMark_ = false;
-      showText_ = false;
-      showParenthesis_ = false;
-      typeTempo_ = 96;
-      leftText_ = QString();
-      rightText_ = QString();
-      swingEighth_ = false;
-      rightNoteType_ = 3;
-      leftNoteDot_ = false;
-      rightNoteDot_ = false;
-      rightSideType_ = 0;
-      }
-
-void Tempo::setLeftNoteType(int type) {
-      leftNoteType_ = type;
-      }
-
-NoteType Tempo::getLeftNoteType() const {
-      return (NoteType) leftNoteType_;
-      }
-
-void Tempo::setShowMark(bool show) {
-      showMark_ = show;
-      }
-
-bool Tempo::getShowMark() const {
-      return showMark_;
-      }
-
-void Tempo::setShowBeforeText(bool show) {
-      showText_ = show;
-      }
-
-bool Tempo::getShowBeforeText() const {
-      return showText_;
-      }
-
-void Tempo::setShowParenthesis(bool show) {
-      showParenthesis_ = show;
-      }
-
-bool Tempo::getShowParenthesis() const {
-      return showParenthesis_;
-      }
-
-void Tempo::setTypeTempo(double tempo) {
-      typeTempo_ = tempo;
-      }
-
-double Tempo::getTypeTempo() const {
-      return typeTempo_;
-      }
-
-double Tempo::getQuarterTempo() const {
-      double factor = pow(2.0, int(NoteType::Note_Quarter) - int(getLeftNoteType()));
-      if (getLeftNoteDot())
-            factor *= 3.0/2.0;
-      double tempo = getTypeTempo() * factor;
+qreal Tempo::quarterTempo() const
+      {
+      qreal factor = pow(2.0, int(NoteType::Note_Quarter) - int(leftNoteType()));
+      if (leftNoteDot())
+            factor *= 1.5;
+      qreal tempo = typeTempo() * factor;
 
       return tempo;
       }
 
-void Tempo::setLeftText(const QString& str) {
-      leftText_ = str;
+//---------------------------------------------------------
+//  Text
+//---------------------------------------------------------
+
+Text::Text()
+      {
+      _musicDataType    = MusicDataType::Text;
+
+      _textType         = TextType::Rehearsal;
+      _horizontalMargin = 8;
+      _verticalMargin   = 8;
+      _lineThick        = 4;
+      _text             = QString();
+      _width            = 0;
+      _height           = 0;
       }
 
-QString Tempo::getLeftText() const {
-      return leftText_;
+//---------------------------------------------------------
+//   TimeSignature
+//---------------------------------------------------------
+
+TimeSignature::TimeSignature()
+      {
+      _numerator      = 4;
+      _denominator    = 4;
+      _isSymbol       = false;
+      _beatLength     = 480;
+      _barLength      = 1920;
+      _barLengthUnits = 0x400;
+      _replaceFont    = false;
+      _showBeatGroup  = false;
+
+      _groupNumerator1   = 0;
+      _groupNumerator2   = 0;
+      _groupNumerator3   = 0;
+      _groupDenominator1 = 4;
+      _groupDenominator2 = 4;
+      _groupDenominator3 = 4;
+
+      _beamGroup1 = 4;
+      _beamGroup2 = 0;
+      _beamGroup3 = 0;
+      _beamGroup4 = 0;
+
+      _beamCount16th = 4;
+      _beamCount32th = 1;
       }
 
-void Tempo::setRightText(const QString& str) {
-      rightText_ = str;
-      }
+//---------------------------------------------------------
+//   TimeSignature::isSymbol
+//---------------------------------------------------------
 
-QString Tempo::getRightText() const {
-      return rightText_;
-      }
-
-void Tempo::setSwingEighth(bool swing) {
-      swingEighth_ = swing;
-      }
-
-bool Tempo::getSwingEighth() const {
-      return swingEighth_;
-      }
-
-void Tempo::setRightNoteType(int type) {
-      rightNoteType_ = type;
-      }
-
-NoteType Tempo::getRightNoteType() const {
-      return (NoteType) rightNoteType_;
-      }
-
-void Tempo::setLeftNoteDot(bool showDot) {
-      leftNoteDot_ = showDot;
-      }
-
-bool Tempo::getLeftNoteDot() const {
-      return leftNoteDot_;
-      }
-
-void Tempo::setRightNoteDot(bool showDot) {
-      rightNoteDot_ = showDot;
-      }
-
-bool Tempo::getRightNoteDot() const {
-      return rightNoteDot_;
-      }
-
-void Tempo::setRightSideType(int type) {
-      rightSideType_ = type;
-      }
-
-int Tempo::getRightSideType() const {
-      return rightSideType_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-Text::Text() {
-      musicDataType_ = MusicDataType::Text;
-
-      textType_ = Type::Rehearsal;
-      horiMargin_ = 8;
-      vertMargin_ = 8;
-      lineThick_ = 4;
-      text_ = QString();
-      width_ = 0;
-      height_ = 0;
-      }
-
-void Text::setTextType(Type type) {
-      textType_ = type;
-      }
-
-Text::Type Text::getTextType() const {
-      return textType_;
-      }
-
-void Text::setHorizontalMargin(int margin) {
-      horiMargin_ = margin;
-      }
-
-int Text::getHorizontalMargin() const {
-      return horiMargin_;
-      }
-
-void Text::setVerticalMargin(int margin) {
-      vertMargin_ = margin;
-      }
-
-int Text::getVerticalMargin() const {
-      return vertMargin_;
-      }
-
-void Text::setLineThick(int thick) {
-      lineThick_ = thick;
-      }
-
-int Text::getLineThick() const {
-      return lineThick_;
-      }
-
-void Text::setText(const QString& text) {
-      text_ = text;
-      }
-
-QString Text::getText() const {
-      return text_;
-      }
-
-void Text::setWidth(int width) {
-      width_ = width;
-      }
-
-int Text::getWidth() const {
-      return width_;
-      }
-
-void Text::setHeight(int height) {
-      height_ = height;
-      }
-
-int Text::getHeight() const {
-      return height_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-TimeSignature::TimeSignature() {
-      numerator_ = 4;
-      denominator_ = 4;
-      isSymbol_ = false;
-      beatLength_ = 480;
-      barLength_ = 1920;
-      barLengthUnits_ = 0x400;
-      replaceFont_ = false;
-      showBeatGroup_ = false;
-
-      groupNumerator1_ = 0;
-      groupNumerator2_ = 0;
-      groupNumerator3_ = 0;
-      groupDenominator1_ = 4;
-      groupDenominator2_ = 4;
-      groupDenominator3_ = 4;
-
-      beamGroup1_ = 4;
-      beamGroup2_ = 0;
-      beamGroup3_ = 0;
-      beamGroup4_ = 0;
-
-      beamCount16th_ = 4;
-      beamCount32th_ = 1;
-      }
-
-void TimeSignature::setNumerator(int numerator) {
-      numerator_ = numerator;
-      }
-
-int TimeSignature::getNumerator() const {
-      return numerator_;
-      }
-
-void TimeSignature::setDenominator(int denominator) {
-      denominator_ = denominator;
-      }
-
-int TimeSignature::getDenominator() const {
-      return denominator_;
-      }
-
-void TimeSignature::setIsSymbol(bool symbol) {
-      isSymbol_ = symbol;
-      }
-
-bool TimeSignature::getIsSymbol() const {
-      if (numerator_ == 2 && denominator_ == 2) {
+bool TimeSignature::isSymbol() const
+      {
+      if (_numerator == 2 && _denominator == 2)
             return true;
-            }
 
-      return isSymbol_;
+      return _isSymbol;
       }
 
-void TimeSignature::setBeatLength(int length) {
-      beatLength_ = length;
-      }
+//---------------------------------------------------------
+//   TimeSignature::addBeat
+//---------------------------------------------------------
 
-int TimeSignature::getBeatLength() const {
-      return beatLength_;
-      }
-
-void TimeSignature::setBarLength(int length) {
-      barLength_ = length;
-      }
-
-int TimeSignature::getBarLength() const {
-      return barLength_;
-      }
-
-void TimeSignature::addBeat(int startUnit, int lengthUnit, int startTick) {
+void TimeSignature::addBeat(int startUnit, int lengthUnit, int startTick)
+      {
       BeatNode node;
-      node.startUnit_ = startUnit;
-      node.lengthUnit_ = lengthUnit;
-      node.startTick_ = startTick;
-      beats_.push_back(node);
+      node._startUnit = startUnit;
+      node._lengthUnit = lengthUnit;
+      node._startTick = startTick;
+      _beats.push_back(node);
       }
 
-void TimeSignature::endAddBeat() {
+//---------------------------------------------------------
+//   TimeSignature::endAddBeat
+//---------------------------------------------------------
+
+void TimeSignature::endAddBeat()
+      {
       int i;
-      barLengthUnits_ = 0;
+      _barLengthUnits = 0;
 
-      for (i = 0; i < beats_.size(); ++i) {
-            barLengthUnits_ += beats_[i].lengthUnit_;
-            }
+      for (i = 0; i < _beats.size(); ++i)
+            _barLengthUnits += _beats[i]._lengthUnit;
       }
 
-int TimeSignature::getUnits() const {
-      return barLengthUnits_;
+//---------------------------------------------------------
+//   Key
+//---------------------------------------------------------
+
+Key::Key()
+      {
+      _key = 0;
+      _set = false;
+      _previousKey = 0;
+      _symbolCount = 0;
       }
 
-void TimeSignature::setReplaceFont(bool replace) {
-      replaceFont_ = replace;
+//---------------------------------------------------------
+//   Key::setKey
+//---------------------------------------------------------
+
+void Key::setKey(int key)
+      {
+      _key = key;
+      _set = true;
       }
 
-bool TimeSignature::getReplaceFont() const {
-      return replaceFont_;
+//---------------------------------------------------------
+//   RepeatSymbol
+//---------------------------------------------------------
+
+RepeatSymbol::RepeatSymbol()
+      {
+      _musicDataType = MusicDataType::Repeat;
+
+      _text          = "#1";
+      _repeatType    = RepeatType::Segno;
       }
 
-void TimeSignature::setShowBeatGroup(bool show) {
-      showBeatGroup_ = show;
+//---------------------------------------------------------
+//   NumericEnding
+//---------------------------------------------------------
+
+NumericEnding::NumericEnding()
+      {
+      _musicDataType = MusicDataType::Numeric_Ending;
+
+      _height        = 0;
+      _text          = QString();
+      _numericHandle = new OffsetElement();
       }
 
-bool TimeSignature::getShowBeatGroup() const {
-      return showBeatGroup_;
+NumericEnding::~NumericEnding()
+      {
+      delete _numericHandle;
       }
 
-void TimeSignature::setGroupNumerator1(int numerator) {
-      groupNumerator1_ = numerator;
-      }
+//---------------------------------------------------------
+//   NumericEnding::numbers
+//---------------------------------------------------------
 
-void TimeSignature::setGroupNumerator2(int numerator) {
-      groupNumerator2_ = numerator;
-      }
-
-void TimeSignature::setGroupNumerator3(int numerator) {
-      groupNumerator3_ = numerator;
-      }
-
-void TimeSignature::setGroupDenominator1(int denominator) {
-      groupDenominator1_ = denominator;
-      }
-
-void TimeSignature::setGroupDenominator2(int denominator) {
-      groupDenominator2_ = denominator;
-      }
-
-void TimeSignature::setGroupDenominator3(int denominator) {
-      groupDenominator3_ = denominator;
-      }
-
-void TimeSignature::setBeamGroup1(int count) {
-      beamGroup1_ = count;
-      }
-
-void TimeSignature::setBeamGroup2(int count) {
-      beamGroup2_ = count;
-      }
-
-void TimeSignature::setBeamGroup3(int count) {
-      beamGroup3_ = count;
-      }
-
-void TimeSignature::setBeamGroup4(int count) {
-      beamGroup4_ = count;
-      }
-
-void TimeSignature::set16thBeamCount(int count) {
-      beamCount16th_ = count;
-      }
-
-void TimeSignature::set32thBeamCount(int count) {
-      beamCount32th_ = count;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-Key::Key() {
-      key_ = 0;
-      set_ = false;
-      previousKey_ = 0;
-      symbolCount_ = 0;
-      }
-
-void Key::setKey(int key) {
-      key_ = key;
-      set_ = true;
-      }
-
-int Key::getKey() const {
-      return key_;
-      }
-
-bool Key::getSetKey() const {
-      return set_;
-      }
-
-void Key::setPreviousKey(int key) {
-      previousKey_ = key;
-      }
-
-int Key::getPreviousKey() const {
-      return previousKey_;
-      }
-
-void Key::setSymbolCount(int count) {
-      symbolCount_ = count;
-      }
-
-int Key::getSymbolCount() const {
-      return symbolCount_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-RepeatSymbol::RepeatSymbol() :
-      text_("#1"), repeatType_(RepeatType::Segno) {
-      musicDataType_ = MusicDataType::Repeat;
-      }
-
-void RepeatSymbol::setText(const QString& text) {
-      text_ = text;
-      }
-
-QString RepeatSymbol::getText() const {
-      return text_;
-      }
-
-void RepeatSymbol::setRepeatType(int repeatType) {
-      repeatType_ = (RepeatType) repeatType;
-      }
-
-RepeatType RepeatSymbol::getRepeatType() const {
-      return repeatType_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-NumericEnding::NumericEnding() {
-      musicDataType_ = MusicDataType::Numeric_Ending;
-
-      height_ = 0;
-      text_ = QString();
-      numericHandle_ = new OffsetElement();
-      }
-
-NumericEnding::~NumericEnding() {
-      delete numericHandle_;
-      }
-
-OffsetElement* NumericEnding::getNumericHandle() const {
-      return numericHandle_;
-      }
-
-void NumericEnding::setHeight(int height) {
-      height_ = height;
-      }
-
-int NumericEnding::getHeight() const {
-      return height_;
-      }
-
-void NumericEnding::setText(const QString& text) {
-      text_ = text;
-      }
-
-QString NumericEnding::getText() const {
-      return text_;
-      }
-
-QList<int> NumericEnding::getNumbers() const {
+QList<int> NumericEnding::numbers() const
+      {
       int i;
-      QStringList strs = text_.split(",", QString::SkipEmptyParts);
+      QStringList strs = _text.split(",", QString::SkipEmptyParts);
       QList<int> endings;
 
       for (i = 0; i < strs.size(); ++i) {
@@ -3041,14 +1454,18 @@ QList<int> NumericEnding::getNumbers() const {
       return endings;
       }
 
-int NumericEnding::getJumpCount() const {
-      QList<int> numbers = getNumbers();
+//---------------------------------------------------------
+//   NumericEnding::jumpCount
+//---------------------------------------------------------
+
+int NumericEnding::jumpCount() const
+      {
+      QList<int> _numbers = numbers();
       int count = 0;
 
-      for (int i = 0; i < numbers.size(); ++i) {
-            if ((int)i + 1 != numbers[i]) {
+      for (int i = 0; i < _numbers.size(); ++i) {
+            if (i + 1 != _numbers[i])
                   break;
-                  }
 
             count = i + 1;
             }
@@ -3056,343 +1473,221 @@ int NumericEnding::getJumpCount() const {
       return count;
       }
 
-///////////////////////////////////////////////////////////////////////////////
-BarNumber::BarNumber() {
-      index_ = 0;
-      showOnParagraphStart_ = false;
-      align_ = 0;
-      showFlag_ = 1; // staff
-      barRange_ = 1; // can't be 0
-      prefix_ = QString();
-      }
+//---------------------------------------------------------
+//   BarNumber
+//---------------------------------------------------------
 
-void BarNumber::setIndex(int index) {
-      index_ = index;
-      }
-
-int BarNumber::getIndex() const {
-      return index_;
-      }
-
-void BarNumber::setShowOnParagraphStart(bool show) {
-      showOnParagraphStart_ = show;
-      }
-
-bool BarNumber::getShowOnParagraphStart() const {
-      return showOnParagraphStart_;
-      }
-
-void BarNumber::setAlign(int align)// 0:left, 1:center, 2:right
+BarNumber::BarNumber()
       {
-      align_ = align;
+      _index                = 0;
+      _showOnParagraphStart = false;
+      _align                = 0;
+      _showFlag             = 1; // staff
+      _barRange             = 1; // can't be 0
+      _prefix               = QString();
       }
 
-int BarNumber::getAlign() const {
-      return align_;
+//---------------------------------------------------------
+//   MidiController
+//---------------------------------------------------------
+
+MidiController::MidiController()
+      {
+      _midiType   = MidiType::Controller;
+
+      _controller = 64; // pedal
+      _value      = 0;
       }
 
-void BarNumber::setShowFlag(int flag) {
-      showFlag_ = flag;
+//---------------------------------------------------------
+//   MidiProgramChange
+//---------------------------------------------------------
+
+MidiProgramChange::MidiProgramChange()
+      {
+      _midiType = MidiType::Program_Change;
+
+      _patch    = 0; // grand piano
       }
 
-int BarNumber::getShowFlag() const {
-      return showFlag_;
+//---------------------------------------------------------
+//   MidiChannelPressure
+//---------------------------------------------------------
+
+MidiChannelPressure::MidiChannelPressure()
+      {
+      _midiType = MidiType::Channel_Pressure;
+
+      _pressure = 0;
       }
 
-void BarNumber::setShowEveryBarCount(int count) {
-      barRange_ = count;
+//---------------------------------------------------------
+//   MidiPitchWheel
+//---------------------------------------------------------
+
+MidiPitchWheel::MidiPitchWheel()
+      {
+      _midiType = MidiType::Pitch_Wheel;
+
+      _value    = 0;
       }
 
-int BarNumber::getShowEveryBarCount() const {
-      return barRange_;
-      }
+//---------------------------------------------------------
+//   Measure
+//---------------------------------------------------------
 
-void BarNumber::setPrefix(const QString& str) {
-      prefix_ = str;
-      }
-
-QString BarNumber::getPrefix() const {
-      return prefix_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-MidiController::MidiController() {
-      midiType_ = MidiType::Controller;
-      controller_ = 64; // pedal
-      value_ = 0;
-      }
-
-void MidiController::setController(int number) {
-      controller_ = number;
-      }
-
-int MidiController::getController() const {
-      return controller_;
-      }
-
-void MidiController::setValue(int value) {
-      value_ = value;
-      }
-
-int MidiController::getValue() const {
-      return value_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-MidiProgramChange::MidiProgramChange() {
-      midiType_ = MidiType::Program_Change;
-      patch_ = 0; // grand piano
-      }
-
-void MidiProgramChange::setPatch(int patch) {
-      patch_ = patch;
-      }
-
-int MidiProgramChange::getPatch() const {
-      return patch_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-MidiChannelPressure::MidiChannelPressure() :
-      pressure_(0) {
-      midiType_ = MidiType::Channel_Pressure;
-      }
-
-void MidiChannelPressure::setPressure(int pressure) {
-      pressure_ = pressure;
-      }
-
-int MidiChannelPressure::getPressure() const {
-      return pressure_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-MidiPitchWheel::MidiPitchWheel() {
-      midiType_ = MidiType::Pitch_Wheel;
-      value_ = 0;
-      }
-
-void MidiPitchWheel::setValue(int value) {
-      value_ = value;
-      }
-
-int MidiPitchWheel::getValue() const {
-      return value_;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-Measure::Measure(int index) {
-      barNumber_ = new BarNumber();
-      barNumber_->setIndex(index);
-      time_ = new TimeSignature();
+Measure::Measure(int index)
+      {
+      _barNumber = new BarNumber();
+      _barNumber->setIndex(index);
+      _timeSig   = new TimeSignature();
 
       clear();
       }
 
-Measure::~Measure(){
+Measure::~Measure()
+      {
       clear();
 
-      delete barNumber_;
-      delete time_;
+      delete _barNumber;
+      delete _timeSig;
       }
 
-BarNumber* Measure::getBarNumber() const {
-      return barNumber_;
+//---------------------------------------------------------
+//   Measure::clear
+//---------------------------------------------------------
+
+void Measure::clear()
+      {
+      _leftBarlineType       = BarLineType::Default;
+      _rightBarlineType      = BarLineType::Default;
+      _repeatCount           = 1;
+      _typeTempo             = 96.00;
+      setLength(0x780); // time = 4/4
+      _isPickup              = false;
+      _isMultiMeasureRest    = false;
+      _multiMeasureRestCount = 0;
       }
 
-TimeSignature* Measure::getTime() const {
-      return time_;
+//---------------------------------------------------------
+//   MeasureData
+//---------------------------------------------------------
+
+MeasureData::MeasureData()
+      {
+      _key  = new Key();
+      _clef = new Clef();
       }
 
-void Measure::setLeftBarline(int barline) {
-      leftBarline_ = (BarLineType) barline;
-      }
-
-BarLineType Measure::getLeftBarline() const {
-      return leftBarline_;
-      }
-
-void Measure::setRightBarline(int barline) {
-      rightBarline_ = (BarLineType) barline;
-      }
-
-BarLineType Measure::getRightBarline() const {
-      return rightBarline_;
-      }
-
-void Measure::setBackwardRepeatCount(int repeatCount) {
-      repeatCount_ = repeatCount;
-      }
-
-int Measure::getBackwardRepeatCount() const {
-      return repeatCount_;
-      }
-
-void Measure::setTypeTempo(double tempo) {
-      typeTempo_ = tempo;
-      }
-
-double Measure::getTypeTempo() const {
-      return typeTempo_;
-      }
-
-void Measure::setIsPickup(bool pickup) {
-      pickup_ = pickup;
-      }
-
-bool Measure::getIsPickup() const {
-      return pickup_;
-      }
-
-void Measure::setIsMultiMeasureRest(bool rest) {
-      multiMeasureRest_ = rest;
-      }
-
-bool Measure::getIsMultiMeasureRest() const {
-      return multiMeasureRest_;
-      }
-
-void Measure::setMultiMeasureRestCount(int count) {
-      multiMeasureRestCount_ = count;
-      }
-
-int Measure::getMultiMeasureRestCount() const {
-      return multiMeasureRestCount_;
-      }
-
-void Measure::clear() {
-      leftBarline_ = BarLineType::Default;
-      rightBarline_ = BarLineType::Default;
-      repeatCount_ = 1;
-      typeTempo_ = 96.00;
-      setLength(0x780); //time = 4/4
-      pickup_ = false;
-      multiMeasureRest_ = false;
-      multiMeasureRestCount_ = 0;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
-MeasureData::MeasureData() {
-      key_ = new Key();
-      clef_ = new Clef();
-      }
-
-MeasureData::~MeasureData(){
+MeasureData::~MeasureData()
+      {
       int i;
-      for(i=0; i<musicDatas_.size(); ++i){
-            delete musicDatas_[i];
-            }
-      musicDatas_.clear();
+      for (i = 0; i < _musicDatas.size(); ++i)
+            delete _musicDatas[i];
+      _musicDatas.clear();
 
-      // noteContainers_ also in musicDatas_, no need to destroy
-      noteContainers_.clear();
+      // _noteContainers also in _musicDatas, no need to destroy
+      _noteContainers.clear();
 
       // only delete at element start
-      for(i=0; i<crossMeasureElements_.size(); ++i){
-            if(crossMeasureElements_[i].second){
-                  delete crossMeasureElements_[i].first;
-                  }
+      for (i = 0; i < _crossMeasureElements.size(); ++i) {
+            if (_crossMeasureElements[i].second)
+                  delete _crossMeasureElements[i].first;
             }
-      crossMeasureElements_.clear();
+      _crossMeasureElements.clear();
 
-      for(i=0; i<midiDatas_.size(); ++i){
-            delete midiDatas_[i];
-            }
-      midiDatas_.clear();
+      for (i = 0; i < _midiDatas.size(); ++i)
+            delete _midiDatas[i];
+      _midiDatas.clear();
 
-      delete key_;
-      delete clef_;
+      delete _key;
+      delete _clef;
       }
 
-Key* MeasureData::getKey() const {
-      return key_;
-      }
+//---------------------------------------------------------
+//   MeasureData::musicDatas
+//---------------------------------------------------------
 
-Clef* MeasureData::getClef() const {
-      return clef_;
-      }
-
-void MeasureData::addNoteContainer(NoteContainer* ptr) {
-      noteContainers_.push_back(ptr);
-      }
-
-QList<NoteContainer*> MeasureData::getNoteContainers() const {
-      return noteContainers_;
-      }
-
-void MeasureData::addMusicData(MusicData* ptr) {
-      musicDatas_.push_back(ptr);
-      }
-
-QList<MusicData*> MeasureData::getMusicDatas(MusicDataType type) {
+QList<MusicData*> MeasureData::musicDatas(MusicDataType type) {
       int i;
       QList<MusicData*> notations;
 
-      for (i = 0; i < musicDatas_.size(); ++i) {
-            if (type == MusicDataType::None || musicDatas_[i]->getMusicDataType() == type) {
-                  notations.push_back(musicDatas_[i]);
-                  }
+      for (i = 0; i < _musicDatas.size(); ++i) {
+            if (type == MusicDataType::None || _musicDatas[i]->musicDataType() == type)
+                  notations.push_back(_musicDatas[i]);
             }
 
       return notations;
       }
 
-void MeasureData::addCrossMeasureElement(MusicData* ptr, bool start) {
-      crossMeasureElements_.push_back(qMakePair(ptr, start));
-      }
+//---------------------------------------------------------
+//   MeasureData::crossMeasureElements
+//---------------------------------------------------------
 
-QList<MusicData*> MeasureData::getCrossMeasureElements(
-            MusicDataType type, PairType pairType)
+QList<MusicData*> MeasureData::crossMeasureElements(MusicDataType type, PairType pairType)
       {
       int i;
       QList<MusicData*> pairs;
 
-      for (i = 0; i < crossMeasureElements_.size(); ++i) {
-            if ((type == MusicDataType::None || crossMeasureElements_[i].first->getMusicDataType() == type)
-                && (pairType == PairType::All || ((crossMeasureElements_[i].second && pairType == PairType::Start)
-                                                 || (!crossMeasureElements_[i].second && pairType == PairType::Stop)))) {
-                  pairs.push_back(crossMeasureElements_[i].first);
-                  }
+      for (i = 0; i < _crossMeasureElements.size(); ++i) {
+            if ((type == MusicDataType::None || _crossMeasureElements[i].first->musicDataType() == type)
+                && (pairType == PairType::All || ((_crossMeasureElements[i].second && pairType == PairType::Start)
+                                                 || (!_crossMeasureElements[i].second && pairType == PairType::Stop))))
+                  pairs.push_back(_crossMeasureElements[i].first);
             }
 
       return pairs;
       }
 
-void MeasureData::addMidiData(MidiData* ptr) {
-      midiDatas_.push_back(ptr);
-      }
+//---------------------------------------------------------
+//   MeasureData::midiDatas
+//---------------------------------------------------------
 
-QList<MidiData*> MeasureData::getMidiDatas(MidiType type) {
+QList<MidiData*> MeasureData::midiDatas(MidiType type)
+      {
       int i;
       QList<MidiData*> datas;
 
-      for (i = 0; i < midiDatas_.size(); ++i) {
-            if (type == MidiType::None || midiDatas_[i]->getMidiType() == type) {
-                  datas.push_back(midiDatas_[i]);
-                  }
+      for (i = 0; i < _midiDatas.size(); ++i) {
+            if (type == MidiType::None || _midiDatas[i]->midiType() == type)
+                  datas.push_back(_midiDatas[i]);
             }
 
       return datas;
       }
 
-//////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////
-StreamHandle::StreamHandle() :
-      size_(0), curPos_(0), point_(NULL) {
+//---------------------------------------------------------
+//   StreamHandle
+//---------------------------------------------------------
+
+StreamHandle::StreamHandle()
+      {
+      _size   = 0;
+      _curPos = 0;
+      _point  = nullptr;
       }
 
-StreamHandle::StreamHandle(unsigned char* p, int size) :
-      size_(size), curPos_(0), point_(p) {
+StreamHandle::StreamHandle(unsigned char* p, int size)
+      {
+      _size   = size;
+      _curPos = 0;
+      _point  = p;
       }
 
-StreamHandle::~StreamHandle() {
-      point_ = NULL;
+StreamHandle::~StreamHandle()
+      {
+      _point = nullptr;
       }
 
-bool StreamHandle::read(char* buff, int size) {
-      if (point_ != NULL && curPos_ + size <= size_) {
-            memcpy(buff, point_ + curPos_, size);
-            curPos_ += size;
+//---------------------------------------------------------
+//   StreamHandle::read
+//---------------------------------------------------------
+
+bool StreamHandle::read(char* buff, int size)
+      {
+      if (_point && _curPos + size <= _size) {
+            memcpy(buff, _point + _curPos, size);
+            _curPos += size;
 
             return true;
             }
@@ -3400,86 +1695,93 @@ bool StreamHandle::read(char* buff, int size) {
       return false;
       }
 
-bool StreamHandle::write(char* /*buff*/, int /*size*/) {
-      return true;
-      }
+//---------------------------------------------------------
+//   Block
+//---------------------------------------------------------
 
-// Block.cpp
-///////////////////////////////////////////////////////////////////////////////////////////////////
-Block::Block() {
+Block::Block()
+      {
       doResize(0);
       }
 
-Block::Block(unsigned int count) {
+Block::Block(unsigned count)
+      {
       doResize(count);
       }
 
-void Block::resize(unsigned int count) {
-      doResize(count);
+//---------------------------------------------------------
+//   Block::doResize
+//---------------------------------------------------------
+
+void Block::doResize(unsigned count)
+      {
+      _data.clear();
+      for (unsigned i = 0; i < count; ++i)
+            _data.push_back('\0');
+      // _data.resize(count);
       }
 
-void Block::doResize(unsigned int count) {
-      data_.clear();
-      for(unsigned int i=0; i<count; ++i) {
-            data_.push_back('\0');
-            }
-      //data_.resize(count);
-      }
+/*
+Suggestions:
 
-const unsigned char* Block::data() const {
-      //return const_cast<unsigned char*>(&data_.front());
-      return &data_.front();
-      }
+> Seeing as it follows a readBuffer(buf, 1) I would go with casting the 1 byte directly
+> So I'd add
+`unsigned char toUnsignedChar() const;
+signed char toChar() const; ` to the Block class there
+> and have the first return *data() and the second return (signed char)(*data())
+> then replace to to(Unsigned)Int calls that follow readBuffer(1)
+> (OR truly refactor and use a real parser then;) )
+*/
 
-unsigned char* Block::data() {
-      return &data_.front();
-      }
+//---------------------------------------------------------
+//   Block::toBool
+//---------------------------------------------------------
 
-int Block::size() const {
-      return data_.size();
-      }
-
-bool Block::toBoolean() const {
-      if (data() == NULL) {
+bool Block::toBool() const
+      {
+      if (!data())
             return false;
-            }
 
       return size() == 1 && data()[0] == 0x01;
       }
 
-unsigned int Block::toUnsignedInt() const {
-      if (data() == NULL) {
+//---------------------------------------------------------
+//   Block::toUnsignedInt
+//---------------------------------------------------------
+
+unsigned Block::toUnsignedInt() const
+      {
+      if (!data())
             return 0;
-            }
 
       int num = 0;
 
-      for (int i = 0; i < (int)sizeof(int) && i < size(); ++i) {
-            num = (num << 8) + *(data() + i);
-            }
+      for (int i = 0; i < int(sizeof(int)) && i < size(); ++i)
+            num = (num << CHAR_BIT) + *(data() + i);
 
       return num;
       }
 
-int Block::toInt() const {
-      if (data() == NULL) {
+//---------------------------------------------------------
+//   Block::toInt
+//---------------------------------------------------------
+
+int Block::toInt() const
+      {
+      if (!data())
             return 0;
-            }
 
       int i;
       int num = 0;
 
-      for (i = 0; i < (int)sizeof(int) && i < size(); ++i) {
-            num = (num << 8) + static_cast<int>(*(data()) + i);
-            }
+      for (i = 0; i < static_cast<int>(sizeof(int)) && i < size(); ++i)
+            num = (num << CHAR_BIT) + static_cast<int>(*(data() + i));
 
-      std::size_t minSize = sizeof(int);
-      if (size() < (int)minSize) {
-            minSize = size();
-            }
+      size_t minSize = sizeof(int);
+      minSize = qMin(size(), static_cast<int>(minSize));
 
-      if ((*(data()) & 0x80) == 0x80) {
-            int maxNum = static_cast<int>(pow(2.0, static_cast<int>(minSize) * 8));
+      if (*(data()) & (SCHAR_MAX + 1)) {
+            int maxNum = static_cast<int>(pow(qreal(SCHAR_MAX + 1), static_cast<int>(minSize)));
             num -= maxNum;
             //num *= -1;
             }
@@ -3487,142 +1789,188 @@ int Block::toInt() const {
       return num;
       }
 
-QByteArray Block::toStrByteArray() const {
-      if (data() == NULL) {
-            return QByteArray();
-            }
+//---------------------------------------------------------
+//   Block::toStrByteArray
+//---------------------------------------------------------
 
-      QByteArray arr((char*) data(), size());
+QByteArray Block::toStrByteArray() const
+      {
+      if (!data())
+            return QByteArray();
+
+      QByteArray arr((char*)(data()), size());
 
       return arr;
       }
 
-QByteArray Block::fixedSizeBufferToStrByteArray() const {
+//---------------------------------------------------------
+//   Block::fixedSizeBufferToStrByteArray
+//---------------------------------------------------------
+
+QByteArray Block::fixedSizeBufferToStrByteArray() const
+      {
       QByteArray str;
 
       for (int i = 0; i < size(); ++i) {
-            if (*(data() + i) == '\0') {
+            if (*(data() + i) == '\0')
                   break;
-                  }
 
-            str += (char) *(data() + i);
+            str += char(*(data() + i));
             }
 
       return str;
       }
 
-bool Block::operator ==(const Block& block) const {
-      if (size() != block.size()) {
+//---------------------------------------------------------
+//   Block::operators
+//---------------------------------------------------------
+
+bool Block::operator==(const Block& block) const
+      {
+      if (size() != block.size())
             return false;
-            }
 
       for (int i = 0; i < size() && i < block.size(); ++i) {
-            if (*(data() + i) != *(block.data() + i)) {
+            if (*(data() + i) != *(block.data() + i))
                   return false;
-                  }
             }
 
       return true;
       }
 
-bool Block::operator !=(const Block& block) const {
+bool Block::operator!=(const Block& block) const
+      {
       return !(*this == block);
       }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
-FixedBlock::FixedBlock() :
-      Block() {
+//---------------------------------------------------------
+//   FixedBlock
+//---------------------------------------------------------
+
+FixedBlock::FixedBlock()
+   : Block() 
+      {
       }
 
-FixedBlock::FixedBlock(unsigned int count) :
-      Block(count) {
+FixedBlock::FixedBlock(unsigned count)
+   : Block(count)
+      {
       }
 
-void FixedBlock::resize(unsigned int /*count*/) {
+//---------------------------------------------------------
+//   FixedBlock::resize
+//---------------------------------------------------------
+
+void FixedBlock::resize(unsigned /*count*/)
+      {
       // Block::resize(size);
       }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
-SizeBlock::SizeBlock() :
-      FixedBlock(4) {
+//---------------------------------------------------------
+//   SizeBlock
+//---------------------------------------------------------
+
+SizeBlock::SizeBlock()
+   : FixedBlock(4)
+      {
       }
 
-unsigned int SizeBlock::toSize() const {
-      unsigned int i;
-      unsigned int num(0);
-      const unsigned int SIZE = 4;
+//---------------------------------------------------------
+//   SizeBlock::toSize()
+//---------------------------------------------------------
 
-      for (i = 0; i < SIZE; ++i) {
-            num = (num << 8) + *(data() + i);
-            }
+unsigned SizeBlock::toSize() const
+      {
+      unsigned i;
+      unsigned num(0);
+
+      for (i = 0; i < int(sizeof(int)); ++i)
+            num = (num << CHAR_BIT) + *(data() + i);
 
       return num;
       }
 
-/*void SizeBlock::fromUnsignedInt(unsigned int count)
- {
- unsigned_int_to_char_buffer(count, data());
- }*/
+#if 0
+void SizeBlock::fromUnsignedInt(unsigned count)
+      {
+      unsigned_int_to_char_buffer(count, data());
+      }
+#endif
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
-NameBlock::NameBlock() :
-      FixedBlock(4) {
+//---------------------------------------------------------
+//   NameBlock
+//---------------------------------------------------------
+
+NameBlock::NameBlock()
+   : FixedBlock(4)
+      {
       }
 
-/*void NameBlock::setValue(const char* const name)
- {
- unsigned int i;
+#if 0
+void NameBlock::setValue(const char* const name)
+      {
+      unsigned i;
 
- for( i=0; i<size() && *(name+i)!='\0'; ++i )
- {
- *(data()+i) = *(name+i);
- }
- }*/
+      for (i = 0; i < size() && *(name+i) != '\0'; ++i)
+            *(data() + i) = *(name + i);
+      }
+#endif
 
-bool NameBlock::isEqual(const QString& name) const {
+//---------------------------------------------------------
+//   NameBlock::isEqual
+//---------------------------------------------------------
+
+bool NameBlock::isEqual(const QString& name) const
+      {
       int nsize = name.size();
 
-      if (nsize != size()) {
+      if (nsize != size())
             return false;
-            }
 
       for (int i = 0; i < size() && nsize; ++i) {
-            if (data()[i] != name[i]) {
+            if (data()[i] != name[i])
                   return false;
-                  }
             }
 
       return true;
       }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
-CountBlock::CountBlock() :
-      FixedBlock(2) {
+//---------------------------------------------------------
+//   CountBlock
+//---------------------------------------------------------
+
+CountBlock::CountBlock() 
+   : FixedBlock(2)
+      {
       }
 
-/*void CountBlock::setValue(unsigned short count)
- {
- unsigned int i;
- unsigned int SIZE = sizeof(unsigned short);
+#if 0
+void CountBlock::setValue(unsigned short count)
+      {
+      unsigned i;
+      unsigned SIZE = sizeof(unsigned short);
 
- for( i=0; i<SIZE; ++i )
- {
- data()[SIZE-1-i] = count % 256;
- count /= 256;
- }
- }*/
+      for (i = 0; i < SIZE; ++i) {
+            data()[SIZE - 1 - i] = count % 256;
+            count /= 256;
+            }
+      }
+#endif
 
-unsigned short CountBlock::toCount() const {
+//---------------------------------------------------------
+//   CountBlock::toCount
+//---------------------------------------------------------
+
+unsigned short CountBlock::toCount() const
+      {
       unsigned short num = 0;
 
-      for (int i = 0; i < size() && i < (int)sizeof(unsigned short); ++i) {
-            num = (num << 8) + *(data() + i);
-            }
+      for (int i = 0; i < size() && i < int(sizeof(unsigned short)); ++i)
+            num = (num << CHAR_BIT) + *(data() + i);
 
       return num;
       }
 
-// Chunk.cpp
 const QString Chunk::TrackName   = "TRAK";
 const QString Chunk::PageName    = "PAGE";
 const QString Chunk::LineName    = "LINE";
@@ -3631,367 +1979,397 @@ const QString Chunk::MeasureName = "MEAS";
 const QString Chunk::ConductName = "COND";
 const QString Chunk::BdatName    = "BDAT";
 
-Chunk::Chunk() {
+//---------------------------------------------------------
+//   Chunk
+//---------------------------------------------------------
+
+Chunk::Chunk()
+      {
       }
 
-NameBlock Chunk::getName() const {
-      return nameBlock_;
+const unsigned SizeChunk::version3TrackSize = 0x13a;
+
+//---------------------------------------------------------
+//   Chunk::name
+//---------------------------------------------------------
+
+NameBlock Chunk::name() const
+      {
+      return _nameBlock;
       }
 
-////////////////////////////////////////////////////////////////////////////////
-const unsigned int SizeChunk::version3TrackSize = 0x13a;
+//---------------------------------------------------------
+//   SizeChunk
+//---------------------------------------------------------
 
-SizeChunk::SizeChunk() :
-      Chunk() {
-      sizeBlock_ = new SizeBlock();
-      dataBlock_ = new Block();
+SizeChunk::SizeChunk()
+   : Chunk()
+      {
+      _sizeBlock = new SizeBlock();
+      _dataBlock = new Block();
       }
 
-SizeChunk::~SizeChunk() {
-      delete sizeBlock_;
-      delete dataBlock_;
+SizeChunk::~SizeChunk()
+      {
+      delete _sizeBlock;
+      delete _dataBlock;
       }
 
-SizeBlock* SizeChunk::getSizeBlock() const {
-      return sizeBlock_;
+//---------------------------------------------------------
+//   GroupChunk
+//---------------------------------------------------------
+
+GroupChunk::GroupChunk()
+   : Chunk()
+      {
+      _childCount = new CountBlock();
       }
 
-Block* SizeChunk::getDataBlock() const {
-      return dataBlock_;
+GroupChunk::~GroupChunk()
+      {
+      delete _childCount;
       }
 
-/////////////////////////////////////////////////////////////////////////////////
-GroupChunk::GroupChunk() : Chunk() {
-      childCount_ = new CountBlock();
-      }
+inline unsigned highNibble(unsigned byte) { return byte / 0x10; }
+inline unsigned lowNibble(unsigned byte)  { return byte % 0x10; }
 
-GroupChunk::~GroupChunk() {
-      delete childCount_;
-      }
+//---------------------------------------------------------
+//   oveKeyToKey
+//---------------------------------------------------------
 
-CountBlock* GroupChunk::getCountBlock() const {
-      return childCount_;
-      }
-
-// ChunkParse.cpp
-unsigned int getHighNibble(unsigned int byte) {
-      return byte / 16;
-      }
-
-unsigned int getLowNibble(unsigned int byte) {
-      return byte % 16;
-      }
-
-int oveKeyToKey(int oveKey) {
+static int oveKeyToKey(int oveKey)
+      {
       int key = 0;
 
-      if( oveKey == 0 ) {
+      if (oveKey == 0)
             key = 0;
-            }
-      else if( oveKey > 7 ) {
+      else if (oveKey > 7)
             key = oveKey - 7;
-            }
-      else if( oveKey <= 7 ) {
+      else if (oveKey <= 7)
             key = oveKey * (-1);
-            }
 
       return key;
       }
 
-///////////////////////////////////////////////////////////////////////////////
-BasicParse::BasicParse(OveSong* ove) :
-      ove_(ove), handle_(NULL), notify_(NULL) {
+//---------------------------------------------------------
+//   BasicParse
+//---------------------------------------------------------
+
+BasicParse::BasicParse(OveSong* ove)
+      {
+      _ove    = ove;
+      _handle = nullptr;
+      _notify = nullptr;
       }
 
-BasicParse::BasicParse() :
-      ove_(NULL), handle_(NULL), notify_(NULL) {
+BasicParse::BasicParse()
+      {
+      _ove    = nullptr;
+      _handle = nullptr;
+      _notify = nullptr;
       }
 
-BasicParse::~BasicParse() {
-      ove_ = NULL;
-      handle_ = NULL;
-      notify_ = NULL;
+BasicParse::~BasicParse()
+      {
+      _ove    = nullptr;
+      _handle = nullptr;
+      _notify = nullptr;
       }
 
-void BasicParse::setNotify(IOveNotify* notify) {
-      notify_ = notify;
-      }
+//---------------------------------------------------------
+//   BasicParse::readBuffer
+//---------------------------------------------------------
 
-bool BasicParse::parse() {
-      return false;
-      }
-
-bool BasicParse::readBuffer(Block& placeHolder, int size) {
-      if (handle_ == NULL) {
+bool BasicParse::readBuffer(Block& placeHolder, int size)
+      {
+      if (!_handle)
             return false;
-            }
-      if (placeHolder.size() != size) {
+      if (placeHolder.size() != size)
             placeHolder.resize(size);
-            }
 
-      if (size > 0) {
-            return handle_->read((char*) placeHolder.data(), placeHolder.size());
-            }
+      if (size > 0)
+            return _handle->read((char*)(placeHolder.data()), placeHolder.size());
 
       return true;
       }
 
-bool BasicParse::jump(int offset) {
-      if (handle_ == NULL || offset < 0) {
+//---------------------------------------------------------
+//   BasicParse::jump
+//---------------------------------------------------------
+
+bool BasicParse::jump(int offset)
+      {
+      if (!_handle || offset < 0)
             return false;
-            }
 
       if (offset > 0) {
             Block placeHolder(offset);
-            return handle_->read((char*) placeHolder.data(), placeHolder.size());
+            return _handle->read((char*)(placeHolder.data()), placeHolder.size());
             }
 
       return true;
       }
 
-void BasicParse::messageOut(const QString& str) {
-      if (notify_ != NULL) {
-            notify_->loadInfo(str);
-            }
+//---------------------------------------------------------
+//   BasicParse::messageOut
+//---------------------------------------------------------
+
+void BasicParse::messageOut(const QString& str)
+      {
+      if (_notify)
+            _notify->loadInfo(str);
       }
 
-///////////////////////////////////////////////////////////////////////////////
-OvscParse::OvscParse(OveSong* ove) :
-      BasicParse(ove), chunk_(NULL) {
+//---------------------------------------------------------
+//   OvscParse
+//---------------------------------------------------------
+
+OvscParse::OvscParse(OveSong* ove)
+   : BasicParse(ove)
+      {
+      _chunk = nullptr;
       }
 
-OvscParse::~OvscParse() {
-      chunk_ = NULL;
+OvscParse::~OvscParse()
+      {
+      _chunk = nullptr;
       }
 
-void OvscParse::setOvsc(SizeChunk* chunk) {
-      chunk_ = chunk;
-      }
+//---------------------------------------------------------
+//   OvscParse::parse
+//---------------------------------------------------------
 
-bool OvscParse::parse() {
-      Block* dataBlock = chunk_->getDataBlock();
-      unsigned int blockSize = chunk_->getSizeBlock()->toSize();
+bool OvscParse::parse()
+      {
+      Block* dataBlock = _chunk->dataBlock();
+      unsigned blockSize = _chunk->sizeBlock()->toSize();
       StreamHandle handle(dataBlock->data(), blockSize);
       Block placeHolder;
 
-      handle_ = &handle;
+      _handle = &handle;
 
       // version
       if (!readBuffer(placeHolder, 1)) { return false; }
-      bool version4 = placeHolder.toUnsignedInt() == 4;
-      ove_->setIsVersion4(version4);
+      bool version4 = (placeHolder.toUnsignedInt() == 4);
+      _ove->setIsVersion4(version4);
 
       QString str = QString("This file is created by Overture ") + (version4 ? "4" : "3") + "\n";
       messageOut(str);
 
-      if( !jump(6) ) { return false; }
+      if (!jump(6)) { return false; }
 
       // show page margin
       if (!readBuffer(placeHolder, 1)) { return false; }
-      ove_->setShowPageMargin(placeHolder.toBoolean());
+      _ove->setShowPageMargin(placeHolder.toBool());
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
       // transpose track
       if (!readBuffer(placeHolder, 1)) { return false; }
-      ove_->setShowTransposeTrack(placeHolder.toBoolean());
+      _ove->setShowTransposeTrack(placeHolder.toBool());
 
       // play repeat
       if (!readBuffer(placeHolder, 1)) { return false; }
-      ove_->setPlayRepeat(placeHolder.toBoolean());
+      _ove->setPlayRepeat(placeHolder.toBool());
 
       // play style
       if (!readBuffer(placeHolder, 1)) { return false; }
       OveSong::PlayStyle style = OveSong::PlayStyle::Record;
-      if(placeHolder.toUnsignedInt() == 1){
+      if (placeHolder.toUnsignedInt() == 1)
             style = OveSong::PlayStyle::Swing;
-            }
-      else if(placeHolder.toUnsignedInt() == 2){
+      else if (placeHolder.toUnsignedInt() == 2)
             style = OveSong::PlayStyle::Notation;
-            }
-      ove_->setPlayStyle(style);
+      _ove->setPlayStyle(style);
 
       // show line break
       if (!readBuffer(placeHolder, 1)) { return false; }
-      ove_->setShowLineBreak(placeHolder.toBoolean());
+      _ove->setShowLineBreak(placeHolder.toBool());
 
       // show ruler
       if (!readBuffer(placeHolder, 1)) { return false; }
-      ove_->setShowRuler(placeHolder.toBoolean());
+      _ove->setShowRuler(placeHolder.toBool());
 
       // show color
       if (!readBuffer(placeHolder, 1)) { return false; }
-      ove_->setShowColor(placeHolder.toBoolean());
+      _ove->setShowColor(placeHolder.toBool());
 
       return true;
       }
 
-///////////////////////////////////////////////////////////////////////////////
+//---------------------------------------------------------
+//   TrackParse
+//---------------------------------------------------------
+
 TrackParse::TrackParse(OveSong* ove)
-      :BasicParse(ove) {
+   : BasicParse(ove)
+      {
+      _chunk = nullptr;
       }
 
-TrackParse::~TrackParse() {
+TrackParse::~TrackParse()
+      {
+      _chunk = nullptr;
       }
 
-void TrackParse::setTrack(SizeChunk* chunk) {
-      chunk_ = chunk;
-      }
+//---------------------------------------------------------
+//   TrackParse::parse
+//---------------------------------------------------------
 
-bool TrackParse::parse() {
-      Block* dataBlock = chunk_->getDataBlock();
-      unsigned int blockSize = ove_->getIsVersion4() ? chunk_->getSizeBlock()->toSize() : SizeChunk::version3TrackSize;
+bool TrackParse::parse()
+      {
+      Block* dataBlock = _chunk->dataBlock();
+      unsigned blockSize = _ove->isVersion4() ? _chunk->sizeBlock()->toSize() : SizeChunk::version3TrackSize;
       StreamHandle handle(dataBlock->data(), blockSize);
       Block placeHolder;
 
-      handle_ = &handle;
+      _handle = &handle;
 
       Track* oveTrack = new Track();
-      ove_->addTrack(oveTrack);
+      _ove->addTrack(oveTrack);
 
       // 2 32bytes long track name buffer
-      if( !readBuffer(placeHolder, 32) ) { return false; }
-      oveTrack->setName(ove_->getCodecString(placeHolder.fixedSizeBufferToStrByteArray()));
+      if (!readBuffer(placeHolder, 32)) { return false; }
+      oveTrack->setName(_ove->codecString(placeHolder.fixedSizeBufferToStrByteArray()));
 
-      if( !readBuffer(placeHolder, 32) ) { return false; }
-      oveTrack->setBriefName(ove_->getCodecString(placeHolder.fixedSizeBufferToStrByteArray()));
+      if (!readBuffer(placeHolder, 32)) { return false; }
+      oveTrack->setBriefName(_ove->codecString(placeHolder.fixedSizeBufferToStrByteArray()));
 
-      if( !jump(8) ) { return false; } //0x fffa0012 fffa0012
-      if( !jump(1) ) { return false; }
+      if (!jump(8)) { return false; } // 0xfffa0012 fffa0012
+      if (!jump(1)) { return false; }
 
       // patch
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      unsigned int thisByte = placeHolder.toInt();
-      oveTrack->setPatch(thisByte&0x7f);
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      unsigned thisByte = placeHolder.toInt();
+      oveTrack->setPatch(thisByte & 0x7f);
 
       // show name
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      oveTrack->setShowName(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      oveTrack->setShowName(placeHolder.toBool());
 
       // show brief name
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      oveTrack->setShowBriefName(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      oveTrack->setShowBriefName(placeHolder.toBool());
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
       // show transpose
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      oveTrack->setShowTranspose(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      oveTrack->setShowTranspose(placeHolder.toBool());
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
       // mute
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      oveTrack->setMute(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      oveTrack->setMute(placeHolder.toBool());
 
       // solo
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      oveTrack->setSolo(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      oveTrack->setSolo(placeHolder.toBool());
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
       // show key each line
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      oveTrack->setShowKeyEachLine(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      oveTrack->setShowKeyEachLine(placeHolder.toBool());
 
       // voice count
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       oveTrack->setVoiceCount(placeHolder.toUnsignedInt());
 
-      if( !jump(3) ) { return false; }
+      if (!jump(3)) { return false; }
 
       // transpose value [-127, 127]
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       oveTrack->setTranspose(placeHolder.toInt());
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // start clef
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      oveTrack->setStartClef(placeHolder.toUnsignedInt());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      oveTrack->setStartClef(ClefType(placeHolder.toUnsignedInt()));
 
-      // transpose celf
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      oveTrack->setTransposeClef(placeHolder.toUnsignedInt());
+      // transpose clef
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      oveTrack->setTransposeClef(ClefType(placeHolder.toUnsignedInt()));
 
       // start key
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      oveTrack->setStartKey(placeHolder.toUnsignedInt());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      oveTrack->setStartKey(KeyType(placeHolder.toUnsignedInt()));
 
       // display percent
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       oveTrack->setDisplayPercent(placeHolder.toUnsignedInt());
 
       // show leger line
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      oveTrack->setShowLegerLine(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      oveTrack->setShowLegerLine(placeHolder.toBool());
 
       // show clef
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      oveTrack->setShowClef(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      oveTrack->setShowClef(placeHolder.toBool());
 
       // show time signature
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      oveTrack->setShowTimeSignature(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      oveTrack->setShowTimeSignature(placeHolder.toBool());
 
       // show key signature
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      oveTrack->setShowKeySignature(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      oveTrack->setShowKeySignature(placeHolder.toBool());
 
       // show barline
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      oveTrack->setShowBarline(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      oveTrack->setShowBarline(placeHolder.toBool());
 
       // fill with rest
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      oveTrack->setFillWithRest(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      oveTrack->setFillWithRest(placeHolder.toBool());
 
       // flat tail
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      oveTrack->setFlatTail(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      oveTrack->setFlatTail(placeHolder.toBool());
 
       // show clef each line
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      oveTrack->setShowClefEachLine(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      oveTrack->setShowClefEachLine(placeHolder.toBool());
 
-      if( !jump(12) ) { return false; }
+      if (!jump(12)) { return false; }
 
       // 8 voices
       int i;
       QList<Voice*> voices;
-      for( i=0; i<8; ++i ) {
+      for (i = 0; i < 8; ++i) {
             Voice* voicePtr = new Voice();
 
-            if( !jump(5) ) { return false; }
+            if (!jump(5)) { return false; }
 
             // channel
-            if( !readBuffer(placeHolder, 1) ) { return false; }
+            if (!readBuffer(placeHolder, 1)) { return false; }
             voicePtr->setChannel(placeHolder.toUnsignedInt());
 
             // volume
-            if( !readBuffer(placeHolder, 1) ) { return false; }
+            if (!readBuffer(placeHolder, 1)) { return false; }
             voicePtr->setVolume(placeHolder.toInt());
 
             // pitch shift
-            if( !readBuffer(placeHolder, 1) ) { return false; }
+            if (!readBuffer(placeHolder, 1)) { return false; }
             voicePtr->setPitchShift(placeHolder.toInt());
 
             // pan
-            if( !readBuffer(placeHolder, 1) ) { return false; }
+            if (!readBuffer(placeHolder, 1)) { return false; }
             voicePtr->setPan(placeHolder.toInt());
 
-            if( !jump(6) ) { return false; }
+            if (!jump(6)) { return false; }
 
             // patch
-            if( !readBuffer(placeHolder, 1) ) { return false; }
+            if (!readBuffer(placeHolder, 1)) { return false; }
             voicePtr->setPatch(placeHolder.toInt());
 
             voices.push_back(voicePtr);
             }
 
       // stem type
-      for( i=0; i<8; ++i ) {
-            if( !readBuffer(placeHolder, 1) ) { return false; }
+      for (i = 0; i < 8; ++i) {
+            if (!readBuffer(placeHolder, 1)) { return false; }
             voices[i]->setStemType(placeHolder.toUnsignedInt());
 
             oveTrack->addVoice(voices[i]);
@@ -3999,373 +2377,433 @@ bool TrackParse::parse() {
 
       // percussion define
       QList<Track::DrumNode> nodes;
-      for(i=0; i<16; ++i) {
+      for (i = 0; i < 16; ++i)
             nodes.push_back(Track::DrumNode());
-            }
 
       // line
-      for( i=0; i<16; ++i ) {
-            if( !readBuffer(placeHolder, 1) ) { return false; }
-            nodes[i].line_ = placeHolder.toInt();
+      for (i = 0; i < 16; ++i) {
+            if (!readBuffer(placeHolder, 1)) { return false; }
+            nodes[i]._line = placeHolder.toInt();
             }
 
       // head type
-      for( i=0; i<16; ++i ) {
-            if( !readBuffer(placeHolder, 1) ) { return false; }
-            nodes[i].headType_ = placeHolder.toUnsignedInt();
+      for (i = 0; i < 16; ++i) {
+            if (!readBuffer(placeHolder, 1)) { return false; }
+            nodes[i]._headType = placeHolder.toUnsignedInt();
             }
 
       // pitch
-      for( i=0; i<16; ++i ) {
-            if( !readBuffer(placeHolder, 1) ) { return false; }
-            nodes[i].pitch_ = placeHolder.toUnsignedInt();
+      for (i = 0; i < 16; ++i) {
+            if (!readBuffer(placeHolder, 1)) { return false; }
+            nodes[i]._pitch = placeHolder.toUnsignedInt();
             }
 
       // voice
-      for( i=0; i<16; ++i ) {
-            if( !readBuffer(placeHolder, 1) ) { return false; }
-            nodes[i].voice_ = placeHolder.toUnsignedInt();
+      for (i = 0; i < 16; ++i) {
+            if (!readBuffer(placeHolder, 1)) { return false; }
+            nodes[i]._voice = placeHolder.toUnsignedInt();
             }
 
-      for( i=0; i<nodes.size(); ++i ) {
+      for (i = 0; i < nodes.size(); ++i)
             oveTrack->addDrum(nodes[i]);
-            }
 
-      /* if( !Jump(17) ) { return false; }
+#if 0
+      if (!jump(17)) { return false; }
 
-   // voice 0 channel
-   if( !ReadBuffer(placeHolder, 1) ) { return false; }
-   oveTrack->setChannel(placeHolder.toUnsignedInt());
+       // voice 0 channel
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      oveTrack->setChannel(placeHolder.toUnsignedInt());
 
-   // to be continued. if anything important...*/
+      // to be continued. if anything important...
+#endif
 
       return true;
       }
 
-///////////////////////////////////////////////////////////////////////////////
+//---------------------------------------------------------
+//   GroupParse
+//---------------------------------------------------------
+
 GroupParse::GroupParse(OveSong* ove)
-      :BasicParse(ove) {
+   : BasicParse(ove)
+      {
+      for (int i = 0; i < int(_sizeChunks.size()); ++i)
+            _sizeChunks[i] = nullptr;
+      _sizeChunks.clear();
       }
 
-GroupParse::~GroupParse(){
-      sizeChunks_.clear();
+GroupParse::~GroupParse()
+      {
+      for (int i = 0; i < int(_sizeChunks.size()); ++i)
+            _sizeChunks[i] = nullptr;
+      _sizeChunks.clear();
       }
 
-void GroupParse::addSizeChunk(SizeChunk* sizeChunk) {
-      sizeChunks_.push_back(sizeChunk);
-      }
+//---------------------------------------------------------
+//   PageGroupParse
+//---------------------------------------------------------
 
-bool GroupParse::parse() {
-      return false;
-      }
-
-///////////////////////////////////////////////////////////////////////////////
 PageGroupParse::PageGroupParse(OveSong* ove)
-      :BasicParse(ove) {
+   : BasicParse(ove)
+      {
+      for (int i = 0; i < int(_pageChunks.size()); ++i)
+            _pageChunks[i] = nullptr;
+      _pageChunks.clear();
       }
 
-PageGroupParse::~PageGroupParse(){
-      pageChunks_.clear();
+PageGroupParse::~PageGroupParse()
+      {
+      for (int i = 0; i < int(_pageChunks.size()); ++i)
+            _pageChunks[i] = nullptr;
+      _pageChunks.clear();
       }
 
-void PageGroupParse::addPage(SizeChunk* chunk) {
-      pageChunks_.push_back(chunk);
-      }
+//---------------------------------------------------------
+//   PageGroupParse::parse
+//---------------------------------------------------------
 
-bool PageGroupParse::parse() {
-      if( pageChunks_.isEmpty() ) {
+bool PageGroupParse::parse()
+      {
+      if (_pageChunks.isEmpty())
             return false;
-            }
 
       int i;
-      for( i=0; i<pageChunks_.size(); ++i ) {
+      for (i = 0; i < _pageChunks.size(); ++i) {
             Page* page = new Page();
-            ove_->addPage(page);
+            _ove->addPage(page);
 
-            if( !parsePage(pageChunks_[i], page) ) { return false; }
+            if (!parsePage(_pageChunks[i], page))
+                  return false;
             }
 
       return true;
       }
 
-bool PageGroupParse::parsePage(SizeChunk* chunk, Page* page) {
-      Block placeHolder(2);
-      StreamHandle handle(chunk->getDataBlock()->data(), chunk->getSizeBlock()->toSize());
+//---------------------------------------------------------
+//   PageGroupParse::parsePage
+//---------------------------------------------------------
 
-      handle_ = &handle;
+bool PageGroupParse::parsePage(SizeChunk* chunk, Page* page)
+      {
+      Block placeHolder(2);
+      StreamHandle handle(chunk->dataBlock()->data(), chunk->sizeBlock()->toSize());
+
+      _handle = &handle;
 
       // begin line
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       page->setBeginLine(placeHolder.toUnsignedInt());
 
       // line count
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       page->setLineCount(placeHolder.toUnsignedInt());
 
-      if( !jump(4) ) { return false; }
+      if (!jump(4)) { return false; }
 
       // staff interval
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       page->setStaffInterval(placeHolder.toUnsignedInt());
 
       // line interval
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       page->setLineInterval(placeHolder.toUnsignedInt());
 
       // staff inline interval
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       page->setStaffInlineInterval(placeHolder.toUnsignedInt());
 
       // line bar count
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       page->setLineBarCount(placeHolder.toUnsignedInt());
 
       // page line count
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       page->setPageLineCount(placeHolder.toUnsignedInt());
 
       // left margin
-      if( !readBuffer(placeHolder, 4) ) { return false; }
+      if (!readBuffer(placeHolder, 4)) { return false; }
       page->setLeftMargin(placeHolder.toUnsignedInt());
 
       // top margin
-      if( !readBuffer(placeHolder, 4) ) { return false; }
+      if (!readBuffer(placeHolder, 4)) { return false; }
       page->setTopMargin(placeHolder.toUnsignedInt());
 
       // right margin
-      if( !readBuffer(placeHolder, 4) ) { return false; }
+      if (!readBuffer(placeHolder, 4)) { return false; }
       page->setRightMargin(placeHolder.toUnsignedInt());
 
       // bottom margin
-      if( !readBuffer(placeHolder, 4) ) { return false; }
+      if (!readBuffer(placeHolder, 4)) { return false; }
       page->setBottomMargin(placeHolder.toUnsignedInt());
 
       // page width
-      if( !readBuffer(placeHolder, 4) ) { return false; }
+      if (!readBuffer(placeHolder, 4)) { return false; }
       page->setPageWidth(placeHolder.toUnsignedInt());
 
       // page height
-      if( !readBuffer(placeHolder, 4) ) { return false; }
+      if (!readBuffer(placeHolder, 4)) { return false; }
       page->setPageHeight(placeHolder.toUnsignedInt());
 
-      handle_ = NULL;
+      _handle = nullptr;
 
       return true;
       }
 
-///////////////////////////////////////////////////////////////////////////////
+//---------------------------------------------------------
+//   StaffCountGetter
+//---------------------------------------------------------
+
 StaffCountGetter::StaffCountGetter(OveSong* ove)
-      :BasicParse(ove) {
+   : BasicParse(ove)
+      {
       }
 
-unsigned int StaffCountGetter::getStaffCount(SizeChunk* chunk) {
-      StreamHandle handle(chunk->getDataBlock()->data(), chunk->getSizeBlock()->toSize());
+//---------------------------------------------------------
+//   StaffCountGetter::staffCount
+//---------------------------------------------------------
+
+unsigned StaffCountGetter::staffCount(SizeChunk* chunk)
+      {
+      StreamHandle handle(chunk->dataBlock()->data(), chunk->sizeBlock()->toSize());
       Block placeHolder;
 
-      handle_ = &handle;
+      _handle = &handle;
 
-      if( !jump(6) ) { return false; }
+      if (!jump(6)) { return false; }
 
       // staff count
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       return placeHolder.toUnsignedInt();
       }
 
-///////////////////////////////////////////////////////////////////////////////
-LineGroupParse::LineGroupParse(OveSong* ove) :
-      BasicParse(ove), chunk_(NULL) {
+//---------------------------------------------------------
+//   LineGroupParse
+//---------------------------------------------------------
+
+LineGroupParse::LineGroupParse(OveSong* ove)
+   : BasicParse(ove)
+      {
+      _chunk = nullptr;
+      for (int i = 0; i < _lineChunks.size(); ++i)
+            _lineChunks[i] = nullptr;
+      _lineChunks.clear();
+      for (int i = 0; i < _staffChunks.size(); ++i)
+            _staffChunks[i] = nullptr;
+      _staffChunks.clear();
       }
 
-LineGroupParse::~LineGroupParse(){
-      chunk_ = NULL;
-      lineChunks_.clear();
-      staffChunks_.clear();
+LineGroupParse::~LineGroupParse()
+      {
+      _chunk = nullptr;
+      for (int i = 0; i < _lineChunks.size(); ++i)
+            _lineChunks[i] = nullptr;
+      _lineChunks.clear();
+      for (int i = 0; i < _staffChunks.size(); ++i)
+            _staffChunks[i] = nullptr;
+      _staffChunks.clear();
       }
 
-void LineGroupParse::setLineGroup(GroupChunk* chunk) {
-      chunk_ = chunk;
-      }
+//---------------------------------------------------------
+//   LineGroupParse::parse
+//---------------------------------------------------------
 
-void LineGroupParse::addLine(SizeChunk* chunk) {
-      lineChunks_.push_back(chunk);
-      }
-
-void LineGroupParse::addStaff(SizeChunk* chunk) {
-      staffChunks_.push_back(chunk);
-      }
-
-bool LineGroupParse::parse() {
-      if( lineChunks_.isEmpty() || staffChunks_.size() % lineChunks_.size() != 0 ) { return false; }
+bool LineGroupParse::parse()
+      {
+      if (_lineChunks.isEmpty() || _staffChunks.size() % _lineChunks.size() != 0)
+            return false;
 
       int i;
-      unsigned int j;
-      unsigned int lineStaffCount = staffChunks_.size() / lineChunks_.size();
+      unsigned j;
+      unsigned lineStaffCount = _staffChunks.size() / _lineChunks.size();
 
-      for( i=0; i<lineChunks_.size(); ++i ) {
+      for (i = 0; i < _lineChunks.size(); ++i) {
             Line* linePtr = new Line();
 
-            ove_->addLine(linePtr);
+            _ove->addLine(linePtr);
 
-            if( !parseLine(lineChunks_[i], linePtr) ) { return false; }
+            if (!parseLine(_lineChunks[i], linePtr))
+                  return false;
 
-            for( j=lineStaffCount*i; j<lineStaffCount*(i+1); ++j ) {
+            for ( j= lineStaffCount * i; j < lineStaffCount * (i + 1); ++j) {
                   Staff* staffPtr = new Staff();
 
                   linePtr->addStaff(staffPtr);
 
-                  if( !parseStaff(staffChunks_[j], staffPtr) ) { return false; }
+                  if (!parseStaff(_staffChunks[j], staffPtr))
+                        return false;
                   }
             }
 
       return true;
       }
 
-bool LineGroupParse::parseLine(SizeChunk* chunk, Line* line) {
+//---------------------------------------------------------
+//   LineGroupParse::parseLine
+//---------------------------------------------------------
+
+bool LineGroupParse::parseLine(SizeChunk* chunk, Line* line)
+      {
       Block placeHolder;
 
-      StreamHandle handle(chunk->getDataBlock()->data(), chunk->getSizeBlock()->toSize());
+      StreamHandle handle(chunk->dataBlock()->data(), chunk->sizeBlock()->toSize());
 
-      handle_ = &handle;
+      _handle = &handle;
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // begin bar
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       line->setBeginBar(placeHolder.toUnsignedInt());
 
       // bar count
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       line->setBarCount(placeHolder.toUnsignedInt());
 
-      if( !jump(6) ) { return false; }
+      if (!jump(6)) { return false; }
 
       // y offset
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       line->setYOffset(placeHolder.toInt());
 
       // left x offset
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       line->setLeftXOffset(placeHolder.toInt());
 
       // right x offset
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       line->setRightXOffset(placeHolder.toInt());
 
-      if( !jump(4) ) { return false; }
+      if (!jump(4)) { return false; }
 
-      handle_ = NULL;
+      _handle = nullptr;
 
       return true;
       }
 
-bool LineGroupParse::parseStaff(SizeChunk* chunk, Staff* staff) {
+//---------------------------------------------------------
+//   LineGroupParse::parseStaff
+//---------------------------------------------------------
+
+bool LineGroupParse::parseStaff(SizeChunk* chunk, Staff* staff)
+      {
       Block placeHolder;
 
-      StreamHandle handle(chunk->getDataBlock()->data(), chunk->getSizeBlock()->toSize());
+      StreamHandle handle(chunk->dataBlock()->data(), chunk->sizeBlock()->toSize());
 
-      handle_ = &handle;
+      _handle = &handle;
 
-      if( !jump(7) ) { return false; }
+      if (!jump(7)) { return false; }
 
       // clef
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      staff->setClefType(placeHolder.toUnsignedInt());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      staff->setClefType((ClefType)placeHolder.toUnsignedInt());
 
       // key
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       staff->setKeyType(oveKeyToKey(placeHolder.toUnsignedInt()));
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // visible
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      staff->setVisible(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      staff->setVisible(placeHolder.toBool());
 
-      if( !jump(12) ) { return false; }
+      if (!jump(12)) { return false; }
 
       // y offset
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       staff->setYOffset(placeHolder.toInt());
 
-      int jumpAmount = ove_->getIsVersion4() ? 26 : 18;
-      if( !jump(jumpAmount) ) { return false; }
+      int jumpAmount = _ove->isVersion4() ? 26 : 18;
+      if (!jump(jumpAmount)) { return false; }
 
       // group type
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       GroupType groupType = GroupType::None;
-      if(placeHolder.toUnsignedInt() == 1) {
-            groupType = GroupType::Brace;
-            } else if(placeHolder.toUnsignedInt() == 2) {
-            groupType = GroupType::Bracket;
-            }
+      if (placeHolder.toUnsignedInt() == 1)
+            groupType = GroupType::Braces;
+      else if (placeHolder.toUnsignedInt() == 2)
+            groupType = GroupType::Brackets;
       staff->setGroupType(groupType);
 
       // group staff count
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       staff->setGroupStaffCount(placeHolder.toUnsignedInt());
 
-      handle_ = NULL;
+      _handle = nullptr;
 
       return true;
       }
 
-///////////////////////////////////////////////////////////////////////////////
-BarsParse::BarsParse(OveSong* ove) :
-      BasicParse(ove) {
+//---------------------------------------------------------
+//   BarsParse
+//---------------------------------------------------------
+
+BarsParse::BarsParse(OveSong* ove)
+   : BasicParse(ove)
+      {
+      for (int i = 0; i < _measureChunks.size(); ++i)
+            _measureChunks[i] = nullptr;
+      _measureChunks.clear();
+      for (int i = 0; i < _conductChunks.size(); ++i)
+            _conductChunks[i] = nullptr;
+      _conductChunks.clear();
+      for (int i = 0; i < _bdatChunks.size(); ++i)
+            _bdatChunks[i] = nullptr;
+      _bdatChunks.clear();
       }
 
-BarsParse::~BarsParse(){
-      measureChunks_.clear();
-      conductChunks_.clear();
-      bdatChunks_.clear();
+BarsParse::~BarsParse()
+      {
+      for (int i = 0; i < _measureChunks.size(); ++i)
+            _measureChunks[i] = nullptr;
+      _measureChunks.clear();
+      for (int i = 0; i < _conductChunks.size(); ++i)
+            _conductChunks[i] = nullptr;
+      _conductChunks.clear();
+      for (int i = 0; i < _bdatChunks.size(); ++i)
+            _bdatChunks[i] = nullptr;
+      _bdatChunks.clear();
       }
 
-void BarsParse::addMeasure(SizeChunk* chunk) {
-      measureChunks_.push_back(chunk);
-      }
+//---------------------------------------------------------
+//   BarsParse::parse
+//---------------------------------------------------------
 
-void BarsParse::addConduct(SizeChunk* chunk) {
-      conductChunks_.push_back(chunk);
-      }
-
-void BarsParse::addBdat(SizeChunk* chunk) {
-      bdatChunks_.push_back(chunk);
-      }
-
-bool BarsParse::parse() {
+bool BarsParse::parse()
+      {
       int i;
-      int trackMeasureCount = ove_->getTrackBarCount();
-      int trackCount = ove_->getTrackCount();
-      int measureDataCount = trackCount * measureChunks_.size();
+      int trackMeasureCount = _ove->trackBarCount();
+      int trackCount = _ove->trackCount();
+      int measureDataCount = trackCount * _measureChunks.size();
       QList<Measure*> measures;
       QList<MeasureData*> measureDatas;
 
-      if (measureChunks_.isEmpty() ||
-          measureChunks_.size() != conductChunks_.size() ||
-          bdatChunks_.size() != measureDataCount) {
+      if (_measureChunks.isEmpty()
+         || _measureChunks.size() != _conductChunks.size()
+         || _bdatChunks.size() != measureDataCount)
             return false;
-            }
 
       // add to ove
-      for ( i = 0; i < measureChunks_.size(); ++i ) {
+      for (i = 0; i < _measureChunks.size(); ++i) {
             Measure* measure = new Measure(i);
 
             measures.push_back(measure);
-            ove_->addMeasure(measure);
+            _ove->addMeasure(measure);
             }
 
-      for ( i = 0; i < measureDataCount; ++i ) {
+      for (i = 0; i < measureDataCount; ++i) {
             MeasureData* oveMeasureData = new MeasureData();
 
             measureDatas.push_back(oveMeasureData);
-            ove_->addMeasureData(oveMeasureData);
+            _ove->addMeasureData(oveMeasureData);
             }
 
-      for ( i = 0; i < measureChunks_.size(); ++i ) {
+      for (i = 0; i < _measureChunks.size(); ++i) {
             Measure* measure = measures[i];
 
             // MEAS
-            if( !parseMeas(measure, measureChunks_[i]) ) {
+            if (!parseMeas(measure, _measureChunks[i])) {
                   QString ss = QString("failed in parse MEAS %1\n").arg(i);
                   messageOut(ss);
 
@@ -4373,9 +2811,9 @@ bool BarsParse::parse() {
                   }
             }
 
-      for ( i = 0; i < conductChunks_.size(); ++i ) {
+      for (i = 0; i < _conductChunks.size(); ++i) {
             // COND
-            if( !parseCond(measures[i], measureDatas[i], conductChunks_[i]) ) {
+            if (!parseCond(measures[i], measureDatas[i], _conductChunks[i])) {
                   QString ss = QString("failed in parse COND %1\n").arg(i);
                   messageOut(ss);
 
@@ -4383,297 +2821,285 @@ bool BarsParse::parse() {
                   }
             }
 
-      for ( i = 0; i < bdatChunks_.size(); ++i ) {
+      for (i = 0; i < _bdatChunks.size(); ++i) {
             int measId = i % trackMeasureCount;
 
             // BDAT
-            if( !parseBdat(measures[measId], measureDatas[i], bdatChunks_[i]) ) {
+            if (!parseBdat(measures[measId], measureDatas[i], _bdatChunks[i])) {
                   QString ss = QString("failed in parse BDAT %1\n").arg(i);
                   messageOut(ss);
 
                   return false;
                   }
 
-            if( notify_ != NULL ) {
+            if (_notify) {
                   int measureID = i % trackMeasureCount;
                   int trackID = i / trackMeasureCount;
 
-                  //msg.msg_ = OVE_IMPORT_POS;
-                  //msg.param1_ = (measureID<<16) + trackMeasureCount;
-                  //msg.param2_ = (trackID<<16) + trackCount;
+                  // msg.msg_ = OVE_IMPORT_POS;
+                  // msg.param1_ = (measureID<<16) + trackMeasureCount;
+                  // msg.param2_ = (trackID<<16) + trackCount;
 
-                  notify_->loadPosition(measureID, trackMeasureCount, trackID, trackCount);
+                  _notify->loadPosition(measureID, trackMeasureCount, trackID, trackCount);
                   }
             }
 
       return true;
       }
 
-bool BarsParse::parseMeas(Measure* measure, SizeChunk* chunk) {
+//---------------------------------------------------------
+//   BarsParse::parseMeas
+//---------------------------------------------------------
+
+bool BarsParse::parseMeas(Measure* measure, SizeChunk* chunk)
+      {
       Block placeHolder;
 
-      StreamHandle measureHandle(chunk->getDataBlock()->data(), chunk->getSizeBlock()->toSize());
+      StreamHandle measureHandle(chunk->dataBlock()->data(), chunk->sizeBlock()->toSize());
 
-      handle_ = &measureHandle;
+      _handle = &measureHandle;
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // multi-measure rest
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      measure->setIsMultiMeasureRest(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      measure->setIsMultiMeasureRest(placeHolder.toBool());
 
       // pickup
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      measure->setIsPickup(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      measure->setIsPickup(placeHolder.toBool());
 
-      if( !jump(4) ) { return false; }
+      if (!jump(4)) { return false; }
 
       // left barline
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      measure->setLeftBarline(placeHolder.toUnsignedInt());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      measure->setLeftBarlineType(BarLineType(placeHolder.toUnsignedInt()));
 
       // right barline
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      measure->setRightBarline(placeHolder.toUnsignedInt());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      measure->setRightBarlineType(BarLineType(placeHolder.toUnsignedInt()));
 
       // tempo
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      double tempo = ((double)placeHolder.toUnsignedInt());
-      if( ove_->getIsVersion4() ) {
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      qreal tempo = qreal(placeHolder.toUnsignedInt());
+      if (_ove->isVersion4())
             tempo /= 100.0;
-            }
       measure->setTypeTempo(tempo);
 
       // bar length(tick)
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       measure->setLength(placeHolder.toUnsignedInt());
 
-      if( !jump(6) ) { return false; }
+      if (!jump(6)) { return false; }
 
       // bar number offset
-      if( !parseOffsetElement(measure->getBarNumber()) ) { return false; }
+      if (!parseOffsetElement(measure->barNumber())) { return false; }
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // multi-measure rest count
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       measure->setMultiMeasureRestCount(placeHolder.toUnsignedInt());
 
-      handle_ = NULL;
+      _handle = nullptr;
 
       return true;
       }
 
-bool BarsParse::parseCond(Measure* measure, MeasureData* measureData, SizeChunk* chunk) {
+//---------------------------------------------------------
+//   BarsParse::parseCond
+//---------------------------------------------------------
+
+bool BarsParse::parseCond(Measure* measure, MeasureData* measureData, SizeChunk* chunk)
+      {
       Block placeHolder;
 
-      StreamHandle handle(chunk->getDataBlock()->data(), chunk->getSizeBlock()->toSize());
+      StreamHandle handle(chunk->dataBlock()->data(), chunk->sizeBlock()->toSize());
 
-      handle_ = &handle;
+      _handle = &handle;
 
       // item count
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      unsigned int cnt = placeHolder.toUnsignedInt();
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      unsigned cnt = placeHolder.toUnsignedInt();
 
-      if( !parseTimeSignature(measure, 36) ) { return false; }
+      if (!parseTimeSignature(measure, 36)) { return false; }
 
-      for( unsigned int i=0; i<cnt; ++i ) {
-            if( !readBuffer(placeHolder, 2) ) { return false; }
-            unsigned int twoByte = placeHolder.toUnsignedInt();
-            unsigned int oldBlockSize = twoByte - 11;
-            unsigned int newBlockSize = twoByte - 7;
+      for (unsigned i = 0; i < cnt; ++i) {
+            if (!readBuffer(placeHolder, 2)) { return false; }
+            unsigned twoByte = placeHolder.toUnsignedInt();
+            unsigned oldBlockSize = twoByte - 11;
+            unsigned newBlockSize = twoByte - 7;
 
             // type id
-            if( !readBuffer(placeHolder, 1) ) { return false; }
-            unsigned int thisByte = placeHolder.toUnsignedInt();
+            if (!readBuffer(placeHolder, 1)) { return false; }
+            unsigned thisByte = placeHolder.toUnsignedInt();
             CondType type;
 
-            if( !getCondElementType(thisByte, type) ) { return false; }
+            if (!condElementType(thisByte, type)) { return false; }
 
             switch (type) {
-                  case CondType::Bar_Number: {
-                        if (!parseBarNumber(measure, twoByte - 1)) {
-                              return false;
-                              }
+                  case CondType::Bar_Number:
+                        if (!parseBarNumber(measure, twoByte - 1)) { return false; }
                         break;
-                        }
-                  case CondType::Repeat: {
-                        if (!parseRepeatSymbol(measureData, oldBlockSize)) {
-                              return false;
-                              }
+                  case CondType::Repeat:
+                        if (!parseRepeatSymbol(measureData, oldBlockSize)) { return false; }
                         break;
-                        }
-                  case CondType::Numeric_Ending: {
-                        if (!parseNumericEndings(measureData, oldBlockSize)) {
-                              return false;
-                              }
+                  case CondType::Numeric_Ending:
+                        if (!parseNumericEnding(measureData, oldBlockSize)) { return false; }
                         break;
-                        }
-                  case CondType::Decorator: {
-                        if (!parseDecorators(measureData, newBlockSize)) {
-                              return false;
-                              }
+                  case CondType::Decorator:
+                        if (!parseDecorator(measureData, newBlockSize)) { return false; }
                         break;
-                        }
-                  case CondType::Tempo: {
-                        if (!parseTempo(measureData, newBlockSize)) {
-                              return false;
-                              }
+                  case CondType::Tempo:
+                        if (!parseTempo(measureData, newBlockSize)) { return false; }
                         break;
-                        }
-                  case CondType::Text: {
-                        if (!parseText(measureData, newBlockSize)) {
-                              return false;
-                              }
+                  case CondType::Text:
+                        if (!parseText(measureData, newBlockSize)) { return false; }
                         break;
-                        }
-                  case CondType::Expression: {
-                        if (!parseExpressions(measureData, newBlockSize)) {
-                              return false;
-                              }
+                  case CondType::Expression:
+                        if (!parseExpression(measureData, newBlockSize)) { return false; }
                         break;
-                        }
-                  case CondType::Time_Parameters: {
-                        if (!parseTimeSignatureParameters(measure, newBlockSize)) {
-                              return false;
-                              }
+                  case CondType::_timeParameters:
+                        if (!parseTimeSignatureParameters(measure, newBlockSize)) { return false; }
                         break;
-                        }
-                  case CondType::Barline_Parameters: {
-                        if (!parseBarlineParameters(measure, newBlockSize)) {
-                              return false;
-                              }
+                  case CondType::Barline_Parameters:
+                        if (!parseBarlineParameters(measure, newBlockSize)) { return false; }
                         break;
-                        }
-                  default: {
-                        if (!jump(newBlockSize)) {
-                              return false;
-                              }
+                  default:
+                        if (!jump(newBlockSize)) { return false; }
                         break;
-                        }
                   }
             }
 
-      handle_ = NULL;
+      _handle = nullptr;
 
       return true;
       }
 
-bool BarsParse::parseTimeSignature(Measure* measure, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseTimeSignature
+//---------------------------------------------------------
+
+bool BarsParse::parseTimeSignature(Measure* measure, int /*length*/)
+      {
       Block placeHolder;
 
-      TimeSignature* timeSignature = measure->getTime();
+      TimeSignature* timeSignature = measure->timeSig();
 
       // numerator
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       timeSignature->setNumerator(placeHolder.toUnsignedInt());
 
       // denominator
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       timeSignature->setDenominator(placeHolder.toUnsignedInt());
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // beat length
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       timeSignature->setBeatLength(placeHolder.toUnsignedInt());
 
       // bar length
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       timeSignature->setBarLength(placeHolder.toUnsignedInt());
 
-      if( !jump(4) ) { return false; }
+      if (!jump(4)) { return false; }
 
       // is symbol
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      timeSignature->setIsSymbol(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      timeSignature->setIsSymbol(placeHolder.toBool());
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
       // replace font
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      timeSignature->setReplaceFont(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      timeSignature->setReplaceFont(placeHolder.toBool());
 
       // color
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       timeSignature->setColor(placeHolder.toUnsignedInt());
 
       // show
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      timeSignature->setShow(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      timeSignature->setShow(placeHolder.toBool());
 
       // show beat group
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      timeSignature->setShowBeatGroup(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      timeSignature->setShowBeatGroup(placeHolder.toBool());
 
-      if( !jump(6) ) { return false; }
+      if (!jump(6)) { return false; }
 
       // numerator 1, 2, 3
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       timeSignature->setGroupNumerator1(placeHolder.toUnsignedInt());
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       timeSignature->setGroupNumerator2(placeHolder.toUnsignedInt());
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       timeSignature->setGroupNumerator3(placeHolder.toUnsignedInt());
 
       // denominator
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       timeSignature->setGroupDenominator1(placeHolder.toUnsignedInt());
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       timeSignature->setGroupDenominator2(placeHolder.toUnsignedInt());
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       timeSignature->setGroupDenominator3(placeHolder.toUnsignedInt());
 
       // beam group 1~4
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       timeSignature->setBeamGroup1(placeHolder.toUnsignedInt());
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       timeSignature->setBeamGroup2(placeHolder.toUnsignedInt());
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       timeSignature->setBeamGroup3(placeHolder.toUnsignedInt());
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       timeSignature->setBeamGroup4(placeHolder.toUnsignedInt());
 
       // beam 16th
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       timeSignature->set16thBeamCount(placeHolder.toUnsignedInt());
 
       // beam 32th
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       timeSignature->set32thBeamCount(placeHolder.toUnsignedInt());
 
       return true;
       }
 
-bool BarsParse::parseTimeSignatureParameters(Measure* measure, int length) {
-      Block placeHolder;
-      TimeSignature* ts = measure->getTime();
+//---------------------------------------------------------
+//   BarsParse::parseTimeSignatureParameters
+//---------------------------------------------------------
 
-      int cursor = ove_->getIsVersion4() ? 10 : 8;
-      if( !jump(cursor) ) { return false; }
+bool BarsParse::parseTimeSignatureParameters(Measure* measure, int length)
+      {
+      Block placeHolder;
+      TimeSignature* ts = measure->timeSig();
+
+      int cursor = _ove->isVersion4() ? 10 : 8;
+      if (!jump(cursor)) { return false; }
 
       // numerator
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      unsigned int numerator = placeHolder.toUnsignedInt();
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      unsigned numerator = placeHolder.toUnsignedInt();
 
-      cursor = ove_->getIsVersion4() ? 11 : 9;
-      if( ( length - cursor ) % 8 != 0 || (length - cursor) / 8 != (int)numerator ) {
+      cursor = _ove->isVersion4() ? 11 : 9;
+      if ((length - cursor) % 8 != 0 || (length - cursor) / 8 != int(numerator))
             return false;
-            }
 
-      for( unsigned int i =0; i<numerator; ++i ) {
+      for (unsigned i = 0; i < numerator; ++i) {
             // beat start unit
-            if( !readBuffer(placeHolder, 2) ) { return false; }
+            if (!readBuffer(placeHolder, 2)) { return false; }
             int beatStart = placeHolder.toUnsignedInt();
 
             // beat length unit
-            if( !readBuffer(placeHolder, 2) ) { return false; }
+            if (!readBuffer(placeHolder, 2)) { return false; }
             int beatLength = placeHolder.toUnsignedInt();
 
-            if( !jump(2) ) { return false; }
+            if (!jump(2)) { return false; }
 
             // beat start tick
-            if( !readBuffer(placeHolder, 2) ) { return false; }
+            if (!readBuffer(placeHolder, 2)) { return false; }
             int beatStartTick = placeHolder.toUnsignedInt();
 
             ts->addBeat(beatStart, beatLength, beatStartTick);
@@ -4684,302 +3110,322 @@ bool BarsParse::parseTimeSignatureParameters(Measure* measure, int length) {
       return true;
       }
 
-bool BarsParse::parseBarlineParameters(Measure* measure, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseBarlineParameters
+//---------------------------------------------------------
+
+bool BarsParse::parseBarlineParameters(Measure* measure, int /*length*/)
+      {
       Block placeHolder;
 
-      int cursor = ove_->getIsVersion4() ? 12 : 10;
-      if( !jump(cursor) ) { return false; }
+      int cursor = _ove->isVersion4() ? 12 : 10;
+      if (!jump(cursor)) { return false; }
 
       // repeat count
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       int repeatCount = placeHolder.toUnsignedInt();
 
       measure->setBackwardRepeatCount(repeatCount);
 
-      if( !jump(6) ) { return false; }
+      if (!jump(6)) { return false; }
 
       return true;
       }
 
-bool BarsParse::parseNumericEndings(MeasureData* measureData, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseNumericEnding
+//---------------------------------------------------------
+
+bool BarsParse::parseNumericEnding(MeasureData* measureData, int /*length*/)
+      {
       Block placeHolder;
 
       NumericEnding* numeric = new NumericEnding();
       measureData->addCrossMeasureElement(numeric, true);
 
-      if( !jump(3) ) { return false; }
+      if (!jump(3)) { return false; }
 
       // common
-      if( !parseCommonBlock(numeric) ) { return false; }
+      if (!parseCommonBlock(numeric)) { return false; }
 
-      if( !jump(6) ) { return false; }
+      if (!jump(6)) { return false; }
 
       // measure count
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       //int offsetMeasure = placeHolder.toUnsignedInt() - 1;
       int offsetMeasure = placeHolder.toUnsignedInt();
       numeric->stop()->setMeasure(offsetMeasure);
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // left x offset
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      numeric->getLeftShoulder()->setXOffset(placeHolder.toInt());
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      numeric->leftShoulder()->setXOffset(placeHolder.toInt());
 
       // height
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       numeric->setHeight(placeHolder.toUnsignedInt());
 
       // left x offset
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      numeric->getRightShoulder()->setXOffset(placeHolder.toInt());
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      numeric->rightShoulder()->setXOffset(placeHolder.toInt());
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // y offset
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      numeric->getLeftShoulder()->setYOffset(placeHolder.toInt());
-      numeric->getRightShoulder()->setYOffset(placeHolder.toInt());
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      numeric->leftShoulder()->setYOffset(placeHolder.toInt());
+      numeric->rightShoulder()->setYOffset(placeHolder.toInt());
 
       // number offset
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      numeric->getNumericHandle()->setXOffset(placeHolder.toInt());
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      numeric->getNumericHandle()->setYOffset(placeHolder.toInt());
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      numeric->numericHandle()->setXOffset(placeHolder.toInt());
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      numeric->numericHandle()->setYOffset(placeHolder.toInt());
 
-      if( !jump(6) ) { return false; }
+      if (!jump(6)) { return false; }
 
       // text size
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      unsigned int size = placeHolder.toUnsignedInt();
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      unsigned size = placeHolder.toUnsignedInt();
 
       // text : size maybe a huge value
-      if( !readBuffer(placeHolder, size) ) { return false; }
-      numeric->setText(ove_->getCodecString(placeHolder.fixedSizeBufferToStrByteArray()));
+      if (!readBuffer(placeHolder, size)) { return false; }
+      numeric->setText(_ove->codecString(placeHolder.fixedSizeBufferToStrByteArray()));
 
       // fix for wedding march.ove
-      if( size % 2 == 0 ) {
-            if( !jump(1) ) { return false; }
-            }
+      if (size % 2 == 0)
+            if (!jump(1)) { return false; }
 
       return true;
       }
 
-bool BarsParse::parseTempo(MeasureData* measureData, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseTempo
+//---------------------------------------------------------
+
+bool BarsParse::parseTempo(MeasureData* measureData, int /*length*/)
+      {
       Block placeHolder;
-      unsigned int thisByte;
+      unsigned thisByte;
 
       Tempo* tempo = new Tempo();
       measureData->addMusicData(tempo);
-      if( !jump(3) )
+      if (!jump(3))
             return false;
       // common
-      if( !parseCommonBlock(tempo) )
+      if (!parseCommonBlock(tempo))
             return false;
-      if( !readBuffer(placeHolder, 1) )
+      if (!readBuffer(placeHolder, 1))
             return false;
       thisByte = placeHolder.toUnsignedInt();
       // show tempo
-      tempo->setShowMark( (getHighNibble(thisByte) & 0x4) == 0x4 );
+      tempo->setShowMark((highNibble(thisByte) & 0x4) == 0x4);
       // show before text
-      tempo->setShowBeforeText( (getHighNibble(thisByte) & 0x8 ) == 0x8 ) ;
+      tempo->setShowBeforeText((highNibble(thisByte) & 0x8) == 0x8);
       // show parenthesis
-      tempo->setShowParenthesis( (getHighNibble(thisByte) & 0x1 ) == 0x1 );
+      tempo->setShowParentheses((highNibble(thisByte) & 0x1) == 0x1);
       // left note type
-      tempo->setLeftNoteType( getLowNibble(thisByte) );
+      tempo->setLeftNoteType(NoteType(lowNibble(thisByte)));
       // left note dot
-      tempo->setLeftNoteDot((getHighNibble(thisByte) & 0x2 ) == 0x2 );
-      if( !jump(1) )  // dimension of the note symbol
+      tempo->setLeftNoteDot((highNibble(thisByte) & 0x2) == 0x2);
+      if (!jump(1))  // dimension of the note symbol
             return false;
-      if( ove_->getIsVersion4() ) {
-            if( !jump(2) )
+      if (_ove->isVersion4()) {
+            if (!jump(2))
                   return false;
             // tempo
-            if( !readBuffer(placeHolder, 2) )
+            if (!readBuffer(placeHolder, 2))
                   return false;
-            tempo->setTypeTempo(((double)placeHolder.toUnsignedInt())/100.0);
+            tempo->setTypeTempo((qreal(placeHolder.toUnsignedInt())) / 100.0);
             }
       else {
             // tempo
-            if( !readBuffer(placeHolder, 2) )
+            if (!readBuffer(placeHolder, 2))
                   return false;
-            tempo->setTypeTempo((double)placeHolder.toUnsignedInt());
-            if( !jump(2) )
+            tempo->setTypeTempo(qreal(placeHolder.toUnsignedInt()));
+            if (!jump(2))
                   return false;
             }
       // offset
-      if( !parseOffsetElement(tempo) )
+      if (!parseOffsetElement(tempo))
             return false;
-      if( !jump(16) )
+      if (!jump(16))
             return false;
       // 31 bytes left text
-      if( !readBuffer(placeHolder, 31) )
+      if (!readBuffer(placeHolder, 31))
             return false;
-      tempo->setLeftText(ove_->getCodecString(placeHolder.fixedSizeBufferToStrByteArray()));
+      tempo->setLeftText(_ove->codecString(placeHolder.fixedSizeBufferToStrByteArray()));
 
-      if( !readBuffer(placeHolder, 1) )
+      if (!readBuffer(placeHolder, 1))
             return false;
       thisByte = placeHolder.toUnsignedInt();
       // swing eighth
-      tempo->setSwingEighth((getHighNibble(thisByte) & 0x4 ) == 0x4 );
+      tempo->setSwingEighth((highNibble(thisByte) & 0x4) == 0x4);
       // right note dot
-      tempo->setRightNoteDot((getHighNibble(thisByte) & 0x1 ) == 0x1 );
+      tempo->setRightNoteDot((highNibble(thisByte) & 0x1) == 0x1);
       // compatibility with v3 files ?
-      tempo->setRightSideType(static_cast<int>(getHighNibble(thisByte) & 0x2));
+      tempo->setRightSideType(static_cast<int>(highNibble(thisByte) & 0x2));
       // right note type
-      tempo->setRightNoteType(getLowNibble(thisByte));
+      tempo->setRightNoteType(NoteType(lowNibble(thisByte)));
       // right text
-      if( ove_->getIsVersion4() ) {
-            if( !readBuffer(placeHolder, 31) )
+      if (_ove->isVersion4()) {
+            if (!readBuffer(placeHolder, 31))
                   return false;
-            tempo->setRightText(ove_->getCodecString(placeHolder.fixedSizeBufferToStrByteArray()));
-            if( !readBuffer(placeHolder, 1) )
+            tempo->setRightText(_ove->codecString(placeHolder.fixedSizeBufferToStrByteArray()));
+            if (!readBuffer(placeHolder, 1))
                   return false;
-            // 00 -> float      03 -> integer(floor)     01 -> notetype    02 -> text
+            // 00 -> float; 01 -> notetype; 02 -> text; 03 -> integer(floor)
             tempo->setRightSideType(placeHolder.toInt());
             }
 
       return true;
       }
 
-bool BarsParse::parseBarNumber(Measure* measure, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseBarNumber
+//---------------------------------------------------------
+
+bool BarsParse::parseBarNumber(Measure* measure, int /*length*/)
+      {
       Block placeHolder;
 
-      BarNumber* barNumber = measure->getBarNumber();
+      BarNumber* barNumber = measure->barNumber();
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // show on paragraph start
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      barNumber->setShowOnParagraphStart(getLowNibble(placeHolder.toUnsignedInt())==8);
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      barNumber->setShowOnParagraphStart(lowNibble(placeHolder.toUnsignedInt()) == 8);
 
-      unsigned int blankSize = ove_->getIsVersion4() ? 9 : 7;
-      if( !jump(blankSize) ) { return false; }
+      unsigned blankSize = _ove->isVersion4() ? 9 : 7;
+      if (!jump(blankSize)) { return false; }
 
       // text align
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       barNumber->setAlign(placeHolder.toUnsignedInt());
 
-      if( !jump(4) ) { return false; }
+      if (!jump(4)) { return false; }
 
       // show flag
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       barNumber->setShowFlag(placeHolder.toUnsignedInt());
 
-      if( !jump(10) ) { return false; }
+      if (!jump(10)) { return false; }
 
       // bar range
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       barNumber->setShowEveryBarCount(placeHolder.toUnsignedInt());
 
       // prefix
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      barNumber->setPrefix(ove_->getCodecString(placeHolder.fixedSizeBufferToStrByteArray()));
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      barNumber->setPrefix(_ove->codecString(placeHolder.fixedSizeBufferToStrByteArray()));
 
-      if( !jump(18) ) { return false; }
+      if (!jump(18)) { return false; }
 
       return true;
       }
 
-bool BarsParse::parseText(MeasureData* measureData, int length) {
+//---------------------------------------------------------
+//   BarsParse::parseText
+//---------------------------------------------------------
+
+bool BarsParse::parseText(MeasureData* measureData, int length)
+      {
       Block placeHolder;
 
       Text* text = new Text();
       measureData->addMusicData(text);
 
-      if( !jump(3) ) { return false; }
+      if (!jump(3)) { return false; }
 
       // common
-      if( !parseCommonBlock(text) ) { return false; }
+      if (!parseCommonBlock(text)) { return false; }
 
       // type
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      unsigned int thisByte = placeHolder.toUnsignedInt();
-      bool includeLineBreak = ( (getHighNibble(thisByte)&0x2) != 0x2 );
-      unsigned int id = getLowNibble(thisByte);
-      Text::Type textType = Text::Type::Rehearsal;
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      unsigned thisByte = placeHolder.toUnsignedInt();
+      bool includeLineBreak = ((highNibble(thisByte)&0x2) != 0x2);
+      unsigned id = lowNibble(thisByte);
+      Text::TextType textType = Text::TextType::Rehearsal;
 
-      if (id == 0) {
-            textType = Text::Type::MeasureText;
-            } else if (id == 1) {
-            textType = Text::Type::SystemText;
-            } else // id ==2
-            {
-            textType = Text::Type::Rehearsal;
-            }
+      if (id == 0)
+            textType = Text::TextType::MeasureText;
+      else if (id == 1)
+            textType = Text::TextType::SystemText;
+      else /*if (id == 2)*/
+            textType = Text::TextType::Rehearsal;
 
       text->setTextType(textType);
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
       // x offset
-      if( !readBuffer(placeHolder, 4) ) { return false; }
+      if (!readBuffer(placeHolder, 4)) { return false; }
       text->setXOffset(placeHolder.toInt());
 
       // y offset
-      if( !readBuffer(placeHolder, 4) ) { return false; }
+      if (!readBuffer(placeHolder, 4)) { return false; }
       text->setYOffset(placeHolder.toInt());
 
       // width
-      if( !readBuffer(placeHolder, 4) ) { return false; }
+      if (!readBuffer(placeHolder, 4)) { return false; }
       text->setWidth(placeHolder.toUnsignedInt());
 
       // height
-      if( !readBuffer(placeHolder, 4) ) { return false; }
+      if (!readBuffer(placeHolder, 4)) { return false; }
       text->setHeight(placeHolder.toUnsignedInt());
 
-      if( !jump(7) ) { return false; }
+      if (!jump(7)) { return false; }
 
       // horizontal margin
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       text->setHorizontalMargin(placeHolder.toUnsignedInt());
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
       // vertical margin
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       text->setVerticalMargin(placeHolder.toUnsignedInt());
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
       // line thick
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       text->setLineThick(placeHolder.toUnsignedInt());
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // text size
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      unsigned int size = placeHolder.toUnsignedInt();
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      unsigned size = placeHolder.toUnsignedInt();
 
       // text string, maybe huge
-      if( !readBuffer(placeHolder, size) ) { return false; }
-      text->setText(ove_->getCodecString(placeHolder.fixedSizeBufferToStrByteArray()));
+      if (!readBuffer(placeHolder, size)) { return false; }
+      text->setText(_ove->codecString(placeHolder.fixedSizeBufferToStrByteArray()));
 
-      if( !includeLineBreak ) {
-            if( !jump(6) ) { return false; }
-            } else {
-            unsigned int cursor = ove_->getIsVersion4() ? 43 : 41;
+      if (!includeLineBreak)
+            if (!jump(6)) { return false; }
+      else {
+            unsigned cursor = _ove->isVersion4() ? 43 : 41;
             cursor += size;
 
             // multi lines of text
-            for( unsigned int i=0; i<2; ++i ) {
-                  if( (int)cursor < length ) {
+            for (unsigned i = 0; i < 2; ++i) {
+                  if (int(cursor) < length) {
                         // line parameters count
-                        if( !readBuffer(placeHolder, 2) ) { return false; }
-                        unsigned int lineCount = placeHolder.toUnsignedInt();
+                        if (!readBuffer(placeHolder, 2)) { return false; }
+                        unsigned lineCount = placeHolder.toUnsignedInt();
 
-                        if( i==0 && int(cursor + 2 + 8*lineCount) > length ) {
+                        if (i == 0 && int(cursor + 2 + 8 * lineCount) > length)
                               return false;
-                              }
 
-                        if( i==1 && int(cursor + 2 + 8*lineCount) != length ) {
+                        if (i == 1 && int(cursor + 2 + 8 * lineCount) != length)
                               return false;
-                              }
 
-                        if( !jump(8*lineCount) ) { return false; }
+                        if (!jump(8 * lineCount)) { return false; }
 
-                        cursor += 2 + 8*lineCount;
+                        cursor += 2 + 8 * lineCount;
                         }
                   }
             }
@@ -4987,457 +3433,444 @@ bool BarsParse::parseText(MeasureData* measureData, int length) {
       return true;
       }
 
-bool BarsParse::parseRepeatSymbol(MeasureData* measureData, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseRepeatSymbol
+//---------------------------------------------------------
+
+bool BarsParse::parseRepeatSymbol(MeasureData* measureData, int /*length*/)
+      {
       Block placeHolder;
 
       RepeatSymbol* repeat = new RepeatSymbol();
       measureData->addMusicData(repeat);
 
-      if( !jump(3) ) { return false; }
+      if (!jump(3)) { return false; }
 
       // common
-      if( !parseCommonBlock(repeat) ) { return false; }
+      if (!parseCommonBlock(repeat)) { return false; }
 
       // RepeatType
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      repeat->setRepeatType(placeHolder.toUnsignedInt());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      repeat->setRepeatType(RepeatType(placeHolder.toUnsignedInt()));
 
-      if( !jump(13) ) { return false; }
+      if (!jump(13)) { return false; }
 
       // offset
-      if( !parseOffsetElement(repeat) ) { return false; }
+      if (!parseOffsetElement(repeat)) { return false; }
 
-      if( !jump(15) ) { return false; }
+      if (!jump(15)) { return false; }
 
       // size
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      unsigned int size = placeHolder.toUnsignedInt();
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      unsigned size = placeHolder.toUnsignedInt();
 
       // text, maybe huge
-      if( !readBuffer(placeHolder, size) ) { return false; }
-      repeat->setText(ove_->getCodecString(placeHolder.fixedSizeBufferToStrByteArray()));
+      if (!readBuffer(placeHolder, size)) { return false; }
+      repeat->setText(_ove->codecString(placeHolder.fixedSizeBufferToStrByteArray()));
 
       // last 0
-      if( size % 2 == 0 ) {
-            if( !jump(1) ) { return false; }
-            }
+      if (size % 2 == 0)
+            if (!jump(1)) { return false; }
 
       return true;
       }
 
-bool BarsParse::parseBdat(Measure* /*measure*/, MeasureData* measureData, SizeChunk* chunk) {
-      Block placeHolder;
-      StreamHandle handle(chunk->getDataBlock()->data(), chunk->getSizeBlock()->toSize());
+//---------------------------------------------------------
+//   BarsParse::parseBdat
+//---------------------------------------------------------
 
-      handle_ = &handle;
+bool BarsParse::parseBdat(Measure* /*measure*/, MeasureData* measureData, SizeChunk* chunk)
+      {
+      Block placeHolder;
+      StreamHandle handle(chunk->dataBlock()->data(), chunk->sizeBlock()->toSize());
+
+      _handle = &handle;
 
       // parse here
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      unsigned int cnt = placeHolder.toUnsignedInt();
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      unsigned cnt = placeHolder.toUnsignedInt();
 
-      for( unsigned int i=0; i<cnt; ++i ) {
+      for (unsigned i = 0; i < cnt; ++i) {
             // 0x0028 or 0x0016 or 0x002C
-            if( !readBuffer(placeHolder, 2) ) { return false; }
-            unsigned int count = placeHolder.toUnsignedInt() - 7;
+            if (!readBuffer(placeHolder, 2)) { return false; }
+            unsigned count = placeHolder.toUnsignedInt() - 7;
 
             // type id
-            if( !readBuffer(placeHolder, 1) ) { return false; }
-            unsigned int thisByte = placeHolder.toUnsignedInt();
+            if (!readBuffer(placeHolder, 1)) { return false; }
+            unsigned thisByte = placeHolder.toUnsignedInt();
             BdatType type;
 
-            if( !getBdatElementType(thisByte, type) ) { return false; }
+            if (!bdatElementType(thisByte, type)) { return false; }
 
-            switch( type ) {
-                  case BdatType::Raw_Note :
-                  case BdatType::Rest :
-                  case BdatType::Note : {
-                        if( !parseNoteRest(measureData, count, type) ) { return false; }
+            switch (type) {
+                  case BdatType::Raw_Note:
+                  case BdatType::Rest:
+                  case BdatType::Note:
+                        if (!parseNoteRest(measureData, count, type)) { return false; }
                         break;
-                        }
-                  case BdatType::Beam : {
-                        if( !parseBeam(measureData, count) ) { return false; }
+                  case BdatType::Beam:
+                        if (!parseBeam(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Harmony : {
-                        if( !parseHarmony(measureData, count) ) { return false; }
+                  case BdatType::Harmony:
+                        if (!parseHarmony(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Clef : {
-                        if( !parseClef(measureData, count) ) { return false; }
+                  case BdatType::Clef:
+                        if (!parseClef(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Dynamics : {
-                        if( !parseDynamics(measureData, count) ) { return false; }
+                  case BdatType::Dynamic:
+                        if (!parseDynamic(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Wedge : {
-                        if( !parseWedge(measureData, count) ) { return false; }
+                  case BdatType::Wedge:
+                        if (!parseWedge(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Glissando : {
-                        if( !parseGlissando(measureData, count) ) { return false; }
+                  case BdatType::Glissando:
+                        if (!parseGlissando(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Decorator : {
-                        if( !parseDecorators(measureData, count) ) { return false; }
+                  case BdatType::Decorator:
+                        if (!parseDecorator(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Key : {
-                        if( !parseKey(measureData, count) ) { return false; }
+                  case BdatType::Key:
+                        if (!parseKey(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Lyric : {
-                        if( !parseLyric(measureData, count) ) { return false; }
+                  case BdatType::Lyric:
+                        if (!parseLyric(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Octave_Shift: {
-                        if( !parseOctaveShift(measureData, count) ) { return false; }
+                  case BdatType::Octave_Shift:
+                        if (!parseOctaveShift(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Slur : {
-                        if( !parseSlur(measureData, count) ) { return false; }
+                  case BdatType::Slur:
+                        if (!parseSlur(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Text : {
-                        if( !parseText(measureData, count) ) { return false; }
+                  case BdatType::Text:
+                        if (!parseText(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Tie : {
-                        if( !parseTie(measureData, count) ) { return false; }
+                  case BdatType::Tie:
+                        if (!parseTie(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Tuplet : {
-                        if( !parseTuplet(measureData, count) ) { return false; }
+                  case BdatType::Tuplet:
+                        if (!parseTuplet(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Guitar_Bend :
-                  case BdatType::Guitar_Barre : {
-                        if( !parseSizeBlock(count) ) { return false; }
+                  case BdatType::Guitar_Bend:
+                  case BdatType::Guitar_Barre:
+                        if (!parseSizeBlock(count)) { return false; }
                         break;
-                        }
-                  case BdatType::Pedal: {
-                        if( !parsePedal(measureData, count) ) { return false; }
+                  case BdatType::Pedal:
+                        if (!parsePedal(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::KuoHao: {
-                        if( !parseKuohao(measureData, count) ) { return false; }
+                  case BdatType::Bracket:
+                        if (!parseBracket(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Expressions: {
-                        if( !parseExpressions(measureData, count) ) { return false; }
+                  case BdatType::Expression:
+                        if (!parseExpression(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Harp_Pedal: {
-                        if( !parseHarpPedal(measureData, count) ) { return false; }
+                  case BdatType::Harp_Pedal:
+                        if (!parseHarpPedal(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Multi_Measure_Rest: {
-                        if( !parseMultiMeasureRest(measureData, count) ) { return false; }
+                  case BdatType::Multi_Measure_Rest:
+                        if (!parseMultiMeasureRest(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Harmony_GuitarFrame: {
-                        if( !parseHarmonyGuitarFrame(measureData, count) ) { return false; }
+                  case BdatType::Harmony_GuitarFrame:
+                        if (!parseHarmonyGuitarFrame(measureData, count)) { return false; }
                         break;
-                        }
                   case BdatType::Graphics_40:
                   case BdatType::Graphics_RoundRect:
                   case BdatType::Graphics_Rect:
                   case BdatType::Graphics_Round:
                   case BdatType::Graphics_Line:
                   case BdatType::Graphics_Curve:
-                  case BdatType::Graphics_WedgeSymbol: {
-                        if( !parseSizeBlock(count) ) { return false; }
+                  case BdatType::Graphics_WedgeSymbol:
+                        if (!parseSizeBlock(count)) { return false; }
                         break;
-                        }
-                  case BdatType::Midi_Controller : {
-                        if( !parseMidiController(measureData, count) ) { return false; }
+                  case BdatType::Midi_Controller:
+                        if (!parseMidiController(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Midi_Program_Change : {
-                        if( !parseMidiProgramChange(measureData, count) ) { return false; }
+                  case BdatType::Midi_Program_Change:
+                        if (!parseMidiProgramChange(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Midi_Channel_Pressure : {
-                        if( !parseMidiChannelPressure(measureData, count) ) { return false; }
+                  case BdatType::Midi_Channel_Pressure:
+                        if (!parseMidiChannelPressure(measureData, count)) { return false; }
                         break;
-                        }
-                  case BdatType::Midi_Pitch_Wheel : {
-                        if( !parseMidiPitchWheel(measureData, count) ) { return false; }
+                  case BdatType::Midi_Pitch_Wheel:
+                        if (!parseMidiPitchWheel(measureData, count)) { return false; }
                         break;
-                        }
-                  default: {
-                        if( !jump(count) ) { return false; }
+                  default:
+                        if (!jump(count)) { return false; }
                         break;
-                        }
                   }
 
-            // if i==count-1 then is bar end place holder
+            // if i == count-1 then is bar end place holder
             }
 
-      handle_ = NULL;
+      _handle = nullptr;
 
       return true;
       }
 
-int getInt(int byte, int bits) {
+//---------------------------------------------------------
+//   getInt
+//---------------------------------------------------------
+
+static int getInt(int byte, int bits)
+      {
       int num = 0;
 
-      if( bits > 0 ) {
-            int factor = int(pow(2.0, bits-1));
-            num = (byte % (factor*2));
+      if (bits > 0) {
+            int factor = int(pow(2.0, bits - 1));
+            num = (byte % (factor * 2));
 
-            if ( (byte & factor) == factor ) {
-                  num -= factor*2;
-                  }
+            if ((byte & factor) == factor)
+                  num -= factor * 2;
             }
 
       return num;
       }
 
-bool BarsParse::parseNoteRest(MeasureData* measureData, int length, BdatType type) {
+//---------------------------------------------------------
+//   parseNoteRest
+//---------------------------------------------------------
+
+bool BarsParse::parseNoteRest(MeasureData* measureData, int length, BdatType type)
+      {
       NoteContainer* container = new NoteContainer();
       Block placeHolder;
-      unsigned int thisByte;
+      unsigned thisByte;
 
       measureData->addNoteContainer(container);
       measureData->addMusicData(container);
 
       // note|rest & grace
-      container->setIsRest(type==BdatType::Rest);
-      container->setIsRaw(type==BdatType::Raw_Note);
+      container->setIsRest(type == BdatType::Rest);
+      container->setIsRaw(type == BdatType::Raw_Note);
 
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       thisByte = placeHolder.toUnsignedInt();
-      container->setIsGrace( thisByte == 0x3C00 );
-      container->setIsCue( thisByte == 0x4B40 || thisByte == 0x3240 );
+      container->setIsGrace(thisByte == 0x3C00);
+      container->setIsCue(thisByte == 0x4B40 || thisByte == 0x3240);
 
       // show / hide
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       thisByte = placeHolder.toUnsignedInt();
-      container->setShow(getLowNibble(thisByte)!=0x8);
+      container->setShow(lowNibble(thisByte) != 0x8);
 
       // voice
-      container->setVoice(getLowNibble(thisByte)&0x7);
+      container->setVoice(lowNibble(thisByte) & 0x7);
 
       // common
-      if( !parseCommonBlock(container) ) { return false; }
+      if (!parseCommonBlock(container)) { return false; }
 
       // tuplet
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       container->setTuplet(placeHolder.toUnsignedInt());
 
       // space
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       container->setSpace(placeHolder.toUnsignedInt());
 
       // in beam
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       thisByte = placeHolder.toUnsignedInt();
-      bool inBeam = ( getHighNibble(thisByte) & 0x1 ) == 0x1;
+      bool inBeam = (highNibble(thisByte) & 0x1) == 0x1;
       container->setInBeam(inBeam);
 
       // grace NoteType
-      container->setGraceNoteType((NoteType)getHighNibble(thisByte));
+      container->setGraceNoteType(NoteType(highNibble(thisByte)));
 
       // dot
-      container->setDot(getLowNibble(thisByte)&0x03);
+      container->setDot(lowNibble(thisByte)&0x03);
 
       // NoteType
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       thisByte = placeHolder.toUnsignedInt();
-      container->setNoteType((NoteType)getLowNibble(thisByte));
+      container->setNoteType((NoteType)lowNibble(thisByte));
 
       int cursor = 0;
 
-      if( type == BdatType::Rest ) {
+      if (type == BdatType::Rest) {
             Note* restPtr = new Note();
             container->addNoteRest(restPtr);
             restPtr->setIsRest(true);
 
             // line
-            if( !readBuffer(placeHolder, 1) ) { return false; }
+            if (!readBuffer(placeHolder, 1)) { return false; }
             restPtr->setLine(placeHolder.toInt());
 
-            if( !jump(1) ) { return false; }
+            if (!jump(1)) { return false; }
 
-            cursor = ove_->getIsVersion4() ? 16 : 14;
-            } else // type == Bdat_Note || type == Bdat_Raw_Note
+            cursor = _ove->isVersion4() ? 16 : 14;
+            }
+      else // type == Bdat_Note || type == Bdat_Raw_Note
             {
             // stem up 0x80, stem down 0x00
-            if( !readBuffer(placeHolder, 1) ) { return false; }
+            if (!readBuffer(placeHolder, 1)) { return false; }
             thisByte = placeHolder.toUnsignedInt();
-            container->setStemUp((getHighNibble(thisByte)&0x8)==0x8);
+            container->setUp((highNibble(thisByte) & 0x8) == 0x8);
 
             // stem length
             int stemOffset = thisByte%0x80;
-            container->setStemLength(getInt(stemOffset, 7)+7/*3.5 line span*/);
+            container->setStemLength(getInt(stemOffset, 7) + 7/*3.5 line span*/);
 
             // show stem 0x00, hide stem 0x40
-            if( !readBuffer(placeHolder, 1) ) { return false; }
-            bool hideStem = getHighNibble(thisByte)==0x4;
+            if (!readBuffer(placeHolder, 1)) { return false; }
+            bool hideStem = (highNibble(thisByte) == 0x4);
             container->setShowStem(!hideStem);
 
-            if( !jump(1) ) { return false; }
+            if (!jump(1)) { return false; }
 
             // note count
-            if( !readBuffer(placeHolder, 1) ) { return false; }
-            unsigned int noteCount = placeHolder.toUnsignedInt();
-            unsigned int i;
+            if (!readBuffer(placeHolder, 1)) { return false; }
+            unsigned noteCount = placeHolder.toUnsignedInt();
+            unsigned i;
 
             // each note 16 bytes
-            for( i=0; i<noteCount; ++i ) {
+            for (i = 0; i < noteCount; ++i) {
                   Note* notePtr = new Note();
                   notePtr->setIsRest(false);
 
                   container->addNoteRest(notePtr);
 
                   // note show / hide
-                  if( !readBuffer(placeHolder, 1) ) { return false; }
+                  if (!readBuffer(placeHolder, 1)) { return false; }
                   thisByte = placeHolder.toUnsignedInt();
-                  notePtr->setShow((thisByte&0x80) != 0x80);
+                  notePtr->setShow((thisByte & 0x80) != 0x80);
 
                   // notehead type
-                  notePtr->setHeadType(thisByte&0x7f);
+                  notePtr->setHeadType(NoteHeadType(thisByte & 0x7f));
 
                   // tie pos
-                  if( !readBuffer(placeHolder, 1) ) { return false; }
+                  if (!readBuffer(placeHolder, 1)) { return false; }
                   thisByte = placeHolder.toUnsignedInt();
-                  notePtr->setTiePos(getHighNibble(thisByte));
+                  notePtr->setTiePos(TiePos(highNibble(thisByte)));
 
                   // offset staff, in {-1, 0, 1}
-                  if( !readBuffer(placeHolder, 1) ) { return false; }
-                  thisByte = getLowNibble(placeHolder.toUnsignedInt());
+                  if (!readBuffer(placeHolder, 1)) { return false; }
+                  thisByte = lowNibble(placeHolder.toUnsignedInt());
                   int offsetStaff = 0;
-                  if( thisByte == 1 ) { offsetStaff = 1; }
-                  if( thisByte == 7 ) { offsetStaff = -1; }
+                  if (thisByte == 1) { offsetStaff = 1; }
+                  if (thisByte == 7) { offsetStaff = -1; }
                   notePtr->setOffsetStaff(offsetStaff);
 
                   // accidental
-                  if( !readBuffer(placeHolder, 1) ) { return false; }
+                  if (!readBuffer(placeHolder, 1)) { return false; }
                   thisByte = placeHolder.toUnsignedInt();
-                  notePtr->setAccidental(getLowNibble(thisByte));
+                  notePtr->setAccidental(AccidentalType(lowNibble(thisByte)));
                   // accidental 0: influenced by key, 4: influenced by previous accidental in measure
-                  //bool notShow = ( getHighNibble(thisByte) == 0 ) || ( getHighNibble(thisByte) == 4 );
-                  bool notShow = !(getHighNibble(thisByte)&0x1);
+                  // bool notShow = (highNibble(thisByte) == 0) || (highNibble(thisByte) == 4);
+                  bool notShow = !(highNibble(thisByte) & 0x1);
                   notePtr->setShowAccidental(!notShow);
 
-                  if( !jump(1) ) { return false; }
+                  if (!jump(1)) { return false; }
 
                   // line
-                  if( !readBuffer(placeHolder, 1) ) { return false; }
+                  if (!readBuffer(placeHolder, 1)) { return false; }
                   notePtr->setLine(placeHolder.toInt());
 
-                  if( !jump(1) ) { return false; }
+                  if (!jump(1)) { return false; }
 
                   // note
-                  if( !readBuffer(placeHolder, 1) ) { return false; }
-                  unsigned int note = placeHolder.toUnsignedInt();
+                  if (!readBuffer(placeHolder, 1)) { return false; }
+                  unsigned note = placeHolder.toUnsignedInt();
                   notePtr->setNote(note);
 
                   // note on velocity
-                  if( !readBuffer(placeHolder, 1) ) { return false; }
-                  unsigned int onVelocity = placeHolder.toUnsignedInt();
+                  if (!readBuffer(placeHolder, 1)) { return false; }
+                  unsigned onVelocity = placeHolder.toUnsignedInt();
                   notePtr->setOnVelocity(onVelocity);
 
                   // note off velocity
-                  if( !readBuffer(placeHolder, 1) ) { return false; }
-                  unsigned int offVelocity = placeHolder.toUnsignedInt();
+                  if (!readBuffer(placeHolder, 1)) { return false; }
+                  unsigned offVelocity = placeHolder.toUnsignedInt();
                   notePtr->setOffVelocity(offVelocity);
 
-                  if( !jump(2) ) { return false; }
+                  if (!jump(2)) { return false; }
 
                   // length (tick)
-                  if( !readBuffer(placeHolder, 2) ) { return false; }
+                  if (!readBuffer(placeHolder, 2)) { return false; }
                   container->setLength(placeHolder.toUnsignedInt());
 
                   // offset tick
-                  if( !readBuffer(placeHolder, 2) ) { return false; }
+                  if (!readBuffer(placeHolder, 2)) { return false; }
                   notePtr->setOffsetTick(placeHolder.toInt());
                   }
 
-            cursor = ove_->getIsVersion4() ? 18 : 16;
-            cursor += noteCount * 16/*note size*/;
+            cursor = _ove->isVersion4() ? 18 : 16;
+            cursor += noteCount * 16 /* note size */;
             }
 
       // articulation
-      while ( cursor < length + 1/* 0x70 || 0x80 || 0x90 */ ) {
+      while (cursor < length + 1 /* 0x70 || 0x80 || 0x90 */) {
             Articulation* art = new Articulation();
             container->addArticulation(art);
 
             // block size
-            if( !readBuffer(placeHolder, 2) ) { return false; }
+            if (!readBuffer(placeHolder, 2)) { return false; }
             int blockSize = placeHolder.toUnsignedInt();
 
             // articulation type
-            if( !readBuffer(placeHolder, 1) ) { return false; }
-            art->setArtType(placeHolder.toUnsignedInt());
+            if (!readBuffer(placeHolder, 1)) { return false; }
+            art->setArticulationType(ArticulationType(placeHolder.toUnsignedInt()));
 
             // placement
-            if( !readBuffer(placeHolder, 1) ) { return false; }
-            art->setPlacementAbove(placeHolder.toUnsignedInt()!=0x00); //0x00:below, 0x30:above
+            if (!readBuffer(placeHolder, 1)) { return false; }
+            art->setPlacementAbove(placeHolder.toUnsignedInt() != 0x00); //0x00:below, 0x30:above
 
             // offset
-            if( !parseOffsetElement(art) ) { return false; }
+            if (!parseOffsetElement(art)) { return false; }
 
-            if( !ove_->getIsVersion4() ) {
-                  if( blockSize - 8 > 0 ) {
-                        if( !jump(blockSize-8) ) { return false; }
-                        }
-                  } else {
+            if (!_ove->isVersion4()) {
+                  if (blockSize - 8 > 0)
+                        if (!jump(blockSize-8)) { return false; }
+                  } 
+            else {
                   // setting
-                  if( !readBuffer(placeHolder, 1) ) { return false; }
+                  if (!readBuffer(placeHolder, 1)) { return false; }
                   thisByte = placeHolder.toUnsignedInt();
-                  const bool changeSoundEffect = ( ( thisByte & 0x1 ) == 0x1 );
-                  const bool changeLength = ( ( thisByte & 0x2 ) == 0x2 );
-                  const bool changeVelocity = ( ( thisByte & 0x4 ) == 0x4 );
-                  //const bool changeExtraLength = ( ( thisByte & 0x20 ) == 0x20 );
+                  const bool changeSoundEffect = ((thisByte & 0x1) == 0x1);
+                  const bool changeLength = ((thisByte & 0x2) == 0x2);
+                  const bool changeVelocity = ((thisByte & 0x4) == 0x4);
+                  //const bool changeExtraLength = ((thisByte & 0x20) == 0x20);
 
-                  if( !jump(8) ) { return false; }
+                  if (!jump(8)) { return false; }
 
                   // velocity type
-                  if( !readBuffer(placeHolder, 1) ) { return false; }
+                  if (!readBuffer(placeHolder, 1)) { return false; }
                   thisByte = placeHolder.toUnsignedInt();
-                  if( changeVelocity ) {
-                        art->setVelocityType((Articulation::VelocityType)thisByte);
-                        }
+                  if (changeVelocity)
+                        art->setVelocityType(Articulation::VelocityType(thisByte));
 
-                  if( !jump(14) ) { return false; }
+                  if (!jump(14)) { return false; }
 
                   // sound effect
-                  if( !readBuffer(placeHolder, 2) ) { return false; }
+                  if (!readBuffer(placeHolder, 2)) { return false; }
                   int from = placeHolder.toInt();
-                  if( !readBuffer(placeHolder, 2) ) { return false; }
+                  if (!readBuffer(placeHolder, 2)) { return false; }
                   int to = placeHolder.toInt();
-                  if( changeSoundEffect ) {
+                  if (changeSoundEffect)
                         art->setSoundEffect(from, to);
-                        }
 
-                  if( !jump(1) ) { return false; }
+                  if (!jump(1)) { return false; }
 
                   // length percentage
-                  if( !readBuffer(placeHolder, 1) ) { return false; }
-                  if( changeLength ) {
+                  if (!readBuffer(placeHolder, 1)) { return false; }
+                  if (changeLength)
                         art->setLengthPercentage(placeHolder.toUnsignedInt());
-                        }
 
                   // velocity
-                  if( !readBuffer(placeHolder, 2) ) { return false; }
-                  if( changeVelocity ) {
-                        art->setVelocityValue(placeHolder.toInt());
-                        }
+                  if (!readBuffer(placeHolder, 2)) { return false; }
+                  if (changeVelocity)
+                        art->setVelocity(placeHolder.toInt());
 
-                  if( Articulation::isTrill(art->getArtType()) ) {
-                        if( !jump(8) ) { return false; }
+                  if (art->isTrill()) {
+                        if (!jump(8)) { return false; }
 
                         // trill note length
-                        if( !readBuffer(placeHolder, 1) ) { return false; }
+                        if (!readBuffer(placeHolder, 1)) { return false; }
                         art->setTrillNoteLength(placeHolder.toUnsignedInt());
 
                         // trill rate
-                        if( !readBuffer(placeHolder, 1) ) { return false; }
+                        if (!readBuffer(placeHolder, 1)) { return false; }
                         thisByte = placeHolder.toUnsignedInt();
                         NoteType trillNoteType = NoteType::Note_Sixteen;
-                        switch ( getHighNibble(thisByte) ) {
+                        switch (highNibble(thisByte)) {
                               case 0:
                                     trillNoteType = NoteType::Note_None;
                                     break;
@@ -5459,23 +3892,23 @@ bool BarsParse::parseNoteRest(MeasureData* measureData, int length, BdatType typ
                         art->setTrillRate(trillNoteType);
 
                         // accelerate type
-                        art->setAccelerateType(thisByte&0xf);
+                        art->setAccelerateType(Articulation::AccelerateType(thisByte & 0xf));
 
-                        if( !jump(1) ) { return false; }
+                        if (!jump(1)) { return false; }
 
                         // auxiliary first
-                        if( !readBuffer(placeHolder, 1) ) { return false; }
-                        art->setAuxiliaryFirst(placeHolder.toBoolean());
+                        if (!readBuffer(placeHolder, 1)) { return false; }
+                        art->setAuxiliaryFirst(placeHolder.toBool());
 
-                        if( !jump(1) ) { return false; }
+                        if (!jump(1)) { return false; }
 
                         // trill interval
-                        if( !readBuffer(placeHolder, 1) ) { return false; }
-                        art->setTrillInterval(placeHolder.toUnsignedInt());
-                        } else {
-                        if( blockSize > 40 ) {
-                              if( !jump( blockSize - 40 ) ) { return false; }
-                              }
+                        if (!readBuffer(placeHolder, 1)) { return false; }
+                        art->setTrillInterval(Articulation::TrillInterval(placeHolder.toUnsignedInt()));
+                        } 
+                  else {
+                        if (blockSize > 40)
+                              if (!jump(blockSize - 40)) { return false; }
                         }
                   }
 
@@ -5485,17 +3918,26 @@ bool BarsParse::parseNoteRest(MeasureData* measureData, int length, BdatType typ
       return true;
       }
 
-int tupletToSpace(int tuplet) {
-      int a(1);
+//---------------------------------------------------------
+//   tupletToSpace
+//---------------------------------------------------------
 
-      while( a*2 < tuplet ) {
+static int tupletToSpace(int tuplet)
+      {
+      int a = 1;
+
+      while (a * 2 < tuplet)
             a *= 2;
-            }
 
       return a;
       }
 
-bool BarsParse::parseBeam(MeasureData* measureData, int length) {
+//---------------------------------------------------------
+//   BarsParse::parseBeam
+//---------------------------------------------------------
+
+bool BarsParse::parseBeam(MeasureData* measureData, int length)
+      {
       int i;
       Block placeHolder;
 
@@ -5508,50 +3950,49 @@ bool BarsParse::parseBeam(MeasureData* measureData, int length) {
       Tuplet* tuplet = new Tuplet();
 
       // is grace
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      beam->setIsGrace(placeHolder.toBoolean());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      beam->setIsGrace(placeHolder.toBool());
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
       // voice
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      beam->setVoice(getLowNibble(placeHolder.toUnsignedInt())&0x7);
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      beam->setVoice(lowNibble(placeHolder.toUnsignedInt())&0x7);
 
       // common
-      if( !parseCommonBlock(beam) ) { return false; }
+      if (!parseCommonBlock(beam)) { return false; }
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // beam count
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       int beamCount = placeHolder.toUnsignedInt();
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
       // left line
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      beam->getLeftLine()->setLine(placeHolder.toInt());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      beam->leftLine()->setLine(placeHolder.toInt());
 
       // right line
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      beam->getRightLine()->setLine(placeHolder.toInt());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      beam->rightLine()->setLine(placeHolder.toInt());
 
-      if( ove_->getIsVersion4() ) {
-            if( !jump(8) ) { return false; }
-            }
+      if (_ove->isVersion4())
+            if (!jump(8)) { return false; }
 
-      int currentCursor = ove_->getIsVersion4() ? 23 : 13;
+      int currentCursor = _ove->isVersion4() ? 23 : 13;
       int count = (length - currentCursor)/16;
 
-      if( count != beamCount ) { return false; }
+      if (count != beamCount) { return false; }
 
-      for( i=0; i<count; ++i ) {
-            if( !jump(1) ) { return false; }
+      for (i = 0; i < count; ++i) {
+            if (!jump(1)) { return false; }
 
             // tuplet
-            if( !readBuffer(placeHolder, 1) ) { return false; }
+            if (!readBuffer(placeHolder, 1)) { return false; }
             int tupletCount = placeHolder.toUnsignedInt();
-            if( tupletCount > 0 ) {
+            if (tupletCount > 0) {
                   createTuplet = true;
                   tuplet->setTuplet(tupletCount);
                   tuplet->setSpace(tupletToSpace(tupletCount));
@@ -5562,744 +4003,732 @@ bool BarsParse::parseBeam(MeasureData* measureData, int length) {
             MeasurePos startMp;
             MeasurePos stopMp;
 
-            if( !readBuffer(placeHolder, 1) ) { return false; }
+            if (!readBuffer(placeHolder, 1)) { return false; }
             startMp.setMeasure(placeHolder.toUnsignedInt());
-            if( !readBuffer(placeHolder, 1) ) { return false; }
+            if (!readBuffer(placeHolder, 1)) { return false; }
             stopMp.setMeasure(placeHolder.toUnsignedInt());
 
-            if( !readBuffer(placeHolder, 2) ) { return false; }
+            if (!readBuffer(placeHolder, 2)) { return false; }
             startMp.setOffset(placeHolder.toInt());
-            if( !readBuffer(placeHolder, 2) ) { return false; }
+            if (!readBuffer(placeHolder, 2)) { return false; }
             stopMp.setOffset(placeHolder.toInt());
 
             beam->addLine(startMp, stopMp);
 
-            if( stopMp.getOffset() > maxEndUnit ) {
-                  maxEndUnit = stopMp.getOffset();
-                  }
+            if (stopMp.offset() > maxEndUnit)
+                  maxEndUnit = stopMp.offset();
 
-            if( i == 0 ) {
-                  if( !jump(4) ) { return false; }
+            if (i == 0) {
+                  if (!jump(4)) { return false; }
 
                   // left offset up+4, down-4
-                  if( !readBuffer(placeHolder, 2) ) { return false; }
-                  beam->getLeftShoulder()->setYOffset(placeHolder.toInt());
+                  if (!readBuffer(placeHolder, 2)) { return false; }
+                  beam->leftShoulder()->setYOffset(placeHolder.toInt());
 
                   // right offset up+4, down-4
-                  if( !readBuffer(placeHolder, 2) ) { return false; }
-                  beam->getRightShoulder()->setYOffset(placeHolder.toInt());
-                  } else {
-                  if( !jump(8) ) { return false; }
+                  if (!readBuffer(placeHolder, 2)) { return false; }
+                  beam->rightShoulder()->setYOffset(placeHolder.toInt());
+                  }
+            else {
+                  if (!jump(8)) { return false; }
                   }
             }
 
-      const QList<QPair<MeasurePos, MeasurePos> > lines = beam->getLines();
+      const QList<QPair<MeasurePos, MeasurePos> > lines = beam->lines();
       MeasurePos offsetMp;
 
-      for( i=0; i<lines.size(); ++i ) {
-            if( lines[i].second > offsetMp ) {
+      for (i = 0; i < lines.size(); ++i) {
+            if (lines[i].second > offsetMp)
                   offsetMp = lines[i].second;
-                  }
             }
 
-      beam->stop()->setMeasure(offsetMp.getMeasure());
-      beam->stop()->setOffset(offsetMp.getOffset());
+      beam->stop()->setMeasure(offsetMp.measure());
+      beam->stop()->setOffset(offsetMp.offset());
 
       // a case that Tuplet block don't exist, and hide inside beam
-      if( createTuplet ) {
+      if (createTuplet) {
             tuplet->copyCommonBlock(*beam);
-            tuplet->getLeftLine()->setLine(beam->getLeftLine()->getLine());
-            tuplet->getRightLine()->setLine(beam->getRightLine()->getLine());
-            tuplet->stop()->setMeasure(beam->stop()->getMeasure());
+            tuplet->leftLine()->setLine(beam->leftLine()->line());
+            tuplet->rightLine()->setLine(beam->rightLine()->line());
+            tuplet->stop()->setMeasure(beam->stop()->measure());
             tuplet->stop()->setOffset(maxEndUnit);
 
             measureData->addCrossMeasureElement(tuplet, true);
-            } else {
+            }
+      else {
             delete tuplet;
             }
 
       return true;
       }
 
-bool BarsParse::parseTie(MeasureData* measureData, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseTie
+//---------------------------------------------------------
+
+bool BarsParse::parseTie(MeasureData* measureData, int /*length*/)
+      {
       Block placeHolder;
 
       Tie* tie = new Tie();
       measureData->addCrossMeasureElement(tie, true);
 
-      if( !jump(3) ) { return false; }
+      if (!jump(3)) { return false; }
 
       // start common
-      if( !parseCommonBlock(tie) ) { return false; }
+      if (!parseCommonBlock(tie)) { return false; }
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
       // note
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       tie->setNote(placeHolder.toUnsignedInt());
 
       // pair lines
-      if( !parsePairLinesBlock(tie) ) { return false; }
+      if (!parsePairLinesBlock(tie)) { return false; }
 
       // offset common
-      if( !parseOffsetCommonBlock(tie) ) { return false; }
+      if (!parseOffsetCommonBlock(tie)) { return false; }
 
       // left shoulder offset
-      if( !parseOffsetElement(tie->getLeftShoulder()) ) { return false; }
+      if (!parseOffsetElement(tie->leftShoulder())) { return false; }
 
       // right shoulder offset
-      if( !parseOffsetElement(tie->getRightShoulder()) ) { return false; }
+      if (!parseOffsetElement(tie->rightShoulder())) { return false; }
 
       // height
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       tie->setHeight(placeHolder.toUnsignedInt());
 
       return true;
       }
 
-bool BarsParse::parseTuplet(MeasureData* measureData, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseTuplet
+//---------------------------------------------------------
+
+bool BarsParse::parseTuplet(MeasureData* measureData, int /*length*/)
+      {
       Block placeHolder;
 
       Tuplet* tuplet = new Tuplet();
       measureData->addCrossMeasureElement(tuplet, true);
 
-      if( !jump(3) ) { return false; }
+      if (!jump(3)) { return false; }
 
       // common
-      if( !parseCommonBlock(tuplet) ) { return false; }
+      if (!parseCommonBlock(tuplet)) { return false; }
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // pair lines
-      if( !parsePairLinesBlock(tuplet) ) { return false; }
+      if (!parsePairLinesBlock(tuplet)) { return false; }
 
       // offset common
-      if( !parseOffsetCommonBlock(tuplet) ) { return false; }
+      if (!parseOffsetCommonBlock(tuplet)) { return false; }
 
       // left shoulder offset
-      if( !parseOffsetElement(tuplet->getLeftShoulder()) ) { return false; }
+      if (!parseOffsetElement(tuplet->leftShoulder())) { return false; }
 
       // right shoulder offset
-      if( !parseOffsetElement(tuplet->getRightShoulder()) ) { return false; }
+      if (!parseOffsetElement(tuplet->rightShoulder())) { return false; }
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // height
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       tuplet->setHeight(placeHolder.toUnsignedInt());
 
       // tuplet
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       tuplet->setTuplet(placeHolder.toUnsignedInt());
 
       // space
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       tuplet->setSpace(placeHolder.toUnsignedInt());
 
       // mark offset
-      if( !parseOffsetElement(tuplet->getMarkHandle()) ) { return false; }
+      if (!parseOffsetElement(tuplet->markHandle())) { return false; }
 
       return true;
       }
 
-QString binaryToHarmonyType(int bin) {
+//---------------------------------------------------------
+//   binaryToHarmonyType
+//---------------------------------------------------------
+
+static QString binaryToHarmonyType(int bin)
+      {
       QString type = "";
       switch (bin) {
-            case 0x0005: { type = "add9(no3)";        break; }
-            case 0x0009: { type = "min(no5)";         break; }
-            case 0x0011: { type = "(no5)";            break; }
-            case 0x0021: { type = "sus(no5)";         break; }
-            case 0x0025: { type = "24";               break; }
-            case 0x0029: { type = "min4(no5)";        break; }
-            case 0x0049: { type = "dim";              break; }
-            case 0x0051: { type = "(b5)";             break; }
-            case 0x0055: { type = "2#4(no5)";         break; }
-            case 0x0081: { type = "(no3)";            break; }
-            case 0x0085: { type = "2";                break; }
-            case 0x0089: { type = "min";              break; }
-            case 0x008D: { type = "min(add9)";        break; }
-            case 0x0091: { type = "";                 break; }
-            case 0x0093: { type = "addb9";            break; }
-            case 0x0095: { type = "add9";             break; }
-            case 0x00A1: { type = "sus4";             break; }
-            case 0x00A5: { type = "sus(add9)";        break; }
-            case 0x00A9: { type = "min4";             break; }
-            case 0x00D5: { type = "2#4";              break; }
-            case 0x0111: { type = "aug";              break; }
-            case 0x0115: { type = "aug(add9)";        break; }
-            case 0x0151: { type = "(b5b6)";           break; }
-            case 0x0155: { type = "+add9#11";         break; }
-            case 0x0189: { type = "minb6";            break; }
-            case 0x018D: { type = "min2b6";           break; }
-            case 0x0191: { type = "(b6)";             break; }
-            case 0x0199: { type = "(add9)b6";         break; }
-            case 0x0205: { type = "26";               break; }
-            case 0x020D: { type = "min69";            break; }
-            case 0x0211: { type = "6";                break; }
-            case 0x0215: { type = "69";               break; }
-            case 0x022D: { type = "min69 11";         break; }
-            case 0x0249: { type = "dim7";             break; }
-            case 0x0251: { type = "6#11";             break; }
-            case 0x0255: { type = "13#11";            break; }
-            case 0x0281: { type = "6(no3)";           break; }
-            case 0x0285: { type = "69(no3)";          break; }
-            case 0x0289: { type = "min6";             break; }
-            case 0x028D: { type = "min69";            break; }
-            case 0x0291: { type = "6";                break; }
-            case 0x0293: { type = "6b9";              break; }
-            case 0x0295: { type = "69";               break; }
-            case 0x02AD: { type = "min69 11";         break; }
-            case 0x02C5: { type = "69#11(no3)";       break; }
-            case 0x02D5: { type = "69#11";            break; }
-            case 0x040D: { type = "min9(no5)";        break; }
-            case 0x0411: { type = "7(no5)";           break; }
-            case 0x0413: { type = "7b9";              break; }
-            case 0x0415: { type = "9";                break; }
-            case 0x0419: { type = "7#9";              break; }
-            case 0x041B: { type = "7b9#9";            break; }
-            case 0x0421: { type = "sus7";             break; }
-            case 0x0429: { type = "min11";            break; }
-            case 0x042D: { type = "min11";            break; }
-            case 0x0445: { type = "9b5(no3)";         break; }
-            case 0x0449: { type = "min7b5";           break; }
-            case 0x044D: { type = "min9b5";           break; }
-            case 0x0451: { type = "7b5";              break; }
-            case 0x0453: { type = "7b9b5";            break; }
-            case 0x0455: { type = "9b5";              break; }
-            case 0x045B: { type = "7b5b9#9";          break; }
-            case 0x0461: { type = "sus7b5";           break; }
-            case 0x0465: { type = "sus9b5";           break; }
-            case 0x0469: { type = "min11b5";          break; }
-            case 0x046D: { type = "min11b5";          break; }
-            case 0x0481: { type = "7(no3)";           break; }
-            case 0x0489: { type = "min7";             break; }
-            case 0x048D: { type = "min9";             break; }
-            case 0x0491: { type = "7";                break; }
-            case 0x0493: { type = "7b9";              break; }
-            case 0x0495: { type = "9";                break; }
-            case 0x0499: { type = "7#9";              break; }
-            case 0x049B: { type = "7b9#9";            break; }
-            case 0x04A1: { type = "sus7";             break; }
-            case 0x04A5: { type = "sus9";             break; }
-            case 0x04A9: { type = "min11";            break; }
-            case 0x04AD: { type = "min11";            break; }
-            case 0x04B5: { type = "11";               break; }
-            case 0x04D5: { type = "9#11";             break; }
-            case 0x0509: { type = "min7#5";           break; }
-            case 0x0511: { type = "aug7";             break; }
-            case 0x0513: { type = "7#5b9";            break; }
-            case 0x0515: { type = "aug9";             break; }
-            case 0x0519: { type = "7#5#9";            break; }
-            case 0x0529: { type = "min11b13";         break; }
-            case 0x0533: { type = "11b9#5";           break; }
-            case 0x0551: { type = "aug7#11";          break; }
-            case 0x0553: { type = "7b5b9b13";         break; }
-            case 0x0555: { type = "aug9#11";          break; }
-            case 0x0559: { type = "aug7#9#11";        break; }
-            case 0x0609: { type = "min13";            break; }
-            case 0x0611: { type = "13";               break; }
-            case 0x0613: { type = "13b9";             break; }
-            case 0x0615: { type = "13";               break; }
-            case 0x0619: { type = "13#9";             break; }
-            case 0x061B: { type = "13b9#9";           break; }
-            case 0x0621: { type = "sus13";            break; }
-            case 0x062D: { type = "min13(11)";        break; }
-            case 0x0633: { type = "13b9add4";         break; }
-            case 0x0635: { type = "13";               break; }
-            case 0x0645: { type = "13#11(no3)";       break; }
-            case 0x0651: { type = "13b5";             break; }
-            case 0x0653: { type = "13b9#11";          break; }
-            case 0x0655: { type = "13#11";            break; }
-            case 0x0659: { type = "13#9b5";           break; }
-            case 0x065B: { type = "13b5b9#9";         break; }
-            case 0x0685: { type = "13(no3)";          break; }
-            case 0x068D: { type = "min13";            break; }
-            case 0x0691: { type = "13";               break; }
-            case 0x0693: { type = "13b9";             break; }
-            case 0x0695: { type = "13";               break; }
-            case 0x0699: { type = "13#9";             break; }
-            case 0x06A5: { type = "sus13";            break; }
-            case 0x06AD: { type = "min13(11)";        break; }
-            case 0x06B5: { type = "13";               break; }
-            case 0x06D5: { type = "13#11";            break; }
-            case 0x0813: { type = "maj7b9";           break; }
-            case 0x0851: { type = "maj7#11";          break; }
-            case 0x0855: { type = "maj9#11";          break; }
-            case 0x0881: { type = "maj7(no3)";        break; }
-            case 0x0889: { type = "min(\u266e7)";     break; }   // "min(<sym>accidentalNatural</sym>7)"
-            case 0x088D: { type = "min9(\u266e7)";    break; }   // "min9(<sym>accidentalNatural</sym>7)"
-            case 0x0891: { type = "maj7";             break; }
-            case 0x0895: { type = "maj9";             break; }
-            case 0x08C9: { type = "dim7(add maj 7)";  break; }
-            case 0x08D1: { type = "maj7#11";          break; }
-            case 0x08D5: { type = "maj9#11";          break; }
-            case 0x0911: { type = "maj7#5";           break; }
-            case 0x0991: { type = "maj7#5";           break; }
-            case 0x0995: { type = "maj9#5";            break; }
-            case 0x0A0D: { type = "min69(\u266e7)";   break; }   // "min69(<sym>accidentalNatural</sym>7)"
-            case 0x0A11: { type = "maj13";            break; }
-            case 0x0A15: { type = "maj13";            break; }
-            case 0x0A51: { type = "maj13#11";         break; }
-            case 0x0A55: { type = "maj13#11";         break; }
-            case 0x0A85: { type = "maj13(no3)";       break; }
-            case 0x0A89: { type = "min13(\u266e7)";   break; }   // "min13(<sym>accidentalNatural</sym>7)"
-            case 0x0A8D: { type = "min69(\u266e7)";   break; }   // "min69(<sym>accidentalNatural</sym>7)"
-            case 0x0A91: { type = "maj13";            break; }
-            case 0x0A95: { type = "maj13";            break; }
-            case 0x0AAD: { type = "min13(\u266e7)";   break; }   // "min13(<sym>accidentalNatural</sym>7)"
-            case 0x0AD5: { type = "maj13#11";         break; }
-            case 0x0B45: { type = "maj13#5#11(no4)";  break; }
-            default: {
+            case 0x0005: type = "add9(no3)";       break;
+            case 0x0009: type = "min(no5)";        break;
+            case 0x0011: type = "(no5)";           break;
+            case 0x0021: type = "sus(no5)";        break;
+            case 0x0025: type = "24";              break;
+            case 0x0029: type = "min4(no5)";       break;
+            case 0x0049: type = "dim";             break;
+            case 0x0051: type = "(b5)";            break;
+            case 0x0055: type = "2#4(no5)";        break;
+            case 0x0081: type = "(no3)";           break;
+            case 0x0085: type = "2";               break;
+            case 0x0089: type = "min";             break;
+            case 0x008D: type = "min(add9)";       break;
+            case 0x0091: type = "";                break;
+            case 0x0093: type = "addb9";           break;
+            case 0x0095: type = "add9";            break;
+            case 0x00A1: type = "sus4";            break;
+            case 0x00A5: type = "sus(add9)";       break;
+            case 0x00A9: type = "min4";            break;
+            case 0x00D5: type = "2#4";             break;
+            case 0x0111: type = "aug";             break;
+            case 0x0115: type = "aug(add9)";       break;
+            case 0x0151: type = "(b5b6)";          break;
+            case 0x0155: type = "+add9#11";        break;
+            case 0x0189: type = "minb6";           break;
+            case 0x018D: type = "min2b6";          break;
+            case 0x0191: type = "(b6)";            break;
+            case 0x0199: type = "(add9)b6";        break;
+            case 0x0205: type = "26";              break;
+            case 0x020D: type = "min69";           break;
+            case 0x0211: type = "6";               break;
+            case 0x0215: type = "69";              break;
+            case 0x022D: type = "min69 11";        break;
+            case 0x0249: type = "dim7";            break;
+            case 0x0251: type = "6#11";            break;
+            case 0x0255: type = "13#11";           break;
+            case 0x0281: type = "6(no3)";          break;
+            case 0x0285: type = "69(no3)";         break;
+            case 0x0289: type = "min6";            break;
+            case 0x028D: type = "min69";           break;
+            case 0x0291: type = "6";               break;
+            case 0x0293: type = "6b9";             break;
+            case 0x0295: type = "69";              break;
+            case 0x02AD: type = "min69 11";        break;
+            case 0x02C5: type = "69#11(no3)";      break;
+            case 0x02D5: type = "69#11";           break;
+            case 0x040D: type = "min9(no5)";       break;
+            case 0x0411: type = "7(no5)";          break;
+            case 0x0413: type = "7b9";             break;
+            case 0x0415: type = "9";               break;
+            case 0x0419: type = "7#9";             break;
+            case 0x041B: type = "7b9#9";           break;
+            case 0x0421: type = "sus7";            break;
+            case 0x0429: type = "min11";           break;
+            case 0x042D: type = "min11";           break;
+            case 0x0445: type = "9b5(no3)";        break;
+            case 0x0449: type = "min7b5";          break;
+            case 0x044D: type = "min9b5";          break;
+            case 0x0451: type = "7b5";             break;
+            case 0x0453: type = "7b9b5";           break;
+            case 0x0455: type = "9b5";             break;
+            case 0x045B: type = "7b5b9#9";         break;
+            case 0x0461: type = "sus7b5";          break;
+            case 0x0465: type = "sus9b5";          break;
+            case 0x0469: type = "min11b5";         break;
+            case 0x046D: type = "min11b5";         break;
+            case 0x0481: type = "7(no3)";          break;
+            case 0x0489: type = "min7";            break;
+            case 0x048D: type = "min9";            break;
+            case 0x0491: type = "7";               break;
+            case 0x0493: type = "7b9";             break;
+            case 0x0495: type = "9";               break;
+            case 0x0499: type = "7#9";             break;
+            case 0x049B: type = "7b9#9";           break;
+            case 0x04A1: type = "sus7";            break;
+            case 0x04A5: type = "sus9";            break;
+            case 0x04A9: type = "min11";           break;
+            case 0x04AD: type = "min11";           break;
+            case 0x04B5: type = "11";              break;
+            case 0x04D5: type = "9#11";            break;
+            case 0x0509: type = "min7#5";          break;
+            case 0x0511: type = "aug7";            break;
+            case 0x0513: type = "7#5b9";           break;
+            case 0x0515: type = "aug9";            break;
+            case 0x0519: type = "7#5#9";           break;
+            case 0x0529: type = "min11b13";        break;
+            case 0x0533: type = "11b9#5";          break;
+            case 0x0551: type = "aug7#11";         break;
+            case 0x0553: type = "7b5b9b13";        break;
+            case 0x0555: type = "aug9#11";         break;
+            case 0x0559: type = "aug7#9#11";       break;
+            case 0x0609: type = "min13";           break;
+            case 0x0611: type = "13";              break;
+            case 0x0613: type = "13b9";            break;
+            case 0x0615: type = "13";              break;
+            case 0x0619: type = "13#9";            break;
+            case 0x061B: type = "13b9#9";          break;
+            case 0x0621: type = "sus13";           break;
+            case 0x062D: type = "min13(11)";       break;
+            case 0x0633: type = "13b9add4";        break;
+            case 0x0635: type = "13";              break;
+            case 0x0645: type = "13#11(no3)";      break;
+            case 0x0651: type = "13b5";            break;
+            case 0x0653: type = "13b9#11";         break;
+            case 0x0655: type = "13#11";           break;
+            case 0x0659: type = "13#9b5";          break;
+            case 0x065B: type = "13b5b9#9";        break;
+            case 0x0685: type = "13(no3)";         break;
+            case 0x068D: type = "min13";           break;
+            case 0x0691: type = "13";              break;
+            case 0x0693: type = "13b9";            break;
+            case 0x0695: type = "13";              break;
+            case 0x0699: type = "13#9";            break;
+            case 0x06A5: type = "sus13";           break;
+            case 0x06AD: type = "min13(11)";       break;
+            case 0x06B5: type = "13";              break;
+            case 0x06D5: type = "13#11";           break;
+            case 0x0813: type = "maj7b9";          break;
+            case 0x0851: type = "maj7#11";         break;
+            case 0x0855: type = "maj9#11";         break;
+            case 0x0881: type = "maj7(no3)";       break;
+            case 0x0889: type = "min(\u266e7)";    break; // "min(<sym>accidentalNatural</sym>7)"
+            case 0x088D: type = "min9(\u266e7)";   break; // "min9(<sym>accidentalNatural</sym>7)"
+            case 0x0891: type = "maj7";            break;
+            case 0x0895: type = "maj9";            break;
+            case 0x08C9: type = "dim7(add maj 7)"; break;
+            case 0x08D1: type = "maj7#11";         break;
+            case 0x08D5: type = "maj9#11";         break;
+            case 0x0911: type = "maj7#5";          break;
+            case 0x0991: type = "maj7#5";          break;
+            case 0x0995: type = "maj9#5";          break;
+            case 0x0A0D: type = "min69(\u266e7)";  break; // "min69(<sym>accidentalNatural</sym>7)"
+            case 0x0A11: type = "maj13";           break;
+            case 0x0A15: type = "maj13";           break;
+            case 0x0A51: type = "maj13#11";        break;
+            case 0x0A55: type = "maj13#11";        break;
+            case 0x0A85: type = "maj13(no3)";      break;
+            case 0x0A89: type = "min13(\u266e7)";  break; // "min13(<sym>accidentalNatural</sym>7)"
+            case 0x0A8D: type = "min69(\u266e7)";  break; // "min69(<sym>accidentalNatural</sym>7)"
+            case 0x0A91: type = "maj13";           break;
+            case 0x0A95: type = "maj13";           break;
+            case 0x0AAD: type = "min13(\u266e7)";  break;   // "min13(<sym>accidentalNatural</sym>7)"
+            case 0x0AD5: type = "maj13#11";        break;
+            case 0x0B45: type = "maj13#5#11(no4)"; break;
+            default:
                   qDebug("Unrecognized harmony type: %04X",bin);
                   type = "";
                   break;
-                  }
             }
       return type;
       }
 
-bool BarsParse::parseHarmony(MeasureData* measureData, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseHarmony
+//---------------------------------------------------------
+
+bool BarsParse::parseHarmony(MeasureData* measureData, int /*length*/)
+      {
       Block placeHolder;
 
       Harmony* harmony = new Harmony();
       measureData->addMusicData(harmony);
 
-      if( !jump(3) ) { return false; }
+      if (!jump(3)) { return false; }
 
       // common
-      if( !parseCommonBlock(harmony) ) { return false; }
+      if (!parseCommonBlock(harmony)) { return false; }
 
       // bass on bottom
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      harmony->setBassOnBottom((getHighNibble(placeHolder.toUnsignedInt()) & 0x4));
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      harmony->setBassOnBottom((highNibble(placeHolder.toUnsignedInt()) & 0x4));
 
       // root alteration
       switch (placeHolder.toUnsignedInt() & 0x18) {
-            case 0: {
+            case 0:
                   harmony->setAlterRoot(0); // natural
                   break;
-                  }
-            case 16: {
+            case 16:
                   harmony->setAlterRoot(-1); // flat
                   break;
-                  }
-            case 8: {
+            case 8:
                   harmony->setAlterRoot(1); // sharp
                   break;
-                  }
-            default: {
+            default:
                   harmony->setAlterRoot(0);
                   break;
-                  }
             }
 
       // bass alteration
       switch (placeHolder.toUnsignedInt() & 0x3) {
-            case 0: {
+            case 0:
                   harmony->setAlterBass(0); // natural
                   break;
-                  }
-            case 2: {
+            case 2:
                   harmony->setAlterBass(-1); // flat
                   break;
-                  }
-            case 1: {
+            case 1:
                   harmony->setAlterBass(1); // sharp
                   break;
-                  }
-            default: {
+            default:
                   harmony->setAlterBass(0);
                   break;
-                  }
             }
 
       // show bass
       bool useBass = placeHolder.toUnsignedInt() & 0x80;
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
       // y offset
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       harmony->setYOffset(placeHolder.toInt());
 
       // harmony type
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       harmony->setHarmonyType(binaryToHarmonyType(placeHolder.toUnsignedInt()));
 
       // root
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       harmony->setRoot(placeHolder.toInt());
 
       // bass
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       if (useBass)
             harmony->setBass(placeHolder.toInt());
 
       // angle
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       harmony->setAngle(placeHolder.toInt());
 
-      if( ove_->getIsVersion4() ) {
+      if (_ove->isVersion4()) {
             // length (tick)
-            if( !readBuffer(placeHolder, 2) ) { return false; }
+            if (!readBuffer(placeHolder, 2)) { return false; }
             harmony->setLength(placeHolder.toUnsignedInt());
 
-            if( !jump(4) ) { return false; }
+            if (!jump(4)) { return false; }
             }
 
       return true;
       }
 
-bool BarsParse::parseClef(MeasureData* measureData, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseClef
+//---------------------------------------------------------
+
+bool BarsParse::parseClef(MeasureData* measureData, int /*length*/)
+      {
       Block placeHolder;
 
       Clef* clef = new Clef();
       measureData->addMusicData(clef);
 
-      if( !jump(3) ) { return false; }
+      if (!jump(3)) { return false; }
 
       // common
-      if( !parseCommonBlock(clef) ) { return false; }
+      if (!parseCommonBlock(clef)) { return false; }
 
       // clef type
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      clef->setClefType(placeHolder.toUnsignedInt());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      clef->setClefType((ClefType)placeHolder.toUnsignedInt());
 
       // line
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       clef->setLine(placeHolder.toInt());
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       return true;
       }
 
-bool BarsParse::parseLyric(MeasureData* measureData, int length) {
+//---------------------------------------------------------
+//   BarsParse::parseLyric
+//---------------------------------------------------------
+
+bool BarsParse::parseLyric(MeasureData* measureData, int length)
+      {
       Block placeHolder;
 
       Lyric* lyric = new Lyric();
       measureData->addMusicData(lyric);
 
-      if( !jump(3) ) { return false; }
+      if (!jump(3)) { return false; }
 
       // common
-      if( !parseCommonBlock(lyric) ) { return false; }
+      if (!parseCommonBlock(lyric)) { return false; }
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // offset
-      if( !parseOffsetElement(lyric) ) { return false; }
+      if (!parseOffsetElement(lyric)) { return false; }
 
-      if( !jump(7) ) { return false; }
+      if (!jump(7)) { return false; }
 
       // verse
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       lyric->setVerse(placeHolder.toUnsignedInt());
 
-      if( ove_->getIsVersion4() ) {
-            if( !jump(6) ) { return false; }
+      if (_ove->isVersion4()) {
+            if (!jump(6)) { return false; }
 
             // lyric
-            if( length > 29 ) {
-                  if( !readBuffer(placeHolder, length-29) ) { return false; }
-                  lyric->setLyric(ove_->getCodecString(placeHolder.fixedSizeBufferToStrByteArray()));
+            if (length > 29) {
+                  if (!readBuffer(placeHolder, length-29)) { return false; }
+                  lyric->setLyric(_ove->codecString(placeHolder.fixedSizeBufferToStrByteArray()));
                   }
             }
 
       return true;
       }
 
-bool BarsParse::parseSlur(MeasureData* measureData, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseSlur
+//---------------------------------------------------------
+
+bool BarsParse::parseSlur(MeasureData* measureData, int /*length*/)
+      {
       Block placeHolder;
 
       Slur* slur = new Slur();
       measureData->addCrossMeasureElement(slur, true);
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // voice
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      slur->setVoice(getLowNibble(placeHolder.toUnsignedInt())&0x7);
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      slur->setVoice(lowNibble(placeHolder.toUnsignedInt()) & 0x7);
 
       // common
-      if( !parseCommonBlock(slur) ) { return false; }
+      if (!parseCommonBlock(slur)) { return false; }
 
       // show on top
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      slur->setShowOnTop(getHighNibble(placeHolder.toUnsignedInt())==0x8);
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      slur->setShowOnTop(highNibble(placeHolder.toUnsignedInt()) == 0x8);
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
       // pair lines
-      if( !parsePairLinesBlock(slur) ) { return false; }
+      if (!parsePairLinesBlock(slur)) { return false; }
 
       // offset common
-      if( !parseOffsetCommonBlock(slur) ) { return false; }
+      if (!parseOffsetCommonBlock(slur)) { return false; }
 
       // handle 1
-      if( !parseOffsetElement(slur->getLeftShoulder()) ) { return false; }
+      if (!parseOffsetElement(slur->leftShoulder())) { return false; }
 
       // handle 4
-      if( !parseOffsetElement(slur->getRightShoulder()) ) { return false; }
+      if (!parseOffsetElement(slur->rightShoulder())) { return false; }
 
       // handle 2
-      if( !parseOffsetElement(slur->getHandle2()) ) { return false; }
+      if (!parseOffsetElement(slur->handle2())) { return false; }
 
       // handle 3
-      if( !parseOffsetElement(slur->getHandle3()) ) { return false; }
+      if (!parseOffsetElement(slur->handle3())) { return false; }
 
-      if( ove_->getIsVersion4() ) {
-            if( !jump(3) ) { return false; }
+      if (_ove->isVersion4()) {
+            if (!jump(3)) { return false; }
 
             // note time percent
-            if( !readBuffer(placeHolder, 1) ) { return false; }
+            if (!readBuffer(placeHolder, 1)) { return false; }
             slur->setNoteTimePercent(placeHolder.toUnsignedInt());
 
-            if( !jump(36) ) { return false; }
+            if (!jump(36)) { return false; }
             }
 
       return true;
       }
 
-bool BarsParse::parseGlissando(MeasureData* measureData, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseGlissando
+//---------------------------------------------------------
+
+bool BarsParse::parseGlissando(MeasureData* measureData, int /*length*/)
+      {
       Block placeHolder;
 
       Glissando* glissando = new Glissando();
       measureData->addCrossMeasureElement(glissando, true);
 
-      if( !jump(3) ) { return false; }
+      if (!jump(3)) { return false; }
 
       // common
-      if( !parseCommonBlock(glissando) ) { return false; }
+      if (!parseCommonBlock(glissando)) { return false; }
 
       // straight or wavy
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      unsigned int thisByte = placeHolder.toUnsignedInt();
-      glissando->setStraightWavy(getHighNibble(thisByte)==4);
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      unsigned thisByte = placeHolder.toUnsignedInt();
+      glissando->setStraightWavy(highNibble(thisByte) == 4);
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
       // pair lines
-      if( !parsePairLinesBlock(glissando) ) { return false; }
+      if (!parsePairLinesBlock(glissando)) { return false; }
 
       // offset common
-      if( !parseOffsetCommonBlock(glissando) ) { return false; }
+      if (!parseOffsetCommonBlock(glissando)) { return false; }
 
       // left shoulder
-      if( !parseOffsetElement(glissando->getLeftShoulder()) ) { return false; }
+      if (!parseOffsetElement(glissando->leftShoulder())) { return false; }
 
       // right shoulder
-      if( !parseOffsetElement(glissando->getRightShoulder()) ) { return false; }
+      if (!parseOffsetElement(glissando->rightShoulder())) { return false; }
 
-      if( ove_->getIsVersion4() ) {
-            if( !jump(1) ) { return false; }
+      if (_ove->isVersion4()) {
+            if (!jump(1)) { return false; }
 
             // line thick
-            if( !readBuffer(placeHolder, 1) ) { return false; }
+            if (!readBuffer(placeHolder, 1)) { return false; }
             glissando->setLineThick(placeHolder.toUnsignedInt());
 
-            if( !jump(12) ) { return false; }
+            if (!jump(12)) { return false; }
 
             // text 32 bytes
-            if( !readBuffer(placeHolder, 32) ) { return false; }
-            glissando->setText(ove_->getCodecString(placeHolder.fixedSizeBufferToStrByteArray()));
+            if (!readBuffer(placeHolder, 32)) { return false; }
+            glissando->setText(_ove->codecString(placeHolder.fixedSizeBufferToStrByteArray()));
 
-            if( !jump(6) ) { return false; }
+            if (!jump(6)) { return false; }
             }
 
       return true;
       }
 
-bool getDecoratorType(
-            unsigned int thisByte,
-            bool& measureRepeat,
-            Decorator::Type& decoratorType,
-            bool& singleRepeat,
-            ArticulationType& artType) {
+//---------------------------------------------------------
+//   getDecoratorType
+//---------------------------------------------------------
+
+static bool getDecoratorType(unsigned thisByte, bool& measureRepeat, Decorator::DecoratorType& decoratorType,
+   bool& singleRepeat, ArticulationType& artType)
+      {
       measureRepeat = false;
-      decoratorType = Decorator::Type::Articulation;
+      decoratorType = Decorator::DecoratorType::Articulation;
       singleRepeat = true;
       artType = ArticulationType::None;
 
       switch (thisByte) {
-            case 0x00: {
-                  decoratorType = Decorator::Type::Dotted_Barline;
+            case 0x00:
+                  decoratorType = Decorator::DecoratorType::Dotted_Barline;
                   break;
-                  }
-            case 0x30: {
+            case 0x30:
                   artType = ArticulationType::Open_String;
                   break;
-                  }
-            case 0x31: {
+            case 0x31:
                   artType = ArticulationType::Finger_1;
                   break;
-                  }
-            case 0x32: {
+            case 0x32:
                   artType = ArticulationType::Finger_2;
                   break;
-                  }
-            case 0x33: {
+            case 0x33:
                   artType = ArticulationType::Finger_3;
                   break;
-                  }
-            case 0x34: {
+            case 0x34:
                   artType = ArticulationType::Finger_4;
                   break;
-                  }
-            case 0x35: {
+            case 0x35:
                   artType = ArticulationType::Finger_5;
                   break;
-                  }
-            case 0x6B: {
+            case 0x6B:
                   artType = ArticulationType::Flat_Accidental_For_Trill;
                   break;
-                  }
-            case 0x6C: {
+            case 0x6C:
                   artType = ArticulationType::Sharp_Accidental_For_Trill;
                   break;
-                  }
-            case 0x6D: {
+            case 0x6D:
                   artType = ArticulationType::Natural_Accidental_For_Trill;
                   break;
-                  }
-            case 0x8d: {
+            case 0x8D:
                   measureRepeat = true;
                   singleRepeat = true;
                   break;
-                  }
-            case 0x8e: {
+            case 0x8E:
                   measureRepeat = true;
                   singleRepeat = false;
                   break;
-                  }
-            case 0xA0: {
+            case 0xA0:
                   artType = ArticulationType::Minor_Trill;
                   break;
-                  }
-            case 0xA1: {
+            case 0xA1:
                   artType = ArticulationType::Major_Trill;
                   break;
-                  }
-            case 0xA2: {
+            case 0xA2:
                   artType = ArticulationType::Trill_Section;
                   break;
-                  }
-            case 0xA6: {
+            case 0xA6:
                   artType = ArticulationType::Turn;
                   break;
-                  }
-            case 0xA8: {
+            case 0xA8:
                   artType = ArticulationType::Tremolo_Eighth;
                   break;
-                  }
-            case 0xA9: {
+            case 0xA9:
                   artType = ArticulationType::Tremolo_Sixteenth;
                   break;
-                  }
-            case 0xAA: {
+            case 0xAA:
                   artType = ArticulationType::Tremolo_Thirty_Second;
                   break;
-                  }
-            case 0xAB: {
+            case 0xAB:
                   artType = ArticulationType::Tremolo_Sixty_Fourth;
                   break;
-                  }
-            case 0xB2: {
+            case 0xB2:
                   artType = ArticulationType::Fermata;
                   break;
-                  }
-            case 0xB3: {
+            case 0xB3:
                   artType = ArticulationType::Fermata_Inverted;
                   break;
-                  }
-            case 0xB9: {
+            case 0xB9:
                   artType = ArticulationType::Pause;
                   break;
-                  }
-            case 0xBA: {
+            case 0xBA:
                   artType = ArticulationType::Grand_Pause;
                   break;
-                  }
-            case 0xC0: {
+            case 0xC0:
                   artType = ArticulationType::Marcato;
                   break;
-                  }
-            case 0xC1: {
+            case 0xC1:
                   artType = ArticulationType::Marcato_Dot;
                   break;
-                  }
-            case 0xC2: {
+            case 0xC2:
                   artType = ArticulationType::SForzando;
                   break;
-                  }
-            case 0xC3: {
+            case 0xC3:
                   artType = ArticulationType::SForzando_Dot;
                   break;
-                  }
-            case 0xC4: {
+            case 0xC4:
                   artType = ArticulationType::SForzando_Inverted;
                   break;
-                  }
-            case 0xC5: {
+            case 0xC5:
                   artType = ArticulationType::SForzando_Dot_Inverted;
                   break;
-                  }
-            case 0xC6: {
+            case 0xC6:
                   artType = ArticulationType::Staccatissimo;
                   break;
-                  }
-            case 0xC7: {
+            case 0xC7:
                   artType = ArticulationType::Staccato;
                   break;
-                  }
-            case 0xC8: {
+            case 0xC8:
                   artType = ArticulationType::Tenuto;
                   break;
-                  }
-            case 0xC9: {
+            case 0xC9:
                   artType = ArticulationType::Natural_Harmonic;
                   break;
-                  }
-            case 0xCA: {
+            case 0xCA:
                   artType = ArticulationType::Artificial_Harmonic;
                   break;
-                  }
-            case 0xCB: {
+            case 0xCB:
                   artType = ArticulationType::Plus_Sign;
                   break;
-                  }
-            case 0xCC: {
+            case 0xCC:
                   artType = ArticulationType::Up_Bow;
                   break;
-                  }
-            case 0xCD: {
+            case 0xCD:
                   artType = ArticulationType::Down_Bow;
                   break;
-                  }
-            case 0xCE: {
+            case 0xCE:
                   artType = ArticulationType::Up_Bow_Inverted;
                   break;
-                  }
-            case 0xCF: {
+            case 0xCF:
                   artType = ArticulationType::Down_Bow_Inverted;
                   break;
-                  }
-            case 0xD0: {
+            case 0xD0:
                   artType = ArticulationType::Pedal_Down;
                   break;
-                  }
-            case 0xD1: {
+            case 0xD1:
                   artType = ArticulationType::Pedal_Up;
                   break;
-                  }
-            case 0xD6: {
+            case 0xD6:
                   artType = ArticulationType::Heavy_Attack;
                   break;
-                  }
-            case 0xD7: {
+            case 0xD7:
                   artType = ArticulationType::Heavier_Attack;
                   break;
-                  }
             default:
                   return false;
                   break;
@@ -6308,563 +4737,605 @@ bool getDecoratorType(
       return true;
       }
 
-bool BarsParse::parseDecorators(MeasureData* measureData, int length) {
+//---------------------------------------------------------
+//   BarsParse::parseDecorator
+//---------------------------------------------------------
+
+bool BarsParse::parseDecorator(MeasureData* measureData, int length)
+      {
       Block placeHolder;
       MusicData* musicData = new MusicData();
 
-      if( !jump(3) ) { return false; }
+      if (!jump(3)) { return false; }
 
       // common
-      if( !parseCommonBlock(musicData) ) { return false; }
+      if (!parseCommonBlock(musicData)) { return false; }
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // y offset
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       musicData->setYOffset(placeHolder.toInt());
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // measure repeat | piano pedal | dotted barline | articulation
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      unsigned int thisByte = placeHolder.toUnsignedInt();
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      unsigned thisByte = placeHolder.toUnsignedInt();
 
-      Decorator::Type decoratorType;
+      Decorator::DecoratorType _decoratorType;
       bool isMeasureRepeat;
       bool isSingleRepeat = true;
       ArticulationType artType = ArticulationType::None;
 
-      getDecoratorType(thisByte, isMeasureRepeat, decoratorType, isSingleRepeat, artType);
+      getDecoratorType(thisByte, isMeasureRepeat, _decoratorType, isSingleRepeat, artType);
 
-      if( isMeasureRepeat ) {
+      if (isMeasureRepeat) {
             MeasureRepeat* measureRepeat = new MeasureRepeat();
             measureData->addCrossMeasureElement(measureRepeat, true);
 
             measureRepeat->copyCommonBlock(*musicData);
-            measureRepeat->setYOffset(musicData->getYOffset());
+            measureRepeat->setYOffset(musicData->yOffset());
 
             measureRepeat->setSingleRepeat(isSingleRepeat);
-            } else {
+            }
+      else {
             Decorator* decorator = new Decorator();
             measureData->addMusicData(decorator);
 
             decorator->copyCommonBlock(*musicData);
-            decorator->setYOffset(musicData->getYOffset());
+            decorator->setYOffset(musicData->yOffset());
 
-            decorator->setDecoratorType(decoratorType);
+            decorator->setDecoratorType(_decoratorType);
             decorator->setArticulationType(artType);
             }
 
-      int cursor = ove_->getIsVersion4() ? 16 : 14;
-      if( !jump(length-cursor) ) { return false; }
+      int cursor = _ove->isVersion4() ? 16 : 14;
+      if (!jump(length-cursor)) { return false; }
 
       return true;
       }
 
-bool BarsParse::parseWedge(MeasureData* measureData, int length) {
+//---------------------------------------------------------
+//   BarsParse::parseWedge
+//---------------------------------------------------------
+
+bool BarsParse::parseWedge(MeasureData* measureData, int length)
+      {
       Block placeHolder;
       Wedge* wedge = new Wedge();
 
-      if( !jump(3) ) { return false; }
+      if (!jump(3)) { return false; }
 
       // common
-      if( !parseCommonBlock(wedge) ) { return false; }
+      if (!parseCommonBlock(wedge)) { return false; }
 
       // wedge type
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      WedgeType wedgeType = WedgeType::Cres_Line;
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      WedgeType wedgeType = WedgeType::Crescendo_Line;
       bool wedgeOrExpression = true;
-      unsigned int highHalfByte = getHighNibble(placeHolder.toUnsignedInt());
-      unsigned int lowHalfByte = getLowNibble(placeHolder.toUnsignedInt());
+      unsigned highHalfByte = highNibble(placeHolder.toUnsignedInt());
+      unsigned lowHalfByte = lowNibble(placeHolder.toUnsignedInt());
 
       switch (highHalfByte) {
-            case 0x0: {
-                  wedgeType = WedgeType::Cres_Line;
+            case 0x0:
+                  wedgeType = WedgeType::Crescendo_Line;
                   wedgeOrExpression = true;
                   break;
-                  }
-            case 0x4: {
-                  wedgeType = WedgeType::Decresc_Line;
+            case 0x4:
+                  wedgeType = WedgeType::Decrescendo_Line;
                   wedgeOrExpression = true;
                   break;
-                  }
-            case 0x6: {
-                  wedgeType = WedgeType::Decresc;
+            case 0x6:
+                  wedgeType = WedgeType::Decrescendo;
                   wedgeOrExpression = false;
                   break;
-                  }
-            case 0x2: {
-                  wedgeType = WedgeType::Cres;
+            case 0x2:
+                  wedgeType = WedgeType::Crescendo;
                   wedgeOrExpression = false;
                   break;
-                  }
             default:
                   break;
             }
 
       // 0xb | 0x8(ove3) , else 3, 0(ove3)
-      if( (lowHalfByte & 0x8) == 0x8 ) {
+      if ((lowHalfByte & 0x8) == 0x8) {
             wedgeType = WedgeType::Double_Line;
             wedgeOrExpression = true;
             }
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
       // y offset
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       wedge->setYOffset(placeHolder.toInt());
 
       // wedge
-      if( wedgeOrExpression ) {
+      if (wedgeOrExpression) {
             measureData->addCrossMeasureElement(wedge, true);
             wedge->setWedgeType(wedgeType);
 
-            if( !jump(2) ) { return false; }
+            if (!jump(2)) { return false; }
 
             // height
-            if( !readBuffer(placeHolder, 2) ) { return false; }
+            if (!readBuffer(placeHolder, 2)) { return false; }
             wedge->setHeight(placeHolder.toUnsignedInt());
 
             // offset common
-            if( !parseOffsetCommonBlock(wedge) ) { return false; }
+            if (!parseOffsetCommonBlock(wedge)) { return false; }
 
-            int cursor = ove_->getIsVersion4() ? 21 : 19;
-            if( !jump(length-cursor) ) { return false; }
+            int cursor = _ove->isVersion4() ? 21 : 19;
+            if (!jump(length-cursor)) { return false; }
             }
       // expression : cresc, decresc
       else {
-            Expressions* express = new Expressions();
+            Expression* express = new Expression();
             measureData->addMusicData(express);
 
             express->copyCommonBlock(*wedge);
-            express->setYOffset(wedge->getYOffset());
+            express->setYOffset(wedge->yOffset());
 
-            if( !jump(4) ) { return false; }
+            if (!jump(4)) { return false; }
 
             // offset common
-            if( !parseOffsetCommonBlock(express) ) { return false; }
+            if (!parseOffsetCommonBlock(express)) { return false; }
 
-            if( ove_->getIsVersion4() ) {
-                  if( !jump(18) ) { return false; }
+            if (_ove->isVersion4()) {
+                  if (!jump(18)) { return false; }
 
                   // words
-                  if( length > 39 ) {
-                        if( !readBuffer(placeHolder, length-39) ) { return false; }
-                        express->setText(ove_->getCodecString(placeHolder.fixedSizeBufferToStrByteArray()));
+                  if (length > 39) {
+                        if (!readBuffer(placeHolder, length-39)) { return false; }
+                        express->setText(_ove->codecString(placeHolder.fixedSizeBufferToStrByteArray()));
                         }
-                  } else {
-                  QString str = wedgeType==WedgeType::Cres ? "cresc" : "decresc";
+                  }
+            else {
+                  QString str = wedgeType == WedgeType::Crescendo ? "cresc" : "decresc";
                   express->setText(str);
 
-                  if( !jump(8) ) { return false; }
+                  if (!jump(8)) { return false; }
                   }
             }
 
       return true;
       }
 
-bool BarsParse::parseDynamics(MeasureData* measureData, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseDynamic
+//---------------------------------------------------------
+
+bool BarsParse::parseDynamic(MeasureData* measureData, int /*length*/)
+      {
       Block placeHolder;
 
-      Dynamics* dynamics = new Dynamics();
-      measureData->addMusicData(dynamics);
+      Dynamic* dynamic = new Dynamic();
+      measureData->addMusicData(dynamic);
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
-      // is playback
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      dynamics->setIsPlayback(getHighNibble(placeHolder.toUnsignedInt())!=0x4);
+      // play
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      dynamic->setPlay(highNibble(placeHolder.toUnsignedInt()) != 0x4);
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
       // common
-      if( !parseCommonBlock(dynamics) ) { return false; }
+      if (!parseCommonBlock(dynamic)) { return false; }
 
       // y offset
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      dynamics->setYOffset(placeHolder.toInt());
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      dynamic->setYOffset(placeHolder.toInt());
 
-      // dynamics type
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      dynamics->setDynamicsType(getLowNibble(placeHolder.toUnsignedInt()));
+      // dynamic type
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      dynamic->setDynamicType(DynamicType(lowNibble(placeHolder.toUnsignedInt())));
 
       // velocity
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      dynamics->setVelocity(placeHolder.toUnsignedInt());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      dynamic->setVelocity(placeHolder.toUnsignedInt());
 
-      int cursor = ove_->getIsVersion4() ? 4 : 2;
+      int cursor = _ove->isVersion4() ? 4 : 2;
 
-      if( !jump(cursor) ) { return false; }
+      if (!jump(cursor)) { return false; }
 
       return true;
       }
 
-bool BarsParse::parseKey(MeasureData* measureData, int /*length*/) {
-      Block placeHolder;
-      Key* key = measureData->getKey();
-      int cursor = ove_->getIsVersion4() ? 9 : 7;
+//---------------------------------------------------------
+//   BarsParse::parseKey
+//---------------------------------------------------------
 
-      if( !jump(cursor) ) { return false; }
+bool BarsParse::parseKey(MeasureData* measureData, int /*length*/)
+      {
+      Block placeHolder;
+      Key* key = measureData->key();
+      int cursor = _ove->isVersion4() ? 9 : 7;
+
+      if (!jump(cursor)) { return false; }
 
       // key
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       key->setKey(oveKeyToKey(placeHolder.toUnsignedInt()));
 
       // previous key
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       key->setPreviousKey(oveKeyToKey(placeHolder.toUnsignedInt()));
 
-      if( !jump(3) ) { return false; }
+      if (!jump(3)) { return false; }
 
       // symbol count
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       key->setSymbolCount(placeHolder.toUnsignedInt());
 
-      if( !jump(4) ) { return false; }
+      if (!jump(4)) { return false; }
 
       return true;
       }
 
-bool BarsParse::parsePedal(MeasureData* measureData, int length) {
+//---------------------------------------------------------
+//   BarsParse::parsePedal
+//---------------------------------------------------------
+
+bool BarsParse::parsePedal(MeasureData* measureData, int length)
+      {
       Block placeHolder;
 
       Pedal* pedal = new Pedal();
       //measureData->addMusicData(pedal); //can't remember why
       measureData->addCrossMeasureElement(pedal, true);
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
-      // is playback
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      pedal->setIsPlayback(getHighNibble(placeHolder.toUnsignedInt())!=4);
+      // play
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      pedal->setPlay(highNibble(placeHolder.toUnsignedInt()) != 4);
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
       // common
-      if( !parseCommonBlock(pedal) ) { return false; }
+      if (!parseCommonBlock(pedal)) { return false; }
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // pair lines
-      if( !parsePairLinesBlock(pedal) ) { return false; }
+      if (!parsePairLinesBlock(pedal)) { return false; }
 
       // offset common
-      if( !parseOffsetCommonBlock(pedal) ) { return false; }
+      if (!parseOffsetCommonBlock(pedal)) { return false; }
 
       // left shoulder
-      if( !parseOffsetElement(pedal->getLeftShoulder()) ) { return false; }
+      if (!parseOffsetElement(pedal->leftShoulder())) { return false; }
 
       // right shoulder
-      if( !parseOffsetElement(pedal->getRightShoulder()) ) { return false; }
+      if (!parseOffsetElement(pedal->rightShoulder())) { return false; }
 
-      int cursor = ove_->getIsVersion4() ? 0x45 : 0x23;
-      int blankCount = ove_->getIsVersion4() ? 42 : 10;
+      int cursor = _ove->isVersion4() ? 0x45 : 0x23;
+      int blankCount = _ove->isVersion4() ? 42 : 10;
 
-      pedal->setHalf( length > cursor );
+      pedal->setHalf(length > cursor);
 
-      if( !jump(blankCount) ) { return false; }
+      if (!jump(blankCount)) { return false; }
 
-      if( length > cursor ) {
-            if( !jump(2) ) { return false; }
+      if (length > cursor) {
+            if (!jump(2)) { return false; }
 
             // handle x offset
-            if( !readBuffer(placeHolder, 2) ) { return false; }
-            pedal->getPedalHandle()->setXOffset(placeHolder.toInt());
+            if (!readBuffer(placeHolder, 2)) { return false; }
+            pedal->pedalHandle()->setXOffset(placeHolder.toInt());
 
-            if( !jump(6) ) { return false; }
+            if (!jump(6)) { return false; }
             }
 
       return true;
       }
 
-bool BarsParse::parseKuohao(MeasureData* measureData, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseBracket
+//---------------------------------------------------------
+
+bool BarsParse::parseBracket(MeasureData* measureData, int /*length*/)
+      {
       Block placeHolder;
 
-      KuoHao* kuoHao = new KuoHao();
-      measureData->addMusicData(kuoHao);
+      Bracket* bracket = new Bracket();
+      measureData->addMusicData(bracket);
 
-      if( !jump(3) ) { return false; }
+      if (!jump(3)) { return false; }
 
       // common
-      if( !parseCommonBlock(kuoHao) ) { return false; }
+      if (!parseCommonBlock(bracket)) { return false; }
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // pair lines
-      if( !parsePairLinesBlock(kuoHao) ) { return false; }
+      if (!parsePairLinesBlock(bracket)) { return false; }
 
-      if( !jump(4) ) { return false; }
+      if (!jump(4)) { return false; }
 
       // left shoulder
-      if( !parseOffsetElement(kuoHao->getLeftShoulder()) ) { return false; }
+      if (!parseOffsetElement(bracket->leftShoulder())) { return false; }
 
       // right shoulder
-      if( !parseOffsetElement(kuoHao->getRightShoulder()) ) { return false; }
+      if (!parseOffsetElement(bracket->rightShoulder())) { return false; }
 
       // kuohao type
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      kuoHao->setKuohaoType(placeHolder.toUnsignedInt());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      bracket->setBracketType(BracketType(placeHolder.toUnsignedInt()));
 
       // height
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      kuoHao->setHeight(placeHolder.toUnsignedInt());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      bracket->setHeight(placeHolder.toUnsignedInt());
 
-      int jumpAmount = ove_->getIsVersion4() ? 40 : 8;
-      if( !jump(jumpAmount) ) { return false; }
+      int jumpAmount = _ove->isVersion4() ? 40 : 8;
+      if (!jump(jumpAmount)) { return false; }
 
       return true;
       }
 
-bool BarsParse::parseExpressions(MeasureData* measureData, int length) {
+//---------------------------------------------------------
+//   BarsParse::parseExpression
+//---------------------------------------------------------
+
+bool BarsParse::parseExpression(MeasureData* measureData, int length)
+      {
       Block placeHolder;
 
-      Expressions* expressions = new Expressions();
-      measureData->addMusicData(expressions);
+      Expression* expression = new Expression();
+      measureData->addMusicData(expression);
 
-      if( !jump(3) ) { return false; }
+      if (!jump(3)) { return false; }
 
       // common00
-      if( !parseCommonBlock(expressions) ) { return false; }
+      if (!parseCommonBlock(expression)) { return false; }
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // y offset
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      expressions->setYOffset(placeHolder.toInt());
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      expression->setYOffset(placeHolder.toInt());
 
       // range bar offset
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       //int barOffset = placeHolder.toUnsignedInt();
 
-      if( !jump(10) ) { return false; }
+      if (!jump(10)) { return false; }
 
       // tempo 1
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      //double tempo1 = ((double)placeHolder.toUnsignedInt()) / 100.0;
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      //qreal tempo1 = ((qreal)placeHolder.toUnsignedInt()) / 100.0;
 
       // tempo 2
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      //double tempo2 = ((double)placeHolder.toUnsignedInt()) / 100.0;
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      //qreal tempo2 = ((qreal)placeHolder.toUnsignedInt()) / 100.0;
 
-      if( !jump(6) ) { return false; }
+      if (!jump(6)) { return false; }
 
       // text
-      int cursor = ove_->getIsVersion4() ? 35 : 33;
-      if( length > cursor ) {
-            if( !readBuffer(placeHolder, length-cursor) ) { return false; }
-            expressions->setText(ove_->getCodecString(placeHolder.fixedSizeBufferToStrByteArray()));
+      int cursor = _ove->isVersion4() ? 35 : 33;
+      if (length > cursor) {
+            if (!readBuffer(placeHolder, length-cursor)) { return false; }
+            expression->setText(_ove->codecString(placeHolder.fixedSizeBufferToStrByteArray()));
             }
 
       return true;
       }
 
-bool BarsParse::parseHarpPedal(MeasureData* measureData, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseHarpPedal
+//---------------------------------------------------------
+
+bool BarsParse::parseHarpPedal(MeasureData* measureData, int /*length*/)
+      {
       Block placeHolder;
 
       HarpPedal* harpPedal = new HarpPedal();
       measureData->addMusicData(harpPedal);
 
-      if( !jump(3) ) { return false; }
+      if (!jump(3)) { return false; }
 
       // common
-      if( !parseCommonBlock(harpPedal) ) { return false; }
+      if (!parseCommonBlock(harpPedal)) { return false; }
 
-      if( !jump(2) ) { return false; }
+      if (!jump(2)) { return false; }
 
       // y offset
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       harpPedal->setYOffset(placeHolder.toInt());
 
       // show type
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      harpPedal->setShowType(placeHolder.toUnsignedInt());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      harpPedal->setType(HarpPedalType(placeHolder.toUnsignedInt()));
 
       // show char flag
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       harpPedal->setShowCharFlag(placeHolder.toUnsignedInt());
 
-      if( !jump(8) ) { return false; }
+      if (!jump(8)) { return false; }
 
       return true;
       }
 
-bool BarsParse::parseMultiMeasureRest(MeasureData* measureData, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseMultiMeasureRest
+//---------------------------------------------------------
+
+bool BarsParse::parseMultiMeasureRest(MeasureData* measureData, int /*length*/)
+      {
       Block placeHolder(2);
       MultiMeasureRest* measureRest = new MultiMeasureRest();
       measureData->addMusicData(measureRest);
 
-      if( !jump(3) ) { return false; }
+      if (!jump(3)) { return false; }
 
       // common
-      if( !parseCommonBlock(measureRest) ) { return false; }
+      if (!parseCommonBlock(measureRest)) { return false; }
 
-      if( !jump(6) ) { return false; }
+      if (!jump(6)) { return false; }
 
       return true;
       }
 
-bool BarsParse::parseHarmonyGuitarFrame(MeasureData* measureData, int length) {
+//---------------------------------------------------------
+//   BarsParse::parseHarmonyGuitarFrame
+//---------------------------------------------------------
+
+bool BarsParse::parseHarmonyGuitarFrame(MeasureData* measureData, int length)
+      {
       Block placeHolder;
 
       Harmony* harmony = new Harmony();
       measureData->addMusicData(harmony);
 
-      if( !jump(3) ) { return false; }
+      if (!jump(3)) { return false; }
 
       // common
-      if( !parseCommonBlock(harmony) ) { return false; }
+      if (!parseCommonBlock(harmony)) { return false; }
 
       // root
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       harmony->setRoot(placeHolder.toUnsignedInt());
 
       // type
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       //harmony->setHarmonyType((HarmonyType)placeHolder.toUnsignedInt()); // TODO
 
       // bass
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       harmony->setBass(placeHolder.toUnsignedInt());
 
-      int jumpAmount = ove_->getIsVersion4() ? length - 12 : length - 10;
-      if( !jump(jumpAmount) ) { return false; }
+      int jumpAmount = _ove->isVersion4() ? length - 12 : length - 10;
+      if (!jump(jumpAmount)) { return false; }
 
       return true;
       }
 
-void extractOctave(unsigned int Bits, OctaveShiftType& octaveShiftType, QList<OctaveShiftPosition>& positions) {
+//---------------------------------------------------------
+//   extractOctave
+//---------------------------------------------------------
+
+static void extractOctave(unsigned Bits, OctaveShiftType& octaveShiftType,
+   QList<OctaveShiftPosition>& positions)
+      {
       octaveShiftType = OctaveShiftType::OS_8;
       positions.clear();
 
       switch (Bits) {
-            case 0x0: {
+            case 0x0:
                   octaveShiftType = OctaveShiftType::OS_8;
                   positions.push_back(OctaveShiftPosition::Continue);
                   break;
-                  }
-            case 0x1: {
+            case 0x1:
                   octaveShiftType = OctaveShiftType::OS_Minus_8;
                   positions.push_back(OctaveShiftPosition::Continue);
                   break;
-                  }
-            case 0x2: {
+            case 0x2:
                   octaveShiftType = OctaveShiftType::OS_15;
                   positions.push_back(OctaveShiftPosition::Continue);
                   break;
-                  }
-            case 0x3: {
+            case 0x3:
                   octaveShiftType = OctaveShiftType::OS_Minus_15;
                   positions.push_back(OctaveShiftPosition::Continue);
                   break;
-                  }
-            case 0x4: {
+            case 0x4:
                   octaveShiftType = OctaveShiftType::OS_8;
                   positions.push_back(OctaveShiftPosition::Stop);
                   break;
-                  }
-            case 0x5: {
+            case 0x5:
                   octaveShiftType = OctaveShiftType::OS_Minus_8;
                   positions.push_back(OctaveShiftPosition::Stop);
                   break;
-                  }
-            case 0x6: {
+            case 0x6:
                   octaveShiftType = OctaveShiftType::OS_15;
                   positions.push_back(OctaveShiftPosition::Stop);
                   break;
-                  }
-            case 0x7: {
+            case 0x7:
                   octaveShiftType = OctaveShiftType::OS_Minus_15;
                   positions.push_back(OctaveShiftPosition::Stop);
                   break;
-                  }
-            case 0x8: {
+            case 0x8:
                   octaveShiftType = OctaveShiftType::OS_8;
                   positions.push_back(OctaveShiftPosition::Start);
                   break;
-                  }
-            case 0x9: {
+            case 0x9:
                   octaveShiftType = OctaveShiftType::OS_Minus_8;
                   positions.push_back(OctaveShiftPosition::Start);
                   break;
-                  }
-            case 0xA: {
+            case 0xA:
                   octaveShiftType = OctaveShiftType::OS_15;
                   positions.push_back(OctaveShiftPosition::Start);
                   break;
-                  }
-            case 0xB: {
+            case 0xB:
                   octaveShiftType = OctaveShiftType::OS_Minus_15;
                   positions.push_back(OctaveShiftPosition::Start);
-                  ;
                   break;
-                  }
-            case 0xC: {
+            case 0xC:
                   octaveShiftType = OctaveShiftType::OS_8;
                   positions.push_back(OctaveShiftPosition::Start);
                   positions.push_back(OctaveShiftPosition::Stop);
                   break;
-                  }
-            case 0xD: {
+            case 0xD:
                   octaveShiftType = OctaveShiftType::OS_Minus_8;
                   positions.push_back(OctaveShiftPosition::Start);
                   positions.push_back(OctaveShiftPosition::Stop);
                   break;
-                  }
-            case 0xE: {
+            case 0xE:
                   octaveShiftType = OctaveShiftType::OS_15;
                   positions.push_back(OctaveShiftPosition::Start);
                   positions.push_back(OctaveShiftPosition::Stop);
                   break;
-                  }
-            case 0xF: {
+            case 0xF:
                   octaveShiftType = OctaveShiftType::OS_Minus_15;
                   positions.push_back(OctaveShiftPosition::Start);
                   positions.push_back(OctaveShiftPosition::Stop);
                   break;
-                  }
             default:
                   break;
             }
       }
 
-bool BarsParse::parseOctaveShift(MeasureData* measureData, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseOctaveShift
+//---------------------------------------------------------
+
+bool BarsParse::parseOctaveShift(MeasureData* measureData, int /*length*/)
+      {
       Block placeHolder;
 
       OctaveShift* octave = new OctaveShift();
       measureData->addCrossMeasureElement(octave, true);
 
-      if( !jump(3) ) { return false; }
+      if (!jump(3)) { return false; }
 
       // common
-      if( !parseCommonBlock(octave) ) { return false; }
+      if (!parseCommonBlock(octave)) { return false; }
 
       // octave
-      if( !readBuffer(placeHolder, 1) ) { return false; }
-      unsigned int type = getLowNibble(placeHolder.toUnsignedInt());
+      if (!readBuffer(placeHolder, 1)) { return false; }
+      unsigned type = lowNibble(placeHolder.toUnsignedInt());
       OctaveShiftType octaveShiftType = OctaveShiftType::OS_8;
       QList<OctaveShiftPosition> positions;
       extractOctave(type, octaveShiftType, positions);
 
       octave->setOctaveShiftType(octaveShiftType);
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
       // y offset
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       octave->setYOffset(placeHolder.toInt());
 
-      if( !jump(4) ) { return false; }
+      if (!jump(4)) { return false; }
 
       // length
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       octave->setLength(placeHolder.toUnsignedInt());
 
       // end tick
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       octave->setEndTick(placeHolder.toUnsignedInt());
 
       // start & stop maybe appear in same measure
-      for (int i=0; i<positions.size(); ++i) {
+      for (int i = 0; i < positions.size(); ++i) {
             OctaveShiftPosition position = positions[i];
             OctaveShiftEndPoint* octavePoint = new OctaveShiftEndPoint();
             measureData->addMusicData(octavePoint);
@@ -6872,24 +5343,28 @@ bool BarsParse::parseOctaveShift(MeasureData* measureData, int /*length*/) {
             octavePoint->copyCommonBlock(*octave);
             octavePoint->setOctaveShiftType(octaveShiftType);
             octavePoint->setOctaveShiftPosition(position);
-            octavePoint->setEndTick(octave->getEndTick());
+            octavePoint->setEndTick(octave->endTick());
 
             // stop
-            if( i==0 && position == OctaveShiftPosition::Stop ) {
-                  octavePoint->start()->setOffset(octave->start()->getOffset()+octave->getLength());
-                  }
+            if (i == 0 && position == OctaveShiftPosition::Stop)
+                  octavePoint->start()->setOffset(octave->start()->offset() + octave->length());
 
             // end point
-            if( i>0 ) {
-                  octavePoint->start()->setOffset(octave->start()->getOffset()+octave->getLength());
-                  octavePoint->setTick(octave->getEndTick());
+            if (i > 0) {
+                  octavePoint->start()->setOffset(octave->start()->offset() + octave->length());
+                  octavePoint->setTick(octave->endTick());
                   }
             }
 
       return true;
       }
 
-bool BarsParse::parseMidiController(MeasureData* measureData, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseMidiController
+//---------------------------------------------------------
+
+bool BarsParse::parseMidiController(MeasureData* measureData, int /*length*/)
+      {
       Block placeHolder;
       MidiController* controller = new MidiController();
       measureData->addMidiData(controller);
@@ -6897,62 +5372,73 @@ bool BarsParse::parseMidiController(MeasureData* measureData, int /*length*/) {
       parseMidiCommon(controller);
 
       // value [0, 128)
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       controller->setValue(placeHolder.toUnsignedInt());
 
       // controller number
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       controller->setController(placeHolder.toUnsignedInt());
 
-      if( ove_->getIsVersion4() ) {
-            if( !jump(2) ) { return false; }
-            }
+      if (_ove->isVersion4())
+            if (!jump(2)) { return false; }
 
       return true;
       }
 
-bool BarsParse::parseMidiProgramChange(MeasureData* measureData, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseMidiProgramChange
+//---------------------------------------------------------
+
+bool BarsParse::parseMidiProgramChange(MeasureData* measureData, int /*length*/)
+      {
       Block placeHolder;
       MidiProgramChange* program = new MidiProgramChange();
       measureData->addMidiData(program);
 
       parseMidiCommon(program);
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
       // patch
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       program->setPatch(placeHolder.toUnsignedInt());
 
-      if( ove_->getIsVersion4() ) {
-            if( !jump(2) ) { return false; }
-            }
+      if (_ove->isVersion4())
+            if (!jump(2)) { return false; }
 
       return true;
       }
 
-bool BarsParse::parseMidiChannelPressure(MeasureData* measureData, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseMidiChannelPressure
+//---------------------------------------------------------
+
+bool BarsParse::parseMidiChannelPressure(MeasureData* measureData, int /*length*/)
+      {
       Block placeHolder;
       MidiChannelPressure* pressure = new MidiChannelPressure();
       measureData->addMidiData(pressure);
 
       parseMidiCommon(pressure);
 
-      if( !jump(1) ) { return false; }
+      if (!jump(1)) { return false; }
 
       // pressure
-      if( !readBuffer(placeHolder, 1) ) { return false; }
+      if (!readBuffer(placeHolder, 1)) { return false; }
       pressure->setPressure(placeHolder.toUnsignedInt());
 
-      if( ove_->getIsVersion4() )
-            {
-            if( !jump(2) ) { return false; }
-            }
+      if (_ove->isVersion4())
+            if (!jump(2)) { return false; }
 
       return true;
       }
 
-bool BarsParse::parseMidiPitchWheel(MeasureData* measureData, int /*length*/) {
+//---------------------------------------------------------
+//   BarsParse::parseMidiPitchWheel
+//---------------------------------------------------------
+
+bool BarsParse::parseMidiPitchWheel(MeasureData* measureData, int /*length*/)
+      {
       Block placeHolder;
       MidiPitchWheel* wheel = new MidiPitchWheel();
       measureData->addMidiData(wheel);
@@ -6960,301 +5446,348 @@ bool BarsParse::parseMidiPitchWheel(MeasureData* measureData, int /*length*/) {
       parseMidiCommon(wheel);
 
       // pitch wheel
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       int value = placeHolder.toUnsignedInt();
       wheel->setValue(value);
 
-      if( ove_->getIsVersion4() ) {
-            if( !jump(2) ) { return false; }
-            }
+      if (_ove->isVersion4())
+            if (!jump(2)) { return false; }
 
       return true;
       }
 
-bool BarsParse::parseSizeBlock(int length) {
-      if( !jump(length) ) { return false; }
+//---------------------------------------------------------
+//   BarsParse::parseSizeBlock
+//---------------------------------------------------------
+
+bool BarsParse::parseSizeBlock(int length)
+      {
+      if (!jump(length)) { return false; }
 
       return true;
       }
 
-bool BarsParse::parseMidiCommon(MidiData* ptr) {
+//---------------------------------------------------------
+//   BarsParse::parseMidiCommon
+//---------------------------------------------------------
+
+bool BarsParse::parseMidiCommon(MidiData* md)
+      {
       Block placeHolder;
 
-      if( !jump(3) ) { return false; }
+      if (!jump(3)) { return false; }
 
       // start position
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      ptr->setTick(placeHolder.toUnsignedInt());
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      md->setTick(placeHolder.toUnsignedInt());
 
       return true;
       }
 
-bool BarsParse::parseCommonBlock(MusicData* ptr) {
+//---------------------------------------------------------
+//   BarsParse::parseCommonBlock
+//---------------------------------------------------------
+
+bool BarsParse::parseCommonBlock(MusicData* md)
+      {
       Block placeHolder;
 
       // start tick
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      ptr->setTick(placeHolder.toInt());
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      md->setTick(placeHolder.toInt());
 
       // start unit
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      ptr->start()->setOffset(placeHolder.toInt());
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      md->start()->setOffset(placeHolder.toInt());
 
-      if( ove_->getIsVersion4() ) {
+      if (_ove->isVersion4()) {
             // color
-            if( !readBuffer(placeHolder, 1) ) { return false; }
-            ptr->setColor(placeHolder.toUnsignedInt());
+            if (!readBuffer(placeHolder, 1)) { return false; }
+            md->setColor(placeHolder.toUnsignedInt());
 
-            if( !jump(1) ) { return false; }
+            if (!jump(1)) { return false; }
             }
 
       return true;
       }
 
-bool BarsParse::parseOffsetCommonBlock(MusicData* ptr) {
+//---------------------------------------------------------
+//   BarsParse::parseOffsetCommonBlock
+//---------------------------------------------------------
+
+bool BarsParse::parseOffsetCommonBlock(MusicData* md)
+      {
       Block placeHolder;
 
       // offset measure
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      ptr->stop()->setMeasure(placeHolder.toUnsignedInt());
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      md->stop()->setMeasure(placeHolder.toUnsignedInt());
 
       // end unit
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      ptr->stop()->setOffset(placeHolder.toInt());
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      md->stop()->setOffset(placeHolder.toInt());
 
       return true;
       }
 
-bool BarsParse::parsePairLinesBlock(PairEnds* ptr) {
+//---------------------------------------------------------
+//   BarsParse::parsePairLinesBlock
+//---------------------------------------------------------
+
+bool BarsParse::parsePairLinesBlock(PairEnds* ptr)
+      {
       Block placeHolder;
 
       // left line
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      ptr->getLeftLine()->setLine(placeHolder.toInt());
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      ptr->leftLine()->setLine(placeHolder.toInt());
 
       // right line
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      ptr->getRightLine()->setLine(placeHolder.toInt());
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      ptr->rightLine()->setLine(placeHolder.toInt());
 
       return true;
       }
 
-bool BarsParse::parseOffsetElement(OffsetElement* ptr) {
+//---------------------------------------------------------
+//   BarsParse::parseOffsetElement
+//---------------------------------------------------------
+
+bool BarsParse::parseOffsetElement(OffsetElement* ptr)
+      {
       Block placeHolder;
 
       // x offset
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       ptr->setXOffset(placeHolder.toInt());
 
       // y offset
-      if( !readBuffer(placeHolder, 2) ) { return false; }
+      if (!readBuffer(placeHolder, 2)) { return false; }
       ptr->setYOffset(placeHolder.toInt());
 
       return true;
       }
 
-bool BarsParse::getCondElementType(unsigned int byteData, CondType& type) {
-      if( byteData == 0x09 ) {
-            type = CondType::Time_Parameters;
-            } else if (byteData == 0x0A) {
+//---------------------------------------------------------
+//   BarsParse::condElementType
+//---------------------------------------------------------
+
+bool BarsParse::condElementType(unsigned byteData, CondType& type)
+      {
+      if (byteData == 0x09)
+            type = CondType::_timeParameters;
+      else if (byteData == 0x0A)
             type = CondType::Bar_Number;
-            } else if (byteData == 0x16) {
+      else if (byteData == 0x16)
             type = CondType::Decorator;
-            } else if (byteData == 0x1C) {
+      else if (byteData == 0x1C)
             type = CondType::Tempo;
-            } else if (byteData == 0x1D) {
+      else if (byteData == 0x1D)
             type = CondType::Text;
-            } else if (byteData == 0x25) {
+      else if (byteData == 0x25)
             type = CondType::Expression;
-            } else if (byteData == 0x30) {
+      else if (byteData == 0x30)
             type = CondType::Barline_Parameters;
-            } else if (byteData == 0x31) {
+      else if (byteData == 0x31)
             type = CondType::Repeat;
-            } else if (byteData == 0x32) {
+      else if (byteData == 0x32)
             type = CondType::Numeric_Ending;
-            } else {
+      else
             return false;
-            }
 
       return true;
       }
 
-bool BarsParse::getBdatElementType(unsigned int byteData, BdatType& type) {
-      if (byteData == 0x70) {
+//---------------------------------------------------------
+//   BarsParse::bdatElementType
+//---------------------------------------------------------
+
+bool BarsParse::bdatElementType(unsigned byteData, BdatType& type)
+      {
+      if (byteData == 0x70)
             type = BdatType::Raw_Note;
-            } else if (byteData == 0x80) {
+      else if (byteData == 0x80)
             type = BdatType::Rest;
-            } else if (byteData == 0x90) {
+      else if (byteData == 0x90)
             type = BdatType::Note;
-            } else if (byteData == 0x10) {
+      else if (byteData == 0x10)
             type = BdatType::Beam;
-            } else if (byteData == 0x11) {
+      else if (byteData == 0x11)
             type = BdatType::Harmony;
-            } else if (byteData == 0x12) {
+      else if (byteData == 0x12)
             type = BdatType::Clef;
-            } else if (byteData == 0x13) {
+      else if (byteData == 0x13)
             type = BdatType::Wedge;
-            } else if (byteData == 0x14) {
-            type = BdatType::Dynamics;
-            } else if (byteData == 0x15) {
+      else if (byteData == 0x14)
+            type = BdatType::Dynamic;
+      else if (byteData == 0x15)
             type = BdatType::Glissando;
-            } else if (byteData == 0x16) {
+      else if (byteData == 0x16)
             type = BdatType::Decorator;
-            } else if (byteData == 0x17) {
+      else if (byteData == 0x17)
             type = BdatType::Key;
-            } else if (byteData == 0x18) {
+      else if (byteData == 0x18)
             type = BdatType::Lyric;
-            } else if (byteData == 0x19) {
+      else if (byteData == 0x19)
             type = BdatType::Octave_Shift;
-            } else if (byteData == 0x1B) {
+      else if (byteData == 0x1B)
             type = BdatType::Slur;
-            } else if (byteData == 0x1D) {
+      else if (byteData == 0x1D)
             type = BdatType::Text;
-            } else if (byteData == 0x1E) {
+      else if (byteData == 0x1E)
             type = BdatType::Tie;
-            } else if (byteData == 0x1F) {
+      else if (byteData == 0x1F)
             type = BdatType::Tuplet;
-            } else if (byteData == 0x21) {
+      else if (byteData == 0x21)
             type = BdatType::Guitar_Bend;
-            } else if (byteData == 0x22) {
+      else if (byteData == 0x22)
             type = BdatType::Guitar_Barre;
-            } else if (byteData == 0x23) {
+      else if (byteData == 0x23)
             type = BdatType::Pedal;
-            } else if (byteData == 0x24) {
-            type = BdatType::KuoHao;
-            } else if (byteData == 0x25) {
-            type = BdatType::Expressions;
-            } else if (byteData == 0x26) {
+      else if (byteData == 0x24)
+            type = BdatType::Bracket;
+      else if (byteData == 0x25)
+            type = BdatType::Expression;
+      else if (byteData == 0x26)
             type = BdatType::Harp_Pedal;
-            } else if (byteData == 0x27) {
+      else if (byteData == 0x27)
             type = BdatType::Multi_Measure_Rest;
-            } else if (byteData == 0x28) {
+      else if (byteData == 0x28)
             type = BdatType::Harmony_GuitarFrame;
-            } else if (byteData == 0x40) {
+      else if (byteData == 0x40)
             type = BdatType::Graphics_40;
-            } else if (byteData == 0x41) {
+      else if (byteData == 0x41)
             type = BdatType::Graphics_RoundRect;
-            } else if (byteData == 0x42) {
+      else if (byteData == 0x42)
             type = BdatType::Graphics_Rect;
-            } else if (byteData == 0x43) {
+      else if (byteData == 0x43)
             type = BdatType::Graphics_Round;
-            } else if (byteData == 0x44) {
+      else if (byteData == 0x44)
             type = BdatType::Graphics_Line;
-            } else if (byteData == 0x45) {
+      else if (byteData == 0x45)
             type = BdatType::Graphics_Curve;
-            } else if (byteData == 0x46) {
+      else if (byteData == 0x46)
             type = BdatType::Graphics_WedgeSymbol;
-            } else if (byteData == 0xAB) {
+      else if (byteData == 0xAB)
             type = BdatType::Midi_Controller;
-            } else if (byteData == 0xAC) {
+      else if (byteData == 0xAC)
             type = BdatType::Midi_Program_Change;
-            } else if (byteData == 0xAD) {
+      else if (byteData == 0xAD)
             type = BdatType::Midi_Channel_Pressure;
-            } else if (byteData == 0xAE) {
+      else if (byteData == 0xAE)
             type = BdatType::Midi_Pitch_Wheel;
-            } else if (byteData == 0xFF) {
+      else if (byteData == 0xFF)
             type = BdatType::Bar_End;
-            } else {
+      else
             return false;
-            }
 
       return true;
       }
 
-///////////////////////////////////////////////////////////////////////////////
-LyricChunkParse::LyricChunkParse(OveSong* ove) :
-      BasicParse(ove) {
+//---------------------------------------------------------
+//   LyricChunkParse
+//---------------------------------------------------------
+
+LyricChunkParse::LyricChunkParse(OveSong* ove)
+   : BasicParse(ove)
+      {
+      _chunk = nullptr;
       }
 
-void LyricChunkParse::setLyricChunk(SizeChunk* chunk) {
-      chunk_ = chunk;
+LyricChunkParse::~LyricChunkParse()
+      {
+      _chunk = nullptr;
       }
 
-// only ove3 has this chunk
-bool LyricChunkParse::parse() {
-      unsigned int i;
-      Block* dataBlock = chunk_->getDataBlock();
-      unsigned int blockSize = chunk_->getSizeBlock()->toSize();
+//---------------------------------------------------------
+//   LyricChunkParse::parse
+//    Only ove3 has this chunk
+//---------------------------------------------------------
+
+bool LyricChunkParse::parse()
+      {
+      unsigned i;
+      Block* dataBlock = _chunk->dataBlock();
+      unsigned blockSize = _chunk->sizeBlock()->toSize();
       StreamHandle handle(dataBlock->data(), blockSize);
       Block placeHolder;
 
-      handle_ = &handle;
+      _handle = &handle;
 
-      if( !jump(4) ) { return false; }
+      if (!jump(4)) { return false; }
 
       // Lyric count
-      if( !readBuffer(placeHolder, 2) ) { return false; }
-      unsigned int count = placeHolder.toUnsignedInt();
+      if (!readBuffer(placeHolder, 2)) { return false; }
+      unsigned count = placeHolder.toUnsignedInt();
 
-      for( i=0; i<count; ++i ) {
+      for (i = 0; i < count; ++i) {
             LyricInfo info;
 
-            if( !readBuffer(placeHolder, 2) ) { return false; }
-            //unsigned int size = placeHolder.toUnsignedInt();
+            if (!readBuffer(placeHolder, 2)) { return false; }
+            //unsigned size = placeHolder.toUnsignedInt();
 
             // 0x0D00
-            if( !jump(2) ) { return false; }
+            if (!jump(2)) { return false; }
 
             // voice
-            if( !readBuffer(placeHolder, 1) ) { return false; }
-            info.voice_ = placeHolder.toUnsignedInt();
+            if (!readBuffer(placeHolder, 1)) { return false; }
+            info._voice = placeHolder.toUnsignedInt();
 
             // verse
-            if( !readBuffer(placeHolder, 1) ) { return false; }
-            info.verse_ = placeHolder.toUnsignedInt();
+            if (!readBuffer(placeHolder, 1)) { return false; }
+            info._verse = placeHolder.toUnsignedInt();
 
             // track
-            if( !readBuffer(placeHolder, 1) ) { return false; }
-            info.track_ = placeHolder.toUnsignedInt();
+            if (!readBuffer(placeHolder, 1)) { return false; }
+            info._track = placeHolder.toUnsignedInt();
 
-            if( !jump(1) ) { return false; }
+            if (!jump(1)) { return false; }
 
             // measure
-            if( !readBuffer(placeHolder, 2) ) { return false; }
-            info.measure_ = placeHolder.toUnsignedInt();
+            if (!readBuffer(placeHolder, 2)) { return false; }
+            info._measure = placeHolder.toUnsignedInt();
 
             // word count
-            if( !readBuffer(placeHolder, 2) ) { return false; }
-            info.wordCount_ = placeHolder.toUnsignedInt();
+            if (!readBuffer(placeHolder, 2)) { return false; }
+            info._wordCount = placeHolder.toUnsignedInt();
 
             // lyric size
-            if( !readBuffer(placeHolder, 2) ) { return false; }
-            info.lyricSize_ = placeHolder.toUnsignedInt();
+            if (!readBuffer(placeHolder, 2)) { return false; }
+            info._lyricSize = placeHolder.toUnsignedInt();
 
-            if( !jump(6) ) { return false; }
+            if (!jump(6)) { return false; }
 
             // name
-            if( !readBuffer(placeHolder, 32) ) { return false; }
-            info.name_ = ove_->getCodecString(placeHolder.fixedSizeBufferToStrByteArray());
+            if (!readBuffer(placeHolder, 32)) { return false; }
+            info._name = _ove->codecString(placeHolder.fixedSizeBufferToStrByteArray());
 
-            if( info.lyricSize_ > 0 ) {
+            if (info._lyricSize > 0) {
                   // lyric
-                  if( info.lyricSize_ > 0 ) {
-                        if( !readBuffer(placeHolder, info.lyricSize_) ) { return false; }
-                        info.lyric_ = ove_->getCodecString(placeHolder.fixedSizeBufferToStrByteArray());
+                  if (info._lyricSize > 0) {
+                        if (!readBuffer(placeHolder, info._lyricSize)) { return false; }
+                        info._lyric = _ove->codecString(placeHolder.fixedSizeBufferToStrByteArray());
                         }
 
-                  if( !jump(4) ) { return false; }
+                  if (!jump(4)) { return false; }
 
                   // font
-                  if( !readBuffer(placeHolder, 2) ) { return false; }
-                  info.font_ = placeHolder.toUnsignedInt();
+                  if (!readBuffer(placeHolder, 2)) { return false; }
+                  info._font = placeHolder.toUnsignedInt();
 
-                  if( !jump(1) ) { return false; }
+                  if (!jump(1)) { return false; }
 
                   // font size
-                  if( !readBuffer(placeHolder, 1) ) { return false; }
-                  info.fontSize_ = placeHolder.toUnsignedInt();
+                  if (!readBuffer(placeHolder, 1)) { return false; }
+                  info._fontSize = placeHolder.toUnsignedInt();
 
                   // font style
-                  if( !readBuffer(placeHolder, 1) ) { return false; }
-                  info.fontStyle_ = placeHolder.toUnsignedInt();
+                  if (!readBuffer(placeHolder, 1)) { return false; }
+                  info._fontStyle = placeHolder.toUnsignedInt();
 
-                  if( !jump(1) ) { return false; }
+                  if (!jump(1)) { return false; }
 
-                  for( int j=0; j<info.wordCount_; ++j ) {
-                        if( !jump(8) ) { return false; }
-                        }
+                  for (int j = 0; j < info._wordCount; ++j)
+                        if (!jump(8)) { return false; }
                   }
 
             processLyricInfo(info);
@@ -7263,48 +5796,60 @@ bool LyricChunkParse::parse() {
       return true;
       }
 
-bool isSpace(char c) {
+#if 0
+//---------------------------------------------------------
+//   isSpace
+//---------------------------------------------------------
+
+static bool isSpace(char c)
+      {
       return c == ' ' || c == '\n';
       }
+#endif
 
-void LyricChunkParse::processLyricInfo(const LyricInfo& info) {
+//---------------------------------------------------------
+//   LyricChunkParse::processLyricInfo
+//---------------------------------------------------------
+
+void LyricChunkParse::processLyricInfo(const LyricInfo& info)
+      {
       int i;
       int j;
-      int index = 0; //words
+      int index = 0; // words
 
-      int measureId = info.measure_-1;
+      int measureId = info._measure - 1;
       bool changeMeasure = true;
       MeasureData* measureData = 0;
-      int trackMeasureCount = ove_->getTrackBarCount();
-      QStringList words = info.lyric_.split(" ", QString::SkipEmptyParts);
+      int trackMeasureCount = _ove->trackBarCount();
+      QStringList words = info._lyric.split(" ", QString::SkipEmptyParts);
 
-      while ( index < words.size() && measureId+1 < trackMeasureCount ) {
-            if( changeMeasure ) {
+      while (index < words.size() && measureId + 1 < trackMeasureCount) {
+            if (changeMeasure) {
                   ++measureId;
-                  measureData = ove_->getMeasureData(info.track_, measureId);
+                  measureData = _ove->measureData(info._track, measureId);
                   changeMeasure = false;
                   }
 
-            if( measureData == 0 ) { return; }
-            QList<NoteContainer*> containers = measureData->getNoteContainers();
-            QList<MusicData*> lyrics = measureData->getMusicDatas(MusicDataType::Lyric);
+            if (measureData == 0)
+                  return;
+            QList<NoteContainer*> containers = measureData->noteContainers();
+            QList<MusicData*> lyrics = measureData->musicDatas(MusicDataType::Lyric);
 
-            for( i=0; i<containers.size() && index<words.size(); ++i ) {
-                  if( containers[i]->getIsRest() ) {
+            for (i = 0; i < containers.size() && index < words.size(); ++i) {
+                  if (containers[i]->isRest())
                         continue;
-                        }
 
-                  for( j=0; j<lyrics.size(); ++j ) {
+                  for (j = 0; j < lyrics.size(); ++j) {
                         Lyric* lyric = static_cast<Lyric*>(lyrics[j]);
 
-                        if( containers[i]->start()->getOffset() == lyric->start()->getOffset() &&
-                            (int)containers[i]->getVoice() == info.voice_ &&
-                            lyric->getVerse() == info.verse_ ) {
-                              if(index<words.size()) {
+                        if (containers[i]->start()->offset() == lyric->start()->offset()
+                           && int(containers[i]->voice()) == info._voice
+                           && lyric->verse() == info._verse) {
+                              if (index < words.size()) {
                                     QString l = words[index].trimmed();
-                                    if(!l.isEmpty()) {
+                                    if (!l.isEmpty()) {
                                           lyric->setLyric(l);
-                                          lyric->setVoice(info.voice_);
+                                          lyric->setVoice(info._voice);
                                           }
                                     }
 
@@ -7317,22 +5862,34 @@ void LyricChunkParse::processLyricInfo(const LyricInfo& info) {
             }
       }
 
-///////////////////////////////////////////////////////////////////////////////
-TitleChunkParse::TitleChunkParse(OveSong* ove) :
-      BasicParse(ove) {
-      titleType_ = 0x00000001;
-      annotateType_ = 0x00010000;
-      writerType_ = 0x00020002;
-      copyrightType_ = 0x00030001;
-      headerType_ = 0x00040000;
-      footerType_ = 0x00050002;
+//---------------------------------------------------------
+//   TitleChunkParse
+//---------------------------------------------------------
+
+TitleChunkParse::TitleChunkParse(OveSong* ove)
+   : BasicParse(ove)
+      {
+      _titleType     = 0x00000001;
+      _annotateType  = 0x00010000;
+      _writerType    = 0x00020002;
+      _copyrightType = 0x00030001;
+      _headerType    = 0x00040000;
+      _footerType    = 0x00050002;
+
+      _chunk = nullptr;
       }
 
-void TitleChunkParse::setTitleChunk(SizeChunk* chunk) {
-      chunk_ = chunk;
+TitleChunkParse::~TitleChunkParse()
+      {
+      _chunk = nullptr;
       }
 
-QByteArray getByteArray(const Block& block) {
+//---------------------------------------------------------
+//   byteArray
+//---------------------------------------------------------
+
+static QByteArray byteArray(const Block& block)
+      {
       QByteArray array((char*)block.data(), block.size());
       int index0 = array.indexOf('\0');
       array = array.left(index0);
@@ -7340,64 +5897,69 @@ QByteArray getByteArray(const Block& block) {
       return array;
       }
 
-bool TitleChunkParse::parse() {
-      Block* dataBlockP = chunk_->getDataBlock();
-      unsigned int blockSize = chunk_->getSizeBlock()->toSize();
+//---------------------------------------------------------
+//   TitleChunkParse::parse
+//---------------------------------------------------------
+
+bool TitleChunkParse::parse()
+      {
+      Block* dataBlockP = _chunk->dataBlock();
+      unsigned blockSize = _chunk->sizeBlock()->toSize();
       StreamHandle handle(dataBlockP->data(), blockSize);
       Block typeBlock;
-      unsigned int titleType;
+      unsigned titleType;
 
-      handle_ = &handle;
+      _handle = &handle;
 
-      if( !readBuffer(typeBlock, 4) ) { return false; }
+      if (!readBuffer(typeBlock, 4)) { return false; }
 
       titleType = typeBlock.toUnsignedInt();
 
-      if( titleType == titleType_ || titleType == annotateType_ || titleType == writerType_ || titleType == copyrightType_ ) {
+      if (titleType == _titleType || titleType == _annotateType
+         || titleType == _writerType || titleType == _copyrightType) {
             Block offsetBlock;
 
-            if( !readBuffer(offsetBlock, 4) ) { return false; }
+            if (!readBuffer(offsetBlock, 4)) { return false; }
 
-            const unsigned int itemCount = 4;
-            unsigned int i;
+            const unsigned itemCount = 4;
+            unsigned i;
 
-            for( i=0; i<itemCount; ++i ) {
-                  if( i>0 ) {
-                        //0x 00 AB 00 0C 00 00
-                        if( !jump(6) ) { return false; }
+            for (i = 0; i < itemCount; ++i) {
+                  if (i > 0) {
+                        // 0x 00 AB 00 0C 00 00
+                        if (!jump(6)) { return false; }
                         }
 
                   Block countBlock;
-                  if( !readBuffer(countBlock, 2) ) { return false; }
-                  unsigned int titleSize = countBlock.toUnsignedInt();
+                  if (!readBuffer(countBlock, 2)) { return false; }
+                  unsigned titleSize = countBlock.toUnsignedInt();
 
                   Block dataBlock;
-                  if( !readBuffer(dataBlock, titleSize) ) { return false; }
+                  if (!readBuffer(dataBlock, titleSize)) { return false; }
 
-                  QByteArray array = getByteArray(dataBlock);
-                  if(!array.isEmpty()) {
-                        addToOve(ove_->getCodecString(array), titleType);
-                        }
+                  QByteArray array = byteArray(dataBlock);
+                  if (!array.isEmpty())
+                        addToOve(_ove->codecString(array), titleType);
                   }
 
             return true;
             }
 
-      if( titleType == headerType_ || titleType == footerType_ ) {
-            if( !jump(10) ) { return false; }
+      if (titleType == _headerType || titleType == _footerType) {
+            if (!jump(10)) { return false; }
 
             Block countBlock;
-            if( !readBuffer(countBlock, 2) ) { return false; }
-            unsigned int titleSize = countBlock.toUnsignedInt();
+            if (!readBuffer(countBlock, 2)) { return false; }
+            unsigned titleSize = countBlock.toUnsignedInt();
 
             Block dataBlock;
-            if( !readBuffer(dataBlock, titleSize) ) { return false; }
+            if (!readBuffer(dataBlock, titleSize)) { return false; }
 
-            QByteArray array = getByteArray(dataBlock);
-            addToOve(ove_->getCodecString(array), titleType);
+            QByteArray array = byteArray(dataBlock);
+            addToOve(_ove->codecString(array), titleType);
 
             //0x 00 AB 00 0C 00 00
-            if( !jump(6) ) { return false; }
+            if (!jump(6)) { return false; }
 
             return true;
             }
@@ -7405,85 +5967,96 @@ bool TitleChunkParse::parse() {
       return false;
       }
 
-void TitleChunkParse::addToOve(const QString& str, unsigned int titleType) {
-      if( str.isEmpty() ) { return; }
+//---------------------------------------------------------
+//   TitleChunkParse::addToOve
+//---------------------------------------------------------
 
-      if (titleType == titleType_) {
-            ove_->addTitle(str);
-            }
+void TitleChunkParse::addToOve(const QString& str, unsigned titleType)
+      {
+      if (str.isEmpty()) { return; }
 
-      if (titleType == annotateType_) {
-            ove_->addAnnotate(str);
-            }
+      if (titleType == _titleType)
+            _ove->addTitle(str);
 
-      if (titleType == writerType_) {
-            ove_->addWriter(str);
-            }
+      if (titleType == _annotateType)
+            _ove->addAnnotate(str);
 
-      if (titleType == copyrightType_) {
-            ove_->addCopyright(str);
-            }
+      if (titleType == _writerType)
+            _ove->addWriter(str);
 
-      if (titleType == headerType_) {
-            ove_->addHeader(str);
-            }
+      if (titleType == _copyrightType)
+            _ove->addCopyright(str);
 
-      if (titleType == footerType_) {
-            ove_->addFooter(str);
-            }
+      if (titleType == _headerType)
+            _ove->addHeader(str);
+
+      if (titleType == _footerType)
+            _ove->addFooter(str);
       }
 
-// OveOrganize.cpp
-OveOrganizer::OveOrganizer(OveSong* ove) {
-      ove_ = ove;
+//---------------------------------------------------------
+//   OveOrganizer
+//---------------------------------------------------------
+
+OveOrganizer::OveOrganizer(OveSong* ove)
+      {
+      _ove = ove;
       }
 
-void OveOrganizer::organize() {
-      if(ove_ == NULL) {
+//---------------------------------------------------------
+//   OveOrganizer::organize
+//---------------------------------------------------------
+
+void OveOrganizer::organize()
+      {
+      if (!_ove)
             return;
-            }
 
       organizeTracks();
       organizeAttributes();
       organizeMeasures();
       }
 
-void OveOrganizer::organizeAttributes() {
+//---------------------------------------------------------
+//   OveOrganizer::organizeAttributes
+//---------------------------------------------------------
+
+void OveOrganizer::organizeAttributes()
+      {
       int i;
       int j;
       int k;
 
       // key
-      if(ove_->getLineCount() > 0) {
-            Line* line = ove_->getLine(0);
-            int partBarCount = ove_->getPartBarCount();
+      if (_ove->lineCount() > 0) {
+            Line* line = _ove->line(0);
+            int partBarCount = _ove->partBarCount();
             int lastKey = 0;
 
-            if(line != 0){
-                  for(i=0; i<line->getStaffCount(); ++i) {
-                        QPair<int, int> partStaff = ove_->trackToPartStaff(i);
-                        Staff* staff = line->getStaff(i);
-                        lastKey = staff->getKeyType();
+            if (line) {
+                  for (i = 0; i < line->staffCount(); ++i) {
+                        QPair<int, int> partStaff = _ove->trackToPartStaff(i);
+                        Staff* staff = line->staff(i);
+                        lastKey = staff->keyType();
 
-                        for(j=0; j<partBarCount; ++j) {
-                              MeasureData* measureData = ove_->getMeasureData(partStaff.first, partStaff.second, j);
+                        for (j = 0; j < partBarCount; ++j) {
+                              MeasureData* measureData = _ove->measureData(partStaff.first, partStaff.second, j);
 
-                              if(measureData != 0) {
-                                    Key* key = measureData->getKey();
+                              if (measureData) {
+                                    Key* key = measureData->key();
 
-                                    if( j==0 ) {
+                                    if (j == 0) {
                                           key->setKey(lastKey);
                                           key->setPreviousKey(lastKey);
                                           }
 
-                                    if( !key->getSetKey() ) {
+                                    if (!key->setKey()) {
                                           key->setKey(lastKey);
                                           key->setPreviousKey(lastKey);
                                           }
                                     else {
-                                          if( key->getKey() != lastKey ) {
-                                                lastKey = key->getKey();
-                                                }
+                                          if (key->key() != lastKey)
+                                                lastKey = key->key();
                                           }
                                     }
                               }
@@ -7492,29 +6065,29 @@ void OveOrganizer::organizeAttributes() {
             }
 
       // clef
-      if( ove_->getLineCount() > 0 ) {
-            Line* line = ove_->getLine(0);
-            int partBarCount = ove_->getPartBarCount();
+      if (_ove->lineCount() > 0) {
+            Line* line = _ove->line(0);
+            int partBarCount = _ove->partBarCount();
             ClefType lastClefType = ClefType::Treble;
 
-            if(line != 0){
-                  for( i=0; i<line->getStaffCount(); ++i ) {
-                        QPair<int, int> partStaff = ove_->trackToPartStaff(i);
-                        Staff* staff = line->getStaff(i);
-                        lastClefType = staff->getClefType();
+            if (line) {
+                  for (i = 0; i < line->staffCount(); ++i) {
+                        QPair<int, int> partStaff = _ove->trackToPartStaff(i);
+                        Staff* staff = line->staff(i);
+                        lastClefType = staff->clefType();
 
-                        for( j=0; j<partBarCount; ++j ) {
-                              MeasureData* measureData = ove_->getMeasureData(partStaff.first, partStaff.second, j);
+                        for (j = 0; j < partBarCount; ++j) {
+                              MeasureData* measureData = _ove->measureData(partStaff.first, partStaff.second, j);
 
-                              if(measureData != 0) {
-                                    Clef* clefPtr = measureData->getClef();
-                                    clefPtr->setClefType((int)lastClefType);
+                              if (measureData) {
+                                    Clef* clefPtr = measureData->clef();
+                                    clefPtr->setClefType(lastClefType);
 
-                                    const QList<MusicData*>& clefs = measureData->getMusicDatas(MusicDataType::Clef);
+                                    const QList<MusicData*>& clefs = measureData->musicDatas(MusicDataType::Clef);
 
-                                    for( k=0; k<clefs.size(); ++k ) {
+                                    for (k = 0; k < clefs.size(); ++k) {
                                           Clef* clef = static_cast<Clef*>(clefs[k]);
-                                          lastClefType = clef->getClefType();
+                                          lastClefType = clef->clefType();
                                           }
                                     }
                               }
@@ -7523,71 +6096,84 @@ void OveOrganizer::organizeAttributes() {
             }
       }
 
-Staff* getStaff(OveSong* ove, int track) {
-      if (ove->getLineCount() > 0) {
-            Line* line = ove->getLine(0);
-            if(line != 0 && line->getStaffCount() > 0) {
-                  Staff* staff = line->getStaff(track);
+//---------------------------------------------------------
+//   getStaff
+//---------------------------------------------------------
+
+static Staff* getStaff(OveSong* ove, int track)
+      {
+      if (ove->lineCount() > 0) {
+            Line* line = ove->line(0);
+            if (line && line->staffCount() > 0) {
+                  Staff* staff = line->staff(track);
                   return staff;
                   }
             }
 
-      return 0;
+      return nullptr;
       }
 
-void OveOrganizer::organizeTracks() {
+//---------------------------------------------------------
+//   OveOrganizer::organizeTracks
+//---------------------------------------------------------
+
+void OveOrganizer::organizeTracks()
+      {
       int i;
-      //QList<QPair<ClefType, int> > trackChannels;
-      QList<Track*> tracks = ove_->getTracks();
+      // QList<QPair<ClefType, int>> trackChannels;
+      QList<Track*> tracks = _ove->tracks();
       QList<bool> comboStaveStarts;
 
-      for( i=0; i<tracks.size(); ++i ) {
+      for (i = 0; i < tracks.size(); ++i)
             comboStaveStarts.push_back(false);
-            }
 
-      for( i=0; i<tracks.size(); ++i ) {
-            Staff* staff = getStaff(ove_, i);
-            if(staff != 0) {
-                  if(staff->getGroupType() == GroupType::Brace && staff->getGroupStaffCount() == 1 ) {
+      for (i = 0; i < tracks.size(); ++i) {
+            Staff* s = getStaff(_ove, i);
+            if (s) {
+                  if (s->groupType() == GroupType::Braces && s->groupStaffCount() == 1)
                         comboStaveStarts[i] = true;
+                  }
+#if 0
+            if (i < tracks.size() - 1) {
+                  if (tracks[i]->startClef() == ClefType::Treble &&
+                     tracks[i+1]->startClef() == ClefType::Bass &&
+                     tracks[i]->channel() == tracks[i+1]->get_channel()) {
                         }
                   }
-
-            /*if( i < tracks.size() - 1 ) {
-         if( tracks[i]->getStartClef() == ClefType::Treble &&
-            tracks[i+1]->getStartClef() == ClefType::Bass &&
-            tracks[i]->getChannel() == tracks[i+1]->get_channel() ) {
-         }
-      }*/
+#endif
             }
 
       int trackId = 0;
       QList<int> partStaffCounts;
 
-      while( trackId < (int)tracks.size() ) {
+      while (trackId < tracks.size()) {
             int partTrackCount = 1;
 
-            if( comboStaveStarts[trackId] ) {
+            if (comboStaveStarts[trackId])
                   partTrackCount = 2;
-                  }
 
             partStaffCounts.push_back(partTrackCount);
             trackId += partTrackCount;
             }
 
-      ove_->setPartStaffCounts(partStaffCounts);
+      _ove->addPartStaffCounts(partStaffCounts);
       }
 
-void OveOrganizer::organizeMeasures() {
-      int trackBarCount = ove_->getTrackBarCount();
+//---------------------------------------------------------
+//   OveOrganizer::organizeMeasures
+//---------------------------------------------------------
 
-      for( int i=0; i<ove_->getPartCount(); ++i ) {
-            int partStaffCount = ove_->getStaffCount(i);
+void OveOrganizer::organizeMeasures()
+      {
+      int trackBarCount = _ove->trackBarCount();
 
-            for( int j=0; j<partStaffCount; ++j ) {
-                  for( int k=0; k<trackBarCount; ++k ) {
-                        Measure* measure = ove_->getMeasure(k);
-                        MeasureData* measureData = ove_->getMeasureData(i, j, k);
+      for (int i = 0; i < _ove->partCount(); ++i) {
+            int partStaffCount = _ove->staffCount(i);
+
+            for (int j = 0; j < partStaffCount; ++j) {
+                  for (int k = 0; k < trackBarCount; ++k) {
+                        Measure* measure = _ove->measure(k);
+                        MeasureData* measureData = _ove->measureData(i, j, k);
 
                         organizeMeasure(i, j, measure, measureData);
                         }
@@ -7595,7 +6181,12 @@ void OveOrganizer::organizeMeasures() {
             }
       }
 
-void OveOrganizer::organizeMeasure(int part, int track, Measure* measure, MeasureData* measureData) {
+//---------------------------------------------------------
+//   OveOrganizer::organizeMeasure
+//---------------------------------------------------------
+
+void OveOrganizer::organizeMeasure(int part, int track, Measure* measure, MeasureData* measureData)
+      {
       // note containers
       organizeContainers(part, track, measure, measureData);
 
@@ -7606,31 +6197,38 @@ void OveOrganizer::organizeMeasure(int part, int track, Measure* measure, Measur
       organizeCrossMeasureElements(part, track, measure, measureData);
       }
 
-void addToList(QList<int>& list, int number) {
-      for(int i=0; i<list.size(); ++i){
-            if(list[i] == number){
+//---------------------------------------------------------
+//   addToList
+//---------------------------------------------------------
+
+static void addToList(QList<int>& list, int number)
+      {
+      for (int i = 0; i < list.size(); ++i) {
+            if (list[i] == number)
                   return;
-                  }
             }
 
       list.push_back(number);
       }
 
-void OveOrganizer::organizeContainers(int /*part*/, int /*track*/,
-                                      Measure* measure, MeasureData* measureData) {
+//---------------------------------------------------------
+//   OveOrganizer::organizeContainers
+//---------------------------------------------------------
+
+void OveOrganizer::organizeContainers(int /*part*/, int /*track*/, Measure* measure, MeasureData* measureData)
+      {
       int i;
-      QList<NoteContainer*> containers = measureData->getNoteContainers();
-      int barUnits = measure->getTime()->getUnits();
+      QList<NoteContainer*> containers = measureData->noteContainers();
+      int barUnits = measure->timeSig()->units();
       QList<int> voices;
 
-      for(i=0; i<containers.size(); ++i){
+      for (i = 0; i < containers.size(); ++i) {
             int endUnit = barUnits;
-            if( i < containers.size() - 1 ) {
-                  endUnit = containers[i+1]->start()->getOffset();
-                  }
+            if (i < containers.size() - 1)
+                  endUnit = containers[i+1]->start()->offset();
 
             containers[i]->stop()->setOffset(endUnit);
-            addToList(voices, containers[i]->getVoice());
+            addToList(voices, containers[i]->voice());
             }
 
       // shift voices
@@ -7639,51 +6237,58 @@ void OveOrganizer::organizeContainers(int /*part*/, int /*track*/,
       for (i = 0; i < voices.size(); ++i) {
             int voice = voices[i];
             // voice -> i
-            for(int j=0; j<(int)containers.size(); ++j) {
-                  int avoice = containers[j]->getVoice();
-                  if ( avoice == voice && avoice != i ) {
+            for (int j = 0; j < containers.size(); ++j) {
+                  int avoice = containers[j]->voice();
+                  if (avoice == voice && avoice != i)
                         containers[j]->setVoice(i);
-                        }
                   }
             }
       }
 
-void OveOrganizer::organizeMusicDatas(int /*part*/, int /*track*/, Measure* measure, MeasureData* measureData) {
-      int i;
-      int barIndex = measure->getBarNumber()->getIndex();
-      QList<MusicData*> datas = measureData->getMusicDatas(MusicDataType::None);
+//---------------------------------------------------------
+//   OveOrganizer::organizeMusicDatas
+//---------------------------------------------------------
 
-      for(i=0; i<datas.size(); ++i) {
+void OveOrganizer::organizeMusicDatas(int /*part*/, int /*track*/, Measure* measure, MeasureData* measureData)
+      {
+      int i;
+      int barIndex = measure->barNumber()->index();
+      QList<MusicData*> datas = measureData->musicDatas(MusicDataType::None);
+
+      for (i = 0; i < datas.size(); ++i)
             datas[i]->start()->setMeasure(barIndex);
-            }
       }
 
-void OveOrganizer::organizeCrossMeasureElements(int part, int track, Measure* measure, MeasureData* measureData) {
-      int i;
-      QList<MusicData*> pairs = measureData->getCrossMeasureElements(MusicDataType::None, MeasureData::PairType::Start);
+//---------------------------------------------------------
+//   OveOrganizer::organizeCrossMeasureElements
+//---------------------------------------------------------
 
-      for(i=0; i<pairs.size(); ++i) {
+void OveOrganizer::organizeCrossMeasureElements(int part, int track, Measure* measure, MeasureData* measureData)
+      {
+      int i;
+      QList<MusicData*> pairs = measureData->crossMeasureElements(MusicDataType::None, MeasureData::PairType::Start);
+
+      for (i = 0; i < pairs.size(); ++i) {
             MusicData* pair = pairs[i];
 
-            switch ( pair->getMusicDataType() ) {
-                  case MusicDataType::Beam :
-                  case MusicDataType::Glissando :
-                  case MusicDataType::Slur :
-                  case MusicDataType::Tie :
-                  case MusicDataType::Tuplet :
-                  case MusicDataType::Pedal :
-                  case MusicDataType::Numeric_Ending :
-                        //case MusicDataType::OctaveShift_EndPoint :
-                  case MusicDataType::Measure_Repeat : {
+            switch (pair->musicDataType()) {
+                  case MusicDataType::Beam:
+                  case MusicDataType::Glissando:
+                  case MusicDataType::Slur:
+                  case MusicDataType::Tie:
+                  case MusicDataType::Tuplet:
+                  case MusicDataType::Pedal:
+                  case MusicDataType::Numeric_Ending:
+                  // case MusicDataType::OctaveShift_EndPoint:
+                  case MusicDataType::Measure_Repeat:
                         organizePairElement(pair, part, track, measure, measureData);
                         break;
-                        }
-                  case MusicDataType::OctaveShift : {
+                  case MusicDataType::OctaveShift: {
                         OctaveShift* octave = static_cast<OctaveShift*>(pair);
                         organizeOctaveShift(octave, measure, measureData);
                         break;
                         }
-                  case MusicDataType::Wedge : {
+                  case MusicDataType::Wedge: {
                         Wedge* wedge = static_cast<Wedge*>(pair);
                         organizeWedge(wedge, part, track, measure, measureData);
                         break;
@@ -7694,109 +6299,109 @@ void OveOrganizer::organizeCrossMeasureElements(int part, int track, Measure* me
             }
       }
 
-void OveOrganizer::organizePairElement(
-            MusicData* data,
-            int part,
-            int track,
-            Measure* measure,
-            MeasureData* measureData) {
-      int bar1Index = measure->getBarNumber()->getIndex();
-      int bar2Index = bar1Index + data->stop()->getMeasure();
-      MeasureData* measureData2 = ove_->getMeasureData(part, track, bar2Index);
+//---------------------------------------------------------
+//   OveOrganizer::organizePairElement
+//---------------------------------------------------------
+
+void OveOrganizer::organizePairElement(MusicData* data, int part, int track,
+   Measure* measure, MeasureData* measureData) 
+      {
+      int bar1Index = measure->barNumber()->index();
+      int bar2Index = bar1Index + data->stop()->measure();
+      MeasureData* measureData2 = _ove->measureData(part, track, bar2Index);
 
       data->start()->setMeasure(bar1Index);
 
-      if(measureData2 != 0 && measureData != measureData2) {
+      if (measureData2 && measureData != measureData2)
             measureData2->addCrossMeasureElement(data, false);
-            }
 
-      if( data->getMusicDataType() == MusicDataType::Tuplet ){
+      if (data->musicDataType() == MusicDataType::Tuplet) {
             Tuplet* tuplet = static_cast<Tuplet*>(data);
-            const QList<NoteContainer*> containers = measureData->getNoteContainers();
+            const QList<NoteContainer*> containers = measureData->noteContainers();
 
-            for(int i=0; i<containers.size(); ++i){
-                  if(containers[i]->getTick() > tuplet->getTick()){
+            for (int i = 0; i < containers.size(); ++i) {
+                  if (containers[i]->tick() > tuplet->tick())
                         break;
-                        }
 
-                  if(containers[i]->getTick() == tuplet->getTick()){
-                        tuplet->setNoteType(containers[i]->getNoteType());
-                        }
+                  else if (containers[i]->tick() == tuplet->tick())
+                        tuplet->setNoteType(containers[i]->noteType());
                   }
 
-            int tupletTick = NoteTypeToTick(tuplet->getNoteType(), ove_->getQuarter())*tuplet->getSpace();
-            if( tuplet->getTick() % tupletTick != 0 ) {
-                  int newStartTick = (tuplet->getTick() / tupletTick) * tupletTick;
+            int tupletTick = noteTypeToTick(tuplet->noteType(), _ove->isQuarter()) * tuplet->space();
+            if (tuplet->tick() % tupletTick != 0) {
+                  int newStartTick = (tuplet->tick() / tupletTick) * tupletTick;
 
-                  for(int i=0; i<containers.size(); ++i){
-                        if( containers[i]->getTick() == newStartTick &&
-                            containers[i]->getTuplet() == tuplet->getTuplet()) {
-                              tuplet->setTick(containers[i]->getTick());
-                              tuplet->start()->setOffset(containers[i]->start()->getOffset());
+                  for (int i = 0; i < containers.size(); ++i) {
+                        if (containers[i]->tick() == newStartTick &&
+                            containers[i]->tuplet() == tuplet->tuplet()) {
+                              tuplet->setTick(containers[i]->tick());
+                              tuplet->start()->setOffset(containers[i]->start()->offset());
                               }
                         }
                   }
             }
       }
 
-void OveOrganizer::organizeOctaveShift(
-            OctaveShift* octave,
-            Measure* measure,
-            MeasureData* measureData) {
+//---------------------------------------------------------
+//   OveOrganizer::organizeOctaveShift
+//---------------------------------------------------------
+
+void OveOrganizer::organizeOctaveShift(OctaveShift* octave, Measure* measure, MeasureData* measureData)
+      {
       // octave shift
       int i;
-      const QList<NoteContainer*> containers = measureData->getNoteContainers();
-      int barIndex = measure->getBarNumber()->getIndex();
+      const QList<NoteContainer*> containers = measureData->noteContainers();
+      int barIndex = measure->barNumber()->index();
 
       octave->start()->setMeasure(barIndex);
 
-      for(i=0; i<containers.size(); ++i) {
-            int noteShift = octave->getNoteShift();
-            int containerTick = containers[i]->getTick();
+      for (i = 0; i < containers.size(); ++i) {
+            int noteShift = octave->noteShift();
+            int containerTick = containers[i]->tick();
 
-            if( octave->getTick() <= containerTick && octave->getEndTick() > containerTick ) {
+            if (octave->tick() <= containerTick && octave->endTick() > containerTick)
                   containers[i]->setNoteShift(noteShift);
-                  }
             }
       }
 
-bool getMiddleUnit(
-            OveSong* ove, int /*part*/, int /*track*/,
-            Measure* measure1, Measure* measure2, int unit1, int /*unit2*/,
-            Measure* middleMeasure, int& middleUnit) {
+//---------------------------------------------------------
+//   getMiddleUnit
+//---------------------------------------------------------
+
+static bool getMiddleUnit(OveSong* ove, int /*part*/, int /*track*/,
+   Measure* measure1, Measure* measure2, int unit1, int /*unit2*/,
+   Measure* middleMeasure, int& middleUnit)
+      {
       Q_UNUSED(middleMeasure); // avoid (bogus?) warning to show up
       QList<int> barUnits;
       int i;
-      int bar1Index = measure1->getBarNumber()->getIndex();
-      int bar2Index = measure2->getBarNumber()->getIndex();
+      int bar1Index = measure1->barNumber()->index();
+      int bar2Index = measure2->barNumber()->index();
       int sumUnit = 0;
 
-      for( int j=bar1Index; j<=bar2Index; ++j ) {
-            Measure* measure = ove->getMeasure(j);
-            barUnits.push_back(measure->getTime()->getUnits());
-            sumUnit += measure->getTime()->getUnits();
+      for (int j = bar1Index; j <= bar2Index; ++j) {
+            Measure* measure = ove->measure(j);
+            barUnits.push_back(measure->timeSig()->units());
+            sumUnit += measure->timeSig()->units();
             }
 
       int currentSumUnit = 0;
-      for( i=0; i<barUnits.size(); ++i ) {
+      for (i = 0; i < barUnits.size(); ++i) {
             int barUnit = barUnits[i];
 
-            if( i==0 ) {
+            if (i == 0)
                   barUnit = barUnits[i] - unit1;
-                  }
 
-            if( currentSumUnit + barUnit < sumUnit/2 ) {
+            if (currentSumUnit + barUnit < sumUnit / 2)
                   currentSumUnit += barUnit;
-                  }
-            else {
+            else
                   break;
-                  }
             }
 
-      if( i < barUnits.size() ) {
+      if (i < barUnits.size()) {
             int barMiddleIndex = bar1Index + i;
-            middleMeasure = ove->getMeasure(barMiddleIndex);
-            middleUnit = sumUnit/2 - currentSumUnit;
+            middleMeasure = ove->measure(barMiddleIndex);
+            middleUnit = sumUnit / 2 - currentSumUnit;
 
             return true;
             }
@@ -7804,75 +6409,78 @@ bool getMiddleUnit(
       return false;
       }
 
-void OveOrganizer::organizeWedge(Wedge* wedge, int part, int track, Measure* measure, MeasureData* measureData) {
-      int bar1Index = measure->getBarNumber()->getIndex();
-      int bar2Index = bar1Index + wedge->stop()->getMeasure();
-      MeasureData* measureData2 = ove_->getMeasureData(part, track, bar2Index);
-      WedgeType wedgeType = wedge->getWedgeType();
+//---------------------------------------------------------
+//   OveOrganizer::organizeWedge
+//---------------------------------------------------------
 
-      if( wedge->getWedgeType() == WedgeType::Double_Line ) {
-            wedgeType = WedgeType::Cres_Line;
-            }
+void OveOrganizer::organizeWedge(Wedge* wedge, int part, int track,
+   Measure* measure, MeasureData* measureData)
+      {
+      int bar1Index = measure->barNumber()->index();
+      int bar2Index = bar1Index + wedge->stop()->measure();
+      MeasureData* measureData2 = _ove->measureData(part, track, bar2Index);
+      WedgeType wedgeType = wedge->wedgeType();
+
+      if (wedge->wedgeType() == WedgeType::Double_Line)
+            wedgeType = WedgeType::Crescendo_Line;
 
       wedge->start()->setMeasure(bar1Index);
 
       WedgeEndPoint* startPoint = new WedgeEndPoint();
       measureData->addMusicData(startPoint);
 
-      startPoint->setTick(wedge->getTick());
-      startPoint->start()->setOffset(wedge->start()->getOffset());
+      startPoint->setTick(wedge->tick());
+      startPoint->start()->setOffset(wedge->start()->offset());
       startPoint->setWedgeStart(true);
       startPoint->setWedgeType(wedgeType);
-      startPoint->setHeight(wedge->getHeight());
+      startPoint->setHeight(wedge->height());
 
       WedgeEndPoint* stopPoint = new WedgeEndPoint();
 
-      stopPoint->setTick(wedge->getTick());
-      stopPoint->start()->setOffset(wedge->stop()->getOffset());
+      stopPoint->setTick(wedge->tick());
+      stopPoint->start()->setOffset(wedge->stop()->offset());
       stopPoint->setWedgeStart(false);
       stopPoint->setWedgeType(wedgeType);
-      stopPoint->setHeight(wedge->getHeight());
+      stopPoint->setHeight(wedge->height());
 
-      if(measureData2 != 0) {
+      if (measureData2)
             measureData2->addMusicData(stopPoint);
-            }
 
-      if( wedge->getWedgeType() == WedgeType::Double_Line ) {
-            Measure* middleMeasure = NULL;
-            int middleUnit = 0;
+      if (wedge->wedgeType() == WedgeType::Double_Line) {
+            Measure* middleMeasure = nullptr;
+            int _middleUnit = 0;
 
-            getMiddleUnit(
-                              ove_, part, track,
-                              measure, ove_->getMeasure(bar2Index),
-                              wedge->start()->getOffset(), wedge->stop()->getOffset(),
-                              middleMeasure, middleUnit);
+            getMiddleUnit(_ove, part, track, measure,
+               _ove->measure(bar2Index), wedge->start()->offset(), wedge->stop()->offset(), middleMeasure, _middleUnit);
 
-            if( middleUnit != 0 ) {
+            if (_middleUnit != 0) {
                   WedgeEndPoint* midStopPoint = new WedgeEndPoint();
                   measureData->addMusicData(midStopPoint);
 
-                  midStopPoint->setTick(wedge->getTick());
-                  midStopPoint->start()->setOffset(middleUnit);
+                  midStopPoint->setTick(wedge->tick());
+                  midStopPoint->start()->setOffset(_middleUnit);
                   midStopPoint->setWedgeStart(false);
-                  midStopPoint->setWedgeType(WedgeType::Cres_Line);
-                  midStopPoint->setHeight(wedge->getHeight());
+                  midStopPoint->setWedgeType(WedgeType::Crescendo_Line);
+                  midStopPoint->setHeight(wedge->height());
 
                   WedgeEndPoint* midStartPoint = new WedgeEndPoint();
                   measureData->addMusicData(midStartPoint);
 
-                  midStartPoint->setTick(wedge->getTick());
-                  midStartPoint->start()->setOffset(middleUnit);
+                  midStartPoint->setTick(wedge->tick());
+                  midStartPoint->start()->setOffset(_middleUnit);
                   midStartPoint->setWedgeStart(true);
-                  midStartPoint->setWedgeType(WedgeType::Decresc_Line);
-                  midStartPoint->setHeight(wedge->getHeight());
+                  midStartPoint->setWedgeType(WedgeType::Decrescendo_Line);
+                  midStartPoint->setHeight(wedge->height());
                   }
             }
       }
 
+//---------------------------------------------------------
+//   ChunkType
+//---------------------------------------------------------
 
-// OveSerialize.cpp
 enum class ChunkType : char {
-      OVSC = 00 ,
+      OVSC = 00,
       TRKL,
       TRAK,
       PAGL,
@@ -7899,104 +6507,107 @@ enum class ChunkType : char {
       NONE
       };
 
-ChunkType nameToChunkType(const NameBlock& name) {
+//---------------------------------------------------------
+//   nameToChunkType
+//---------------------------------------------------------
+
+static ChunkType nameToChunkType(const NameBlock& name)
+      {
       ChunkType type = ChunkType::NONE;
 
-      if (name.isEqual("OVSC")) {
+      if (name.isEqual("OVSC"))
             type = ChunkType::OVSC;
-            } else if (name.isEqual("TRKL")) {
+      else if (name.isEqual("TRKL"))
             type = ChunkType::TRKL;
-            } else if (name.isEqual("TRAK")) {
+      else if (name.isEqual("TRAK"))
             type = ChunkType::TRAK;
-            } else if (name.isEqual("PAGL")) {
+      else if (name.isEqual("PAGL"))
             type = ChunkType::PAGL;
-            } else if (name.isEqual("PAGE")) {
+      else if (name.isEqual("PAGE"))
             type = ChunkType::PAGE;
-            } else if (name.isEqual("LINL")) {
+      else if (name.isEqual("LINL"))
             type = ChunkType::LINL;
-            } else if (name.isEqual("LINE")) {
+      else if (name.isEqual("LINE"))
             type = ChunkType::LINE;
-            } else if (name.isEqual("STAF")) {
+      else if (name.isEqual("STAF"))
             type = ChunkType::STAF;
-            } else if (name.isEqual("BARL")) {
+      else if (name.isEqual("BARL"))
             type = ChunkType::BARL;
-            } else if (name.isEqual("MEAS")) {
+      else if (name.isEqual("MEAS"))
             type = ChunkType::MEAS;
-            } else if (name.isEqual("COND")) {
+      else if (name.isEqual("COND"))
             type = ChunkType::COND;
-            } else if (name.isEqual("BDAT")) {
+      else if (name.isEqual("BDAT"))
             type = ChunkType::BDAT;
-            } else if (name.isEqual("PACH")) {
+      else if (name.isEqual("PACH"))
             type = ChunkType::PACH;
-            } else if (name.isEqual("FNTS")) {
+      else if (name.isEqual("FNTS"))
             type = ChunkType::FNTS;
-            } else if (name.isEqual("ODEV")) {
+      else if (name.isEqual("ODEV"))
             type = ChunkType::ODEV;
-            } else if (name.isEqual("TITL")) {
+      else if (name.isEqual("TITL"))
             type = ChunkType::TITL;
-            } else if (name.isEqual("ALOT")) {
+      else if (name.isEqual("ALOT"))
             type = ChunkType::ALOT;
-            } else if (name.isEqual("ENGR")) {
+      else if (name.isEqual("ENGR"))
             type = ChunkType::ENGR;
-            } else if (name.isEqual("FMAP")) {
+      else if (name.isEqual("FMAP"))
             type = ChunkType::FMAP;
-            } else if (name.isEqual("PCPR")) {
+      else if (name.isEqual("PCPR"))
             type = ChunkType::PCPR;
-            } else if (name.isEqual("LYRC")) {
+      else if (name.isEqual("LYRC"))
             type = ChunkType::LYRC;
-            }
 
       return type;
       }
 
-int chunkTypeToMaxTimes(ChunkType type) {
+//---------------------------------------------------------
+//   chunkTypeToMaxTimes
+//---------------------------------------------------------
+
+static int chunkTypeToMaxTimes(ChunkType type)
+      {
       int maxTimes = -1; // no limit
 
       switch (type) {
-            case ChunkType::OVSC: {
+            case ChunkType::OVSC:
                   maxTimes = 1;
                   break;
-                  }
-            case ChunkType::TRKL: {// case ChunkType::TRAK :
+            case ChunkType::TRKL:
+            // case ChunkType::TRAK:
                   maxTimes = 1;
                   break;
-                  }
-            case ChunkType::PAGL: {// case ChunkType::PAGE :
+            case ChunkType::PAGL:
+            // case ChunkType::PAGE:
                   maxTimes = 1;
                   break;
-                  }
-                  // case ChunkType::LINE :
-                  // case ChunkType::STAF :
-            case ChunkType::LINL: {
+            // case ChunkType::LINE:
+            // case ChunkType::STAF:
+            case ChunkType::LINL:
                   maxTimes = 1;
                   break;
-                  }
-                  // case ChunkType::MEAS :
-                  // case ChunkType::COND :
-                  // case ChunkType::BDAT :
-            case ChunkType::BARL: {
+            // case ChunkType::MEAS:
+            // case ChunkType::COND:
+            // case ChunkType::BDAT:
+            case ChunkType::BARL:
                   maxTimes = 1;
                   break;
-                  }
             case ChunkType::PACH:
             case ChunkType::FNTS:
             case ChunkType::ODEV:
             case ChunkType::ALOT:
             case ChunkType::ENGR:
             case ChunkType::FMAP:
-            case ChunkType::PCPR: {
+            case ChunkType::PCPR:
                   maxTimes = 1;
                   break;
-                  }
-            case ChunkType::TITL: {
+            case ChunkType::TITL:
                   maxTimes = 8;
                   break;
-                  }
-            case ChunkType::LYRC: {
+            case ChunkType::LYRC:
                   maxTimes = 1;
                   break;
-                  }
-                  // case ChunkType::NONE :
+            // case ChunkType::NONE:
             default:
                   break;
             }
@@ -8004,61 +6615,67 @@ int chunkTypeToMaxTimes(ChunkType type) {
       return maxTimes;
       }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+//---------------------------------------------------------
+//   OveSerialize
+//---------------------------------------------------------
 
-OveSerialize::OveSerialize() :
-      ove_(0),
-      streamHandle_(0),
-      notify_(0) {
+OveSerialize::OveSerialize()
+      {
+      _ove          = nullptr;
+      _streamHandle = nullptr;
+      _notify       = nullptr;
       }
 
-OveSerialize::~OveSerialize() {
-      if(streamHandle_ != 0) {
-            delete streamHandle_;
-            streamHandle_ = 0;
+OveSerialize::~OveSerialize()
+      {
+      _ove = nullptr;
+      if (_streamHandle) {
+            delete _streamHandle;
+            _streamHandle = nullptr;
             }
+      _notify = nullptr;
       }
 
-void OveSerialize::setOve(OveSong* ove) {
-      ove_ = ove;
+//---------------------------------------------------------
+//   OveSerialize::messageOutError
+//---------------------------------------------------------
+
+void OveSerialize::messageOutError()
+      {
+      if (_notify)
+            _notify->loadError();
       }
 
-void OveSerialize::setFileStream(unsigned char* buffer, unsigned int size) {
-      streamHandle_ = new StreamHandle(buffer, size);
+//---------------------------------------------------------
+//   OveSerialize::messageOut
+//---------------------------------------------------------
+
+void OveSerialize::messageOut(const QString& str)
+      {
+      if (_notify)
+            _notify->loadInfo(str);
       }
 
-void OveSerialize::setNotify(IOveNotify* notify) {
-      notify_ = notify;
-      }
+//---------------------------------------------------------
+//   OveSerialize::load
+//---------------------------------------------------------
 
-void OveSerialize::messageOutError() {
-      if (notify_ != NULL) {
-            notify_->loadError();
-            }
-      }
-
-void OveSerialize::messageOut(const QString& str) {
-      if (notify_ != NULL) {
-            notify_->loadInfo(str);
-            }
-      }
-
-bool OveSerialize::load(void) {
-      if(streamHandle_ == 0)
+bool OveSerialize::load()
+      {
+      if (!_streamHandle)
             return false;
 
-      if( !readHeader() ) {
+      if (!readHeader()) {
             messageOutError();
             return false;
             }
 
-      unsigned int i;
+      unsigned i;
       QMap<ChunkType, int> chunkTimes;
       //bool firstEnter = true;
 
-      for( i=(int)ChunkType::OVSC; i<(int)ChunkType::NONE; ++i ) {
-            chunkTimes[(ChunkType)i] = 0;
-            }
+      for (i = int(ChunkType::OVSC); i < int(ChunkType::NONE); ++i)
+            chunkTimes[ChunkType(i)] = 0;
 
       ChunkType chunkType = ChunkType::NONE;
 
@@ -8066,70 +6683,59 @@ bool OveSerialize::load(void) {
             NameBlock nameBlock;
             SizeChunk sizeChunk;
 
-            if( !readNameBlock(nameBlock) ) { return false; }
+            if (!readNameBlock(nameBlock)) { return false; }
 
             chunkType = nameToChunkType(nameBlock);
             ++chunkTimes[chunkType];
             int maxTime = chunkTypeToMaxTimes(chunkType);
 
-            if( maxTime > 0 && chunkTimes[chunkType] > maxTime ) {
+            if (maxTime > 0 && chunkTimes[chunkType] > maxTime) {
                   messageOut("format not support, chunk appear more than accept.\n");
                   return false;
                   }
 
             switch (chunkType) {
-                  /*case ChunkType::OVSC :
-       {
-       if( !readHeadData(&sizeChunk) )
-       {
-       messageOut_error();
-       return false;
-       }
-
-       break;
-       }*/
-                  case ChunkType::TRKL: {
-                        if (!readTracksData()) {
+#if 0
+                  case ChunkType::OVSC:
+                        if (!readHeadData(&sizeChunk)) {
                               messageOutError();
                               return false;
                               }
-
                         break;
-                        }
-                  case ChunkType::PAGL: {
-                        if (!readPagesData()) {
+#endif
+                  case ChunkType::TRKL:
+                        if (!readTrackData()) {
                               messageOutError();
                               return false;
                               }
-
                         break;
-                        }
-                  case ChunkType::LINL: {
-                        if (!readLinesData()) {
+                  case ChunkType::PAGL:
+                        if (!readPageData()) {
                               messageOutError();
                               return false;
                               }
-
                         break;
-                        }
-                  case ChunkType::BARL: {
-                        if (!readBarsData()) {
+                  case ChunkType::LINL:
+                        if (!readLineData()) {
                               messageOutError();
                               return false;
                               }
-
                         break;
-                        }
+                  case ChunkType::BARL:
+                        if (!readBarData()) {
+                              messageOutError();
+                              return false;
+                              }
+                        break;
                   case ChunkType::TRAK:
                   case ChunkType::PAGE:
                   case ChunkType::LINE:
                   case ChunkType::STAF:
                   case ChunkType::MEAS:
                   case ChunkType::COND:
-                  case ChunkType::BDAT: {
+                  case ChunkType::BDAT:
                         return false;
                         break;
-                        }
                   case ChunkType::LYRC: {
                         SizeChunk lyricChunk;
                         if (!readSizeChunk(&lyricChunk)) {
@@ -8137,7 +6743,7 @@ bool OveSerialize::load(void) {
                               return false;
                               }
 
-                        LyricChunkParse parse(ove_);
+                        LyricChunkParse parse(_ove);
 
                         parse.setLyricChunk(&lyricChunk);
                         parse.parse();
@@ -8151,7 +6757,7 @@ bool OveSerialize::load(void) {
                               return false;
                               }
 
-                        TitleChunkParse titleChunkParse(ove_);
+                        TitleChunkParse titleChunkParse(_ove);
 
                         titleChunkParse.setTitleChunk(&titleChunk);
                         titleChunkParse.parse();
@@ -8164,60 +6770,67 @@ bool OveSerialize::load(void) {
                   case ChunkType::ALOT:
                   case ChunkType::ENGR:
                   case ChunkType::FMAP:
-                  case ChunkType::PCPR: {
+                  case ChunkType::PCPR:
                         if (!readSizeChunk(&sizeChunk)) {
                               messageOutError();
                               return false;
                               }
-
                         break;
-                        }
                   default:
-                        /*if( firstEnter )
-          {
-          QString info = "Not compatible file, try to load and save with newer version, Overture 4 is recommended.\n";
-          messageOut(info);
-          messageOutError();
+#if 0
+                        if (firstEnter) {
+                              QString info = "Not compatible file, try to load and save with newer version, Overture 4 is recommended.\n";
+                              messageOut(info);
+                              messageOutError();
 
-          return false;
-          }*/
-
+                              return false;
+                              }
+#endif
                         break;
                   }
 
-            //firstEnter = false;
+            // firstEnter = false;
             }
-      while ( chunkType != ChunkType::NONE );
 
-      // if( !readOveEnd() ) { return false; }
+      while (chunkType != ChunkType::NONE); // ?
+
+      // if (!readOveEnd()) { return false; }
 
       // organize OveData
-      OVE::OveOrganizer organizer(ove_);
+      Ove::OveOrganizer organizer(_ove);
       organizer.organize();
 
       return true;
       }
 
-void OveSerialize::release() {
+//---------------------------------------------------------
+//   OveSerialize::release
+//---------------------------------------------------------
+
+void OveSerialize::release()
+      {
       delete this;
       }
 
-bool OveSerialize::readHeader() {
+//---------------------------------------------------------
+//   OveSerialize::readHeader
+//---------------------------------------------------------
+
+bool OveSerialize::readHeader()
+      {
       ChunkType chunkType = ChunkType::NONE;
       NameBlock nameBlock;
       SizeChunk sizeChunk;
 
-      if (!readNameBlock(nameBlock)) {
+      if (!readNameBlock(nameBlock))
             return false;
-            }
 
       chunkType = nameToChunkType(nameBlock);
-      //int maxTime = chunkTypeToMaxTimes(chunkType);
+      // int maxTime = chunkTypeToMaxTimes(chunkType);
 
       if (chunkType == ChunkType::OVSC) {
-            if (readHeadData(&sizeChunk)) {
+            if (readHeadData(&sizeChunk))
                   return true;
-                  }
             }
 
       QString info = "Not compatible file, try to load and save with newer version, Overture 4 is recommended.\n";
@@ -8226,45 +6839,52 @@ bool OveSerialize::readHeader() {
       return false;
       }
 
-bool OveSerialize::readHeadData(SizeChunk* ovscChunk) {
+//---------------------------------------------------------
+//   OveSerialize::readHeadData
+//---------------------------------------------------------
+
+bool OveSerialize::readHeadData(SizeChunk* ovscChunk)
+      {
       if (!readSizeChunk(ovscChunk))
             return false;
 
-      OvscParse ovscParse(ove_);
+      OvscParse ovscParse(_ove);
 
-      ovscParse.setNotify(notify_);
+      ovscParse.setNotify(_notify);
       ovscParse.setOvsc(ovscChunk);
 
       return ovscParse.parse();
       }
 
-bool OveSerialize::readTracksData() {
+//---------------------------------------------------------
+//   OveSerialize::readTrackData
+//---------------------------------------------------------
+
+bool OveSerialize::readTrackData()
+      {
       GroupChunk trackGroupChunk;
 
       if (!readGroupChunk(&trackGroupChunk))
             return false;
 
-      unsigned int i;
-      unsigned short trackCount = trackGroupChunk.getCountBlock()->toCount();
+      unsigned i;
+      unsigned short trackCount = trackGroupChunk.countBlock()->toCount();
 
       for (i = 0; i < trackCount; ++i) {
             SizeChunk* trackChunk = new SizeChunk();
 
-            if (ove_->getIsVersion4()) {
-                  if (!readChunkName(trackChunk, Chunk::TrackName)) {
+            if (_ove->isVersion4()) {
+                  if (!readChunkName(trackChunk, Chunk::TrackName))
                         return false;
-                        }
-                  if (!readSizeChunk(trackChunk)) {
+                  if (!readSizeChunk(trackChunk))
                         return false;
-                        }
-                  } else {
-                  if (!readDataChunk(trackChunk->getDataBlock(),
-                                     SizeChunk::version3TrackSize)) {
+                  } 
+            else {
+                  if (!readDataChunk(trackChunk->dataBlock(), SizeChunk::version3TrackSize))
                         return false;
-                        }
                   }
 
-            TrackParse trackParse(ove_);
+            TrackParse trackParse(_ove);
 
             trackParse.setTrack(trackChunk);
             trackParse.parse();
@@ -8273,119 +6893,122 @@ bool OveSerialize::readTracksData() {
       return true;
       }
 
-bool OveSerialize::readPagesData() {
+//---------------------------------------------------------
+//   OveSerialize::readPageData
+//---------------------------------------------------------
+
+bool OveSerialize::readPageData()
+      {
       GroupChunk pageGroupChunk;
 
       if (!readGroupChunk(&pageGroupChunk))
             return false;
 
-      unsigned short pageCount = pageGroupChunk.getCountBlock()->toCount();
-      unsigned int i;
-      PageGroupParse parse(ove_);
+      unsigned short pageCount = pageGroupChunk.countBlock()->toCount();
+      unsigned i;
+      PageGroupParse parse(_ove);
 
       for (i = 0; i < pageCount; ++i) {
             SizeChunk* pageChunk = new SizeChunk();
 
-            if (!readChunkName(pageChunk, Chunk::PageName)) {
+            if (!readChunkName(pageChunk, Chunk::PageName))
                   return false;
-                  }
-            if (!readSizeChunk(pageChunk)) {
+            if (!readSizeChunk(pageChunk))
                   return false;
-                  }
 
             parse.addPage(pageChunk);
             }
 
-      if (!parse.parse()) {
+      if (!parse.parse())
             return false;
-            }
 
       return true;
       }
 
-bool OveSerialize::readLinesData() {
+//---------------------------------------------------------
+//   OveSerialize::readLineData
+//---------------------------------------------------------
+
+bool OveSerialize::readLineData()
+      {
       GroupChunk lineGroupChunk;
       if (!readGroupChunk(&lineGroupChunk))
             return false;
 
-      unsigned short lineCount = lineGroupChunk.getCountBlock()->toCount();
+      unsigned short lineCount = lineGroupChunk.countBlock()->toCount();
       int i;
-      unsigned int j;
+      unsigned j;
       QList<SizeChunk*> lineChunks;
       QList<SizeChunk*> staffChunks;
 
       for (i = 0; i < lineCount; ++i) {
             SizeChunk* lineChunk = new SizeChunk();
 
-            if (!readChunkName(lineChunk, Chunk::LineName)) {
+            if (!readChunkName(lineChunk, Chunk::LineName))
                   return false;
-                  }
-            if (!readSizeChunk(lineChunk)) {
+            if (!readSizeChunk(lineChunk))
                   return false;
-                  }
 
             lineChunks.push_back(lineChunk);
 
-            StaffCountGetter getter(ove_);
-            unsigned int staffCount = getter.getStaffCount(lineChunk);
+            StaffCountGetter getter(_ove);
+            unsigned staffCount = getter.staffCount(lineChunk);
 
             for (j = 0; j < staffCount; ++j) {
                   SizeChunk* staffChunk = new SizeChunk();
 
-                  if (!readChunkName(staffChunk, Chunk::StaffName)) {
+                  if (!readChunkName(staffChunk, Chunk::StaffName))
                         return false;
-                        }
-                  if (!readSizeChunk(staffChunk)) {
+                  if (!readSizeChunk(staffChunk))
                         return false;
-                        }
 
                   staffChunks.push_back(staffChunk);
                   }
             }
 
-      LineGroupParse parse(ove_);
+      LineGroupParse parse(_ove);
 
       parse.setLineGroup(&lineGroupChunk);
 
-      for (i = 0; i < lineChunks.size(); ++i) {
+      for (i = 0; i < lineChunks.size(); ++i)
             parse.addLine(lineChunks[i]);
-            }
 
-      for (i = 0; i < staffChunks.size(); ++i) {
+      for (i = 0; i < staffChunks.size(); ++i)
             parse.addStaff(staffChunks[i]);
-            }
 
-      if (!parse.parse()) {
+      if (!parse.parse())
             return false;
-            }
 
       return true;
       }
 
-bool OveSerialize::readBarsData() {
+//---------------------------------------------------------
+//   OveSerialize::readBarData
+//---------------------------------------------------------
+
+bool OveSerialize::readBarData()
+      {
       GroupChunk barGroupChunk;
       if (!readGroupChunk(&barGroupChunk))
             return false;
 
-      unsigned short measCount = barGroupChunk.getCountBlock()->toCount();
+      unsigned short measCount = barGroupChunk.countBlock()->toCount();
       int i;
 
       QList<SizeChunk*> measureChunks;
       QList<SizeChunk*> conductChunks;
       QList<SizeChunk*> bdatChunks;
 
-      ove_->setTrackBarCount(measCount);
+      _ove->setTrackBarCount(measCount);
 
       // read chunks
       for (i = 0; i < measCount; ++i) {
             SizeChunk* measureChunkPtr = new SizeChunk();
 
-            if (!readChunkName(measureChunkPtr, Chunk::MeasureName)) {
+            if (!readChunkName(measureChunkPtr, Chunk::MeasureName))
                   return false;
-                  }
-            if (!readSizeChunk(measureChunkPtr)) {
+            if (!readSizeChunk(measureChunkPtr))
                   return false;
-                  }
 
             measureChunks.push_back(measureChunkPtr);
             }
@@ -8402,36 +7025,31 @@ bool OveSerialize::readBarsData() {
             conductChunks.push_back(conductChunkPtr);
             }
 
-      int bdatCount = ove_->getTrackCount() * measCount;
+      int bdatCount = _ove->trackCount() * measCount;
       for (i = 0; i < bdatCount; ++i) {
             SizeChunk* batChunkPtr = new SizeChunk();
 
-            if (!readChunkName(batChunkPtr, Chunk::BdatName)) {
+            if (!readChunkName(batChunkPtr, Chunk::BdatName))
                   return false;
-                  }
-            if (!readSizeChunk(batChunkPtr)) {
+            if (!readSizeChunk(batChunkPtr))
                   return false;
-                  }
 
             bdatChunks.push_back(batChunkPtr);
             }
 
       // parse bars
-      BarsParse barsParse(ove_);
+      BarsParse barsParse(_ove);
 
-      for (i = 0; i < measureChunks.size(); ++i) {
+      for (i = 0; i < measureChunks.size(); ++i)
             barsParse.addMeasure(measureChunks[i]);
-            }
 
-      for (i = 0; i < conductChunks.size(); ++i) {
+      for (i = 0; i < conductChunks.size(); ++i)
             barsParse.addConduct(conductChunks[i]);
-            }
 
-      for (i = 0; i < bdatChunks.size(); ++i) {
+      for (i = 0; i < bdatChunks.size(); ++i)
             barsParse.addBdat(bdatChunks[i]);
-            }
 
-      barsParse.setNotify(notify_);
+      barsParse.setNotify(_notify);
       if (!barsParse.parse()) {
             return false;
             }
@@ -8439,21 +7057,26 @@ bool OveSerialize::readBarsData() {
       return true;
       }
 
-bool OveSerialize::readOveEnd() {
-      if (streamHandle_ == 0)
+//---------------------------------------------------------
+//   OveSerialize::readOveEnd
+//---------------------------------------------------------
+
+bool OveSerialize::readOveEnd()
+      {
+      if (!_streamHandle)
             return false;
 
-      const unsigned int END_OVE1 = 0xffffffff;
-      const unsigned int END_OVE2 = 0x00000000;
-      unsigned int buffer;
+      const unsigned END_OVE1 = 0xffffffff;
+      const unsigned END_OVE2 = 0x00000000;
+      unsigned buffer;
 
-      if (!streamHandle_->read((char*) &buffer, sizeof(unsigned int)))
+      if (!_streamHandle->read((char*) &buffer, sizeof(unsigned)))
             return false;
 
       if (buffer != END_OVE1)
             return false;
 
-      if (!streamHandle_->read((char*) &buffer, sizeof(unsigned int)))
+      if (!_streamHandle->read((char*) &buffer, sizeof(unsigned)))
             return false;
 
       if (buffer != END_OVE2)
@@ -8462,24 +7085,33 @@ bool OveSerialize::readOveEnd() {
       return true;
       }
 
-/////////////////////////////////////////////////////////////////////////////////////////
-bool OveSerialize::readNameBlock(NameBlock& nameBlock) {
-      if (streamHandle_ == 0)
+//---------------------------------------------------------
+//   OveSerialize::readNameBlock
+//---------------------------------------------------------
+
+bool OveSerialize::readNameBlock(NameBlock& nameBlock)
+      {
+      if (!_streamHandle)
             return false;
 
-      if (!streamHandle_->read((char*) nameBlock.data(), nameBlock.size()))
+      if (!_streamHandle->read((char*) nameBlock.data(), nameBlock.size()))
             return false;
 
       return true;
       }
 
-bool OveSerialize::readChunkName(Chunk* /*chunk*/, const QString& name) {
-      if (streamHandle_ == 0)
+//---------------------------------------------------------
+//   OveSerialize::readChunkName
+//---------------------------------------------------------
+
+bool OveSerialize::readChunkName(Chunk* /*chunk*/, const QString& name)
+      {
+      if (!_streamHandle)
             return false;
 
       NameBlock nameBlock;
 
-      if (!streamHandle_->read((char*) nameBlock.data(), nameBlock.size()))
+      if (!_streamHandle->read((char*) nameBlock.data(), nameBlock.size()))
             return false;
 
       if (!(nameBlock.toStrByteArray() == name))
@@ -8488,52 +7120,72 @@ bool OveSerialize::readChunkName(Chunk* /*chunk*/, const QString& name) {
       return true;
       }
 
-bool OveSerialize::readSizeChunk(SizeChunk* sizeChunk) {
-      if (streamHandle_ == 0)
+//---------------------------------------------------------
+//   OveSerialize::readSizeChunk
+//---------------------------------------------------------
+
+bool OveSerialize::readSizeChunk(SizeChunk* sizeChunk)
+      {
+      if (!_streamHandle)
             return false;
 
-      SizeBlock* sizeBlock = sizeChunk->getSizeBlock();
+      SizeBlock* sizeBlock = sizeChunk->sizeBlock();
 
-      if (!streamHandle_->read((char*) sizeBlock->data(), sizeBlock->size()))
+      if (!_streamHandle->read((char*) sizeBlock->data(), sizeBlock->size()))
             return false;
 
-      unsigned int blockSize = sizeBlock->toSize();
+      unsigned blockSize = sizeBlock->toSize();
 
-      sizeChunk->getDataBlock()->resize(blockSize);
+      sizeChunk->dataBlock()->resize(blockSize);
 
-      Block* dataBlock = sizeChunk->getDataBlock();
+      Block* dataBlock = sizeChunk->dataBlock();
 
-      if (!streamHandle_->read((char*) dataBlock->data(), blockSize))
+      if (!_streamHandle->read((char*) dataBlock->data(), blockSize))
             return false;
 
       return true;
       }
 
-bool OveSerialize::readDataChunk(Block* block, unsigned int size) {
-      if (streamHandle_ == 0)
+//---------------------------------------------------------
+//   OveSerialize::readDataChunk
+//---------------------------------------------------------
+
+bool OveSerialize::readDataChunk(Block* block, unsigned size)
+      {
+      if (!_streamHandle)
             return false;
 
       block->resize(size);
 
-      if (!streamHandle_->read((char*) block->data(), size))
+      if (!_streamHandle->read((char*) block->data(), size))
             return false;
 
       return true;
       }
 
-bool OveSerialize::readGroupChunk(GroupChunk* groupChunk) {
-      if (streamHandle_ == 0)
+//---------------------------------------------------------
+//   OveSerialize::readGroupChunk
+//---------------------------------------------------------
+
+bool OveSerialize::readGroupChunk(GroupChunk* groupChunk)
+      {
+      if (!_streamHandle)
             return false;
 
-      CountBlock* countBlock = groupChunk->getCountBlock();
+      CountBlock* countBlock = groupChunk->countBlock();
 
-      if (!streamHandle_->read((char*) countBlock->data(), countBlock->size()))
+      if (!_streamHandle->read((char*) countBlock->data(), countBlock->size()))
             return false;
 
       return true;
       }
 
-IOVEStreamLoader* createOveStreamLoader() {
+//---------------------------------------------------------
+//   createOveStreamLoader
+//---------------------------------------------------------
+
+IOVEStreamLoader* createOveStreamLoader()
+      {
       return new OveSerialize;
       }
 

--- a/mscore/ove.h
+++ b/mscore/ove.h
@@ -26,7 +26,7 @@
 #define DLL_EXPORT
 #endif
 
-namespace OVE {
+namespace Ove {
 
 class OveSong;
 class Track;
@@ -54,12 +54,12 @@ class Articulation;
 class Glissando;
 class Decorator;
 class MeasureRepeat;
-class Dynamics;
+class Dynamic;
 class Wedge;
 class WedgeEndPoint;
 class Pedal;
-class KuoHao;
-class Expressions;
+class Bracket;
+class Expression;
 class HarpPedal;
 class MultiMeasureRest;
 class OctaveShift;
@@ -77,13 +77,17 @@ class MidiProgramChange;
 class MidiChannelPressure;
 class MidiPitchWheel;
 
-const int TWELVE_TONE = 12 ;
-const int INVALID_NOTE = -1 ;
-const int OCTAVE = 7 ;
+const int TWELVE_TONE = 12;
+const int INVALID_NOTE = -1;
+const int OCTAVE = 7;
+
+//---------------------------------------------------------
+//   enum classes
+//---------------------------------------------------------
 
 enum class CondType : char {
       None,
-      Time_Parameters    = 0x09, // size - 7, TimeSignature
+      _timeParameters    = 0x09, // size - 7, TimeSignature
       Bar_Number         = 0x0A, // size, compatible with previous version
       Decorator          = 0x16,
       Tempo              = 0x1C, // size - 7
@@ -102,7 +106,7 @@ enum class BdatType : unsigned char {
       Beam                  = 0x10,
       Harmony               = 0x11,
       Clef                  = 0x12,
-      Dynamics              = 0x13,
+      Dynamic               = 0x13,
       Wedge                 = 0x14, // cresendo, decresendo
       Glissando             = 0x15,
       Decorator             = 0x16, // measure repeat | piano pedal | dotted barline
@@ -116,8 +120,8 @@ enum class BdatType : unsigned char {
       Guitar_Bend           = 0x21, //
       Guitar_Barre          = 0x22, //
       Pedal                 = 0x23,
-      KuoHao                = 0x24, // () [] {}
-      Expressions           = 0x25,
+      Bracket               = 0x24, // () [] {}
+      Expression            = 0x25,
       Harp_Pedal            = 0x26,
       Multi_Measure_Rest    = 0x27,
       Harmony_GuitarFrame   = 0x28,
@@ -135,8 +139,6 @@ enum class BdatType : unsigned char {
       Bar_End               = 0xFF,
       };
 
-////////////////////////////////////////
-
 enum class MusicDataType : char {
       None,
 
@@ -149,12 +151,12 @@ enum class MusicDataType : char {
       Tempo,
 
       // direction
-      Dynamics,
+      Dynamic,
       Wedge,
       Wedge_EndPoint,
       OctaveShift,
       OctaveShift_EndPoint,
-      Expressions,
+      Expression,
       Repeat,
       Text,
       Harp_Pedal,
@@ -175,7 +177,7 @@ enum class MusicDataType : char {
       // barline
       Numeric_Ending,
 
-      KuoHao,
+      Bracket,
       Bar_End,
       Decorator,
       Multi_Measure_Rest,
@@ -208,8 +210,8 @@ enum class ClefType : char {
 
 enum class GroupType : char {
       None = 0,
-      Brace,
-      Bracket
+      Braces,
+      Brackets
       };
 
 enum class AccidentalType : char {
@@ -330,14 +332,14 @@ enum class ArticulationType : char {
 
       None
 
-      /*	Detached_Legato,
+      /* Detached_Legato,
       Spiccato,
       Scoop,
       Plop,
       Doit,
       Falloff,
       Breath_Mark,
-      Caesura,*/
+      Caesura */
       };
 
 enum class NoteType : char {
@@ -355,12 +357,13 @@ enum class NoteType : char {
       Note_None
       };
 
-inline int NoteTypeToTick(NoteType type, int quarter) {
-      int c = int(pow(2.0, int(type))) ;
-      return quarter * 4 * 2 / c ;
+inline int noteTypeToTick(NoteType type, int quarter)
+      {
+      int c = int(pow(2.0, int(type)));
+      return quarter * 4 * 2 / c;
       }
 
-enum class DynamicsType : char {
+enum class DynamicType : char {
       PPPP = 0,
       PPP,
       PP,
@@ -380,17 +383,24 @@ enum class DynamicsType : char {
       };
 
 enum class WedgeType : char {
-      Cres_Line = 0, // <
-      Double_Line,   // <>, not appear in xml
-      Decresc_Line,  // >
-      Cres,          // cresc., not appear in xml, will create Expression
-      Decresc        // decresc., not appear in xml, will create Expression
+      Crescendo_Line = 0, // <
+      Double_Line,        // <>, not appear in xml
+      Decrescendo_Line,   // >
+      Crescendo,          // cresc., not appear in xml, will create Expression
+      Decrescendo         // decresc., not appear in xml, will create Expression
       };
 
-enum class KuoHaoType : char {
+enum class BracketType : char {
       Parentheses = 0,
-      Brace,
-      Bracket
+      Braces,
+      Brackets
+      };
+
+enum class HarpPedalType : char {
+      Graph = 0,
+      Char,
+      Char_Cut,
+      Change
       };
 
 enum class OctaveShiftType : char {
@@ -401,7 +411,7 @@ enum class OctaveShiftType : char {
       };
 
 enum class OctaveShiftPosition : char {
-      Start = 0 ,
+      Start = 0,
       Continue,
       Stop
       };
@@ -420,26 +430,26 @@ enum class RepeatType : char {
       };
 
 enum class BarLineType : char {
-      Default = 0, //0x00 will be | or final (at last measure)
-      Double,      //0x01 ||
-      RepeatLeft,  //0x02 ||:
-      RepeatRight, //0x03 :||
-      Final,       //0x04
-      Dashed,      //0x05
-      Null         //0x06
-      } ;
+      Default = 0,  // 0x00 will be | or final (at last measure)
+      Double,       // 0x01 ||
+      Repeat_Left,  // 0x02 ||:
+      Repeat_Right, // 0x03 :||
+      Final,        // 0x04
+      Dashed,       // 0x05
+      Null          // 0x06
+      };
 
 enum class NoteDuration {
-      D_256 = 15,
-      D_128 = NoteDuration::D_256 * 2,           // 30
-      D_64 = NoteDuration::D_128 * 2,            // 60
-      D_32 = NoteDuration::D_64 * 2,             // 120
-      D_16 = NoteDuration::D_32 * 2,             // 240
-      D_8 = NoteDuration::D_16 * 2,              // 480
-      D_4 = NoteDuration::D_8 * 2,               // 960
-      D_2 = NoteDuration::D_4 * 2,               // 1920
-      D_Whole = NoteDuration::D_2 * 2,           // 3840
-      D_Double_Whole = NoteDuration::D_Whole * 2 // 7680
+      D_256   = 15,
+      D_128   = D_256 * 2,         // 30
+      D_64    = D_128 * 2,         // 60
+      D_32    = D_64 * 2,          // 120
+      D_16    = D_32 * 2,          // 240
+      D_8     = D_16 * 2,          // 480
+      D_4     = D_8 * 2,           // 960
+      D_2     = D_4 * 2,           // 1920
+      D_Whole = D_2 * 2,           // 3840
+      D_Double_Whole = D_Whole * 2 // 7680
       };
 
 enum class ToneType : char {
@@ -470,26 +480,31 @@ enum class KeyType : char {
       Key_Sharp_7		// C#
       };
 
-// IOveNotify.h
+//---------------------------------------------------------
+//   IOveNotify
+//---------------------------------------------------------
+
 class IOveNotify {
-public:
+   public:
       IOveNotify() {}
       virtual ~IOveNotify() {}
 
-public:
       virtual void loadInfo(const QString& info) = 0;
       virtual void loadError() = 0;
       virtual void loadPosition(int currentMeasure, int totalMeasure, int currentTrack, int totalTrack) = 0;
       };
 
+//---------------------------------------------------------
+//   IOVEStreamLoader
+//---------------------------------------------------------
+
 class IOVEStreamLoader {
-public:
+   public:
       IOVEStreamLoader() {}
       virtual ~IOVEStreamLoader() {}
 
-public:
       virtual void setNotify(IOveNotify* notify) = 0;
-      virtual void setFileStream(unsigned char* buffer, unsigned int size) = 0;
+      virtual void setFileStream(unsigned char* buffer, unsigned size) = 0;
       virtual void setOve(OveSong* ove) = 0;
 
       // read stream, set read data to setOve(ove)
@@ -500,675 +515,722 @@ public:
 
 DLL_EXPORT IOVEStreamLoader* createOveStreamLoader();
 
-/////////////////////////////////////////////////////////////////////////////
-// basic element
+//---------------------------------------------------------
+//   TickElement
+//---------------------------------------------------------
+
 class TickElement {
-public:
+      int _tick;
+
+   public:
       TickElement();
       virtual ~TickElement() {}
 
-public:
-      void setTick(int tick);
-      int getTick(void) const;
-
-private:
-      int tick_;
+      void setTick(int tick)  { _tick = tick; }
+      int tick() const        { return _tick; }
       };
 
+//---------------------------------------------------------
+//   MeasurePos
+//---------------------------------------------------------
+
 class MeasurePos {
-public:
+      int _measure;
+      int _offset;
+
+   public:
       MeasurePos();
       virtual ~MeasurePos() {}
 
-public:
-      void setMeasure(int measure);
-      int getMeasure() const;
+      void setMeasure(int measure) { _measure = measure; }
+      int measure() const          { return _measure;    }
 
-      void setOffset(int offset);
-      int getOffset() const;
+      void setOffset(int offset)   { _offset = offset;   }
+      int offset() const           { return _offset;     }
 
       MeasurePos shiftMeasure(int measure) const;
       MeasurePos shiftOffset(int offset) const; // ignore cross measure
 
-      bool operator ==(const MeasurePos& mp) const;
-      bool operator !=(const MeasurePos& mp) const;
-      bool operator <(const MeasurePos& mp) const;
-      bool operator <=(const MeasurePos& mp) const;
-      bool operator >(const MeasurePos& mp) const;
-      bool operator >=(const MeasurePos& mp) const;
-
-private:
-      int measure_;
-      int offset_;
+      bool operator==(const MeasurePos& mp) const;
+      bool operator!=(const MeasurePos& mp) const;
+      bool operator<(const MeasurePos& mp) const;
+      bool operator<=(const MeasurePos& mp) const;
+      bool operator>(const MeasurePos& mp) const;
+      bool operator>=(const MeasurePos& mp) const;
       };
 
+//---------------------------------------------------------
+//   PairElement
+//---------------------------------------------------------
+
 class PairElement {
-public:
+      MeasurePos* _start;
+      MeasurePos* _stop;
+
+   public:
       PairElement();
       virtual ~PairElement();
 
-public:
-      MeasurePos* start() const;
-      MeasurePos* stop() const;
-
-private:
-      MeasurePos* start_;
-      MeasurePos* stop_;
+      MeasurePos* start() const { return _start; }
+      MeasurePos* stop() const  { return _stop;  }
       };
 
+//---------------------------------------------------------
+//   PairEnds
+//---------------------------------------------------------
+
 class PairEnds {
-public:
+      LineElement* _leftLine;
+      LineElement* _rightLine;
+      OffsetElement* _leftShoulder;
+      OffsetElement* _rightShoulder;
+
+   public:
       PairEnds();
       virtual ~PairEnds();
 
-public:
-      LineElement* getLeftLine() const;
-      LineElement* getRightLine() const;
+      LineElement* leftLine() const        { return _leftLine;      }
+      LineElement* rightLine() const       { return _rightLine;     }
 
-      OffsetElement* getLeftShoulder() const;
-      OffsetElement* getRightShoulder() const;
-
-private:
-      LineElement* leftLine_;
-      LineElement* rightLine_;
-      OffsetElement* leftShoulder_;
-      OffsetElement* rightShoulder_;
+      OffsetElement* leftShoulder() const  { return _leftShoulder;  }
+      OffsetElement* rightShoulder() const { return _rightShoulder; }
       };
 
+//---------------------------------------------------------
+//   LineElement
+//---------------------------------------------------------
+
 class LineElement {
-public:
+      int _line;
+
+   public:
       LineElement();
       virtual ~LineElement() {}
 
-public:
-      virtual void setLine(int line); // middle line (3rd line of each clef) is set 0
-      virtual int getLine(void) const;
-
-private:
-      int line_;
+      // middle line (3rd line of each clef) is set 0
+      virtual void setLine(int line) { _line = line; }
+      virtual int line() const       { return _line; }
       };
 
+//---------------------------------------------------------
+//   OffsetElement
+//---------------------------------------------------------
+
 class OffsetElement {
-public:
+      int _xOffset;
+      int _yOffset;
+
+   public:
       OffsetElement();
       virtual ~OffsetElement() {}
 
-public:
-      virtual void setXOffset(int offset);
-      virtual int getXOffset() const;
+      virtual void setXOffset(int offset) { _xOffset = offset; }
+      virtual int xOffset() const         { return _xOffset;   }
 
-      virtual void setYOffset(int offset);
-      virtual int getYOffset() const;
-
-private:
-      int xOffset_;
-      int yOffset_;
+      virtual void setYOffset(int offset) { _yOffset = offset; }
+      virtual int yOffset() const         { return _yOffset;   }
       };
 
+//---------------------------------------------------------
+//   LengthElement
+//---------------------------------------------------------
+
 class LengthElement {
-public:
+      int _length; // tick
+
+   public:
       LengthElement();
       virtual ~LengthElement() {}
 
-public:
-      void setLength(int length);
-      int getLength() const;
-
-private:
-      int length_; // tick
+      void setLength(int length) { _length = length; }
+      int length() const         { return _length;   }
       };
 
-// base class of many ove music element
-class MusicData: public TickElement, public PairElement, public OffsetElement {
-public:
+//---------------------------------------------------------
+//   MusicData
+//    Base class of many ove music element
+//---------------------------------------------------------
+
+class MusicData : public TickElement, public PairElement, public OffsetElement {
+      bool _show;
+      unsigned _color;
+      unsigned _voice;
+
+   protected:
+      MusicDataType _musicDataType;
+
+   public:
       MusicData();
       virtual ~MusicData() {}
-
-public:
-      MusicDataType getMusicDataType() const;
 
       enum class XmlDataType : char {
             Attributes = 0, NoteBeam, Notations, Direction, None
             };
-      static XmlDataType getXmlDataType(MusicDataType type);
-      //	static bool get_is_pair_element(MusicDataType type) ;
+      static XmlDataType xmlDataType(MusicDataType type);
+      // static bool isPairElement(MusicDataType type);
 
-      // show / hide
-      void setShow(bool show);
-      bool getShow() const;
+      void setShow(bool show)       { _show = show;   }
+      bool show() const             { return _show;   }
 
-      // color
-      void setColor(unsigned int color); // not exists in ove 3
-      unsigned int getColor() const;
+      void setColor(unsigned color) { _color = color; } // not exists in ove 3
+      unsigned color() const        { return _color;  }
 
-      void setVoice(unsigned int voice);
-      unsigned int getVoice() const;
+      void setVoice(unsigned voice) { _voice = voice; }
+      unsigned voice() const        { return _voice;  }
+
+      MusicDataType musicDataType() const { return _musicDataType; }
 
       void copyCommonBlock(const MusicData& source);
-
-protected:
-      MusicDataType musicDataType_;
-
-private:
-      bool show_;
-      unsigned int color_;
-      unsigned int voice_;
       };
 
-class MidiData: public TickElement {
-public:
+//---------------------------------------------------------
+//   MidiData
+//---------------------------------------------------------
+
+class MidiData : public TickElement {
+   protected:
+      MidiType _midiType;
+
+   public:
       MidiData();
       virtual ~MidiData() {}
 
-public:
-      MidiType getMidiType() const;
-
-protected:
-      MidiType midiType_;
+      MidiType midiType() const { return _midiType; }
       };
 
+//---------------------------------------------------------
+//   OveSong
+//---------------------------------------------------------
 
-////////////////////////////////////////////////////////////////////////////////
 class OveSong {
-public:
+      bool _version4;
+      int _quarter;
+
+      bool _showPageMargin;
+      bool _showTransposeTrack;
+      bool _showLineBreak;
+      bool _showRuler;
+      bool _showColor;
+      bool _playRepeat;
+
+      QList<QString> _titles;
+      QList<QString> _annotates;
+      QList<QString> _writers;
+      QList<QString> _copyrights;
+      QList<QString> _headers;
+      QList<QString> _footers;
+
+      QList<Track*> _tracks;
+      QList<Page*> _pages;
+      QList<Line*> _lines;
+      QList<Measure*> _measures;
+      QList<MeasureData*> _measureDatas;
+      int _trackBarCount;	//equal to measures_.size()
+
+      QList<int> _partStaffCounts;
+      QTextCodec* _codec;
+
+   public:
       OveSong();
       ~OveSong();
 
-public:
-      void setIsVersion4(bool version4 = true);
-      bool getIsVersion4() const;
+      void setIsVersion4(bool version4 = true) { _version4 = version4;        }
+      bool isVersion4() const                  { return _version4;            }
 
-      void setQuarter(int tick);
-      int getQuarter(void) const;
+      void setQuarter(int tick)                { _quarter = tick;             }
+      int isQuarter() const                    { return _quarter;             }
 
-      void setShowPageMargin(bool show);
-      bool getShowPageMargin() const;
+      void setShowPageMargin(bool show)        { _showPageMargin = show;      }
+      bool showPageMargin() const              { return _showPageMargin;      }
 
-      void setShowTransposeTrack(bool show);
-      bool getShowTransposeTrack() const;
+      void setShowTransposeTrack(bool show)    { _showTransposeTrack = show;  }
+      bool showTransposeTrack() const          { return _showTransposeTrack;  }
 
-      void setShowLineBreak(bool show);
-      bool getShowLineBreak() const;
+      void setShowLineBreak(bool show)         { _showLineBreak = show;       }
+      bool showLineBreak() const               { return _showLineBreak;       }
+      
+      void setShowRuler(bool show)             { _showRuler = show;           }
+      bool showRuler() const                   { return _showRuler;           }
 
-      void setShowRuler(bool show);
-      bool getShowRuler() const;
+      void setShowColor(bool show)             { _showColor = show;           }
+      bool showColor() const                   { return _showColor;           }
 
-      void setShowColor(bool show);
-      bool getShowColor() const;
-
-      void setPlayRepeat(bool play);
-      bool getPlayRepeat() const;
+      void setPlayRepeat(bool play)            { _playRepeat = play;          }
+      bool playRepeat() const                  { return _playRepeat;          }
 
       enum class PlayStyle : char {
             Record, Swing, Notation
             };
-      void setPlayStyle(PlayStyle style);
-      PlayStyle getPlayStyle() const;
 
-      void addTitle(const QString& str);
-      QList<QString> getTitles(void) const;
+      void setPlayStyle(PlayStyle style)       { _playStyle = style;          }
+      PlayStyle playStyle() const              { return _playStyle;           }
 
-      void addAnnotate(const QString& str);
-      QList<QString> getAnnotates(void) const;
+      void addTitle(const QString& str)        { _titles.push_back(str);      }
+      QList<QString> titles() const            { return _titles;              }
 
-      void addWriter(const QString& str);
-      QList<QString> getWriters(void) const;
+      void addAnnotate(const QString& str)     { _annotates.push_back(str);   }
+      QList<QString> annotates() const         { return _annotates;           }
 
-      void addCopyright(const QString& str);
-      QList<QString> getCopyrights(void) const;
+      void addWriter(const QString& str)       { _writers.push_back(str);     }
+      QList<QString> writers() const           { return _writers;             }
 
-      void addHeader(const QString& str);
-      QList<QString> getHeaders(void) const;
+      void addCopyright(const QString& str)    { _copyrights.push_back(str);  }
+      QList<QString> copyrights() const        { return _copyrights;          }
 
-      void addFooter(const QString& str);
-      QList<QString> getFooters(void) const;
+      void addHeader(const QString& str)       { _headers.push_back(str);     }
+      QList<QString> headers() const           { return _headers;             }
 
-      void addTrack(Track* ptr);
-      int getTrackCount(void) const;
-      QList<Track*> getTracks() const;
-      Track* getTrack(int part, int staff) const;
+      void addFooter(const QString& str)       { _footers.push_back(str);     }
+      QList<QString> footers() const           { return _footers;             }
 
-      void setTrackBarCount(int count);
-      int getTrackBarCount() const;
+      void addTrack(Track* t)                  { _tracks.push_back(t);        }
+      int trackCount() const                   { return _tracks.size();       }
+      QList<Track*> tracks() const             { return _tracks;              }
+      Track* track(int part, int staff) const;
 
-      bool addPage(Page* page);
-      int getPageCount() const;
-      Page* getPage(int idx);
+      void setTrackBarCount(int count)         { _trackBarCount = count;      }
+      int trackBarCount() const                { return _trackBarCount;       }
 
-      void addLine(Line* ptr);
-      int getLineCount() const;
-      Line* getLine(int idx) const;
+      void addPage(Page* page)                 { _pages.push_back(page);      }
+      int pageCount() const                    { return _pages.size();        }
+      Page* page(int idx) const;
 
-      void addMeasure(Measure* ptr);
-      int getMeasureCount(void) const;
-      Measure* getMeasure(int bar) const;
+      void addLine(Line* line)                 { _lines.push_back(line);      }
+      int lineCount() const                    { return _lines.size();        }
+      Line* line(int idx) const;
 
-      void addMeasureData(MeasureData* ptr);
-      int getMeasureDataCount(void) const;
-      MeasureData* getMeasureData(int part, int staff/*=0*/, int bar) const;
-      MeasureData* getMeasureData(int track, int bar) const;
+      void addMeasure(Measure* m)              { _measures.push_back(m);      }
+      int measureCount() const                 { return _measures.size();     }
+      Measure* measure(int m) const;
+
+      void addMeasureData(MeasureData* md)     { _measureDatas.push_back(md); }
+      int measureDataCount() const             { return _measureDatas.size(); }
+      MeasureData* measureData(int part, int staff/*= 0*/, int bar) const;
+      MeasureData* measureData(int track, int bar) const;
 
       // tool
-      void setPartStaffCounts(const QList<int>& partStaffCounts);
-      int getPartCount() const;
-      int getStaffCount(int part) const;
-      int getPartBarCount() const;
+      void addPartStaffCounts(const QList<int>& partStaffCounts);
+      int partCount() const                    { return _partStaffCounts.size(); }
+      int staffCount(int part) const;
+      int partBarCount() const   { return _measureDatas.size() / _tracks.size(); }
 
-      void clear(void);
+      void clear();
 
       QPair<int, int> trackToPartStaff(int track) const;
 
-      void setTextCodecName(const QString& codecName);
-      QString getCodecString(const QByteArray& text);
+      void setTextCodecName(const QString& codecName) { _codec = QTextCodec::codecForName(codecName.toLatin1()); }
+      QString codecString(const QByteArray& text);
 
-private:
+   private:
+      PlayStyle _playStyle;
+
       int partStaffToTrack(int part, int staff) const;
-
-private:
-      bool version4_;
-      int quarter_;
-
-      bool showPageMargin_;
-      bool showTransposeTrack;
-      bool showLineBreak_;
-      bool showRuler_;
-      bool showColor_;
-      bool playRepeat_;
-      PlayStyle playStyle_;
-
-      QList<QString> titles_;
-      QList<QString> annotates_;
-      QList<QString> writers_;
-      QList<QString> copyrights_;
-      QList<QString> headers_;
-      QList<QString> footers_;
-
-      QList<Track*> tracks_;
-      QList<Page*> pages_;
-      QList<Line*> lines_;
-      QList<Measure*> measures_;
-      QList<MeasureData*> measureDatas_;
-      int trackBarCount_;	//equal to measures_.size()
-
-      QList<int> partStaffCounts_;
-      QTextCodec* codec_;
       };
+
+//---------------------------------------------------------
+//   Voice
+//---------------------------------------------------------
 
 class Voice {
-public:
+      int _channel;    // [0, 15]
+      int _volume;     // [-1, 127], -1 default
+      int _pitchShift; // [-36, 36]
+      int _pan;        // [-64, 63]
+      int _patch;      // [0, 127]
+      int _stemType;   // 0, 1, 2
+
+   public:
       Voice();
-      ~Voice(){}
+      ~Voice() {}
 
-public:
-      void setChannel(int channel);
-      int getChannel() const;
+      void setChannel(int channel)       { _channel = channel;       }
+      int channel() const                { return _channel;          }
 
-      void setVolume(int volume);
-      int getVolume() const;
+      void setVolume(int volume)         { _volume = volume;         }
+      int volume() const                 { return _volume;           }
 
-      void setPitchShift(int pitchShift);
-      int getPitchShift() const;
+      void setPitchShift(int pitchShift) { _pitchShift = pitchShift; }
+      int pitchShift() const             { return _pitchShift;       }
 
-      void setPan(int pan);
-      int getPan() const;
+      void setPan(int pan)               { _pan = pan;               }
+      int pan() const                    { return _pan;              }
 
-      void setPatch(int patch);
-      int getPatch() const;
+      void setPatch(int patch)           { _patch = patch;           }
+      int patch() const                  { return _patch;            }
 
-      void setStemType(int stemType);
-      int getStemType() const;
+      void setStemType(int stemType)     { _stemType = stemType;     }
+      int stemType() const               { return _stemType;         }
 
-      static int getDefaultPatch();
-      static int getDefaultVolume();
-
-private:
-      int channel_;		// [0, 15]
-      int volume_;		// [-1, 127], -1 default
-      int pitchShift_;	// [-36, 36]
-      int pan_;			// [-64, 63]
-      int patch_;			// [0, 127]
-      int stemType_;		// 0, 1, 2
+      static int defaultPatch()          { return -1;                }
+      static int defaultVolume()         { return -1;                }
       };
 
+//---------------------------------------------------------
+//   Track
+//---------------------------------------------------------
+
 class Track {
-public:
+      int _number;
+      QString _name;
+      QString _briefName;
+      unsigned _patch;
+      int _channel;
+      int _transpose;
+      bool _showTranspose;
+      int _noteShift;
+      ClefType _startClef;
+      ClefType _transposeClef;
+      unsigned _displayPercent;
+      KeyType _startKey;
+      int _voiceCount;
+      QList<Voice*> _voices;
+
+      bool _showName;
+      bool _showBriefName;
+      bool _showKeyEachLine;
+      bool _showLegerLine;
+      bool _showClef;
+      bool _showTimeSignature;
+      bool _showKeySignature;
+      bool _showBarline;
+      bool _showClefEachLine;
+
+      bool _fillWithRest;
+      bool _flatTail;
+
+      bool _mute;
+      bool _solo;
+
+      int _part;
+
+   public:
       Track();
       ~Track();
 
-public:
-      void setName(const QString& str);
-      QString getName(void) const;
+      void setName(const QString& str)      { _name = str;               }
+      QString name() const                  { return _name;              }
 
-      void setBriefName(const QString& str);
-      QString getBriefName(void) const;
+      void setBriefName(const QString& str) { _briefName = str;          }
+      QString briefName() const             { return _briefName;         }
 
-      void setPatch(unsigned int patch); // -1: percussion
-      unsigned int getPatch() const;
+      void setPatch(unsigned patch)         { _patch = patch;            } // -1: percussion
+      unsigned patch() const                { return _patch;             }
 
-      void setChannel(int channel);
-      int getChannel() const;
+      void setChannel(int channel)          { _channel = channel;        }
+      int channel() const                   { return _channel;           }
 
-      void setShowName(bool show);
-      bool getShowName() const;
+      void setShowName(bool show)           { _showName = show;          }
+      bool showName() const                 { return _showName;          }
 
-      void setShowBriefName(bool show);
-      bool getShowBriefName() const;
+      void setShowBriefName(bool show)      { _showBriefName = show;     }
+      bool showBriefName() const            { return _showBriefName;     }
 
-      void setMute(bool mute);
-      bool getMute() const;
+      void setMute(bool mute)               { _mute = mute;              }
+      bool mute() const                     { return _mute;              }
 
-      void setSolo(bool solo);
-      bool getSolo() const;
+      void setSolo(bool solo)               { _solo = solo;              }
+      bool solo() const                     { return _solo;              }
 
-      void setShowKeyEachLine(bool show);
-      bool getShowKeyEachLine() const;
+      void setShowKeyEachLine(bool show)    { _showKeyEachLine = show;   }
+      bool showKeyEachLine() const          { return _showKeyEachLine;   }
 
-      void setVoiceCount(int voices);
-      int getVoiceCount() const;
+      void setVoiceCount(int voices)        { _voiceCount = voices;      }
+      int voiceCount() const                { return _voiceCount;        }
 
-      void addVoice(Voice* voice);
-      QList<Voice*> getVoices() const;
+      void addVoice(Voice* voice)           { _voices.push_back(voice);  }
+      QList<Voice*> voices() const          { return _voices;            }
 
-      void setShowTranspose(bool show);
-      bool getShowTranspose() const;
+      void setShowTranspose(bool show)      { _showTranspose = show;     }
+      bool showTranspose() const            { return _showTranspose;     }
 
-      void setTranspose(int transpose);
-      int getTranspose() const;
+      void setTranspose(int transpose)      { _transpose = transpose;    }
+      int transpose() const                 { return _transpose;         }
 
-      void setNoteShift(int shift);
-      int getNoteShift() const;
+      void setNoteShift(int shift)          { _noteShift = shift;        }
+      int noteShift() const                 { return _noteShift;         }
 
-      void setStartClef(int clef/*in ClefType*/);
-      ClefType getStartClef() const;
+      void setStartClef(ClefType clef)      { _startClef = clef;         }
+      ClefType startClef() const            { return _startClef;         }
 
-      void setTransposeClef(int clef/*in ClefType*/);
-      ClefType getTansposeClef() const;
+      void setTransposeClef(ClefType clef)  { _transposeClef = clef;     }
+      ClefType transposeClef() const        { return _transposeClef;     }
 
-      void setStartKey(int key/*in KeyType*/);
-      int getStartKey() const;
+      void setStartKey(KeyType key)         { _startKey = key;           }
+      KeyType startKey() const              { return _startKey;          }
 
-      void setDisplayPercent(unsigned int percent/*25~100*/);
-      unsigned int getDisplayPercent() const;
+      void setDisplayPercent(unsigned percent/*25~100*/) { _displayPercent = percent; }
+      unsigned displayPercent() const                    { return _displayPercent;    }
 
-      void setShowLegerLine(bool show);
-      bool getShowLegerLine() const;
+      void setShowLegerLine(bool show)      { _showLegerLine = show;     }
+      bool showLegerLine() const            { return _showLegerLine;     }
 
-      void setShowClef(bool show);
-      bool getShowClef() const;
+      void setShowClef(bool show)           { _showClef = show;          }
+      bool showClef() const                 { return _showClef;          }
 
-      void setShowTimeSignature(bool show);
-      bool getShowTimeSignature() const;
+      void setShowTimeSignature(bool show)  { _showTimeSignature = show; }
+      bool showTimeSignature() const        { return _showTimeSignature; }
 
-      void setShowKeySignature(bool show);
-      bool getShowKeySignature() const;
+      void setShowKeySignature(bool show)   { _showKeySignature = show;  }
+      bool showKeySignature() const         { return _showKeySignature;  }
 
-      void setShowBarline(bool show);
-      bool getShowBarline() const;
+      void setShowBarline(bool show)        { _showBarline = show;       }
+      bool showBarline() const              { return _showBarline;       }
 
-      void setFillWithRest(bool fill);
-      bool getFillWithRest() const;
+      void setFillWithRest(bool fill)       { _fillWithRest = fill;      }
+      bool fillWithRest() const             { return _fillWithRest;      }
 
-      void setFlatTail(bool flat);
-      bool getFlatTail() const;
+      void setFlatTail(bool flat)           { _flatTail = flat;          }
+      bool flatTail() const                 { return _flatTail;          }
 
-      void setShowClefEachLine(bool show);
-      bool getShowClefEachLine() const;
+      void setShowClefEachLine(bool show)   { _showClefEachLine = show;  }
+      bool showClefEachLine() const         { return _showClefEachLine;  }
 
       struct DrumNode {
-            int line_;
-            int headType_;
-            int pitch_;
-            int voice_;
+            int _line;
+            int _headType;
+            int _pitch;
+            int _voice;
 
-      public:
-            DrumNode():line_(0), headType_(0), pitch_(0), voice_(0){}
+         public:
+            DrumNode():
+                  _line(0), _headType(0), _pitch(0), _voice(0) {}
             };
-      void addDrum(const DrumNode& node);
-      QList<DrumNode> getDrumKit() const;
+      void addDrum(const DrumNode& node)    { _drumKit.push_back(node);  }
+      QList<DrumNode> drumKit() const       { return _drumKit;           }
 
-      void clear(void);
+      void clear();
 
-      /////////////////////////////////////////////////
-      void setPart(int part);
-      int getPart() const;
+      void setPart(int part)                { _part = part;              }
+      int part() const                      { return _part;              }
 
-private:
-      int number_;
-      QString name_;
-      QString briefName_;
-      unsigned int patch_;
-      int channel_;
-      int transpose_;
-      bool showTranspose_;
-      int noteShift_;
-      ClefType startClef_;
-      ClefType transposeClef_;
-      unsigned int displayPercent_;
-      int startKey_;
-      int voiceCount_;
-      QList<Voice*> voices_;
-
-      bool showName_;
-      bool showBriefName_;
-      bool showKeyEachLine_;
-      bool showLegerLine_;
-      bool showClef_;
-      bool showTimeSignature_;
-      bool showKeySignature_;
-      bool showBarline_;
-      bool showClefEachLine_;
-
-      bool fillWithRest_;
-      bool flatTail_;
-
-      bool mute_;
-      bool solo_;
-
-      QList<DrumNode> drumKit_;
-
-      //////////////////////////////
-      int part_;
+   private:
+      QList<DrumNode> _drumKit;
       };
+
+//---------------------------------------------------------
+//   Page
+//---------------------------------------------------------
 
 class Page {
-public:
+      int _beginLine;
+      int _lineCount;
+
+      int _lineInterval;
+      int _staffInterval;
+      int _staffInlineInterval;
+
+      int _lineBarCount;
+      int _pageLineCount;
+
+      int _leftMargin;
+      int _topMargin;
+      int _rightMargin;
+      int _bottomMargin;
+
+      int _pageWidth;
+      int _pageHeight;
+
+   public:
       Page();
-      ~Page(){}
+      ~Page() {}
 
-public:
-      void setBeginLine(int line);
-      int getBeginLine() const;
+      void setBeginLine(int line)               { _beginLine = line;               }
+      int beginLine() const                     { return _beginLine;               }
 
-      void setLineCount(int count);
-      int getLineCount() const;
+      void setLineCount(int count)              { _lineCount = count;              }
+      int lineCount() const                     { return _lineCount;               }
 
-      void setLineInterval(int interval);	// between system
-      int getLineInterval() const;
+      void setLineInterval(int interval)        { _lineInterval = interval;        } // between system
+      int lineInterval() const                  { return _lineInterval;            }
 
-      void setStaffInterval(int interval);
-      int getStaffInterval() const;
+      void setStaffInterval(int interval)       { _staffInterval = interval;       }
+      int staffInterval() const                 { return _staffInterval;           }
 
-      void setStaffInlineInterval(int interval); // between treble-bass staff
-      int getStaffInlineInterval() const;
+      void setStaffInlineInterval(int interval) { _staffInlineInterval = interval; } // between treble-bass staff
+      int staffInlineInterval() const           { return _staffInlineInterval;     }
 
-      void setLineBarCount(int count);
-      int getLineBarCount() const;
+      void setLineBarCount(int count)           { _lineBarCount = count;           }
+      int lineBarCount() const                  { return _lineBarCount;            }
 
-      void setPageLineCount(int count);
-      int getPageLineCount() const;
+      void setPageLineCount(int count)          { _pageLineCount = count;          }
+      int pageLineCount() const                 { return _pageLineCount;           }
 
-      void setLeftMargin(int margin);
-      int getLeftMargin() const;
+      void setLeftMargin(int margin)            { _leftMargin = margin;            }
+      int leftMargin() const                    { return _leftMargin;              }
 
-      void setTopMargin(int margin);
-      int getTopMargin() const;
+      void setTopMargin(int margin)             { _topMargin = margin;             }
+      int topMargin() const                     { return _topMargin;               }
 
-      void setRightMargin(int margin);
-      int getRightMargin() const;
+      void setRightMargin(int margin)           { _rightMargin = margin;           }
+      int rightMargin() const                   { return _rightMargin;             }
 
-      void setBottomMargin(int margin);
-      int getBottomMargin() const;
+      void setBottomMargin(int margin)          { _bottomMargin = margin;          }
+      int bottomMargin() const                  { return _bottomMargin;            }
 
-      void setPageWidth(int width);
-      int getPageWidth() const;
+      void setPageWidth(int width)              { _pageWidth = width;              }
+      int pageWidth() const                     { return _pageWidth;               }
 
-      void setPageHeight(int height);
-      int getPageHeight() const;
-
-private:
-      int beginLine_;
-      int lineCount_;
-
-      int lineInterval_;
-      int staffInterval_;
-      int staffInlineInterval_;
-
-      int lineBarCount_;
-      int pageLineCount_;
-
-      int leftMargin_;
-      int topMargin_;
-      int rightMargin_;
-      int bottomMargin_;
-
-      int pageWidth_;
-      int pageHeight_;
+      void setPageHeight(int height)            { _pageHeight = height;            }
+      int pageHeight() const                    { return _pageHeight;              }
       };
 
+//---------------------------------------------------------
+//   Line
+//---------------------------------------------------------
+
 class Line {
-public:
+      QList<Staff*> _staffs;
+      unsigned _beginBar;
+      unsigned _barCount;
+      int _yOffset;
+      int _leftXOffset;
+      int _rightXOffset;
+
+   public:
       Line();
       ~Line();
 
-public:
-      void addStaff(Staff* staff);
-      int getStaffCount() const;
-      Staff* getStaff(int idx) const;
+      void addStaff(Staff* staff)      { _staffs.push_back(staff); }
+      int staffCount() const           { return _staffs.size();    }
+      Staff* staff(int idx) const;
 
-      void setBeginBar(unsigned int bar);
-      unsigned int getBeginBar() const;
+      void setBeginBar(unsigned bar)   { _beginBar = bar;          }
+      unsigned beginBar() const        { return _beginBar;         }
 
-      void setBarCount(unsigned int count);
-      unsigned int getBarCount() const;
+      void setBarCount(unsigned count) { _barCount = count;        }
+      unsigned barCount() const        { return _barCount;         }
 
-      void setYOffset(int offset);
-      int getYOffset() const;
+      void setYOffset(int offset)      { _yOffset = offset;        }
+      int yOffset() const              { return _yOffset;          }
 
-      void setLeftXOffset(int offset);
-      int getLeftXOffset() const;
+      void setLeftXOffset(int offset)  { _leftXOffset = offset;    }
+      int leftXOffset() const          { return _leftXOffset;      }
 
-      void setRightXOffset(int offset);
-      int getRightXOffset() const;
-
-private:
-      QList<Staff*> staffs_;
-      unsigned int beginBar_;
-      unsigned int barCount_;
-      int yOffset_;
-      int leftXOffset_;
-      int rightXOffset_;
+      void setRightXOffset(int offset) { _rightXOffset = offset;   }
+      int rightXOffset() const         { return _rightXOffset;     }
       };
+
+//---------------------------------------------------------
+//   Staff
+//---------------------------------------------------------
 
 class Staff : public OffsetElement {
-public:
+      ClefType _clef;
+      int _keyType;
+      bool _visible;
+      GroupType _groupType;
+      int _groupStaffCount;
+
+   public:
       Staff();
-      virtual ~Staff(){}
+      virtual ~Staff() {}
 
-public:
-      void setClefType(int clef);
-      ClefType getClefType() const;
+      void setClefType(ClefType clef)    { _clef = clef;             }
+      ClefType clefType() const          { return _clef;             }
 
-      void setKeyType(int key);
-      int getKeyType() const;
+      void setKeyType(int key)           { _keyType = key;           }
+      int keyType() const                { return _keyType;          }
 
-      void setVisible(bool visible);
-      bool setVisible() const;
+      void setVisible(bool visible)      { _visible = visible;       }
+      bool visible() const               { return _visible;          }
 
-      void setGroupType(GroupType type);
-      GroupType getGroupType() const;
+      void setGroupType(GroupType type)  { _groupType = type;        }
+      GroupType groupType() const        { return _groupType;        }
 
-      void setGroupStaffCount(int count);
-      int getGroupStaffCount() const;
-
-private:
-      ClefType clef_;
-      int key_;
-      bool visible_;
-      GroupType groupType_;
-      int groupStaffCount_;
+      void setGroupStaffCount(int count) { _groupStaffCount = count; }
+      int groupStaffCount() const        { return _groupStaffCount;  }
       };
 
-///////////////////////////////////////////////////////////////////////////////
+//---------------------------------------------------------
+//   Note
+//---------------------------------------------------------
 
 class Note : public LineElement {
-public:
+      bool _isRest;
+      unsigned _note;
+      AccidentalType _accidental;
+      bool _showAccidental;
+      unsigned _onVelocity;
+      unsigned _offVelocity;
+      NoteHeadType _headType;
+      TiePos _tiePos;
+      int _offsetStaff;
+      bool _show;
+      int _offsetTick; // for playback
+
+   public:
       Note();
-      virtual ~Note(){}
+      virtual ~Note() {}
 
-public:
-      void setIsRest(bool rest);
-      bool getIsRest() const;
+      void setIsRest(bool rest)               { _isRest = rest;          }
+      bool isRest() const                     { return _isRest;          }
 
-      void setNote(unsigned int note);
-      unsigned int getNote() const;
+      void setNote(unsigned note)             { _note = note;            }
+      unsigned note() const                   { return _note;            }
 
-      void setAccidental(int type);		//AccidentalType
-      AccidentalType getAccidental() const;
+      void setAccidental(AccidentalType type) { _accidental = type;      }
+      AccidentalType accidental() const       { return _accidental;      }
 
-      void setShowAccidental(bool show);
-      bool getShowAccidental() const;
+      void setShowAccidental(bool show)       { _showAccidental = show;  }
+      bool showAccidental() const             { return _showAccidental;  }
 
-      void setOnVelocity(unsigned int velocity);
-      unsigned int getOnVelocity() const;
+      void setOnVelocity(unsigned velocity)   { _onVelocity = velocity;  }
+      unsigned onVelocity() const             { return _onVelocity;      }
 
-      void setOffVelocity(unsigned int velocity);
-      unsigned int getOffVelocity() const;
+      void setOffVelocity(unsigned velocity)  { _offVelocity = velocity; }
+      unsigned offVelocity() const            { return _offVelocity;     }
 
-      void setHeadType(int type);		//NoteHeadType
-      NoteHeadType getHeadType() const;
+      void setHeadType(NoteHeadType type)     { _headType = type;        }
+      NoteHeadType headType() const           { return _headType;        }
 
-      void setTiePos(int tiePos);
-      TiePos getTiePos() const;
+      void setTiePos(TiePos tiePos)           { _tiePos = tiePos;        }
+      TiePos tiePos() const                   { return _tiePos;          }
 
-      void setOffsetStaff(int offset);	// cross staff notes
-      int getOffsetStaff() const;
+      void setOffsetStaff(int offset)         { _offsetStaff = offset;   } // cross staff notes
+      int offsetStaff() const                 { return _offsetStaff;     }
 
-      void setShow(bool show);
-      bool getShow() const;
+      void setShow(bool show)                 { _show = show;            }
+      bool show() const                       { return _show;            }
 
-      void setOffsetTick(int offset);
-      int getOffsetTick() const;
-
-private:
-      bool rest_;
-      unsigned int note_;
-      AccidentalType accidental_;
-      bool showAccidental_;
-      unsigned int onVelocity_;
-      unsigned int offVelocity_;
-      NoteHeadType headType_;
-      TiePos tiePos_;
-      int offsetStaff_;
-      bool show_;
-      int offsetTick_;//for playback
+      void setOffsetTick(int offset)          { _offsetTick = offset;    }
+      int offsetTick() const                  { return _offsetTick;      }
       };
 
+//---------------------------------------------------------
+//   Articulation
+//---------------------------------------------------------
+
 class Articulation : public OffsetElement {
-public:
+      ArticulationType _type;
+      bool _above;
+
+      bool _changeSoundEffect;
+      QPair<int, int> _soundEffect;
+      bool _changeLength;
+      int _lengthPercentage;
+      bool _changeVelocity;
+      int _velocity;
+      bool _changeExtraLength;
+      int _extraLength;
+
+      bool _auxiliaryFirst;
+      NoteType _trillRate;
+      int _trillNoteLength;
+
+   public:
       Articulation();
-      virtual ~Articulation(){}
+      virtual ~Articulation() {}
 
-public:
-      void setArtType(int type);//ArticulationType
-      ArticulationType getArtType() const;
+      void setArticulationType(ArticulationType type) { _type = type;   }
+      ArticulationType articulationType() const       { return _type;   }
 
-      void setPlacementAbove(bool above);
-      bool getPlacementAbove() const;
+      void setPlacementAbove(bool above)              { _above = above; }
+      bool placementAbove() const                     { return _above;  }
 
       // for midi
       bool willAffectNotes() const;
 
-      static bool isTrill(ArticulationType type);
+      bool isTrill() const;
 
       // for xml
       enum class XmlType : char {
@@ -1181,1293 +1243,1375 @@ public:
 
             Unknown
             };
-      XmlType getXmlType() const;
+      XmlType xmlType() const;
 
       // sound setting
-      bool getChangeSoundEffect() const;
+      bool changeSoundEffect() const      { return _changeSoundEffect; }
       void setSoundEffect(int soundFrom, int soundTo);
-      QPair<int, int> getSoundEffect() const;
+      QPair<int, int> soundEffect() const { return _soundEffect;       }
 
-      bool getChangeLength() const;
+      bool changeLength() const           { return _changeLength;      }
       void setLengthPercentage(int percentage);
-      int getLengthPercentage() const;
+      int lengthPercentage() const        { return _lengthPercentage;  }
 
-      bool getChangeVelocity() const;
+      bool changeVelocity() const         { return _changeVelocity;    }
       enum class VelocityType : char {
             Offset,
             SetValue,
             Percentage
             };
       void setVelocityType(VelocityType type);
-      VelocityType getVelocityType() const;
+      VelocityType velocityType() const   { return _velocityType;      }
 
-      void setVelocityValue(int value);
-      int getVelocityValue() const;
+      void setVelocity(int value)         { _velocity = value;         }
+      int velocity() const                { return _velocity;          }
 
-      bool getChangeExtraLength() const;
+      bool changeExtraLength() const      { return _changeExtraLength; }
       void setExtraLength(int length);
-      int getExtraLength() const;
+      int extraLength() const             { return _extraLength;       }
 
-      // trill
       enum class TrillInterval : char {
             Diatonic = 0,
             Chromatic,
             Whole
             };
-      void setTrillInterval(int interval);
-      TrillInterval getTrillInterval() const;
+      void setTrillInterval(TrillInterval interval) { _trillInterval = interval; }
+      TrillInterval trillInterval() const           { return _trillInterval;     }
 
-      void setAuxiliaryFirst(bool first);
-      bool getAuxiliaryFirst() const;
+      void setAuxiliaryFirst(bool first)  { _auxiliaryFirst = first;   }
+      bool auxiliaryFirst() const         { return _auxiliaryFirst;    }
 
-      void setTrillRate(NoteType rate);
-      NoteType getTrillRate() const;
+      void setTrillRate(NoteType rate)    { _trillRate = rate;         }
+      NoteType trillRate() const          { return _trillRate;         }
 
-      void setTrillNoteLength(int length);
-      int getTrillNoteLength() const;
+      void setTrillNoteLength(int length) { _trillNoteLength = length; }
+      int trillNoteLength() const         { return _trillNoteLength;   }
 
       enum class AccelerateType : char {
-            None = 0 ,
+            None = 0,
             Slow,
             Normal,
             Fast
             };
-      void setAccelerateType(int type);
-      AccelerateType getAccelerateType() const;
+      void setAccelerateType(AccelerateType type) { _accelerateType = type; }
+      AccelerateType accelerateType() const       { return _accelerateType; }
 
-private:
-      ArticulationType type_;
-      bool above_;
-
-      bool changeSoundEffect_;
-      QPair<int, int> soundEffect_;
-      bool changeLength_;
-      int lengthPercentage_;
-      bool changeVelocity_;
-      VelocityType velocityType_;
-      int velocityValue_;
-      bool changeExtraLength_;
-      int extraLength_;
-
-      // trill
-      TrillInterval trillInterval_;
-      bool auxiliaryFirst_;
-      NoteType trillRate_;
-      int trillNoteLength_;
-      AccelerateType accelerateType_;
+   private:
+      VelocityType _velocityType;
+      TrillInterval _trillInterval;
+      AccelerateType _accelerateType;
       };
 
+//---------------------------------------------------------
+//   NoteContainer
+//---------------------------------------------------------
+
 class NoteContainer : public MusicData, public LengthElement {
-public:
+      bool _isGrace;
+      bool _isCue;
+      bool _isRest;
+      bool _isRaw;
+      NoteType _noteType;
+      int _dot;
+      NoteType _graceNoteType;
+      int _tuplet;
+      int _space;
+      bool _inBeam;
+      bool _up;
+      bool _showStem;
+      int _stemLength; // line count span
+      int _noteShift;
+
+      QList<Note*> _notes;
+      QList<Articulation*> _articulations;
+
+   public:
       NoteContainer();
       virtual ~NoteContainer();
 
-public:
-      void setIsGrace(bool grace);
-      bool getIsGrace() const;
+      void setIsGrace(bool grace)                { _isGrace = grace;      }
+      bool isGrace() const                       { return _isGrace;       }
 
-      void setIsCue(bool cue);
-      bool getIsCue() const;
+      void setIsCue(bool cue)                    { _isCue = cue;          }
+      bool isCue() const                         { return _isCue;         }
 
-      void setIsRest(bool rest/*or note*/);
-      bool getIsRest() const;
+      void setIsRest(bool rest)                  { _isRest = rest;        }
+      bool isRest() const                        { return _isRest;        }
 
-      void setIsRaw(bool raw);
-      bool getIsRaw() const;
+      void setIsRaw(bool raw)                    { _isRaw = raw;          }
+      bool isRaw() const                         { return _isRaw;         }
 
       void setNoteType(NoteType type);
-      NoteType getNoteType() const;
+      NoteType noteType() const                  { return _noteType;      }
 
-      void setDot(int dot);
-      int getDot() const;
+      void setDot(int dot)                       { _dot = dot;            }
+      int dot() const                            { return _dot;           }
 
-      void setGraceNoteType(NoteType type);
-      NoteType getGraceNoteType() const;
+      void setGraceNoteType(NoteType type)       { _graceNoteType = type; }
+      NoteType graceNoteType() const             { return _graceNoteType; }
 
-      void setInBeam(bool in);
-      bool getInBeam() const;
+      void setInBeam(bool in)                    { _inBeam = in;          }
+      bool inBeam() const                        { return _inBeam;        }
 
-      void setStemUp(bool up);
-      bool getStemUp(void) const;
+      void setUp(bool up)                        { _up = up;              }
+      bool up() const                            { return _up;            }
 
-      void setShowStem(bool show);
-      bool getShowStem() const;
+      void setShowStem(bool show)                { _showStem = show;      }
+      bool showStem() const                      { return _showStem;      }
 
-      void setStemLength(int line);
-      int getStemLength() const;
+      void setStemLength(int line)               { _stemLength = line;    }
+      int stemLength() const                     { return _stemLength;    }
 
-      void setTuplet(int tuplet);
-      int getTuplet() const;
+      void setTuplet(int tuplet)                 { _tuplet = tuplet;      }
+      int tuplet() const                         { return _tuplet;        }
 
-      void setSpace(int space);
-      int getSpace() const;
+      void setSpace(int space)                   { _space = space;        }
+      int space() const                          { return _space;         }
 
-      void addNoteRest(Note* note);
-      QList<Note*> getNotesRests() const;
+      void addNoteRest(Note* note)               { _notes.push_back(note);        }
+      QList<Note*> notesRests() const            { return _notes;                 }
 
-      void addArticulation(Articulation* art);
-      QList<Articulation*> getArticulations() const;
+      void addArticulation(Articulation* art)    { _articulations.push_back(art); }
+      QList<Articulation*> articulations() const { return _articulations;         }
 
-      void setNoteShift(int octave);
-      int getNoteShift() const;
+      void setNoteShift(int octave)              { _noteShift = octave;   }
+      int noteShift() const                      { return _noteShift;     }
 
-      int getOffsetStaff() const;
+      int offsetStaff() const;
 
-      int getDuration() const;
-
-private:
-      bool grace_;
-      bool cue_;
-      bool rest_;
-      bool raw_;
-      NoteType noteType_;
-      int dot_;
-      NoteType graceNoteType_;
-      int tuplet_;
-      int space_;
-      bool inBeam_;
-      bool stemUp_;
-      bool showStem_;
-      int stemLength_;	// line count span
-      int noteShift_;
-
-      QList<Note*> notes_;
-      QList<Articulation*> articulations_;
+      int duration() const;
       };
+
+//---------------------------------------------------------
+//   Beam
+//---------------------------------------------------------
 
 class Beam : public MusicData, public PairEnds {
-public:
+      bool _isGrace;
+      QList<QPair<MeasurePos, MeasurePos>> _lines;
+
+   public:
       Beam();
-      virtual ~Beam(){}
+      virtual ~Beam() {}
 
-public:
-      void setIsGrace(bool grace);
-      bool getIsGrace() const;
+      void setIsGrace(bool grace) { _isGrace = grace; }
+      bool isGrace() const        { return _isGrace;  }
 
-      void addLine(const MeasurePos& startMp, const MeasurePos& endMp);
-      const QList<QPair<MeasurePos, MeasurePos> > getLines() const;
-
-private:
-      bool grace_;
-      QList<QPair<MeasurePos, MeasurePos> > lines_;
+      void addLine(const MeasurePos& startMp, const MeasurePos& endMp) { _lines.push_back(qMakePair(startMp, endMp)); }
+      const QList<QPair<MeasurePos, MeasurePos>> lines() const         { return _lines; }
       };
+
+//---------------------------------------------------------
+//   Tie
+//---------------------------------------------------------
 
 class Tie : public MusicData, public PairEnds {
-public:
+      bool _showOnTop;
+      int _note;
+      int _height;
+
+   public:
       Tie();
-      virtual ~Tie(){}
+      virtual ~Tie() {}
 
-public:
-      void setShowOnTop(bool top);
-      bool getShowOnTop() const;
+      void setShowOnTop(bool top) { _showOnTop = top;  }
+      bool showOnTop() const      { return _showOnTop; }
 
-      void setNote(int note);// note value tie point to
-      int getNote() const;
+      void setNote(int note)      { _note = note;      } // note value tie point to
+      int note() const            { return _note;      }
 
-      void setHeight(int height);
-      int getHeight() const;
-
-private:
-      bool showOnTop_;
-      int note_;
-      int height_;
+      void setHeight(int height)  { _height = height;  }
+      int height() const          { return _height;    }
       };
+
+//---------------------------------------------------------
+//   Glissando
+//---------------------------------------------------------
 
 class Glissando : public MusicData, public PairEnds {
-public:
+      bool _straight;
+      QString _text;
+      int _lineThick;
+
+   public:
       Glissando();
-      virtual ~Glissando(){}
+      virtual ~Glissando() {}
 
-public:
-      void setStraightWavy(bool straight);
-      bool getStraightWavy() const;
+      void setStraightWavy(bool straight) { _straight = straight; }
+      bool straightWavy() const           { return _straight;     }
 
-      void setText(const QString& text);
-      QString getText() const;
+      void setText(const QString& text)   { _text = text;         }
+      QString text() const                { return _text;         }
 
-      void setLineThick(int thick);
-      int getLineThick() const;
-
-private:
-      bool straight_;
-      QString text_;
-      int lineThick_;
+      void setLineThick(int thick)        { _lineThick = thick;   }
+      int lineThick() const               { return _lineThick;    }
       };
 
-class Decorator : public MusicData {
-public:
-      Decorator();
-      virtual ~Decorator(){}
+//---------------------------------------------------------
+//   Decorator
+//---------------------------------------------------------
 
-public:
-      enum class Type : char {
+class Decorator : public MusicData {
+      ArticulationType _articulationType;
+
+   public:
+      Decorator();
+      virtual ~Decorator() {}
+
+      enum class DecoratorType : char {
             Dotted_Barline = 0,
             Articulation
             };
-      void setDecoratorType(Type type);
-      Type getDecoratorType() const;
+      void setDecoratorType(DecoratorType type)       { _decoratorType = type;    }
+      DecoratorType decoratorType() const             { return _decoratorType;    }
 
-      void setArticulationType(ArticulationType type);
-      ArticulationType getArticulationType() const;
+      void setArticulationType(ArticulationType type) { _articulationType = type; }
+      ArticulationType articulationType() const       { return _articulationType; }
 
-private:
-      Type decoratorType_;
-      ArticulationType artType_;
+   private:
+      DecoratorType _decoratorType;
       };
+
+//---------------------------------------------------------
+//   MeasureRepeat
+//---------------------------------------------------------
 
 class MeasureRepeat : public MusicData {
-public:
+      bool _singleRepeat;
+
+   public:
       MeasureRepeat();
-      virtual ~MeasureRepeat(){}
+      virtual ~MeasureRepeat() {}
 
-public:
-      void setSingleRepeat(bool single); // false : double
-      bool getSingleRepeat() const;
-
-private:
-      bool singleRepeat_;
+      void setSingleRepeat(bool single); // false : qreal
+      bool singleRepeat() const { return _singleRepeat; }
       };
 
+//---------------------------------------------------------
+//   Tuplet
+//---------------------------------------------------------
+
 class Tuplet : public MusicData, public PairEnds {
-public:
+      int _tuplet;
+      int _space;
+      int _height;
+      NoteType _noteType;
+      OffsetElement* _mark;
+
+   public:
       Tuplet();
       virtual ~Tuplet();
 
-public:
-      void setTuplet(int tuplet=3);
-      int getTuplet() const;
+      void setTuplet(int tuplet = 3)    { _tuplet = tuplet; }
+      int tuplet() const                { return _tuplet;   }
 
-      void setSpace(int space=2);
-      int getSpace() const;
+      void setSpace(int space = 2)      { _space = space;   }
+      int space() const                 { return _space;    }
 
-      void setHeight(int height);
-      int getHeight() const;
+      void setHeight(int height)        { _height = height; }
+      int height() const                { return _height;   }
 
-      void setNoteType(NoteType type);
-      NoteType getNoteType() const;
+      void setNoteType(NoteType type)   { _noteType = type; }
+      NoteType noteType() const         { return _noteType; }
 
-      OffsetElement* getMarkHandle() const;
-
-private:
-      int tuplet_;
-      int space_;
-      int height_;
-      NoteType noteType_;
-      OffsetElement* mark_;
+      OffsetElement* markHandle() const { return _mark;     }
       };
+
+//---------------------------------------------------------
+//   Harmony
+//---------------------------------------------------------
 
 class Harmony : public MusicData, public LengthElement {
-public:
+      QString _harmonyType;
+      int _root;
+      int _bass;
+      int _alterRoot;
+      int _alterBass;
+      bool _bassOnBottom;
+      int _angle;
+
+   public:
       Harmony();
-      virtual ~Harmony(){}
+      virtual ~Harmony() {}
 
-public:
-      void setHarmonyType(QString type);
-      QString getHarmonyType() const;
+      void setHarmonyType(QString type) { _harmonyType = type;  }
+      QString harmonyType() const       { return _harmonyType;  }
 
-      void setRoot(int root=0);//C
-      int getRoot() const;
+      void setRoot(int root = 0)        { _root = root;         } // C
+      int root() const                  { return _root;         }
 
-      void setBass(int bass);
-      int getBass() const;
+      void setBass(int bass)            { _bass = bass;         }
+      int bass() const                  { return _bass;         }
 
-      void setAlterRoot(int val);
-      int getAlterRoot() const;
+      void setAlterRoot(int val)        { _alterRoot = val;     }
+      int alterRoot() const             { return _alterRoot;    }
 
-      void setAlterBass(int val);
-      int getAlterBass() const;
+      void setAlterBass(int val)        { _alterBass = val;     }
+      int alterBass() const             { return _alterBass;    }
 
-      void setBassOnBottom(bool on);
-      bool getBassOnBottom() const;
+      void setBassOnBottom(bool on)     { _bassOnBottom = on;   }
+      bool bassOnBottom() const         { return _bassOnBottom; }
 
-      void setAngle(int angle);
-      int getAngle() const;
-
-private:
-      QString harmonyType_;
-      int root_;
-      int bass_;
-      int alterRoot_;
-      int alterBass_;
-      bool bassOnBottom_;
-      int angle_;
+      void setAngle(int angle)          { _angle = angle;       }
+      int angle() const                 { return _angle;        }
       };
+
+//---------------------------------------------------------
+//   Clef
+//---------------------------------------------------------
 
 class Clef : public MusicData, public LineElement {
-public:
+      ClefType _clefType;
+
+   public:
       Clef();
-      virtual ~Clef(){}
+      virtual ~Clef() {}
 
-public:
-      void setClefType(int type);	// ClefType
-      ClefType getClefType() const;
-
-private:
-      ClefType clefType_;
+      void setClefType(ClefType type) { _clefType = type; }
+      ClefType clefType() const       { return _clefType; }
       };
+
+//---------------------------------------------------------
+//   Lyric
+//---------------------------------------------------------
 
 class Lyric : public MusicData {
-public:
+      QString _lyric;
+      int _verse;
+
+   public:
       Lyric();
-      virtual ~Lyric(){}
+      virtual ~Lyric() {}
 
-public:
-      void setLyric(const QString& lyricText);
-      QString getLyric() const;
+      void setLyric(const QString& lyricText) { _lyric = lyricText; }
+      QString lyric() const                   { return _lyric;      }
 
-      void setVerse(int verse);
-      int getVerse() const;
-
-private:
-      QString lyric_;
-      int verse_;
+      void setVerse(int verse)                { _verse = verse;     }
+      int verse() const                       { return _verse;      }
       };
 
-class Slur: public MusicData, public PairEnds {
-public:
+//---------------------------------------------------------
+//   Slur
+//---------------------------------------------------------
+
+class Slur : public MusicData, public PairEnds {
+      int _containerCount;
+      bool _showOnTop;
+      int _noteTimePercent;
+      OffsetElement* _handle2;
+      OffsetElement* _handle3;
+
+   public:
       Slur();
       virtual ~Slur();
 
-public:
-      void setContainerCount(int count); // span
-      int getContainerCount() const;
+      void setContainerCount(int count)    { _containerCount = count;    } // span
+      int containerCount() const           { return _containerCount;     }
 
-      void setShowOnTop(bool top);
-      bool getShowOnTop() const;
+      void setShowOnTop(bool top)          { _showOnTop = top;           }
+      bool showOnTop() const               { return _showOnTop;          }
 
-      OffsetElement* getHandle2() const;
-      OffsetElement* getHandle3() const;
+      OffsetElement* handle2() const       { return _handle2;            }
+      OffsetElement* handle3() const       { return _handle3;            }
 
-      void setNoteTimePercent(int percent); // 50% ~ 200%
-      int getNoteTimePercent() const;
-
-private:
-      int containerCount_;
-      bool showOnTop_;
-      int noteTimePercent_;
-      OffsetElement* handle_2_;
-      OffsetElement* handle_3_;
+      void setNoteTimePercent(int percent) { _noteTimePercent = percent; } // 50% ~ 200%
+      int noteTimePercent() const          { return _noteTimePercent;    }
       };
 
-class Dynamics: public MusicData {
-public:
-      Dynamics();
-      virtual ~Dynamics() {}
+//---------------------------------------------------------
+//   Dynamic
+//---------------------------------------------------------
 
-public:
-      void setDynamicsType(int type);//DynamicsType
-      DynamicsType getDynamicsType() const;
+class Dynamic : public MusicData {
+      DynamicType _dynamicType;
+      bool _play;
+      int _velocity;
 
-      void setIsPlayback(bool play);
-      bool getIsPlayback() const;
+   public:
+      Dynamic();
+      virtual ~Dynamic() {}
 
-      void setVelocity(int vel);
-      int getVelocity() const;
+      void setDynamicType(DynamicType type) { _dynamicType = type; }
+      DynamicType dynamicType() const       { return _dynamicType; }
 
-private:
-      DynamicsType dynamicsType_;
-      bool playback_;
-      int velocity_;
+      void setPlay(bool play)               { _play = play;        }
+      bool play() const                     { return _play;        }
+
+      void setVelocity(int vel)             { _velocity = vel;     }
+      int velocity() const                  { return _velocity;    }
       };
 
-class WedgeEndPoint: public MusicData {
-public:
+//---------------------------------------------------------
+//   WedgeEndPoint
+//---------------------------------------------------------
+
+class WedgeEndPoint : public MusicData {
+      int _height;
+      WedgeType _wedgeType;
+      bool _wedgeStart;
+
+   public:
       WedgeEndPoint();
       virtual ~WedgeEndPoint() {}
 
-public:
-      void setWedgeType(WedgeType type);
-      WedgeType getWedgeType() const;
+      void setWedgeType(WedgeType type)   { _wedgeType = type;        }
+      WedgeType wedgeType() const         { return _wedgeType;        }
 
-      void setHeight(int height);
-      int getHeight() const;
+      void setHeight(int height)          { _height = height;         }
+      int height() const                  { return _height;           }
 
-      void setWedgeStart(bool wedgeStart);
-      bool getWedgeStart() const;
-
-private:
-      int height_;
-      WedgeType wedgeType_;
-      bool wedgeStart_;
+      void setWedgeStart(bool wedgeStart) { _wedgeStart = wedgeStart; }
+      bool wedgeStart() const             { return _wedgeStart;       }
       };
 
-class Wedge: public MusicData {
-public:
+//---------------------------------------------------------
+//   Wedge
+//---------------------------------------------------------
+
+class Wedge : public MusicData {
+      int _height;
+      WedgeType _wedgeType;
+
+   public:
       Wedge();
       virtual ~Wedge() {}
 
-public:
-      void setWedgeType(WedgeType type);
-      WedgeType getWedgeType() const;
+      void setWedgeType(WedgeType type) { _wedgeType = type; }
+      WedgeType wedgeType() const       { return _wedgeType; }
 
-      void setHeight(int height);
-      int getHeight() const;
-
-private:
-      int height_;
-      WedgeType wedgeType_;
+      void setHeight(int height)        { _height = height;  }
+      int height() const                { return _height;    }
       };
 
-class Pedal: public MusicData, public PairEnds {
-public:
+//---------------------------------------------------------
+//   Pedal
+//---------------------------------------------------------
+
+class Pedal : public MusicData, public PairEnds {
+      bool _half;
+      bool _play;
+      int _playOffset;
+      OffsetElement* _pedalHandle;
+
+   public:
       Pedal();
       virtual ~Pedal();
 
-public:
-      void setHalf(bool half);
-      bool getHalf() const;
+      void setHalf(bool half)            { _half = half;         }
+      bool half() const                  { return _half;         }
 
-      void setIsPlayback(bool playback);
-      bool getIsPlayback() const;
+      void setPlay(bool play)            { _play = play;         }
+      bool play() const                  { return _play;         }
 
-      void setPlayOffset(int offset); // -127~127
-      int getPlayOffset() const;
+      void setPlayOffset(int offset)     { _playOffset = offset; } // -127~127
+      int playOffset() const             { return _playOffset;   }
 
-      OffsetElement* getPedalHandle() const; //only on half pedal
-
-private:
-      bool half_;
-      bool playback_;
-      int playOffset_;
-      OffsetElement* pedalHandle_;
+      OffsetElement* pedalHandle() const { return _pedalHandle;  } // only on half pedal
       };
 
-class KuoHao: public MusicData, public PairEnds {
-public:
-      KuoHao();
-      virtual ~KuoHao() {}
+//---------------------------------------------------------
+//   Bracket
+//---------------------------------------------------------
 
-public:
-      void setHeight(int height);
-      int getHeight() const;
+class Bracket : public MusicData, public PairEnds {
+      int _height;
+      BracketType _bracketType;
 
-      void setKuohaoType(int type);// KuoHaoType
-      KuoHaoType getKuohaoType() const;
+   public:
+      Bracket();
+      virtual ~Bracket() {}
 
-private:
-      int height_;
-      KuoHaoType kuohaoType_;
+      void setHeight(int height)            { _height = height;    }
+      int height() const                    { return _height;      }
+
+      void setBracketType(BracketType type) { _bracketType = type; }
+      BracketType bracketType() const       { return _bracketType; }
       };
 
-class Expressions: public MusicData {
-public:
-      Expressions();
-      virtual ~Expressions() {}
+//---------------------------------------------------------
+//   Expression
+//---------------------------------------------------------
 
-public:
-      void setText(const QString& str);
-      QString getText() const;
+class Expression : public MusicData {
+      QString _text;
 
-private:
-      QString text_;
+   public:
+      Expression();
+      virtual ~Expression() {}
+
+      void setText(const QString& str) { _text = str;  }
+      QString text() const             { return _text; }
       };
 
-class HarpPedal: public MusicData {
-public:
+//---------------------------------------------------------
+//   HarpPedal
+//---------------------------------------------------------
+
+class HarpPedal : public MusicData {
+      HarpPedalType _type;
+      int _showCharFlag;
+
+   public:
       HarpPedal();
       virtual ~HarpPedal() {}
 
-public:
-      void setShowType(int type);//0:graph, 1:char, 2:char cut, 3:change
-      int getShowType() const;
+      void setType(HarpPedalType type) { _type = type;         }
+      HarpPedalType type() const       { return _type;         }
 
-      void setShowCharFlag(int flag);//each bit is a bool, total 7 bools
-      int getShowCharFlag() const;
-
-private:
-      int showType_;
-      int showCharFlag_;
+      // each bit is a bool, total 7 bools
+      void setShowCharFlag(int flag)   { _showCharFlag = flag; }
+      int showCharFlag() const         { return _showCharFlag; }
       };
 
-class OctaveShift: public MusicData, public LengthElement {
-public:
+//---------------------------------------------------------
+//   OctaveShift
+//---------------------------------------------------------
+
+class OctaveShift : public MusicData, public LengthElement {
+      OctaveShiftType _octaveShiftType;
+      OctaveShiftPosition _octaveShiftPosition;
+      int _endTick;
+
+   public:
       OctaveShift();
       virtual ~OctaveShift() {}
 
-public:
-      void setOctaveShiftType(OctaveShiftType type);
-      OctaveShiftType getOctaveShiftType() const;
+      void setOctaveShiftType(OctaveShiftType type) { _octaveShiftType = type; }
+      OctaveShiftType octaveShiftType() const       { return _octaveShiftType; }
 
-      void setOctaveShiftPosition(OctaveShiftPosition position);
-      OctaveShiftPosition getOctaveShiftPosition() const;
+      void setOctaveShiftPosition(OctaveShiftPosition position) { _octaveShiftPosition = position; }
+      OctaveShiftPosition octaveShiftPosition() const           { return _octaveShiftPosition;     }
 
-      int getNoteShift() const;
+      int noteShift() const;
 
-      void setEndTick(int tick);
-      int getEndTick() const;
-
-private:
-      OctaveShiftType octaveShiftType_;
-      OctaveShiftPosition octaveShiftPosition_;
-      int endTick_;
+      void setEndTick(int tick) { _endTick = tick; }
+      int endTick() const       { return _endTick; }
       };
 
-class OctaveShiftEndPoint: public MusicData, public LengthElement {
-public:
+//---------------------------------------------------------
+//   OctaveShiftEndPoint
+//---------------------------------------------------------
+
+class OctaveShiftEndPoint : public MusicData, public LengthElement {
+      OctaveShiftType _octaveShiftType;
+      OctaveShiftPosition _octaveShiftPosition;
+      int _endTick;
+
+   public:
       OctaveShiftEndPoint();
       virtual ~OctaveShiftEndPoint() {}
 
-public:
-      void setOctaveShiftType(OctaveShiftType type);
-      OctaveShiftType getOctaveShiftType() const;
+      void setOctaveShiftType(OctaveShiftType type) { _octaveShiftType = type; }
+      OctaveShiftType octaveShiftType() const       { return _octaveShiftType; }
 
-      void setOctaveShiftPosition(OctaveShiftPosition position);
-      OctaveShiftPosition getOctaveShiftPosition() const;
+      void setOctaveShiftPosition(OctaveShiftPosition position) { _octaveShiftPosition = position; }
+      OctaveShiftPosition octaveShiftPosition() const           { return _octaveShiftPosition;     }
 
-      void setEndTick(int tick);
-      int getEndTick() const;
-
-private:
-      OctaveShiftType octaveShiftType_;
-      OctaveShiftPosition octaveShiftPosition_;
-      int endTick_;
+      void setEndTick(int tick) { _endTick = tick; }
+      int endTick() const       { return _endTick; }
       };
 
-class MultiMeasureRest: public MusicData {
-public:
+//---------------------------------------------------------
+//   MultiMeasureRest
+//---------------------------------------------------------
+
+class MultiMeasureRest : public MusicData {
+      int _measureCount;
+
+   public:
       MultiMeasureRest();
       virtual ~MultiMeasureRest() {}
 
-public:
-      void setMeasureCount(int count);
-      int getMeasureCount() const;
-
-private:
-      int measureCount_;
+      void setMeasureCount(int count) { _measureCount = count; }
+      int measureCount() const        { return _measureCount;  }
       };
 
-class Tempo: public MusicData {
-public:
+//---------------------------------------------------------
+//   Tempo
+//---------------------------------------------------------
+
+class Tempo : public MusicData {
+      bool _showMark;
+      bool _showBeforeText;
+      bool _showParentheses;
+      qreal _typeTempo;
+      QString _leftText;
+      QString _rightText;
+      bool _swingEighth;
+      NoteType _leftNoteType;
+      NoteType _rightNoteType;
+      bool _leftNoteDot;
+      bool _rightNoteDot;
+      int _rightSideType;
+
+   public:
       Tempo();
       virtual ~Tempo() {}
 
-public:
-      void setLeftNoteType(int type);//NoteType
-      NoteType getLeftNoteType() const;
+      void setShowMark(bool show)           { _showMark = show;        }
+      bool showMark() const                 { return _showMark;        }
 
-      void setShowMark(bool show);
-      bool getShowMark() const;
+      void setShowBeforeText(bool show)     { _showBeforeText = show;  }
+      bool showBeforeText() const           { return _showBeforeText;  }
 
-      void setShowBeforeText(bool show);
-      bool getShowBeforeText() const;
+      void setShowParentheses(bool show)    { _showParentheses = show; }
+      bool showParentheses() const          { return _showParentheses; }
 
-      void setShowParenthesis(bool show);
-      bool getShowParenthesis() const;
+      void setTypeTempo(qreal tempo)        { _typeTempo = tempo;      } // 0x2580 = 96.00
+      qreal typeTempo() const               { return _typeTempo;       }
+      qreal quarterTempo() const;
 
-      void setTypeTempo(double tempo); //0x2580 = 96.00
-      double getTypeTempo() const;
-      double getQuarterTempo() const;
+      void setLeftText(const QString& str)  { _leftText = str;         } // string at left of the mark
+      QString leftText() const              { return _leftText;        }
 
-      void setLeftText(const QString& str);// string at left of the mark
-      QString getLeftText() const;
+      void setRightText(const QString& str) { _rightText = str;        }
+      QString rightText() const             { return _rightText;       }
 
-      void setRightText(const QString& str);
-      QString getRightText() const;
+      void setSwingEighth(bool swing)       { _swingEighth = swing;    }
+      bool swingEighth() const              { return _swingEighth;     }
 
-      void setSwingEighth(bool swing);
-      bool getSwingEighth() const;
+      void setLeftNoteType(NoteType type)   { _leftNoteType = type;    }
+      NoteType leftNoteType() const         { return _leftNoteType;    }
 
-      void setRightNoteType(int type);
-      NoteType getRightNoteType() const;
+      void setRightNoteType(NoteType type)  { _rightNoteType = type;   }
+      NoteType rightNoteType() const        { return _rightNoteType;   }
 
-      void setLeftNoteDot(bool showDot);
-      bool getLeftNoteDot() const;
+      void setLeftNoteDot(bool showDot)     { _leftNoteDot = showDot;  }
+      bool leftNoteDot() const              { return _leftNoteDot;     }
 
-      void setRightNoteDot(bool showDot);
-      bool getRightNoteDot() const;
+      void setRightNoteDot(bool showDot)    { _rightNoteDot = showDot; }
+      bool rightNoteDot() const             { return _rightNoteDot;    }
 
-      void setRightSideType(int type);
-      int getRightSideType() const;
-
-private:
-      int leftNoteType_;
-      bool showMark_;
-      bool showText_;
-      bool showParenthesis_;
-      double typeTempo_;
-      QString leftText_;
-      QString rightText_;
-      bool swingEighth_;
-      int rightNoteType_;
-      bool leftNoteDot_;
-      bool rightNoteDot_;
-      int rightSideType_;
+      void setRightSideType(int type)       { _rightSideType = type;   }
+      int rightSideType() const             { return _rightSideType;   }
       };
 
-class Text: public MusicData, public LengthElement {
-public:
+//---------------------------------------------------------
+//  Text
+//---------------------------------------------------------
+
+class Text : public MusicData, public LengthElement {
+      int _horizontalMargin;
+      int _verticalMargin;
+      int _lineThick;
+      QString _text;
+      int _width;
+      int _height;
+
+   public:
       Text();
       virtual ~Text() {}
 
-public:
-      enum class Type : char {
+      enum class TextType : char {
             Rehearsal,
             SystemText,
             MeasureText
             };
 
-      void setTextType(Type type);
-      Type getTextType() const;
+      void setTextType(TextType type)      { _textType = type;           }
+      TextType textType() const            { return _textType;           }
 
-      void setHorizontalMargin(int margin);
-      int getHorizontalMargin() const;
+      void setHorizontalMargin(int margin) { _horizontalMargin = margin; }
+      int horizontalMargin() const         { return _horizontalMargin;   }
 
-      void setVerticalMargin(int margin);
-      int getVerticalMargin() const;
+      void setVerticalMargin(int margin)   { _verticalMargin = margin;   }
+      int verticalMargin() const           { return _verticalMargin;     }
 
-      void setLineThick(int thick);
-      int getLineThick() const;
+      void setLineThick(int thick)         { _lineThick = thick;         }
+      int lineThick() const                { return _lineThick;          }
 
-      void setText(const QString& text);
-      QString getText() const;
+      void setText(const QString& str)     { _text = str;                }
+      QString text() const                 { return _text;               }
 
-      void setWidth(int width);
-      int getWidth() const;
+      void setWidth(int width)             { _width = width;             }
+      int width() const                    { return _width;              }
 
-      void setHeight(int height);
-      int getHeight() const;
+      void setHeight(int height)           { _height = height;           }
+      int height() const                   { return _height;             }
 
-private:
-      Type textType_;
-      int horiMargin_;
-      int vertMargin_;
-      int lineThick_;
-      QString text_;
-      int width_;
-      int height_;
+   private:
+      TextType _textType;
       };
 
-///////////////////////////////////////////////////////////////////////////////
+//---------------------------------------------------------
+//   TimeSignature
+//---------------------------------------------------------
 
-class TimeSignature: public MusicData {
-public:
+class TimeSignature : public MusicData {
+      int _numerator;
+      int _denominator;
+      bool _isSymbol;
+      int _beatLength;
+      int _barLength;
+
+      struct BeatNode {
+            int _startUnit;
+            int _lengthUnit;
+            int _startTick;
+
+            BeatNode() :
+                  _startUnit(0), _lengthUnit(0), _startTick(0) {}
+      };
+      QList<BeatNode> _beats;
+      int _barLengthUnits;
+
+      bool _replaceFont;
+      bool _showBeatGroup;
+
+      int _groupNumerator1;
+      int _groupNumerator2;
+      int _groupNumerator3;
+      int _groupDenominator1;
+      int _groupDenominator2;
+      int _groupDenominator3;
+
+      int _beamGroup1;
+      int _beamGroup2;
+      int _beamGroup3;
+      int _beamGroup4;
+
+      int _beamCount16th;
+      int _beamCount32th;
+
+   public:
       TimeSignature();
       virtual ~TimeSignature() {}
 
-public:
-      void setNumerator(int numerator);
-      int getNumerator() const;
+      void setNumerator(int numerator)     { _numerator = numerator;     }
+      int numerator() const                { return _numerator;          }
 
-      void setDenominator(int denominator);
-      int getDenominator() const;
+      void setDenominator(int denominator) { _denominator = denominator; }
+      int denominator() const              { return _denominator;        }
 
-      void setIsSymbol(bool symbol); //4/4:common, 2/2:cut
-      bool getIsSymbol() const;
+      void setIsSymbol(bool symbol)        { _isSymbol = symbol;         } // 4/4: common, 2/2: cut
+      bool isSymbol() const;
 
-      void setBeatLength(int length); // tick
-      int getBeatLength() const;
+      void setBeatLength(int length)       { _beatLength = length;       } // tick
+      int beatLength() const               { return _beatLength;         }
 
-      void setBarLength(int length); // tick
-      int getBarLength() const;
+      void setBarLength(int length)        { _barLength = length;        } // tick
+      int barLength() const                { return _barLength;          }
 
       void addBeat(int startUnit, int lengthUnit, int startTick);
       void endAddBeat();
-      int getUnits() const;
+      int units() const                    { return _barLengthUnits;     }
 
-      void setReplaceFont(bool replace);
-      bool getReplaceFont() const;
+      void setReplaceFont(bool replace)    { _replaceFont = replace;     }
+      bool replaceFont() const             { return _replaceFont;        }
 
-      void setShowBeatGroup(bool show);
-      bool getShowBeatGroup() const;
+      void setShowBeatGroup(bool show)     { _showBeatGroup = show;      }
+      bool showBeatGroup() const           { return _showBeatGroup;      }
 
-      void setGroupNumerator1(int numerator);
-      void setGroupNumerator2(int numerator);
-      void setGroupNumerator3(int numerator);
-      void setGroupDenominator1(int denominator);
-      void setGroupDenominator2(int denominator);
-      void setGroupDenominator3(int denominator);
+      void setGroupNumerator1(int numerator)     { _groupNumerator1 = numerator;     }
+      void setGroupNumerator2(int numerator)     { _groupNumerator2 = numerator;     }
+      void setGroupNumerator3(int numerator)     { _groupNumerator3 = numerator;     }
+      void setGroupDenominator1(int denominator) { _groupDenominator1 = denominator; }
+      void setGroupDenominator2(int denominator) { _groupDenominator2 = denominator; }
+      void setGroupDenominator3(int denominator) { _groupDenominator3 = denominator; }
 
-      void setBeamGroup1(int count);
-      void setBeamGroup2(int count);
-      void setBeamGroup3(int count);
-      void setBeamGroup4(int count);
+      void setBeamGroup1(int count)        { _beamGroup1 = count;        }
+      void setBeamGroup2(int count)        { _beamGroup2 = count;        }
+      void setBeamGroup3(int count)        { _beamGroup3 = count;        }
+      void setBeamGroup4(int count)        { _beamGroup4 = count;        }
 
-      void set16thBeamCount(int count);
-      void set32thBeamCount(int count);
-
-private:
-      int numerator_;
-      int denominator_;
-      bool isSymbol_;
-      int beatLength_;
-      int barLength_;
-
-      struct BeatNode {
-            int startUnit_;
-            int lengthUnit_;
-            int startTick_;
-
-            BeatNode() :
-                  startUnit_(0),
-                  lengthUnit_(0),
-                  startTick_(0) {
-                  }
-            };
-      QList<BeatNode> beats_;
-      int barLengthUnits_;
-
-      bool replaceFont_;
-      bool showBeatGroup_;
-
-      int groupNumerator1_;
-      int groupNumerator2_;
-      int groupNumerator3_;
-      int groupDenominator1_;
-      int groupDenominator2_;
-      int groupDenominator3_;
-
-      int beamGroup1_;
-      int beamGroup2_;
-      int beamGroup3_;
-      int beamGroup4_;
-
-      int beamCount16th_;
-      int beamCount32th_;
+      void set16thBeamCount(int count)     { _beamCount16th = count;     }
+      void set32thBeamCount(int count)     { _beamCount32th = count;     }
       };
 
-class Key: public MusicData {
-public:
+//---------------------------------------------------------
+//   Key
+//---------------------------------------------------------
+
+class Key : public MusicData {
+      int _key;
+      bool _set;
+      int _previousKey;
+      int _symbolCount;
+
+   public:
       Key();
       virtual ~Key() {}
 
-public:
-      void setKey(int key); //C=0x0, G=0x8, C#=0xE, F=0x1, Db=0x7
-      int getKey() const;
-      bool getSetKey() const;
+      void setKey(int key); // C=0x0, G=0x8, C#=0xE, F=0x1, Db=0x7
+      int key() const                { return _key;          }
+      bool setKey() const            { return _set;          }
 
-      void setPreviousKey(int key);
-      int getPreviousKey() const;
+      void setPreviousKey(int key)   { _previousKey = key;   }
+      int previousKey() const        { return _previousKey;  }
 
-      void setSymbolCount(int count);
-      int getSymbolCount() const;
-
-private:
-      int key_;
-      bool set_;
-      int previousKey_;
-      int symbolCount_;
+      void setSymbolCount(int count) { _symbolCount = count; }
+      int symbolCount() const        { return _symbolCount;  }
       };
 
-class RepeatSymbol: public MusicData {
-public:
+//---------------------------------------------------------
+//   RepeatSymbol
+//---------------------------------------------------------
+
+class RepeatSymbol : public MusicData {
+      QString _text;
+      RepeatType _repeatType;
+
+   public:
       RepeatSymbol();
       virtual ~RepeatSymbol() {}
 
-public:
-      void setText(const QString& text);
-      QString getText() const;
+      void setText(const QString& text)         { _text = text;             }
+      QString text() const                      { return _text;             }
 
-      void setRepeatType(int repeatType);
-      RepeatType getRepeatType() const;
-
-private:
-      QString text_;
-      RepeatType repeatType_;
+      void setRepeatType(RepeatType repeatType) { _repeatType = repeatType; }
+      RepeatType repeatType() const             { return _repeatType;       }
       };
 
-class NumericEnding: public MusicData, public PairEnds {
-public:
+//---------------------------------------------------------
+//   NumericEnding
+//---------------------------------------------------------
+
+class NumericEnding : public MusicData, public PairEnds {
+      int _height;
+      QString _text;
+      OffsetElement* _numericHandle;
+
+   public:
       NumericEnding();
       virtual ~NumericEnding();
 
-public:
-      OffsetElement* getNumericHandle() const;
+      OffsetElement* numericHandle() const { return _numericHandle; }
 
-      void setHeight(int height);
-      int getHeight() const;
+      void setHeight(int height)           { _height = height;      }
+      int height() const                   { return _height;        }
 
-      void setText(const QString& text);
-      QString getText() const;
-      QList<int> getNumbers() const;
-      int getJumpCount() const;
+      void setText(const QString& text)    { _text = text;          }
+      QString text() const                 { return _text;          }
 
-private:
-      int height_;
-      QString text_;
-      OffsetElement* numericHandle_;
+      QList<int> numbers() const;
+      int jumpCount() const;
       };
 
-class BarNumber: public MusicData {
-public:
+//---------------------------------------------------------
+//   BarNumber
+//---------------------------------------------------------
+
+class BarNumber : public MusicData {
+      int _index;
+      bool _showOnParagraphStart;
+      int _align;
+      int _showFlag;
+      int _barRange;
+      QString _prefix;
+
+   public:
       BarNumber();
       virtual ~BarNumber() {}
 
-public:
-      void setIndex(int index);
-      int getIndex() const;
+      void setIndex(int index)                { _index = index;               }
+      int index() const                       { return _index;                }
 
-      void setShowOnParagraphStart(bool show);
-      bool getShowOnParagraphStart() const;
+      void setShowOnParagraphStart(bool show) { _showOnParagraphStart = show; }
+      bool showOnParagraphStart() const       { return _showOnParagraphStart; }
 
-      void setAlign(int align);// 0:left, 1:center, 2:right
-      int getAlign() const;
+      void setAlign(int align)                { _align = align;               } // 0: left, 1: center, 2: right
+      int align() const                       { return _align;                }
 
-      void setShowFlag(int flag); // 0:page, 1:staff, 2:bar, 3:none
-      int getShowFlag() const;
+      void setShowFlag(int flag)              { _showFlag = flag;             } // 0: page, 1: staff, 2: bar, 3: none
+      int showFlag() const                    { return _showFlag;             }
 
-      void setShowEveryBarCount(int count);
-      int getShowEveryBarCount() const;
+      void setShowEveryBarCount(int count)    { _barRange = count;            }
+      int showEveryBarCount() const           { return _barRange;             }
 
-      void setPrefix(const QString& str);
-      QString getPrefix() const;
-
-private:
-      int index_;
-      bool showOnParagraphStart_;
-      int align_;
-      int showFlag_;
-      int barRange_;
-      QString prefix_;
+      void setPrefix(const QString& str)      { _prefix = str;                }
+      QString prefix() const                  { return _prefix;               }
       };
 
-///////////////////////////////////////////////////////////////////////////////
-// MIDI
-class MidiController: public MidiData {
-public:
+//---------------------------------------------------------
+//   MidiController
+//---------------------------------------------------------
+
+class MidiController : public MidiData {
+      int _controller;
+      int _value;
+
+   public:
       MidiController();
       virtual ~MidiController() {}
 
-public:
-      void setController(int number);
-      int getController() const;
+      void setController(int number) { _controller = number; }
+      int controller() const         { return _controller;   }
 
-      void setValue(int value);
-      int getValue() const;
-
-private:
-      int controller_;
-      int value_;
+      void setValue(int value)       { _value = value;       }
+      int value() const              { return _value;        }
       };
 
-class MidiProgramChange: public MidiData {
-public:
+//---------------------------------------------------------
+//   MidiProgramChange
+//---------------------------------------------------------
+
+class MidiProgramChange : public MidiData {
+      int _patch;
+
+   public:
       MidiProgramChange();
       virtual ~MidiProgramChange() {}
 
-public:
-      void setPatch(int patch);
-      int getPatch() const;
-
-private:
-      int patch_;
+      void setPatch(int patch) { _patch = patch; }
+      int patch() const        { return _patch;  }
       };
 
-class MidiChannelPressure: public MidiData {
-public:
+//---------------------------------------------------------
+//   MidiChannelPressure
+//---------------------------------------------------------
+
+class MidiChannelPressure : public MidiData {
+      int _pressure;
+
+   public:
       MidiChannelPressure();
       virtual ~MidiChannelPressure() {}
 
-public:
-      void setPressure(int pressure);
-      int getPressure() const;
-
-private:
-      int pressure_;
+      void setPressure(int pressure) { _pressure = pressure; }
+      int pressure() const           { return _pressure;     }
       };
 
-class MidiPitchWheel: public MidiData {
-public:
+//---------------------------------------------------------
+//   MidiPitchWheel
+//---------------------------------------------------------
+
+class MidiPitchWheel : public MidiData {
+      int _value;
+
+   public:
       MidiPitchWheel();
       virtual ~MidiPitchWheel() {}
 
-public:
-      void setValue(int value);
-      int getValue() const;
-
-private:
-      int value_;
+      void setValue(int value) { _value = value; }
+      int value() const        { return _value;  }
       };
 
-///////////////////////////////////////////////////////////////////////////////
-class Measure: public LengthElement {
-public:
+//---------------------------------------------------------
+//   Measure
+//---------------------------------------------------------
+
+class Measure : public LengthElement {
+      BarNumber* _barNumber;
+      TimeSignature* _timeSig;
+
+      BarLineType _leftBarlineType;
+      BarLineType _rightBarlineType;
+      int _repeatCount;
+      qreal _typeTempo; // based on some type
+      bool _isPickup;
+      bool _isMultiMeasureRest;
+      int _multiMeasureRestCount;
+
+   public:
       Measure(int index = 0);
       virtual ~Measure();
 
-private:
+   private:
       Measure();
 
-public:
-      BarNumber* getBarNumber() const;
-      TimeSignature* getTime() const;
+   public:
+      BarNumber* barNumber() const                 { return _barNumber;              }
+      TimeSignature* timeSig() const               { return _timeSig;                }
 
-      void setLeftBarline(int barline/*in BarLineType*/);
-      BarLineType getLeftBarline() const;
+      void setLeftBarlineType(BarLineType type)    { _leftBarlineType = type;        }
+      BarLineType leftBarlineType() const          { return _leftBarlineType;        }
 
-      void setRightBarline(int barline/*in BarLineType*/);
-      BarLineType getRightBarline() const;
+      void setRightBarlineType(BarLineType type)   { _rightBarlineType = type;       }
+      BarLineType rightBarlineType() const         { return _rightBarlineType;       }
 
-      // set when rightBarline == Baline_Backward
-      void setBackwardRepeatCount(int repeatCount);
-      int getBackwardRepeatCount() const;
+      // set when rightBarlineType == BarLineType::Repeat_Right
+      void setBackwardRepeatCount(int repeatCount) { _repeatCount = repeatCount;     }
+      int backwardRepeatCount() const              { return _repeatCount;            }
 
-      void setTypeTempo(double tempo);
-      double getTypeTempo() const;
+      void setTypeTempo(qreal tempo)               { _typeTempo = tempo;             }
+      qreal typeTempo() const                      { return _typeTempo;              }
 
-      void setIsPickup(bool pickup);
-      bool getIsPickup() const;
+      void setIsPickup(bool pickup)                { _isPickup = pickup;             }
+      bool isPickup() const                        { return _isPickup;               }
 
-      void setIsMultiMeasureRest(bool rest);
-      bool getIsMultiMeasureRest() const;
+      void setIsMultiMeasureRest(bool mm)          { _isMultiMeasureRest = mm;       }
+      bool isMultiMeasureRest() const              { return _isMultiMeasureRest;     }
 
-      void setMultiMeasureRestCount(int count);
-      int getMultiMeasureRestCount() const;
+      void setMultiMeasureRestCount(int count)     { _multiMeasureRestCount = count; }
+      int multiMeasureRestCount() const            { return _multiMeasureRestCount;  }
 
-private:
+   private:
       void clear();
-
-      BarNumber* barNumber_;
-      TimeSignature* time_;
-
-      BarLineType leftBarline_;
-      BarLineType rightBarline_;
-      int repeatCount_;
-      double typeTempo_; // based on some type
-      bool pickup_;
-      bool multiMeasureRest_;
-      int multiMeasureRestCount_;
       };
 
+//---------------------------------------------------------
+//   MeasureData
+//---------------------------------------------------------
+
 class MeasureData {
-public:
+      Key* _key;
+      Clef* _clef;
+      QList<MusicData*> _musicDatas;
+      QList<NoteContainer*> _noteContainers;
+      QList<QPair<MusicData*, bool>> _crossMeasureElements;
+      QList<MidiData*> _midiDatas;
+
+   public:
       MeasureData();
       ~MeasureData();
 
-public:
-      Clef* getClef() const;
-      Key* getKey() const;
+      Clef* clef() const { return _clef; }
+      Key* key() const   { return _key;  }
 
-      void addNoteContainer(NoteContainer* ptr);
-      QList<NoteContainer*> getNoteContainers() const;
+      void addNoteContainer(NoteContainer* ptr)    { _noteContainers.push_back(ptr); }
+      QList<NoteContainer*> noteContainers() const { return _noteContainers;         }
 
       // put Tempo, Text, RepeatSymbol to MeasureData at part=0 && staff=0
-      void addMusicData(MusicData* ptr);
-      // if type==MusicData_None, return all
-      QList<MusicData*> getMusicDatas(MusicDataType type);//MusicXml: note|direction|harmony
+      void addMusicData(MusicData* ptr)            { _musicDatas.push_back(ptr);     }
+      // if type == MusicDataType::None, return all
+      QList<MusicData*> musicDatas(MusicDataType type); // MusicXml: note | direction | harmony
 
       // put NumericEnding to MeasureData at part=0 && staff=0
-      void addCrossMeasureElement(MusicData* ptr, bool start);
+      void addCrossMeasureElement(MusicData* ptr, bool start) { _crossMeasureElements.push_back(qMakePair(ptr, start)); }
       enum class PairType : char {
             Start,
             Stop,
             All
             };
-      QList<MusicData*> getCrossMeasureElements(MusicDataType type, PairType pairType);
+      QList<MusicData*> crossMeasureElements(MusicDataType type, PairType pairType);
 
       // for midi
-      void addMidiData(MidiData* ptr);
-      QList<MidiData*> getMidiDatas(MidiType type);
-
-private:
-      Key* key_;
-      Clef* clef_;
-      QList<MusicData*> musicDatas_;
-      QList<NoteContainer*> noteContainers_;
-      QList<QPair<MusicData*, bool> > crossMeasureElements_;
-      QList<MidiData*> midiDatas_;
+      void addMidiData(MidiData* data)             { _midiDatas.push_back(data);     }
+      QList<MidiData*> midiDatas(MidiType type);
       };
 
-// StreamHandle
+//---------------------------------------------------------
+//   StreamHandle
+//---------------------------------------------------------
+
 class StreamHandle {
-public:
+      int _size;
+      int _curPos;
+      unsigned char* _point;
+
+   public:
       StreamHandle(unsigned char* p, int size);
       virtual ~StreamHandle();
 
-private:
+   private:
       StreamHandle();
 
-public:
+   public:
       virtual bool read(char* buff, int size);
-      virtual bool write(char* buff, int size);
-
-private:
-      int size_;
-      int curPos_;
-      unsigned char* point_;
+      virtual bool write(char* /*buff*/, int /*size*/) { return true; }
       };
 
-// Block.h
-// base block, or resizable block in ove to store data
+//---------------------------------------------------------
+//   Block
+//    Base block, or resizable block in ove to store data
+//---------------------------------------------------------
+
 class Block {
-public:
-      Block();
-      explicit Block(unsigned int size);
-      virtual ~Block() {
-            }
-
-public:
-      // size > 0, check this in use code
-      virtual void resize(unsigned int count);
-
-      const unsigned char* data() const;
-      unsigned char* data();
-      int size() const;
-
-      bool operator ==(const Block& block) const;
-      bool operator !=(const Block& block) const;
-
-      bool toBoolean() const;
-      unsigned int toUnsignedInt() const;
-      int toInt() const;
-      QByteArray toStrByteArray() const;					// string
-      QByteArray fixedSizeBufferToStrByteArray() const;	// string
-
-private:
-      void doResize(unsigned int count);
-
-private:
       // char [-128, 127], unsigned char [0, 255]
-      QList<unsigned char> data_;
+      QList<unsigned char> _data;
+
+   public:
+      Block();
+      explicit Block(unsigned size);
+      virtual ~Block() {}
+
+      // size > 0, check this in use code
+      virtual void resize(unsigned count) { doResize(count); }
+
+      const unsigned char* data() const { return &_data.front(); }
+      unsigned char* data()             { return &_data.front(); }
+      int size() const                  { return _data.size();   }
+
+      bool operator==(const Block& block) const;
+      bool operator!=(const Block& block) const;
+
+      bool toBool() const;
+      unsigned toUnsignedInt() const;
+      int toInt() const;
+      QByteArray toStrByteArray() const; // string
+      QByteArray fixedSizeBufferToStrByteArray() const; // string
+
+   private:
+      void doResize(unsigned count);
       };
 
-class FixedBlock: public Block {
-public:
-      explicit FixedBlock(unsigned int count);
-      virtual ~FixedBlock() {
-            }
+//---------------------------------------------------------
+//   FixedBlock
+//---------------------------------------------------------
 
-private:
+class FixedBlock : public Block {
+   public:
+      explicit FixedBlock(unsigned count);
+      virtual ~FixedBlock() {}
+
+   private:
       FixedBlock();
 
-private:
       // can't resize
-      virtual void resize(unsigned int count);
+      virtual void resize(unsigned count);
       };
 
-///////////////////////////////////////////////////////////////////////////////
-// 4 byte block in ove to store size
-class SizeBlock: public FixedBlock {
-public:
+//---------------------------------------------------------
+//   SizeBlock
+//    4 byte block in ove to store size
+//---------------------------------------------------------
+
+class SizeBlock : public FixedBlock {
+   public:
       SizeBlock();
-      virtual ~SizeBlock() {
-            }
+      virtual ~SizeBlock() {}
 
-public:
-      //	void fromUnsignedInt(unsigned int count) ;
-
-      unsigned int toSize() const;
+      unsigned toSize() const;
       };
 
-// 4 bytes block in ove to store name
-class NameBlock: public FixedBlock {
-public:
-      NameBlock();
-      virtual ~NameBlock() {
-            }
+//---------------------------------------------------------
+//   NameBlock
+//    4 byte block in ove to store name
+//---------------------------------------------------------
 
-public:
+class NameBlock : public FixedBlock {
+   public:
+      NameBlock();
+      virtual ~NameBlock() {}
+
       // ignore data more than 4 bytes
       bool isEqual(const QString& name) const;
       };
 
-// 2 bytes block in ove to store count
-class CountBlock: public FixedBlock {
-public:
-      CountBlock();
-      virtual ~CountBlock() {
-            }
+//---------------------------------------------------------
+//   CountBlock
+//    2 byte block in ove to store count
+//---------------------------------------------------------
 
-public:
-      //	void setValue(unsigned short count) ;
+class CountBlock : public FixedBlock {
+   public:
+      CountBlock();
+      virtual ~CountBlock() {}
 
       unsigned short toCount() const;
       };
 
-// Chunk.h
-// content : name
+//---------------------------------------------------------
+//   Chunk
+//    content : name
+//---------------------------------------------------------
+
 class Chunk {
-public:
+   public:
       Chunk();
-      virtual ~Chunk() {
-            }
+      virtual ~Chunk() {}
 
-public:
-      const static QString TrackName;
-      const static QString PageName;
-      const static QString LineName;
-      const static QString StaffName;
-      const static QString MeasureName;
-      const static QString ConductName;
-      const static QString BdatName;
+      static const QString TrackName;
+      static const QString PageName;
+      static const QString LineName;
+      static const QString StaffName;
+      static const QString MeasureName;
+      static const QString ConductName;
+      static const QString BdatName;
 
-      NameBlock getName() const;
+      NameBlock name() const;
 
-protected:
-      NameBlock nameBlock_;
+   protected:
+      NameBlock _nameBlock;
       };
 
-// content : name / size / data
-class SizeChunk: public Chunk {
-public:
+//---------------------------------------------------------
+//   SizeChunk
+//    content : name / size / data
+//---------------------------------------------------------
+
+class SizeChunk : public Chunk {
+   public:
       SizeChunk();
       virtual ~SizeChunk();
 
-public:
-      SizeBlock* getSizeBlock() const;
-      Block* getDataBlock() const;
+      SizeBlock* sizeBlock() const { return _sizeBlock; }
+      Block* dataBlock() const     { return _dataBlock; }
 
-      const static unsigned int version3TrackSize;
+      static const unsigned version3TrackSize;
 
-protected:
-      SizeBlock* sizeBlock_;
-      Block* dataBlock_;
+   protected:
+      SizeBlock* _sizeBlock;
+      Block* _dataBlock;
       };
 
-// content : name / count
-class GroupChunk: public Chunk {
-public:
+//---------------------------------------------------------
+//   GroupChunk
+//    content : name / count
+//---------------------------------------------------------
+
+class GroupChunk : public Chunk {
+   public:
       GroupChunk();
       virtual ~GroupChunk();
 
-public:
-      CountBlock* getCountBlock() const;
+      CountBlock* countBlock() const { return _childCount; }
 
-protected:
-      CountBlock* childCount_;
+   protected:
+      CountBlock* _childCount;
       };
 
-// ChunkParse.h
+//---------------------------------------------------------
+//   BasicParse
+//---------------------------------------------------------
+
 class BasicParse {
-public:
+   public:
       BasicParse(OveSong* ove);
       virtual ~BasicParse();
 
-private:
+   private:
       BasicParse();
 
-public:
-      void setNotify(IOveNotify* notify);
-      virtual bool parse();
+   public:
+      void setNotify(IOveNotify* notify) { _notify = notify; }
+      virtual bool parse()               { return false;     }
 
-protected:
+   protected:
       bool readBuffer(Block& placeHolder, int size);
       bool jump(int offset);
 
       void messageOut(const QString& str);
 
-protected:
-      OveSong* ove_;
-      StreamHandle* handle_;
-      IOveNotify* notify_;
+      OveSong* _ove;
+      StreamHandle* _handle;
+      IOveNotify* _notify;
       };
 
-///////////////////////////////////////////////////////////////////////////////
+//---------------------------------------------------------
+//   OvscParse
+//---------------------------------------------------------
 
-class OvscParse: public BasicParse {
-public:
+class OvscParse : public BasicParse {
+      SizeChunk* _chunk;
+
+   public:
       OvscParse(OveSong* ove);
       virtual ~OvscParse();
 
-public:
-      void setOvsc(SizeChunk* chunk);
+      void setOvsc(SizeChunk* chunk) { _chunk = chunk; }
 
       virtual bool parse();
-
-private:
-      SizeChunk* chunk_;
       };
 
-class TrackParse: public BasicParse {
-public:
+//---------------------------------------------------------
+//   TrackParse
+//---------------------------------------------------------
+
+class TrackParse : public BasicParse {
+      SizeChunk* _chunk;
+
+   public:
       TrackParse(OveSong* ove);
       virtual ~TrackParse();
 
-public:
-      void setTrack(SizeChunk* chunk);
+      void setTrack(SizeChunk* chunk) { _chunk = chunk; }
 
       virtual bool parse();
-
-private:
-      SizeChunk* chunk_;
       };
 
-class GroupParse: BasicParse {
-public:
+//---------------------------------------------------------
+//   GroupParse
+//---------------------------------------------------------
+
+class GroupParse : BasicParse {
+      QList<SizeChunk*> _sizeChunks;
+
+   public:
       GroupParse(OveSong* ove);
       virtual ~GroupParse();
 
-public:
-      void addSizeChunk(SizeChunk* sizeChunk);
+      void addSizeChunk(SizeChunk* sizeChunk) { _sizeChunks.push_back(sizeChunk); }
 
-      virtual bool parse();
-
-private:
-      QList<SizeChunk*> sizeChunks_;
+      virtual bool parse() { return false; }
       };
 
-class PageGroupParse: public BasicParse {
-public:
+//---------------------------------------------------------
+//   PageGroupParse
+//---------------------------------------------------------
+
+class PageGroupParse : public BasicParse {
+      QList<SizeChunk*> _pageChunks;
+
+   public:
       PageGroupParse(OveSong* ove);
       virtual ~PageGroupParse();
 
-public:
-      void addPage(SizeChunk* chunk);
+      void addPage(SizeChunk* chunk) { _pageChunks.push_back(chunk); }
 
       virtual bool parse();
 
-private:
+   private:
       bool parsePage(SizeChunk* chunk, Page* page);
-
-private:
-      QList<SizeChunk*> pageChunks_;
       };
 
-class StaffCountGetter: public BasicParse {
-public:
+//---------------------------------------------------------
+//   StaffCountGetter
+//---------------------------------------------------------
+
+class StaffCountGetter : public BasicParse {
+   public:
       StaffCountGetter(OveSong* ove);
       virtual ~StaffCountGetter() {}
 
-public:
-      unsigned int getStaffCount(SizeChunk* chunk);
+      unsigned staffCount(SizeChunk* chunk);
       };
 
-class LineGroupParse: public BasicParse {
-public:
+//---------------------------------------------------------
+//   LineGroupParse
+//---------------------------------------------------------
+
+class LineGroupParse : public BasicParse {
+      GroupChunk* _chunk;
+      QList<SizeChunk*> _lineChunks;
+      QList<SizeChunk*> _staffChunks;
+
+   public:
       LineGroupParse(OveSong* ove);
       virtual ~LineGroupParse();
 
-public:
-      void setLineGroup(GroupChunk* chunk);
-      void addLine(SizeChunk* chunk);
-      void addStaff(SizeChunk* chunk);
+      void setLineGroup(GroupChunk* chunk) { _chunk = chunk;                }
+      void addLine(SizeChunk* chunk)       { _lineChunks.push_back(chunk);  }
+      void addStaff(SizeChunk* chunk)      { _staffChunks.push_back(chunk); }
 
       virtual bool parse();
 
-private:
+   private:
       bool parseLine(SizeChunk* chunk, Line* line);
       bool parseStaff(SizeChunk* chunk, Staff* staff);
-
-private:
-      GroupChunk* chunk_;
-      QList<SizeChunk*> lineChunks_;
-      QList<SizeChunk*> staffChunks_;
       };
 
-class BarsParse: public BasicParse {
-public:
+//---------------------------------------------------------
+//   BarsParse
+//---------------------------------------------------------
+
+class BarsParse : public BasicParse {
+      QList<SizeChunk*> _measureChunks;
+      QList<SizeChunk*> _conductChunks;
+      QList<SizeChunk*> _bdatChunks;
+
+   public:
       BarsParse(OveSong* ove);
       virtual ~BarsParse();
 
-public:
-      void addMeasure(SizeChunk* chunk);
-      void addConduct(SizeChunk* chunk);
-      void addBdat(SizeChunk* chunk);
+      void addMeasure(SizeChunk* chunk) { _measureChunks.push_back(chunk); }
+      void addConduct(SizeChunk* chunk) { _conductChunks.push_back(chunk); }
+      void addBdat(SizeChunk* chunk)    { _bdatChunks.push_back(chunk);    }
 
       virtual bool parse();
 
-private:
       bool parseMeas(Measure* measure, SizeChunk* chunk);
       bool parseCond(Measure* measure, MeasureData* measureData, SizeChunk* chunk);
       bool parseBdat(Measure* measure, MeasureData* measureData, SizeChunk* chunk);
 
-      bool getCondElementType(unsigned int byteData, CondType& type);
-      bool getBdatElementType(unsigned int byteData, BdatType& type);
+      bool condElementType(unsigned byteData, CondType& type);
+      bool bdatElementType(unsigned byteData, BdatType& type);
 
       // COND
       bool parseTimeSignature(Measure* measure, int length);
       bool parseTimeSignatureParameters(Measure* measure, int length);
       bool parseRepeatSymbol(MeasureData* measureData, int length);
-      bool parseNumericEndings(MeasureData* measureData, int length);
+      bool parseNumericEnding(MeasureData* measureData, int length);
       bool parseTempo(MeasureData* measureData, int length);
       bool parseBarNumber(Measure* measure, int length);
       bool parseText(MeasureData* measureData, int length);
@@ -2483,13 +2627,13 @@ private:
       bool parseLyric(MeasureData* measureData, int length);
       bool parseSlur(MeasureData* measureData, int length);
       bool parseGlissando(MeasureData* measureData, int length);
-      bool parseDecorators(MeasureData* measureData, int length);
-      bool parseDynamics(MeasureData* measureData, int length);
+      bool parseDecorator(MeasureData* measureData, int length);
+      bool parseDynamic(MeasureData* measureData, int length);
       bool parseWedge(MeasureData* measureData, int length);
       bool parseKey(MeasureData* measureData, int length);
       bool parsePedal(MeasureData* measureData, int length);
-      bool parseKuohao(MeasureData* measureData, int length);
-      bool parseExpressions(MeasureData* measureData, int length);
+      bool parseBracket(MeasureData* measureData, int length);
+      bool parseExpression(MeasureData* measureData, int length);
       bool parseHarpPedal(MeasureData* measureData, int length);
       bool parseMultiMeasureRest(MeasureData* measureData, int length);
       bool parseHarmonyGuitarFrame(MeasureData* measureData, int length);
@@ -2503,145 +2647,140 @@ private:
       bool parseMidiCommon(MidiData* ptr);
       bool parseCommonBlock(MusicData* ptr);
       bool parseOffsetCommonBlock(MusicData* ptr);
-      bool parsePairLinesBlock(PairEnds* ptr); //size==2
-      bool parseOffsetElement(OffsetElement* ptr);//size==2
-
-private:
-      QList<SizeChunk*> measureChunks_;
-      QList<SizeChunk*> conductChunks_;
-      QList<SizeChunk*> bdatChunks_;
+      bool parsePairLinesBlock(PairEnds* ptr); // size == 2
+      bool parseOffsetElement(OffsetElement* ptr); // size == 2
       };
 
-class LyricChunkParse: public BasicParse {
-public:
-      LyricChunkParse(OveSong* ove);
-      virtual ~LyricChunkParse() {}
+//---------------------------------------------------------
+//   LyricChunkParse
+//---------------------------------------------------------
 
-public:
-      void setLyricChunk(SizeChunk* chunk);
+class LyricChunkParse : public BasicParse {
+      SizeChunk* _chunk;
+
+   public:
+      LyricChunkParse(OveSong* ove);
+      virtual ~LyricChunkParse();
+
+      void setLyricChunk(SizeChunk* chunk) { _chunk = chunk; }
 
       virtual bool parse();
 
-private:
+   private:
       struct LyricInfo {
-            int track_;
-            int measure_;
-            int verse_;
-            int voice_;
-            int wordCount_;
-            int lyricSize_;
-            QString name_;
-            QString lyric_;
-            int font_;
-            int fontSize_;
-            int fontStyle_;
+            int _track;
+            int _measure;
+            int _verse;
+            int _voice;
+            int _wordCount;
+            int _lyricSize;
+            QString _name;
+            QString _lyric;
+            int _font;
+            int _fontSize;
+            int _fontStyle;
 
             LyricInfo() :
-                  track_(0), measure_(0), verse_(0), voice_(0), wordCount_(0),
-                  lyricSize_(0), name_(QString()), lyric_(QString()),
-                  font_(0), fontSize_(12), fontStyle_(0) {}
+                  _track(0), _measure(0), _verse(0), _voice(0), _wordCount(0),
+                  _lyricSize(0), _name(QString()), _lyric(QString()),
+                  _font(0), _fontSize(12), _fontStyle(0) {}
             };
 
       void processLyricInfo(const LyricInfo& info);
-
-private:
-      SizeChunk* chunk_;
       };
 
-class TitleChunkParse: public BasicParse {
-public:
-      TitleChunkParse(OveSong* ove);
-      virtual ~TitleChunkParse() {}
+//---------------------------------------------------------
+//   TitleChunkParse
+//---------------------------------------------------------
 
-public:
-      void setTitleChunk(SizeChunk* chunk);
+class TitleChunkParse : public BasicParse {
+      unsigned _titleType;
+      unsigned _annotateType;
+      unsigned _writerType;
+      unsigned _copyrightType;
+      unsigned _headerType;
+      unsigned _footerType;
+
+      SizeChunk* _chunk;
+
+   public:
+      TitleChunkParse(OveSong* ove);
+      virtual ~TitleChunkParse();
+
+      void setTitleChunk(SizeChunk* chunk) { _chunk = chunk; }
 
       virtual bool parse();
 
-private:
-      void addToOve(const QString& str, unsigned int titleType);
-
-private:
-      unsigned int titleType_;
-      unsigned int annotateType_;
-      unsigned int writerType_;
-      unsigned int copyrightType_;
-      unsigned int headerType_;
-      unsigned int footerType_;
-
-      SizeChunk* chunk_;
+   private:
+      void addToOve(const QString& str, unsigned titleType);
       };
 
-// OveOrganizer.h
+//---------------------------------------------------------
+//   OveOrganizer
+//---------------------------------------------------------
+
 class OveOrganizer {
-public:
-      OveOrganizer(OveSong* ove) ;
-      virtual ~OveOrganizer(){}
+      OveSong* _ove;
 
-public:
-      void organize() ;
+   public:
+      OveOrganizer(OveSong* ove);
+      virtual ~OveOrganizer() {}
 
-private:
-      void organizeAttributes() ;
-      void organizeTracks() ;
-      void organizeMeasures() ;
-      void organizeMeasure(int part, int track, Measure* measure, MeasureData* measureData) ;
+      void organize();
 
-      void organizeContainers(int part, int track, Measure* measure, MeasureData* measureData) ;
-      void organizeMusicDatas(int part, int track, Measure* measure, MeasureData* measureData) ;
-      void organizeCrossMeasureElements(int part, int track, Measure* measure, MeasureData* measureData) ;
+   private:
+      void organizeAttributes();
+      void organizeTracks();
+      void organizeMeasures();
+      void organizeMeasure(int part, int track, Measure* measure, MeasureData* measureData);
 
-      void organizePairElement(MusicData* data, int part, int track, Measure* measure, MeasureData* measureData) ;
-      void organizeOctaveShift(OctaveShift* octave, Measure* measure, MeasureData* measureData) ;
-      void organizeWedge(Wedge* wedge, int part, int track, Measure* measure, MeasureData* measureData) ;
+      void organizeContainers(int part, int track, Measure* measure, MeasureData* measureData);
+      void organizeMusicDatas(int part, int track, Measure* measure, MeasureData* measureData);
+      void organizeCrossMeasureElements(int part, int track, Measure* measure, MeasureData* measureData);
 
-private:
-      OveSong* ove_ ;
+      void organizePairElement(MusicData* data, int part, int track, Measure* measure, MeasureData* measureData);
+      void organizeOctaveShift(OctaveShift* octave, Measure* measure, MeasureData* measureData);
+      void organizeWedge(Wedge* wedge, int part, int track, Measure* measure, MeasureData* measureData);
       };
 
-// OveSerialize.h
-class StreamHandle;
-class Block;
-class NameBlock;
-class Chunk;
-class SizeChunk;
-class GroupChunk;
+//---------------------------------------------------------
+//   OveSerialize
+//---------------------------------------------------------
 
-class OveSerialize: public IOVEStreamLoader {
-public:
+class OveSerialize : public IOVEStreamLoader {
+      OveSong* _ove;
+      StreamHandle* _streamHandle;
+      IOveNotify* _notify;
+
+   public:
       OveSerialize();
       virtual ~OveSerialize();
 
-public:
-      virtual void setOve(OveSong* ove);
-      virtual void setFileStream(unsigned char* buffer, unsigned int size);
-      virtual void setNotify(IOveNotify* notify);
-      virtual bool load(void);
+      virtual void setOve(OveSong* ove)          { _ove = ove;       }
+      virtual void setFileStream(unsigned char* buffer, unsigned size)
+         { _streamHandle = new StreamHandle(buffer, size); }
+      virtual void setNotify(IOveNotify* notify) { _notify = notify; }
+      virtual bool load();
 
       virtual void release();
 
-private:
+   private:
       bool readNameBlock(NameBlock& nameBlock);
       bool readChunkName(Chunk* chunk, const QString& name);
       bool readSizeChunk(SizeChunk* sizeChunk); // contains a SizeChunk and data buffer
-      bool readDataChunk(Block* block, unsigned int size);
+      bool readDataChunk(Block* block, unsigned size);
       bool readGroupChunk(GroupChunk* groupChunk);
 
       bool readHeader();
       bool readHeadData(SizeChunk* ovscChunk);
-      bool readTracksData();
-      bool readPagesData();
-      bool readLinesData();
-      bool readBarsData();
+      bool readTrackData();
+      bool readPageData();
+      bool readLineData();
+      bool readBarData();
       bool readOveEnd();
 
       void messageOutError();
       void messageOut(const QString& str);
-
-private:
-      OveSong* ove_;
-      StreamHandle* streamHandle_;
-      IOveNotify* notify_;
       };
 
 }


### PR DESCRIPTION
Right now the code of these three files are really hard to maintain because of inconsistencies and violations of MuseScore coding rules, so I've made this reorganization. This reorganization doesn't change any of the existing functionalities, and any code reduction (really not much) is only for formatting and simplification purposes.

Here is a list of the major changes I made:

- Rename the namespace `OVE` to `Ove` (to be consistent with `Ms`, `Awl`, etc.)
- Apply MuseScore coding rules (of braces, indentation, etc.)
- Move definitions of classes in `importove.cpp` to a new file `importove.h`
- Move most of the one-line functions (especially getters and setters, except class constructors and destructors) to `ove.h`
- Rename all class variable names from `<name>_` to `_<name>` (to be consistent with other files)
- Rename all getter functions (except some `static` ones in `.cpp` files to avoid ambiguity) from `get<Variable>()` to `<variable>()` (to be consistent with other files)
- Replace `unsigned int` with `uint`.