### PR TITLE
fix #302304: prevent potential crash when adding instruments

### DIFF
--- a/libmscore/midimapping.cpp
+++ b/libmscore/midimapping.cpp
@@ -143,7 +143,7 @@ void MasterScore::rebuildExcerptsMidiMapping()
             for (Part* p : ex->partScore()->parts()) {
                   const Part* masterPart = p->masterPart();
                   if (!masterPart->score()->isMaster()) {
-                        qWarning("reorderMidiMapping: no part in master score is linked");
+                        qWarning() << "rebuildExcerptsMidiMapping: no part in master score is linked with " << p->partName();
                         continue;
                         }
                   Q_ASSERT(p->instruments()->size() == masterPart->instruments()->size());

--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -519,6 +519,8 @@ void MuseScore::editInstrList()
             else {
                   for (Staff* s : sl) {
                         const LinkedElements* sll = s->links();
+                        if (!sll)
+                              continue;
                         for (auto le : *sll) {
                               Staff* ss = toStaff(le);
                               if (ss->primaryStaff()) {


### PR DESCRIPTION
esp. to score with parts imported from MuseScore 1.x

Resolves https://musescore.org/en/node/302304