### PR TITLE
Rebase segment-anchored lines on dragging

### DIFF
--- a/libmscore/CMakeLists.txt
+++ b/libmscore/CMakeLists.txt
@@ -62,8 +62,8 @@ add_library (
       fermata.cpp articulation.cpp barline.cpp beam.cpp bend.cpp box.cpp
       bracket.cpp breath.cpp bsp.cpp changeMap.cpp chord.cpp chordline.cpp
       chordlist.cpp chordrest.cpp clef.cpp cleflist.cpp
-      drumset.cpp durationtype.cpp dynamic.cpp edit.cpp noteentry.cpp
-      element.cpp excerpt.cpp
+      drumset.cpp durationtype.cpp dynamic.cpp dynamichairpingroup.cpp edit.cpp noteentry.cpp
+      element.cpp elementgroup.cpp excerpt.cpp
       fifo.cpp fret.cpp glissando.cpp hairpin.cpp
       harmony.cpp hook.cpp image.cpp iname.cpp instrchange.cpp
       instrtemplate.cpp instrument.cpp interval.cpp

--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -2565,7 +2565,7 @@ void Beam::initBeamEditData(EditData& ed)
       bed->editFragment = 0;
       ed.addData(bed);
 
-      QPointF pt(ed.startMove - pagePos());
+      QPointF pt(ed.normalizedStartMove - pagePos());
       qreal ydiff = 100000000.0;
       int idx = (_direction == Direction::AUTO || _direction == Direction::DOWN) ? 0 : 1;
       int i = 0;

--- a/libmscore/box.cpp
+++ b/libmscore/box.cpp
@@ -603,7 +603,7 @@ Element* Box::drop(EditData& data)
 QRectF HBox::drag(EditData& data)
       {
       QRectF r(canvasBoundingRect());
-      qreal diff = data.delta.x();
+      qreal diff = data.evtDelta.x();
       qreal x1   = offset().x() + diff;
       if (parent()->type() == ElementType::VBOX) {
             VBox* vb = toVBox(parent());

--- a/libmscore/dynamic.cpp
+++ b/libmscore/dynamic.cpp
@@ -11,6 +11,7 @@
 //=============================================================================
 
 #include "dynamic.h"
+#include "dynamichairpingroup.h"
 #include "xml.h"
 #include "score.h"
 #include "measure.h"
@@ -342,6 +343,19 @@ void Dynamic::endEdit(EditData& ed)
 void Dynamic::reset()
       {
       TextBase::reset();
+      }
+
+//---------------------------------------------------------
+//   getDragGroup
+//---------------------------------------------------------
+
+std::unique_ptr<ElementGroup> Dynamic::getDragGroup(std::function<bool(const Element*)> isDragged)
+      {
+      if (auto g = HairpinWithDynamicsDragGroup::detectFor(this, isDragged))
+            return g;
+      if (auto g = DynamicNearHairpinsDragGroup::detectFor(this, isDragged))
+            return g;
+      return TextBase::getDragGroup(isDragged);
       }
 
 //---------------------------------------------------------

--- a/libmscore/dynamic.cpp
+++ b/libmscore/dynamic.cpp
@@ -359,15 +359,18 @@ QRectF Dynamic::drag(EditData& ed)
       if (km != (Qt::ShiftModifier | Qt::ControlModifier)) {
             int si       = staffIdx();
             Segment* seg = segment();
-            score()->dragPosition(ed.pos, &si, &seg);
+            score()->dragPosition(canvasPos(), &si, &seg);
             if (seg != segment() || staffIdx() != si) {
+                  const QPointF oldOffset = offset();
                   QPointF pos1(canvasPos());
                   score()->undo(new ChangeParent(this, seg, si));
                   setOffset(QPointF());
                   layout();
                   QPointF pos2(canvasPos());
-                  setOffset(pos1 - pos2);
-                  ed.startMove = pos2;
+                  const QPointF newOffset = pos1 - pos2;
+                  setOffset(newOffset);
+                  ElementEditData* eed = ed.getData(this);
+                  eed->initOffset += newOffset - oldOffset;
                   }
             }
       return f;

--- a/libmscore/dynamic.h
+++ b/libmscore/dynamic.h
@@ -137,6 +137,8 @@ class Dynamic final : public TextBase {
       Pid propertyId(const QStringRef& xmlName) const override;
       QString propertyUserValue(Pid) const override;
 
+      std::unique_ptr<ElementGroup> getDragGroup(std::function<bool(const Element*)> isDragged) override;
+
       QString accessibleInfo() const override;
       QString screenReaderInfo() const override;
       void doAutoplace();

--- a/libmscore/dynamichairpingroup.cpp
+++ b/libmscore/dynamichairpingroup.cpp
@@ -1,0 +1,190 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#include "dynamichairpingroup.h"
+#include "dynamic.h"
+#include "hairpin.h"
+#include "score.h"
+#include "segment.h"
+
+namespace Ms {
+
+static std::pair<Hairpin*, Hairpin*> findAdjacentHairpins(Dynamic* d)
+      {
+      Score* score = d->score();
+      const Segment* dSeg = d->segment();
+      Hairpin* leftHairpin = nullptr;
+      Hairpin* rightHairpin = nullptr;
+
+      const Fraction tick = dSeg->tick();
+      const int intTick = tick.ticks();
+
+      const auto& nearSpanners = score->spannerMap().findOverlapping(intTick - 1, intTick + 1);
+      for (auto i : nearSpanners) {
+            Spanner* s = i.value;
+            if (s->track() == d->track() && s->isHairpin()) {
+                  Hairpin* h = toHairpin(s);
+                  if (h->tick() == tick)
+                        rightHairpin = h;
+                  else if (h->tick2() == tick)
+                        leftHairpin = h;
+                  }
+            }
+
+      return { leftHairpin, rightHairpin };
+      }
+
+std::unique_ptr<ElementGroup> HairpinWithDynamicsDragGroup::detectFor(HairpinSegment* hs, std::function<bool(const Element*)> isDragged)
+      {
+      if (!hs->isSingleType())
+            return nullptr;
+
+      Hairpin* hairpin = hs->hairpin();
+
+      Segment* startSegment = hairpin->startSegment();
+      Segment* endSegment = hairpin->endSegment();
+      const int track = hs->track();
+
+      Dynamic* startDynamic = toDynamic(startSegment->findAnnotation(ElementType::DYNAMIC, track, track));
+      Dynamic* endDynamic = toDynamic(endSegment->findAnnotation(ElementType::DYNAMIC, track, track));
+
+      // Include only dragged dynamics to this group
+      if (!isDragged(startDynamic))
+            startDynamic = nullptr;
+      if (!isDragged(endDynamic))
+            endDynamic = nullptr;
+
+      if (startDynamic || endDynamic)
+            return std::unique_ptr<ElementGroup>(new HairpinWithDynamicsDragGroup(startDynamic, hs, endDynamic));
+      return nullptr;
+      }
+
+std::unique_ptr<ElementGroup> HairpinWithDynamicsDragGroup::detectFor(Dynamic* d, std::function<bool(const Element*)> isDragged)
+      {
+      Hairpin* leftHairpin = nullptr;
+      Hairpin* rightHairpin = nullptr;
+
+      std::tie(leftHairpin, rightHairpin) = findAdjacentHairpins(d);
+
+      // Dynamic will be governed bt HairpinWithDynamicsDragGroup if any of adjacent
+      // hairpins is dragged, disable separate drag logic for dynamic in this case.
+      if (isDragged(leftHairpin))
+            return std::unique_ptr<ElementGroup>(new DisabledElementGroup());
+      if (isDragged(rightHairpin))
+            return std::unique_ptr<ElementGroup>(new DisabledElementGroup());
+
+      return nullptr;
+      }
+
+void HairpinWithDynamicsDragGroup::startDrag(EditData& ed)
+      {
+      if (startDynamic)
+            startDynamic->startDrag(ed);
+      static_cast<Element*>(hairpinSegment)->startDrag(ed);
+      if (endDynamic)
+            endDynamic->startDrag(ed);
+      }
+
+QRectF HairpinWithDynamicsDragGroup::drag(EditData& ed)
+      {
+      QRectF r;
+
+      if (startDynamic)
+            r |= static_cast<Element*>(startDynamic)->drag(ed);
+      r |= hairpinSegment->drag(ed);
+      if (endDynamic)
+            r |= static_cast<Element*>(endDynamic)->drag(ed);
+
+      Hairpin* h = hairpinSegment->hairpin();
+
+      const Fraction startTick = startDynamic ? startDynamic->segment()->tick() : h->tick();
+      const Fraction endTick = endDynamic ? endDynamic->segment()->tick() : h->tick2();
+
+      if (endTick > startTick) {
+            if (h->tick() != startTick)
+                  h->undoChangeProperty(Pid::SPANNER_TICK, startTick);
+            if (h->tick2() != endTick)
+                  h->undoChangeProperty(Pid::SPANNER_TICKS, endTick - startTick);
+            }
+
+      return r;
+      }
+
+void HairpinWithDynamicsDragGroup::endDrag(EditData& ed)
+      {
+      if (startDynamic) {
+            startDynamic->endDrag(ed);
+            startDynamic->triggerLayout();
+            }
+
+      hairpinSegment->endDrag(ed);
+      hairpinSegment->triggerLayout();
+
+      if (endDynamic) {
+            endDynamic->endDrag(ed);
+            endDynamic->triggerLayout();
+            }
+      }
+
+std::unique_ptr<ElementGroup> DynamicNearHairpinsDragGroup::detectFor(Dynamic* d, std::function<bool(const Element*)> isDragged)
+      {
+      Hairpin* leftHairpin = nullptr;
+      Hairpin* rightHairpin = nullptr;
+
+      std::tie(leftHairpin, rightHairpin) = findAdjacentHairpins(d);
+
+      // Drag hairpins according to this rule only if they are not being dragged themselves
+      if (isDragged(leftHairpin))
+            leftHairpin = nullptr;
+      if (isDragged(rightHairpin))
+            rightHairpin = nullptr;
+
+      if (leftHairpin || rightHairpin)
+            return std::unique_ptr<ElementGroup>(new DynamicNearHairpinsDragGroup(leftHairpin, d, rightHairpin));
+      return nullptr;
+      }
+
+void DynamicNearHairpinsDragGroup::startDrag(EditData& ed)
+      {
+      dynamic->startDrag(ed);
+      }
+
+QRectF DynamicNearHairpinsDragGroup::drag(EditData& ed)
+      {
+      QRectF r(static_cast<Element*>(dynamic)->drag(ed));
+
+      const Fraction tick = dynamic->segment()->tick();
+
+      if (leftHairpin && leftHairpin->tick2() != tick && tick > leftHairpin->tick())
+            leftHairpin->undoChangeProperty(Pid::SPANNER_TICKS, tick - leftHairpin->tick());
+
+      if (rightHairpin && rightHairpin->tick() != tick) {
+            const Fraction tick2 = rightHairpin->tick2();
+            if (tick < tick2) {
+                  rightHairpin->undoChangeProperty(Pid::SPANNER_TICK, tick);
+                  rightHairpin->undoChangeProperty(Pid::SPANNER_TICKS, tick2 - tick);
+                  }
+            }
+
+      if (leftHairpin || rightHairpin)
+            dynamic->triggerLayout();
+
+      return r;
+      }
+
+void DynamicNearHairpinsDragGroup::endDrag(EditData& ed)
+      {
+      dynamic->endDrag(ed);
+      dynamic->triggerLayout();
+      }
+
+} // namespace Ms

--- a/libmscore/dynamichairpingroup.h
+++ b/libmscore/dynamichairpingroup.h
@@ -1,0 +1,68 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#ifndef __DYNAMICHAIPRINGROUP_H__
+#define __DYNAMICHAIRPINGROUP_H__
+
+#include "elementgroup.h"
+
+namespace Ms {
+
+class Dynamic;
+class Hairpin;
+class HairpinSegment;
+
+//-------------------------------------------------------------------
+//   HairpinWithDynamicsDragGroup
+///   Sequence of Dynamics and Hairpins
+//-------------------------------------------------------------------
+
+class HairpinWithDynamicsDragGroup : public ElementGroup {
+      Dynamic* startDynamic;
+      HairpinSegment* hairpinSegment;
+      Dynamic* endDynamic;
+
+   public:
+      HairpinWithDynamicsDragGroup(Dynamic* start, HairpinSegment* hs, Dynamic* end)
+         : startDynamic(start), hairpinSegment(hs), endDynamic(end) {}
+
+      void startDrag(EditData&) override;
+      QRectF drag(EditData&) override;
+      void endDrag(EditData&) override;
+
+      static std::unique_ptr<ElementGroup> detectFor(HairpinSegment* hs, std::function<bool(const Element*)> isDragged);
+      static std::unique_ptr<ElementGroup> detectFor(Dynamic* d, std::function<bool(const Element*)> isDragged);
+      };
+
+//-------------------------------------------------------------------
+//   DynamicNearHairpinsDragGroup
+//-------------------------------------------------------------------
+
+class DynamicNearHairpinsDragGroup : public ElementGroup {
+      Hairpin* leftHairpin;
+      Dynamic* dynamic;
+      Hairpin* rightHairpin;
+
+   public:
+      DynamicNearHairpinsDragGroup(Hairpin* left, Dynamic* d, Hairpin* right)
+         : leftHairpin(left), dynamic(d), rightHairpin(right) {}
+
+      void startDrag(EditData&) override;
+      QRectF drag(EditData&) override;
+      void endDrag(EditData&) override;
+
+      static std::unique_ptr<ElementGroup> detectFor(Dynamic* d, std::function<bool(const Element*)> isDragged);
+      };
+
+} // namespace Ms
+
+#endif

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1946,6 +1946,7 @@ void Element::startDrag(EditData& ed)
       eed->e = this;
       eed->pushProperty(Pid::OFFSET);
       eed->pushProperty(Pid::AUTOPLACE);
+      eed->initOffset = offset();
       ed.addData(eed);
       if (ed.modifiers & Qt::AltModifier)
             setAutoplace(false);
@@ -1963,8 +1964,11 @@ QRectF Element::drag(EditData& ed)
 
       const QRectF r0(canvasBoundingRect());
 
-      qreal x = ed.delta.x();
-      qreal y = ed.delta.y();
+      const ElementEditData* eed = ed.getData(this);
+
+      const QPointF offset0 = ed.moveDelta + eed->initOffset;
+      qreal x = offset0.x();
+      qreal y = offset0.y();
 
       qreal _spatium = spatium();
       if (ed.hRaster) {

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -13,6 +13,7 @@
 #ifndef __ELEMENT_H__
 #define __ELEMENT_H__
 
+#include "elementgroup.h"
 #include "spatium.h"
 #include "fraction.h"
 #include "scoreElement.h"
@@ -295,6 +296,9 @@ class Element : public ScoreElement {
 
       virtual void write(XmlWriter&) const;
       virtual void read(XmlReader&);
+
+//       virtual ElementGroup getElementGroup() { return SingleElementGroup(this); }
+      virtual std::unique_ptr<ElementGroup> getDragGroup(std::function<bool(const Element*)> isDragged) { Q_UNUSED(isDragged); return std::unique_ptr<ElementGroup>(new SingleElementGroup(this)); }
 
       virtual void startDrag(EditData&);
       virtual QRectF drag(EditData&);

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -120,9 +120,12 @@ class EditData {
 
       QPointF pos;
       QPointF startMove;
+      QPointF normalizedStartMove; ///< Introduced for transition of drag logic. Don't use in new code.
       QPoint  startMovePixel;
       QPointF lastPos;
-      QPointF delta;
+      QPointF delta; ///< This property is deprecated, use evtDelta or moveDelta instead. In normal drag equals to moveDelta, in edit drag - to evtDelta
+      QPointF evtDelta; ///< Mouse offset for the last mouse move event
+      QPointF moveDelta; ///< Mouse offset from the start of mouse move
       bool hRaster                     { false };
       bool vRaster                     { false };
 
@@ -535,6 +538,7 @@ class ElementEditData {
    public:
       Element* e;
       QList<PropertyData> propertyData;
+      QPointF initOffset; ///< for dragging: difference between actual offset and editData.moveDelta
 
       virtual ~ElementEditData() = default;
       void pushProperty(Pid pid) { propertyData.push_back(PropertyData({ pid, e->getProperty(pid), e->propertyFlags(pid) })); }

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -253,6 +253,9 @@ class Element : public ScoreElement {
       qreal pageX() const;
       qreal canvasX() const;
 
+      QPointF mapFromCanvas(const QPointF& p) const { return p - canvasPos(); }
+      QPointF mapToCanvas(const QPointF& p) const { return p + canvasPos(); }
+
       const QPointF& offset() const               { return _offset;  }
       virtual void setOffset(const QPointF& o)    { _offset = o;     }
       void setOffset(qreal x, qreal y)            { _offset.rx() = x, _offset.ry() = y; }

--- a/libmscore/elementgroup.cpp
+++ b/libmscore/elementgroup.cpp
@@ -1,0 +1,34 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#include "elementgroup.h"
+#include "element.h"
+
+namespace Ms {
+
+void SingleElementGroup::startDrag(EditData& ed)
+      {
+      e->startDrag(ed);
+      }
+
+QRectF SingleElementGroup::drag(EditData& ed)
+      {
+      return e->drag(ed);
+      }
+
+void SingleElementGroup::endDrag(EditData& ed)
+      {
+      e->endDrag(ed);
+      e->triggerLayout();
+      }
+
+} // namespace Ms

--- a/libmscore/elementgroup.h
+++ b/libmscore/elementgroup.h
@@ -1,0 +1,68 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#ifndef __ELEMENTGROUP_H__
+#define __ELEMENTGROUP_H__
+
+namespace Ms {
+
+class Element;
+class EditData;
+
+//-------------------------------------------------------------------
+//   ElementGroup
+///   Base class for implementing logic to handle groups of elements
+///   together in certain operations.
+//-------------------------------------------------------------------
+
+class ElementGroup {
+   public:
+      virtual ~ElementGroup() {}
+
+      virtual void startDrag(EditData&) = 0;
+      virtual QRectF drag(EditData&) = 0;
+      virtual void endDrag(EditData&) = 0;
+
+      virtual bool enabled() const { return true; }
+      };
+
+//-------------------------------------------------------------------
+//   DisabledElementGroup
+//-------------------------------------------------------------------
+
+class DisabledElementGroup final : public ElementGroup {
+   public:
+      bool enabled() const override { return false; }
+
+      void startDrag(EditData&) override {}
+      QRectF drag(EditData&) override { return QRectF(); }
+      void endDrag(EditData&) override {}
+      };
+
+//-------------------------------------------------------------------
+//   SingleElementGroup
+///   Element group for single element.
+//-------------------------------------------------------------------
+
+class SingleElementGroup final : public ElementGroup {
+      Element* e;
+   public:
+      SingleElementGroup(Element* el) : e(el) {}
+
+      void startDrag(EditData& ed) override;
+      QRectF drag(EditData& ed) override;
+      void endDrag(EditData& ed) override;
+      };
+
+} // namespace Ms
+
+#endif

--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -11,6 +11,7 @@
 //=============================================================================
 
 #include "hairpin.h"
+#include "dynamichairpingroup.h"
 #include "style.h"
 #include "xml.h"
 #include "utils.h"
@@ -398,6 +399,17 @@ std::vector<QPointF> HairpinSegment::gripsPositions(const EditData&) const
       grips[int(Grip::APERTURE)] = gripLineAperturePoint + pp;
 
       return grips;
+      }
+
+//---------------------------------------------------------
+//   getDragGroup
+//---------------------------------------------------------
+
+std::unique_ptr<ElementGroup> HairpinSegment::getDragGroup(std::function<bool(const Element*)> isDragged)
+      {
+      if (auto g = HairpinWithDynamicsDragGroup::detectFor(this, isDragged))
+            return g;
+      return TextLineBaseSegment::getDragGroup(isDragged);
       }
 
 //---------------------------------------------------------

--- a/libmscore/hairpin.h
+++ b/libmscore/hairpin.h
@@ -67,6 +67,8 @@ class HairpinSegment final : public TextLineBaseSegment {
 
       int gripsCount() const override { return 4; }
       std::vector<QPointF> gripsPositions(const EditData& = EditData()) const override;
+
+      std::unique_ptr<ElementGroup> getDragGroup(std::function<bool(const Element*)> isDragged) override;
       };
 
 //---------------------------------------------------------

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -547,7 +547,7 @@ QVector<QLineF> LineSegment::dragAnchorLines() const
 
 QRectF LineSegment::drag(EditData& ed)
       {
-      setOffset(offset() + (ed.pos - ed.lastPos));
+      setOffset(offset() + ed.evtDelta);
       setOffsetChanged(true);
 
       if (isStyled(Pid::OFFSET))

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -130,7 +130,7 @@ QPointF LineSegment::rightAnchorPosition(const qreal& systemPositionY) const
     return result;
     }
 
-void LineSegment::moveLeftAnchor(const QPointF &positionDelta)
+void LineSegment::moveLeftAnchor(const QPointF& positionDelta)
     {
     if (line()->anchor() == Spanner::Anchor::SEGMENT && isSingleBeginType()) {
           int staffIndex = staffIdx();
@@ -164,7 +164,7 @@ void LineSegment::moveLeftAnchor(const QPointF &positionDelta)
         }
     }
 
-void LineSegment::moveRightAnchor(const QPointF &positionDelta)
+void LineSegment::moveRightAnchor(const QPointF& positionDelta)
     {
     if (line()->anchor() == Spanner::Anchor::SEGMENT && isSingleEndType()) {
           int staffIndex = track2staff(line()->effectiveTrack2());

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -233,6 +233,17 @@ QVector<QLineF> LineSegment::gripAnchorLines(Grip grip) const
       }
 
 //---------------------------------------------------------
+//   startDrag
+//---------------------------------------------------------
+
+void LineSegment::startDrag(EditData& ed)
+      {
+      SpannerSegment::startDrag(ed);
+      ElementEditData* eed = ed.getData(this);
+      eed->pushProperty(Pid::OFFSET2);
+      }
+
+//---------------------------------------------------------
 //   startEditDrag
 //---------------------------------------------------------
 

--- a/libmscore/line.h
+++ b/libmscore/line.h
@@ -65,8 +65,13 @@ class LineSegment : public SpannerSegment {
 private:
       QPointF leftAnchorPosition(const qreal& systemPositionY) const;
       QPointF rightAnchorPosition(const qreal& systemPositionY) const;
-      void rebaseLeftAnchor();
-      void rebaseRightAnchor();
+
+      Segment* findSegmentForGrip(Grip grip, QPointF pos) const;
+      static QPointF deltaRebaseLeft(const Segment* oldSeg, const Segment* newSeg);
+      static QPointF deltaRebaseRight(const Segment* oldSeg, const Segment* newSeg, int staffIdx);
+      static Fraction lastSegmentEndTick(const Segment* lastSeg, const Spanner* s);
+      LineSegment* rebaseAnchor(Grip grip, Segment* newSeg);
+      void rebaseAnchors(EditData&, Grip);
       };
 
 //---------------------------------------------------------

--- a/libmscore/line.h
+++ b/libmscore/line.h
@@ -60,9 +60,12 @@ class LineSegment : public SpannerSegment {
       std::vector<QPointF> gripsPositions(const EditData& = EditData()) const override;
 
       virtual QVector<QLineF> dragAnchorLines() const override;
+      QRectF drag(EditData &ed) override;
 private:
       QPointF leftAnchorPosition(const qreal& systemPositionY) const;
       QPointF rightAnchorPosition(const qreal& systemPositionY) const;
+      void moveLeftAnchor(const QPointF& positionDelta);
+      void moveRightAnchor(const QPointF& positionDelta);
       };
 
 //---------------------------------------------------------

--- a/libmscore/line.h
+++ b/libmscore/line.h
@@ -65,8 +65,8 @@ class LineSegment : public SpannerSegment {
 private:
       QPointF leftAnchorPosition(const qreal& systemPositionY) const;
       QPointF rightAnchorPosition(const qreal& systemPositionY) const;
-      void moveLeftAnchor(const QPointF& positionDelta);
-      void moveRightAnchor(const QPointF& positionDelta);
+      void rebaseLeftAnchor();
+      void rebaseRightAnchor();
       };
 
 //---------------------------------------------------------

--- a/libmscore/line.h
+++ b/libmscore/line.h
@@ -37,6 +37,7 @@ class LineSegment : public SpannerSegment {
       virtual bool edit(EditData&) override;
       QVector<QLineF> gripAnchorLines(Grip) const override;
       virtual void startEditDrag(EditData&) override;
+      void startDrag(EditData&) override;
 
    public:
       LineSegment(Spanner* sp, Score* s, ElementFlags f = ElementFlag::NOTHING) : SpannerSegment(sp, s, f) {}

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3081,7 +3081,7 @@ Fraction Measure::snapNote(const Fraction& /*tick*/, const QPointF p, int staff)
 ///   \returns The segment that was found.
 //---------------------------------------------------------
 
-Segment* Measure::searchSegment(qreal x, SegmentType st, int strack, int etrack, const Segment* preferredSegment) const
+Segment* Measure::searchSegment(qreal x, SegmentType st, int strack, int etrack, const Segment* preferredSegment, qreal spacingFactor) const
       {
       const int lastTrack = etrack - 1;
       for (Segment* segment = first(st); segment; segment = segment->next(st)) {
@@ -3103,7 +3103,7 @@ Segment* Measure::searchSegment(qreal x, SegmentType st, int strack, int etrack,
                         return segment;
                   }
             else {
-                  if (x < (segment->x() + (ns->x() - segment->x())/2.0))
+                  if (x < (segment->x() + (ns->x() - segment->x()) * spacingFactor))
                         return segment;
                   }
             }

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3066,6 +3066,51 @@ Fraction Measure::snapNote(const Fraction& /*tick*/, const QPointF p, int staff)
       }
 
 //---------------------------------------------------------
+//   searchSegment
+///   Finds a segment which x position is most close to the
+///   given \p x.
+///   \param x The x coordinate in measure coordinates.
+///   \param st Type of segments to search.
+///   \param strack start of track range (strack included)
+///   in which the found segment should contain elements.
+///   \param etrack end of track range (etrack excluded)
+///   in which the found segment should contain elements.
+///   \param preferredSegment If not nullptr, will give
+///   more space to the given segment when searching it by
+///   coordinate.
+///   \returns The segment that was found.
+//---------------------------------------------------------
+
+Segment* Measure::searchSegment(qreal x, SegmentType st, int strack, int etrack, const Segment* preferredSegment) const
+      {
+      const int lastTrack = etrack - 1;
+      for (Segment* segment = first(st); segment; segment = segment->next(st)) {
+            if (!segment->hasElements(strack, lastTrack))
+                  continue;
+            Segment* ns = segment->next(st);
+            for (; ns; ns = ns->next(st)) {
+                  if (ns->hasElements(strack, lastTrack))
+                        break;
+                  }
+            if (!ns)
+                  return segment;
+            if (preferredSegment == segment) {
+                  if (x < (segment->x() + (ns->x() - segment->x())))
+                        return segment;
+                  }
+            else if (preferredSegment == ns) {
+                  if (x <= segment->x())
+                        return segment;
+                  }
+            else {
+                  if (x < (segment->x() + (ns->x() - segment->x())/2.0))
+                        return segment;
+                  }
+            }
+      return nullptr;
+      }
+
+//---------------------------------------------------------
 //   getProperty
 //---------------------------------------------------------
 

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -163,6 +163,8 @@ class Measure final : public MeasureBase {
       Fraction snap(const Fraction& tick, const QPointF p) const;
       Fraction snapNote(const Fraction& tick, const QPointF p, int staff) const;
 
+      Segment* searchSegment(qreal x, SegmentType st, int strack, int etrack, const Segment* preferredSegment = nullptr) const;
+
       void insertStaff(Staff*, int staff);
       void insertMStaff(MStaff* staff, int idx);
       void removeMStaff(MStaff* staff, int idx);

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -163,7 +163,7 @@ class Measure final : public MeasureBase {
       Fraction snap(const Fraction& tick, const QPointF p) const;
       Fraction snapNote(const Fraction& tick, const QPointF p, int staff) const;
 
-      Segment* searchSegment(qreal x, SegmentType st, int strack, int etrack, const Segment* preferredSegment = nullptr) const;
+      Segment* searchSegment(qreal x, SegmentType st, int strack, int etrack, const Segment* preferredSegment = nullptr, qreal spacingFactor = 0.5) const;
 
       void insertStaff(Staff*, int staff);
       void insertMStaff(MStaff* staff, int idx);

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2424,7 +2424,7 @@ QRectF Note::drag(EditData& ed)
             return QRectF();
             }
 
-      QPointF delta = ed.pos - ed.lastPos;
+      QPointF delta = ed.evtDelta;
       noteEditData->delta = delta;
 
       if (noteEditData->mode == NoteEditData::EditMode_Undefined) {
@@ -2468,11 +2468,11 @@ void Note::editDrag(EditData& editData)
       if (ch->notes().size() == 1) {
             // if the chord contains only this note, then move the whole chord
             // including stem, flag etc.
-            ch->undoChangeProperty(Pid::OFFSET, ch->offset() + offset() + editData.delta);
+            ch->undoChangeProperty(Pid::OFFSET, ch->offset() + offset() + editData.evtDelta);
             setOffset(QPointF());
             }
       else
-            setOffset(offset() + editData.delta);
+            setOffset(offset() + editData.evtDelta);
 
       triggerLayout();
       }
@@ -2495,7 +2495,7 @@ void Note::verticalDrag(EditData &ed)
       qreal _spatium      = spatium();
       bool tab            = st->isTabStaff();
       qreal step          = _spatium * (tab ? st->lineDistance().val() : 0.5);
-      int lineOffset      = lrint(ed.delta.y() / step);
+      int lineOffset      = lrint(ed.moveDelta.y() / step);
 
       if (tab) {
             const StringData* strData = staff()->part()->instrument()->stringData();
@@ -2582,7 +2582,7 @@ void Note::horizontalDrag(EditData &ed)
           (((ed.buttons & Qt::LeftButton) && !(ed.modifiers & Qt::ControlModifier))
            || (ed.modifiers & Qt::ShiftModifier))) {
 
-            if (ed.delta.x() < 0)
+            if (ed.moveDelta.x() < 0)
                   normalizeLeftDragDelta(seg, ed, ned);
             }
 

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -579,34 +579,7 @@ Measure* Score::pos2measure(const QPointF& p, int* rst, int* pitch, Segment** se
       System* s = m->system();
       qreal y   = p.y() - s->canvasPos().y();
 
-      int i = 0;
-      for (; i < nstaves();) {
-            SysStaff* stff = s->staff(i);
-            if (!stff->show() || !staff(i)->show()) {
-                  ++i;
-                  continue;
-                  }
-            int ni = i;
-            for (;;) {
-                  ++ni;
-                  if (ni == nstaves() || (s->staff(ni)->show() && staff(ni)->show()))
-                        break;
-                  }
-
-            qreal sy2;
-            if (ni != nstaves()) {
-                  SysStaff* nstaff = s->staff(ni);
-                  qreal s1y2 = stff->bbox().y() + stff->bbox().height();
-                  sy2 = s1y2 + (nstaff->bbox().y() - s1y2)/2;
-                  }
-            else
-                  sy2 = s->page()->height() - s->pos().y();   // s->height();
-            if (y > sy2) {
-                  i   = ni;
-                  continue;
-                  }
-            break;
-            }
+      const int i = s->searchStaff(y);
 
       // search for segment + offset
       QPointF pppp = p - m->canvasPos();
@@ -662,39 +635,7 @@ void Score::dragPosition(const QPointF& p, int* rst, Segment** seg) const
       System* s = m->system();
       qreal y   = p.y() - s->canvasPos().y();
 
-      int i;
-      for (i = 0; i < nstaves();) {
-            SysStaff* stff = s->staff(i);
-            if (!stff->show() || !staff(i)->show()) {
-                  ++i;
-                  continue;
-                  }
-            int ni = i;
-            for (;;) {
-                  ++ni;
-                  if (ni == nstaves() || (s->staff(ni)->show() && staff(ni)->show()))
-                        break;
-                  }
-
-            qreal sy2;
-            if (ni != nstaves()) {
-                  SysStaff* nstaff = s->staff(ni);
-                  qreal s1y2       = stff->bbox().y() + stff->bbox().height();
-                  if (i == *rst)
-                        sy2 = s1y2 + (nstaff->bbox().y() - s1y2);
-                  else if (ni == *rst)
-                        sy2 = s1y2;
-                  else
-                        sy2 = s1y2 + (nstaff->bbox().y() - s1y2) * .5;
-                  }
-            else
-                  sy2 = s->page()->height() - s->pos().y();
-            if (y > sy2) {
-                  i   = ni;
-                  continue;
-                  }
-            break;
-            }
+      const int i = s->searchStaff(y, *rst);
 
       // search for segment + offset
       QPointF pppp = p - m->canvasPos();

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -606,17 +606,17 @@ Measure* Score::pos2measure(const QPointF& p, int* rst, int* pitch, Segment** se
 ///              \b output: new segment for drag position
 //---------------------------------------------------------
 
-void Score::dragPosition(const QPointF& p, int* rst, Segment** seg) const
+void Score::dragPosition(const QPointF& p, int* rst, Segment** seg, qreal spacingFactor) const
       {
       const System* preferredSystem = (*seg) ? (*seg)->system() : nullptr;
-      Measure* m = searchMeasure(p, preferredSystem);
+      Measure* m = searchMeasure(p, preferredSystem, spacingFactor);
       if (m == 0)
             return;
 
       System* s = m->system();
       qreal y   = p.y() - s->canvasPos().y();
 
-      const int i = s->searchStaff(y, *rst);
+      const int i = s->searchStaff(y, *rst, spacingFactor);
 
       // search for segment + offset
       QPointF pppp = p - m->canvasPos();
@@ -626,7 +626,7 @@ void Score::dragPosition(const QPointF& p, int* rst, Segment** seg) const
       int etrack = staff(i)->part()->nstaves() * VOICES + strack;
 
       constexpr SegmentType st = SegmentType::ChordRest;
-      Segment* segment = m->searchSegment(pppp.x(), st, strack, etrack, *seg);
+      Segment* segment = m->searchSegment(pppp.x(), st, strack, etrack, *seg, spacingFactor);
       if (segment) {
             *rst = i;
             *seg = segment;
@@ -907,7 +907,7 @@ Page* Score::searchPage(const QPointF& p) const
 ///   \returns List of found systems.
 //---------------------------------------------------------
 
-QList<System*> Score::searchSystem(const QPointF& pos, const System* preferredSystem) const
+QList<System*> Score::searchSystem(const QPointF& pos, const System* preferredSystem, qreal spacingFactor) const
       {
       QList<System*> systems;
       Page* page = searchPage(pos);
@@ -935,7 +935,7 @@ QList<System*> Score::searchSystem(const QPointF& pos, const System* preferredSy
                   else if (ns == preferredSystem)
                         y2 = sy2;
                   else
-                        y2 = sy2 + (ns->y() - sy2) * .5;
+                        y2 = sy2 + (ns->y() - sy2) * spacingFactor;
                   }
             if (y < y2) {
                   systems.append(s);
@@ -957,9 +957,9 @@ QList<System*> Score::searchSystem(const QPointF& pos, const System* preferredSy
 ///   space to measures in this system when searching.
 //---------------------------------------------------------
 
-Measure* Score::searchMeasure(const QPointF& p, const System* preferredSystem) const
+Measure* Score::searchMeasure(const QPointF& p, const System* preferredSystem, qreal spacingFactor) const
       {
-      QList<System*> systems = searchSystem(p, preferredSystem);
+      QList<System*> systems = searchSystem(p, preferredSystem, spacingFactor);
       for (System* system : systems) {
             qreal x = p.x() - system->canvasPos().x();
             for (MeasureBase* mb : system->measures()) {

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -620,10 +620,10 @@ void Score::dragPosition(const QPointF& p, int* rst, Segment** seg, qreal spacin
 
       // search for segment + offset
       QPointF pppp = p - m->canvasPos();
-      int strack   = i * VOICES;
+      int strack = staff2track(i);
       if (!staff(i))
             return;
-      int etrack = staff(i)->part()->nstaves() * VOICES + strack;
+      int etrack = staff2track(i + 1);
 
       constexpr SegmentType st = SegmentType::ChordRest;
       Segment* segment = m->searchSegment(pppp.x(), st, strack, etrack, *seg, spacingFactor);

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -648,7 +648,7 @@ class Score : public QObject, public ScoreElement {
       Staff* staff(int n) const              { return ((n >= 0) && (n < _staves.size())) ? _staves.at(n) : nullptr; }
 
       Measure* pos2measure(const QPointF&, int* staffIdx, int* pitch, Segment**, QPointF* offset) const;
-      void dragPosition(const QPointF&, int* staffIdx, Segment**) const;
+      void dragPosition(const QPointF&, int* staffIdx, Segment**, qreal spacingFactor = 0.5) const;
 
       void undoAddElement(Element* element);
       void undoAddCR(ChordRest* element, Measure*, const Fraction& tick);
@@ -958,8 +958,8 @@ class Score : public QObject, public ScoreElement {
       void lassoSelectEnd();
 
       Page* searchPage(const QPointF&) const;
-      QList<System*> searchSystem(const QPointF& p, const System* preferredSystem = nullptr) const;
-      Measure* searchMeasure(const QPointF& p, const System* preferredSystem = nullptr) const;
+      QList<System*> searchSystem(const QPointF& p, const System* preferredSystem = nullptr, qreal spacingFactor = 0.5) const;
+      Measure* searchMeasure(const QPointF& p, const System* preferredSystem = nullptr, qreal spacingFactor = 0.5) const;
 
       bool getPosition(Position* pos, const QPointF&, int voice) const;
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -833,6 +833,7 @@ class Score : public QObject, public ScoreElement {
       Segment* tick2segmentMM(const Fraction& tick, bool first) const;
       Segment* tick2leftSegment(const Fraction& tick, bool useMMrest = false) const;
       Segment* tick2rightSegment(const Fraction& tick, bool useMMrest = false) const;
+      Segment* tick2leftSegmentMM(const Fraction& tick) { return tick2leftSegment(tick, /* useMMRest */ true); }
       void fixTicks();
       void rebuildTempoAndTimeSigMaps(Measure* m);
       Element* nextElement();

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -958,8 +958,8 @@ class Score : public QObject, public ScoreElement {
       void lassoSelectEnd();
 
       Page* searchPage(const QPointF&) const;
-      QList<System*> searchSystem(const QPointF& p) const;
-      Measure* searchMeasure(const QPointF& p) const;
+      QList<System*> searchSystem(const QPointF& p, const System* preferredSystem = nullptr) const;
+      Measure* searchMeasure(const QPointF& p, const System* preferredSystem = nullptr) const;
 
       bool getPosition(Position* pos, const QPointF&, int voice) const;
 

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -293,6 +293,21 @@ Segment* Segment::next(SegmentType types) const
       }
 
 //---------------------------------------------------------
+//   nextInStaff
+///   Returns next \c Segment in the staff with given index
+//---------------------------------------------------------
+
+Segment* Segment::nextInStaff(int staffIdx, SegmentType type) const
+      {
+      Segment* s = next(type);
+      const int minTrack = staffIdx * VOICES;
+      const int maxTrack = (staffIdx + 1) * VOICES - 1;
+      while (s && !s->hasElements(minTrack, maxTrack))
+            s = s->next(type);
+      return s;
+      }
+
+//---------------------------------------------------------
 //   prev
 //    got to previous segment which has subtype in types
 //---------------------------------------------------------
@@ -908,6 +923,49 @@ bool Segment::setProperty(Pid propertyId, const QVariant& v)
             }
       triggerLayout();
       return true;
+      }
+
+//---------------------------------------------------------
+//   widthInStaff
+//---------------------------------------------------------
+
+qreal Segment::widthInStaff(int staffIdx, SegmentType t) const
+      {
+      const qreal segX = x();
+      qreal nextSegX = segX;
+
+      Segment* nextSeg = nextInStaff(staffIdx, t);
+      if (nextSeg)
+            nextSegX = nextSeg->x();
+      else {
+            Segment* lastSeg = measure()->last();
+            if (lastSeg->segmentType() & t)
+                  nextSegX = lastSeg->x() + lastSeg->width();
+            else
+                  nextSegX = lastSeg->x();
+            }
+
+      return nextSegX - segX;
+      }
+
+//---------------------------------------------------------
+//   ticksInStaff
+//---------------------------------------------------------
+
+Fraction Segment::ticksInStaff(int staffIdx) const
+      {
+      const Fraction segTick = tick();
+      Fraction nextSegTick = segTick;
+
+      Segment* nextSeg = nextInStaff(staffIdx, durationSegmentsMask);
+      if (nextSeg)
+            nextSegTick = nextSeg->tick();
+      else {
+            Segment* lastSeg = measure()->last();
+            nextSegTick = lastSeg->tick() + lastSeg->ticks();
+            }
+
+      return nextSegTick - segTick;
       }
 
 //---------------------------------------------------------

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -982,6 +982,19 @@ bool Segment::hasElements() const
       }
 
 //---------------------------------------------------------
+//   hasElements
+///  return true if an annotation of type type or and element is found in the track range
+//---------------------------------------------------------
+
+bool Segment::hasElements(int minTrack, int maxTrack) const
+      {
+      for (int curTrack = minTrack; curTrack <= maxTrack; curTrack++)
+            if (element(curTrack))
+                  return true;
+      return false;
+      }
+
+//---------------------------------------------------------
 //   hasAnnotationOrElement
 ///  return true if an annotation of type type or and element is found in the track range
 //---------------------------------------------------------
@@ -991,10 +1004,7 @@ bool Segment::hasAnnotationOrElement(ElementType type, int minTrack, int maxTrac
       for (const Element* e : _annotations)
             if (e->type() == type && e->track() >= minTrack && e->track() <= maxTrack)
                   return true;
-      for (int curTrack = minTrack; curTrack <= maxTrack; curTrack++)
-            if (element(curTrack))
-                  return true;
-      return false;
+      return hasElements(minTrack, maxTrack);
       }
 
 //---------------------------------------------------------

--- a/libmscore/segment.h
+++ b/libmscore/segment.h
@@ -86,6 +86,7 @@ class Segment final : public Element {
       Segment* next(SegmentType) const;
       Segment* nextActive() const;
       Segment* nextEnabled() const;
+      Segment* nextInStaff(int staffIdx, SegmentType t = SegmentType::ChordRest) const;
       void setNext(Segment* e)            { _next = e;      }
 
       Segment* prev() const               { return _prev;   }
@@ -162,6 +163,9 @@ class Segment final : public Element {
 
       Fraction ticks() const                     { return _ticks;   }
       void setTicks(const Fraction& v)           { _ticks = v;      }
+
+      qreal widthInStaff(int staffIdx, SegmentType t = SegmentType::ChordRest) const;
+      Fraction ticksInStaff(int staffIdx) const;
 
       bool splitsTuplet() const;
 
@@ -240,6 +244,8 @@ class Segment final : public Element {
       bool isEndBarLineType() const         { return _segmentType == SegmentType::EndBarLine; }
       bool isKeySigAnnounceType() const     { return _segmentType == SegmentType::KeySigAnnounce; }
       bool isTimeSigAnnounceType() const    { return _segmentType == SegmentType::TimeSigAnnounce; }
+
+      static constexpr SegmentType durationSegmentsMask = SegmentType::ChordRest; // segment types which may have non-zero tick length
       };
 
 //---------------------------------------------------------

--- a/libmscore/segment.h
+++ b/libmscore/segment.h
@@ -172,7 +172,7 @@ class Segment final : public Element {
       Element* findAnnotation(ElementType type, int minTrack, int maxTrack);
       std::vector<Element*> findAnnotations(ElementType type, int minTrack, int maxTrack);
       bool hasElements() const;
-
+      bool hasElements(int minTrack, int maxTrack) const;
 
       qreal dotPosX(int staffIdx) const          { return _dotPosX[staffIdx];  }
       void setDotPosX(int staffIdx, qreal val)   { _dotPosX[staffIdx] = val;   }

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -525,6 +525,7 @@ bool Spanner::setProperty(Pid propertyId, const QVariant& v)
       {
       switch (propertyId) {
             case Pid::SPANNER_TICK:
+                  triggerLayout(); // spanner may have moved to another system
                   setTick(v.value<Fraction>());
                   setStartElement(0);     // invalidate
                   setEndElement(0);       //
@@ -532,6 +533,7 @@ bool Spanner::setProperty(Pid propertyId, const QVariant& v)
                         score()->addSpanner(this);
                   break;
             case Pid::SPANNER_TICKS:
+                  triggerLayout(); // spanner may now span for a smaller number of systems
                   setTicks(v.value<Fraction>());
                   setEndElement(0);       // invalidate
                   break;

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -825,6 +825,56 @@ int System::y2staff(qreal y) const
       }
 
 //---------------------------------------------------------
+//   searchStaff
+///   Finds a staff which y position is most close to the
+///   given \p y.
+///   \param y The y coordinate in system coordinates.
+///   \param preferredStaff If not -1, will give more space
+///   to a staff with the given number when searching it by
+///   coordinate.
+///   \returns Number of the found staff.
+//---------------------------------------------------------
+
+int System::searchStaff(qreal y, int preferredStaff /* = -1 */) const
+      {
+      int i = 0;
+      const int nstaves = score()->nstaves();
+      for (; i < nstaves;) {
+            SysStaff* stff = staff(i);
+            if (!stff->show() || !score()->staff(i)->show()) {
+                  ++i;
+                  continue;
+                  }
+            int ni = i;
+            for (;;) {
+                  ++ni;
+                  if (ni == nstaves || (staff(ni)->show() && score()->staff(ni)->show()))
+                        break;
+                  }
+
+            qreal sy2;
+            if (ni != nstaves) {
+                  SysStaff* nstaff = staff(ni);
+                  qreal s1y2       = stff->bbox().y() + stff->bbox().height();
+                  if (i == preferredStaff)
+                        sy2 = s1y2 + (nstaff->bbox().y() - s1y2);
+                  else if (ni == preferredStaff)
+                        sy2 = s1y2;
+                  else
+                        sy2 = s1y2 + (nstaff->bbox().y() - s1y2) * .5;
+                  }
+            else
+                  sy2 = page()->height() - pos().y();
+            if (y > sy2) {
+                  i   = ni;
+                  continue;
+                  }
+            break;
+            }
+      return i;
+      }
+
+//---------------------------------------------------------
 //   add
 //---------------------------------------------------------
 

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -835,7 +835,7 @@ int System::y2staff(qreal y) const
 ///   \returns Number of the found staff.
 //---------------------------------------------------------
 
-int System::searchStaff(qreal y, int preferredStaff /* = -1 */) const
+int System::searchStaff(qreal y, int preferredStaff /* = -1 */, qreal spacingFactor) const
       {
       int i = 0;
       const int nstaves = score()->nstaves();
@@ -861,7 +861,7 @@ int System::searchStaff(qreal y, int preferredStaff /* = -1 */) const
                   else if (ni == preferredStaff)
                         sy2 = s1y2;
                   else
-                        sy2 = s1y2 + (nstaff->bbox().y() - s1y2) * .5;
+                        sy2 = s1y2 + (nstaff->bbox().y() - s1y2) * spacingFactor;
                   }
             else
                   sy2 = page()->height() - pos().y();

--- a/libmscore/system.h
+++ b/libmscore/system.h
@@ -138,7 +138,7 @@ public:
       void adjustStavesNumber(int);
 
       int y2staff(qreal y) const;
-      int searchStaff(qreal y, int preferredStaff = -1) const;
+      int searchStaff(qreal y, int preferredStaff = -1, qreal spacingFactor = 0.5) const;
       void setInstrumentNames(bool longName, Fraction tick = {0,1});
       Fraction snap(const Fraction& tick, const QPointF p) const;
       Fraction snapNote(const Fraction& tick, const QPointF p, int staff) const;

--- a/libmscore/system.h
+++ b/libmscore/system.h
@@ -138,6 +138,7 @@ public:
       void adjustStavesNumber(int);
 
       int y2staff(qreal y) const;
+      int searchStaff(qreal y, int preferredStaff = -1) const;
       void setInstrumentNames(bool longName, Fraction tick = {0,1});
       Fraction snap(const Fraction& tick, const QPointF p) const;
       Fraction snapNote(const Fraction& tick, const QPointF p, int staff) const;

--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -135,7 +135,7 @@ Segment* Score::tick2segment(const Fraction& t, bool first, SegmentType st, bool
       if (useMMrest) {
             m = tick2measureMM(tick);
             // When mmRest force tick to the first segment of mmRest.
-            if (m && m->isMMRest())
+            if (m && m->isMMRest() && tick != m->endTick())
                   tick = m->tick();
             }
       else

--- a/mscore/dragelement.cpp
+++ b/mscore/dragelement.cpp
@@ -79,6 +79,8 @@ void ScoreView::doDragElement(QMouseEvent* ev)
                   mscore->play(e);
                   _score->setPlayNote(false);
                   }
+            _score->update();
+
             QVector<QLineF> anchorLines = e->dragAnchorLines();
             const QPointF pageOffset(e->findAncestor(ElementType::PAGE)->pos());
 
@@ -108,6 +110,7 @@ void ScoreView::endDrag()
       _score->selection().unlock("drag");
       setDropTarget(0); // this also resets dropAnchor
       _score->endCmd();
+      updateGrips();
       if (editData.element->normalModeEditBehavior() == Element::EditBehavior::Edit && _score->selection().element() == editData.element)
             startEdit(/* editMode */ false);
       }

--- a/mscore/dragelement.cpp
+++ b/mscore/dragelement.cpp
@@ -31,7 +31,7 @@ void ScoreView::startDrag()
       {
       editData.grips = 0;
       editData.clearData();
-      editData.startMove  -= editData.element->offset();
+      editData.normalizedStartMove = editData.startMove - editData.element->offset();
 
       _score->startCmd();
 
@@ -47,21 +47,29 @@ void ScoreView::startDrag()
 
 void ScoreView::doDragElement(QMouseEvent* ev)
       {
-      QPointF delta = toLogical(ev->pos()) - editData.startMove;
+      const QPointF logicalPos = toLogical(ev->pos());
+      QPointF delta = logicalPos - editData.normalizedStartMove;
+      QPointF evtDelta = logicalPos - editData.pos;
 
       TourHandler::startTour("autoplace-tour");
 
       QPointF pt(delta);
-      if (qApp->keyboardModifiers() == Qt::ShiftModifier)
-            pt.setX(editData.element->offset().x());
-      else if (qApp->keyboardModifiers() == Qt::ControlModifier)
-            pt.setY(editData.element->offset().y());
+      if (qApp->keyboardModifiers() == Qt::ShiftModifier) {
+            pt.setX(editData.delta.x());
+            evtDelta.setX(0.0);
+            }
+      else if (qApp->keyboardModifiers() == Qt::ControlModifier) {
+            pt.setY(editData.delta.y());
+            evtDelta.setY(0.0);
+            }
 
       editData.lastPos = editData.pos;
       editData.hRaster = mscore->hRaster();
       editData.vRaster = mscore->vRaster();
       editData.delta   = pt;
-      editData.pos     = toLogical(ev->pos());
+      editData.moveDelta = pt + (editData.normalizedStartMove - editData.startMove); // TODO: restructure
+      editData.evtDelta = evtDelta;
+      editData.pos     = logicalPos;
 
       const Selection& sel = _score->selection();
       const bool filterType = sel.isRange();

--- a/mscore/editelement.cpp
+++ b/mscore/editelement.cpp
@@ -243,9 +243,9 @@ void ScoreView::endDragEdit()
 
       editData.element->endEditDrag(editData);
       score()->endCmd();            // calls update()
-      updateGrips();
       _score->addRefresh(editData.element->canvasBoundingRect());
       setDropTarget(0);
+      updateGrips();
       _score->rebuildBspTree();
       }
 }

--- a/mscore/editelement.cpp
+++ b/mscore/editelement.cpp
@@ -118,7 +118,10 @@ void ScoreView::startEdit(Element* element, Grip startGrip)
             return;
             }
 
-      const bool forceStartEdit = (state == ViewState::EDIT && element != editData.element);
+      const bool forceStartEdit = (
+         (state == ViewState::EDIT || state == ViewState::DRAG_EDIT)
+         && element != editData.element
+         );
       editData.element = element;
       if (forceStartEdit) // call startEdit() forcibly to reinitialize edit mode.
             startEdit();
@@ -198,6 +201,9 @@ void ScoreView::doDragEdit(QMouseEvent* ev)
                   editData.pos.setY(editData.lastPos.y());
             }
       editData.delta = editData.pos - editData.lastPos;
+      editData.evtDelta = editData.pos - editData.lastPos;
+      editData.moveDelta = editData.pos - editData.startMove;
+
       score()->addRefresh(editData.element->canvasBoundingRect());
 
       if (editData.element->isTextBase()) {

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3931,9 +3931,20 @@ void ScoreView::cloneElement(Element* e)
 
 void ScoreView::changeEditElement(Element* e)
       {
-      Grip grip = editData.curGrip;
+      if (editData.element == e)
+            return;
+
+      const Grip grip = editData.curGrip;
+      const bool dragEdit = (state == ViewState::DRAG_EDIT);
+
+      if (editData.element && dragEdit)
+            editData.element->endEditDrag(editData);
+
       endEdit();
       startEdit(e, grip);
+
+      if (editData.element && dragEdit)
+            editData.element->startEditDrag(editData);
       }
 
 //---------------------------------------------------------

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -15,6 +15,7 @@
 
 #include "globals.h"
 #include "libmscore/element.h"
+#include "libmscore/elementgroup.h"
 #include "libmscore/durationtype.h"
 #include "libmscore/mscore.h"
 #include "libmscore/mscoreview.h"
@@ -115,6 +116,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       QFocusFrame* focusFrame;
 
       EditData editData;
+      std::vector<std::unique_ptr<ElementGroup>> dragGroups;
 
       //--input state:
       PositionCursor* _cursor;


### PR DESCRIPTION
This PR (currently based on the branch from #5738) contains reworking dragging system, primarily related to dragging segment-anchored lines (like hairpins). These changes make hairpin anchors be recalculated based on actual hairpin position on dragging without the need to use special key combinations like Shift+arrow for this purpose. This should make editing score dynamics (as well as aspects related to other segment-anchored lines) easier.