### PR TITLE
Optimize commit message retrieval when building artifacts + collect_a…

### DIFF
--- a/.github/workflows/collect_artifacts.yml
+++ b/.github/workflows/collect_artifacts.yml
@@ -11,10 +11,11 @@ jobs:
     steps:
     - name: Clone repository
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 3
     - name: get commit message
       run: |
-         curl -L -o commits.json ${{ github.event.pull_request.commits_url }}
-         export commitmsg="$(jq -r '.[-1].commit.message' commits.json)"
+         export commitmsg="$(git log --format=%B -n 1 --skip 1 | head -1)"
          echo "::set-env name=commitmsg::${commitmsg}"
     - name: Build the AppImage
       if: contains( env.commitmsg, 'collect_artifacts')
@@ -32,10 +33,11 @@ jobs:
     steps:
     - name: Clone repository
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 3
     - name: get commit message
       run: |
-         curl -L -o commits.json ${{ github.event.pull_request.commits_url }}
-         export commitmsg="$(jq -r '.[-1].commit.message' commits.json)"
+         export commitmsg="$(git log --format=%B -n 1 --skip 1 | head -1)"
          echo "::set-env name=commitmsg::${commitmsg}"
     - name: Setup environment and build
       if: contains( env.commitmsg, 'collect_artifacts')


### PR DESCRIPTION
…rtifacts

This should solve the "API rate limit exceeded" error message from Github API, which was sometimes preventing the proper retrieval of the correct commit message and therefore the compilation of artifacts.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [N/A] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
