### PR TITLE
fix #301753: Figures under rests

### DIFF
--- a/libmscore/figuredbass.cpp
+++ b/libmscore/figuredbass.cpp
@@ -1749,7 +1749,7 @@ void FiguredBass::writeMusicXML(XmlWriter& xml, bool isOriginalFigure, int crEnd
 FiguredBass* Score::addFiguredBass()
       {
       Element* el = selection().element();
-      if (el == 0 || (el->type() != ElementType::NOTE && el->type() != ElementType::FIGURED_BASS)) {
+      if (!el || (!(el->isNote()) && !(el->isRest()) && !(el->isFiguredBass()))) {
             MScore::setError(NO_NOTE_FIGUREDBASS_SELECTED);
             return 0;
             }
@@ -1759,6 +1759,10 @@ FiguredBass* Score::addFiguredBass()
       if (el->isNote()) {
             ChordRest * cr = toNote(el)->chord();
             fb = FiguredBass::addFiguredBassToSegment(cr->segment(), cr->staffIdx() * VOICES, Fraction(0,1), &bNew);
+            }
+      else if (el->isRest()) {
+            ChordRest* cr = toRest(el);
+            fb = FiguredBass::addFiguredBassToSegment(cr->segment(), cr->staffIdx() * VOICES, Fraction(0, 1), &bNew);
             }
       else if (el->isFiguredBass()) {
             fb = toFiguredBass(el);


### PR DESCRIPTION
 Altered condition within libmscore/figuredbass.cpp to allow for figures to be written
 under rests.

Resolves: #301753 Allow figured bass directly on selected rest(in bass line)

Allows figured bass to be written under both notes and rests, not just notes.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://musescore.org/en/cla)
- [X] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [X] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
