### PR TITLE
Fix some spanner segments not scaled after spatium change

### DIFF
--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -99,6 +99,17 @@ void SpannerSegment::setSystem(System* s)
       }
 
 //---------------------------------------------------------
+//   spatiumChanged
+//---------------------------------------------------------
+
+void SpannerSegment::spatiumChanged(qreal ov, qreal nv) 
+      {
+      Element::spatiumChanged(ov, nv);
+      if (sizeIsSpatiumDependent())
+            _offset2 *= (nv / ov);
+      }
+
+//---------------------------------------------------------
 //   mimeData
 //---------------------------------------------------------
 

--- a/libmscore/spanner.h
+++ b/libmscore/spanner.h
@@ -100,6 +100,8 @@ class SpannerSegment : public Element {
 
       QByteArray mimeData(const QPointF& dragOffset) const override;
 
+      virtual void spatiumChanged(qreal ov, qreal nv) override;
+
       virtual QVariant getProperty(Pid id) const override;
       virtual bool setProperty(Pid id, const QVariant& v) override;
       virtual QVariant propertyDefault(Pid id) const override;

--- a/libmscore/textlinebase.cpp
+++ b/libmscore/textlinebase.cpp
@@ -382,6 +382,8 @@ void TextLineBaseSegment::layout()
 
 void TextLineBaseSegment::spatiumChanged(qreal ov, qreal nv)
       {
+      LineSegment::spatiumChanged(ov, nv);
+
       textLineBase()->spatiumChanged(ov, nv);
       _text->spatiumChanged(ov, nv);
       _endText->spatiumChanged(ov, nv);


### PR DESCRIPTION
Spanner segments need to have `_offset2` scaled too, so I created `SpannerSegment::spatiumChanged()`. For text lines, neither `_offset` nor `_offset2` is scaled, so I called `SpannerSegment::spatiumChanged()` in `TextLineBaseSegment::spatiumChanged()`.

And of course, for this change to make a difference, PR #5699 is required to be merged first.