### PR TITLE
fix #148311 by adding dummy note events to end of loop during playback

### DIFF
--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -1750,7 +1750,15 @@ void Seq::setLoopSelection()
 
       if (score && score->selection().isRange()) {
             cs->setLoopInTick(score->selection().tickStart());
-            cs->setLoopOutTick(score->selection().tickEnd());
+            cs->setLoopOutTick(score->selection().tickEnd());      
+            }
+      
+      // add a dummy event to loop end if it is not already there
+      // this is to let the playback reach the end completely before starting again
+      if (!events.count(cs->loopOutTick().ticks())) {
+            NPlayEvent ev;
+            ev.setValue(ME_INVALID);
+            events.insert(std::pair<int, Ms::NPlayEvent>(cs->loopOutTick().ticks(), ev));
             }
       }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/148311

The playback in MuseScore relies on midi events to know when to stop playing / loop back to start. By default, metronome ticks are added to the events map at every beat, but if there is a note after the last tick, playback will loop back simply after playing the last note and will not reach the end of the measure.

One possible solution was to add an end-of-track (or similar) midi event to the last measure, however, that won't fix the issue because the user may try to loop a portion of the score, which might not end on a measure boundary. In this commit, I have added a dummy NPlayEvent at the end whenever the user selects a loop. This works even for loops within measures. As I have not modified libmscore/rendermidi.cpp, the exported MIDI files are not affected.