### PR TITLE
fix #301684: fix clef for "Electric Guitar (Treble Clef)" in concert pitch

### DIFF
--- a/mtest/guitarpro/UncompletedMeasure.gpx-ref.mscx
+++ b/mtest/guitarpro/UncompletedMeasure.gpx-ref.mscx
@@ -41,7 +41,8 @@
         <transposeDiatonic>-7</transposeDiatonic>
         <transposeChromatic>-12</transposeChromatic>
         <instrumentId>pluck.guitar.electric</instrumentId>
-        <clef>G8vb</clef>
+        <concertClef>G8vb</concertClef>
+        <transposingClef>G</transposingClef>
         <singleNoteDynamics>0</singleNoteDynamics>
         <StringData>
           <frets>24</frets>
@@ -203,7 +204,8 @@
           <transposeDiatonic>-7</transposeDiatonic>
           <transposeChromatic>-12</transposeChromatic>
           <instrumentId>pluck.guitar.electric</instrumentId>
-          <clef>G8vb</clef>
+          <concertClef>G8vb</concertClef>
+          <transposingClef>G</transposingClef>
           <singleNoteDynamics>0</singleNoteDynamics>
           <StringData>
             <frets>24</frets>

--- a/mtest/guitarpro/artificial-harmonic.gpx-ref.mscx
+++ b/mtest/guitarpro/artificial-harmonic.gpx-ref.mscx
@@ -41,7 +41,8 @@
         <transposeDiatonic>-7</transposeDiatonic>
         <transposeChromatic>-12</transposeChromatic>
         <instrumentId>pluck.guitar.electric</instrumentId>
-        <clef>G8vb</clef>
+        <concertClef>G8vb</concertClef>
+        <transposingClef>G</transposingClef>
         <singleNoteDynamics>0</singleNoteDynamics>
         <StringData>
           <frets>24</frets>
@@ -378,7 +379,8 @@
           <transposeDiatonic>-7</transposeDiatonic>
           <transposeChromatic>-12</transposeChromatic>
           <instrumentId>pluck.guitar.electric</instrumentId>
-          <clef>G8vb</clef>
+          <concertClef>G8vb</concertClef>
+          <transposingClef>G</transposingClef>
           <singleNoteDynamics>0</singleNoteDynamics>
           <StringData>
             <frets>24</frets>

--- a/mtest/guitarpro/free-time.gpx-ref.mscx
+++ b/mtest/guitarpro/free-time.gpx-ref.mscx
@@ -41,7 +41,8 @@
         <transposeDiatonic>-7</transposeDiatonic>
         <transposeChromatic>-12</transposeChromatic>
         <instrumentId>pluck.guitar.electric</instrumentId>
-        <clef>G8vb</clef>
+        <concertClef>G8vb</concertClef>
+        <transposingClef>G</transposingClef>
         <singleNoteDynamics>0</singleNoteDynamics>
         <StringData>
           <frets>24</frets>
@@ -267,7 +268,8 @@
           <transposeDiatonic>-7</transposeDiatonic>
           <transposeChromatic>-12</transposeChromatic>
           <instrumentId>pluck.guitar.electric</instrumentId>
-          <clef>G8vb</clef>
+          <concertClef>G8vb</concertClef>
+          <transposingClef>G</transposingClef>
           <singleNoteDynamics>0</singleNoteDynamics>
           <StringData>
             <frets>24</frets>

--- a/mtest/guitarpro/let-ring.gpx-ref.mscx
+++ b/mtest/guitarpro/let-ring.gpx-ref.mscx
@@ -41,7 +41,8 @@
         <transposeDiatonic>-7</transposeDiatonic>
         <transposeChromatic>-12</transposeChromatic>
         <instrumentId>pluck.guitar.electric</instrumentId>
-        <clef>G8vb</clef>
+        <concertClef>G8vb</concertClef>
+        <transposingClef>G</transposingClef>
         <singleNoteDynamics>0</singleNoteDynamics>
         <StringData>
           <frets>24</frets>
@@ -248,7 +249,8 @@
           <transposeDiatonic>-7</transposeDiatonic>
           <transposeChromatic>-12</transposeChromatic>
           <instrumentId>pluck.guitar.electric</instrumentId>
-          <clef>G8vb</clef>
+          <concertClef>G8vb</concertClef>
+          <transposingClef>G</transposingClef>
           <singleNoteDynamics>0</singleNoteDynamics>
           <StringData>
             <frets>24</frets>

--- a/mtest/guitarpro/ottava2.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava2.gpx-ref.mscx
@@ -119,7 +119,8 @@
         <transposeDiatonic>-7</transposeDiatonic>
         <transposeChromatic>-12</transposeChromatic>
         <instrumentId>pluck.guitar.electric</instrumentId>
-        <clef>G8vb</clef>
+        <concertClef>G8vb</concertClef>
+        <transposingClef>G</transposingClef>
         <singleNoteDynamics>0</singleNoteDynamics>
         <StringData>
           <frets>24</frets>
@@ -1017,7 +1018,8 @@
           <transposeDiatonic>-7</transposeDiatonic>
           <transposeChromatic>-12</transposeChromatic>
           <instrumentId>pluck.guitar.electric</instrumentId>
-          <clef>G8vb</clef>
+          <concertClef>G8vb</concertClef>
+          <transposingClef>G</transposingClef>
           <singleNoteDynamics>0</singleNoteDynamics>
           <StringData>
             <frets>24</frets>

--- a/mtest/guitarpro/ottava3.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava3.gpx-ref.mscx
@@ -119,7 +119,8 @@
         <transposeDiatonic>-7</transposeDiatonic>
         <transposeChromatic>-12</transposeChromatic>
         <instrumentId>pluck.guitar.electric</instrumentId>
-        <clef>G8vb</clef>
+        <concertClef>G8vb</concertClef>
+        <transposingClef>G</transposingClef>
         <singleNoteDynamics>0</singleNoteDynamics>
         <StringData>
           <frets>24</frets>
@@ -537,7 +538,8 @@
           <transposeDiatonic>-7</transposeDiatonic>
           <transposeChromatic>-12</transposeChromatic>
           <instrumentId>pluck.guitar.electric</instrumentId>
-          <clef>G8vb</clef>
+          <concertClef>G8vb</concertClef>
+          <transposingClef>G</transposingClef>
           <singleNoteDynamics>0</singleNoteDynamics>
           <StringData>
             <frets>24</frets>

--- a/mtest/guitarpro/ottava4.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava4.gpx-ref.mscx
@@ -119,7 +119,8 @@
         <transposeDiatonic>-7</transposeDiatonic>
         <transposeChromatic>-12</transposeChromatic>
         <instrumentId>pluck.guitar.electric</instrumentId>
-        <clef>G8vb</clef>
+        <concertClef>G8vb</concertClef>
+        <transposingClef>G</transposingClef>
         <singleNoteDynamics>0</singleNoteDynamics>
         <StringData>
           <frets>24</frets>
@@ -1051,7 +1052,8 @@
           <transposeDiatonic>-7</transposeDiatonic>
           <transposeChromatic>-12</transposeChromatic>
           <instrumentId>pluck.guitar.electric</instrumentId>
-          <clef>G8vb</clef>
+          <concertClef>G8vb</concertClef>
+          <transposingClef>G</transposingClef>
           <singleNoteDynamics>0</singleNoteDynamics>
           <StringData>
             <frets>24</frets>

--- a/mtest/guitarpro/ottava5.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava5.gpx-ref.mscx
@@ -119,7 +119,8 @@
         <transposeDiatonic>-7</transposeDiatonic>
         <transposeChromatic>-12</transposeChromatic>
         <instrumentId>pluck.guitar.electric</instrumentId>
-        <clef>G8vb</clef>
+        <concertClef>G8vb</concertClef>
+        <transposingClef>G</transposingClef>
         <singleNoteDynamics>0</singleNoteDynamics>
         <StringData>
           <frets>24</frets>
@@ -696,7 +697,8 @@
           <transposeDiatonic>-7</transposeDiatonic>
           <transposeChromatic>-12</transposeChromatic>
           <instrumentId>pluck.guitar.electric</instrumentId>
-          <clef>G8vb</clef>
+          <concertClef>G8vb</concertClef>
+          <transposingClef>G</transposingClef>
           <singleNoteDynamics>0</singleNoteDynamics>
           <StringData>
             <frets>24</frets>

--- a/mtest/guitarpro/palm-mute.gpx-ref.mscx
+++ b/mtest/guitarpro/palm-mute.gpx-ref.mscx
@@ -41,7 +41,8 @@
         <transposeDiatonic>-7</transposeDiatonic>
         <transposeChromatic>-12</transposeChromatic>
         <instrumentId>pluck.guitar.electric</instrumentId>
-        <clef>G8vb</clef>
+        <concertClef>G8vb</concertClef>
+        <transposingClef>G</transposingClef>
         <singleNoteDynamics>0</singleNoteDynamics>
         <StringData>
           <frets>24</frets>
@@ -248,7 +249,8 @@
           <transposeDiatonic>-7</transposeDiatonic>
           <transposeChromatic>-12</transposeChromatic>
           <instrumentId>pluck.guitar.electric</instrumentId>
-          <clef>G8vb</clef>
+          <concertClef>G8vb</concertClef>
+          <transposingClef>G</transposingClef>
           <singleNoteDynamics>0</singleNoteDynamics>
           <StringData>
             <frets>24</frets>

--- a/mtest/guitarpro/repeated-bars.gpx-ref.mscx
+++ b/mtest/guitarpro/repeated-bars.gpx-ref.mscx
@@ -41,7 +41,8 @@
         <transposeDiatonic>-7</transposeDiatonic>
         <transposeChromatic>-12</transposeChromatic>
         <instrumentId>pluck.guitar.electric</instrumentId>
-        <clef>G8vb</clef>
+        <concertClef>G8vb</concertClef>
+        <transposingClef>G</transposingClef>
         <singleNoteDynamics>0</singleNoteDynamics>
         <StringData>
           <frets>24</frets>
@@ -240,7 +241,8 @@
           <transposeDiatonic>-7</transposeDiatonic>
           <transposeChromatic>-12</transposeChromatic>
           <instrumentId>pluck.guitar.electric</instrumentId>
-          <clef>G8vb</clef>
+          <concertClef>G8vb</concertClef>
+          <transposingClef>G</transposingClef>
           <singleNoteDynamics>0</singleNoteDynamics>
           <StringData>
             <frets>24</frets>

--- a/mtest/guitarpro/rest-centered.gpx-ref.mscx
+++ b/mtest/guitarpro/rest-centered.gpx-ref.mscx
@@ -41,7 +41,8 @@
         <transposeDiatonic>-7</transposeDiatonic>
         <transposeChromatic>-12</transposeChromatic>
         <instrumentId>pluck.guitar.electric</instrumentId>
-        <clef>G8vb</clef>
+        <concertClef>G8vb</concertClef>
+        <transposingClef>G</transposingClef>
         <singleNoteDynamics>0</singleNoteDynamics>
         <StringData>
           <frets>24</frets>
@@ -216,7 +217,8 @@
           <transposeDiatonic>-7</transposeDiatonic>
           <transposeChromatic>-12</transposeChromatic>
           <instrumentId>pluck.guitar.electric</instrumentId>
-          <clef>G8vb</clef>
+          <concertClef>G8vb</concertClef>
+          <transposingClef>G</transposingClef>
           <singleNoteDynamics>0</singleNoteDynamics>
           <StringData>
             <frets>24</frets>

--- a/mtest/guitarpro/text.gpx-ref.mscx
+++ b/mtest/guitarpro/text.gpx-ref.mscx
@@ -41,7 +41,8 @@
         <transposeDiatonic>-7</transposeDiatonic>
         <transposeChromatic>-12</transposeChromatic>
         <instrumentId>pluck.guitar.electric</instrumentId>
-        <clef>G8vb</clef>
+        <concertClef>G8vb</concertClef>
+        <transposingClef>G</transposingClef>
         <singleNoteDynamics>0</singleNoteDynamics>
         <StringData>
           <frets>24</frets>
@@ -235,7 +236,8 @@
           <transposeDiatonic>-7</transposeDiatonic>
           <transposeChromatic>-12</transposeChromatic>
           <instrumentId>pluck.guitar.electric</instrumentId>
-          <clef>G8vb</clef>
+          <concertClef>G8vb</concertClef>
+          <transposingClef>G</transposingClef>
           <singleNoteDynamics>0</singleNoteDynamics>
           <StringData>
             <frets>24</frets>

--- a/mtest/guitarpro/trill.gpx-ref.mscx
+++ b/mtest/guitarpro/trill.gpx-ref.mscx
@@ -41,7 +41,8 @@
         <transposeDiatonic>-7</transposeDiatonic>
         <transposeChromatic>-12</transposeChromatic>
         <instrumentId>pluck.guitar.electric</instrumentId>
-        <clef>G8vb</clef>
+        <concertClef>G8vb</concertClef>
+        <transposingClef>G</transposingClef>
         <singleNoteDynamics>0</singleNoteDynamics>
         <StringData>
           <frets>24</frets>
@@ -241,7 +242,8 @@
           <transposeDiatonic>-7</transposeDiatonic>
           <transposeChromatic>-12</transposeChromatic>
           <instrumentId>pluck.guitar.electric</instrumentId>
-          <clef>G8vb</clef>
+          <concertClef>G8vb</concertClef>
+          <transposingClef>G</transposingClef>
           <singleNoteDynamics>0</singleNoteDynamics>
           <StringData>
             <frets>24</frets>

--- a/mtest/guitarpro/vibrato.gpx-ref.mscx
+++ b/mtest/guitarpro/vibrato.gpx-ref.mscx
@@ -41,7 +41,8 @@
         <transposeDiatonic>-7</transposeDiatonic>
         <transposeChromatic>-12</transposeChromatic>
         <instrumentId>pluck.guitar.electric</instrumentId>
-        <clef>G8vb</clef>
+        <concertClef>G8vb</concertClef>
+        <transposingClef>G</transposingClef>
         <singleNoteDynamics>0</singleNoteDynamics>
         <StringData>
           <frets>24</frets>
@@ -363,7 +364,8 @@
           <transposeDiatonic>-7</transposeDiatonic>
           <transposeChromatic>-12</transposeChromatic>
           <instrumentId>pluck.guitar.electric</instrumentId>
-          <clef>G8vb</clef>
+          <concertClef>G8vb</concertClef>
+          <transposingClef>G</transposingClef>
           <singleNoteDynamics>0</singleNoteDynamics>
           <StringData>
             <frets>24</frets>

--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -9637,7 +9637,8 @@
                         <string>59</string>
                         <string>64</string>
                   </StringData>
-                  <clef>G8vb</clef>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>G8vb</concertClef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>40-86</aPitchRange>
                   <pPitchRange>40-88</pPitchRange>


### PR DESCRIPTION
to make it consistent with "Guitar (Treble Clef)" and "Acoustic Guitar (Treble Clef)"
Resolves an issue that came up in a side track of https://musescore.org/en/node/301684