### PR TITLE
fix #301605: Undoing slur addition to a range only removes one slur

### DIFF
--- a/libmscore/mscoreview.h
+++ b/libmscore/mscoreview.h
@@ -57,7 +57,7 @@ class MuseScoreView {
       virtual QCursor cursor() const { return QCursor(); }
       virtual void setCursor(const QCursor&) {};
       virtual void setDropRectangle(const QRectF&) {};
-      virtual void cmdAddSlur(ChordRest*, ChordRest*, const Slur* /* slurTemplate */) {};
+      virtual void addSlur(ChordRest*, ChordRest*, const Slur* /* slurTemplate */) {};
       virtual void startEdit(Element*, Grip /*startGrip*/) {};
       virtual void startNoteEntryMode() {};
       virtual void drawBackground(QPainter*, const QRectF&) const = 0;

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1625,7 +1625,7 @@ Element* Note::drop(EditData& data)
                   return 0;
 
             case ElementType::SLUR:
-                  data.view->cmdAddSlur(chord(), nullptr, toSlur(e));
+                  data.view->addSlur(chord(), nullptr, toSlur(e));
                   delete e;
                   return 0;
 

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -550,7 +550,7 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
                   score->cmdToggleLayoutBreak(breakElement->layoutBreakType());
                   }
             else if (element->isSlur() && addSingle) {
-                  viewer->addSlur(toSlur(element));
+                  viewer->cmdAddSlur(toSlur(element));
                   }
             else if (element->isSLine() && !element->isGlissando() && addSingle) {
                   Segment* startSegment = cr1->segment();
@@ -702,7 +702,7 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
                         }
                   }
             else if (element->isSlur()) {
-                  viewer->addSlur(toSlur(element));
+                  viewer->cmdAddSlur(toSlur(element));
                   }
             else if (element->isSLine() && element->type() != ElementType::GLISSANDO) {
                   Segment* startSegment = sel.startSegment();

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -335,8 +335,8 @@ class ScoreView : public QWidget, public MuseScoreView {
       void doDragEdit(QMouseEvent* ev);
       bool testElementDragTransition(QMouseEvent* ev);
       bool fotoEditElementDragTransition(QMouseEvent* ev);
-      void addSlur(const Slur* slurTemplate = nullptr);
-      void cmdAddSlur(ChordRest*, ChordRest*, const Slur*) override;
+      void cmdAddSlur(const Slur* slurTemplate = nullptr);
+      void addSlur(ChordRest*, ChordRest*, const Slur*) override;
       virtual void cmdAddHairpin(HairpinType);
       void cmdAddNoteLine();
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/301605.

Prior to this commit, ScoreView::cmdAddSlur() could be called multiple times from within ScoreView::addSlur(), resulting in the need for multiple "undo" commands to completely undo a single "add-slur" command. This commit swaps the names of these two functions, and, more importantly, only calls Score::startCmd() and Score::endCmd() once for the entire operation.