### PR TITLE
Fix #302171: Preferences | Shortcuts should also search by keyboard shortcut

### DIFF
--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -711,11 +711,7 @@ void  PreferenceDialog::filterShortcutsTextChanged(const QString &query )
       QTreeWidgetItem *item;
       for(int i = 0; i < shortcutList->topLevelItemCount(); i++) {
           item = shortcutList->topLevelItem(i);
-
-          if(item->text(0).toLower().contains(query.toLower()))
-              item->setHidden(false);
-          else
-              item->setHidden(true);
+          item->setHidden(!(item->text(0).contains(query, Qt::CaseInsensitive) || item->text(1).contains(query, Qt::CaseInsensitive)));
           }
       }
 


### PR DESCRIPTION
Resolves: [#302171](https://musescore.org/en/node/302171)

Enhanced the *Search* box on the *Shortcuts* tab of the *Preferences* dialog to support searching for currently defined keyboard shortcuts in addition to action descriptions.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made