### PR TITLE
fix #153656: Added advanced preference key io/midi/pedalEventsMinTicks for tweaking the amount of ticks between a pedal off event and a pedal on event

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -79,6 +79,7 @@
 #define PREF_IO_MIDI_ENABLEINPUT                            "io/midi/enableInput"
 #define PREF_IO_MIDI_EXPANDREPEATS                          "io/midi/expandRepeats"
 #define PREF_IO_MIDI_EXPORTRPNS                             "io/midi/exportRPNs"
+#define PREF_IO_MIDI_PEDAL_EVENTS_MIN_TICKS                 "io/midi/pedalEventsMinTicks"
 #define PREF_IO_MIDI_REALTIMEDELAY                          "io/midi/realtimeDelay"
 #define PREF_IO_MIDI_REMOTE                                 "io/midi/remote"
 #define PREF_IO_MIDI_SHORTESTNOTE                           "io/midi/shortestNote"

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -94,6 +94,7 @@ QColor  MScore::frameMarginColor;
 QColor  MScore::bgColor;
 QColor  MScore::dropColor;
 bool    MScore::warnPitchRange;
+int     MScore::pedalEventsMinTicks;
 
 bool    MScore::playRepeats;
 bool    MScore::panPlayback;
@@ -306,6 +307,7 @@ void MScore::init()
       dropColor           = QColor("#1778db");
       defaultPlayDuration = 300;      // ms
       warnPitchRange      = true;
+      pedalEventsMinTicks = 1;
       playRepeats         = true;
       panPlayback         = true;
 

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -331,6 +331,7 @@ class MScore {
       static QColor frameMarginColor;
       static QColor bgColor;
       static bool warnPitchRange;
+      static int pedalEventsMinTicks;
 
       static bool playRepeats;
       static bool panPlayback;

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -887,13 +887,13 @@ void MidiRenderer::renderSpanners(const Chunk& chunk, EventMap* events)
                         // Handle "overlapping" pedal segments (usual case for connected pedal line)
                         if (lastEvent.second.first == false && lastEvent.first >= (st + tickOffset + 2)) {
                               channelPedalEvents.at(channel).pop_back();
-                              channelPedalEvents.at(channel).push_back(std::pair<int, std::pair<bool, int>>(st + tickOffset + 1, std::pair<bool, int>(false, staff)));
+                              channelPedalEvents.at(channel).push_back(std::pair<int, std::pair<bool, int>>(st + tickOffset + (2 - MScore::pedalEventsMinTicks), std::pair<bool, int>(false, staff)));
                               }
                         int a = st + tickOffset + 2;
                         channelPedalEvents.at(channel).push_back(std::pair<int, std::pair<bool, int>>(a, std::pair<bool, int>(true, staff)));
                         }
                   if (s->tick2().ticks() >= tick1 && s->tick2().ticks() <= tick2) {
-                        int t = s->tick2().ticks() + tickOffset + 1;
+                        int t = s->tick2().ticks() + tickOffset + (2 - MScore::pedalEventsMinTicks);
                         const RepeatSegment& lastRepeat = *score->repeatList().back();
                         if (t > lastRepeat.utick + lastRepeat.len())
                               t = lastRepeat.utick + lastRepeat.len();

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -406,6 +406,7 @@ void updateExternalValuesFromPreferences() {
       MScore::panPlayback = preferences.getBool(PREF_APP_PLAYBACK_PANPLAYBACK);
       MScore::playRepeats = preferences.getBool(PREF_APP_PLAYBACK_PLAYREPEATS);
       MScore::warnPitchRange = preferences.getBool(PREF_SCORE_NOTE_WARNPITCHRANGE);
+      MScore::pedalEventsMinTicks = preferences.getInt(PREF_IO_MIDI_PEDAL_EVENTS_MIN_TICKS);
       MScore::layoutBreakColor = preferences.getColor(PREF_UI_SCORE_LAYOUTBREAKCOLOR);
       MScore::frameMarginColor = preferences.getColor(PREF_UI_SCORE_FRAMEMARGINCOLOR);
       MScore::setVerticalOrientation(preferences.getBool(PREF_UI_CANVAS_SCROLL_VERTICALORIENTATION));

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -127,6 +127,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_IO_MIDI_ENABLEINPUT,                             new BoolPreference(true, false)},
             {PREF_IO_MIDI_EXPANDREPEATS,                           new BoolPreference(true, false)},
             {PREF_IO_MIDI_EXPORTRPNS,                              new BoolPreference(false, false)},
+            {PREF_IO_MIDI_PEDAL_EVENTS_MIN_TICKS,                  new IntPreference(1)},
             {PREF_IO_MIDI_REALTIMEDELAY,                           new IntPreference(750 /* ms */, false)},
             {PREF_IO_MIDI_SHORTESTNOTE,                            new IntPreference(MScore::division/4, false)},
             {PREF_IO_MIDI_SHOWCONTROLSINMIXER,                     new BoolPreference(false, false)},


### PR DESCRIPTION
This preference key represents the minimal amount of ticks that can occur between a pedal off event and a pedal on event. Currently, its default value is 1, thus there is no difference with the previous implementation. When increasing its value, the pedal off event will be moving backwards by the specified amount of ticks (i.e. it will happen earlier), so that the distance with the next pedal on (if any) event will grow.

Resolves: https://musescore.org/en/node/153656

I have been able to reproduce that issue with a hardware synth (stage piano Roland RD-700NX) and software synth (Pianoteq 6 Demo). With a piano sound staff, it can be quite subtle or quite annoying, depending on the score. But with a "sustain-forever" sound, like an organ, it can be harmful.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
