### PR TITLE
[MU4] fix #302104: slur and grace note (acciaccatura) fails

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1324,8 +1324,11 @@ bool ChordRest::isBefore(const ChordRest* o) const
             bool oGrace      = o->isGrace();
             bool grace       = isGrace();
             // normal note are initialized at graceIndex 0 and graceIndex is 0 based
-            int oGraceIndex  = oGrace ? toChord(o)->graceIndex() +  1 : 0;
-            int graceIndex   = grace ? toChord(this)->graceIndex() + 1 : 0;
+            int oGraceIndex  = toChord(o)->graceIndex();
+            int graceIndex   = toChord(this)->graceIndex();
+            // Smaller indexes are further away from the note, and larger indexes are closer to the note.
+            // We want to reverse that. Subtracting a 0-based index from the size results in a 1-based index,
+            // which is exactly what we want.
             if (oGrace)
                   oGraceIndex = toChord(o->parent())->graceNotes().size() - oGraceIndex;
             if (grace)

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -549,7 +549,7 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
                   LayoutBreak* breakElement = toLayoutBreak(element);
                   score->cmdToggleLayoutBreak(breakElement->layoutBreakType());
                   }
-            else if (element->isSlur() && addSingle) {
+            else if (element->isSlur()) {
                   viewer->cmdAddSlur(toSlur(element));
                   }
             else if (element->isSLine() && !element->isGlissando() && addSingle) {

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3590,9 +3590,9 @@ void ScoreView::cmdAddSlur(const Slur* slurTemplate)
                         if (!e->isChord())
                               continue;
                         ChordRest* cr = toChordRest(e);
-                        if (!cr1 || cr1->tick() > cr->tick())
+                        if (!cr1 || cr->isBefore(cr1))
                               cr1 = cr;
-                        if (!cr2 || cr2->tick() < cr->tick())
+                        if (!cr2 || cr2->isBefore(cr))
                               cr2 = cr;
                         }
                   if (cr1 && (cr1 != cr2))
@@ -3658,7 +3658,7 @@ void ScoreView::addSlur(ChordRest* cr1, ChordRest* cr2, const Slur* slurTemplate
             _score->inputState().setSlur(slur);
             ss->setSelected(true);
             }
-      else if (switchToSlur) {
+      else if (switchToSlur && score()->selection().isSingle()) {
             startEditMode(ss);
             }
       }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/302104.

This commit does the following:
- Allows a slur to be added from a grace note to its main note if a range selection is used.
- Changes the behavior of applying the Slur palette element to a list selection of more than two notes so that it is consistent with how the "S" keyboard shortcut already behaves.
- Does not start edit mode for a newly created slur if the selection contains more than one element.
- Fixes a mathematical error in ChordRest::isBefore() that can cause a slur to be added with an incorrect span if grace notes are involved.
