### PR TITLE
fix #301108: Difficulty canceling a selection

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -611,7 +611,6 @@ void ScoreView::adjustCursorForTextEditing(QMouseEvent* mouseEvent)
 
 void ScoreView::mouseMoveEvent(QMouseEvent* me)
       {
-      modifySelection = false;
       adjustCursorForTextEditing(me);
 
       if (state != ViewState::NOTE_ENTRY && editData.buttons == Qt::NoButton)
@@ -643,6 +642,7 @@ void ScoreView::mouseMoveEvent(QMouseEvent* me)
                               }
                         }
                   changeState(ViewState::DRAG);
+                  modifySelection = false;
                   break;
 
             case ViewState::NOTE_ENTRY: {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/301108.

There is code in `ScoreView::mouseMoveEvent()` that allows tiny mouse movements to be ignored before beginning an actual drag. The problem is that `modifySelection` is being set to false before even determining whether the movement was large enough to constitute a drag. The solution is to only set `modifySelection` to false if an actual drag is begun.