### PR TITLE
Fix #301124: Always show correct pathname in Score Properties

### DIFF
--- a/mscore/metaedit.cpp
+++ b/mscore/metaedit.cpp
@@ -50,7 +50,9 @@ MetaEditDialog::MetaEditDialog(Score* s, QWidget* parent)
       if (previousFileName.isEmpty() || previousFileName == currentFileName) // New score or no "Save as" used
             filePath->setText(previousFileName);
       else
-            filePath->setText(QString("%1\n%2\n%3").arg(currentFileName, tr("initially read from:"), previousFileName));
+            filePath->setText(QString("%1\n%2\n%3")
+                              .arg(QFileInfo::exists(currentFileName) ? currentFileName : "<b>" + tr("Not saved yet,") + "</b>",
+                                   tr("initially read from:"), previousFileName));
       filePath->setTextInteractionFlags(Qt::TextSelectableByMouse);
 
       int idx = 0;

--- a/mscore/metaedit.cpp
+++ b/mscore/metaedit.cpp
@@ -44,7 +44,13 @@ MetaEditDialog::MetaEditDialog(Score* s, QWidget* parent)
             revision->setText(QString::number(rev, 16));
       else
             revision->setText(QString::number(rev, 10));
-      filePath->setText(score->importedFilePath());
+
+      QString currentFileName  = score->masterScore()->fileInfo()->absoluteFilePath();
+      QString previousFileName = score->importedFilePath();
+      if (previousFileName.isEmpty() || previousFileName == currentFileName) // New score or no "Save as" used
+            filePath->setText(previousFileName);
+      else
+            filePath->setText(QString("%1\n%2\n%3").arg(currentFileName, tr("initially read from:"), previousFileName));
       filePath->setTextInteractionFlags(Qt::TextSelectableByMouse);
 
       int idx = 0;


### PR DESCRIPTION
even after a "Save as", then also show where the file initialy got read from

Solves https://musescore.org/en/node/301124