### PR TITLE
fix #239181: make fret diagrams accessible for screenreaders

### DIFF
--- a/libmscore/fret.h
+++ b/libmscore/fret.h
@@ -125,7 +125,7 @@ class FretDiagram final : public Element {
       int _fretOffset    { 0  };
       int _maxFrets      { 24 };
       bool _showNut      { true };
-      
+
       // Barres are stored in the format: K: fret, V: barre struct
       BarreMap _barres;
 
@@ -216,7 +216,7 @@ class FretDiagram final : public Element {
 
       Harmony* harmony() const { return _harmony; }
 
-      void init(Ms::StringData *, Chord*);
+      void init(Ms::StringData*, Chord*);
 
       void add(Element*) override;
       void remove(Element*) override;
@@ -233,6 +233,9 @@ class FretDiagram final : public Element {
 
       qreal userMag() const         { return _userMag;   }
       void setUserMag(qreal m)      { _userMag = m;      }
+
+      virtual QString accessibleInfo() const override;
+      virtual QString screenReaderInfo() const override;
 
       friend class FretUndoData;
       };

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1895,8 +1895,16 @@ QString Harmony::accessibleInfo() const
 
 QString Harmony::screenReaderInfo() const
       {
-      QString rez = userName();
+      return QString("%1 %2").arg(userName(), generateScreenReaderInfo());
+      }
 
+//---------------------------------------------------------
+//   generateScreenReaderInfo
+//---------------------------------------------------------
+
+QString Harmony::generateScreenReaderInfo() const
+      {
+      QString rez;
       switch (_harmonyType) {
             case HarmonyType::ROMAN: {
                   QString aux = _textName;

--- a/libmscore/harmony.h
+++ b/libmscore/harmony.h
@@ -204,6 +204,7 @@ class Harmony final : public TextBase {
 
       QString userName() const override;
       QString accessibleInfo() const override;
+      QString generateScreenReaderInfo() const;
       QString screenReaderInfo() const override;
 
       bool acceptDrop(EditData&) const override;

--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -292,11 +292,12 @@ void ScoreAccessibility::currentInfoChanged()
 
             statusBarLabel->setText(rez);
             QString screenReaderRez;
-            if (rez != oldStatus || oldScreenReaderInfo.isEmpty()) {
+            QString newScreenReaderInfo = e->screenReaderInfo();
+            if (rez != oldStatus || newScreenReaderInfo != oldScreenReaderInfo || oldScreenReaderInfo.isEmpty()) {
                   // status has changed since last call, or there is no existing screenreader info
                   //
                   // build new screenreader info
-                  screenReaderRez = QString("%1%2 %3 %4").arg(e->screenReaderInfo()).arg(optimizedBarsAndBeats).arg(optimizedStaff).arg(e->accessibleExtraInfo());
+                  screenReaderRez = QString("%1%2 %3 %4").arg(newScreenReaderInfo).arg(optimizedBarsAndBeats).arg(optimizedStaff).arg(e->accessibleExtraInfo());
                   makeReadable(screenReaderRez);
                   }
             else {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/239181

Sample output for fret diagram below:

'Fretboard diagram with chord symbol C minor, 6 strings, string 1 cross marker, string 3 dot on fret 5, string 4 2 dots on frets 5 and 6, string 5 dot on fret 4, partial barré fret 3 starting string 2'

![image](https://user-images.githubusercontent.com/8274049/74554167-cb98fb00-4f50-11ea-8baa-fa3d99b8a567.png)
