### PR TITLE
fix #301115: invisible articulations affect layout of other articulations

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -3499,7 +3499,8 @@ void Chord::layoutArticulations2()
                         a->setPos(x, chordTopY);
                         a->doAutoplace();
                         }
-                  chordTopY = a->y() - a->height() - 0.5 * _spatium;
+                  if (a->visible())
+                        chordTopY = a->y() - a->height() - 0.5 * _spatium;
                   }
             else {
                   if (!a->layoutCloseToNote()) {
@@ -3507,7 +3508,8 @@ void Chord::layoutArticulations2()
                         a->setPos(x, chordBotY);
                         a->doAutoplace();
                         }
-                  chordBotY = a->y() + a->height() + 0.5 * _spatium;
+                  if (a->visible())
+                        chordBotY = a->y() + a->height() + 0.5 * _spatium;
                   }
             }
       //
@@ -3522,11 +3524,13 @@ void Chord::layoutArticulations2()
                   a->layout();
                   if (a->up()) {
                         a->setPos(x, staffTopY);
-                        staffTopY -= distance0;
+                        if (a->visible())
+                              staffTopY -= distance0;
                         }
                   else {
                         a->setPos(x, staffBotY);
-                        staffBotY += distance0;
+                        if (a->visible())
+                              staffBotY += distance0;
                         }
                   a->doAutoplace();
                   }


### PR DESCRIPTION
Resolves: https://musescore.org/node/301115.

If the articulation is not visible, don't increase top/bottom distance from chord/staff for the next one.