### PR TITLE
emit failure signal if the vtests are changed (only for PRs)

### DIFF
--- a/.github/workflows/vtests.yml
+++ b/.github/workflows/vtests.yml
@@ -103,13 +103,13 @@ jobs:
       with:
         message: 'This is an automatic message. This PR appears to change some of the visual tests.
           Please carefully review the new visual test results in the uploaded artifact that can be found
-          [here](https://github.com/musescore/MuseScore/actions/runs/${{ github.run_id }})'
+          [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})'
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Emit failure signal for PR if differences are found
       if: github.event_name == 'pull_request' && contains( env.found, '1') && contains( env.VTEST_DIFF_FOUND, 'true')
       run: |
         echo "This PR appears to change some of the visual tests."
-        echo "Please carefully review the new visual test results in the uploaded artifact that can be found here: https://github.com/musescore/MuseScore/actions/runs/${{ github.run_id }}"
+        echo "Please carefully review the new visual test results in the uploaded artifact that can be found here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         exit 1
     - name: Comment push commit
       if: github.event_name == 'push' && contains( env.found, '1') && contains( env.VTEST_DIFF_FOUND, 'true')
@@ -120,5 +120,5 @@ jobs:
           Please carefully review the new visual test results in the uploaded artifact that can be found
           [here][1]
           
-          [1]: https://github.com/musescore/MuseScore/actions/runs/${{ github.run_id }}
+          [1]: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vtests.yml
+++ b/.github/workflows/vtests.yml
@@ -104,6 +104,12 @@ jobs:
           Please carefully review the new visual test results in the uploaded artifact that can be found
           [here](https://github.com/musescore/MuseScore/actions/runs/${{ github.run_id }})'
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Emit failure signal for PR if differences are found
+      if: github.event_name == 'pull_request' && contains( env.found, '1') && contains( env.VTEST_DIFF_FOUND, 'true')
+      run: |
+        echo "This PR appears to change some of the visual tests."
+        echo "Please carefully review the new visual test results in the uploaded artifact that can be found here: https://github.com/musescore/MuseScore/actions/runs/${{ github.run_id }}"
+        exit 1
     - name: Comment push commit
       if: github.event_name == 'push' && contains( env.found, '1') && contains( env.VTEST_DIFF_FOUND, 'true')
       uses: peter-evans/commit-comment@v1.1.0

--- a/.github/workflows/vtests.yml
+++ b/.github/workflows/vtests.yml
@@ -53,6 +53,7 @@ jobs:
         echo "::set-env name=PATH::${PATH}"
         echo "::set-env name=QT_PLUGIN_PATH::${QT_PLUGIN_PATH}"
         echo "::set-env name=QML2_IMPORT_PATH::${QML2_IMPORT_PATH}"
+        git checkout -- build/travis/job1_Tests/environment.sh
     - name: Build
       if: contains( env.found, '1')
       run: |

--- a/.github/workflows/vtests.yml
+++ b/.github/workflows/vtests.yml
@@ -45,6 +45,7 @@ jobs:
         sudo apt-get install libasound2-dev portaudio19-dev libmp3lame-dev libsndfile1-dev libportmidi-dev
         sudo apt-get install libssl-dev libpulse-dev libfreetype6-dev libfreetype6
         sudo apt-get install libdrm-dev libgl1-mesa-dev libegl1-mesa-dev
+        sudo apt-get install ccache
     - name: Setup the environment
       if: contains( env.found, '1')
       run: |


### PR DESCRIPTION
So that there is an early feedback to the PR author.
This failure signal is emitted _only_ in the case of a PR

Additional correction: after setting the environment, revert environment.sh to original state before git checkout to base branch (to avoid conflict when switching to base branch if the PR or the push is changing that file).

Additional correction: use the current Github repository for the link in the warning message.

Additional correction: added missing ccache package (for CI compilation)

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [N/A] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
