### PR TITLE
Fix #301210: Paste Half Duration / Paste Double Duration missing from various context menus

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -294,6 +294,8 @@ void ScoreView::objectPopup(const QPoint& pos, Element* obj)
       popup->addAction(getAction("cut"));
       popup->addAction(getAction("copy"));
       popup->addAction(getAction("paste"));
+      popup->addAction(getAction("paste-half"));
+      popup->addAction(getAction("paste-double"));
       popup->addAction(getAction("swap"));
       popup->addAction(getAction("delete"));
 
@@ -401,6 +403,8 @@ void ScoreView::measurePopup(QContextMenuEvent* ev, Measure* obj)
       popup->addAction(getAction("cut"));
       popup->addAction(getAction("copy"));
       popup->addAction(getAction("paste"));
+      popup->addAction(getAction("paste-half"));
+      popup->addAction(getAction("paste-double"));
       popup->addAction(getAction("swap"));
       popup->addAction(getAction("delete"));
 


### PR DESCRIPTION
Resolves: [#301210](https://musescore.org/en/node/301210)

Added “Paste Half Duration” and “Paste Double Duration” menu items to the context menus for score elements and measures.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made