### PR TITLE
fix #300635: crash when dropping symbol on text that had just been moved

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -186,6 +186,7 @@ class BarLineEditData : public ElementEditData {
    public:
       qreal yoff1;
       qreal yoff2;
+      virtual EditDataType type() override      { return EditDataType::BarLineEditData; }
       };
 
 //---------------------------------------------------------

--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -2122,6 +2122,7 @@ void Beam::read(XmlReader& e)
 class BeamEditData : public ElementEditData {
    public:
       int editFragment;
+      virtual EditDataType type() override      { return EditDataType::BeamEditData; }
       };
 
 //---------------------------------------------------------

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -495,6 +495,15 @@ class Element : public ScoreElement {
 //    endEditDrag(EditData&)      use data to create undo records
 //-----------------------------------------------------------------------------
 
+enum class EditDataType : signed char {
+      ElementEditData,
+      TextEditData,
+      BarLineEditData,
+      BeamEditData,
+      NoteEditData,
+      SpannerEditData
+      };
+
 struct PropertyData {
       Pid id;
       QVariant data;
@@ -508,6 +517,7 @@ class ElementEditData {
 
       virtual ~ElementEditData() = default;
       void pushProperty(Pid pid) { propertyData.push_back(PropertyData({ pid, e->getProperty(pid), e->propertyFlags(pid) })); }
+      virtual EditDataType type()   { return EditDataType::ElementEditData; }
       };
 
 //---------------------------------------------------------

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1495,6 +1495,8 @@ class NoteEditData : public ElementEditData {
       EditMode mode = EditMode_Undefined;
       QPointF delta;
 
+      virtual EditDataType type() override      { return EditDataType::NoteEditData; }
+
       static constexpr double MODE_TRANSITION_LIMIT_DEGREES = 15.0;
 
       static inline EditMode editModeByDragDirection(const qreal& deltaX, const qreal& deltaY)

--- a/libmscore/spanner.h
+++ b/libmscore/spanner.h
@@ -40,6 +40,8 @@ class SpannerEditData : public ElementEditData {
       int editTrack2;
       QList<QPointF> userOffsets;
       QList<QPointF> userOffsets2;
+
+      virtual EditDataType type() override      { return EditDataType::SpannerEditData; }
       };
 
 //---------------------------------------------------------

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -1927,7 +1927,8 @@ void TextBase::layoutEdit()
 bool TextBase::acceptDrop(EditData& data) const
       {
       // do not accept the drop if this text element is not being edited
-      if (!data.getData(this))
+      ElementEditData* eed = data.getData(this);
+      if (!eed || eed->type() != EditDataType::TextEditData)
             return false;
       ElementType type = data.dropElement->type();
       return type == ElementType::SYMBOL || type == ElementType::FSYMBOL;

--- a/libmscore/textedit.h
+++ b/libmscore/textedit.h
@@ -31,6 +31,8 @@ struct TextEditData : public ElementEditData {
 
       TextEditData(TextBase* t) : cursor(t)  {}
       ~TextEditData() {}
+
+      virtual EditDataType type() override      { return EditDataType::TextEditData; }
       };
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/300635

This happened because the acceptDrop check wasn't checking that the editData it had for the text element was TextEditData. So, if the text had been moved before, then it would have ElementEditData, and acceptDrop would incorrectly return true.

This fixes the problem by adding a type() method to ElementEditData and its derived classes so a proper check can be carried out in acceptDrop.