### PR TITLE
[MU4] fix #301768: Unexpected tieing behaviour

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1243,7 +1243,10 @@ void Score::cmdAddTie(bool addToChord)
       for (Note* note : noteList) {
             if (note->tieFor()) {
                   qDebug("cmdAddTie: note %p has already tie? noteFor: %p", note, note->tieFor());
-                  continue;
+                  if (addToChord)
+                        continue;
+                  else
+                        undoRemoveElement(note->tieFor());
                   }
 
             if (noteEntryMode()) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/301768.

The `cmdAddTie()` function currently skips over notes that already have an existing tie. This is fine when handling the "chord-tie" command, for which `addToChord` is `true`. But when `addToChord` is `false`, as is the case for the regular "tie" command, what we really want to do is remove the existing tie, and then treat the note as if it never had a tie in the first place. 