### PR TITLE
fix #301672 - [MusicXML import] crash on empty credit-words

### DIFF
--- a/mscore/importmxmlpass1.cpp
+++ b/mscore/importmxmlpass1.cpp
@@ -1171,8 +1171,6 @@ void MusicXMLParserPass1::credit(CreditWordsList& credits)
             CreditWords* cw = new CreditWords(page, defaultx, defaulty, justify, halign, valign, crwords);
             credits.append(cw);
             }
-      else
-            _e.skipCurrentElement();  // skip but don't log
 
       Q_ASSERT(_e.isEndElement() && _e.name() == "credit");
       }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/301672

Fix incorrect error handling on reading an empty credit-words element, preventing a crash (debug build) or invalid internal data (production build).

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n/a] I created the test (mtest, vtest, script test) to verify the changes I made