### PR TITLE
fix #300926: Problem selecting and entering a whole note

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1248,8 +1248,11 @@ void Score::changeCRlen(ChordRest* cr, const Fraction& dstF, bool fillWithRest)
             return;
             }
       Fraction srcF(cr->ticks());
-      if (srcF == dstF)
+      if (srcF == dstF) {
+            if (cr->isFullMeasureRest())
+                  undoChangeChordRestLen(cr, dstF);
             return;
+            }
 
       //keep selected element if any
       Element* selElement = selection().isSingle() ? getSelectedElement() : 0;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/300926.

This allows a full measure rest to be changed into a "normal" rest even if the actual length of the rest is not being changed.
