### PR TITLE
[WIP] partly fix #270782: change forbidden cursor when dragging with ctrl + shift in the score

### DIFF
--- a/mscore/data/cursor-forbidden.svg
+++ b/mscore/data/cursor-forbidden.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<!-- cursor-forbidden.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ev="http://www.w3.org/2001/xml-events"
+		xmlns:v="http://schemas.microsoft.com/visio/2003/SVGExtensions/" width="8.5in" height="11in" viewBox="0 0 612 792"
+		xml:space="preserve" color-interpolation-filters="sRGB" class="st3">
+	<v:documentProperties v:langID="1033" v:metric="true" v:viewMarkup="false"/>
+
+	<style type="text/css">
+	<![CDATA[
+		.st1 {fill:#000000;stroke:none;stroke-linecap:butt;stroke-width:1.1953}
+		.st2 {fill:#c00000;stroke:none;stroke-linecap:butt;stroke-width:1.1953}
+		.st3 {fill:none;fill-rule:evenodd;font-size:12px;overflow:visible;stroke-linecap:square;stroke-miterlimit:3}
+	]]>
+	</style>
+
+	<g v:mID="0" v:index="1" v:groupContext="foregroundPage">
+		<title>Capa_1</title>
+		<v:pageProperties v:drawingScale="1" v:pageScale="1" v:drawingUnits="19" v:shadowOffsetX="9" v:shadowOffsetY="-9"/>
+		<g id="group1-1" transform="translate(76.5016,-88.984)" v:mID="1" v:groupContext="group">
+			<title>Feuille.1</title>
+			<g id="shape2-2" v:mID="2" v:groupContext="shape">
+				<title>Feuille.2</title>
+				<path d="M345.64 487.52 C342.95 485.01 339.24 483.72 335.61 484.12 C330.05 484.69 324.42 484.98 318.75 484.98 C227.36
+							 484.98 153 410.62 153 319.23 L153.35 312.47 C153.45 308.82 152 305.3 149.34 302.78 L21.49 182.45 C17.78
+							 178.97 12.33 178.03 7.7 180.03 C3.01 182.05 0 186.64 0 191.73 L0 778.23 C0 783.38 3.11 788.04 7.87 790.01
+							 C12.6 792 18.1 790.88 21.76 787.24 L142.24 666.75 L205.52 784.27 C207.81 788.54 212.22 790.98 216.75
+							 790.98 C218.67 790.98 220.63 790.54 222.45 789.63 L324.45 738.63 C327.54 737.09 329.85 734.36 330.9
+							 731.08 C331.95 727.79 331.6 724.22 329.98 721.19 L271.43 612.48 L446.25 612.48 C451.48 612.48 456.18
+							 609.29 458.1 604.44 C460.02 599.57 458.8 594.03 454.99 590.44 L345.64 487.52 Z" class="st1"/>
+			</g>
+			<g id="shape3-4" v:mID="3" v:groupContext="shape" transform="translate(178.499,-332.518)">
+				<title>Feuille.3</title>
+				<path d="M140.25 792 C217.58 792 280.5 729.09 280.5 651.75 C280.5 574.42 217.58 511.5 140.25 511.5 C62.91 511.5 0
+							 574.42 0 651.75 C0 729.08 62.91 792 140.25 792 ZM140.25 562.5 C189.46 562.5 229.5 602.54 229.5 651.75
+							 C229.5 667.07 225.26 681.27 218.44 693.88 L98.12 573.56 C110.73 566.74 124.93 562.5 140.25 562.5 ZM62.06
+							 609.62 L182.38 729.94 C169.77 736.77 155.56 741 140.25 741 C91.04 741 51 700.96 51 651.75 C51 636.44
+							 55.23 622.23 62.06 609.62 Z" class="st2"/>
+			</g>
+		</g>
+	</g>
+</svg>

--- a/mscore/musescore.qrc
+++ b/mscore/musescore.qrc
@@ -41,6 +41,7 @@
         <file>data/musescore-logo-transbg-m.png</file>
         <file>data/musescore_logo_full.png</file>
         <file>data/greendot.svg</file>
+        <file>data/cursor-forbidden.svg</file>
         <file>data/darkgreendot.svg</file>
         <file>data/recordOn.svg</file>
         <file>data/recordOff.svg</file>

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -418,6 +418,8 @@ void Palette::mouseMoveEvent(QMouseEvent* ev)
                   QPoint hotsp(drag->pixmap().rect().bottomRight());
                   drag->setHotSpot(hotsp);
 
+                  drag->setDragCursor(QIcon(":data/cursor-forbidden.svg").pixmap(QSize(20, 20)), Qt::IgnoreAction); // Ignored under Windows
+
                   Qt::DropActions da;
                   if (!(_readOnly || filterActive) && (ev->modifiers() & Qt::ShiftModifier)) {
                         dragCells = cells;      // backup
@@ -491,7 +493,7 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
 //             element = cell->element.get();
       if (element == 0)
             return false;
-      
+
       if (element->isSpanner())
             TourHandler::startTour("spanner-drop-apply");
 
@@ -1926,7 +1928,7 @@ void Palette::dropEvent(QDropEvent* event)
             event->ignore();
             return;
             }
-      
+
       if (e->isFretDiagram()) {
             name = toFretDiagram(e)->harmonyText();
             }
@@ -1947,4 +1949,3 @@ void Palette::dropEvent(QDropEvent* event)
       }
 
 }
-

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3847,6 +3847,8 @@ void ScoreView::cloneElement(Element* e)
       if (e->isMeasure() || e->isNote() || e->isVBox())
             return;
       QDrag* drag = new QDrag(this);
+      drag->setDragCursor(QIcon(":data/cursor-forbidden.svg").pixmap(QSize(20, 20)), Qt::IgnoreAction); // Ignored under Windows
+
       QMimeData* mimeData = new QMimeData;
       if (e->isSpannerSegment())
             e = toSpannerSegment(e)->spanner();


### PR DESCRIPTION
partly resolves: [#270782](https://musescore.org/en/node/270782)

This PR is marked as WIP because Qt hasn't implemented it under Windows. ([See this stack overflow answer explains it](https://stackoverflow.com/questions/12617686/how-override-cursor-when-dragging-out-the-app))

I just thought I might push the PR because it should now work under macOS and Linux.

There are multiple Qt bugs associated with `setDragCursor` (see [the full list](https://bugreports.qt.io/browse/QTBUG-20835?jql=text%20~%20%22setDragCursor%22))

The Icon is not really consistent with others, but at the same time it shows that you entered drag mode. A better cursor is still needed. Ideas welcome!
![image](https://user-images.githubusercontent.com/35939574/75620978-f001f380-5b5c-11ea-825d-71123e591da2.png)
