### PR TITLE
Add debug configuration for VSCode

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -40,6 +40,7 @@
                     "${workspaceFolder}/share/",
                     "${workspaceFolder}/synthesizer/",
                     "${workspaceFolder}/test/",
+                    "${workspaceFolder}/telemetry/",
                     "${workspaceFolder}/thirdparty/",
                     "${workspaceFolder}/vtest/",
                     "${workspaceFolder}/zerberus/",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+      // Use IntelliSense to learn about possible attributes.
+      // Hover to view descriptions of existing attributes.
+      // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+      "version": "0.2.0",
+      "configurations": [
+            {
+                  "name": "gdb debug from debug build",
+                  "type": "cppdbg",
+                  "request": "launch",
+                  "program": "${workspaceFolder}/build.debug/main/mscore",
+                  "args": ["-d"],
+                  "stopAtEntry": false,
+                  "cwd": "${workspaceFolder}",
+                  "environment": [],
+                  "externalConsole": false,
+                  "MIMode": "gdb",
+                  "setupCommands": [
+                        {
+                              "description": "Enable pretty-printing for gdb",
+                              "text": "-enable-pretty-printing",
+                              "ignoreFailures": true
+                        }
+                  ],
+                  "miDebuggerPath": "/usr/bin/gdb"
+            }
+      ]
+}


### PR DESCRIPTION
This allows automatic debugging from within the VSCode editor. I've also included a small change to the other config file to include the telemetry directory.