### PR TITLE
make checklist instruction a hidden comment in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@ Resolves: *(direct link to the issue)*
 
 *(short description of the changes and the motivation to make the changes)*
 
-*Use "x" letter to fill the checkboxes below like [x]*
+<!-- Use "x" to fill the checkboxes below like [x] -->
 
 - [ ] I signed [CLA](https://musescore.org/en/cla)
 - [ ] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)


### PR DESCRIPTION
You can hide comments and notes like this, using HTML comments:

```md
<!-- hey, this is secret -->
```

This is a pretty minor change, but I just thought it's bit of redundant text that appears in every PR if it's kept as visible text. With this change it's always hidden, but can be seen by the person editing the PR description.
