### PR TITLE
Timeline optimizations

### DIFF
--- a/libmscore/measurebase.cpp
+++ b/libmscore/measurebase.cpp
@@ -603,7 +603,7 @@ int MeasureBase::index() const
 int MeasureBase::measureIndex() const
       {
       int idx = 0;
-      MeasureBase* m = score()->first();
+      MeasureBase* m = score()->firstMeasure();
       while (m) {
             if (m == this)
                   return idx;

--- a/mscore/measureproperties.cpp
+++ b/mscore/measureproperties.cpp
@@ -287,7 +287,7 @@ void MeasureProperties::apply()
 
       score->select(m, SelectType::SINGLE, 0);
       score->update();
-      mscore->timeline()->updateGrid();
+      mscore->timeline()->updateGridFull();
       }
 
 //---------------------------------------------------------

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5943,7 +5943,7 @@ void MuseScore::endCmd(bool undoRedo)
       getPluginEngine()->beginEndCmd(this, undoRedo);
 #endif
       if (timeline())
-            timeline()->updateGrid();
+            timeline()->updateGridFromCmdState();
       if (MScore::_error != MS_NO_ERROR)
             showError();
       if (cs) {

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -486,7 +486,7 @@ void TRowLabels::mousePressEvent(QMouseEvent* event)
             mouseOver(mapToScene(mapFromGlobal(QCursor::pos())));
 
             parent->setCollapsed(!parent->collapsed());
-            parent->updateGrid();
+            parent->updateGridView();
             }
       else {
             // Check if pixmap was selected
@@ -893,25 +893,69 @@ Timeline::Timeline(TDockWidget* dockWidget, QWidget* parent)
 //   Timeline::drawGrid
 //---------------------------------------------------------
 
-void Timeline::drawGrid(int globalRows, int globalCols)
+void Timeline::drawGrid(int globalRows, int globalCols, int startMeasure, int endMeasure)
       {
-      clearScene();
+      if (endMeasure < 0)
+            endMeasure = globalCols;
+      if (startMeasure < 0)
+            endMeasure = startMeasure;
+
+      const bool rebuildAll = (
+         gridRows != globalRows || gridCols != globalCols
+         || (startMeasure == 0 && 2 * (endMeasure - startMeasure) > globalCols) // rebuild all if more than half of score has changed
+         );
+      const bool rebuildPartial = !rebuildAll && (startMeasure >= 0);
+
+      const unsigned numMetas = nmetas();
+
+      if (rebuildAll) {
+            clearScene();
+            startMeasure = 0;
+            endMeasure = globalCols;
+            }
+      else {
+            if (rebuildPartial) {
+                  const QRectF replacedRect = getMeasureRect(startMeasure, 0, numMetas) | getMeasureRect(endMeasure - 1, globalRows - 1, numMetas);
+                  const QList<QGraphicsItem*> replacedItems = scene()->items(replacedRect, Qt::ContainsItemShape);
+                  for (QGraphicsItem* item : replacedItems) {
+                        if (item->data(keyItemType).value<ItemType>() != ItemType::TYPE_MEASURE)
+                              continue;
+                        scene()->removeItem(item);
+                        delete item;
+                        }
+                  }
+
+            // Meta rows are still rebuilt from scratch, remove old meta rows manually
+            const QList<QGraphicsItem*> items = scene()->items();
+            for (QGraphicsItem* item : items) {
+                  if (item->data(keyItemType).value<ItemType>() != ItemType::TYPE_META)
+                        continue;
+                  scene()->removeItem(item);
+                  delete item;
+                  }
+            }
+
       _metaRows.clear();
 
       if (globalRows == 0 || globalCols == 0)
             return;
+
       int stagger = 0;
-      unsigned numMetas = nmetas();
       setMinimumHeight(_gridHeight * (numMetas + 1) + 5 + horizontalScrollBar()->height());
       setMinimumWidth(_gridWidth * 3);
       _globalZValue = 1;
 
       // Draw grid
       Measure* currMeasure = _score->firstMeasure();
+      for (int i = 0; i < startMeasure; ++i)
+            currMeasure = currMeasure->nextMeasure();
+
       QList<Part*> partList = getParts();
-      for (int col = 0; col < globalCols; col++) {
+
+      for (int col = startMeasure; col < endMeasure; col++) {
             for (int row = 0; row < globalRows; row++) {
                   QGraphicsRectItem* graphicsRectItem = new QGraphicsRectItem(getMeasureRect(col, row, numMetas));
+                  graphicsRectItem->setData(keyItemType, QVariant::fromValue(ItemType::TYPE_MEASURE));
 
                   setMetaData(graphicsRectItem, row, ElementType::INVALID, currMeasure, false, 0);
 
@@ -937,15 +981,16 @@ void Timeline::drawGrid(int globalRows, int globalCols)
             }
       setSceneRect(0, 0, getWidth(), getHeight());
 
-      //Draw meta rows and separator
+      // Draw meta rows and separator
       QGraphicsLineItem* graphicsLineItemSeparator = new QGraphicsLineItem(0,
                                                                            _gridHeight * numMetas + verticalScrollBar()->value() + 1,
                                                                            getWidth() - 1,
                                                                            _gridHeight * numMetas + verticalScrollBar()->value() + 1);
+      graphicsLineItemSeparator->setData(keyItemType, QVariant::fromValue(ItemType::TYPE_META));
       graphicsLineItemSeparator->setPen(QPen(activeTheme().gridColor1, 4));
       graphicsLineItemSeparator->setZValue(-2);
       scene()->addItem(graphicsLineItemSeparator);
-      std::pair<QGraphicsItem*, int> pairGraphicsIntSeparator = std::make_pair(graphicsLineItemSeparator, numMetas);
+      std::pair<QGraphicsItem*, int> pairGraphicsIntSeparator(graphicsLineItemSeparator, numMetas);
       _metaRows.push_back(pairGraphicsIntSeparator);
 
       for (unsigned row = 0; row < numMetas; row++) {
@@ -953,13 +998,14 @@ void Timeline::drawGrid(int globalRows, int globalCols)
                                                                _gridHeight * row + verticalScrollBar()->value(),
                                                                getWidth(),
                                                                _gridHeight);
+            metaRow->setData(keyItemType, QVariant::fromValue(ItemType::TYPE_META));
             metaRow->setBrush(QBrush(activeTheme().gridColor2));
             metaRow->setPen(QPen(activeTheme().gridColor1));
             metaRow->setData(0, QVariant::fromValue<int>(-1));
 
             scene()->addItem(metaRow);
 
-            std::pair<QGraphicsItem*, int> pairGraphicsIntMeta = std::make_pair(metaRow, row);
+            std::pair<QGraphicsItem*, int> pairGraphicsIntMeta(metaRow, row);
             _metaRows.push_back(pairGraphicsIntMeta);
             }
 
@@ -1038,7 +1084,9 @@ void Timeline::drawGrid(int globalRows, int globalCols)
             xPos += _gridWidth;
             std::get<4>(_repeatInfo) = false;
             }
-      drawSelection();
+
+      gridRows = globalRows;
+      gridCols = globalCols;
       }
 
 //---------------------------------------------------------
@@ -1384,6 +1432,7 @@ void Timeline::measureMeta(Segment* , int* , int pos)
       // Add measure number
       QString measureNumber = (currMeasure->irregular())? "( )" : QString::number(currMeasure->no() + 1);
       QGraphicsTextItem* graphicsTextItem = new QGraphicsTextItem(measureNumber);
+      graphicsTextItem->setData(keyItemType, QVariant::fromValue(ItemType::TYPE_META));
       graphicsTextItem->setDefaultTextColor(activeTheme().measureMetaColor);
       graphicsTextItem->setX(pos);
       graphicsTextItem->setY(_gridHeight * row + verticalScrollBar()->value());
@@ -1539,6 +1588,9 @@ bool Timeline::addMetaValue(int x, int pos, QString metaText, int row, ElementTy
       setMetaData(graphicsRectItem, -1, elementType, measure, true, element, itemToAdd, seg);
       setMetaData(itemToAdd, -1, elementType, measure, true, element, graphicsRectItem, seg);
 
+      graphicsRectItem->setData(keyItemType, QVariant::fromValue(ItemType::TYPE_META));
+      itemToAdd->setData(keyItemType, QVariant::fromValue(ItemType::TYPE_META));
+
       graphicsRectItem->setZValue(_globalZValue);
       itemToAdd->setZValue(_globalZValue);
 
@@ -1663,6 +1715,7 @@ void Timeline::clearScene()
       // clear pointers to scene items, they have been deleted by clear()
       nonVisiblePathItem = nullptr;
       visiblePathItem = nullptr;
+      selectionItem = nullptr;
       }
 
 //---------------------------------------------------------
@@ -1842,7 +1895,7 @@ void Timeline::drawSelection()
                   }
             }
 
-      QList<QGraphicsItem*> graphicsItemList = scene()->items();
+      const QList<QGraphicsItem*> graphicsItemList = scene()->items();
       for (QGraphicsItem* graphicsItem : graphicsItemList) {
             int stave = graphicsItem->data(0).value<int>();
             ElementType elementType = graphicsItem->data(1).value<ElementType>();
@@ -1895,15 +1948,21 @@ void Timeline::drawSelection()
                   }
             }
 
-      QGraphicsPathItem* graphicsPathItem = new QGraphicsPathItem(_selectionPath.simplified());
-      if (selection.isRange())
-            graphicsPathItem->setPen(QPen(QColor(0, 0, 255), 3));
-      else
-            graphicsPathItem->setPen(QPen(QColor(0, 0, 0), 1));
+      if (selectionItem) {
+            scene()->removeItem(selectionItem);
+            delete selectionItem;
+            selectionItem = nullptr;
+            }
 
-      graphicsPathItem->setBrush(Qt::NoBrush);
-      graphicsPathItem->setZValue(-1);
-      scene()->addItem(graphicsPathItem);
+      selectionItem = new QGraphicsPathItem(_selectionPath.simplified());
+      if (selection.isRange())
+            selectionItem->setPen(QPen(QColor(0, 0, 255), 3));
+      else
+            selectionItem->setPen(QPen(QColor(0, 0, 0), 1));
+
+      selectionItem->setBrush(Qt::NoBrush);
+      selectionItem->setZValue(-1);
+      scene()->addItem(selectionItem);
 
       if (std::get<0>(_oldHoverInfo)) {
             std::get<0>(_oldHoverInfo) = nullptr;
@@ -2241,11 +2300,11 @@ void Timeline::wheelEvent(QWheelEvent* event)
 
             if (event->angleDelta().y() > 0 && _gridWidth < _maxZoom) {
                   _gridWidth++;
-                  updateGrid();
+                  updateGridFull();
                   }
             else if (event->angleDelta().y() < 0 && _gridWidth > _minZoom) {
                   _gridWidth--;
-                  updateGrid();
+                  updateGridFull();
                   }
 
             // Attempt to keep mouse in original spot
@@ -2262,22 +2321,64 @@ void Timeline::wheelEvent(QWheelEvent* event)
       }
 
 //---------------------------------------------------------
+//   showEvent
+//---------------------------------------------------------
+
+void Timeline::showEvent(QShowEvent* evt)
+      {
+      QGraphicsView::showEvent(evt);
+      if (!evt->spontaneous())
+            setScore(_score);
+      }
+
+//---------------------------------------------------------
 //   Timeline::updateGrid
 //---------------------------------------------------------
 
-void Timeline::updateGrid()
+void Timeline::updateGrid(int startMeasure, int endMeasure)
       {
       if (!isVisible())
             return;
 
       if (_score && _score->firstMeasure()) {
-            drawGrid(nstaves(), _score->nmeasures());
+            drawGrid(nstaves(), _score->nmeasures(), startMeasure, endMeasure);
             updateView();
             drawSelection();
             mouseOver(mapToScene(mapFromGlobal(QCursor::pos())));
             _rowNames->updateLabels(getLabels(), _gridHeight);
             }
       viewport()->update();
+      }
+
+//---------------------------------------------------------
+//   updateGridFromCmdState
+//---------------------------------------------------------
+
+void Timeline::updateGridFromCmdState()
+      {
+      if (!isVisible())
+            return;
+
+      if (!_score) {
+            updateGridFull();
+            return;
+            }
+
+      const CmdState& state = _score->cmdState();
+
+      const bool layoutChanged = state.layoutRange();
+
+      if (!layoutChanged) {
+            updateGridView();
+            return;
+            }
+
+      const bool layoutAll = layoutChanged && (state.startTick() < Fraction(0, 1) || state.endTick() < Fraction(0, 1));
+
+      const int startMeasure = layoutAll ? 0 : _score->tick2measure(state.startTick())->measureIndex();
+      const int endMeasure = layoutAll ? _score->nmeasures() : (_score->tick2measure(state.endTick())->measureIndex() + 1);
+
+      updateGrid(startMeasure, endMeasure);
       }
 
 //---------------------------------------------------------
@@ -2289,9 +2390,15 @@ void Timeline::setScore(Score* s)
       _score = s;
       clearScene();
 
-      if (_score) {
+      if (_score)
             connect(_score, &QObject::destroyed, this, &Timeline::objectDestroyed, Qt::UniqueConnection);
+
+      if (!isVisible())
+            return;
+
+      if (_score) {
             drawGrid(nstaves(), _score->nmeasures());
+            drawSelection();
             changeSelection(SelState::NONE);
             _rowNames->updateLabels(getLabels(), _gridHeight);
             }
@@ -2852,7 +2959,8 @@ QString Timeline::cursorIsOn()
                   for (QGraphicsItem* currGraphicsItem : graphicsItemList) {
                         Measure* currMeasure = static_cast<Measure*>(currGraphicsItem->data(2).value<void*>());
                         int stave = currGraphicsItem->data(0).value<int>();
-                        if (currMeasure && !numToStaff(stave)->show())
+                        const Staff* st = numToStaff(stave);
+                        if (currMeasure && !(st && st->show()))
                               return "invalid";
                         }
                   return "instrument";

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -895,7 +895,7 @@ Timeline::Timeline(TDockWidget* dockWidget, QWidget* parent)
 
 void Timeline::drawGrid(int globalRows, int globalCols)
       {
-      scene()->clear();
+      clearScene();
       _metaRows.clear();
 
       if (globalRows == 0 || globalCols == 0)
@@ -911,10 +911,7 @@ void Timeline::drawGrid(int globalRows, int globalCols)
       QList<Part*> partList = getParts();
       for (int col = 0; col < globalCols; col++) {
             for (int row = 0; row < globalRows; row++) {
-                  QGraphicsRectItem* graphicsRectItem = new QGraphicsRectItem(col * _gridWidth,
-                                                                              _gridHeight * (row + numMetas) + 3,
-                                                                              _gridWidth,
-                                                                              _gridHeight);
+                  QGraphicsRectItem* graphicsRectItem = new QGraphicsRectItem(getMeasureRect(col, row, numMetas));
 
                   setMetaData(graphicsRectItem, row, ElementType::INVALID, currMeasure, false, 0);
 
@@ -1656,6 +1653,19 @@ QList<Part*> Timeline::getParts()
       }
 
 //---------------------------------------------------------
+//   clearScene
+//---------------------------------------------------------
+
+void Timeline::clearScene()
+      {
+      scene()->clear();
+
+      // clear pointers to scene items, they have been deleted by clear()
+      nonVisiblePathItem = nullptr;
+      visiblePathItem = nullptr;
+      }
+
+//---------------------------------------------------------
 //   Timeline::changeSelection
 //---------------------------------------------------------
 
@@ -2277,7 +2287,7 @@ void Timeline::updateGrid()
 void Timeline::setScore(Score* s)
       {
       _score = s;
-      scene()->clear();
+      clearScene();
 
       if (_score) {
             connect(_score, &QObject::destroyed, this, &Timeline::objectDestroyed, Qt::UniqueConnection);
@@ -2339,21 +2349,28 @@ void Timeline::updateView()
       if (_cv && _score) {
             QRectF canvas = QRectF(_cv->matrix().inverted().mapRect(_cv->geometry()));
 
-            std::set<std::pair<Measure*, int>> visibleItemsSet;
+            // Find visible elements in timeline
+            QPainterPath visiblePainterPath = QPainterPath();
+            visiblePainterPath.setFillRule(Qt::WindingFill);
 
             // Find visible measures of score
-            for (Measure* currMeasure = _score->firstMeasure(); currMeasure; currMeasure = currMeasure->nextMeasure()) {
+            int measureIndex = 0;
+            const int numMetas = nmetas();
+
+            for (Measure* currMeasure = _score->firstMeasure(); currMeasure; currMeasure = currMeasure->nextMeasure(), ++measureIndex) {
                   System* system = currMeasure->system();
 
                   if (currMeasure->mmRest() && _score->styleB(Sid::createMultiMeasureRests)) {
                         // Handle mmRests
                         Measure* mmrestMeasure = currMeasure->mmRest();
                         system = mmrestMeasure->system();
-                        if (!system)
+                        if (!system) {
+                              measureIndex += currMeasure->mmRestCount();
                               continue;
+                              }
 
                         // Add all measures within mmRest to visibleItemsSet if mmRest_visible
-                        for (; currMeasure != mmrestMeasure->mmRestLast(); currMeasure = currMeasure->nextMeasure()) {
+                        for (; currMeasure != mmrestMeasure->mmRestLast(); currMeasure = currMeasure->nextMeasure(), ++measureIndex) {
                               for (int staff = 0; staff < _score->staves().length(); staff++) {
                                     if (!_score->staff(staff)->show())
                                           continue;
@@ -2364,8 +2381,7 @@ void Timeline::updateView()
                                     QRectF showRect = mmrestMeasure->canvasBoundingRect().intersected(staveRect);
 
                                     if (canvas.intersects(showRect)) {
-                                          std::pair<Measure*, int> p = std::make_pair(currMeasure, staff);
-                                          visibleItemsSet.insert(p);
+                                          visiblePainterPath.addRect(getMeasureRect(measureIndex, staff, numMetas));
                                           }
                                     }
                               }
@@ -2381,8 +2397,7 @@ void Timeline::updateView()
                               QRectF showRect = mmrestMeasure->canvasBoundingRect().intersected(staveRect);
 
                               if (canvas.intersects(showRect)) {
-                                    std::pair<Measure*, int> p = std::make_pair(currMeasure, staff);
-                                    visibleItemsSet.insert(p);
+                                    visiblePainterPath.addRect(getMeasureRect(measureIndex, staff, numMetas));
                                     }
                               }
                         continue;
@@ -2401,26 +2416,20 @@ void Timeline::updateView()
                         QRectF showRect = currMeasure->canvasBoundingRect().intersected(staveRect);
 
                         if (canvas.intersects(showRect)) {
-                              std::pair<Measure*, int> p = std::make_pair(currMeasure, staff);
-                              visibleItemsSet.insert(p);
+                              visiblePainterPath.addRect(getMeasureRect(measureIndex, staff, numMetas));
                               }
                         }
                   }
 
-            // Find respective visible elements in timeline
-            QPainterPath visiblePainterPath = QPainterPath();
-            visiblePainterPath.setFillRule(Qt::WindingFill);
-            for (QGraphicsItem* graphicsItem : scene()->items()) {
-                  int stave = graphicsItem->data(0).value<int>();
-                  Measure* measure = static_cast<Measure*>(graphicsItem->data(2).value<void*>());
-                  if (numToStaff(stave) && !numToStaff(stave)->show())
-                        continue;
-
-                  std::pair<Measure*, int> tmp = std::make_pair(measure, stave);
-                  std::set<std::pair<Measure*, int>>::iterator it;
-                  it = visibleItemsSet.find(tmp);
-                  if (it != visibleItemsSet.end())
-                        visiblePainterPath.addRect(graphicsItem->boundingRect());
+            if (nonVisiblePathItem) {
+                  scene()->removeItem(nonVisiblePathItem);
+                  delete nonVisiblePathItem;
+                  nonVisiblePathItem = nullptr;
+                  }
+            if (visiblePathItem) {
+                  scene()->removeItem(visiblePathItem);
+                  delete visiblePathItem;
+                  visiblePathItem = nullptr;
                   }
 
             QPainterPath nonVisiblePainterPath = QPainterPath();
@@ -2431,7 +2440,7 @@ void Timeline::updateView()
 
             nonVisiblePainterPath = nonVisiblePainterPath.subtracted(visiblePainterPath);
 
-            QGraphicsPathItem* nonVisiblePathItem = new QGraphicsPathItem(nonVisiblePainterPath.simplified());
+            nonVisiblePathItem = new QGraphicsPathItem(nonVisiblePainterPath.simplified());
 
             QPen nonVisiblePen = QPen(activeTheme().nonVisiblePenColor);
             QBrush nonVisibleBrush = QBrush(activeTheme().nonVisibleBrushColor);
@@ -2439,24 +2448,13 @@ void Timeline::updateView()
             nonVisiblePathItem->setBrush(nonVisibleBrush);
             nonVisiblePathItem->setZValue(-3);
 
-            QGraphicsPathItem* visible = new QGraphicsPathItem(visiblePainterPath.simplified());
-            visible->setPen(nonVisiblePen);
-            visible->setBrush(Qt::NoBrush);
-            visible->setZValue(-2);
-
-            // Find old path, remove it
-            for (QGraphicsItem* graphicsItem : scene()->items()) {
-                  if (graphicsItem->type() == QGraphicsPathItem().type()) {
-                        QGraphicsPathItem* oldPathItem = static_cast<QGraphicsPathItem*>(graphicsItem);
-                        QBrush oldBrush = oldPathItem->brush();
-                        QPen oldPen = oldPathItem->pen();
-                        if (oldBrush == nonVisibleBrush || oldPen == nonVisiblePen)
-                              scene()->removeItem(oldPathItem);
-                        }
-                  }
+            visiblePathItem = new QGraphicsPathItem(visiblePainterPath.simplified());
+            visiblePathItem->setPen(nonVisiblePen);
+            visiblePathItem->setBrush(Qt::NoBrush);
+            visiblePathItem->setZValue(-2);
 
             scene()->addItem(nonVisiblePathItem);
-            scene()->addItem(visible);
+            scene()->addItem(visiblePathItem);
             }
       }
 

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -1946,6 +1946,12 @@ void Timeline::drawSelection()
                                                              255)));
                   _selectionPath.addRect(graphicsRectItem->rect());
                   }
+            else {
+                  // Ensure unselected measures are not marked selected
+                  QGraphicsRectItem* graphicsRectItem = qgraphicsitem_cast<QGraphicsRectItem*>(graphicsItem);
+                  if (graphicsRectItem && graphicsRectItem->data(keyItemType).value<ItemType>() == ItemType::TYPE_MEASURE)
+                        graphicsRectItem->setBrush(QBrush(colorBox(graphicsRectItem)));
+                  }
             }
 
       if (selectionItem) {
@@ -2761,12 +2767,12 @@ void Timeline::mouseOver(QPointF pos)
       QGraphicsRectItem* graphicsRectItem2 = qgraphicsitem_cast<QGraphicsRectItem*>(pairItem);
       if (graphicsRectItem1) {
             std::get<2>(_oldHoverInfo) = graphicsRectItem1->brush().color();
-            if (std::get<2>(_oldHoverInfo) != QColor(173,216,230))
+            if (std::get<2>(_oldHoverInfo) != activeTheme().selectionColor)
                   graphicsRectItem1->setBrush(QBrush(activeTheme().backgroundColor));
             }
       if (graphicsRectItem2) {
             std::get<2>(_oldHoverInfo) = graphicsRectItem2->brush().color();
-            if (std::get<2>(_oldHoverInfo) != QColor(173,216,230))
+            if (std::get<2>(_oldHoverInfo) != activeTheme().selectionColor)
                   graphicsRectItem2->setBrush(QBrush(activeTheme().backgroundColor));
             }
       }

--- a/mscore/timeline.h
+++ b/mscore/timeline.h
@@ -144,6 +144,9 @@ class Timeline : public QGraphicsView {
       Score* _score { nullptr };
       ScoreView* _cv { nullptr };
 
+      QGraphicsPathItem* nonVisiblePathItem = nullptr;
+      QGraphicsPathItem* visiblePathItem = nullptr;
+
       QGraphicsRectItem* _selectionBox { nullptr };
       std::vector<std::pair<QGraphicsItem*, int>> _metaRows;
 
@@ -184,6 +187,9 @@ class Timeline : public QGraphicsView {
       int correctStave(int stave);
 
       QList<Part*> getParts();
+
+      QRectF getMeasureRect(int measureIndex, int row, int numMetas) { return QRectF(measureIndex * _gridWidth, _gridHeight * (row + numMetas) + 3, _gridWidth, _gridHeight); }
+      void clearScene();
 
    private slots:
       void handleScroll(int value);

--- a/mscore/timeline.h
+++ b/mscore/timeline.h
@@ -124,6 +124,17 @@ struct TimelineTheme {
 class Timeline : public QGraphicsView {
       Q_OBJECT
 
+   public:
+      enum class ItemType {
+            TYPE_UNKNOWN = 0,
+            TYPE_MEASURE,
+            TYPE_META,
+            };
+      Q_ENUM(ItemType);
+
+   private:
+      static constexpr int keyItemType = 15;
+
       int _gridWidth = 20;
       int _gridHeight = 20;
       int _maxZoom = 50;
@@ -144,8 +155,12 @@ class Timeline : public QGraphicsView {
       Score* _score { nullptr };
       ScoreView* _cv { nullptr };
 
+      int gridRows = 0;
+      int gridCols = 0;
+
       QGraphicsPathItem* nonVisiblePathItem = nullptr;
       QGraphicsPathItem* visiblePathItem = nullptr;
+      QGraphicsPathItem* selectionItem = nullptr;
 
       QGraphicsRectItem* _selectionBox { nullptr };
       std::vector<std::pair<QGraphicsItem*, int>> _metaRows;
@@ -182,6 +197,7 @@ class Timeline : public QGraphicsView {
       virtual void mouseReleaseEvent(QMouseEvent*);
       virtual void wheelEvent(QWheelEvent *event);
       virtual void leaveEvent(QEvent*);
+      void showEvent(QShowEvent*) override;
 
       unsigned correctMetaRow(unsigned row);
       int correctStave(int stave);
@@ -190,6 +206,8 @@ class Timeline : public QGraphicsView {
 
       QRectF getMeasureRect(int measureIndex, int row, int numMetas) { return QRectF(measureIndex * _gridWidth, _gridHeight * (row + numMetas) + 3, _gridWidth, _gridHeight); }
       void clearScene();
+
+      void updateGrid(int startMeasure = -1, int endMeasure = -1);
 
    private slots:
       void handleScroll(int value);
@@ -213,7 +231,7 @@ class Timeline : public QGraphicsView {
       int correctPart(int stave);
 
       void drawSelection();
-      void drawGrid(int globalRows, int globalCols);
+      void drawGrid(int globalRows, int globalCols, int startMeasure = 0, int endMeasure = -1);
 
       void setScore(Score* s);
       void setScoreView(ScoreView* sv);
@@ -224,7 +242,9 @@ class Timeline : public QGraphicsView {
       int getHeight() const;
       const TimelineTheme& activeTheme() const;
 
-      void updateGrid();
+      void updateGridFull() { updateGrid(0, -1); }
+      void updateGridView() { updateGrid(-1, -1); }
+      void updateGridFromCmdState();
 
       QColor colorBox(QGraphicsRectItem* item);
 


### PR DESCRIPTION
As full timeline refactoring (#4542) has not been finished as for this moment, this PR tries to fix the most prominent performance issues of the old Timeline implementation. In general, the following optimizations are implemented:
1) Optimize the procedure of highlighting currently visible measures by avoiding iterating over all timeline items. This mostly affects score scrolling which could previously be noticeably slowed down on large scores if Timeline was open.
2) Implement partial updating of measure rectangles in Timeline. Top panel with metadata (tempo changes, time signatures etc.) is still fully updated on each action but the overall procedure of Timeline updating is still much faster than it was before.
3) Don't update data of invisible Timeline when loading or switching a score. This case has been missed from the previous optimizations for not updating invisible Timeline.

Although Timeline performance is still not ideal with this PR and could be optimized further, this PR should still hopefully make Timeline more usable for people working on relatively large scores. Users who don't use Timeline should also benefit from this PR due to the last optimization for invisible Timeline.