### PR TITLE
fix #284682: position offset when moving cross-beam notes with the mouse

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2393,7 +2393,7 @@ void Note::editDrag(EditData& editData)
 
 void Note::verticalDrag(EditData &ed)
       {
-      Fraction _tick           = chord()->tick();
+      Fraction _tick      = chord()->tick();
       const Staff* stf    = staff();
       const StaffType* st = stf->staffType(_tick);
 
@@ -2425,7 +2425,8 @@ void Note::verticalDrag(EditData &ed)
             }
       else {
             Key key = staff()->key(_tick);
-            int newPitch = line2pitch(ned->line + lineOffset, staff()->clef(_tick), key);
+            int idx = chord()->vStaffIdx();
+            int newPitch = line2pitch(ned->line + lineOffset, score()->staff(idx)->clef(_tick), key);
 
             if (!concertPitch()) {
                   Interval interval = staff()->part()->instrument(_tick)->transpose();

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -286,7 +286,7 @@ class Note final : public Element {
 
       void normalizeLeftDragDelta(Segment* seg, EditData &ed, NoteEditData* ned);
 
-public:
+   public:
       Note(Score* s = 0);
       Note(const Note&, bool link = false);
       ~Note();
@@ -324,7 +324,7 @@ public:
       void setHeadGroup(NoteHead::Group val);
       void setHeadType(NoteHead::Type t);
 
-      virtual int subtype() const override { return (int) _headGroup; }
+      virtual int subtype() const override { return int(_headGroup); }
       virtual QString subtypeName() const override;
 
       void setPitch(int val);


### PR DESCRIPTION
The staff index did not count `staffMove()` in, which resulted in possibly getting the wrong clef for `line2pitch()`. This commit uses `chord->vStaffIdx()` to get the right staff index.