### PR TITLE
Fix #65241: add property and style for position of multimeasure rest numbers

### DIFF
--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -199,6 +199,7 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::SPANNER_TRACK2,          false, "track2",                P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "track2")           },
       { Pid::OFFSET2,                 false, "userOff2",              P_TYPE::POINT_SP,            DUMMY_QT_TRANSLATE_NOOP("propertyName", "offset2")         },
       { Pid::BREAK_MMR,               false, "breakMultiMeasureRest", P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "breaking multimeasure rest")},
+      { Pid::MMREST_NUMBER_POS,       false, "mmRestNumberPos",       P_TYPE::SPATIUM,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "vertical position of multimeasure rest number")},
       { Pid::REPEAT_COUNT,            true,  "endRepeat",             P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "end repeat")       },
 
       { Pid::USER_STRETCH,            false, "stretch",               P_TYPE::REAL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "stretch")          },

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -208,6 +208,7 @@ enum class Pid {
       SPANNER_TRACK2,
       OFFSET2,
       BREAK_MMR,
+      MMREST_NUMBER_POS,
       REPEAT_COUNT,
 
       USER_STRETCH,

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -33,6 +33,14 @@
 namespace Ms {
 
 //---------------------------------------------------------
+//   restStyle
+//---------------------------------------------------------
+
+static const ElementStyle restStyle {
+      { Sid::mmRestNumberPos, Pid::MMREST_NUMBER_POS },
+      };
+
+//---------------------------------------------------------
 //    Rest
 //--------------------------------------------------------
 
@@ -42,6 +50,8 @@ Rest::Rest(Score* s)
       _mmWidth   = 0;
       _beamMode  = Beam::Mode::NONE;
       _sym       = SymId::restQuarter;
+      if (score())
+            initElementStyle(&restStyle);
       }
 
 Rest::Rest(Score* s, const TDuration& d)
@@ -53,6 +63,8 @@ Rest::Rest(Score* s, const TDuration& d)
       setDurationType(d);
       if (d.fraction().isValid())
             setTicks(d.fraction());
+      if (score())
+            initElementStyle(&restStyle);
       }
 
 Rest::Rest(const Rest& r, bool link)
@@ -93,29 +105,36 @@ void Rest::draw(QPainter* painter) const
             //only on voice 1
             if (track() % VOICES)
                   return;
-            Measure* m = measure();
-            int n      = m->mmRestCount();
-            qreal pw   = _spatium * .7;
+
+            // draw number
+            int n = measure()->mmRestCount();
+            std::vector<SymId>&& s = toTimeSigString(QString("%1").arg(n));
+            qreal y = _mmRestNumberPos * spatium() - staff()->height() * .5;
+            qreal x = (_mmWidth - symBbox(s).width()) * .5;
+            drawSymbols(s, painter, QPointF(x, y));
+
+            // draw horizontal line
+            qreal pw = _spatium * .7;
             QPen pen(painter->pen());
             pen.setWidthF(pw);
             painter->setPen(pen);
+            qreal x1 = pw * .5;
+            qreal x2 = _mmWidth - x1;
+            if (_mmRestNumberPos > 0.7 && _mmRestNumberPos < 3.3) { // hack for when number encounters horizontal line
+                  qreal gapDistance = symBbox(s).width() * .5 + _spatium;
+                  qreal midpoint = (x1 + x2) * .5;
+                  painter->drawLine(QLineF(x1, 0.0, midpoint - gapDistance, 0.0));
+                  painter->drawLine(QLineF(midpoint + gapDistance, 0.0, x2, 0.0));
+                  }
+            else {
+                  painter->drawLine(QLineF(x1, 0.0, x2, 0.0));
+                  }
 
-            qreal w  = _mmWidth;
-            qreal x2 =  w;
-            pw *= .5;
-            painter->drawLine(QLineF(pw, 0.0, _mmWidth - pw, 0.0));
-
-            // draw vertical lines:
+            // draw vertical lines
             pen.setWidthF(_spatium * .2);
             painter->setPen(pen);
             painter->drawLine(QLineF(0.0, -_spatium, 0.0, _spatium));
-            painter->drawLine(QLineF(x2,  -_spatium, x2,  _spatium));
-
-            std::vector<SymId>&& s = toTimeSigString(QString("%1").arg(n));
-            qreal y = -_spatium * 1.5 - staff()->height() *.5;
-            qreal x = x2 * .5;
-            x      -= symBbox(s).width() * .5;
-            drawSymbols(s, painter, QPointF(x, y));
+            painter->drawLine(QLineF(_mmWidth, -_spatium, _mmWidth,  _spatium));
             }
       else
             drawSymbol(_sym, painter);
@@ -926,20 +945,6 @@ void Rest::localSpatiumChanged(qreal oldValue, qreal newValue)
       }
 
 //---------------------------------------------------------
-//   getProperty
-//---------------------------------------------------------
-
-QVariant Rest::getProperty(Pid propertyId) const
-      {
-      switch (propertyId) {
-            case Pid::GAP:
-                  return _gap;
-            default:
-                  return ChordRest::getProperty(propertyId);
-            }
-      }
-
-//---------------------------------------------------------
 //   propertyDefault
 //---------------------------------------------------------
 
@@ -948,8 +953,47 @@ QVariant Rest::propertyDefault(Pid propertyId) const
       switch (propertyId) {
             case Pid::GAP:
                   return false;
+            case Pid::MMREST_NUMBER_POS:
+                  return score()->styleV(Sid::mmRestNumberPos);
             default:
                   return ChordRest::propertyDefault(propertyId);
+            }
+      }
+
+//————————————————————————————
+//   resetProperty
+//————————————————————————————
+
+void Rest::resetProperty(Pid id)
+      {
+      setProperty(id, propertyDefault(id));
+      return;
+      }
+
+//————————————————————————————
+//   getPropertyStyle
+//————————————————————————————
+
+Sid Rest::getPropertyStyle(Pid pid) const
+      {
+      if (pid == Pid::MMREST_NUMBER_POS)
+            return Sid::mmRestNumberPos;
+      return ChordRest::getPropertyStyle(pid);
+      }
+
+//---------------------------------------------------------
+//   getProperty
+//---------------------------------------------------------
+
+QVariant Rest::getProperty(Pid propertyId) const
+      {
+      switch (propertyId) {
+            case Pid::GAP:
+                  return _gap;
+            case Pid::MMREST_NUMBER_POS:
+                  return _mmRestNumberPos;
+            default:
+                  return ChordRest::getProperty(propertyId);
             }
       }
 
@@ -975,6 +1019,10 @@ bool Rest::setProperty(Pid propertyId, const QVariant& v)
                   score()->addRefresh(canvasBoundingRect());
                   if (measure() && durationType().type() == TDuration::DurationType::V_MEASURE)
                          measure()->triggerLayout();
+                  triggerLayout();
+                  break;
+            case Pid::MMREST_NUMBER_POS:
+                  _mmRestNumberPos = v.toDouble();
                   triggerLayout();
                   break;
             default:
@@ -1024,12 +1072,13 @@ Shape Rest::shape() const
                   qreal _spatium = spatium();
                   shape.add(QRectF(0.0, -_spatium, _mmWidth, 2.0 * _spatium));
 
-                  int n    = measure()->mmRestCount();
+                  int n = measure()->mmRestCount();
                   std::vector<SymId>&& s = toTimeSigString(QString("%1").arg(n));
-                  qreal x  = _mmWidth * .5;
-                  qreal y  = -_spatium * 1.5 - staff()->height() *.5;
+                  
                   QRectF r = symBbox(s);
-                  x       -= r.width() * .5;
+                  qreal y = _mmRestNumberPos * spatium() - staff()->height() * .5;
+                  qreal x = .5 * (_mmWidth - r.width());
+
                   r.translate(QPointF(x, y));
                   shape.add(r);
                   }

--- a/libmscore/rest.h
+++ b/libmscore/rest.h
@@ -30,7 +30,8 @@ class Rest : public ChordRest {
       // values calculated by layout:
       SymId _sym;
       int dotline    { -1  };       // depends on rest symbol
-      qreal _mmWidth;               // width of multi measure rest
+      qreal _mmWidth;               // width of multimeasure rest
+      qreal _mmRestNumberPos;       // vertical position of number of multimeasure rest
       bool _gap      { false };     // invisible and not selectable for user
       std::vector<NoteDot*> _dots;
 
@@ -38,6 +39,7 @@ class Rest : public ChordRest {
       virtual qreal upPos()   const override;
       virtual qreal downPos() const override;
       virtual void setOffset(const QPointF& o) override;
+      virtual Sid getPropertyStyle(Pid pid) const override; 
 
 
    public:
@@ -93,10 +95,11 @@ class Rest : public ChordRest {
       virtual QPointF stemPosBeam() const;
 
       virtual void localSpatiumChanged(qreal oldValue, qreal newValue) override;
-      virtual bool setProperty(Pid propertyId, const QVariant& v) override;
-      void undoChangeDotsVisible(bool v);
-      virtual QVariant getProperty(Pid propertyId) const override;
       virtual QVariant propertyDefault(Pid) const override;
+      void resetProperty(Pid id);
+      virtual bool setProperty(Pid propertyId, const QVariant& v) override;
+      virtual QVariant getProperty(Pid propertyId) const override;
+      void undoChangeDotsVisible(bool v);
 
       virtual Element* nextElement() override;
       virtual Element* prevElement() override;

--- a/libmscore/rest.h
+++ b/libmscore/rest.h
@@ -35,11 +35,11 @@ class Rest : public ChordRest {
       bool _gap      { false };     // invisible and not selectable for user
       std::vector<NoteDot*> _dots;
 
-      virtual QRectF drag(EditData&) override;
-      virtual qreal upPos()   const override;
-      virtual qreal downPos() const override;
-      virtual void setOffset(const QPointF& o) override;
-      virtual Sid getPropertyStyle(Pid pid) const override; 
+      QRectF drag(EditData&) override;
+      qreal upPos() const override;
+      qreal downPos() const override;
+      void setOffset(const QPointF& o) override;
+      Sid getPropertyStyle(Pid pid) const override;
 
 
    public:
@@ -51,28 +51,28 @@ class Rest : public ChordRest {
       virtual ElementType type() const override { return ElementType::REST; }
       Rest &operator=(const Rest&) = delete;
 
-      virtual Rest* clone() const override        { return new Rest(*this, false); }
-      virtual Element* linkedClone()              { return new Rest(*this, true); }
-      virtual Measure* measure() const override   { return parent() ? (Measure*)(parent()->parent()) : 0; }
-      virtual qreal mag() const override;
-      virtual void draw(QPainter*) const override;
-      virtual void scanElements(void* data, void (*func)(void*, Element*), bool all=true) override;
+      Rest* clone() const override        { return new Rest(*this, false); }
+      Element* linkedClone() override     { return new Rest(*this, true); }
+      Measure* measure() const override   { return parent() ? toMeasure(parent()->parent()) : 0; }
+      qreal mag() const override;
+      void draw(QPainter*) const override;
+      void scanElements(void* data, void (*func)(void*, Element*), bool all = true) override;
       void setTrack(int val);
 
-      virtual bool acceptDrop(EditData&) const override;
-      virtual Element* drop(EditData&) override;
-      virtual void layout() override;
+      bool acceptDrop(EditData&) const override;
+      Element* drop(EditData&) override;
+      void layout() override;
 
       bool isGap() const               { return _gap;     }
       virtual void setGap(bool v)      { _gap = v;        }
 
-      virtual void reset() override;
+      void reset() override;
 
       virtual void add(Element*);
       virtual void remove(Element*);
 
-      virtual void read(XmlReader&) override;
-      virtual void write(XmlWriter& xml) const override;
+      void read(XmlReader&) override;
+      void write(XmlWriter& xml) const override;
 
       void layoutMMRest(qreal val);
       qreal mmWidth() const        { return _mmWidth; }
@@ -94,17 +94,17 @@ class Rest : public ChordRest {
       virtual qreal stemPosX() const;
       virtual QPointF stemPosBeam() const;
 
-      virtual void localSpatiumChanged(qreal oldValue, qreal newValue) override;
-      virtual QVariant propertyDefault(Pid) const override;
+      void localSpatiumChanged(qreal oldValue, qreal newValue) override;
+      QVariant propertyDefault(Pid) const override;
       void resetProperty(Pid id);
-      virtual bool setProperty(Pid propertyId, const QVariant& v) override;
-      virtual QVariant getProperty(Pid propertyId) const override;
+      bool setProperty(Pid propertyId, const QVariant& v) override;
+      QVariant getProperty(Pid propertyId) const override;
       void undoChangeDotsVisible(bool v);
 
-      virtual Element* nextElement() override;
-      virtual Element* prevElement() override;
-      virtual QString accessibleInfo() const override;
-      virtual QString screenReaderInfo() const override;
+      Element* nextElement() override;
+      Element* prevElement() override;
+      QString accessibleInfo() const override;
+      QString screenReaderInfo() const override;
       Shape shape() const override;
       };
 

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -401,6 +401,7 @@ static const StyleType styleTypes[] {
       { Sid::createMultiMeasureRests, "createMultiMeasureRests", QVariant(false) },
       { Sid::minEmptyMeasures,        "minEmptyMeasures",        QVariant(2) },
       { Sid::minMMRestWidth,          "minMMRestWidth",          Spatium(4) },
+      { Sid::mmRestNumberPos,         "mmRestNumberPos",         Spatium(-1.5) },
       { Sid::hideEmptyStaves,         "hideEmptyStaves",         QVariant(false) },
       { Sid::dontHideStavesInFirstSystem,
                                  "dontHidStavesInFirstSystm",    QVariant(true) },

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -371,6 +371,7 @@ enum class Sid {
       createMultiMeasureRests,
       minEmptyMeasures,
       minMMRestWidth,
+      mmRestNumberPos,
       hideEmptyStaves,
       dontHideStavesInFirstSystem,
       alwaysShowBracketsWhenEmptyStavesAreHidden,

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -165,6 +165,7 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       { Sid::createMultiMeasureRests, false, multiMeasureRests,       0 },
       { Sid::minEmptyMeasures,        false, minEmptyMeasures,        0 },
       { Sid::minMMRestWidth,          false, minMeasureWidth,         resetMinMMRestWidth },
+      { Sid::mmRestNumberPos,         false, mmRestNumberPos,         resetMMRestNumberPos },
       { Sid::hideEmptyStaves,         false, hideEmptyStaves,         0 },
       { Sid::dontHideStavesInFirstSystem, false, dontHideStavesInFirstSystem, 0 },
       { Sid::alwaysShowBracketsWhenEmptyStavesAreHidden, false, alwaysShowBrackets, 0 },

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -390,6 +390,29 @@
              <layout class="QVBoxLayout" name="verticalLayout_5">
               <item>
                <layout class="QGridLayout" name="gridLayout_30">
+                <item row="0" column="1">
+                 <widget class="QSpinBox" name="minEmptyMeasures">
+                  <property name="minimum">
+                   <number>1</number>
+                  </property>
+                  <property name="value">
+                   <number>2</number>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="1">
+                 <widget class="QDoubleSpinBox" name="minMeasureWidth">
+                  <property name="suffix">
+                   <string>sp</string>
+                  </property>
+                  <property name="minimum">
+                   <double>2.000000000000000</double>
+                  </property>
+                  <property name="value">
+                   <double>4.000000000000000</double>
+                  </property>
+                 </widget>
+                </item>
                 <item row="1" column="2">
                  <widget class="QToolButton" name="resetMinMMRestWidth">
                   <property name="toolTip">
@@ -407,22 +430,6 @@
                   </property>
                  </widget>
                 </item>
-                <item row="0" column="1">
-                 <widget class="QSpinBox" name="minEmptyMeasures">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimum">
-                   <number>1</number>
-                  </property>
-                  <property name="value">
-                   <number>2</number>
-                  </property>
-                 </widget>
-                </item>
                 <item row="0" column="0">
                  <widget class="QLabel" name="label_15">
                   <property name="text">
@@ -430,25 +437,6 @@
                   </property>
                   <property name="buddy">
                    <cstring>minEmptyMeasures</cstring>
-                  </property>
-                 </widget>
-                </item>
-                <item row="1" column="1">
-                 <widget class="QDoubleSpinBox" name="minMeasureWidth">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="suffix">
-                   <string>sp</string>
-                  </property>
-                  <property name="minimum">
-                   <double>2.000000000000000</double>
-                  </property>
-                  <property name="value">
-                   <double>4.000000000000000</double>
                   </property>
                  </widget>
                 </item>
@@ -474,6 +462,43 @@
                    </size>
                   </property>
                  </spacer>
+                </item>
+                <item row="2" column="0">
+                 <widget class="QLabel" name="label_92">
+                  <property name="text">
+                   <string>Vertical position of number:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="1">
+                 <widget class="QDoubleSpinBox" name="mmRestNumberPos">
+                  <property name="suffix">
+                   <string>sp</string>
+                  </property>
+                  <property name="minimum">
+                   <double>-99.989999999999995</double>
+                  </property>
+                  <property name="singleStep">
+                   <double>0.500000000000000</double>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="2">
+                 <widget class="QToolButton" name="resetMMRestNumberPos">
+                  <property name="toolTip">
+                   <string>Reset to default</string>
+                  </property>
+                  <property name="accessibleName">
+                   <string>Reset 'Vertical position of number' value</string>
+                  </property>
+                  <property name="text">
+                   <string notr="true"/>
+                  </property>
+                  <property name="icon">
+                   <iconset resource="musescore.qrc">
+                    <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                  </property>
+                 </widget>
                 </item>
                </layout>
               </item>

--- a/mscore/inspector/inspector.cmake
+++ b/mscore/inspector/inspector.cmake
@@ -127,6 +127,7 @@ set (INSPECTOR_UI
     ${CMAKE_CURRENT_LIST_DIR}/inspector_lyric.ui
     ${CMAKE_CURRENT_LIST_DIR}/inspector_marker.ui
     ${CMAKE_CURRENT_LIST_DIR}/inspector_measurenumber.ui
+    ${CMAKE_CURRENT_LIST_DIR}/inspector_mmrest.ui
     ${CMAKE_CURRENT_LIST_DIR}/inspector_notedot.ui
     ${CMAKE_CURRENT_LIST_DIR}/inspector_note.ui
     ${CMAKE_CURRENT_LIST_DIR}/inspector_ottava.ui

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -238,7 +238,10 @@ void Inspector::update(Score* s)
                               ie = new InspectorAccidental(this);
                               break;
                         case ElementType::REST:
-                              ie = new InspectorRest(this);
+                              if (toRest(element())->measure()->isMMRest())
+                                    ie = new InspectorMMRest(this);
+                              else
+                                    ie = new InspectorRest(this);
                               break;
                         case ElementType::CLEF:
                               ie = new InspectorClef(this);
@@ -864,6 +867,23 @@ void InspectorRest::tupletClicked()
             rest->score()->update();
             inspector->update();
             }
+      }
+
+//---------------------------------------------------------
+//   InspectorMMRest
+//---------------------------------------------------------
+
+InspectorMMRest::InspectorMMRest(QWidget* parent)
+   : InspectorElementBase(parent)
+      {
+      m.setupUi(addWidget());
+
+      const std::vector<InspectorItem> iiList = {
+            { Pid::MMREST_NUMBER_POS, 0, m.yPos, m.resetYPos }
+            };
+
+      const std::vector<InspectorPanel> ppList = { { m.title, m.panel } };
+      mapSignals(iiList, ppList);
       }
 
 //---------------------------------------------------------

--- a/mscore/inspector/inspector.h
+++ b/mscore/inspector/inspector.h
@@ -28,6 +28,7 @@
 #include "ui_inspector_note.h"
 #include "ui_inspector_chord.h"
 #include "ui_inspector_rest.h"
+#include "ui_inspector_mmrest.h"
 #include "ui_inspector_clef.h"
 #include "ui_inspector_timesig.h"
 #include "ui_inspector_keysig.h"
@@ -212,6 +213,19 @@ class InspectorRest : public InspectorElementBase {
    public:
       InspectorRest(QWidget* parent);
       virtual void setElement() override;
+      };
+
+//---------------------------------------------------------
+//   InspectorMMRest
+//---------------------------------------------------------
+
+class InspectorMMRest : public InspectorElementBase {
+      Q_OBJECT
+
+      Ui::InspectorMMRest m;
+
+   public:
+      InspectorMMRest(QWidget* parent);
       };
 
 //---------------------------------------------------------

--- a/mscore/inspector/inspector_mmrest.ui
+++ b/mscore/inspector/inspector_mmrest.ui
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>InspectorMMRest</class>
+ <widget class="QWidget" name="InspectorMMRest">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>210</width>
+    <height>79</height>
+   </rect>
+  </property>
+  <property name="accessibleName">
+   <string>Multimeasure Rest Inspector</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QFrame" name="frame">
+     <property name="toolTipDuration">
+      <number>30</number>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::HLine</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QToolButton" name="title">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Multimeasure Rest</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="panel" native="true">
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="leftMargin">
+       <number>3</number>
+      </property>
+      <property name="topMargin">
+       <number>3</number>
+      </property>
+      <property name="rightMargin">
+       <number>3</number>
+      </property>
+      <property name="bottomMargin">
+       <number>3</number>
+      </property>
+      <property name="spacing">
+       <number>3</number>
+      </property>
+      <item row="0" column="2">
+       <widget class="Ms::ResetButton" name="resetYPos" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Small' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QDoubleSpinBox" name="yPos">
+        <property name="suffix">
+         <string>sp</string>
+        </property>
+        <property name="minimum">
+         <double>-99.989999999999995</double>
+        </property>
+        <property name="singleStep">
+         <double>0.500000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Number position:</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Ms::ResetButton</class>
+   <extends>QWidget</extends>
+   <header>inspector/resetButton.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>title</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/65241

Adds an additional Inspector property for the vertical position of multimeasure rest numbers, and a corresponding linked style parameter.

![Capture](https://user-images.githubusercontent.com/11616153/80526063-35298280-8960-11ea-8284-6fbdbf1a0d91.gif)

- [x] I signed [CLA](https://musescore.org/en/cla)
- [X] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [X] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
