### PR TITLE
Layout optimizations

### DIFF
--- a/libmscore/accidental.cpp
+++ b/libmscore/accidental.cpp
@@ -281,7 +281,7 @@ void Accidental::layout()
       QRectF r;
       // TODO: remove Accidental in layout()
       // don't show accidentals for tab or slash notation
-      if ((staff() && staff()->isTabStaff(tick())) || (note() && note()->fixed())) {
+      if (onTabStaff() || (note() && note()->fixed())) {
             setbbox(r);
             return;
             }
@@ -341,7 +341,7 @@ AccidentalType Accidental::value2subtype(AccidentalVal v)
 void Accidental::draw(QPainter* painter) const
       {
       // don't show accidentals for tab or slash notation
-      if ((staff() && staff()->isTabStaff(tick())) || (note() && note()->fixed()))
+      if (onTabStaff() || (note() && note()->fixed()))
             return;
       painter->setPen(curColor());
       for (const SymElement& e : el)

--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -1260,7 +1260,7 @@ void BarLine::layout()
       setPos(QPointF());
       // barlines hidden on this staff
       if (staff() && segment()) {
-            if ((!staff()->staffType(tick())->showBarlines() && segment()->segmentType() == SegmentType::EndBarLine)
+            if ((!staff()->staffTypeForElement(this)->showBarlines() && segment()->segmentType() == SegmentType::EndBarLine)
                 || (staff()->hideSystemBarLine() && segment()->segmentType() == SegmentType::BeginBarLine)) {
                   setbbox(QRectF());
                   return;
@@ -1328,7 +1328,7 @@ void BarLine::layout2()
       {
       // barlines hidden on this staff
       if (staff() && segment()) {
-            if ((!staff()->staffType(tick())->showBarlines() && segment()->segmentType() == SegmentType::EndBarLine)
+            if ((!staff()->staffTypeForElement(this)->showBarlines() && segment()->segmentType() == SegmentType::EndBarLine)
                 || (staff()->hideSystemBarLine() && segment()->segmentType() == SegmentType::BeginBarLine)) {
                   setbbox(QRectF());
                   return;

--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -1544,7 +1544,7 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
             _beamDist = score()->styleP(Sid::beamWidth) * (1 + score()->styleD(Sid::beamDistance));
 
       _beamDist *= mag();
-      _beamDist *= c1->staff()->mag(c1->tick());
+      _beamDist *= c1->staff()->mag(c1);
       size_t n = crl.size();
 
       const StaffType* tab = 0;

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -71,10 +71,10 @@ Note* Chord::upNote() const
       Q_ASSERT(!_notes.empty());
 
       Note* result = _notes.back();
-      if (!staff())
+      const Staff* stf = staff();
+      if (!stf)
             return result;
 
-      const Staff* stf = staff();
       const StaffType* st  = stf->staffTypeForElement(this);
       if (st->isDrumStaff()) {
             for (Note* n : _notes) {
@@ -108,10 +108,10 @@ Note* Chord::downNote() const
       Q_ASSERT(!_notes.empty());
 
       Note* result = _notes.front();
-      if (!staff())
+      const Staff* stf = staff();
+      if (!stf)
             return result;
 
-      const Staff* stf = staff();
       const StaffType* st  = stf->staffTypeForElement(this);
       if (st->isDrumStaff()) {
             for (Note* n : _notes) {
@@ -193,7 +193,7 @@ int Chord::downString() const
 
       const StaffType* tab = st->staffTypeForElement(this);
       if (!tab->isTabStaff())                // if staff not a TAB, return bottom line
-            return staff()->lines(tick())-1;
+            return st->lines(tick())-1;
 
       int line = 0;         // start at top line
       int noteLine;
@@ -2899,7 +2899,8 @@ void Chord::removeMarkings(bool keepTremolo)
 
 qreal Chord::mag() const
       {
-      qreal m = staff() ? staff()->mag(this) : 1.0;
+      const Staff* st = staff();
+      qreal m = st ? st->mag(this) : 1.0;
       if (small())
             m *= score()->styleD(Sid::smallNoteMag);
       if (_noteType != NoteType::NORMAL)

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -75,7 +75,7 @@ Note* Chord::upNote() const
             return result;
 
       const Staff* stf = staff();
-      const StaffType* st  = stf->staffType(tick());
+      const StaffType* st  = stf->staffTypeForElement(this);
       if (st->isDrumStaff()) {
             for (Note* n : _notes) {
                   if (n->line() < result->line()) {
@@ -112,7 +112,7 @@ Note* Chord::downNote() const
             return result;
 
       const Staff* stf = staff();
-      const StaffType* st  = stf->staffType(tick());
+      const StaffType* st  = stf->staffTypeForElement(this);
       if (st->isDrumStaff()) {
             for (Note* n : _notes) {
                   if (n->line() > result->line()) {
@@ -142,12 +142,12 @@ Note* Chord::downNote() const
 
 int Chord::upLine() const
       {
-      return (staff() && staff()->isTabStaff(tick())) ? upString()*2 : upNote()->line();
+      return onTabStaff() ? upString()*2 : upNote()->line();
       }
 
 int Chord::downLine() const
       {
-      return (staff() && staff()->isTabStaff(tick())) ? downString()*2 : downNote()->line();
+      return onTabStaff() ? downString()*2 : downNote()->line();
       }
 
 //---------------------------------------------------------
@@ -164,10 +164,14 @@ int Chord::downLine() const
 int Chord::upString() const
       {
       // if no staff or staff not a TAB, return 0 (=topmost line)
-      if(!staff() || !staff()->isTabStaff(tick()))
-            return 0;
       const Staff* st = staff();
-      const StaffType* tab = st->staffType(tick());
+      if (!st)
+            return 0;
+
+      const StaffType* tab = st->staffTypeForElement(this);
+      if (!tab->isTabStaff())
+            return 0;
+
       int       line = tab->lines() - 1;      // start at bottom line
       int                     noteLine;
       // scan each note: if TAB strings are not in sequential order,
@@ -183,12 +187,14 @@ int Chord::upString() const
 
 int Chord::downString() const
       {
-      if (!staff())                              // if no staff, return 0
-            return 0;
-      if (!staff()->isTabStaff(tick()))                // if staff not a TAB, return bottom line
-            return staff()->lines(tick())-1;
       const Staff* st = staff();
-      const StaffType* tab = st->staffType(tick());
+      if (!st)                                         // if no staff, return 0
+            return 0;
+
+      const StaffType* tab = st->staffTypeForElement(this);
+      if (!tab->isTabStaff())                // if staff not a TAB, return bottom line
+            return staff()->lines(tick())-1;
+
       int line = 0;         // start at top line
       int noteLine;
       size_t n = _notes.size();
@@ -371,7 +377,7 @@ qreal Chord::noteHeadWidth() const
 qreal Chord::stemPosX() const
       {
       const Staff* stf = staff();
-      const StaffType* st = stf ? stf->staffType(tick()) : 0;
+      const StaffType* st = stf ? stf->staffTypeForElement(this) : 0;
       if (st && st->isTabStaff())
             return st->chordStemPosX(this) * spatium();
       return _up ? noteHeadWidth() : 0.0;
@@ -387,7 +393,7 @@ QPointF Chord::stemPos() const
       QPointF p(pagePos());
 
       const Staff* stf = staff();
-      const StaffType* st = stf ? stf->staffType(tick()) : 0;
+      const StaffType* st = stf ? stf->staffTypeForElement(this) : 0;
       if (st && st->isTabStaff())
             return st->chordStemPos(this) * spatium() + p;
 
@@ -413,7 +419,7 @@ QPointF Chord::stemPosBeam() const
       QPointF p(pagePos());
 
       const Staff* stf = staff();
-      const StaffType* st = stf ? stf->staffType(tick()) : 0;
+      const StaffType* st = stf ? stf->staffTypeForElement(this) : 0;
 
       if (st && st->isTabStaff())
             return st->chordStemPosBeam(this) * _spatium + p;
@@ -859,7 +865,7 @@ void Chord::computeUp()
       {
       Q_ASSERT(!_notes.empty());
       const Staff* st = staff();
-      const StaffType* tab = st ? st->staffType(tick()) : 0;
+      const StaffType* tab = st ? st->staffTypeForElement(this) : 0;
       bool tabStaff  = tab && tab->isTabStaff();
       // TAB STAVES
       if (tabStaff) {
@@ -1151,8 +1157,9 @@ qreal Chord::centerX() const
       {
       // TAB 'notes' are always centered on the stem
       const Staff* st = staff();
-      if (st->isTabStaff(tick()))
-            return st->staffType(tick())->chordStemPosX(this) * spatium();
+      const StaffType* stt = st->staffTypeForElement(this);
+      if (stt->isTabStaff())
+            return stt->chordStemPosX(this) * spatium();
 
       const Note* note = up() ? upNote() : downNote();
       qreal x = note->pos().x() + note->noteheadCenterX();
@@ -1310,7 +1317,8 @@ qreal Chord::defaultStemLength() const
       const Staff* st    = staff();
       qreal lineDistance = st ? st->lineDistance(tick()) : 1.0;
 
-      const StaffType* tab = (st && st->isTabStaff(tick())) ? st->staffType(tick()) : nullptr;
+      const StaffType* stt = st ? st->staffTypeForElement(this) : nullptr;
+      const StaffType* tab = (stt && stt->isTabStaff()) ? stt : nullptr;
       if (tab) {
             // require stems only if TAB is not stemless and this chord has a stem
             if (!tab->stemless() && _stem) {
@@ -1474,7 +1482,7 @@ qreal Chord::minAbsStemLength() const
 void Chord::layoutStem1()
       {
       const Staff* stf = staff();
-      const StaffType* st = stf ? stf->staffType(tick()) : 0;
+      const StaffType* st = stf ? stf->staffTypeForElement(this) : 0;
       if (durationType().hasStem() && !(_noStem || (measure() && measure()->stemless(staffIdx())) || (st && st->isTabStaff() && st->stemless()))) {
             if (!_stem) {
                   Stem* stem = new Stem(score());
@@ -1535,7 +1543,7 @@ void Chord::layoutStem()
       // TAB
       //
       const Staff* st = staff();
-      const StaffType* tab = st ? st->staffType(tick()) : 0;
+      const StaffType* tab = st ? st->staffTypeForElement(this) : 0;
       if (tab && tab->isTabStaff()) {
             // if stemless TAB
             if (tab->stemless()) {
@@ -1715,7 +1723,7 @@ void Chord::cmdUpdateNotes(AccidentalState* as)
       // in the context of the all of the chords of the whole segment
 
       const Staff* st = staff();
-      StaffGroup staffGroup = st->staffType(tick())->group();
+      StaffGroup staffGroup = st->staffTypeForElement(this)->group();
       if (staffGroup == StaffGroup::TAB) {
             const Instrument* instrument = part()->instrument();
             for (Chord* ch : graceNotes())
@@ -1794,7 +1802,7 @@ void Chord::layout()
       {
       if (_notes.empty())
             return;
-      if (staff() && staff()->isTabStaff(tick()))
+      if (onTabStaff())
             layoutTablature();
       else
             layoutPitched();
@@ -2110,7 +2118,7 @@ void Chord::layoutTablature()
       Note* upnote      = upNote();
       qreal headWidth   = symWidth(SymId::noteheadBlack);
       const Staff* st   = staff();
-      const StaffType* tab = st->staffType(tick());
+      const StaffType* tab = st->staffTypeForElement(this);
       qreal lineDist    = tab->lineDistance().val() *_spatium;
       qreal stemX       = tab->chordStemPosX(this) *_spatium;
       int   ledgerLines = 0;
@@ -3342,7 +3350,7 @@ void Chord::layoutArticulations()
       if (_articulations.empty())
             return;
       const Staff* st = staff();
-      const StaffType* staffType = st->staffType(tick());
+      const StaffType* staffType = st->staffTypeForElement(this);
       qreal mag            = (staffType->small() ? score()->styleD(Sid::smallStaffMag) : 1.0) * staffType->userMag();
       qreal _spatium       = score()->spatium() * mag;
       qreal _spStaff       = _spatium * staffType->lineDistance().val();

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1735,7 +1735,8 @@ void Chord::cmdUpdateNotes(AccidentalState* as)
       // PITCHED_ and PERCUSSION_STAFF can go note by note
 
       if (staffGroup == StaffGroup::STANDARD) {
-            for (Chord* ch : graceNotesBefore()) {
+            const QVector<Chord*> gnb(graceNotesBefore());
+            for (Chord* ch : gnb) {
                   std::vector<Note*> notes(ch->notes());  // we need a copy!
                   for (Note* note : notes)
                         note->updateAccidental(as);
@@ -1754,7 +1755,8 @@ void Chord::cmdUpdateNotes(AccidentalState* as)
                         }
                   note->updateAccidental(as);
                   }
-            for (Chord* ch : graceNotesAfter()) {
+            const QVector<Chord*> gna(graceNotesAfter());
+            for (Chord* ch : gna) {
                   std::vector<Note*> notes(ch->notes());  // we need a copy!
                   for (Note* note : notes)
                         note->updateAccidental(as);
@@ -1815,20 +1817,20 @@ void Chord::layout()
 void Chord::layoutPitched()
       {
       int gi = 0;
-      for (Chord* c : _graceNotes) {
+      for (Chord* c : qAsConst(_graceNotes)) {
             // HACK: graceIndex is not well-maintained on add & remove
             // so rebuild now
             c->setGraceIndex(gi++);
             if (c->isGraceBefore())
                   c->layoutPitched();
             }
-      QVector<Chord*> graceNotesBefore = Chord::graceNotesBefore();
-      int gnb = graceNotesBefore.size();
+      const QVector<Chord*> graceNotesBefore = Chord::graceNotesBefore();
+      const int gnb = graceNotesBefore.size();
 
       // lay out grace notes after separately so they are processed left to right
       // (they are normally stored right to left)
 
-      QVector<Chord*> gna = graceNotesAfter();
+      const QVector<Chord*> gna = graceNotesAfter();
       for (Chord* c : gna)
             c->layoutPitched();
 

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1648,7 +1648,7 @@ void Chord::layout2()
       for (Chord* c : _graceNotes)
             c->layout2();
 
-      qreal mag = staff()->mag(tick());
+      const qreal mag = staff()->mag(this);
 
       //
       // position after-chord grace notes
@@ -1833,7 +1833,7 @@ void Chord::layoutPitched()
             c->layoutPitched();
 
       qreal _spatium         = spatium();
-      qreal mag_             = staff() ? staff()->mag(tick()) : 1.0;    // palette elements do not have a staff
+      qreal mag_             = staff() ? staff()->mag(this) : 1.0;    // palette elements do not have a staff
       qreal dotNoteDistance  = score()->styleP(Sid::dotNoteDistance)  * mag_;
       qreal minNoteDistance  = score()->styleP(Sid::minNoteDistance)  * mag_;
       qreal minTieLength     = score()->styleP(Sid::MinTieLength)     * mag_;
@@ -2897,7 +2897,7 @@ void Chord::removeMarkings(bool keepTremolo)
 
 qreal Chord::mag() const
       {
-      qreal m = staff() ? staff()->mag(tick()) : 1.0;
+      qreal m = staff() ? staff()->mag(this) : 1.0;
       if (small())
             m *= score()->styleD(Sid::smallNoteMag);
       if (_noteType != NoteType::NORMAL)

--- a/libmscore/clef.cpp
+++ b/libmscore/clef.cpp
@@ -119,7 +119,7 @@ void Clef::layout()
       // check clef visibility and type compatibility
       if (clefSeg && staff()) {
             Fraction tick = clefSeg->tick();
-            StaffType* st = staffType();
+            const StaffType* st = staff()->staffType(tick);
             bool show     = st->genClef();        // check staff type allows clef display
 
             // check clef is compatible with staff type group:

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -134,7 +134,7 @@ qreal Element::spatium() const
             }
       else {
             Staff* s = staff();
-            return s ? s->spatium(tick()) : score()->spatium();
+            return s ? s->spatium(this) : score()->spatium();
             }
       }
 
@@ -2374,7 +2374,7 @@ void Element::autoplaceSegmentElement(bool above, bool add)
                         si = firstVis;
                   }
             else {
-                  qreal mag = staff()->mag(tick());
+                  qreal mag = staff()->mag(this);
                   sp *= mag;
                   }
             qreal minDistance = _minDistance.val() * sp;

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -263,10 +263,20 @@ Staff* Element::staff() const
 //   staffType
 //---------------------------------------------------------
 
-StaffType* Element::staffType() const
+const StaffType* Element::staffType() const
       {
       Staff* s = staff();
-      return s ? s->staffType(tick()) : 0;
+      return s ? s->staffTypeForElement(this) : nullptr;
+      }
+
+//---------------------------------------------------------
+//   onTabStaff
+//---------------------------------------------------------
+
+bool Element::onTabStaff() const
+      {
+      const StaffType* stt = staffType();
+      return stt ? stt->isTabStaff() : false;
       }
 
 //---------------------------------------------------------

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -324,7 +324,8 @@ class Element : public ScoreElement {
       int voice() const                       { return _track & 3;         }
       void setVoice(int v)                    { _track = (_track / VOICES) * VOICES + v; }
       Staff* staff() const;
-      StaffType* staffType() const;
+      const StaffType* staffType() const;
+      bool onTabStaff() const;
       Part* part() const;
 
       virtual void add(Element*);

--- a/libmscore/fraction.h
+++ b/libmscore/fraction.h
@@ -76,6 +76,7 @@ class Fraction {
 
       bool isZero() const        { return _numerator == 0;      }
       bool isNotZero() const     { return _numerator != 0;      }
+      bool negative() const      { return _numerator < 0;       }
 
       bool isValid() const       { return _denominator != 0;    }
 

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2637,7 +2637,7 @@ void Score::getNextMeasure(LayoutContext& lc)
                         ks->layout();
                         }
                   else if (segment.isChordRestType()) {
-                        const StaffType* st = staff->staffType(segment.tick());
+                        const StaffType* st = staff->staffTypeForElement(&segment);
                         int track     = staffIdx * VOICES;
                         int endTrack  = track + VOICES;
 

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -147,8 +147,9 @@ void Score::layoutChords1(Segment* segment, int staffIdx)
       const Staff* staff = Score::staff(staffIdx);
       const int startTrack = staffIdx * VOICES;
       const int endTrack   = startTrack + VOICES;
+      const Fraction tick = segment->tick();
 
-      if (staff->isTabStaff(segment->tick())) {
+      if (staff->isTabStaff(tick)) {
             layoutSegmentElements(segment, startTrack, endTrack);
             return;
             }
@@ -158,7 +159,7 @@ void Score::layoutChords1(Segment* segment, int staffIdx)
       std::vector<Note*> downStemNotes;
       int upVoices       = 0;
       int downVoices     = 0;
-      qreal nominalWidth = noteHeadWidth() * staff->mag(segment->tick());
+      qreal nominalWidth = noteHeadWidth() * staff->mag(tick);
       qreal maxUpWidth   = 0.0;
       qreal maxDownWidth = 0.0;
       qreal maxUpMag     = 0.0;
@@ -238,7 +239,7 @@ void Score::layoutChords1(Segment* segment, int staffIdx)
                   maxDownWidth = qMax(maxDownWidth, hw);
                   }
 
-            qreal sp                 = staff->spatium(segment->tick());
+            qreal sp                 = staff->spatium(tick);
             qreal upOffset           = 0.0;      // offset to apply to upstem chords
             qreal downOffset         = 0.0;      // offset to apply to downstem chords
             qreal dotAdjust          = 0.0;      // additional chord offset to account for dots
@@ -262,7 +263,7 @@ void Score::layoutChords1(Segment* segment, int staffIdx)
             // amount by which actual width exceeds nominal, adjusted for staff mag() only
             qreal headDiff = maxUpWidth - nominalWidth;
             // amount by which actual width exceeds nominal, adjusted for staff & chord/note mag()
-            qreal headDiff2 = maxUpWidth - nominalWidth * (maxUpMag / staff->mag(segment->tick()));
+            qreal headDiff2 = maxUpWidth - nominalWidth * (maxUpMag / staff->mag(tick));
             if (headDiff > centerThreshold) {
                   // larger than nominal
                   centerUp = headDiff * -0.5;
@@ -2645,7 +2646,7 @@ void Score::getNextMeasure(LayoutContext& lc)
                               ChordRest* cr = segment.cr(t);
                               if (!cr)
                                     continue;
-                              qreal m = staff->mag(segment.tick());
+                              qreal m = staff->mag(&segment);
                               if (cr->small())
                                     m *= score()->styleD(Sid::smallNoteMag);
 

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -807,9 +807,10 @@ SymId Note::noteHead() const
       if (_headType != NoteHead::Type::HEAD_AUTO)
             ht = _headType;
 
+      const Staff* st = chord() ? chord()->staff() : nullptr;
+
       if (_headGroup == NoteHead::Group::HEAD_CUSTOM) {
-            if (chord() && chord()->staff()) {
-                  const Staff* st = chord()->staff();
+            if (st) {
                   if (st->staffTypeForElement(chord())->isDrumStaff())
                         return st->part()->instrument(chord()->tick())->drumset()->noteHeads(_pitch, ht);
                   }
@@ -820,10 +821,9 @@ SymId Note::noteHead() const
 
       Key key = Key::C;
       NoteHeadScheme scheme = NoteHeadScheme::HEAD_NORMAL;
-      if (chord() && chord()->staff()){
+      if (st) {
             Fraction tick = chord()->tick();
             if (tick >= Fraction(0,1)) {
-                  const Staff* st = chord()->staff();
                   key    = st->key(tick);
                   scheme = st->staffTypeForElement(chord())->noteHeadScheme();
                   }

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -597,7 +597,7 @@ Note::Note(const Note& n, bool link)
 
       // types in _el: SYMBOL, IMAGE, FINGERING, TEXT, BEND
       const Staff* stf = staff();
-      bool tabFingering = stf->staffType(tick())->showTabFingering();
+      bool tabFingering = stf->staffTypeForElement(this)->showTabFingering();
       for (Element* e : n._el) {
             if (e->isFingering() && staff()->isTabStaff(tick()) && !tabFingering)    // tablature has no fingering
                   continue;
@@ -810,7 +810,7 @@ SymId Note::noteHead() const
       if (_headGroup == NoteHead::Group::HEAD_CUSTOM) {
             if (chord() && chord()->staff()) {
                   const Staff* st = chord()->staff();
-                  if (st->staffType(chord()->tick())->isDrumStaff())
+                  if (st->staffTypeForElement(chord())->isDrumStaff())
                         return st->part()->instrument(chord()->tick())->drumset()->noteHeads(_pitch, ht);
                   }
             else {
@@ -825,7 +825,7 @@ SymId Note::noteHead() const
             if (tick >= Fraction(0,1)) {
                   const Staff* st = chord()->staff();
                   key    = st->key(tick);
-                  scheme = st->staffType(tick)->noteHeadScheme();
+                  scheme = st->staffTypeForElement(chord())->noteHeadScheme();
                   }
             }
       SymId t = noteHead(up, _headGroup, ht, tpc(), key, scheme);
@@ -1091,7 +1091,7 @@ bool Note::isNoteName() const
       {
       if (chord() && chord()->staff()) {
             const Staff* st = staff();
-            NoteHeadScheme s = st->staffType(tick())->noteHeadScheme();
+            NoteHeadScheme s = st->staffTypeForElement(this)->noteHeadScheme();
             return s == NoteHeadScheme::HEAD_PITCHNAME || s == NoteHeadScheme::HEAD_PITCHNAME_GERMAN || s == NoteHeadScheme::HEAD_SOLFEGE || s == NoteHeadScheme::HEAD_SOLFEGE_FIXED;
             }
       return false;
@@ -1113,7 +1113,7 @@ void Note::draw(QPainter* painter) const
       // tablature
       if (tablature) {
             const Staff* st = staff();
-            const StaffType* tab = st->staffType(tick());
+            const StaffType* tab = st->staffTypeForElement(this);
             if (tieBack() && !tab->showBackTied()) {
                   if (chord()->measure()->system() == tieBack()->startNote()->chord()->measure()->system() && el().size() == 0)
                         // fret should be hidden, so return without drawing it
@@ -1538,7 +1538,7 @@ bool Note::acceptDrop(EditData& data) const
             }
       const Staff* st   = staff();
       bool isTablature  = st->isTabStaff(tick());
-      bool tabFingering = st->staffType(tick())->showTabFingering();
+      bool tabFingering = st->staffTypeForElement(this)->showTabFingering();
       return (type == ElementType::ARTICULATION
          || type == ElementType::FERMATA
          || type == ElementType::CHORDLINE
@@ -1601,7 +1601,7 @@ Element* Note::drop(EditData& data)
 
       const Staff* st = staff();
       bool isTablature = st->isTabStaff(tick());
-      bool tabFingering = st->staffType(tick())->showTabFingering();
+      bool tabFingering = st->staffTypeForElement(this)->showTabFingering();
       Chord* ch = chord();
 
       switch(e->type()) {
@@ -1840,7 +1840,7 @@ void Note::setDotY(Direction pos)
             // with TAB's, dotPosX is not set:
             // get dot X from width of fret text and use TAB default spacing
             const Staff* st = staff();
-            const StaffType* tab = st->staffType(tick());
+            const StaffType* tab = st->staffTypeForElement(this);
             if (tab->stemThrough() ) {
                   // if fret mark on lines, use standard processing
                   if (tab->onLines())
@@ -1906,7 +1906,7 @@ void Note::layout()
       bool useTablature = staff() && staff()->isTabStaff(chord()->tick());
       if (useTablature) {
             const Staff* st = staff();
-            const StaffType* tab = st->staffType(tick());
+            const StaffType* tab = st->staffTypeForElement(this);
             qreal mags = magS();
             bool paren = false;
             if (tieBack() && !tab->showBackTied()) {
@@ -1958,7 +1958,7 @@ void Note::layout2()
             // if TAB and stems through staff
             if (staff()->isTabStaff(chord()->tick())) {
                   const Staff* st = staff();
-                  const StaffType* tab = st->staffType(tick());
+                  const StaffType* tab = st->staffTypeForElement(this);
                   if (tab->stemThrough()) {
                         // with TAB's, dot Y is not calculated during layoutChords3(),
                         // as layoutChords3() is not even called for TAB's;
@@ -1990,7 +1990,7 @@ void Note::layout2()
                   if (sym->sym() == SymId::noteheadParenthesisRight) {
                         if (staff()->isTabStaff(chord()->tick())) {
                               const Staff* st = staff();
-                              const StaffType* tab = st->staffType(tick());
+                              const StaffType* tab = st->staffTypeForElement(this);
                               w = tabHeadWidth(tab);
                               }
                         e->rxpos() += w;
@@ -2535,14 +2535,14 @@ void Note::updateRelLine(int relLine, bool undoable)
       int idx      = chord()->vStaffIdx();
 
       const Staff* staff  = score()->staff(idx);
-      const StaffType* st = staff->staffType(tick());
+      const StaffType* st = staff->staffTypeForElement(this);
 
       if (chord()->staffMove()) {
             // check that destination staff makes sense (might have been deleted)
             int minStaff = part()->startTrack() / VOICES;
             int maxStaff = part()->endTrack() / VOICES;
             const Staff* stf = this->staff();
-            if (idx < minStaff || idx >= maxStaff || st->group() != stf->staffType(tick())->group()) {
+            if (idx < minStaff || idx >= maxStaff || st->group() != stf->staffTypeForElement(this)->group()) {
                   qDebug("staffMove out of scope %d + %d min %d max %d",
                      staffIdx(), chord()->staffMove(), minStaff, maxStaff);
                   chord()->undoChangeProperty(Pid::STAFF_MOVE, 0);

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -2376,7 +2376,7 @@ static void readStaff(Staff* staff, XmlReader& e)
                         }
                   }
             else if (tag == "small")
-                  staff->setSmall(Fraction(0,1), e.readInt());
+                  staff->staffType(Fraction(0,1))->setSmall(e.readInt());
             else if (tag == "invisible")
                   staff->setInvisible(e.readInt());
             else if (tag == "slashStyle")

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -74,10 +74,11 @@ Rest::Rest(const Rest& r, bool link)
 
 void Rest::draw(QPainter* painter) const
       {
+      const StaffType* stt = staff() ? staff()->staffTypeForElement(this) : nullptr;
       if (
-         (staff() && staff()->isTabStaff(tick())
+         (stt && stt->isTabStaff()
          // in tab staff, do not draw rests is rests are off OR if dur. symbols are on
-         && (!staff()->staffType(tick())->showRests() || staff()->staffType(tick())->genDurations())
+         && (!stt->showRests() || stt->genDurations())
          && (!measure() || !measure()->isMMRest()))        // show multi measure rest always
          || generated()
             )
@@ -348,8 +349,9 @@ void Rest::layout()
             }
 
       rxpos() = 0.0;
-      if (staff() && staff()->isTabStaff(tick())) {
-            const StaffType* tab = staff()->staffType(tick());
+      const StaffType* stt = staffType();
+      if (stt && stt->isTabStaff()) {
+            const StaffType* tab = stt;
             // if rests are shown and note values are shown as duration symbols
             if (tab->showRests() && tab->genDurations()) {
                   TDuration::DurationType type = durationType().type();
@@ -386,7 +388,7 @@ void Rest::layout()
 
       qreal yOff       = offset().y();
       const Staff* stf = staff();
-      const StaffType*  st = stf->staffType(tick());
+      const StaffType*  st = stf->staffTypeForElement(this);
       qreal lineDist = st ? st->lineDistance().val() : 1.0;
       int userLine   = yOff == 0.0 ? 0 : lrint(yOff / (lineDist * _spatium));
       int lines      = st ? st->lines() : 5;

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -692,7 +692,7 @@ void Rest::reset()
 
 qreal Rest::mag() const
       {
-      qreal m = staff()->mag(tick());
+      qreal m = staff()->mag(this);
       if (small())
             m *= score()->styleD(Sid::smallNoteMag);
       return m;

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1228,9 +1228,9 @@ bool Score::getPosition(Position* pos, const QPointF& p, int voice) const
       //
       // TODO: restrict to reasonable values (pitch 0-127)
       //
-      Staff* s      = staff(pos->staffIdx);
-      qreal mag     = s->mag(segment->tick());
-      Fraction tick = segment->tick();
+      const Staff* s      = staff(pos->staffIdx);
+      const Fraction tick = segment->tick();
+      const qreal mag     = s->mag(tick);
       // in TABs, step from one string to another; in other staves, step on and between lines
       qreal lineDist = s->staffType(tick)->lineDistance().val() * (s->isTabStaff(measure->tick()) ? 1 : .5) * mag * spatium();
 
@@ -3702,8 +3702,9 @@ void Score::appendPart(const QString& name)
       for (int i = 0; i < t->nstaves(); ++i) {
             Staff* staff = new Staff(this);
             staff->setPart(part);
-            staff->setLines(Fraction(0,1), t->staffLines[i]);
-            staff->setSmall(Fraction(0,1), t->smallStaff[i]);
+            StaffType* stt = staff->staffType(Fraction(0,1));
+            stt->setLines(t->staffLines[i]);
+            stt->setSmall(t->smallStaff[i]);
             if (i == 0) {
                   staff->setBracketType(0, t->bracket[0]);
                   staff->setBracketSpan(0, t->nstaves());

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -718,7 +718,7 @@ bool Staff::readProperties(XmlReader& e)
             setDefaultClefType(ClefTypeList(defaultClefType()._concertClef, Clef::clefType(val)));
             }
       else if (tag == "small")                  // obsolete
-            setSmall(Fraction(0,1), e.readInt());
+            staffType(Fraction(0,1))->setSmall(e.readInt());
       else if (tag == "invisible")
             setInvisible(e.readInt());
       else if (tag == "hideWhenEmpty")
@@ -808,49 +808,28 @@ qreal Staff::spatium(const Fraction& tick) const
       return score()->spatium() * mag(tick);
       }
 
+qreal Staff::spatium(const Element* e) const
+      {
+      return score()->spatium() * mag(e);
+      }
+
 //---------------------------------------------------------
 //   mag
 //---------------------------------------------------------
 
+qreal Staff::mag(const StaffType* stt) const
+      {
+      return (stt->small() ? score()->styleD(Sid::smallStaffMag) : 1.0) * stt->userMag();
+      }
+
 qreal Staff::mag(const Fraction& tick) const
       {
-      return (small(tick) ? score()->styleD(Sid::smallStaffMag) : 1.0) * userMag(tick);
+      return mag(staffType(tick));
       }
 
-//---------------------------------------------------------
-//   userMag
-//---------------------------------------------------------
-
-qreal Staff::userMag(const Fraction& tick) const
+qreal Staff::mag(const Element* e) const
       {
-      return staffType(tick)->userMag();
-      }
-
-//---------------------------------------------------------
-//   setUserMag
-//---------------------------------------------------------
-
-void Staff::setUserMag(const Fraction& tick, qreal m)
-      {
-      staffType(tick)->setUserMag(m);
-      }
-
-//---------------------------------------------------------
-//   small
-//---------------------------------------------------------
-
-bool Staff::small(const Fraction& tick) const
-      {
-      return staffType(tick)->small();
-      }
-
-//---------------------------------------------------------
-//   setSmall
-//---------------------------------------------------------
-
-void Staff::setSmall(const Fraction& tick, bool val)
-      {
-      staffType(tick)->setSmall(val);
+      return mag(staffTypeForElement(e));
       }
 
 //---------------------------------------------------------
@@ -1058,12 +1037,12 @@ void Staff::init(const InstrumentTemplate* t, const StaffType* staffType, int ci
       if (!pst)
             pst = StaffType::getDefaultPreset(t->staffGroup);
 
-      setStaffType(Fraction(0,1), *pst);
+      StaffType* stt = setStaffType(Fraction(0,1), *pst);
       if (cidx >= MAX_STAVES) {
-            setSmall(Fraction(0,1), false);
+            stt->setSmall(false);
             }
       else {
-            setSmall(Fraction(0,1),       t->smallStaff[cidx]);
+            stt->setSmall(t->smallStaff[cidx]);
             setBracketType(0, t->bracket[cidx]);
             setBracketSpan(0, t->bracketSpan[cidx]);
             setBarLineSpan(t->barlineSpan[cidx]);
@@ -1283,9 +1262,9 @@ QVariant Staff::getProperty(Pid id) const
       {
       switch (id) {
             case Pid::SMALL:
-                  return small(Fraction(0,1));
+                  return staffType(Fraction(0,1))->small();
             case Pid::MAG:
-                  return userMag(Fraction(0,1));
+                  return staffType(Fraction(0,1))->userMag();
             case Pid::COLOR:
                   return color();
             case Pid::PLAYBACK_VOICE1:
@@ -1321,13 +1300,13 @@ bool Staff::setProperty(Pid id, const QVariant& v)
       switch (id) {
             case Pid::SMALL: {
                   qreal _spatium = spatium(Fraction(0,1));
-                  setSmall(Fraction(0,1), v.toBool());
+                  staffType(Fraction(0,1))->setSmall(v.toBool());
                   localSpatiumChanged(_spatium, spatium(Fraction(0,1)), Fraction(0, 1));
                   break;
                   }
             case Pid::MAG: {
                   qreal _spatium = spatium(Fraction(0,1));
-                  setUserMag(Fraction(0,1), v.toReal());
+                  staffType(Fraction(0,1))->setUserMag(v.toReal());
                   localSpatiumChanged(_spatium, spatium(Fraction(0,1)), Fraction(0, 1));
                   }
                   break;

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -996,6 +996,13 @@ StaffType* Staff::staffType(const Fraction& tick)
       return &_staffTypeList.staffType(tick);
       }
 
+const StaffType* Staff::staffTypeForElement(const Element* e) const
+      {
+      if (_staffTypeList.uniqueStaffType()) // optimize if one staff type spans for the entire staff
+            return &_staffTypeList.staffType({0, 1});
+      return &_staffTypeList.staffType(e->tick());
+      }
+
 //---------------------------------------------------------
 //   staffTypeListChanged
 //    Signal that the staffTypeList has changed at

--- a/libmscore/staff.h
+++ b/libmscore/staff.h
@@ -99,6 +99,8 @@ class Staff final : public ScoreElement {
       void fillBrackets(int);
       void cleanBrackets();
 
+      qreal mag(const StaffType*) const;
+
    public:
       Staff(Score* score = 0);
       void init(const InstrumentTemplate*, const StaffType *staffType, int);
@@ -216,12 +218,10 @@ class Staff final : public ScoreElement {
       int middleLine(const Fraction&) const;
       int bottomLine(const Fraction&) const;
 
-      qreal userMag(const Fraction&) const;
-      void setUserMag(const Fraction&, qreal m);
       qreal mag(const Fraction&) const;
-      bool small(const Fraction&) const;
-      void setSmall(const Fraction&, bool val);
+      qreal mag(const Element*) const;
       qreal spatium(const Fraction&) const;
+      qreal spatium(const Element*) const;
       //===========
 
       ChangeMap& velocities()           { return _velocities;     }

--- a/libmscore/staff.h
+++ b/libmscore/staff.h
@@ -198,6 +198,7 @@ class Staff final : public ScoreElement {
       //==== staff type helper function
       const StaffType* staffType(const Fraction&) const;
       const StaffType* constStaffType(const Fraction&) const;
+      const StaffType* staffTypeForElement(const Element*) const;
       StaffType* staffType(const Fraction&);
       StaffType* setStaffType(const Fraction&, const StaffType&);
       void removeStaffType(const Fraction&);

--- a/libmscore/stafftypelist.h
+++ b/libmscore/stafftypelist.h
@@ -25,14 +25,19 @@ class XmlReader;
 //    to keep track of staff type changes
 //---------------------------------------------------------
 
-class StaffTypeList : public std::map<int, StaffType> {
+class StaffTypeList {
+      StaffType firstStaffType; ///< staff type at tick 0
+      std::map<int, StaffType> staffTypeChanges;
 
    public:
       StaffTypeList() {}
       StaffType& staffType(const Fraction&);
-      const StaffType& staffType(const Fraction&) const;
+      const StaffType& staffType(const Fraction& f) const;
       StaffType* setStaffType(const Fraction&, const StaffType&);
+      bool removeStaffType(const Fraction&);
       void read(XmlReader&, Score*);
+
+      std::pair<int, int> staffTypeRange(const Fraction&) const;
       };
 
 }

--- a/libmscore/stafftypelist.h
+++ b/libmscore/stafftypelist.h
@@ -37,6 +37,7 @@ class StaffTypeList {
       bool removeStaffType(const Fraction&);
       void read(XmlReader&, Score*);
 
+      bool uniqueStaffType() const { return staffTypeChanges.empty(); }
       std::pair<int, int> staffTypeRange(const Fraction&) const;
       };
 

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -2430,13 +2430,15 @@ const char* MStyle::valueType(const Sid i)
 //   value
 //---------------------------------------------------------
 
-QVariant MStyle::value(Sid idx) const
+const QVariant& MStyle::value(Sid idx) const
       {
-      if (!_values[int(idx)].isValid()) {
+      const QVariant& val = _values[int(idx)];
+      if (!val.isValid()) {
             qDebug("invalid style value %d %s", int(idx), MStyle::valueName(idx));
-            return QVariant();
+            static QVariant emptyVal;
+            return emptyVal;
             }
-      return _values[int(idx)];
+      return val;
       }
 
 //---------------------------------------------------------

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -1301,7 +1301,7 @@ class MStyle {
       MStyle();
 
       void precomputeValues();
-      QVariant value(Sid idx) const;
+      const QVariant& value(Sid idx) const;
       qreal pvalue(Sid idx) const    { return _precomputedValues[int(idx)]; }
       void set(Sid idx, const QVariant& v);
 

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -640,7 +640,9 @@ void TextBlock::layout(TextBase* t)
             _lineSpacing = fm.lineSpacing();
             }
       else {
-            for (TextFragment& f : _fragments) {
+            const auto fiLast = --_fragments.end();
+            for (auto fi = _fragments.begin(); fi != _fragments.end(); ++fi) {
+                  TextFragment& f = *fi;
                   f.pos.setX(x);
                   QFontMetricsF fm(f.font(t), MScore::paintDevice());
                   if (f.format.valign() != VerticalAlignment::AlignNormal) {
@@ -653,9 +655,15 @@ void TextBlock::layout(TextBase* t)
                         }
                   else
                         f.pos.setY(0.0);
-                  qreal w  = fm.width(f.text);
+
+                  // Optimization: don't calculate character position
+                  // for the next fragment if there is no next fragment
+                  if (fi != fiLast) {
+                        const qreal w  = fm.width(f.text);
+                        x += w;
+                        }
+
                   _bbox   |= fm.tightBoundingRect(f.text).translated(f.pos);
-                  x += w;
                   _lineSpacing = qMax(_lineSpacing, fm.lineSpacing());
                   }
             }

--- a/libmscore/timesig.cpp
+++ b/libmscore/timesig.cpp
@@ -256,7 +256,7 @@ void TimeSig::layout()
 
       if (_staff) {
             // if staff is without time sig, format as if no text at all
-            if (!_staff->staffType(tick())->genTimesig() ) {
+            if (!_staff->staffTypeForElement(this)->genTimesig()) {
                   // reset position and box sizes to 0
                   // qDebug("staff: no time sig");
                   pointLargeLeftParen.rx() = 0.0;

--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -166,7 +166,8 @@ void Tuplet::layout()
             return;
             }
       // is in a TAB without stems, skip any format: tuplets are not shown
-      if (staff() && staff()->isTabStaff(tick()) && staff()->staffType(tick())->stemless())
+      const StaffType* stt = staffType();
+      if (stt && stt->isTabStaff() && stt->stemless())
             return;
 
       //
@@ -668,7 +669,8 @@ void Tuplet::layout()
 void Tuplet::draw(QPainter* painter) const
       {
       // if in a TAB without stems, tuplets are not shown
-      if (staff() && staff()->isTabStaff(tick()) && staff()->staffType(tick())->stemless())
+      const StaffType* stt = staffType();
+      if (stt && stt->isTabStaff() && stt->stemless())
             return;
 
       QColor color(curColor());

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -122,7 +122,7 @@ void updateNoteLines(Segment* segment, int track)
 
 UndoCommand::~UndoCommand()
       {
-      for (auto c : childList)
+      for (auto c : qAsConst(childList))
             delete c;
       }
 

--- a/mscore/capella.cpp
+++ b/mscore/capella.cpp
@@ -1211,7 +1211,7 @@ void convertCapella(Score* score, Capella* cap, bool capxMode)
                   bstaff = 0;
                   }
 
-            s->setSmall(Fraction(0,1), cl->bSmall);
+            s->staffType(Fraction(0,1))->setSmall(cl->bSmall);
             part->insertStaff(s, -1);
             Interval interval;
             // guess diatonic transposition from chromatic transposition for the instrument

--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -97,8 +97,8 @@ void EditStaff::setStaff(Staff* s, const Fraction& tick)
       instrument        = *part->instrument(tick);
       Score* score      = part->score();
       staff             = new Staff(score);
-      staff->setStaffType(Fraction(0,1), *orgStaff->staffType(Fraction(0,1)));
-      staff->setSmall(Fraction(0,1), orgStaff->small(Fraction(0,1)));
+      StaffType* stt = staff->setStaffType(Fraction(0,1), *orgStaff->staffType(Fraction(0,1)));
+      stt->setSmall(orgStaff->staffType(Fraction(0,1))->small());
       staff->setInvisible(orgStaff->invisible());
       staff->setUserDist(orgStaff->userDist());
       staff->setColor(orgStaff->color());
@@ -106,7 +106,7 @@ void EditStaff::setStaff(Staff* s, const Fraction& tick)
       staff->setCutaway(orgStaff->cutaway());
       staff->setHideWhenEmpty(orgStaff->hideWhenEmpty());
       staff->setShowIfEmpty(orgStaff->showIfEmpty());
-      staff->setUserMag(Fraction(0,1), orgStaff->userMag(Fraction(0,1)));
+      stt->setUserMag(orgStaff->staffType(Fraction(0,1))->userMag());
       staff->setHideSystemBarLine(orgStaff->hideSystemBarLine());
 
       // get tick range for instrument
@@ -124,14 +124,14 @@ void EditStaff::setStaff(Staff* s, const Fraction& tick)
       // set dlg controls
       spinExtraDistance->setValue(s->userDist() / score->spatium());
       invisible->setChecked(staff->invisible());
-      small->setChecked(staff->small(Fraction(0,1)));
+      small->setChecked(stt->small());
       color->setColor(s->color());
       partName->setText(part->partName());
       cutaway->setChecked(staff->cutaway());
       hideMode->setCurrentIndex(int(staff->hideWhenEmpty()));
       showIfEmpty->setChecked(staff->showIfEmpty());
       hideSystemBarLine->setChecked(staff->hideSystemBarLine());
-      mag->setValue(staff->userMag(Fraction(0,1)) * 100.0);
+      mag->setValue(stt->userMag() * 100.0);
       updateStaffType();
       updateInstrument();
       updateNextPreviousButtons();


### PR DESCRIPTION
This PR contains various optimizations for layout process. Most of optimizations used here are largely dependent on actual score content but should notably improve performance for most common use cases. The optimizations introduced here include:
1) Optimizations for staff type searching and the corresponding segment tick calculations if no staff type changes happen in the given staff. Performance improvements here result from:
    - Avoiding searching through `map` of staff type changes if no changes actually occur;
    - Avoiding calculating tick for miscellaneous elements like chords, rests, notes etc. This helps to improve performance since tick calculation for them leads to calculation of tick of their segment which is not actually a cheap operation since it involves addition of two `Fraction`s (measure tick + segment tick relative to measure).
2) Optimization which allows not to calculate text fragment width for the last fragment in a line (if text has line breaks, each line is considered separately in this context). This optimization will have small effect for text elements which contain lots of inline formatting changes but is considerable for most common pattern of text elements usage (one or multiple text lines with low number of formatting options changes in the middle of the line).
3) Avoid unnecessarily copying `QVariant` instance when getting style values.
3) Optimizations for Qt containers to avoid triggering `detach()` for them if that happens to be possible.
4) Avoid redundant `Element::staff()` calls as each call involves numerous boundary conditions checks for safety. This is not a very significant optimization but it still has its effect.

The overall performance benefit, according to the benchmark in `mtest/libmscore/layout` launched on a score based on the [OpenScore edition](https://musescore.com/openscore/scores/4861738) of Mozart's Symhony No. 41, converted to `.mscx` and with one instrument part generated, decrease layout time by around 30% for full layout and by 35-37% for partial layout triggered in the first measure of test score. Optimizations for the first 4 commits (staff type optimizations + QVariant copying optimization in `MStyle`) decrease layout time by around 25% for full layout and by 22-25% for partial layout triggered in the first measure of test score. Therefore staff type optimizations are most significant in this PR but other ones also have a measurable effect.