### PR TITLE
Completing shortcuts for beaming.

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3863,6 +3863,7 @@ void Score::cmd(const QAction* a, EditData& ed)
             { "no-beam",                    [this]{ cmdSetBeamMode(Beam::Mode::NONE);                           }},
             { "beam32",                     [this]{ cmdSetBeamMode(Beam::Mode::BEGIN32);                        }},
             { "beam64",                     [this]{ cmdSetBeamMode(Beam::Mode::BEGIN64);                        }},
+            { "auto-beam",                  [this]{ cmdSetBeamMode(Beam::Mode::AUTO);                           }},
             { "sharp2",                     [this,ed]{ toggleAccidental(AccidentalType::SHARP2, ed);            }},
             { "sharp",                      [this,ed]{ toggleAccidental(AccidentalType::SHARP, ed);             }},
             { "nat",                        [this,ed]{ toggleAccidental(AccidentalType::NATURAL, ed);           }},

--- a/mscore/keyb.cpp
+++ b/mscore/keyb.cpp
@@ -172,6 +172,7 @@ void MuseScore::updateInputState(Score* score)
       getAction("beam-mid")->setChecked(is.beamMode()   == Beam::Mode::MID);
       getAction("no-beam")->setChecked(is.beamMode()    == Beam::Mode::NONE);
       getAction("beam32")->setChecked(is.beamMode()     == Beam::Mode::BEGIN32);
+      getAction("beam64")->setChecked(is.beamMode()     == Beam::Mode::BEGIN64);
       getAction("auto-beam")->setChecked(is.beamMode()  == Beam::Mode::AUTO);
 
       if(is.noteEntryMode() && !is.rest())


### PR DESCRIPTION
[PR5321](https://github.com/musescore/MuseScore/pull/5321) solved [#110386]. However, there were still some beaming shortcuts missing and it was suggested by @Jojo-Schmitz  to implement there too but due a misunderstanding from me this wasn't done by then.
This PR implements these suggestions and makes the shortcuts for beaming complete.

Completes: https://musescore.org/en/node/110386

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n.a.] I created the test (mtest, vtest, script test) to verify the changes I made
