### PR TITLE
fix #300912: fix grips remaining after undoing adding a slur

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4881,6 +4881,9 @@ void ScoreView::updateEditElement()
                         else
                               setEditElement(e);
                         }
+                  else {
+                        setEditElement(nullptr);
+                        }
                   break;
             }
       }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/300912

Handle the remaining unhandled case in updateEditElement() to dismiss edit grips in case of list selection.