### PR TITLE
fix #301584: test for duplicates names in palette

### DIFF
--- a/libmscore/arpeggio.cpp
+++ b/libmscore/arpeggio.cpp
@@ -23,6 +23,15 @@
 
 namespace Ms {
 
+const std::array<const char*, 6> Arpeggio::arpeggioTypeNames = {
+      QT_TRANSLATE_NOOP("Palette", "Arpeggio"),
+      QT_TRANSLATE_NOOP("Palette", "Up Arpgeggio"),
+      QT_TRANSLATE_NOOP("Palette", "Down arpeggio"),
+      QT_TRANSLATE_NOOP("Palette", "Bracket arpeggio"),
+      QT_TRANSLATE_NOOP("Palette", "Up arpeggio straight"),
+      QT_TRANSLATE_NOOP("Palette", "Down arpeggio straight")
+      };
+
 //---------------------------------------------------------
 //   Arpeggio
 //---------------------------------------------------------

--- a/libmscore/arpeggio.h
+++ b/libmscore/arpeggio.h
@@ -48,6 +48,8 @@ class Arpeggio final : public Element {
       QVector<QLineF> gripAnchorLines(Grip) const override;
       void startEdit(EditData&) override;
 
+      static const std::array<const char*, 6> arpeggioTypeNames;
+
    public:
       Arpeggio(Score* s);
 
@@ -56,6 +58,7 @@ class Arpeggio final : public Element {
 
       ArpeggioType arpeggioType() const    { return _arpeggioType; }
       void setArpeggioType(ArpeggioType v) { _arpeggioType = v;    }
+      QString arpeggioTypeName()           { return qApp->translate("Palette", arpeggioTypeNames[int(_arpeggioType)]); }
 
       Chord* chord() const                 { return (Chord*)parent(); }
 

--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -194,14 +194,14 @@ class BarLineEditData : public ElementEditData {
 //---------------------------------------------------------
 
 const std::vector<BarLineTableItem> BarLine::barLineTable {
-      { BarLineType::NORMAL,           QT_TRANSLATE_NOOP("Palette", "Normal barline"),   "normal" },
-      { BarLineType::DOUBLE,           QT_TRANSLATE_NOOP("Palette", "Double barline"),   "double" },
-      { BarLineType::START_REPEAT,     QT_TRANSLATE_NOOP("Palette", "Start repeat"),     "start-repeat" },
-      { BarLineType::END_REPEAT,       QT_TRANSLATE_NOOP("Palette", "End repeat"),       "end-repeat" },
-      { BarLineType::BROKEN,           QT_TRANSLATE_NOOP("Palette", "Dashed barline"),   "dashed" },
-      { BarLineType::END,              QT_TRANSLATE_NOOP("Palette", "Final barline"),    "end" },
-      { BarLineType::END_START_REPEAT, QT_TRANSLATE_NOOP("Palette", "End-start repeat"), "end-start-repeat" },
-      { BarLineType::DOTTED,           QT_TRANSLATE_NOOP("Palette", "Dotted barline"),   "dotted" },
+      { BarLineType::NORMAL,           QT_TRANSLATE_NOOP("Palette", "Normal barline"),           "normal" },
+      { BarLineType::DOUBLE,           QT_TRANSLATE_NOOP("Palette", "Double barline"),           "double" },
+      { BarLineType::START_REPEAT,     QT_TRANSLATE_NOOP("Palette", "Start repeat barline"),     "start-repeat" },
+      { BarLineType::END_REPEAT,       QT_TRANSLATE_NOOP("Palette", "End repeat barline"),       "end-repeat" },
+      { BarLineType::BROKEN,           QT_TRANSLATE_NOOP("Palette", "Dashed barline"),           "dashed" },
+      { BarLineType::END,              QT_TRANSLATE_NOOP("Palette", "Final barline"),            "end" },
+      { BarLineType::END_START_REPEAT, QT_TRANSLATE_NOOP("Palette", "End-start repeat barline"), "end-start-repeat" },
+      { BarLineType::DOTTED,           QT_TRANSLATE_NOOP("Palette", "Dotted barline"),           "dotted" },
       };
 
 //---------------------------------------------------------

--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -50,6 +50,11 @@ static const ElementStyle glissandoElementStyle {
 static const qreal      GLISS_PALETTE_WIDTH           = 4.0;
 static const qreal      GLISS_PALETTE_HEIGHT          = 4.0;
 
+const std::array<const char *, 2> Glissando::glissandoTypeNames = {
+      QT_TRANSLATE_NOOP("Palette", "Straight glissando"),
+      QT_TRANSLATE_NOOP("Palette", "Wavy glissando")
+      };
+
 //---------------------------------------------------------
 //   GlisandoSegment
 //---------------------------------------------------------

--- a/libmscore/glissando.h
+++ b/libmscore/glissando.h
@@ -57,12 +57,16 @@ class Glissando final : public SLine {
       M_PROPERTY(bool, playGlissando, setPlayGlissando)
       M_PROPERTY(FontStyle, fontStyle, setFontStyle)
 
+      static const std::array<const char *, 2> glissandoTypeNames;
+
    public:
       Glissando(Score* s);
       Glissando(const Glissando&);
 
       static Note* guessInitialNote(Chord* chord);
       static Note* guessFinalNote(Chord* chord);
+
+      QString glissandoTypeName() { return qApp->translate("Palette", glissandoTypeNames[int(glissandoType())]); }
 
       // overridden inherited methods
       Glissando* clone() const override     { return new Glissando(*this);   }

--- a/libmscore/sym.cpp
+++ b/libmscore/sym.cpp
@@ -3331,7 +3331,7 @@ const std::array<const char*, int(SymId::lastSym)+1> Sym::symUserNames = { {
       "Smooth lift, short",
       QT_TRANSLATE_NOOP("symUserNames", "Muted (closed)"),
       "Half-muted (half-closed)",
-      QT_TRANSLATE_NOOP("symUserNames", "Open"),
+      QT_TRANSLATE_NOOP("symUserNames", "Opened"),
       "Plop",
       "Scoop",
       "Smear",

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -332,6 +332,7 @@ void MuseScore::showPalette(bool visible)
 
 struct TempoPattern {
       QString pattern;
+      const char* name;
       double f;
       bool relative;
       bool italian;
@@ -339,7 +340,7 @@ struct TempoPattern {
       bool basic;
       bool masterOnly;
 
-      TempoPattern(const QString& s, double v, bool r, bool i, bool f, bool b, bool m) : pattern(s), f(v), relative(r), italian(i), followText(f), basic(b), masterOnly(m) {}
+      TempoPattern(const QString& s, const char* n, double v, bool r, bool i, bool f, bool b, bool m) : pattern(s), name(n), f(v), relative(r), italian(i), followText(f), basic(b), masterOnly(m) {}
       };
 
 //---------------------------------------------------------
@@ -878,7 +879,7 @@ PalettePanel* MuseScore::newNoteHeadsPalettePanel()
       QAction* action = s->action();
       QIcon icon(action->icon());
       ik->setAction("add-parentheses", icon);
-      sp->append(ik, s->help());
+      sp->append(ik, QT_TRANSLATE_NOOP("action", "Add parentheses to notehead"));
       return sp;
       }
 
@@ -1099,10 +1100,10 @@ PalettePanel* MuseScore::newBracketsPalettePanel()
       sp->setDrawGrid(true);
 
       for (auto t : std::array<std::pair<BracketType,const char*>, 4> {
-         {{ BracketType::NORMAL, QT_TRANSLATE_NOOP("Palette", "Bracket") },
-          { BracketType::BRACE,  QT_TRANSLATE_NOOP("Palette", "Brace")   },
-          { BracketType::SQUARE, QT_TRANSLATE_NOOP("Palette", "Square")  },
-          { BracketType::LINE,   QT_TRANSLATE_NOOP("Palette", "Line")    }}
+         {{ BracketType::NORMAL, QT_TRANSLATE_NOOP("Palette", "Bracket")          },
+          { BracketType::BRACE,  QT_TRANSLATE_NOOP("Palette", "Brace")            },
+          { BracketType::SQUARE, QT_TRANSLATE_NOOP("Palette", "Square")           },
+          { BracketType::LINE,   QT_TRANSLATE_NOOP("Palette", "Straight Line")    }}
          } ) {
             Bracket* b1      = new Bracket(gscore);
             BracketItem* bi1 = new BracketItem(gscore);
@@ -1148,12 +1149,12 @@ PalettePanel* MuseScore::newArpeggioPalettePanel()
       for (int i = 0; i < 6; ++i) {
             Arpeggio* a = new Arpeggio(gscore);
             a->setArpeggioType(ArpeggioType(i));
-            sp->append(a, QT_TRANSLATE_NOOP("Palette", "Arpeggio"));
+            sp->append(a, a->arpeggioTypeName());
             }
       for (int i = 0; i < 2; ++i) {
             Glissando* a = new Glissando(gscore);
             a->setGlissandoType(GlissandoType(i));
-            sp->append(a, QT_TRANSLATE_NOOP("Palette", "Glissando"));
+            sp->append(a, a->glissandoTypeName());
             }
 
       //fall and doits
@@ -1414,7 +1415,7 @@ PalettePanel* MuseScore::newLinesPalettePanel()
       pedal->setBeginText("<sym>keyboardPedalPed</sym>");
       pedal->setContinueText("(<sym>keyboardPedalPed</sym>)");
       pedal->setEndHookType(HookType::HOOK_90);
-      sp->append(pedal, QT_TRANSLATE_NOOP("Palette", "Pedal"));
+      sp->append(pedal, QT_TRANSLATE_NOOP("Palette", "Pedal (with ped and line)"));
 
       pedal = new Pedal(gscore);
       pedal->setLen(w);
@@ -1422,31 +1423,31 @@ PalettePanel* MuseScore::newLinesPalettePanel()
       pedal->setContinueText("(<sym>keyboardPedalPed</sym>)");
       pedal->setEndText("<sym>keyboardPedalUp</sym>");
       pedal->setLineVisible(false);
-      sp->append(pedal, QT_TRANSLATE_NOOP("Palette", "Pedal"));
+      sp->append(pedal, QT_TRANSLATE_NOOP("Palette", "Pedal (with ped and asterisk)"));
 
       pedal = new Pedal(gscore);
       pedal->setLen(w);
       pedal->setBeginHookType(HookType::HOOK_90);
       pedal->setEndHookType(HookType::HOOK_90);
-      sp->append(pedal, QT_TRANSLATE_NOOP("Palette", "Pedal"));
+      sp->append(pedal, QT_TRANSLATE_NOOP("Palette", "Pedal (straight hooks)"));
 
       pedal = new Pedal(gscore);
       pedal->setLen(w);
       pedal->setBeginHookType(HookType::HOOK_90);
       pedal->setEndHookType(HookType::HOOK_45);
-      sp->append(pedal, QT_TRANSLATE_NOOP("Palette", "Pedal"));
+      sp->append(pedal, QT_TRANSLATE_NOOP("Palette", "Pedal (angled end hook)"));
 
       pedal = new Pedal(gscore);
       pedal->setLen(w);
       pedal->setBeginHookType(HookType::HOOK_45);
       pedal->setEndHookType(HookType::HOOK_45);
-      sp->append(pedal, QT_TRANSLATE_NOOP("Palette", "Pedal"));
+      sp->append(pedal, QT_TRANSLATE_NOOP("Palette", "Pedal (both hooks angled)"));
 
       pedal = new Pedal(gscore);
       pedal->setLen(w);
       pedal->setBeginHookType(HookType::HOOK_45);
       pedal->setEndHookType(HookType::HOOK_90);
-      sp->append(pedal, QT_TRANSLATE_NOOP("Palette", "Pedal"));
+      sp->append(pedal, QT_TRANSLATE_NOOP("Palette", "Pedal (angled start hook)"));
 
       for (int i = 0; i < trillTableSize(); i++) {
             Trill* trill = new Trill(gscore);
@@ -1503,35 +1504,35 @@ PalettePanel* MuseScore::newTempoPalettePanel(bool defaultPalettePanel)
       sp->setDrawGrid(true);
 
       static const TempoPattern tps[] = {
-            TempoPattern("<sym>metNoteHalfUp</sym> = 80",    80.0/ 30.0, false, false, true, true, false),                // 1/2
-            TempoPattern("<sym>metNoteQuarterUp</sym> = 80", 80.0/ 60.0, false, false, true, true, false),                // 1/4
-            TempoPattern("<sym>metNote8thUp</sym> = 80",     80.0/120.0, false, false, true, true, false),                // 1/8
-            TempoPattern("<sym>metNoteHalfUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = 80",    120/ 30.0, false, false, true, false, false),   // dotted 1/2
-            TempoPattern("<sym>metNoteQuarterUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = 80", 120/ 60.0, false, false, true, true, false),   // dotted 1/4
-            TempoPattern("<sym>metNote8thUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = 80",     120/120.0, false, false, true, false, false),   // dotted 1/8
+            TempoPattern("<sym>metNoteHalfUp</sym> = 80",    QT_TRANSLATE_NOOP("Palette", "Half note = 80 BPM"),    80.0/ 30.0, false, false, true, true, false),                // 1/2
+            TempoPattern("<sym>metNoteQuarterUp</sym> = 80", QT_TRANSLATE_NOOP("Palette", "Quarter note = 80 BPM"), 80.0/ 60.0, false, false, true, true, false),                // 1/4
+            TempoPattern("<sym>metNote8thUp</sym> = 80",     QT_TRANSLATE_NOOP("Palette", "Eighth note = 80 BPM"),  80.0/120.0, false, false, true, true, false),                // 1/8
+            TempoPattern("<sym>metNoteHalfUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = 80",    QT_TRANSLATE_NOOP("Palette", "Dotted half note = 80 BPM"),    120/ 30.0, false, false, true, false, false),   // dotted 1/2
+            TempoPattern("<sym>metNoteQuarterUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = 80", QT_TRANSLATE_NOOP("Palette", "Dotted quarter note = 80 BPM"), 120/ 60.0, false, false, true, true,  false),   // dotted 1/4
+            TempoPattern("<sym>metNote8thUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = 80",     QT_TRANSLATE_NOOP("Palette", "Dotted eighth note = 80 BPM"),  120/120.0, false, false, true, false, false),   // dotted 1/8
 
-            TempoPattern("Grave",             35.0/60.0, false, true, false, false, false),
-            TempoPattern("Largo",             50.0/60.0, false, true, false, false, false),
-            TempoPattern("Lento",             52.5/60.0, false, true, false, false, false),
-            TempoPattern("Larghetto",         63.0/60.0, false, true, false, false, true),
-            TempoPattern("Adagio",            71.0/60.0, false, true, false, false, false),
-            TempoPattern("Andante",           92.0/60.0, false, true, false, false, false),
-            TempoPattern("Andantino",         94.0/60.0, false, true, false, false, true),
-            TempoPattern("Moderato",         114.0/60.0, false, true, false, false, false),
-            TempoPattern("Allegretto",       116.0/60.0, false, true, false, false, false),
-            TempoPattern("Allegro moderato", 118.0/60.0, false, true, false, false, true),
-            TempoPattern("Allegro",          144.0/60.0, false, true, false, false, false),
-            TempoPattern("Vivace",           172.0/60.0, false, true, false, false, false),
-            TempoPattern("Presto",           187.0/60.0, false, true, false, false, false),
-            TempoPattern("Prestissimo",      200.0/60.0, false, true, false, false, true),
+            TempoPattern("Grave",            "Grave",             35.0/60.0, false, true, false, false, false),
+            TempoPattern("Largo",            "Largo",             50.0/60.0, false, true, false, false, false),
+            TempoPattern("Lento",            "Lento",             52.5/60.0, false, true, false, false, false),
+            TempoPattern("Larghetto",        "Larghetto",         63.0/60.0, false, true, false, false, true),
+            TempoPattern("Adagio",           "Adagio",            71.0/60.0, false, true, false, false, false),
+            TempoPattern("Andante",          "Andante",           92.0/60.0, false, true, false, false, false),
+            TempoPattern("Andantino",        "Andantino",         94.0/60.0, false, true, false, false, true),
+            TempoPattern("Moderato",         "Moderato",         114.0/60.0, false, true, false, false, false),
+            TempoPattern("Allegretto",       "Allegretto",       116.0/60.0, false, true, false, false, false),
+            TempoPattern("Allegro moderato", "Allegro moderato", 118.0/60.0, false, true, false, false, true),
+            TempoPattern("Allegro",          "Allegro",          144.0/60.0, false, true, false, false, false),
+            TempoPattern("Vivace",           "Vivace",           172.0/60.0, false, true, false, false, false),
+            TempoPattern("Presto",           "Presto",           187.0/60.0, false, true, false, false, false),
+            TempoPattern("Prestissimo",      "Prestissimo",      200.0/60.0, false, true, false, false, true),
 
-            TempoPattern("<sym>metNoteQuarterUp</sym> = <sym>metNoteQuarterUp</sym><sym>space</sym><sym>metAugmentationDot</sym>", 3.0/2.0, true, false, true, false, false),
-            TempoPattern("<sym>metNoteQuarterUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = <sym>metNoteQuarterUp</sym>", 2.0/3.0, true, false, true, false, false),
-            TempoPattern("<sym>metNoteHalfUp</sym> = <sym>metNoteQuarterUp</sym>",    1.0/2.0, true, false, true, false, false),
-            TempoPattern("<sym>metNoteQuarterUp</sym> = <sym>metNoteHalfUp</sym>",    2.0/1.0, true, false, true, false, false),
-            TempoPattern("<sym>metNote8thUp</sym> = <sym>metNote8thUp</sym>",         1.0/1.0, true, false, true, false, false),
-            TempoPattern("<sym>metNoteQuarterUp</sym> = <sym>metNoteQuarterUp</sym>", 1.0/1.0, true, false, true, false, false),
-            TempoPattern("<sym>metNote8thUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = <sym>metNoteQuarterUp</sym>", 2.0/3.0, true, false, true, false, false),
+            TempoPattern("<sym>metNoteQuarterUp</sym> = <sym>metNoteQuarterUp</sym><sym>space</sym><sym>metAugmentationDot</sym>", QT_TRANSLATE_NOOP("Palette", "Quarter note = dotted quarter note metric modulation"), 3.0/2.0, true, false, true, false, false),
+            TempoPattern("<sym>metNoteQuarterUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = <sym>metNoteQuarterUp</sym>", QT_TRANSLATE_NOOP("Palette", "Dotted quarter note = quarter note metric modulation"), 2.0/3.0, true, false, true, false, false),
+            TempoPattern("<sym>metNoteHalfUp</sym> = <sym>metNoteQuarterUp</sym>",    QT_TRANSLATE_NOOP("Palette", "Half note = quarter note metric modulation"),    1.0/2.0, true, false, true, false, false),
+            TempoPattern("<sym>metNoteQuarterUp</sym> = <sym>metNoteHalfUp</sym>",    QT_TRANSLATE_NOOP("Palette", "Quarter note = half note metric modulation"),    2.0/1.0, true, false, true, false, false),
+            TempoPattern("<sym>metNote8thUp</sym> = <sym>metNote8thUp</sym>",         QT_TRANSLATE_NOOP("Palette", "Eighth note = eighth note metric modulation"),   1.0/1.0, true, false, true, false, false),
+            TempoPattern("<sym>metNoteQuarterUp</sym> = <sym>metNoteQuarterUp</sym>", QT_TRANSLATE_NOOP("Palette", "Quarter note = quarter note metric modulation"), 1.0/1.0, true, false, true, false, false),
+            TempoPattern("<sym>metNote8thUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = <sym>metNoteQuarterUp</sym>",     QT_TRANSLATE_NOOP("Palette", "Dotted eighth note = quarter note metric modulation"),  2.0/3.0, true, false, true, false, false),
             };
       for (TempoPattern tp : tps) {
             TempoText* tt = new TempoText(gscore);
@@ -1539,15 +1540,15 @@ PalettePanel* MuseScore::newTempoPalettePanel(bool defaultPalettePanel)
             tt->setXmlText(tp.pattern);
             if (tp.relative) {
                   tt->setRelative(tp.f);
-                  sp->append(tt, QT_TRANSLATE_NOOP("Palette", "Metric modulation"), QString(), 1.5);
+                  sp->append(tt, qApp->translate("Palette", tp.name), QString(), 1.5);
                   }
             else if (tp.italian) {
                   tt->setTempo(tp.f);
-                  sp->append(tt, QT_TRANSLATE_NOOP("Palette", "Tempo text"), QString(), 1.3);
+                  sp->append(tt, tp.name, QString(), 1.3);
                   }
             else {
                   tt->setTempo(tp.f);
-                  sp->append(tt, QT_TRANSLATE_NOOP("Palette", "Tempo text"), QString(), 1.5);
+                  sp->append(tt, qApp->translate("Palette", tp.name), QString(), 1.5);
                   }
             }
       sp->setMoreElements(false);

--- a/mtest/CMakeLists.txt
+++ b/mtest/CMakeLists.txt
@@ -213,6 +213,7 @@ subdirs (
 #        libmscore/text        work in progress...
         libmscore/utils
         mscore/workspaces
+        mscore/palette
         importmidi
         capella
         biab

--- a/mtest/mscore/palette/CMakeLists.txt
+++ b/mtest/mscore/palette/CMakeLists.txt
@@ -1,0 +1,24 @@
+#=============================================================================
+#  MuseScore
+#  Music Composition & Notation
+#
+#  Copyright (C) 2020 MuseScore BVBA and others
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#=============================================================================
+
+set(TARGET tst_palette)
+
+set(MTEST_LINK_MSCOREAPP TRUE)
+
+include(${PROJECT_SOURCE_DIR}/mtest/cmake.inc)

--- a/mtest/mscore/palette/tst_palette.cpp
+++ b/mtest/mscore/palette/tst_palette.cpp
@@ -1,0 +1,139 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#include <QtTest/QtTest>
+#include "mtest/testutils.h"
+#include "mscore/musescore.h"
+#include "mscore/workspace.h"
+#include "mscore/palette/palettemodel.h"
+#include "mscore/palette/palettetree.h"
+
+using namespace Ms;
+
+class TestPaletteModel : public QObject, public MTest
+      {
+      Q_OBJECT
+
+      PaletteTreeModel* paletteModel;
+      QMap<QString, vector<QString>> paletteItemNames;
+
+      void initMuseScore();
+      void iterateOverModel(QAbstractItemModel *model, QModelIndex parent = QModelIndex());
+      void loadPaletteModel(QString name);
+
+   private slots:
+      void initTestCase();
+      void cleanupTestCase();
+
+      void testDuplicateItemNames_data();
+      void testDuplicateItemNames();
+      };
+
+//---------------------------------------------------------
+//   TestPaletteModel::testDuplicateItemNames_data
+//---------------------------------------------------------
+
+void TestPaletteModel::testDuplicateItemNames_data()
+      {
+      QTest::addColumn<QString>("workspaceName");
+      QTest::addRow("Basic") << "Basic";
+      QTest::addRow("Advanced") << "Advanced";
+      }
+
+//---------------------------------------------------------
+//   TestPaletteModel::testDuplicateItemNames
+//---------------------------------------------------------
+
+void TestPaletteModel::testDuplicateItemNames()
+      {
+      QFETCH(QString, workspaceName);
+      loadPaletteModel(workspaceName);
+      paletteItemNames.clear();
+      iterateOverModel(paletteModel);
+      bool duplicates = false;
+      qDebug("In %s workspace", qPrintable(workspaceName));
+      for (auto name = paletteItemNames.begin(); name != paletteItemNames.end(); ++name) {
+            if (name.value().size() != 1) {
+                  duplicates = true;
+                  for (auto parent : name.value())
+                        qDebug("%s (in %s)", qPrintable(name.key()), qPrintable(parent));
+                  }
+            }
+      // make sure there are no duplicates
+      QVERIFY(!duplicates);
+      }
+
+//---------------------------------------------------------
+//   TestPaletteModel::iterateOverModel
+//---------------------------------------------------------
+
+void TestPaletteModel::iterateOverModel(QAbstractItemModel* model, QModelIndex parent)
+      {
+      for (int r = 0; r < model->rowCount(parent); ++r) {
+            QModelIndex index = model->index(r, 0, parent);
+            QString name = model->data(index, Qt::AccessibleTextRole).toString();
+            QString parentName = model->data(parent, Qt::AccessibleTextRole).toString();
+
+            paletteItemNames[name].push_back(parentName);
+            
+            if (model->hasChildren(index))
+                  iterateOverModel(model, index);
+            }
+      }
+
+//---------------------------------------------------------
+//   TestPaletteModel::initTestCase
+//---------------------------------------------------------
+
+void TestPaletteModel::initTestCase()
+      {
+      initMuseScore();
+      }
+
+//---------------------------------------------------------
+//   TestPaletteModel::loadPaletteModel
+//---------------------------------------------------------
+
+void TestPaletteModel::loadPaletteModel(QString name)
+      {
+      Workspace* w = WorkspacesManager::findByName(name);
+      paletteModel = new PaletteTreeModel(w->getPaletteTree());
+      }
+
+//---------------------------------------------------------
+//   TestPaletteModel::initMuseScore
+//---------------------------------------------------------
+
+void TestPaletteModel::initMuseScore()
+      {
+      qputenv("QML_DISABLE_DISK_CACHE", "true");
+      qSetMessagePattern("%{function}: %{message}");
+      MScore::noGui = true;
+      MScore::testMode = true;
+      initMuseScoreResources();
+      QStringList temp;
+      MuseScore::init(temp);
+      }
+
+//---------------------------------------------------------
+//   TestPaletteModel::cleanupTestCase
+//---------------------------------------------------------
+
+void TestPaletteModel::cleanupTestCase()
+      {
+      qApp->processEvents();
+      delete Ms::mscore;
+      Ms::mscore = nullptr;
+      }
+
+QTEST_MAIN(TestPaletteModel)
+#include "tst_palette.moc"

--- a/mtest/mtest.cpp
+++ b/mtest/mtest.cpp
@@ -57,6 +57,7 @@ const char* tests[] = {
       "libmscore/selectionrangedelete/tst_selectionrangedelete",
       "libmscore/parts/tst_parts",
       "testscript/tst_runscripts",
+      "mscore/palette/tst_palette"
 #endif
 #if 0
       "libmscore/spanners/tst_spanners",              // FAIL

--- a/share/workspaces/Advanced.xml
+++ b/share/workspaces/Advanced.xml
@@ -403,7 +403,7 @@
           <Bracket type="Square">
             </Bracket>
           </Cell>
-        <Cell name="Line">
+        <Cell name="Straight Line">
           <Bracket type="Line">
             </Bracket>
           </Cell>
@@ -640,7 +640,7 @@
             <subtype>wiggleVibratoLargeSlowest</subtype>
             </Articulation>
           </Cell>
-        <Cell name="Open">
+        <Cell name="Opened">
           <Articulation>
             <subtype>brassMuteOpen</subtype>
             </Articulation>
@@ -998,7 +998,7 @@
             <name>noteShapeTriangleRoundWhite</name>
             </NoteHead>
           </Cell>
-        <Cell name="Add parentheses to element">
+        <Cell name="Add parentheses to notehead">
           <Icon>
             <subtype>22</subtype>
             <action>add-parentheses</action>
@@ -1127,7 +1127,7 @@
             <track>0</track>
             </Ottava>
           </Cell>
-        <Cell name="Pedal">
+        <Cell name="Pedal (with ped and line)">
           <Pedal id="18">
             <endHookType>1</endHookType>
             <beginText>&lt;sym&gt;keyboardPedalPed&lt;/sym&gt;</beginText>
@@ -1135,7 +1135,7 @@
             <track>0</track>
             </Pedal>
           </Cell>
-        <Cell name="Pedal">
+        <Cell name="Pedal (with ped and asterisk)">
           <Pedal id="19">
             <beginText>&lt;sym&gt;keyboardPedalPed&lt;/sym&gt;</beginText>
             <continueText>(&lt;sym&gt;keyboardPedalPed&lt;/sym&gt;)</continueText>
@@ -1144,28 +1144,28 @@
             <track>0</track>
             </Pedal>
           </Cell>
-        <Cell name="Pedal">
+        <Cell name="Pedal (straight hooks)">
           <Pedal id="20">
             <endHookType>1</endHookType>
             <beginHookType>1</beginHookType>
             <track>0</track>
             </Pedal>
           </Cell>
-        <Cell name="Pedal">
+        <Cell name="Pedal (angled end hook)">
           <Pedal id="21">
             <endHookType>2</endHookType>
             <beginHookType>1</beginHookType>
             <track>0</track>
             </Pedal>
           </Cell>
-        <Cell name="Pedal">
+        <Cell name="Pedal (both hooks angled)">
           <Pedal id="22">
             <endHookType>2</endHookType>
             <beginHookType>2</beginHookType>
             <track>0</track>
             </Pedal>
           </Cell>
-        <Cell name="Pedal">
+        <Cell name="Pedal (angled start hook)">
           <Pedal id="23">
             <endHookType>1</endHookType>
             <beginHookType>2</beginHookType>
@@ -1291,19 +1291,19 @@
             <subtype>double</subtype>
             </BarLine>
           </Cell>
-        <Cell name="Start repeat">
+        <Cell name="Start repeat barline">
           <staff>1</staff>
           <BarLine>
             <subtype>start-repeat</subtype>
             </BarLine>
           </Cell>
-        <Cell name="End repeat">
+        <Cell name="End repeat barline">
           <staff>1</staff>
           <BarLine>
             <subtype>end-repeat</subtype>
             </BarLine>
           </Cell>
-        <Cell name="End-start repeat">
+        <Cell name="End-start repeat barline">
           <staff>1</staff>
           <BarLine>
             <subtype>end-start-repeat</subtype>
@@ -1368,32 +1368,32 @@
             <subtype>0</subtype>
             </Arpeggio>
           </Cell>
-        <Cell name="Arpeggio">
+        <Cell name="Up arpeggio">
           <Arpeggio>
             <subtype>1</subtype>
             </Arpeggio>
           </Cell>
-        <Cell name="Arpeggio">
+        <Cell name="Down arpeggio">
           <Arpeggio>
             <subtype>2</subtype>
             </Arpeggio>
           </Cell>
-        <Cell name="Arpeggio">
+        <Cell name="Bracket arpeggio">
           <Arpeggio>
             <subtype>3</subtype>
             </Arpeggio>
           </Cell>
-        <Cell name="Arpeggio">
+        <Cell name="Up arpeggio straight">
           <Arpeggio>
             <subtype>4</subtype>
             </Arpeggio>
           </Cell>
-        <Cell name="Arpeggio">
+        <Cell name="Down arpeggio straight">
           <Arpeggio>
             <subtype>5</subtype>
             </Arpeggio>
           </Cell>
-        <Cell name="Glissando">
+        <Cell name="Straight glissando">
           <Glissando id="36">
             <text>gliss.</text>
             <ticks>0</ticks>
@@ -1403,7 +1403,7 @@
             <length>100</length>
             </Glissando>
           </Cell>
-        <Cell name="Glissando">
+        <Cell name="Wavy glissando">
           <Glissando id="37">
             <text>gliss.</text>
             <subtype>1</subtype>
@@ -1603,7 +1603,7 @@
         <mag>0.65</mag>
         <grid>1</grid>
         <moreElements>0</moreElements>
-        <Cell name="Tempo text">
+        <Cell name="Half note = 80 BPM">
           <mag>1.5</mag>
           <Tempo>
             <tempo>2.66667</tempo>
@@ -1611,7 +1611,7 @@
             <text><sym>metNoteHalfUp</sym> = 80</text>
             </Tempo>
           </Cell>
-        <Cell name="Tempo text">
+        <Cell name="Quarter note = 80 BPM">
           <mag>1.5</mag>
           <Tempo>
             <tempo>1.33333</tempo>
@@ -1619,7 +1619,7 @@
             <text><sym>metNoteQuarterUp</sym> = 80</text>
             </Tempo>
           </Cell>
-        <Cell name="Tempo text">
+        <Cell name="Eighth note = 80 BPM">
           <mag>1.5</mag>
           <Tempo>
             <tempo>0.666667</tempo>
@@ -1627,7 +1627,7 @@
             <text><sym>metNote8thUp</sym> = 80</text>
             </Tempo>
           </Cell>
-        <Cell name="Tempo text">
+        <Cell name="Dotted half note = 80 BPM">
           <mag>1.5</mag>
           <Tempo>
             <tempo>4</tempo>
@@ -1635,7 +1635,7 @@
             <text><sym>metNoteHalfUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = 80</text>
             </Tempo>
           </Cell>
-        <Cell name="Tempo text">
+        <Cell name="Dotted quarter note = 80 BPM">
           <mag>1.5</mag>
           <Tempo>
             <tempo>2</tempo>
@@ -1643,7 +1643,7 @@
             <text><sym>metNoteQuarterUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = 80</text>
             </Tempo>
           </Cell>
-        <Cell name="Tempo text">
+        <Cell name="Dotted eighth note = 80 BPM">
           <mag>1.5</mag>
           <Tempo>
             <tempo>1</tempo>
@@ -1651,77 +1651,77 @@
             <text><sym>metNote8thUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = 80</text>
             </Tempo>
           </Cell>
-        <Cell name="Tempo text">
+        <Cell name="Grave">
           <mag>1.3</mag>
           <Tempo>
             <tempo>0.583333</tempo>
             <text>Grave</text>
             </Tempo>
           </Cell>
-        <Cell name="Tempo text">
+        <Cell name="Largo">
           <mag>1.3</mag>
           <Tempo>
             <tempo>0.833333</tempo>
             <text>Largo</text>
             </Tempo>
           </Cell>
-        <Cell name="Tempo text">
+        <Cell name="Lento">
           <mag>1.3</mag>
           <Tempo>
             <tempo>0.875</tempo>
             <text>Lento</text>
             </Tempo>
           </Cell>
-        <Cell name="Tempo text">
+        <Cell name="Adagio">
           <mag>1.3</mag>
           <Tempo>
             <tempo>1.18333</tempo>
             <text>Adagio</text>
             </Tempo>
           </Cell>
-        <Cell name="Tempo text">
+        <Cell name="Andante">
           <mag>1.3</mag>
           <Tempo>
             <tempo>1.53333</tempo>
             <text>Andante</text>
             </Tempo>
           </Cell>
-        <Cell name="Tempo text">
+        <Cell name="Moderato">
           <mag>1.3</mag>
           <Tempo>
             <tempo>1.9</tempo>
             <text>Moderato</text>
             </Tempo>
           </Cell>
-        <Cell name="Tempo text">
+        <Cell name="Allegretto">
           <mag>1.3</mag>
           <Tempo>
             <tempo>1.93333</tempo>
             <text>Allegretto</text>
             </Tempo>
           </Cell>
-        <Cell name="Tempo text">
+        <Cell name="Allegro">
           <mag>1.3</mag>
           <Tempo>
             <tempo>2.4</tempo>
             <text>Allegro</text>
             </Tempo>
           </Cell>
-        <Cell name="Tempo text">
+        <Cell name="Vivace">
           <mag>1.3</mag>
           <Tempo>
             <tempo>2.86667</tempo>
             <text>Vivace</text>
             </Tempo>
           </Cell>
-        <Cell name="Tempo text">
+        <Cell name="Presto">
           <mag>1.3</mag>
           <Tempo>
             <tempo>3.11667</tempo>
             <text>Presto</text>
             </Tempo>
           </Cell>
-        <Cell name="Metric modulation">
+        <Cell name="Quarter note = dotted quarter note metric modulation">
           <mag>1.5</mag>
           <Tempo>
             <tempo>2</tempo>
@@ -1729,7 +1729,7 @@
             <text><sym>metNoteQuarterUp</sym> = <sym>metNoteQuarterUp</sym><sym>space</sym><sym>metAugmentationDot</sym></text>
             </Tempo>
           </Cell>
-        <Cell name="Metric modulation">
+        <Cell name="Dotted quarter note = quarter note metric modulation">
           <mag>1.5</mag>
           <Tempo>
             <tempo>2</tempo>
@@ -1737,7 +1737,7 @@
             <text><sym>metNoteQuarterUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = <sym>metNoteQuarterUp</sym></text>
             </Tempo>
           </Cell>
-        <Cell name="Metric modulation">
+        <Cell name="Half note = quarter note metric modulation">
           <mag>1.5</mag>
           <Tempo>
             <tempo>2</tempo>
@@ -1745,7 +1745,7 @@
             <text><sym>metNoteHalfUp</sym> = <sym>metNoteQuarterUp</sym></text>
             </Tempo>
           </Cell>
-        <Cell name="Metric modulation">
+        <Cell name="Quarter note = half note metric modulation">
           <mag>1.5</mag>
           <Tempo>
             <tempo>2</tempo>
@@ -1753,7 +1753,7 @@
             <text><sym>metNoteQuarterUp</sym> = <sym>metNoteHalfUp</sym></text>
             </Tempo>
           </Cell>
-        <Cell name="Metric modulation">
+        <Cell name="Eighth note = eighth note metric modulation">
           <mag>1.5</mag>
           <Tempo>
             <tempo>2</tempo>
@@ -1761,7 +1761,7 @@
             <text><sym>metNote8thUp</sym> = <sym>metNote8thUp</sym></text>
             </Tempo>
           </Cell>
-        <Cell name="Metric modulation">
+        <Cell name="Quarter note = quarter note metric modulation">
           <mag>1.5</mag>
           <Tempo>
             <tempo>2</tempo>
@@ -2223,7 +2223,7 @@
             <subtype>end-start-repeat</subtype>
             </BarLine>
           </Cell>
-      </Palette>
+        </Palette>
       <Palette name="Fretboard Diagrams">
         <type>FretboardDiagram</type>
         <gridWidth>42</gridWidth>

--- a/share/workspaces/Basic.xml
+++ b/share/workspaces/Basic.xml
@@ -256,7 +256,7 @@
             <action>add-brackets</action>
             </Icon>
           </Cell>
-        <Cell name="Add parentheses to element">
+        <Cell name="Add parentheses to accidental">
           <Icon>
             <subtype>22</subtype>
             <action>add-parentheses</action>
@@ -418,28 +418,28 @@
             <track>0</track>
             </Ottava>
           </Cell>
-        <Cell name="Pedal">
+        <Cell name="Pedal (straight hooks)">
           <Pedal id="12">
             <endHookType>1</endHookType>
             <beginHookType>1</beginHookType>
             <track>0</track>
             </Pedal>
           </Cell>
-        <Cell name="Pedal">
+        <Cell name="Pedal (angled end hook)">
           <Pedal id="13">
             <endHookType>2</endHookType>
             <beginHookType>1</beginHookType>
             <track>0</track>
             </Pedal>
           </Cell>
-        <Cell name="Pedal">
+        <Cell name="Pedal (both hooks angled)">
           <Pedal id="14">
             <endHookType>2</endHookType>
             <beginHookType>2</beginHookType>
             <track>0</track>
             </Pedal>
           </Cell>
-        <Cell name="Pedal">
+        <Cell name="Pedal (angled start hook)">
           <Pedal id="15">
             <endHookType>1</endHookType>
             <beginHookType>2</beginHookType>
@@ -464,19 +464,19 @@
             <subtype>double</subtype>
             </BarLine>
           </Cell>
-        <Cell name="Start repeat">
+        <Cell name="Start repeat barline">
           <staff>1</staff>
           <BarLine>
             <subtype>start-repeat</subtype>
             </BarLine>
           </Cell>
-        <Cell name="End repeat">
+        <Cell name="End repeat barline">
           <staff>1</staff>
           <BarLine>
             <subtype>end-repeat</subtype>
             </BarLine>
           </Cell>
-        <Cell name="End-start repeat">
+        <Cell name="End-start repeat barline">
           <staff>1</staff>
           <BarLine>
             <subtype>end-start-repeat</subtype>
@@ -585,7 +585,7 @@
         <mag>0.65</mag>
         <grid>1</grid>
         <moreElements>1</moreElements>
-        <Cell name="Tempo text">
+        <Cell name="Half note = 80 BPM">
           <mag>1.5</mag>
           <Tempo>
             <tempo>2.66667</tempo>
@@ -593,7 +593,7 @@
             <text><sym>metNoteHalfUp</sym> = 80</text>
             </Tempo>
           </Cell>
-        <Cell name="Tempo text">
+        <Cell name="Quarter note = 80 BPM">
           <mag>1.5</mag>
           <Tempo>
             <tempo>1.33333</tempo>
@@ -601,7 +601,7 @@
             <text><sym>metNoteQuarterUp</sym> = 80</text>
             </Tempo>
           </Cell>
-        <Cell name="Tempo text">
+        <Cell name="Eigth note = 80 BPM">
           <mag>1.5</mag>
           <Tempo>
             <tempo>0.666667</tempo>
@@ -609,7 +609,7 @@
             <text><sym>metNote8thUp</sym> = 80</text>
             </Tempo>
           </Cell>
-        <Cell name="Tempo text">
+        <Cell name="Dotted Quarter note = 80 BPM">
           <mag>1.5</mag>
           <Tempo>
             <tempo>2</tempo>

--- a/share/workspaces/Basic.xml
+++ b/share/workspaces/Basic.xml
@@ -609,7 +609,7 @@
             <text><sym>metNote8thUp</sym> = 80</text>
             </Tempo>
           </Cell>
-        <Cell name="Dotted Quarter note = 80 BPM">
+        <Cell name="Dotted quarter note = 80 BPM">
           <mag>1.5</mag>
           <Tempo>
             <tempo>2</tempo>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/301584

This commit adds a test for checking if there are duplicate names in the palettes in the default workspaces and manually removes the duplicate items from `Advanced.xml` and `Basic.xml` by making the names more descriptive.