### PR TITLE
fix #279967: image resize not correctly honoring aspect ratio

### DIFF
--- a/mscore/inspector/inspectorImage.cpp
+++ b/mscore/inspector/inspectorImage.cpp
@@ -47,6 +47,12 @@ InspectorImage::InspectorImage(QWidget* parent)
             };
       const std::vector<InspectorPanel> ppList = { { b.title, b.panel } };
 
+      updateAspectRatio(); // initiate aspectRatio
+      connect(b.lockAspectRatio, &QCheckBox::toggled, this, &InspectorImage::lockAspectRatioClicked);
+
+      connect(b.size->xVal, QOverload<qreal>::of(&QDoubleSpinBox::valueChanged), this, &InspectorImage::widthChanged);
+      connect(b.size->yVal, QOverload<qreal>::of(&QDoubleSpinBox::valueChanged), this, &InspectorImage::heightChanged);
+
       mapSignals(iiList, ppList);
       }
 
@@ -56,8 +62,53 @@ InspectorImage::InspectorImage(QWidget* parent)
 
 void InspectorImage::valueChanged(int idx)
       {
-      InspectorBase::valueChanged(idx);
+      InspectorElementBase::valueChanged(idx);
       setElement();     // DEBUG
+      }
+
+//---------------------------------------------------------
+//   updateAspectRatio
+//---------------------------------------------------------
+
+void InspectorImage::updateAspectRatio()
+      {
+      Image* image = toImage(inspector->element());
+      qreal widthVal = image->size().width();
+      qreal heightVal = image->size().height();
+
+      _aspectRatio = heightVal != 0.0 ? widthVal / heightVal : 1.0;
+      }
+
+//---------------------------------------------------------
+//   lockAspectRatioClicked
+//---------------------------------------------------------
+
+void InspectorImage::lockAspectRatioClicked(bool checked)
+      {
+      if (checked)
+            updateAspectRatio();
+      }
+
+//---------------------------------------------------------
+//   widthChanged
+//---------------------------------------------------------
+
+void InspectorImage::widthChanged(qreal val)
+      {
+      Image* image = toImage(inspector->element());
+      if (image->lockAspectRatio() && val != 0.0) // to avoid stack overflow
+            b.size->yVal->setValue(val / _aspectRatio);
+      }
+
+//---------------------------------------------------------
+//   heightChanged
+//---------------------------------------------------------
+
+void InspectorImage::heightChanged(qreal val)
+      {
+      Image* image = toImage(inspector->element());
+      if (image->lockAspectRatio() && val != 0.0) // to avoid stack overflow
+            b.size->xVal->setValue(val * _aspectRatio);
       }
 
 //---------------------------------------------------------

--- a/mscore/inspector/inspectorImage.h
+++ b/mscore/inspector/inspectorImage.h
@@ -27,14 +27,21 @@ class InspectorImage : public InspectorElementBase {
       Q_OBJECT
 
       Ui::InspectorImage b;
+      qreal _aspectRatio; // used for widthChanged/heightChanged
 
       virtual void postInit();
 
    protected slots:
       virtual void valueChanged(int idx) override;
+      void lockAspectRatioClicked(bool checked);
+      void widthChanged(qreal val);
+      void heightChanged(qreal val);
 
    public:
       InspectorImage(QWidget* parent);
+
+   protected:
+      void updateAspectRatio();
       };
 
 


### PR DESCRIPTION
Resolves: https://musescore.org/node/279967.

A new member variable `_aspectRatio` of `InspectorImage` is added to remember the image's original ratio. It is also updated when "Lock aspect ratio" is checked in `lockAspectRatioClicked()`. The new two slots `widthChanged()` and `heightChanged()` help changing the value other than the one changed by user.