### PR TITLE
fix #301259: wrong offset used for non-default text styles

### DIFF
--- a/libmscore/dynamic.cpp
+++ b/libmscore/dynamic.cpp
@@ -522,7 +522,7 @@ QString Dynamic::propertyUserValue(Pid pid) const
 
 Sid Dynamic::getPropertyStyle(Pid pid) const
       {
-      if (pid == Pid::OFFSET)
+      if (pid == Pid::OFFSET && tid() == Tid::DYNAMICS)
             return placeAbove() ? Sid::dynamicsPosAbove : Sid::dynamicsPosBelow;
       return TextBase::getPropertyStyle(pid);
       }

--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -580,7 +580,7 @@ QVariant Lyrics::propertyDefault(Pid id) const
 
 Sid Lyrics::getPropertyStyle(Pid pid) const
       {
-      if (pid == Pid::OFFSET)
+      if (pid == Pid::OFFSET && (tid() == Tid::LYRICS_ODD || tid() == Tid::LYRICS_EVEN))
             return placeAbove() ? Sid::lyricsPosAbove : Sid::lyricsPosBelow;
       return TextBase::getPropertyStyle(pid);
       }

--- a/libmscore/rehearsalmark.cpp
+++ b/libmscore/rehearsalmark.cpp
@@ -102,7 +102,7 @@ QVariant RehearsalMark::propertyDefault(Pid id) const
 
 Sid RehearsalMark::getPropertyStyle(Pid pid) const
       {
-      if (pid == Pid::OFFSET)
+      if (pid == Pid::OFFSET && tid() == Tid::REHEARSAL_MARK)
             return placeAbove() ? Sid::rehearsalMarkPosAbove : Sid::rehearsalMarkPosBelow;
       return TextBase::getPropertyStyle(pid);
       }

--- a/libmscore/stafftext.cpp
+++ b/libmscore/stafftext.cpp
@@ -68,7 +68,7 @@ QVariant StaffText::propertyDefault(Pid id) const
 
 Sid StaffText::getPropertyStyle(Pid pid) const
       {
-      if (pid == Pid::OFFSET)
+      if (pid == Pid::OFFSET && tid() == Tid::STAFF)
             return placeAbove() ? Sid::staffTextPosAbove : Sid::staffTextPosBelow;
       return TextBase::getPropertyStyle(pid);
       }

--- a/libmscore/sticking.cpp
+++ b/libmscore/sticking.cpp
@@ -97,7 +97,7 @@ QVariant Sticking::propertyDefault(Pid id) const
 
 Sid Sticking::getPropertyStyle(Pid pid) const
       {
-      if (pid == Pid::OFFSET)
+      if (pid == Pid::OFFSET && tid() == Tid::STICKING)
             return placeAbove() ? Sid::stickingPosAbove : Sid::stickingPosBelow;
       return TextBase::getPropertyStyle(pid);
       }

--- a/libmscore/systemtext.cpp
+++ b/libmscore/systemtext.cpp
@@ -63,7 +63,7 @@ void SystemText::layout()
 
 Sid SystemText::getPropertyStyle(Pid pid) const
       {
-      if (pid == Pid::OFFSET)
+      if (pid == Pid::OFFSET && tid() == Tid::SYSTEM)
             return placeAbove() ? Sid::systemTextPosAbove : Sid::systemTextPosBelow;
       return TextBase::getPropertyStyle(pid);
       }

--- a/libmscore/tempotext.cpp
+++ b/libmscore/tempotext.cpp
@@ -480,7 +480,7 @@ QString TempoText::accessibleInfo() const
 
 Sid TempoText::getPropertyStyle(Pid pid) const
       {
-      if (pid == Pid::OFFSET)
+      if (pid == Pid::OFFSET && tid() == Tid::TEMPO)
             return placeAbove() ? Sid::tempoPosAbove : Sid::tempoPosBelow;
       return TextBase::getPropertyStyle(pid);
       }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/301259

As shown in the issue description, there are several related problems
that all stem from the same cause, in StaffText::getPropertyStyle():
we assume the Pid::OFFSET should always map to Sid::staffTextPosAbove
(or Sid::staffTextPosBelow, if placement is below)
even if the staff text has been assigned a non-default text style.
This causes score load, set as style, and other operations
to always use the Staff Text style setting for offset
rather than the actual offset setting for the current text style.
Other text style properties work as expected,
only offset fails in this way.

Fix is simple enough: we need to check Tid before mapping Pid to Sid.
If the Tid is anything but the normal text style for the element type,
we should skip the assignment of the Sid for Above/Below position,
and just fall through to the using TextBase::getPropertyStyle().

Since it's not just staff text affected, I considered making this change
further upstream.  However, while I found two relevant call sites,
I had much less confidence this would fix all cases.
So I elected to fix at each of the sources.
Probably the code could be refactored a bit,
by somehow associating the two above/below Sid values with the text style,
but that seemed like its own project for another day.

I have verified this fixes the problems documented in the issue.
More testing would still be advisable to make sure nothing else broke.
I have yet to add an automated test, as I'm not sure the best way
to do that.