### PR TITLE
[MU4] fix #12815: new feature, ability to change the color of instrument names individually

### DIFF
--- a/libmscore/instrument.cpp
+++ b/libmscore/instrument.cpp
@@ -101,6 +101,7 @@ Instrument::Instrument()
       _useDrumset  = false;
       _drumset     = 0;
       _singleNoteDynamics = true;
+      _nameColor = MScore::defaultColor;
       }
 
 Instrument::Instrument(const Instrument& i)
@@ -125,6 +126,7 @@ Instrument::Instrument(const Instrument& i)
       for (Channel* c : i._channel)
             _channel.append(new Channel(*c));
       _clefType     = i._clefType;
+      _nameColor    = i._nameColor;
       }
 
 void Instrument::operator=(const Instrument& i)
@@ -153,6 +155,7 @@ void Instrument::operator=(const Instrument& i)
       for (Channel* c : i._channel)
             _channel.append(new Channel(*c));
       _clefType     = i._clefType;
+      _nameColor    = i._nameColor;
       }
 
 //---------------------------------------------------------
@@ -213,6 +216,7 @@ void Instrument::write(XmlWriter& xml, const Part* part) const
       _shortNames.write(xml, "shortName");
 //      if (!_trackName.empty())
             xml.tag("trackName", _trackName);
+      xml.tag("nameColor", _nameColor, MScore::defaultColor);
       if (_minPitchP > 0)
             xml.tag("minPitchP", _minPitchP);
       if (_maxPitchP < 127)
@@ -316,6 +320,8 @@ bool Instrument::readProperties(XmlReader& e, Part* part, bool* customDrumset)
             name.read(e);
             _shortNames.append(name);
             }
+      else if (tag == "nameColor")
+            _nameColor = e.readColor();
       else if (tag == "trackName")
             _trackName = e.readElementText();
       else if (tag == "minPitch") {      // obsolete
@@ -1193,7 +1199,8 @@ bool Instrument::operator==(const Instrument& i) const
          &&  i._transpose.chromatic == _transpose.chromatic
          &&  i._trackName == _trackName
          &&  *i.stringData() == *stringData()
-         &&  i._singleNoteDynamics == _singleNoteDynamics;
+         &&  i._singleNoteDynamics == _singleNoteDynamics
+         &&  i._nameColor == _nameColor;
       }
 
 //---------------------------------------------------------

--- a/libmscore/instrument.h
+++ b/libmscore/instrument.h
@@ -251,6 +251,7 @@ class Instrument {
       StaffNameList _longNames;
       StaffNameList _shortNames;
       QString _trackName;
+      QColor _nameColor;
 
       char _minPitchA, _maxPitchA, _minPitchP, _maxPitchP;
       Interval _transpose;
@@ -345,6 +346,8 @@ class Instrument {
       void setSingleNoteDynamicsFromTemplate();
       bool getSingleNoteDynamicsFromTemplate() const;
       void switchExpressive(MasterScore* score, Synthesizer* synth, bool expressive, bool force = false);
+      QColor getNameColor() const                     { return _nameColor; }
+      void setNameColor(const QColor &nameColor)      { _nameColor = nameColor; }
       };
 
 //---------------------------------------------------------

--- a/libmscore/part.h
+++ b/libmscore/part.h
@@ -78,6 +78,7 @@ class Part final : public ScoreElement {
       QString instrumentName(const Fraction& tick = { -1, 1 } ) const;
       QString instrumentId(const Fraction& tick = { -1, 1 } ) const;
 
+      const QColor namesColor(const  Fraction& tick = { -1, 1 }) const { return instrument(tick)->getNameColor(); }
       const QList<StaffName>& longNames(const  Fraction& tick = { -1, 1 } ) const { return instrument(tick)->longNames();  }
       const QList<StaffName>& shortNames(const Fraction& tick = { -1, 1 } ) const { return instrument(tick)->shortNames(); }
 

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -785,7 +785,8 @@ void System::setInstrumentNames(bool longName, Fraction tick)
                         iname->setTrack(staffIdx * VOICES);
                         iname->setInstrumentNameType(longName ? InstrumentNameType::LONG : InstrumentNameType::SHORT);
                         iname->setLayoutPos(sn.pos());
-                        score()->addElement(iname);
+                        iname->setColor(part->namesColor(tick));
+                        score()->addElement(iname); // Add the instrument name to the score.
                         }
                   iname->setXmlText(sn.name());
                   ++idx;

--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -192,6 +192,7 @@ void EditStaff::updateInstrument()
       maxPitchA->setText(midiCodeToStr(_maxPitchA));
       minPitchP->setText(midiCodeToStr(_minPitchP));
       maxPitchP->setText(midiCodeToStr(_maxPitchP));
+      color_2->setColor(instrument.getNameColor());
       singleNoteDynamics->setChecked(instrument.singleNoteDynamics());
 
       // only show string data controls if instrument has strings
@@ -337,6 +338,7 @@ void EditStaff::apply()
 
       instrument.setShortName(sn);
       instrument.setLongName(ln);
+      instrument.setNameColor(color_2->color());
 
       instrument.setSingleNoteDynamics(singleNoteDynamics->isChecked());
 

--- a/mscore/editstaff.ui
+++ b/mscore/editstaff.ui
@@ -361,17 +361,35 @@
          </layout>
         </item>
         <item row="3" column="0">
-         <widget class="QLabel" name="label_PartName">
-          <property name="text">
-           <string>Part name:</string>
-          </property>
-          <property name="buddy">
-           <cstring>partName</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QLineEdit" name="partName"/>
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
+          <item>
+           <widget class="QLabel" name="label_PartName">
+            <property name="text">
+             <string>Part name:</string>
+            </property>
+            <property name="buddy">
+             <cstring>partName</cstring>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="partName"/>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_InstrumentNameColor">
+            <property name="text">
+             <string>Instrument Name Color:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="Awl::ColorLabel" name="color_2">
+            <property name="focusPolicy">
+             <enum>Qt::TabFocus</enum>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </item>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/12815

Added a color field for the class InstrumentName and the corresponding UI in Editstaff to be able to change the color of the names of the instruments.

![Screenshot from 2020-04-14 01-02-11](https://user-images.githubusercontent.com/21060365/79165424-c7237e00-7deb-11ea-864f-d99a0e47ec54.png)
![Screenshot from 2020-04-14 01-02-24](https://user-images.githubusercontent.com/21060365/79165428-c8ed4180-7deb-11ea-9674-bd2a058eebd6.png)


- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
