### PR TITLE
copy `#include <QMultiMap>` to all.h

### DIFF
--- a/all.h
+++ b/all.h
@@ -79,6 +79,7 @@
 #include <QPointF>
 #include <QVariant>
 #include <QMap>
+#include <QMultiMap>
 #include <QByteArray>
 #include <QDateTime>
 #include <QtGlobal>

--- a/libmscore/changeMap.h
+++ b/libmscore/changeMap.h
@@ -13,6 +13,8 @@
 #ifndef __CHANGEMAP_H__
 #define __CHANGEMAP_H__
 
+#include <QMultiMap>
+
 #include "fraction.h"
 
 /**

--- a/libmscore/excerpt.h
+++ b/libmscore/excerpt.h
@@ -13,6 +13,8 @@
 #ifndef __EXCERPT_H__
 #define __EXCERPT_H__
 
+#include <QMultiMap>
+
 #include "fraction.h"
 
 namespace Ms {
@@ -29,7 +31,6 @@ class XmlReader;
 //   @@ Excerpt
 //---------------------------------------------------------
 
-#include <QMultiMap>
 
 class Excerpt : public QObject {
       MasterScore* _oscore;

--- a/libmscore/xml.h
+++ b/libmscore/xml.h
@@ -13,6 +13,8 @@
 #ifndef __XML_H__
 #define __XML_H__
 
+#include <QMultiMap>
+
 #include "connector.h"
 #include "stafftype.h"
 #include "interval.h"


### PR DESCRIPTION
but continue to use it directly in excerpt.h (but before the 'internal'
headers) and use it directly in xm.h and changeMap.h too, which so far
don't seem to include them directly nor indirectly