### PR TITLE
Add Measure Number element to palettes

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -98,7 +98,7 @@ void Score::getSelectedChordRest2(ChordRest** cr1, ChordRest** cr2) const
       {
       *cr1 = 0;
       *cr2 = 0;
-      foreach(Element* e, selection().elements()) {
+      for (Element* e : selection().elements()) {
             if (e->isNote())
                   e = e->parent();
             if (e->isChordRest()) {
@@ -1886,7 +1886,7 @@ void Score::deleteItem(Element* el)
                   if (m->isMMRest()) {
                         // propagate to original measure
                         m = m->mmRestLast();
-                        foreach(Element* e, m->el()) {
+                        for (Element* e : m->el()) {
                               if (e->isLayoutBreak()) {
                                     undoRemoveElement(e);
                                     break;
@@ -2740,7 +2740,7 @@ void Score::colorItem(Element* element)
       if (!c.isValid())
             return;
 
-      foreach(Element* e, selection().elements()) {
+      for (Element* e : selection().elements()) {
             if (e->color() != c) {
                   e->undoChangeProperty(Pid::COLOR, c);
                   e->setGenerated(false);
@@ -4302,6 +4302,9 @@ void Score::undoAddElement(Element* element)
                         ne->setParent(m);
                         undo(new AddElement(ne));
                         }
+                  else if (et == ElementType::MEASURE_NUMBER) {
+                        toMeasure(element->parent())->undoChangeProperty(Pid::MEASURE_NUMBER_MODE, static_cast<int>(MeasureNumberMode::SHOW));
+                        }
                   else {
                         Segment* segment  = toSegment(element->parent());
                         Fraction tick     = segment->tick();
@@ -4418,7 +4421,7 @@ void Score::undoAddElement(Element* element)
             return;
             }
 
-      foreach (Staff* staff, ostaff->staffList()) {
+      for (Staff* staff : ostaff->staffList()) {
             Score* score = staff->score();
             int staffIdx = staff->idx();
 

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1351,6 +1351,9 @@ bool Measure::acceptDrop(EditData& data) const
                         viewer->setDropRectangle(canvasBoundingRect());
                   return true;
 
+            case ElementType::MEASURE_NUMBER:
+                  viewer->setDropRectangle(canvasBoundingRect());
+                  return true;
             case ElementType::BRACKET:
             case ElementType::REPEAT_MEASURE:
             case ElementType::MEASURE:
@@ -1440,6 +1443,11 @@ Element* Measure::drop(EditData& data)
                   score()->undoAddElement(e);
                   return e;
 
+            case ElementType::MEASURE_NUMBER:
+                  undoChangeProperty(Pid::MEASURE_NUMBER_MODE, static_cast<int>(MeasureNumberMode::SHOW));
+                  delete e;
+                  break;
+
             case ElementType::BRACKET:
                   {
                   Bracket* b = toBracket(e);
@@ -1456,7 +1464,7 @@ Element* Measure::drop(EditData& data)
                   score()->undoAddBracket(staff, level, b->bracketType(), 1);
                   delete b;
                   }
-                  return 0;
+                  break;
 
             case ElementType::CLEF:
                   score()->undoChangeClef(staff, this, toClef(e)->clefType());
@@ -1483,7 +1491,7 @@ Element* Measure::drop(EditData& data)
 
             case ElementType::TIMESIG:
                   score()->cmdAddTimeSig(this, staffIdx, toTimeSig(e), data.modifiers & Qt::ControlModifier);
-                  return 0;
+                  break;
 
             case ElementType::LAYOUT_BREAK: {
                   LayoutBreak* b = toLayoutBreak(e);
@@ -1852,7 +1860,7 @@ void Measure::adjustToLen(Fraction nf, bool appendRestsIfNecessary)
             //
             //  CHECK: do not remove all slurs
             //
-            foreach (Element* e, m->el()) {
+            for (Element* e : m->el()) {
                   if (e->isSlur())
                         s->undoRemoveElement(e);
                   }
@@ -2990,7 +2998,7 @@ Measure* Measure::cloneMeasure(Score* sc, const Fraction& tick, TieMap* tieMap)
                   s->add(ne);
                   }
             }
-      foreach(Element* e, el()) {
+      for (Element* e : el()) {
             Element* ne = e->clone();
             ne->setScore(sc);
             ne->setOffset(e->offset());
@@ -4338,4 +4346,3 @@ void Measure::computeMinWidth()
       }
 
 }
-

--- a/libmscore/measurenumber.cpp
+++ b/libmscore/measurenumber.cpp
@@ -60,18 +60,21 @@ void MeasureNumber::layout()
       setPos(QPointF());
       if (!parent())
             setOffset(0.0, 0.0);
-      //else if (isStyled(Pid::OFFSET))
-      //      setOffset(propertyDefault(Pid::OFFSET).toPointF());
 
-      const StaffType* st = staff()->constStaffType(measure()->tick());
-      if (st->lines() == 1 && staff())
-            rypos() = (placeBelow() ? 2.0 : -2.0) * spatium();
-      else {
-            if (placeBelow())
-                  rypos() = staff() ? staff()->height() : 0.0;
+      Staff* stf = staff();
+      if (stf && measure()) {
+            const StaffType* st = stf->constStaffType(measure()->tick());
+            if (st->lines() == 1)
+                  rypos() = (placeBelow() ? 2.0 : -2.0) * spatium();
+            else {
+                  if (placeBelow())
+                        rypos() = stf->height();
+                  }
             }
+      else 
+            rypos() = 0.0;
       TextBase::layout1();
       }
 
-}
+} // namespace MS
 

--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -382,6 +382,7 @@ void ScoreView::dragMoveEvent(QDragMoveEvent* event)
             case ElementType::ARPEGGIO:
             case ElementType::BREATH:
             case ElementType::GLISSANDO:
+            case ElementType::MEASURE_NUMBER:
             case ElementType::BRACKET:
             case ElementType::ARTICULATION:
             case ElementType::FERMATA:
@@ -521,6 +522,7 @@ void ScoreView::dropEvent(QDropEvent* event)
                   case ElementType::ARPEGGIO:
                   case ElementType::BREATH:
                   case ElementType::GLISSANDO:
+                  case ElementType::MEASURE_NUMBER:
                   case ElementType::BRACKET:
                   case ElementType::ARTICULATION:
                   case ElementType::FERMATA:
@@ -562,7 +564,7 @@ void ScoreView::dropEvent(QDropEvent* event)
                               }
                         _score->addRefresh(el->canvasBoundingRect());
 
-                        // HACK ALERT!
+                        // TODO: HACK ALERT!
                         if (el->isMeasure() && editData.dropElement->isLayoutBreak()) {
                               Measure* m = toMeasure(el);
                               if (m->isMMRest())
@@ -692,5 +694,5 @@ bool ScoreView::dropCanvas(Element* e)
       return false;
       }
 
-}
+} // namespace Ms
 

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -83,6 +83,7 @@
 #include "libmscore/vibrato.h"
 #include "libmscore/palmmute.h"
 #include "libmscore/fermata.h"
+#include "libmscore/measurenumber.h"
 
 #include "palette/palettetree.h"
 #include "palette/palettewidget.h"
@@ -1602,6 +1603,15 @@ PalettePanel* MuseScore::newTextPalettePanel(bool defaultPalettePanel)
       stxt = new SystemText(gscore);
       stxt->setXmlText(QT_TRANSLATE_NOOP("Palette", "System Text"));
       sp->append(stxt, QT_TRANSLATE_NOOP("Palette", "System text"))->setElementTranslated(true);
+
+      // Measure numbers, unlike other elements (but like most text elements),
+      // are not copied directly into the score when drop.
+      // Instead, they simply set the corresponding measure's MeasureNumberMode to SHOW
+      // Because of that, the element shown in the palettes does not have to have any particular formatting.
+      MeasureNumber* meaNum = new MeasureNumber(gscore);
+      meaNum->setProperty(Pid::SUB_STYLE, int(Tid::STAFF)); // Make the element bigger in the palettes (using the default measure number style makes it too small)
+      meaNum->setXmlText(QT_TRANSLATE_NOOP("Palette", "Measure Number"));
+      sp->append(meaNum, QT_TRANSLATE_NOOP("Palette", "Measure Number"))->setElementTranslated(true);
 
       if (!defaultPalettePanel) {
             StaffText* pz = new StaffText(gscore);


### PR DESCRIPTION
This is the first part of the [Bar Number redesign](https://musescore.org/en/node/301867).
You can now drag and drop Bar Numbers into the score from the palettes.

Some have had concerns about having the bar number element in the palettes, as the current way of modifying whether or not to show bar numbers on a specific measure is via the Measure Properties dialog. This is considered the *correct* way of modifying how and when bar numbers show up. However, as most users are getting used to the palettes, I believe it would be more user-friendly to have the element in the palettes too.
Also, having the possibility to add measure numbers from the palettes may lure users into thinking that this is the correct way to add measure numbers, while in fact it should be done via style->Bar Numbers.

