### PR TITLE
Fix #301543: Selection Filter's Checkbox Not Checked After Restart

### DIFF
--- a/mscore/selectionwindow.cpp
+++ b/mscore/selectionwindow.cpp
@@ -192,6 +192,7 @@ void MuseScore::showSelectionWindow(bool visible)
                   }
             }
       reDisplayDockWidget(selectionWindow, visible);
+      a->setChecked(visible);
       if (visible) {
             selectionWindow->raise();
             }


### PR DESCRIPTION
Resolves: [#301543](https://musescore.org/en/node/301543)

Fixed a problem that caused the “Selection Filter” item in the “View Menu” to be unchecked at application startup when the “Selection Filter” panel was in fact visible.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made