### PR TITLE
fix #302011: Grace note tie crash

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1254,6 +1254,7 @@ void Score::cmdAddTie(bool addToChord)
                   if (c->isGraceBefore()) {
                         // tie grace note before to main note
                         cr = toChord(c->parent());
+                        addToChord = true;
                         }
                   else {
                         _is.setSegment(note->chord()->segment());


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/302011.

When creating a tie from a grace note to its main note, make sure not to overwrite the main note's chord, thus destroying the grace note and creating a tie from a note to itself.