### PR TITLE
[MU4] FIX#301367 - exclude ties from System::scanElements()

### DIFF
--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -1090,7 +1090,9 @@ void System::scanElements(void* data, void (*func)(void*, Element*), bool all)
                         }
                   v = v1 || v2; // hide spanner if both chords are hidden
                   }
-            if (all || (score()->staff(staffIdx)->show() && _staves[staffIdx]->show() && v) || spanner->isVolta())
+            if (all || 
+               (score()->staff(staffIdx)->show() && _staves[staffIdx]->show() && v && !spanner->isTie()) || 
+               spanner->isVolta())
                   ss->scanElements(data, func, all);
             }
       }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/301367

Added a check for element type TIE to System::scanElements() in order to exclude ties from the collection.  They should be excluded because they are handled by Note::scanElements() already.

*Use "x" letter to fill the checkboxes below like [x]*

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
