### PR TITLE
fix #301478: Relative text position inside a frame is not saved for scores imported from 2.x

### DIFF
--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -369,8 +369,10 @@ static bool readTextProperties(XmlReader& e, TextBase* t, Element*)
             }
       else if (tag == "foregroundColor")  // same as "color" ?
             e.skipCurrentElement();
-      else if (tag == "frame")
+      else if (tag == "frame") {
             t->setFrameType(e.readBool() ? FrameType::SQUARE : FrameType::NO_FRAME);
+            t->setPropertyFlags(Pid::FRAME_TYPE, PropertyFlags::UNSTYLED);
+            }
       else if (tag == "halign") {
             Align align = Align(int(t->align()) & int(~Align::HMASK));
             const QString& val(e.readElementText());
@@ -383,6 +385,7 @@ static bool readTextProperties(XmlReader& e, TextBase* t, Element*)
             else
                   qDebug("readText: unknown alignment: <%s>", qPrintable(val));
             t->setAlign(align);
+            t->setPropertyFlags(Pid::ALIGN, PropertyFlags::UNSTYLED);
             }
       else if (tag == "valign") {
             Align align = Align(int(t->align()) & int(~Align::VMASK));
@@ -398,6 +401,7 @@ static bool readTextProperties(XmlReader& e, TextBase* t, Element*)
             else
                   qDebug("readText: unknown alignment: <%s>", qPrintable(val));
             t->setAlign(align);
+            t->setPropertyFlags(Pid::ALIGN, PropertyFlags::UNSTYLED);
             }
       else if (tag == "rxoffset") {       // TODO
             e.readElementText();

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -1595,10 +1595,12 @@ static bool readTextProperties206(XmlReader& e, TextBase* t)
             }
       else if (tag == "foregroundColor")  // same as "color" ?
             e.skipCurrentElement();
-      else if (tag == "frame")
+      else if (tag == "frame") {
             t->setFrameType(e.readBool() ? FrameType::SQUARE : FrameType::NO_FRAME);
+            t->setPropertyFlags(Pid::FRAME_TYPE, PropertyFlags::UNSTYLED);
+            }
       else if (tag == "frameRound")
-            t->setFrameRound(e.readInt());
+            t->readProperty(e, Pid::FRAME_ROUND);
       else if (tag == "circle") {
             if (e.readBool())
                   t->setFrameType(FrameType::CIRCLE);
@@ -1606,15 +1608,16 @@ static bool readTextProperties206(XmlReader& e, TextBase* t)
                   if (t->circle())
                         t->setFrameType(FrameType::SQUARE);
                   }
+            t->setPropertyFlags(Pid::FRAME_TYPE, PropertyFlags::UNSTYLED);
             }
       else if (tag == "paddingWidthS")
-            t->setPaddingWidth(Spatium(e.readDouble()));
+            t->readProperty(e, Pid::FRAME_PADDING);
       else if (tag == "frameWidthS")
-            t->setFrameWidth(Spatium(e.readDouble()));
+            t->readProperty(e, Pid::FRAME_WIDTH);
       else if (tag == "frameColor")
-            t->setFrameColor(e.readColor());
+            t->readProperty(e, Pid::FRAME_FG_COLOR);
       else if (tag == "backgroundColor")
-            t->setBgColor(e.readColor());
+            t->readProperty(e, Pid::FRAME_BG_COLOR);
       else if (tag == "halign") {
             Align align = Align(int(t->align()) & int(~Align::HMASK));
             const QString& val(e.readElementText());
@@ -1627,6 +1630,7 @@ static bool readTextProperties206(XmlReader& e, TextBase* t)
             else
                   qDebug("unknown alignment: <%s>", qPrintable(val));
             t->setAlign(align);
+            t->setPropertyFlags(Pid::ALIGN, PropertyFlags::UNSTYLED);
             }
       else if (tag == "valign") {
             Align align = Align(int(t->align()) & int(~Align::VMASK));
@@ -1642,6 +1646,7 @@ static bool readTextProperties206(XmlReader& e, TextBase* t)
             else
                   qDebug("unknown alignment: <%s>", qPrintable(val));
             t->setAlign(align);
+            t->setPropertyFlags(Pid::ALIGN, PropertyFlags::UNSTYLED);
             }
       else if (tag == "pos") {
             t->readProperty(e, Pid::OFFSET);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/301478.

When importing scores from 1.x or 2.x, the property flags for styled properties must be set to UNSTYLED. Otherwise, the properties will not be written when the score is saved. ScoreElement::readProperty() should be used wherever possible, since it takes care of setting the property flags correctly. When it is not possible to use ScoreElement::readProperty(), ScoreElement::setPropertyFlags() must be called after setting the property.