### PR TITLE
Rework anchor lines drawing

### DIFF
--- a/libmscore/arpeggio.cpp
+++ b/libmscore/arpeggio.cpp
@@ -290,15 +290,17 @@ void Arpeggio::editDrag(EditData& ed)
       }
 
 //---------------------------------------------------------
-//   dragAnchor
+//   dragAnchorLines
 //---------------------------------------------------------
 
-QLineF Arpeggio::dragAnchor() const
+QVector<QLineF> Arpeggio::dragAnchorLines() const
       {
+      QVector<QLineF> result;
+
       Chord* c = chord();
       if (c)
-            return QLineF(pagePos(), c->upNote()->pagePos());
-      return QLineF();
+            result << QLineF(pagePos(), c->upNote()->pagePos());
+      return QVector<QLineF>();
       }
 
 //---------------------------------------------------------

--- a/libmscore/arpeggio.cpp
+++ b/libmscore/arpeggio.cpp
@@ -304,25 +304,30 @@ QVector<QLineF> Arpeggio::dragAnchorLines() const
       }
 
 //---------------------------------------------------------
-//   gripAnchor
+//   gripAnchorLines
 //---------------------------------------------------------
 
-QPointF Arpeggio::gripAnchor(Grip n) const
+QVector<QLineF> Arpeggio::gripAnchorLines(Grip grip) const
       {
-      Chord* c = chord();
-      if (c == 0)
-            return QPointF();
-      if (n == Grip::START)
-            return c->upNote()->pagePos();
-      else if (n == Grip::END) {
-            Note* dnote = c->downNote();
+      QVector<QLineF> result;
+
+      Chord* _chord = chord();
+      if (!_chord)
+            return result;
+
+      QPointF gripPosition = gripsPositions()[static_cast<int>(grip)];
+
+      if (grip == Grip::START)
+            result << QLineF(_chord->upNote()->pagePos(), gripPosition);
+      else if (grip == Grip::END) {
+            Note* downNote = _chord->downNote();
             int btrack  = track() + (_span - 1) * VOICES;
-            Element* e = c->segment()->element(btrack);
+            Element* e = _chord->segment()->element(btrack);
             if (e && e->isChord())
-                  dnote = toChord(e)->downNote();
-            return dnote->pagePos();
+                  downNote = toChord(e)->downNote();
+            result << QLineF(downNote->pagePos(), gripPosition);
             }
-      return QPointF();
+      return result;
       }
 
 //---------------------------------------------------------

--- a/libmscore/arpeggio.h
+++ b/libmscore/arpeggio.h
@@ -45,7 +45,7 @@ class Arpeggio final : public Element {
 
       void spatiumChanged(qreal /*oldValue*/, qreal /*newValue*/) override;
       QVector<QLineF> dragAnchorLines() const override;
-      QPointF gripAnchor(Grip) const override;
+      QVector<QLineF> gripAnchorLines(Grip) const override;
       void startEdit(EditData&) override;
 
    public:
@@ -96,7 +96,7 @@ class Arpeggio final : public Element {
       int gripsCount() const override { return 2; }
       Grip initialEditModeGrip() const override { return Grip::END; }
       Grip defaultGrip() const override { return Grip::START; }
-      std::vector<QPointF> gripsPositions(const EditData&) const override;
+      std::vector<QPointF> gripsPositions(const EditData& = EditData()) const override;
       };
 
 

--- a/libmscore/arpeggio.h
+++ b/libmscore/arpeggio.h
@@ -44,7 +44,7 @@ class Arpeggio final : public Element {
       void symbolLine2(SymId end, SymId fill);
 
       void spatiumChanged(qreal /*oldValue*/, qreal /*newValue*/) override;
-      QLineF dragAnchor() const override;
+      QVector<QLineF> dragAnchorLines() const override;
       QPointF gripAnchor(Grip) const override;
       void startEdit(EditData&) override;
 

--- a/libmscore/articulation.cpp
+++ b/libmscore/articulation.cpp
@@ -272,12 +272,14 @@ bool Articulation::layoutCloseToNote() const
       }
 
 //---------------------------------------------------------
-//   dragAnchor
+//   dragAnchorLines
 //---------------------------------------------------------
 
-QLineF Articulation::dragAnchor() const
+QVector<QLineF> Articulation::dragAnchorLines() const
       {
-      return QLineF(canvasPos(), parent()->canvasPos());
+      QVector<QLineF> result;
+      result << QLineF(canvasPos(), parent()->canvasPos());
+      return result;
       }
 
 //---------------------------------------------------------

--- a/libmscore/articulation.h
+++ b/libmscore/articulation.h
@@ -98,7 +98,7 @@ class Articulation final : public Element {
       void write(XmlWriter& xml) const override;
       bool readProperties(XmlReader&) override;
 
-      QLineF dragAnchor() const override;
+      QVector<QLineF> dragAnchorLines() const override;
 
       QVariant getProperty(Pid propertyId) const override;
       bool setProperty(Pid propertyId, const QVariant&) override;

--- a/libmscore/bsymbol.cpp
+++ b/libmscore/bsymbol.cpp
@@ -208,19 +208,7 @@ QRectF BSymbol::drag(EditData& ed)
 
 QVector<QLineF> BSymbol::dragAnchorLines() const
       {
-      QVector<QLineF> result;
-
-      if (parent() && parent()->type() == ElementType::SEGMENT) {
-            System* system = segment()->measure()->system();
-            qreal y        = system->staffCanvasYpage(staffIdx());
-            QPointF anchor(segment()->canvasPos().x(), y);
-            result << QLineF(canvasPos(), anchor);
-            }
-      else {
-            result << QLineF(canvasPos(), parent()->canvasPos());
-            }
-
-      return result;
+      return genericDragAnchorLines();
       }
 
 //---------------------------------------------------------

--- a/libmscore/bsymbol.cpp
+++ b/libmscore/bsymbol.cpp
@@ -203,20 +203,24 @@ QRectF BSymbol::drag(EditData& ed)
       }
 
 //---------------------------------------------------------
-//   dragAnchor
+//   dragAnchorLines
 //---------------------------------------------------------
 
-QLineF BSymbol::dragAnchor() const
+QVector<QLineF> BSymbol::dragAnchorLines() const
       {
+      QVector<QLineF> result;
+
       if (parent() && parent()->type() == ElementType::SEGMENT) {
             System* system = segment()->measure()->system();
             qreal y        = system->staffCanvasYpage(staffIdx());
             QPointF anchor(segment()->canvasPos().x(), y);
-            return QLineF(canvasPos(), anchor);
+            result << QLineF(canvasPos(), anchor);
             }
       else {
-            return QLineF(canvasPos(), parent()->canvasPos());
+            result << QLineF(canvasPos(), parent()->canvasPos());
             }
+
+      return result;
       }
 
 //---------------------------------------------------------

--- a/libmscore/bsymbol.h
+++ b/libmscore/bsymbol.h
@@ -50,7 +50,7 @@ class BSymbol : public Element {
       QList<Element*>& leafs()             { return _leafs; }
       virtual QPointF pagePos() const override;
       virtual QPointF canvasPos() const override;
-      virtual QLineF dragAnchor() const override;
+      QVector<QLineF> dragAnchorLines() const override;
       Segment* segment() const            { return (Segment*)parent(); }
       };
 

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1394,6 +1394,26 @@ bool Element::isPrintable() const
       }
 
 //---------------------------------------------------------
+//   findAncestor
+//---------------------------------------------------------
+
+Element* Element::findAncestor(ElementType t)
+      {
+      Element* e = this;
+      while (e && e->type() != t)
+            e = e->parent();
+      return e;
+      }
+
+const Element* Element::findAncestor(ElementType t) const
+      {
+      const Element* e = this;
+      while (e && e->type() != t)
+            e = e->parent();
+      return e;
+      }
+
+//---------------------------------------------------------
 //   findMeasure
 //---------------------------------------------------------
 

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -2035,7 +2035,10 @@ QVector<QLineF> Element::genericDragAnchorLines() const
       qreal yp;
       if (parent()->isSegment()) {
             System* system = toSegment(parent())->measure()->system();
-            yp = system->staffCanvasYpage(staffIdx());
+            const int stIdx = staffIdx();
+            yp = system->staffCanvasYpage(stIdx);
+            if (placement() == Placement::BELOW)
+                  yp += system->staff(stIdx)->bbox().height();
             }
       else
             yp = parent()->canvasPos().y();

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -2024,6 +2024,27 @@ void Element::endDrag(EditData& ed)
       }
 
 //---------------------------------------------------------
+//   genericDragAnchorLines
+//---------------------------------------------------------
+
+QVector<QLineF> Element::genericDragAnchorLines() const
+      {
+      qreal xp = 0.0;
+      for (Element* e = parent(); e; e = e->parent())
+            xp += e->x();
+      qreal yp;
+      if (parent()->isSegment()) {
+            System* system = toSegment(parent())->measure()->system();
+            yp = system->staffCanvasYpage(staffIdx());
+            }
+      else
+            yp = parent()->canvasPos().y();
+      QPointF p1(xp, yp);
+      QLineF anchorLine(p1, canvasPos());
+      return { anchorLine };
+      }
+
+//---------------------------------------------------------
 //   updateGrips
 //---------------------------------------------------------
 

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -291,7 +291,7 @@ class Element : public ScoreElement {
       virtual void startDrag(EditData&);
       virtual QRectF drag(EditData&);
       virtual void endDrag(EditData&);
-      virtual QLineF dragAnchor() const       { return QLineF(); }
+      virtual QVector<QLineF> dragAnchorLines() const       { return QVector<QLineF>(); }
 
       virtual bool isEditable() const         { return !flag(ElementFlag::GENERATED); }
 

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -193,6 +193,10 @@ class Element : public ScoreElement {
 
       Element* parent() const                 { return _parent;     }
       void setParent(Element* e)              { _parent = e;        }
+
+      Element* findAncestor(ElementType t);
+      const Element* findAncestor(ElementType t) const;
+
       Measure* findMeasure();
       const Measure* findMeasure() const;
       MeasureBase* findMeasureBase();
@@ -291,6 +295,7 @@ class Element : public ScoreElement {
       virtual void startDrag(EditData&);
       virtual QRectF drag(EditData&);
       virtual void endDrag(EditData&);
+      /** Returns anchor lines displayed while dragging element in page coordinates. */
       virtual QVector<QLineF> dragAnchorLines() const       { return QVector<QLineF>(); }
 
       virtual bool isEditable() const         { return !flag(ElementFlag::GENERATED); }
@@ -308,12 +313,14 @@ class Element : public ScoreElement {
       void updateGrips(EditData&) const;
       virtual bool nextGrip(EditData&) const;
       virtual bool prevGrip(EditData&) const;
+      /** Returns anchor lines displayed while dragging element's grip in page coordinates. */
       virtual QVector<QLineF> gripAnchorLines(Grip) const     { return QVector<QLineF>(); }
 
       virtual EditBehavior normalModeEditBehavior() const { return EditBehavior::SelectOnly; }
       virtual int gripsCount() const { return 0; }
       virtual Grip initialEditModeGrip() const { return Grip::NO_GRIP; }
       virtual Grip defaultGrip() const { return Grip::NO_GRIP; }
+      /** Returns grips positions in page coordinates. */
       virtual std::vector<QPointF> gripsPositions(const EditData& = EditData()) const { return std::vector<QPointF>(); }
 
       int track() const                       { return _track; }

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -297,6 +297,16 @@ class Element : public ScoreElement {
       virtual void endDrag(EditData&);
       /** Returns anchor lines displayed while dragging element in page coordinates. */
       virtual QVector<QLineF> dragAnchorLines() const       { return QVector<QLineF>(); }
+      /**
+       * A generic \ref dragAnchorLines() implementation which can be used in
+       * dragAnchorLines() overrides in descendants. It is not made its default
+       * implementation in Element class since showing anchor lines is not
+       * desirable for most element types.
+       * TODO: maybe Annotation class could be extracted which would be a base
+       * class of various annotation types and which would have this
+       * dragAnchorLines() implementation by default.
+       */
+      QVector<QLineF> genericDragAnchorLines() const;
 
       virtual bool isEditable() const         { return !flag(ElementFlag::GENERATED); }
 

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -137,7 +137,7 @@ class EditData {
       Element* element                 { 0     };
       Element* dropElement             { 0     };
 
-      EditData(MuseScoreView* v) : view(v) {}
+      EditData(MuseScoreView* v = nullptr) : view(v) {}
       void clearData();
 
       ElementEditData* getData(const Element*) const;
@@ -308,13 +308,13 @@ class Element : public ScoreElement {
       void updateGrips(EditData&) const;
       virtual bool nextGrip(EditData&) const;
       virtual bool prevGrip(EditData&) const;
-      virtual QPointF gripAnchor(Grip) const     { return QPointF(); }
+      virtual QVector<QLineF> gripAnchorLines(Grip) const     { return QVector<QLineF>(); }
 
       virtual EditBehavior normalModeEditBehavior() const { return EditBehavior::SelectOnly; }
       virtual int gripsCount() const { return 0; }
       virtual Grip initialEditModeGrip() const { return Grip::NO_GRIP; }
       virtual Grip defaultGrip() const { return Grip::NO_GRIP; }
-      virtual std::vector<QPointF> gripsPositions(const EditData&) const { return std::vector<QPointF>(); }
+      virtual std::vector<QPointF> gripsPositions(const EditData& = EditData()) const { return std::vector<QPointF>(); }
 
       int track() const                       { return _track; }
       virtual void setTrack(int val)          { _track = val;  }

--- a/libmscore/fermata.cpp
+++ b/libmscore/fermata.cpp
@@ -247,12 +247,14 @@ void Fermata::layout()
       }
 
 //---------------------------------------------------------
-//   dragAnchor
+//   dragAnchorLines
 //---------------------------------------------------------
 
-QLineF Fermata::dragAnchor() const
+QVector<QLineF> Fermata::dragAnchorLines() const
       {
-      return QLineF(canvasPos(), parent()->canvasPos());
+      QVector<QLineF> result;
+      result << QLineF(canvasPos(), parent()->canvasPos());
+      return result;
       }
 
 //---------------------------------------------------------

--- a/libmscore/fermata.h
+++ b/libmscore/fermata.h
@@ -59,7 +59,7 @@ class Fermata final : public Element {
       void write(XmlWriter& xml) const override;
       bool readProperties(XmlReader&) override;
 
-      QLineF dragAnchor() const override;
+      QVector<QLineF> dragAnchorLines() const override;
 
       QVariant getProperty(Pid propertyId) const override;
       bool setProperty(Pid propertyId, const QVariant&) override;

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -159,20 +159,7 @@ QPointF FretDiagram::pagePos() const
 
 QVector<QLineF> FretDiagram::dragAnchorLines() const
       {
-      QVector<QLineF> result;
-      qreal xp = 0.0;
-      for (Element* e = parent(); e; e = e->parent())
-            xp += e->x();
-      qreal yp;
-      if (parent()->isSegment()) {
-            System* system = toSegment(parent())->measure()->system();
-            yp = system->staffCanvasYpage(staffIdx());
-            }
-      else
-            yp = parent()->canvasPos().y();
-      QPointF p1(xp, yp);
-      result << QLineF(p1, canvasPos());
-      return result;
+      return genericDragAnchorLines();
 #if 0 // TODOxx
       if (parent()->isSegment()) {
             Segment* s     = toSegment(parent());

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -154,11 +154,12 @@ QPointF FretDiagram::pagePos() const
       }
 
 //---------------------------------------------------------
-//   dragAnchor
+//   dragAnchorLines
 //---------------------------------------------------------
 
-QLineF FretDiagram::dragAnchor() const
+QVector<QLineF> FretDiagram::dragAnchorLines() const
       {
+      QVector<QLineF> result;
       qreal xp = 0.0;
       for (Element* e = parent(); e; e = e->parent())
             xp += e->x();
@@ -170,7 +171,8 @@ QLineF FretDiagram::dragAnchor() const
       else
             yp = parent()->canvasPos().y();
       QPointF p1(xp, yp);
-      return QLineF(p1, canvasPos());
+      result << QLineF(p1, canvasPos());
+      return result;
 #if 0 // TODOxx
       if (parent()->isSegment()) {
             Segment* s     = toSegment(parent());

--- a/libmscore/fret.h
+++ b/libmscore/fret.h
@@ -170,7 +170,7 @@ class FretDiagram final : public Element {
       void writeOld(XmlWriter& xml) const;
       void read(XmlReader&) override;
       void readNew(XmlReader&);
-      QLineF dragAnchor() const override;
+      QVector<QLineF> dragAnchorLines() const override;
       QPointF pagePos() const override;
 
       // read / write MusicXML

--- a/libmscore/hairpin.h
+++ b/libmscore/hairpin.h
@@ -66,7 +66,7 @@ class HairpinSegment final : public TextLineBaseSegment {
       Shape shape() const override;
 
       int gripsCount() const override { return 4; }
-      std::vector<QPointF> gripsPositions(const EditData&) const override;
+      std::vector<QPointF> gripsPositions(const EditData& = EditData()) const override;
       };
 
 //---------------------------------------------------------

--- a/libmscore/image.h
+++ b/libmscore/image.h
@@ -50,7 +50,7 @@ class Image final : public BSymbol {
       bool isEditable() const override { return true; }
       void startEditDrag(EditData&) override;
       void editDrag(EditData& ed) override;
-      QPointF gripAnchor(Grip) const override { return QPointF(); }
+      QVector<QLineF> gripAnchorLines(Grip) const override { return QVector<QLineF>(); }
 
    public:
       Image(Score* = 0);

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -416,18 +416,12 @@ Element* LineSegment::propertyDelegate(Pid pid)
       }
 
 //---------------------------------------------------------
-//   dragAnchor
+//   dragAnchorLines
 //---------------------------------------------------------
 
-QLineF LineSegment::dragAnchor() const
+QVector<QLineF> LineSegment::dragAnchorLines() const
       {
-      if (spannerSegmentType() != SpannerSegmentType::SINGLE && spannerSegmentType() != SpannerSegmentType::BEGIN)
-            return QLineF();
-      System* s;
-      QPointF p = line()->linePos(Grip::START, &s);
-      p += QPointF(s->canvasPos().x(), s->staffCanvasYpage(line()->staffIdx()));
-
-      return QLineF(p, canvasPos());
+      return gripAnchorLines(Grip::MIDDLE);
       }
 
 //---------------------------------------------------------

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -144,8 +144,15 @@ QVector<QLineF> LineSegment::gripAnchorLines(Grip grip) const
             return result;
 
       // note-anchored spanners are relative to the system
-      qreal y = spanner()->anchor() == Spanner::Anchor::NOTE ?
-                system()->pos().y() : system()->staffYpage(staffIdx());
+      qreal y;
+      if (spanner()->anchor() == Spanner::Anchor::NOTE)
+            y = system()->pos().y();
+      else {
+            const int stIdx = staffIdx();
+            y = system()->staffYpage(stIdx);
+            if (line()->placement() == Placement::BELOW)
+                  y += system()->staff(stIdx)->bbox().height();
+            }
 
       switch (grip) {
       case Grip::START:

--- a/libmscore/line.h
+++ b/libmscore/line.h
@@ -35,7 +35,7 @@ class LineSegment : public SpannerSegment {
    protected:
       virtual void editDrag(EditData&) override;
       virtual bool edit(EditData&) override;
-      virtual QPointF gripAnchor(Grip) const override;
+      QVector<QLineF> gripAnchorLines(Grip) const override;
       virtual void startEditDrag(EditData&) override;
 
    public:
@@ -57,9 +57,12 @@ class LineSegment : public SpannerSegment {
       int gripsCount() const override { return 3; }
       Grip initialEditModeGrip() const override { return Grip::END; }
       Grip defaultGrip() const override { return Grip::MIDDLE; }
-      std::vector<QPointF> gripsPositions(const EditData&) const override;
+      std::vector<QPointF> gripsPositions(const EditData& = EditData()) const override;
 
-      virtual QLineF dragAnchor() const override;
+      virtual QVector<QLineF> dragAnchorLines() const override;
+private:
+      QPointF leftAnchorPosition(const qreal& systemPositionY) const;
+      QPointF rightAnchorPosition(const qreal& systemPositionY) const;
       };
 
 //---------------------------------------------------------

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -646,13 +646,11 @@ Measure* Score::pos2measure(const QPointF& p, int* rst, int* pitch, Segment** se
 
 //---------------------------------------------------------
 //   dragPosition
-//    on input:
-//          p   - canvas relative drag position
-//          rst - current staff index
-//          seg - current segment
-//    on output:
-//          rst - new staff index for drag position
-//          seg - new segment for drag position
+///   \param p   drag position in canvas coordinates
+///   \param rst \b input: current staff index \n
+///              \b output: new staff index for drag position
+///   \param seg \b input: current segment \n
+///              \b output: new segment for drag position
 //---------------------------------------------------------
 
 void Score::dragPosition(const QPointF& p, int* rst, Segment** seg) const

--- a/libmscore/slurtie.cpp
+++ b/libmscore/slurtie.cpp
@@ -43,33 +43,45 @@ SlurTieSegment::SlurTieSegment(const SlurTieSegment& b)
       }
 
 //---------------------------------------------------------
-//   gripAnchor
+//   gripAnchorLines
 //---------------------------------------------------------
 
-QPointF SlurTieSegment::gripAnchor(Grip grip) const
+QVector<QLineF> SlurTieSegment::gripAnchorLines(Grip grip) const
       {
+      QVector<QLineF> result;
+
       if (!system() || (grip != Grip::START && grip != Grip::END))
-            return QPointF();
+            return result;
 
       QPointF sp(system()->pagePos());
       QPointF pp(pagePos());
       QPointF p1(ups(Grip::START).p + pp);
       QPointF p2(ups(Grip::END).p + pp);
 
+      QPointF anchorPosition;
+      int gripIndex = static_cast<int>(grip);
+
       switch (spannerSegmentType()) {
             case SpannerSegmentType::SINGLE:
-                  return grip == Grip::START ? p1 : p2;
+                  anchorPosition = (grip == Grip::START ? p1 : p2);
+                  break;
 
             case SpannerSegmentType::BEGIN:
-                  return grip == Grip::START ? p1 : system()->abbox().topRight();
+                  anchorPosition = (grip == Grip::START ? p1 : system()->abbox().topRight());
+                  break;
 
             case SpannerSegmentType::MIDDLE:
-                  return grip == Grip::START ? sp : system()->abbox().topRight();
+                  anchorPosition = (grip == Grip::START ? sp : system()->abbox().topRight());
+                  break;
 
             case SpannerSegmentType::END:
-                  return grip == Grip::START ? sp : p2;
+                  anchorPosition = (grip == Grip::START ? sp : p2);
+                  break;
             }
-      return QPointF();
+
+      result << QLineF(anchorPosition, gripsPositions().at(gripIndex));
+
+      return result;
       }
 
 //---------------------------------------------------------

--- a/libmscore/slurtie.h
+++ b/libmscore/slurtie.h
@@ -86,7 +86,7 @@ class SlurTieSegment : public SpannerSegment {
       Shape _shape;
 
       virtual void changeAnchor(EditData&, Element*) = 0;
-      virtual QPointF gripAnchor(Grip grip) const override;
+      QVector<QLineF> gripAnchorLines(Grip grip) const override;
 
    public:
       SlurTieSegment(Score*);
@@ -115,7 +115,7 @@ class SlurTieSegment : public SpannerSegment {
       int gripsCount() const override { return int(Grip::GRIPS); }
       Grip initialEditModeGrip() const override{ return Grip::END; }
       Grip defaultGrip() const override { return Grip::DRAG; }
-      std::vector<QPointF> gripsPositions(const EditData&) const override;
+      std::vector<QPointF> gripsPositions(const EditData& = EditData()) const override;
 
       void writeSlur(XmlWriter& xml, int no) const;
       void read(XmlReader&);

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -1861,11 +1861,13 @@ void TextBase::dragTo(EditData& ed)
       }
 
 //---------------------------------------------------------
-//   dragAnchor
+//   dragAnchorLines
 //---------------------------------------------------------
 
-QLineF TextBase::dragAnchor() const
+QVector<QLineF> TextBase::dragAnchorLines() const
       {
+      QVector<QLineF> result;
+
       qreal xp = 0.0;
       for (Element* e = parent(); e; e = e->parent())
             xp += e->x();
@@ -1880,7 +1882,10 @@ QLineF TextBase::dragAnchor() const
       QPointF p2 = canvasPos();
       if (layoutToParentWidth())
             p2 += bbox().topLeft();
-      return QLineF(p1, p2);
+
+      result << QLineF(p1, p2);
+
+      return result;
       }
 
 //---------------------------------------------------------

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -1866,24 +1866,12 @@ void TextBase::dragTo(EditData& ed)
 
 QVector<QLineF> TextBase::dragAnchorLines() const
       {
-      QVector<QLineF> result;
+      QVector<QLineF> result(genericDragAnchorLines());
 
-      qreal xp = 0.0;
-      for (Element* e = parent(); e; e = e->parent())
-            xp += e->x();
-      qreal yp;
-      if (parent()->isSegment()) {
-            System* system = toSegment(parent())->measure()->system();
-            yp = system->staffCanvasYpage(staffIdx());
+      if (layoutToParentWidth() && !result.empty()) {
+            QLineF& line = result[0];
+            line.setP2(line.p2() + bbox().topLeft());
             }
-      else
-            yp = parent()->canvasPos().y();
-      QPointF p1(xp, yp);
-      QPointF p2 = canvasPos();
-      if (layoutToParentWidth())
-            p2 += bbox().topLeft();
-
-      result << QLineF(p1, p2);
 
       return result;
       }

--- a/libmscore/textbase.h
+++ b/libmscore/textbase.h
@@ -316,7 +316,7 @@ class TextBase : public Element {
 
       void dragTo(EditData&);
 
-      virtual QLineF dragAnchor() const override;
+      QVector<QLineF> dragAnchorLines() const override;
 
       virtual bool acceptDrop(EditData&) const override;
       virtual Element* drop(EditData&) override;

--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -48,8 +48,8 @@ void ScoreView::setDropTarget(const Element* el)
                   dropTarget->setDropTarget(true);
                   }
             }
-      if (!m_dropAnchorList.isEmpty())
-            m_dropAnchorList.clear();
+      if (!m_dropAnchorLines.isEmpty())
+            m_dropAnchorLines.clear();
 
       if (dropRectangle.isValid()) {
             dropRectangle = QRectF();
@@ -71,12 +71,12 @@ void ScoreView::setDropRectangle(const QRectF& r)
             _score->addRefresh(dropTarget->canvasBoundingRect());
             dropTarget = 0;
             }
-      else if (!m_dropAnchorList.isEmpty()) {
+      else if (!m_dropAnchorLines.isEmpty()) {
             QRectF rf;
-            rf.setTopLeft(m_dropAnchorList.first().p1());
-            rf.setBottomRight(m_dropAnchorList.first().p2());
+            rf.setTopLeft(m_dropAnchorLines.first().p1());
+            rf.setBottomRight(m_dropAnchorLines.first().p2());
             _score->addRefresh(rf.normalized());
-            m_dropAnchorList.clear();
+            m_dropAnchorLines.clear();
             }
 
       update();
@@ -87,8 +87,8 @@ void ScoreView::setDropRectangle(const QRectF& r)
 //---------------------------------------------------------
 void ScoreView::setDropAnchorLines(const QVector<QLineF>& anchorList)
       {
-      if (m_dropAnchorList != anchorList)
-            m_dropAnchorList = anchorList;
+      if (m_dropAnchorLines != anchorList)
+            m_dropAnchorLines = anchorList;
 
       if (dropRectangle.isValid())
             dropRectangle = QRectF();

--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -48,12 +48,9 @@ void ScoreView::setDropTarget(const Element* el)
                   dropTarget->setDropTarget(true);
                   }
             }
-      if (!dropAnchor.isNull()) {
-            QRectF r;
-            r.setTopLeft(dropAnchor.p1());
-            r.setBottomRight(dropAnchor.p2());
-            dropAnchor = QLineF();
-            }
+      if (!m_dropAnchorList.isEmpty())
+            m_dropAnchorList.clear();
+
       if (dropRectangle.isValid()) {
             dropRectangle = QRectF();
             }
@@ -74,46 +71,28 @@ void ScoreView::setDropRectangle(const QRectF& r)
             _score->addRefresh(dropTarget->canvasBoundingRect());
             dropTarget = 0;
             }
-      else if (!dropAnchor.isNull()) {
+      else if (!m_dropAnchorList.isEmpty()) {
             QRectF rf;
-            rf.setTopLeft(dropAnchor.p1());
-            rf.setBottomRight(dropAnchor.p2());
+            rf.setTopLeft(m_dropAnchorList.first().p1());
+            rf.setBottomRight(m_dropAnchorList.first().p2());
             _score->addRefresh(rf.normalized());
-            dropAnchor = QLineF();
+            m_dropAnchorList.clear();
             }
-//      _score->addRefresh(r);
+
       update();
       }
 
 //---------------------------------------------------------
-//   setDropAnchor
+//   setDropAnchorList
 //---------------------------------------------------------
-
-void ScoreView::setDropAnchor(const QLineF& l)
+void ScoreView::setDropAnchorLines(const QVector<QLineF>& anchorList)
       {
-      if (!dropAnchor.isNull()) {
-            qreal w = 2 / _matrix.m11();
-            QRectF r;
-            r.setTopLeft(dropAnchor.p1());
-            r.setBottomRight(dropAnchor.p2());
-            r = r.normalized();
-            r.adjust(-w, -w, 2*w, 2*w);
-//            _score->addRefresh(r);
-            }
-      if (dropRectangle.isValid()) {
-//            _score->addRefresh(dropRectangle);
+      if (m_dropAnchorList != anchorList)
+            m_dropAnchorList = anchorList;
+
+      if (dropRectangle.isValid())
             dropRectangle = QRectF();
-            }
-      dropAnchor = l;
-      if (!dropAnchor.isNull()) {
-            qreal w = 2 / _matrix.m11();
-            QRectF r;
-            r.setTopLeft(dropAnchor.p1());
-            r.setBottomRight(dropAnchor.p2());
-            r = r.normalized();
-            r.adjust(-w, -w, 2*w, 2*w);
-//            _score->addRefresh(r);
-            }
+
       update();
       }
 
@@ -155,7 +134,7 @@ bool ScoreView::dragTimeAnchorElement(const QPointF& pos)
             System* s  = m->system();
             qreal y    = s->staff(staffIdx)->y() + s->pos().y() + s->page()->pos().y();
             QPointF anchor(seg->canvasBoundingRect().x(), y);
-            setDropAnchor(QLineF(pos, anchor));
+            setDropAnchorLines({ QLineF(pos, anchor) });
             editData.dropElement->score()->addRefresh(editData.dropElement->canvasBoundingRect());
             editData.dropElement->setTrack(track);
             editData.dropElement->score()->addRefresh(editData.dropElement->canvasBoundingRect());
@@ -187,7 +166,7 @@ bool ScoreView::dragMeasureAnchorElement(const QPointF& pos)
             if (pos.x() >= (b.x() + b.width() * .5) && m != _score->lastMeasureMM() && m->nextMeasure()->system() == m->system())
                   m = m->nextMeasure();
             QPointF anchor(m->canvasBoundingRect().x(), y);
-            setDropAnchor(QLineF(pos, anchor));
+            setDropAnchorLines({ QLineF(pos, anchor) });
             editData.dropElement->score()->addRefresh(editData.dropElement->canvasBoundingRect());
             editData.dropElement->setTrack(track);
             editData.dropElement->score()->addRefresh(editData.dropElement->canvasBoundingRect());

--- a/mscore/dragelement.cpp
+++ b/mscore/dragelement.cpp
@@ -78,7 +78,7 @@ void ScoreView::doDragElement(QMouseEvent* ev)
             QVector<QLineF> anchorLines = e->dragAnchorLines();
 
             if (!anchorLines.isEmpty())
-                  setDropAnchorList(anchorLines);
+                  setDropAnchorLines(anchorLines);
             else
                   setDropTarget(0); // this also resets dropAnchor
             }

--- a/mscore/dragelement.cpp
+++ b/mscore/dragelement.cpp
@@ -76,9 +76,13 @@ void ScoreView::doDragElement(QMouseEvent* ev)
                   _score->setPlayNote(false);
                   }
             QVector<QLineF> anchorLines = e->dragAnchorLines();
+            const QPointF pageOffset(e->findAncestor(ElementType::PAGE)->pos());
 
-            if (!anchorLines.isEmpty())
+            if (!anchorLines.isEmpty()) {
+                  for (QLineF& l : anchorLines)
+                        l.translate(pageOffset);
                   setDropAnchorLines(anchorLines);
+                  }
             else
                   setDropTarget(0); // this also resets dropAnchor
             }

--- a/mscore/dragelement.cpp
+++ b/mscore/dragelement.cpp
@@ -75,10 +75,10 @@ void ScoreView::doDragElement(QMouseEvent* ev)
                   mscore->play(e);
                   _score->setPlayNote(false);
                   }
-            QLineF anchor = e->dragAnchor();
+            QVector<QLineF> anchorLines = e->dragAnchorLines();
 
-            if (!anchor.isNull())
-                  setDropAnchor(anchor);
+            if (!anchorLines.isEmpty())
+                  setDropAnchorList(anchorLines);
             else
                   setDropTarget(0); // this also resets dropAnchor
             }

--- a/mscore/editelement.cpp
+++ b/mscore/editelement.cpp
@@ -71,9 +71,9 @@ void ScoreView::updateGrips()
                   score()->addRefresh(grip.adjusted(-dx, -dy, dx, dy));
                   }
 
-            QPointF anchor = (editData.curGrip != Grip::NO_GRIP) ? editData.element->gripAnchor(editData.curGrip) : QPointF();
-            if (!anchor.isNull())
-                  setDropAnchor(QLineF(anchor + pageOffset, editData.grip[int(editData.curGrip)].center()));
+            QVector<QLineF> anchorLines = (editData.curGrip != Grip::NO_GRIP) ? editData.element->gripAnchorLines(editData.curGrip) : QVector<QLineF>();
+            if (!anchorLines.isEmpty())
+                  setDropAnchorLines(anchorLines);
             else
                   setDropTarget(0); // this also resets dropAnchor
             }

--- a/mscore/editelement.cpp
+++ b/mscore/editelement.cpp
@@ -68,7 +68,8 @@ void ScoreView::updateGrips()
                   score()->addRefresh(grip.adjusted(-dx, -dy, dx, dy));
                   }
 
-            QVector<QLineF> anchorLines = (editData.curGrip != Grip::NO_GRIP) ? editData.element->gripAnchorLines(editData.curGrip) : QVector<QLineF>();
+            const Grip anchorLinesGrip = editData.curGrip == Grip::NO_GRIP ? editData.element->defaultGrip() : editData.curGrip;
+            QVector<QLineF> anchorLines = editData.element->gripAnchorLines(anchorLinesGrip);
 
             if (!anchorLines.isEmpty()) {
                   for (QLineF& l : anchorLines)

--- a/mscore/editelement.cpp
+++ b/mscore/editelement.cpp
@@ -61,10 +61,7 @@ void ScoreView::updateGrips()
             // updateGrips returns grips in page coordinates,
             // transform to view coordinates:
 
-            Element* page = editData.element;
-            while (page->parent())
-                  page = page->parent();
-            QPointF pageOffset(page->pos());
+            const QPointF pageOffset(editData.element->findAncestor(ElementType::PAGE)->pos());
 
             for (QRectF& grip : editData.grip) {
                   grip.translate(pageOffset);
@@ -72,8 +69,12 @@ void ScoreView::updateGrips()
                   }
 
             QVector<QLineF> anchorLines = (editData.curGrip != Grip::NO_GRIP) ? editData.element->gripAnchorLines(editData.curGrip) : QVector<QLineF>();
-            if (!anchorLines.isEmpty())
+
+            if (!anchorLines.isEmpty()) {
+                  for (QLineF& l : anchorLines)
+                        l.translate(pageOffset);
                   setDropAnchorLines(anchorLines);
+                  }
             else
                   setDropTarget(0); // this also resets dropAnchor
             }

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -896,11 +896,37 @@ void ScoreView::setShadowNote(const QPointF& p)
       }
 
 //---------------------------------------------------------
+//   drawAnchorLines
+//---------------------------------------------------------
+void ScoreView::drawAnchorLines(QPainter& painter)
+      {
+      if (m_dropAnchorLines.isEmpty())
+            return;
+
+      const auto dropAnchorColor = preferences.getColor(PREF_UI_SCORE_VOICE4_COLOR);
+      QPen pen(QBrush(dropAnchorColor), 2.0 / painter.worldTransform().m11(), Qt::DotLine);
+
+      for (const QLineF& anchor : m_dropAnchorLines) {
+            painter.setPen(pen);
+            painter.drawLine(anchor);
+
+            qreal d = 4.0 / painter.worldTransform().m11();
+            QRectF rect(-d, -d, 2 * d, 2 * d);
+
+            painter.setBrush(QBrush(dropAnchorColor));
+            painter.setPen(Qt::NoPen);
+            rect.moveCenter(anchor.p1());
+            painter.drawEllipse(rect);
+            rect.moveCenter(anchor.p2());
+            painter.drawEllipse(rect);
+            }
+      }
+
+//---------------------------------------------------------
 //   paintEvent
 //    Note: desktop background and paper background are not
 //    scaled
 //---------------------------------------------------------
-
 void ScoreView::paintEvent(QPaintEvent* ev)
       {
       if (!_score)
@@ -925,22 +951,7 @@ void ScoreView::paintEvent(QPaintEvent* ev)
             lasso->draw(&vp);
       shadowNote->draw(&vp);
 
-      if (!dropAnchor.isNull()) {
-            const auto dropAnchorColor = preferences.getColor(PREF_UI_SCORE_VOICE4_COLOR);
-            QPen pen(QBrush(dropAnchorColor), 2.0 / vp.worldTransform().m11(), Qt::DotLine);
-            vp.setPen(pen);
-            vp.drawLine(dropAnchor);
-
-            qreal d = 4.0 / vp.worldTransform().m11();
-            QRectF r(-d, -d, 2 * d, 2 * d);
-
-            vp.setBrush(QBrush(dropAnchorColor));
-            vp.setPen(Qt::NoPen);
-            r.moveCenter(dropAnchor.p1());
-            vp.drawEllipse(r);
-            r.moveCenter(dropAnchor.p2());
-            vp.drawEllipse(r);
-            }
+      drawAnchorLines(vp);
       }
 
 //---------------------------------------------------------

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -107,6 +107,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       const Element* dropTarget;    ///< current drop target during dragMove
       QRectF dropRectangle;         ///< current drop rectangle during dragMove
       QLineF dropAnchor;            ///< line to current anchor point during dragMove
+      QVector<QLineF> m_dropAnchorLines;
 
       QTransform _matrix, imatrix;
       MagIdx _magIdx;
@@ -349,7 +350,7 @@ class ScoreView : public QWidget, public MuseScoreView {
 
       virtual void setDropRectangle(const QRectF&);
       virtual void setDropTarget(const Element*) override;
-      void setDropAnchor(const QLineF&);
+      void setDropAnchorLines(const QVector<QLineF> &anchorList);
       const QTransform& matrix() const  { return _matrix; }
       qreal mag() const;
       qreal lmag() const;
@@ -434,7 +435,9 @@ class ScoreView : public QWidget, public MuseScoreView {
       void updateGrips();
       bool moveWhenInactive() const { return _moveWhenInactive; }
       bool moveWhenInactive(bool move) { bool m = _moveWhenInactive; _moveWhenInactive = move; return m; }
-      };
+   private:
+      void drawAnchorLines(QPainter& painter);
+    };
 
 } // namespace Ms
 #endif


### PR DESCRIPTION
This is a part of redesign of elements dragging system which I got split off the [`anchors_rebasing`](https://github.com/dmitrio95/MuseScore/tree/anchors_rebasing) branch to make the amount of changes more manageable. This PR is dedicated to anchor lines drawing redesign and includes:
- Support for drawing several anchor lines simultaneously so elements like hairpins could show both anchors at once (implemented by @vpereverzev);
- Showing haiprins/lines anchors even if they are not being dragged to make their segment bindings more clear;
- Making anchor lines reflect placement of the element for which they are drawn. 

Possibly some more changes could be added in future.