### PR TITLE
Display "Properties" button in inspector too for system texts

### DIFF
--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -1212,7 +1212,8 @@ void InspectorStaffText::propertiesClicked()
 void InspectorStaffText::setElement()
       {
       InspectorTextBase::setElement();
-      s.properties->setVisible(inspector->element()->isStaffText());
+      Element* e = inspector->element();
+      s.properties->setVisible(e->isStaffText() || e->isSystemText());
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Today the thing I learnt about MuseScore was: there has always been a System Text Properties ;-)