### PR TITLE
[MU4] fix #301016: Copying a partial measure leaves rest(s) missing in voices 2-4.

### DIFF
--- a/libmscore/check.cpp
+++ b/libmscore/check.cpp
@@ -319,7 +319,7 @@ bool Score::checkClefs()
 //   fillGap
 //---------------------------------------------------------
 
-void Measure::fillGap(const Fraction& pos, const Fraction& len, int track, const Fraction& stretch)
+void Measure::fillGap(const Fraction& pos, const Fraction& len, int track, const Fraction& stretch, bool useGapRests)
       {
       qDebug("measure %6d pos %d, len %d/%d, stretch %d/%d track %d",
          tick().ticks(),
@@ -334,7 +334,7 @@ void Measure::fillGap(const Fraction& pos, const Fraction& len, int track, const
             rest->setTicks(len);
             rest->setDurationType(d);
             rest->setTrack(track);
-            rest->setGap(true);
+            rest->setGap(useGapRests);
             score()->undoAddCR(rest, this, (pos / stretch) + tick());
             }
       }
@@ -346,7 +346,7 @@ void Measure::fillGap(const Fraction& pos, const Fraction& len, int track, const
 //    with invisible rests
 //---------------------------------------------------------
 
-void Measure::checkMeasure(int staffIdx)
+void Measure::checkMeasure(int staffIdx, bool useGapRests)
       {
       if (isMMRest())
             return;
@@ -388,7 +388,7 @@ void Measure::checkMeasure(int staffIdx)
             if (f > expectedPos) {
                   // don't fill empty voices
                   if (expectedPos.isNotZero())
-                        fillGap(expectedPos, ticks() - expectedPos, track, stretch);
+                        fillGap(expectedPos, ticks() - expectedPos, track, stretch, useGapRests);
                   }
             else if (f < expectedPos)
                   qDebug("measure overrun %6d, %d > %d, track %d", tick().ticks(), expectedPos.ticks(), f.ticks(), track);

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -86,7 +86,7 @@ class Measure final : public MeasureBase {
       void push_back(Segment* e);
       void push_front(Segment* e);
 
-      void fillGap(const Fraction& pos, const Fraction& len, int track, const Fraction& stretch);
+      void fillGap(const Fraction& pos, const Fraction& len, int track, const Fraction& stretch, bool useGapRests = true);
       void computeMinWidth(Segment* s, qreal x, bool isSystemHeader);
 
       void readVoice(XmlReader& e, int staffIdx, bool irregular);
@@ -108,7 +108,7 @@ class Measure final : public MeasureBase {
       void writeBox(XmlWriter&) const;
       void readBox(XmlReader&);
       virtual bool isEditable() const override { return false; }
-      void checkMeasure(int idx);
+      void checkMeasure(int idx, bool useGapRests = true);
 
       virtual void add(Element*) override;
       virtual void remove(Element*) override;

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -482,7 +482,7 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff, Fraction scale)
             Measure* endM = tick2measure(dstTick + tickLen);
             for (int i = dstStaff; i < endStaff; i++) {
                   for (Measure* m = dstM; m && m != endM->nextMeasure(); m = m->nextMeasure())
-                        m->checkMeasure(i);
+                        m->checkMeasure(i, false);
                   }
             _selection.setRangeTicks(dstTick, dstTick + tickLen, dstStaff, endStaff);
 

--- a/mtest/libmscore/copypaste/copypaste14-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste14-ref.mscx
@@ -179,6 +179,9 @@
               <tpc>14</tpc>
               </Note>
             </Chord>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
           </voice>
         </Measure>
       <Measure>

--- a/mtest/libmscore/copypaste/copypaste15-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste15-ref.mscx
@@ -179,6 +179,9 @@
               <tpc>18</tpc>
               </Note>
             </Chord>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
           </voice>
         </Measure>
       <Measure>

--- a/mtest/libmscore/copypaste/copypaste16-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste16-ref.mscx
@@ -162,6 +162,9 @@
               <tpc>18</tpc>
               </Note>
             </Chord>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
           </voice>
         </Measure>
       <Measure>

--- a/mtest/libmscore/copypaste/copypaste21-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste21-ref.mscx
@@ -177,6 +177,9 @@
               <tpc>18</tpc>
               </Note>
             </Chord>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
           </voice>
         </Measure>
       <Measure>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/301016.