### PR TITLE
fix #301488: Changing instruments from a tablature crashes the program

### DIFF
--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -497,6 +497,11 @@ void EditStaff::showInstrumentDialog()
       si.setWindowModality(Qt::WindowModal);
       if (si.exec()) {
             instrument = Instrument::fromTemplate(si.instrTemplate());
+            const StaffType* staffType = si.instrTemplate()->staffTypePreset;
+            if (!staffType)
+                  staffType = StaffType::getDefaultPreset(StaffGroup::STANDARD);
+            staff->setStaffType(Fraction(0,1), *staffType);
+            updateStaffType();
             updateInstrument();
             }
       }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/301488.

When the user chooses a different instrument in the "Edit Staff" dialog box, it is important to make sure that the new instrument is not incompatible with the staff type. This is accomplished by setting the staff type to the preset staff type for the chosen instrument.

Update: This now does the right thing when changing an instrument partway through the score, with either an InstrumentChange element or a StaffTypeChange element. In order to accomplish this, the ChangeStaffType class had to be modified so that a starting tick could be specified.

Update 2: I was so focused on getting undo and redo to work properly that I forgot to make sure that simply deleting an instrument change would delete any automatic staff type change, and that the staff type changes would persist after save and reload. If an instrument change requires a staff type change, then an actual StaffTypeChange object probably needs to be added to the score.

Update 3: After experimenting with allowing this to change the staff type at a tick other than Fraction(0,1), I have decided to return to my original solution, which works as expected as long as there are no StaffTypeChange or InstrumentChange elements in the score.