### PR TITLE
Build Linux AppImage and MacOS Artifact on pull requests containing collect_artifacts

### DIFF
--- a/.github/workflows/collect_artifacts.yml
+++ b/.github/workflows/collect_artifacts.yml
@@ -1,0 +1,60 @@
+name: CI_artifacts
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  collect_artifacts_Linux:
+    runs-on: ubuntu-latest
+    if: "contains(github.event.head_commit.message, 'collect_artifacts')"
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+    - name: Build the AppImage
+      run: |
+        sudo docker run -i -v "${PWD}:/MuseScore" "musescore/musescore-x86_64:latest" ./Recipe
+    - name: Upload Linux AppImage artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: MuseScore-x86_64.AppImage
+        path: ./build.release/MuseScore-x86_64.AppImage
+
+  collect_artifacts_MacOS:
+    runs-on: macos-latest
+    if: "contains(github.event.head_commit.message, 'collect_artifacts')"
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+    - name: Setup environment and build
+      run: |
+              curl -LO https://github.com/macports/macports-base/releases/download/v2.6.2/MacPorts-2.6.2-10.15-Catalina.pkg
+              sudo installer -verbose -pkg MacPorts-2.6.2-10.15-Catalina.pkg -target /
+              rm MacPorts-2.6.2-10.15-Catalina.pkg
+              export PATH="/opt/local/bin:/opt/local/sbin:$PATH"
+              export MACOSX_DEPLOYMENT_TARGET=10.10
+              echo -e "universal_target 10.10\nmacosx_deployment_target 10.10\nmacosx_sdk_version 10.10" | sudo tee -a /opt/local/etc/macports/macports.conf
+              sudo port install git pkgconfig cmake
+              sudo port -s install libsndfile lame portaudio jack
+              export QT_SHORT_VERSION=5.9
+              export QT_PATH=$HOME/qt
+              export QT_MACOS=$QT_PATH/$QT_SHORT_VERSION/clang_64
+              export PATH=$PATH:$QT_MACOS/bin
+              echo "::set-env name=PATH::${PATH}"
+              wget -nv -O qt5.zip https://s3.amazonaws.com/utils.musescore.org/qt598_mac.zip
+              mkdir -p $QT_MACOS
+              unzip -qq qt5.zip -d $QT_MACOS
+              rm qt5.zip
+              make -f Makefile.osx ci
+    - name: Package MuseScore
+      run: |
+              mkdir -p applebuild/mscore.app/Contents/Resources/Frameworks
+              wget -c --no-check-certificate -nv -O musescore_dependencies_macos.zip  http://utils.musescore.org.s3.amazonaws.com/musescore_dependencies_macos.zip
+              unzip musescore_dependencies_macos.zip -d applebuild/mscore.app/Contents/Resources/Frameworks
+              build/package_mac "PR"
+    - name: Upload MacOS artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: MuseScoreNightly-PR.dmg
+        path: ./applebuild/MuseScoreNightly-PR.dmg


### PR DESCRIPTION
…ollect_artifacts

This PR uses Github Actions to build a Linux AppImage and a MacOS package.
Artifacts are kept by Github for 90 days since the last commit to the PR, and they can be downloaded only after signing in to Github.
For the MacOS artifact (MuseScoreNightly.app) it is most probably needed to run "xattr -d com.apple.quarantine /Applications/MuseScoreNightly.app" to remove the "quarantine" attribute that MacOS automatically applies for a downloaded application.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [N/A] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
