### PR TITLE
fix tst_durationtype.cpp conflict with minGW - "wingdi.h" defined Chord type

### DIFF
--- a/mtest/libmscore/durationtype/tst_durationtype.cpp
+++ b/mtest/libmscore/durationtype/tst_durationtype.cpp
@@ -71,7 +71,7 @@ void TestDurationType::halfDuration()
 
       score->startCmd();
       score->cmdAddPitch(42, false, false);
-      Chord* c = score->firstMeasure()->findChord(Fraction(0,1), 0);
+      Ms::Chord* c = score->firstMeasure()->findChord(Fraction(0,1), 0);
       QVERIFY(c->ticks() == Fraction(1, 1));
       score->endCmd();
 
@@ -80,7 +80,7 @@ void TestDurationType::halfDuration()
             score->startCmd();
             score->cmdHalfDuration();
             score->endCmd();
-            Chord* c = score->firstMeasure()->findChord(Fraction(0,1), 0);
+            Ms::Chord* c = score->firstMeasure()->findChord(Fraction(0,1), 0);
             QVERIFY(c->ticks() == Fraction(i / 2, 128));
             }
       }
@@ -106,7 +106,7 @@ void TestDurationType::doubleDuration()
       // repeatedly double-duration from V_128 to V_WHOLE
       for (int i = 1; i < 128; i *= 2) {
             score->cmdDoubleDuration();
-            Chord* c = score->firstMeasure()->findChord(Fraction(0,1), 0);
+            Ms::Chord* c = score->firstMeasure()->findChord(Fraction(0,1), 0);
             QVERIFY(c->ticks() == Fraction(2 * i, 128));
             }
       score->endCmd();
@@ -128,13 +128,13 @@ void TestDurationType::decDurationDotted()
 
       score->startCmd();
       score->cmdAddPitch(42, false, false);
-      Chord* c = score->firstMeasure()->findChord(Fraction(0,1), 0);
+      Ms::Chord* c = score->firstMeasure()->findChord(Fraction(0,1), 0);
       QVERIFY(c->ticks() == Fraction(1, 1));
 
       // repeatedly dec-duration-dotted from V_WHOLE to V_128
       for (int i = 128; i > 1; i /= 2) {
             score->cmdDecDurationDotted();
-            Chord* c = score->firstMeasure()->findChord(Fraction(0,1), 0);
+            Ms::Chord* c = score->firstMeasure()->findChord(Fraction(0,1), 0);
             QVERIFY(c->ticks() == Fraction(i + i/2, 256));
 
             score->cmdDecDurationDotted();


### PR DESCRIPTION
Resolves error when compiling mtest/libmscore/durationtype/tst_durationtype.cpp

Error encountered: "error: reference to 'Chord' is ambiguous" 
which refers to minGW "wingdi.h" headers which defines a Chord type of its own.

*Use "x" letter to fill the checkboxes below like [x]*

- [X] I signed [CLA](https://musescore.org/en/cla)
- [X] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [X] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A ] I created the test (mtest, vtest, script test) to verify the changes I made
