### PR TITLE
[MU4] fix #300978: enable importing external images in palettes

### DIFF
--- a/mscore/palette/palettetree.cpp
+++ b/mscore/palette/palettetree.cpp
@@ -344,6 +344,24 @@ PaletteCellPtr PaletteCell::readElementMimeData(const QByteArray& data)
       }
 
 //---------------------------------------------------------
+//   PaletteCell::readImageUri
+//---------------------------------------------------------
+
+PaletteCellPtr PaletteCell::readImageUri(const QUrl& u)
+      {
+      QFileInfo fi(u.path());
+      Image* s = new Image(gscore);
+      QString filePath(u.toLocalFile());
+      s->load(filePath);
+      std::unique_ptr<Element> e(s);
+      QFileInfo f(filePath);
+      
+      const QString name = f.completeBaseName();
+      return PaletteCellPtr(new PaletteCell(std::move(e), name));
+      }
+
+
+//---------------------------------------------------------
 //   PaletteCell::mimeData
 //---------------------------------------------------------
 

--- a/mscore/palette/palettetree.h
+++ b/mscore/palette/palettetree.h
@@ -67,6 +67,7 @@ struct PaletteCell {
       QByteArray mimeData() const;
       static PaletteCellPtr readMimeData(const QByteArray& data);
       static PaletteCellPtr readElementMimeData(const QByteArray& data);
+      static PaletteCellPtr readImageUri(const QUrl& u);
       };
 
 //---------------------------------------------------------

--- a/mscore/qml/palettes/Palette.qml
+++ b/mscore/qml/palettes/Palette.qml
@@ -175,14 +175,15 @@ GridView {
                     onEntered(drag);
                     return;
                 }
-
-                if (drag.source.dragged) {
-                    drag.source.internalDrag = internal;
-                    drag.source.dragCopy = action == Qt.CopyAction;
-                    paletteView.state = "drag";
-                    drag.source.paletteDrag = true;
-                } else if (typeof drag.source.paletteDrag !== "undefined") // if this is a palette and not, e.g., scoreview
-                    return;
+                if (drag.source) {
+                    if (drag.source.dragged) {
+                        drag.source.internalDrag = internal;
+                        drag.source.dragCopy = action == Qt.CopyAction;
+                        paletteView.state = "drag";
+                        drag.source.paletteDrag = true;
+                    } else if (typeof drag.source.paletteDrag !== "undefined") // if this is a palette and not, e.g., scoreview
+                        return;
+                }
 
                 drag.accept(action); // confirm we accept the action we determined inside onEntered
 
@@ -197,10 +198,9 @@ GridView {
 
             onEntered: {
                 onDragOverPaletteFinished();
-
                 // first check if controller allows dropping this item here
                 const mimeData = Utils.dropEventMimeData(drag);
-                internal = (drag.source.parentModelIndex == paletteView.paletteRootIndex);
+                internal = drag.source && (drag.source.parentModelIndex == paletteView.paletteRootIndex);
                 action = paletteView.paletteController.dropAction(mimeData, drag.proposedAction, paletteView.paletteRootIndex, internal);
                 proposedAction = drag.proposedAction;
 
@@ -245,8 +245,8 @@ GridView {
                 // Therefore record the necessary information to move cells later.
                 const data = {
                     action: action,
-                    srcParentModelIndex: drag.source.parentModelIndex,
-                    srcRowIndex: drag.source.rowIndex,
+                    srcParentModelIndex: drag.source ? drag.source.parentModelIndex : undefined,
+                    srcRowIndex: drag.source ? drag.source.rowIndex : undefined,
                     paletteView: paletteView,
                     destIndex: destIndex,
                     mimeData: Utils.dropEventMimeData(drop)


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/300978

This adds back the ability to drop an image file onto a palette and have it imported.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
