### PR TITLE
Make measure numbers deletable

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1622,7 +1622,7 @@ void Score::deleteItem(Element* el)
       if (!el)
             return;
       // cannot remove generated elements
-      if (el->generated() && !(el->isBracket() || el->isBarLine() || el->isClef()))
+      if (el->generated() && !(el->isBracket() || el->isBarLine() || el->isClef() || el->isMeasureNumber()))
             return;
 //      qDebug("%s", el->name());
 
@@ -1925,6 +1925,29 @@ void Score::deleteItem(Element* el)
                   }
                   break;
 
+            case ElementType::MEASURE_NUMBER:
+                  {
+                  Measure* mea = toMeasure(el->parent());
+                  switch (mea->measureNumberMode()) {
+                        // If the user tries to remove an automatically generated measure number,
+                        // we should force the measure not to show any measure number
+                        case MeasureNumberMode::AUTO:
+                              mea->undoChangeProperty(Pid::MEASURE_NUMBER_MODE, static_cast<int>(MeasureNumberMode::HIDE));
+                              break;
+
+                        // If the user tries to remove a measure number that he added manually,
+                        // then we should set the MeasureNumberMode to AUTO only if will not show if set to auto.
+                        // If after setting the MeasureNumberMode to AUTO, the measure number still shows,
+                        // We need to force the measure to hide its measure number.
+                        case MeasureNumberMode::SHOW:
+                              if (mea->showsMeasureNumberInAutoMode())
+                                    mea->undoChangeProperty(Pid::MEASURE_NUMBER_MODE, static_cast<int>(MeasureNumberMode::HIDE));
+                              else
+                                    mea->undoChangeProperty(Pid::MEASURE_NUMBER_MODE, static_cast<int>(MeasureNumberMode::AUTO));
+                              break;
+                        }
+                  }
+                  break;
             case ElementType::REHEARSAL_MARK:
             case ElementType::TEMPO_TEXT:
                   {

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -469,30 +469,69 @@ qreal Measure::tick2pos(Fraction tck) const
       }
 
 //---------------------------------------------------------
+//   showsMeasureNumberInAutoMode
+///    Wheter the measure will show measure number(s) when MeasureNumberMode is set to AUTO
+//---------------------------------------------------------
+
+bool Measure::showsMeasureNumberInAutoMode()
+      {
+      // Check wheter any measure number should be shown
+      if (!score()->styleB(Sid::showMeasureNumber))
+            return false;
+
+      // Measure numbers should not be shown on irregular measures.
+      if (irregular())
+            return false;
+
+      // Measure numbers should not show on first measure unless specified with Sid::showMeasureNumberOne
+      if (!no())
+            return score()->styleB(Sid::showMeasureNumberOne);
+
+      if (score()->styleB(Sid::measureNumberSystem))
+            // Show either if
+            //   1) This is the first measure of the system OR
+            //   2) The previous measure in the system is the first, and is irregular.
+            return (system()->firstMeasure() == this)
+                        || (prevMeasure() && prevMeasure()->irregular() && system()->firstMeasure() == prevMeasure());
+      else {
+            // In the case of an interval, we should show the measure number either if:
+            //   1) We should show them every measure
+            int interval = score()->styleI(Sid::measureNumberInterval);
+            if (interval == 1)
+                  return true;
+
+            //   2) (measureNumber + 1) % interval == 0 (or 1 if measure number one is numbered.)
+            // If measure number 1 is numbered, and the interval is let's say 5, then we should number #1, 6, 11, 16, etc.
+            // If measure number 1 is not numbered, with the same interval (5), then we should number #5, 10, 15, 20, etc.
+            return (((no() + 1) % score()->styleI(Sid::measureNumberInterval)) == (score()->styleB(Sid::showMeasureNumberOne) ? 1 : 0));
+            }
+      }
+
+//---------------------------------------------------------
+//   showsMeasureNumber
+///     Wheter the Measure shows a MeasureNumber
+//---------------------------------------------------------
+
+bool Measure::showsMeasureNumber()
+      {
+      if (_noMode == MeasureNumberMode::SHOW)
+            return true;
+      else if (_noMode == MeasureNumberMode::HIDE)
+            return false;
+      else {
+            return showsMeasureNumberInAutoMode();
+            }
+      }
+
+//---------------------------------------------------------
 //   layoutMeasureNumber
+///    Layouts the Measure Numbers according to the Measure's MeasureNumberMode
 //---------------------------------------------------------
 
 void Measure::layoutMeasureNumber()
       {
-      bool smn = false;
+      bool smn = showsMeasureNumber();
 
-      if (_noMode == MeasureNumberMode::SHOW)
-            smn = true;
-      else if (_noMode == MeasureNumberMode::HIDE)
-            smn = false;
-      else {
-            if (score()->styleB(Sid::showMeasureNumber)
-               && !irregular()
-               && (no() || score()->styleB(Sid::showMeasureNumberOne))) {
-                  if (score()->styleB(Sid::measureNumberSystem))
-                        smn = (system()->firstMeasure() == this) || (prevMeasure() && prevMeasure()->irregular() && system()->firstMeasure() == prevMeasure());
-                  else {
-                        smn = (no() == 0 && score()->styleB(Sid::showMeasureNumberOne)) ||
-                              ( ((no() + 1) % score()->styleI(Sid::measureNumberInterval)) == (score()->styleB(Sid::showMeasureNumberOne) ? 1 : 0) ) ||
-                              (score()->styleI(Sid::measureNumberInterval) == 1);
-                        }
-                  }
-            }
       QString s;
       if (smn)
             s = QString("%1").arg(no() + 1);

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -155,6 +155,9 @@ class Measure final : public MeasureBase {
       void stretchMeasure(qreal stretch);
       Fraction computeTicks();
       void layout2();
+
+      bool showsMeasureNumber();
+      bool showsMeasureNumberInAutoMode();
       void layoutMeasureNumber();
 
       Chord* findChord(Fraction tick, int track);


### PR DESCRIPTION
This is the second part of the [Bar Number redesign](https://musescore.org/en/node/301867).

Measure numbers can now be deleted like other elements.
