### PR TITLE
Musicxml import fix todo's ws

### DIFF
--- a/mscore/importmxmlpass1.cpp
+++ b/mscore/importmxmlpass1.cpp
@@ -1258,6 +1258,24 @@ static void updateStyles(Score* score,
       }
 
 //---------------------------------------------------------
+//   setPageFormat
+//---------------------------------------------------------
+
+static void setPageFormat(Score* score, const PageFormat& pf)
+      {
+      score->style().set(Sid::pageWidth, pf.size.width());
+      score->style().set(Sid::pageHeight, pf.size.height());
+      score->style().set(Sid::pagePrintableWidth, pf.printableWidth);
+      score->style().set(Sid::pageEvenLeftMargin, pf.evenLeftMargin);
+      score->style().set(Sid::pageOddLeftMargin, pf.oddLeftMargin);
+      score->style().set(Sid::pageEvenTopMargin, pf.evenTopMargin);
+      score->style().set(Sid::pageEvenBottomMargin, pf.evenBottomMargin);
+      score->style().set(Sid::pageOddTopMargin, pf.oddTopMargin);
+      score->style().set(Sid::pageOddBottomMargin, pf.oddBottomMargin);
+      score->style().set(Sid::pageTwosided, pf.twosided);
+      }
+
+//---------------------------------------------------------
 //   defaults
 //---------------------------------------------------------
 
@@ -1297,8 +1315,8 @@ void MusicXMLParserPass1::defaults()
             else if (_e.name() == "page-layout") {
                   PageFormat pf;
                   pageLayout(pf, millimeter / (tenths * INCH));
-//TODO:ws                  if (preferences.musicxmlImportLayout)
-//                        _score->setPageFormat(pf);
+                  if (preferences.getBool(PREF_IMPORT_MUSICXML_IMPORTLAYOUT))
+                        setPageFormat(_score, pf);
                   }
             else if (_e.name() == "system-layout") {
                   while (_e.readNextStartElement()) {
@@ -1363,8 +1381,11 @@ void MusicXMLParserPass1::defaults()
 //---------------------------------------------------------
 
 /**
- Parse the /score-partwise/defaults/page-layout node:
- read the page layout.
+ Parse the /score-partwise/defaults/page-layout node: read the page layout.
+ Note that MuseScore does not support a separate value for left and right margins
+ for odd and even pages. Only odd and even left margins are used, together  with
+ the printable width, which is calculated from the left and right margins in the
+ MusicXML file.
  */
 
 void MusicXMLParserPass1::pageLayout(PageFormat& pf, const qreal conversion)


### PR DESCRIPTION
Resolves:
https://musescore.org/en/node/300542
https://musescore.org/en/node/301113

Fix old regressions in file mscore/importmxmlpass1.cpp marked with "TODO WS". Leftovers from Werner's migrations in early 2017. Restores the import from MusicXML of word font and page size and margins.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made