### PR TITLE
fix #302316, fix #297501 - slurs and fingering

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3794,6 +3794,7 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
       //-------------------------------------------------------------
 
       for (Segment* s : sl) {
+            std::set<int> recreateShapes;
             for (Element* e : s->elist()) {
                   if (!e || !e->isChordRest() || !score()->staff(e->staffIdx())->show())
                         continue;
@@ -3836,9 +3837,12 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                                     QRectF r = f->bbox().translated(f->pos() + n->pos() + n->chord()->pos() + s->pos() + s->measure()->pos());
                                     system->staff(f->note()->chord()->vStaffIdx())->skyline().add(r);
                                     }
+                              recreateShapes.insert(f->staffIdx());
                               }
                         }
                   }
+            for (auto staffIdx : recreateShapes)
+                  s->createShape(staffIdx);
             }
 
       //-------------------------------------------------------------


### PR DESCRIPTION
Resolves: [#302316 - String number under slur interferes with slur.](https://musescore.org/en/node/302316)
Resolves: [#297501 - Layout shift of slur after reload](https://musescore.org/en/node/297501)

When a score, containing a fingering under a slur is loaded, the slur crosses the fingering. Only after a re-layout the slur is drawn higher so it won't intersect the fingering (issue

The root cause of this issue is the shapes of the fingering elements where not available when the bezier of the slur is calculated. The fingering shapes are calculated after the slur bezier is calculated. This explains why a re-layout will solve the issue, then the fingering shapes are available. The shapes are calculated during the calculation of the note shapes but there was no call the fingering <code>layout()</code> method, making the <code>bbox</code> of the fingering shape invalid and therefor it is not added.

This issue is solved by, in <code>Score::layoutSystemElements()</code>, calling the <code>Segment::createShapes()</code> when lay-outing the fingering elements.

This solution also solves #302316 which also requires a re-layout after a String Fingering is added to note under a slur.

This PR replaces [PR5797](https://github.com/musescore/MuseScore/pull/5797) which was just a quick solution.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
