### PR TITLE
Fix #290409 - Stave brackets disappear on a 1 line percussion staff

### DIFF
--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -437,7 +437,7 @@ void System::setBracketsXPosition(const qreal xPosition)
             for (const Bracket* b2 : _brackets) {
                   bool b1FirstStaffInB2 = (b1->firstStaff() >= b2->firstStaff() && b1->firstStaff() <= b2->lastStaff());
                   bool b1LastStaffInB2 = (b1->lastStaff() >= b2->firstStaff() && b1->lastStaff() <= b2->lastStaff());
-                  if (b1->column() > b2->column() && 
+                  if (b1->column() > b2->column() &&
                         (b1FirstStaffInB2 || b1LastStaffInB2))
                         xOffset += b2->width() + bracketDistance;
                   }
@@ -514,17 +514,26 @@ void System::layout2()
             Staff* staff  = score()->staff(si1);
             auto ni       = i + 1;
 
-            qreal h = staff->height();
+            qreal dist = staff->height();
+            qreal yOffset;
+            qreal h;
+            if (staff->lines(Fraction(0, 1)) == 1) {
+                  yOffset = _spatium * BARLINE_SPAN_1LINESTAFF_TO * 0.5;
+                  h = _spatium * (BARLINE_SPAN_1LINESTAFF_TO - BARLINE_SPAN_1LINESTAFF_FROM) * 0.5;
+                  }
+            else {
+                  yOffset = 0.0;
+                  h = staff->height();
+                  }
             if (ni == visibleStaves.end()) {
 //                  ss->setYOff(staff->lines(0) == 1 ? _spatium * staff->mag(0) : 0.0);
-                  ss->setYOff(0.0);
-                  ss->bbox().setRect(_leftMargin, y, width() - _leftMargin, h);
+                  ss->setYOff(yOffset);
+                  ss->bbox().setRect(_leftMargin, y - yOffset, width() - _leftMargin, h);
                   break;
                   }
 
             int si2        = ni->first;
             Staff* staff2  = score()->staff(si2);
-            qreal dist     = h;
 
 #if 1
             if (staff->part() == staff2->part()) {
@@ -592,7 +601,7 @@ void System::layout2()
                         }
                   sp = m->vspacerUp(si2);
                   if (sp)
-                        dist = qMax(dist, sp->gap() + h);
+                        dist = qMax(dist, sp->gap() + staff->height());
                   }
             if (!fixedSpace) {
                   qreal d = score()->lineMode() ? 0.0 : ss->skyline().minDistance(System::staff(si2)->skyline());
@@ -601,8 +610,8 @@ void System::layout2()
 #endif
 
 //            ss->setYOff(staff->lines(0) == 1 ? _spatium * staff->mag(0) : 0.0);
-            ss->setYOff(0.0);
-            ss->bbox().setRect(_leftMargin, y, width() - _leftMargin, h);
+            ss->setYOff(yOffset);
+            ss->bbox().setRect(_leftMargin, y - yOffset, width() - _leftMargin, h);
             y += dist;
             }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/290409

Original code was using the height of the staff to calculate the hight of the
brackets. But for single line staff (percussion instruments!) there is only one
line, resulting in a height of zero, meaning a height of zero.
Now, for single line staves, the height of the barlines is taken. Since barlines
can span several staves in a system the calculation of the barline height has to
implemented in this code itself.
By setting the correct bbox and yOffset for the SysStaff object, this changes will
affect the layout of the system. Compared with version 3.4 all staves of a system
are on exactly the same position.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n.a.] I created the test (mtest, vtest, script test) to verify the changes I made
