### PR TITLE
fix #301103: "Straight" text does not work

### DIFF
--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -863,9 +863,8 @@ SwingParameters Staff::swing(const Fraction& tick) const
       int swingUnit = 0;
       QString unit = score()->styleSt(Sid::swingUnit);
       int swingRatio = score()->styleI(Sid::swingRatio);
-      if (unit == TDuration(TDuration::DurationType::V_EIGHTH).name()) {
+      if (unit == TDuration(TDuration::DurationType::V_EIGHTH).name())
             swingUnit = MScore::division / 2;
-            }
       else if (unit == TDuration(TDuration::DurationType::V_16TH).name())
             swingUnit = MScore::division / 4;
       else if (unit == TDuration(TDuration::DurationType::V_ZERO).name())

--- a/libmscore/stafftextbase.h
+++ b/libmscore/stafftextbase.h
@@ -51,7 +51,7 @@ class StaffTextBase : public TextBase  {
       Segment* segment() const;
       QString channelName(int voice) const                { return _channelNames[voice]; }
       void setChannelName(int v, const QString& s)        { _channelNames[v] = s;        }
-      void setSwingParameters(int unit, int ratio)        {  _swingParameters.swingUnit = unit; _swingParameters.swingRatio = ratio; }
+      void setSwingParameters(int unit, int ratio)        { _swingParameters.swingUnit = unit; _swingParameters.swingRatio = ratio; }
       const QList<ChannelActions>* channelActions() const { return &_channelActions;    }
       QList<ChannelActions>* channelActions()             { return &_channelActions;    }
       const SwingParameters* swingParameters() const      { return &_swingParameters;   }

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -493,7 +493,7 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
 
       chordDescriptionFileButton->setIcon(*icons[int(Icons::fileOpen_ICON)]);
 
-      connect(SwingOff,            SIGNAL(toggled(bool)),             SLOT(setSwingParams(bool)));
+      connect(swingOff,            SIGNAL(toggled(bool)),             SLOT(setSwingParams(bool)));
       connect(swingEighth,         SIGNAL(toggled(bool)),             SLOT(setSwingParams(bool)));
       connect(swingSixteenth,      SIGNAL(toggled(bool)),             SLOT(setSwingParams(bool)));
 
@@ -1063,7 +1063,7 @@ void EditStyle::setValues()
             swingBox->setEnabled(true);
             }
       else if (unit == TDuration(TDuration::DurationType::V_ZERO).name()) {
-            SwingOff->setChecked(true);
+            swingOff->setChecked(true);
             swingBox->setEnabled(false);
             }
       QString s(lstyle.value(Sid::chordDescriptionFile).toString());
@@ -1143,7 +1143,7 @@ void EditStyle::setSwingParams(bool checked)
       if (!checked)
             return;
       QVariant val;
-      if (SwingOff->isChecked()) {
+      if (swingOff->isChecked()) {
             val = TDuration(TDuration::DurationType::V_ZERO).name();
             swingBox->setEnabled(false);
             }

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -540,7 +540,7 @@
                  </widget>
                 </item>
                 <item>
-                 <widget class="QRadioButton" name="SwingOff">
+                 <widget class="QRadioButton" name="swingOff">
                   <property name="text">
                    <string>Off</string>
                   </property>
@@ -10547,7 +10547,7 @@
   <tabstop>dontHideStavesInFirstSystem</tabstop>
   <tabstop>crossMeasureValues</tabstop>
   <tabstop>hideInstrumentNameIfOneInstrument</tabstop>
-  <tabstop>SwingOff</tabstop>
+  <tabstop>swingOff</tabstop>
   <tabstop>swingEighth</tabstop>
   <tabstop>swingSixteenth</tabstop>
   <tabstop>swingBox</tabstop>

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -1595,7 +1595,10 @@ PalettePanel* MuseScore::newTextPalettePanel(bool defaultPalettePanel)
       stxt = new SystemText(gscore, Tid::TEMPO);
       /*: System text to switch from swing rhythm back to straight rhythm */
       stxt->setXmlText(QT_TRANSLATE_NOOP("Palette", "Straight"));
-      stxt->setSwing(false); // redundant, being the default anyhow, but for documentation
+      // need to be true to enable the "Off" option
+      stxt->setSwing(true);
+      // 0 (swingUnit) turns of swing; swingRatio is set to default
+      stxt->setSwingParameters(0, stxt->score()->styleI(Sid::swingRatio));
       /*: System text to switch from swing rhythm back to straight rhythm */
       sp->append(stxt, QT_TRANSLATE_NOOP("Palette", "Straight"))->setElementTranslated(true);
 

--- a/mscore/stafftext.ui
+++ b/mscore/stafftext.ui
@@ -4077,7 +4077,7 @@ VI</string>
             </widget>
            </item>
            <item>
-            <widget class="QRadioButton" name="SwingOff">
+            <widget class="QRadioButton" name="swingOff">
              <property name="enabled">
               <bool>true</bool>
              </property>
@@ -4342,7 +4342,7 @@ VI</string>
   <tabstop>stop_1_14</tabstop>
   <tabstop>stop_1_15</tabstop>
   <tabstop>setSwingBox</tabstop>
-  <tabstop>SwingOff</tabstop>
+  <tabstop>swingOff</tabstop>
   <tabstop>swingEighth</tabstop>
   <tabstop>swingSixteenth</tabstop>
   <tabstop>swingBox</tabstop>

--- a/mscore/stafftextproperties.cpp
+++ b/mscore/stafftextproperties.cpp
@@ -152,13 +152,13 @@ StaffTextProperties::StaffTextProperties(const StaffTextBase* st, QWidget* paren
                   }
             else if (_staffText->swingParameters()->swingUnit == 0) {
                  swingBox->setEnabled(false);
-                 SwingOff->setChecked(true);
+                 swingOff->setChecked(true);
                  swingBox->setValue(_staffText->swingParameters()->swingRatio);
                  }
             }
 
       connect(mapper, SIGNAL(mapped(int)), SLOT(voiceButtonClicked(int)));
-      connect(SwingOff, SIGNAL(toggled(bool)), SLOT(setSwingControls(bool)));
+      connect(swingOff, SIGNAL(toggled(bool)), SLOT(setSwingControls(bool)));
       connect(swingEighth, SIGNAL(toggled(bool)), SLOT(setSwingControls(bool)));
       connect(swingSixteenth, SIGNAL(toggled(bool)), SLOT(setSwingControls(bool)));
 
@@ -291,7 +291,7 @@ void StaffTextProperties::setSwingControls(bool checked)
       {
       if (!checked)
             return;
-      if (SwingOff->isChecked())
+      if (swingOff->isChecked())
             swingBox->setEnabled(false);
       else if (swingEighth->isChecked())
             swingBox->setEnabled(true);
@@ -465,7 +465,7 @@ void StaffTextProperties::saveValues()
             }
       if (setSwingBox->isChecked()) {
             _staffText->setSwing(true);
-            if (SwingOff->isChecked()) {
+            if (swingOff->isChecked()) {
                   _staffText->setSwingParameters(0, swingBox->value());
                   swingBox->setEnabled(false);
                   }


### PR DESCRIPTION
Resolves: https://musescore.org/node/301103.

+ rename "SwingOff" to "swingOff" for consistency