### PR TITLE
fix #302282: Note entry does not begin on first chord or rest in selected range

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2775,7 +2775,7 @@ void ScoreView::startNoteEntry()
                   }
             }
 
-      Element* el = _score->selection().activeCR() ? _score->selection().activeCR() : _score->selection().element();
+      Element* el = _score->selection().element();
       if (!el)
             el = _score->selection().firstChordRest();
       if (el == 0 || (el->type() != ElementType::CHORD && el->type() != ElementType::REST && el->type() != ElementType::NOTE)) {

--- a/mtest/testscript/scripts/#173381-mmrest-copy.script
+++ b/mtest/testscript/scripts/#173381-mmrest-copy.script
@@ -14,9 +14,10 @@ cmd escape
 cmd select-next-chord
 cmd copy
 cmd note-input
-cmd next-chord
-cmd next-chord
 cmd escape
+cmd next-chord
+cmd next-chord
+cmd next-chord
 cmd next-chord
 cmd paste
 test score #173381-mmrest-copy.mscx


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/302282.

When beginning note entry on a range selection, ignore the selection's active ChordRest and just begin on the first ChordRest in the selection.