### PR TITLE
fix #290034: play repeats button not respected  in new score

### DIFF
--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -1230,7 +1230,7 @@ class MasterScore : public Score {
       TimeSigMap* _sigmap;
       TempoMap* _tempomap;
       RepeatList* _repeatList;
-      bool _expandRepeats     { true };
+      bool _expandRepeats     { MScore::playRepeats };
       bool _playlistDirty     { true };
       QList<Excerpt*> _excerpts;
       std::vector<PartChannelSettingsLink> _playbackSettingsLinks;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/290034

The issue was caused because the `_expandRepeats` property in `MasterScore` was initialised to true by default, and it was changed whenever the button was clicked. The current value of the button was not taken into account while initialising. This is fixed by reading the property from `MScore::playRepeats` which contains the correct value read from `PREF_APP_PLAYBACK_PLAYREPEATS` when MuseScore starts up.