### PR TITLE
Fix #297501 - Layout shift of slur after reload

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -2137,7 +2137,7 @@ bool MuseScore::savePdf(QList<Score*> cs_, const QString& saveName)
 #else
       printer.setOutputFormat(QPrinter::PdfFormat);
 #endif
-      
+
       printer.setCreator("MuseScore Version: " VERSION);
       if (!printer.setPageMargins(QMarginsF()))
             qDebug("unable to clear printer margins");
@@ -2350,6 +2350,7 @@ Score::FileError readScore(MasterScore* score, QString name, bool ignoreVersionE
             s->setPlaylistDirty();
             s->addLayoutFlags(LayoutFlag::FIX_PITCH_VELO);
             s->setLayoutAll();
+            s->doLayout();
             }
       score->updateChannel();
       score->updateExpressive(MuseScore::synthesizer("Fluid"));


### PR DESCRIPTION
Resolves: [#297501 - Layout shift of slur after reload](https://musescore.org/en/node/297501)

Root cause is a incomplete layout during the load of the file. Solved by adding a <code>doLayout()</code> for each score. As suggester by Marc Sabatella in the ticket.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
