### PR TITLE
Fix #301929: No reminder to save, if you quit program before entering anything in a new score

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -355,18 +355,16 @@ void MuseScore::closeEvent(QCloseEvent* ev)
       unloadPlugins();
       QList<MasterScore*> removeList;
       for (MasterScore* score : scoreList) {
-            if (score->created() && !score->dirty())
+            if (!score->created() && !score->dirty())
                   removeList.append(score);
             else {
                   if (checkDirty(score)) {      // ask user if file is dirty
                         ev->ignore();
                         return;
                         }
-                  //
-                  // if score is still dirty, then the user has discarded the
-                  // score and we can remove it from the list
-                  //
-                  if (score->created() && score->dirty())
+                  // If the score has never been saved or is still dirty (or both), the user has discarded the score and we can remove it from the list.
+                  // Note that it's necessary to consider either flag in case we're dealing with a newly created score that hasn't been edited at all.
+                  if (score->created() || score->dirty())
                         removeList.append(score);
                   }
             }


### PR DESCRIPTION
Resolves: [#301929](https://musescore.org/en/node/301929)

Fixed a problem that caused MuseScore to fail to prompt the user to save any newly created scores when exiting the app if they hadn't been edited at all.

Note that this problem occurred only when exiting the app, and not when closing an individual score.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
