### PR TITLE
Prevent adding two staff type changes to the same measure (fix #301848)

### DIFF
--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -88,14 +88,15 @@ enum class ElementFlag {
       PAGE_BREAK             = 0x00040000,
       SECTION_BREAK          = 0x00080000,
       NO_BREAK               = 0x00100000,
-      HEADER                 = 0x00200000,
-      TRAILER                = 0x00400000,    // also used in segment
-      KEYSIG                 = 0x00800000,
+      STAFF_TYPE_CHANGE      = 0x00200000,
+      HEADER                 = 0x00400000,
+      TRAILER                = 0x00800000,    // also used in segment
+      KEYSIG                 = 0x01000000,
 
       // segment flags
-      ENABLED                = 0x01000000,    // used for segments
-      EMPTY                  = 0x02000000,
-      WRITTEN                = 0x04000000,
+      ENABLED                = 0x02000000,    // used for segments
+      EMPTY                  = 0x04000000,
+      WRITTEN                = 0x08000000,
       };
 
 typedef QFlags<ElementFlag> ElementFlags;

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1880,6 +1880,7 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
       mmr->setRepeatStart(m->repeatStart() || lm->repeatStart());
       mmr->setRepeatEnd(m->repeatEnd() || lm->repeatEnd());
       mmr->setSectionBreak(lm->sectionBreak());
+      mmr->setStaffTypeChange(m->staffTypeChange());
 
       ElementList oldList = mmr->takeElements();
       ElementList newList = lm->el();

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -888,6 +888,8 @@ void Measure::add(Element* e)
 
             case ElementType::STAFFTYPE_CHANGE:
                   {
+                  if (staffTypeChange())
+                        break;
                   StaffTypeChange* stc = toStaffTypeChange(e);
                   Staff* staff = stc->staff();
                   const StaffType* st = stc->staffType();
@@ -911,6 +913,7 @@ void Measure::add(Element* e)
                   staff->staffTypeListChanged(tick());
                   stc->setStaffType(nst);
                   MeasureBase::add(e);
+                  setStaffTypeChange(true);
                   }
                   break;
 
@@ -1007,6 +1010,7 @@ void Measure::remove(Element* e)
                         stc->setStaffType(st);
                         }
                   MeasureBase::remove(e);
+                  setStaffTypeChange(false);
                   }
                   break;
 
@@ -2913,7 +2917,8 @@ Measure* Measure::cloneMeasure(Score* sc, const Fraction& tick, TieMap* tieMap)
       m->setTick(tick);
       m->setLineBreak(lineBreak());
       m->setPageBreak(pageBreak());
-      m->setSectionBreak(sectionBreak() ? new LayoutBreak(*sectionBreakElement()) : 0);
+      m->setSectionBreak(sectionBreak());
+      m->setStaffTypeChange(staffTypeChange());
 
       m->setHeader(header()); m->setTrailer(trailer());
 

--- a/libmscore/measurebase.h
+++ b/libmscore/measurebase.h
@@ -168,6 +168,9 @@ class MeasureBase : public Element {
       bool noBreak() const             { return flag(ElementFlag::NO_BREAK);      }
       void setNoBreak(bool v)          { setFlag(ElementFlag::NO_BREAK, v);       }
 
+      bool staffTypeChange() const     { return flag(ElementFlag::STAFF_TYPE_CHANGE); }
+      void setStaffTypeChange(bool v)  { setFlag(ElementFlag::STAFF_TYPE_CHANGE, v);  }
+
       bool hasCourtesyKeySig() const   { return flag(ElementFlag::KEYSIG);        }
       void setHasCourtesyKeySig(int v) { setFlag(ElementFlag::KEYSIG, v);         }
 


### PR DESCRIPTION
This automatically fixes issues (discovered and potential) like https://musescore.org/node/301848.