### PR TITLE
[MU4] fix #301525: Assign 'High Floor Tom' to 1st voice. Update templates.

### DIFF
--- a/libmscore/drumset.cpp
+++ b/libmscore/drumset.cpp
@@ -254,7 +254,7 @@ void initDrumset()
       smDrumset->drum(40) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Electric Snare"),     NoteHead::Group::HEAD_NORMAL,   3, Direction::UP);
       smDrumset->drum(41) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Low Floor Tom"),      NoteHead::Group::HEAD_NORMAL,   5, Direction::UP);
       smDrumset->drum(42) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Closed Hi-Hat"),      NoteHead::Group::HEAD_CROSS,   -1, Direction::UP, 0, Qt::Key_G);
-      smDrumset->drum(43) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "High Floor Tom"),     NoteHead::Group::HEAD_NORMAL,   5, Direction::DOWN, 1);
+      smDrumset->drum(43) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "High Floor Tom"),     NoteHead::Group::HEAD_NORMAL,   5, Direction::UP);
       smDrumset->drum(44) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Pedal Hi-Hat"),       NoteHead::Group::HEAD_CROSS,    9, Direction::DOWN, 1, Qt::Key_F);
       smDrumset->drum(45) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Low Tom"),            NoteHead::Group::HEAD_NORMAL,   2, Direction::UP);
       smDrumset->drum(46) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Open Hi-Hat"),        NoteHead::Group::HEAD_CROSS,    1, Direction::UP);

--- a/mtest/importmidi/perc_drums.mscx
+++ b/mtest/importmidi/perc_drums.mscx
@@ -92,9 +92,9 @@
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
-          <voice>1</voice>
+          <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>

--- a/mtest/importmidi/perc_no_grand_staff.mscx
+++ b/mtest/importmidi/perc_no_grand_staff.mscx
@@ -164,9 +164,9 @@
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
-          <voice>1</voice>
+          <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>

--- a/mtest/importmidi/perc_remove_ties.mscx
+++ b/mtest/importmidi/perc_remove_ties.mscx
@@ -92,9 +92,9 @@
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
-          <voice>1</voice>
+          <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>

--- a/mtest/importmidi/perc_short_notes.mscx
+++ b/mtest/importmidi/perc_short_notes.mscx
@@ -92,9 +92,9 @@
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
-          <voice>1</voice>
+          <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>

--- a/mtest/importmidi/perc_tuplet_simplify.mscx
+++ b/mtest/importmidi/perc_tuplet_simplify.mscx
@@ -92,9 +92,9 @@
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
-          <voice>1</voice>
+          <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>

--- a/mtest/importmidi/perc_tuplet_simplify2.mscx
+++ b/mtest/importmidi/perc_tuplet_simplify2.mscx
@@ -92,9 +92,9 @@
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
-          <voice>1</voice>
+          <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>

--- a/mtest/importmidi/perc_tuplet_voice.mscx
+++ b/mtest/importmidi/perc_tuplet_voice.mscx
@@ -92,9 +92,9 @@
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
-          <voice>1</voice>
+          <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>

--- a/share/templates/05-Jazz/02-Big_Band.mscx
+++ b/share/templates/05-Jazz/02-Big_Band.mscx
@@ -1176,9 +1176,9 @@
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
-          <voice>1</voice>
+          <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>

--- a/share/templates/05-Jazz/03-Jazz_Combo.mscx
+++ b/share/templates/05-Jazz/03-Jazz_Combo.mscx
@@ -637,9 +637,9 @@
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
-          <voice>1</voice>
+          <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>

--- a/share/templates/06-Popular/01-Rock_Band.mscx
+++ b/share/templates/06-Popular/01-Rock_Band.mscx
@@ -463,9 +463,9 @@
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
-          <voice>1</voice>
+          <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>

--- a/share/templates/07-Band_and_Percussion/07-Large_Pit_Percussion.mscx
+++ b/share/templates/07-Band_and_Percussion/07-Large_Pit_Percussion.mscx
@@ -1164,9 +1164,9 @@
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
-          <voice>1</voice>
+          <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>

--- a/share/templates/07-Band_and_Percussion/08-Small_Pit_Percussion.mscx
+++ b/share/templates/07-Band_and_Percussion/08-Small_Pit_Percussion.mscx
@@ -606,9 +606,9 @@
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
-          <voice>1</voice>
+          <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/301525

The _High Floor Tom_ note is now in the 1st voice, consistent with the other toms & parts of the kit that are hit with a stick.

Besides fixing `drumset.cpp` for freshly generated drumsets, I searched for static occurences of the old configuration in XML (`grep -ir '<Drum pitch="43"'`):
- **Score templates in `share/templates` that include drumset have been updated accordingly.**
  - No change to `drumset_fr.drm`, as French notation apparently puts all toms in the 2nd voice (?).  Not familiar with it, but appears to be consistent.
- **I have NOT looked at the matching files from the test directories**:  *mtest/* (28), *vtest/* (11), *test/* (1).  Just too many to go through manually, and I have not yet come up with a good enough awk script to robustly automate this.  If a few of them are especially important, I can update them manually for now.
- No change to `mscore/importgtp.cpp`.  Externally generated in GP5; toms appear to be at least consistent.
- No change to `share/instruments/instruments.xml`.  Correct in *tom-toms* instrument.  Other match is for triangle & hence not applicable.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made