### PR TITLE
fix #281601 and fix #284218 [workaround]: broken on-screen rendering …

### DIFF
--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -529,20 +529,16 @@ void TextFragment::draw(QPainter* p, const TextBase* t) const
             // in Qt 5.12.x this workaround should be no more necessary if
             // env variable QT_MAX_CACHED_GLYPH_SIZE is set to 1
             p->save();
-            qreal deviceLogicalDpi = (p->device()->logicalDpiX() + p->device()->logicalDpiY()) / 2.0;
-            QScreen* screen = QGuiApplication::primaryScreen();
-            qreal screenDpi = screen->logicalDotsPerInch();
             qreal dx = p->worldTransform().dx();
             qreal dy = p->worldTransform().dy();
             // diagonal elements will now be changed to 1.0
             p->setMatrix(QMatrix(1.0, 0.0, 0.0, 1.0, dx, dy));
             // correction factor for bold text drawing, due to the change of the diagonal elements
             qreal factor = 1.0 / mm;
-            QFont fold(f);
-            f.setPointSizeF(f.pointSizeF() / factor * deviceLogicalDpi / screenDpi);
-            QRawFont fRaw = QRawFont::fromFont(f);
-            QTextLayout textLayout(text);
-            textLayout.setFont(fold);
+            QFont fnew(f, p->device());
+            fnew.setPointSizeF(f.pointSizeF() / factor);
+            QRawFont fRaw = QRawFont::fromFont(fnew);
+            QTextLayout textLayout(text, f, p->device());
             textLayout.beginLayout();
             while (true) {
                   QTextLine line = textLayout.createLine();
@@ -556,7 +552,7 @@ void TextFragment::draw(QPainter* p, const TextBase* t) const
             qreal offset = 0;
             // glyphrun drawing has an offset equal to the max ascent of the text fragment
             for (int i = 0; i < glyphruns.length(); i++) {
-                  qreal value = glyphruns.at(i).rawFont().ascent() / factor * deviceLogicalDpi / screenDpi;
+                  qreal value = glyphruns.at(i).rawFont().ascent() / factor;
                   if (value > offset)
                         offset = value;
                   }
@@ -565,15 +561,15 @@ void TextFragment::draw(QPainter* p, const TextBase* t) const
                   QVector<QPointF> positions2;
                   // calculate the new positions for the scaled geometry
                   for (int j = 0; j < positions1.length(); j++) {
-                        QPointF punto = positions1.at(j) / factor * deviceLogicalDpi / screenDpi;
-                        positions2.append(punto);
+                        QPointF newPoint = positions1.at(j) / factor;
+                        positions2.append(newPoint);
                         }
                   QGlyphRun glyphrun2 = glyphruns.at(i);
                   glyphrun2.setPositions(positions2);
                   // change the glyphs with the correct glyphs
                   // and account for glyph substitution
-                  if (glyphrun2.rawFont().familyName() != f.family()) {
-                        QFont f2(f);
+                  if (glyphrun2.rawFont().familyName() != fnew.family()) {
+                        QFont f2(fnew);
                         f2.setFamily(glyphrun2.rawFont().familyName());
                         glyphrun2.setRawFont(QRawFont::fromFont(f2));
                         }

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -519,8 +519,81 @@ void TextFragment::draw(QPainter* p, const TextBase* t) const
       {
       QFont f(font(t));
       f.setPointSizeF(f.pointSizeF() * MScore::pixelRatio);
+#ifndef Q_OS_MACOS
+      qreal mm = p->worldTransform().m11();
+      if (!(MScore::pdfPrinting) && (mm < 1.0) && f.bold()) {
+            // workaround for https://musescore.org/en/node/284218
+            // and https://musescore.org/en/node/281601
+            // only needed for certain artificially emboldened fonts
+            // see https://musescore.org/en/node/281601#comment-900261
+            // in Qt 5.12.x this workaround should be no more necessary if
+            // env variable QT_MAX_CACHED_GLYPH_SIZE is set to 1
+            p->save();
+            qreal deviceLogicalDpi = (p->device()->logicalDpiX() + p->device()->logicalDpiY()) / 2.0;
+            QScreen* screen = QGuiApplication::primaryScreen();
+            qreal screenDpi = screen->logicalDotsPerInch();
+            qreal dx = p->worldTransform().dx();
+            qreal dy = p->worldTransform().dy();
+            // diagonal elements will now be changed to 1.0
+            p->setMatrix(QMatrix(1.0, 0.0, 0.0, 1.0, dx, dy));
+            // correction factor for bold text drawing, due to the change of the diagonal elements
+            qreal factor = 1.0 / mm;
+            QFont fold(f);
+            f.setPointSizeF(f.pointSizeF() / factor * deviceLogicalDpi / screenDpi);
+            QRawFont fRaw = QRawFont::fromFont(f);
+            QTextLayout textLayout(text);
+            textLayout.setFont(fold);
+            textLayout.beginLayout();
+            while (true) {
+                  QTextLine line = textLayout.createLine();
+                  if (!line.isValid())
+                        break;
+                  }
+            textLayout.endLayout();
+            // glyphruns with correct positions, but potentially wrong glyphs
+            // (see bug https://musescore.org/en/node/117191 regarding positions and DPI)
+            QList<QGlyphRun> glyphruns = textLayout.glyphRuns();
+            qreal offset = 0;
+            // glyphrun drawing has an offset equal to the max ascent of the text fragment
+            for (int i = 0; i < glyphruns.length(); i++) {
+                  qreal value = glyphruns.at(i).rawFont().ascent() / factor * deviceLogicalDpi / screenDpi;
+                  if (value > offset)
+                        offset = value;
+                  }
+            for (int i = 0; i < glyphruns.length(); i++) {
+                  QVector<QPointF> positions1 = glyphruns.at(i).positions();
+                  QVector<QPointF> positions2;
+                  // calculate the new positions for the scaled geometry
+                  for (int j = 0; j < positions1.length(); j++) {
+                        QPointF punto = positions1.at(j) / factor * deviceLogicalDpi / screenDpi;
+                        positions2.append(punto);
+                        }
+                  QGlyphRun glyphrun2 = glyphruns.at(i);
+                  glyphrun2.setPositions(positions2);
+                  // change the glyphs with the correct glyphs
+                  // and account for glyph substitution
+                  if (glyphrun2.rawFont().familyName() != f.family()) {
+                        QFont f2(f);
+                        f2.setFamily(glyphrun2.rawFont().familyName());
+                        glyphrun2.setRawFont(QRawFont::fromFont(f2));
+                        }
+                  else
+                        glyphrun2.setRawFont(fRaw);
+                  p->drawGlyphRun(QPointF(pos.x() / factor, pos.y() / factor - offset),glyphrun2);
+                  positions2.clear();
+                  }
+            // Restore the QPainter to its former state
+            p->setMatrix(QMatrix(mm, 0.0, 0.0, mm, dx, dy));
+            p->restore();
+            }
+      else {
+            p->setFont(f);
+            p->drawText(pos, text);
+            }
+#else
       p->setFont(f);
       p->drawText(pos, text);
+#endif
       }
 
 //---------------------------------------------------------

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -130,7 +130,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_EXPORT_MP3_BITRATE,                              new IntPreference(128, false)},
             {PREF_EXPORT_MUSICXML_EXPORTBREAKS,                    new EnumPreference(QVariant::fromValue(MusicxmlExportBreaks::ALL), false)},
             {PREF_EXPORT_MUSICXML_EXPORTLAYOUT,                    new BoolPreference(true, false)},
-            {PREF_EXPORT_PDF_DPI,                                  new IntPreference(300, false)},
+            {PREF_EXPORT_PDF_DPI,                                  new IntPreference(DPI, false)},
             {PREF_EXPORT_PNG_RESOLUTION,                           new DoublePreference(DPI, false)},
             {PREF_EXPORT_PNG_USETRANSPARENCY,                      new BoolPreference(true, false)},
             {PREF_IMPORT_GUITARPRO_CHARSET,                        new StringPreference("UTF-8", false)},


### PR DESCRIPTION
…of synthetically emboldened fonts

Resolves: https://musescore.org/en/node/284218 and https://musescore.org/en/node/281601

See https://musescore.org/en/node/281601#comment-900261 for the explanation of the Qt bug involved.
This is a workaround.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
