### PR TITLE
fix #298108 : Sporadic Crash when dragging a Brace from palette to score using Bravura

### DIFF
--- a/libmscore/bracket.cpp
+++ b/libmscore/bracket.cpp
@@ -34,6 +34,7 @@ Bracket::Bracket(Score* s)
       _firstStaff  = 0;
       _lastStaff   = 0;
       _bi          = 0;
+      _braceSymbol = SymId::noSym;
       setGenerated(true);     // brackets are not saved
       }
 
@@ -152,6 +153,8 @@ void Bracket::layout()
                         _shape.add(bbox());
                         }
                   else {
+                        if (_braceSymbol == SymId::noSym)
+                              _braceSymbol = SymId::brace;
                         qreal h = h2 * 2;
                         qreal w = symWidth(_braceSymbol) * _magx;
                         bbox().setRect(0, 0, w, h);


### PR DESCRIPTION
…ore using Bravura

Resolves: https://musescore.org/en/node/298108

The problem was due to the use of an uninitialized _braceSymbol, but only if the font symbol was not Emmentaler nor Gonville.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
