### PR TITLE
Fix #287955: In Windows Explorer, files with special characters in filepath don't open when double-clicked

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -21,6 +21,12 @@
 
 #include "modulessetup.h"
 
+#if (defined (_MSCVER) || defined (_MSC_VER))
+#include <vector>
+#include <algorithm>
+#include <windows.h>
+#endif
+
 static void initResources()
       {
 #ifdef Q_OS_MAC
@@ -44,9 +50,44 @@ static void initResources()
 
 int main(int argc, char** argv)
       {
+      // Force the 8-bit text encoding to UTF-8. This is the default encoding on all supported platforms except for MSVC under Windows, which
+      // would otherwise default to the local ANSI code page and cause corruption of any non-ANSI Unicode characters in command-line arguments.
+      QTextCodec::setCodecForLocale(QTextCodec::codecForName("UTF-8"));
+
       initResources();
 
       ModulesSetup::instance()->setup();
 
-      return Ms::runApplication(argc, argv);
+#if (defined (_MSCVER) || defined (_MSC_VER))
+      // On MSVC under Windows, we need to manually retrieve the command-line arguments and convert them from UTF-16 to UTF-8.
+      // This prevents data loss if there are any characters that wouldn't fit in the local ANSI code page.
+      int argcUTF16 = 0;
+      LPWSTR* argvUTF16 = CommandLineToArgvW(GetCommandLineW(), &argcUTF16);
+
+      std::vector<QByteArray> argvUTF8Q;
+
+      std::for_each(argvUTF16, argvUTF16 + argcUTF16, [&argvUTF8Q](const auto& arg) {
+            argvUTF8Q.emplace_back(QString::fromUtf16(reinterpret_cast<const char16_t*>(arg), -1).toUtf8());
+            });
+
+      LocalFree(argvUTF16);
+
+      // Ms::runApplication() wants an argv-style array of raw pointers to the arguments, so let's create a vector of them.
+      std::vector<char*> argvUTF8;
+
+      for (auto& arg : argvUTF8Q)
+            argvUTF8.push_back(arg.data());
+
+      // Don't use the arguments passed to main(), because they're in the local ANSI code page.
+      Q_UNUSED(argc);
+      Q_UNUSED(argv);
+
+      int argcFinal = argcUTF16;
+      char** argvFinal = argvUTF8.data();
+#else
+      int argcFinal = argc;
+      char** argvFinal = argv;
+#endif
+
+      return Ms::runApplication(argcFinal, argvFinal);
       }


### PR DESCRIPTION
Resolves: [#287955](https://musescore.org/en/node/287955)

Fixed a problem that caused MuseScore to fail to open files that contained non-ASCII Unicode characters under Windows.

*Use "x" letter to fill the checkboxes below like [x]*

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made