### PR TITLE
Fix #301847 - Crash on copying a measure Number

### DIFF
--- a/libmscore/measurenumber.cpp
+++ b/libmscore/measurenumber.cpp
@@ -57,6 +57,11 @@ QVariant MeasureNumber::propertyDefault(Pid id) const
 
 void MeasureNumber::layout()
       {
+      // In some cases, e.g. Ctrl + Shift + drag, the parent is 0.
+      // To prevent a crash, make sure the parent exists and is a measure.
+      if (!measure())
+            return;
+
       setPos(QPointF());
       if (!parent())
             setOffset(0.0, 0.0);


### PR DESCRIPTION
Resolves: [#301847](https://musescore.org/en/node/301847)

When dragging a <code>MeasureNumber</code> using Ctrl+Shift the parent is not a <code>Measure</code> but is expected to be a <code>Measure</code> in <code>MeasureNumber::layout()</code>.
Solved by returning <code>MeasureNumber::layout()</code> if parent is not a <code>Measure</code>.

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
