### PR TITLE
fix #301414: Corrupt tie created on paste of tied note that requires additional tie

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1432,10 +1432,13 @@ void Note::readAddConnector(ConnectorInfoReader* info, bool pasteMode)
                         sp->setTrack(l.track());
                         sp->setTick(tick());
                         if (sp->isTie()) {
+                              Note* n = this;
+                              while (n->tieFor())
+                                    n = n->tieFor()->endNote();
                               Tie* tie = toTie(sp);
-                              tie->setParent(this);
-                              tie->setStartNote(this);
-                              _tieFor = tie;
+                              tie->setParent(n);
+                              tie->setStartNote(n);
+                              n->_tieFor = tie;
                               }
                         else {
                               sp->setAnchor(Spanner::Anchor::NOTE);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/301414.

During paste, if a note has a tie, that tie is remembered as a pending connector which is later added to the score when XmlReader::checkConnectors() is called. If a note is too long to fit in the measure, it is split up into a series of tied notes, but the pending tie needs to be adjusted to begin at the last tied note in the series, instead of at the original note.