### PR TITLE
fix #279471 Set note cutoff length

### DIFF
--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -31,6 +31,7 @@
 #include "ottava.h"
 #include "harmony.h"
 #include "bracketItem.h"
+#include "chord.h"
 
 // #define DEBUG_CLEFS
 
@@ -872,6 +873,44 @@ int Staff::capo(const Fraction& tick) const
             return 0;
       --i;
       return i.value();
+      }
+
+//---------------------------------------------------------
+//   getNotes
+//---------------------------------------------------------
+
+QList<Note*> Staff::getNotes() const
+      {
+      QList<Note*> list;
+
+      int staffIdx = idx();
+
+      SegmentType st = SegmentType::ChordRest;
+      for (Segment* s = score()->firstSegment(st); s; s = s->next1(st)) {
+            for (int voice = 0; voice < VOICES; ++voice) {
+                  int track = voice + staffIdx * VOICES;
+                  Element* e = s->element(track);
+                  if (e && e->isChord())
+                        addChord(list, toChord(e), voice);
+                  }
+            }
+
+      return list;
+      }
+
+//---------------------------------------------------------
+//   addChord
+//---------------------------------------------------------
+
+void Staff::addChord(QList<Note*>& list, Chord* chord, int voice) const
+      {
+      for (Chord* c : chord->graceNotes())
+            addChord(list, c, voice);
+      for (Note* note : chord->notes()) {
+            if (note->tieBack())
+                  continue;
+            list.append(note);
+            }
       }
 
 //---------------------------------------------------------

--- a/libmscore/staff.h
+++ b/libmscore/staff.h
@@ -42,6 +42,7 @@ class Clef;
 class TimeSig;
 class Ottava;
 class BracketItem;
+class Note;
 
 enum class Key;
 
@@ -186,6 +187,10 @@ class Staff final : public ScoreElement {
       qreal height() const;
 
       int channel(const Fraction&, int voice) const;
+
+      QList<Note*> getNotes() const;
+      void addChord(QList<Note*>& list, Chord* chord, int voice) const;
+
       void clearChannelList(int voice)                               { _channelList[voice].clear(); }
       void insertIntoChannelList(int voice, const Fraction& tick, int channelId) { _channelList[voice].insert(tick.ticks(), channelId); }
 

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -67,6 +67,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/importmidi_ui/importmidi_ui.cmake)
 
 QT5_WRAP_UI (ui_headers
       ${MSCORE_MIXER_UI}
+      ${PIANOROLL_UI}
       ${CLOUD_UI}
       ${DEBUGGER_UI}
       ${INSPECTOR_UI}

--- a/mscore/pianoroll/notetweakerdialog.cpp
+++ b/mscore/pianoroll/notetweakerdialog.cpp
@@ -1,0 +1,171 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#include "notetweakerdialog.h"
+
+#include "libmscore/segment.h"
+#include "libmscore/score.h"
+#include "libmscore/staff.h"
+#include "libmscore/chord.h"
+#include "libmscore/rest.h"
+#include "libmscore/note.h"
+#include "libmscore/slur.h"
+#include "libmscore/tie.h"
+#include "libmscore/tuplet.h"
+#include "libmscore/noteevent.h"
+#include "libmscore/undo.h"
+
+namespace Ms{
+
+
+//---------------------------------------------------------
+//   NoteTweakerDialog
+//---------------------------------------------------------
+
+NoteTweakerDialog::NoteTweakerDialog(QWidget *parent) :
+      QDialog(parent),
+      _staff(nullptr),
+      ui(new Ui::NoteTweakerDialog)
+      {
+      ui->setupUi(this);
+
+      connect(ui->bnClose, &QPushButton::clicked, this, &QDialog::close);
+      connect(ui->bnSetNoteOffTime, &QPushButton::clicked, this, &NoteTweakerDialog::setNoteOffTime);
+      }
+
+
+//---------------------------------------------------------
+//   ~NoteTweakerDialog
+//---------------------------------------------------------
+
+NoteTweakerDialog::~NoteTweakerDialog()
+      {
+      delete ui;
+      }
+
+
+//---------------------------------------------------------
+//   setNoteOffTime
+//---------------------------------------------------------
+
+void NoteTweakerDialog::setNoteOffTime()
+      {
+      if (!_staff)
+            return;
+
+      QString s = ui->comboOffTimeFrac->currentText();
+      QStringList parts = s.split("/");
+      int num = parts[0].toInt();
+      double denom = parts[1].toInt();
+      double gapTicks = MScore::division * num / denom;
+
+      Score* score = _staff->score();
+
+      score->startCmd();
+
+      for (Note* note: noteList) {
+            if (!note->selected())
+                  continue;
+
+            Chord* chord = note->chord();
+            int ticks = chord->ticks().ticks();
+
+            int scalar = 1000 * (ticks - gapTicks) / ticks;
+            if (scalar <= 0)
+                  scalar = 1;
+
+            for (NoteEvent& e : note->playEvents()) {
+                  NoteEvent ne = e;
+                  ne.setLen(scalar);
+                  score->undo(new ChangeNoteEvent(note, &e, ne));
+                  }
+            }
+
+      score->endCmd();
+
+      emit notesChanged();
+      }
+
+//---------------------------------------------------------
+//   setStaff
+//---------------------------------------------------------
+
+void NoteTweakerDialog::setStaff(Staff* s)
+      {
+      if (_staff == s)
+            return;
+
+      _staff    = s;
+      updateNotes();
+      }
+
+//---------------------------------------------------------
+//   addChord
+//---------------------------------------------------------
+
+void NoteTweakerDialog::addChord(Chord* chord, int voice)
+      {
+      for (Chord* c : chord->graceNotes())
+            addChord(c, voice);
+      for (Note* note : chord->notes()) {
+            if (note->tieBack())
+                  continue;
+            noteList.append(note);
+            }
+      }
+
+//---------------------------------------------------------
+//   updateNotes
+//---------------------------------------------------------
+
+void NoteTweakerDialog::updateNotes()
+      {
+      clearNoteData();
+
+      if (!_staff) {
+            return;
+            }
+
+      int staffIdx = _staff->idx();
+      if (staffIdx == -1)
+            return;
+
+      SegmentType st = SegmentType::ChordRest;
+      for (Segment* s = _staff->score()->firstSegment(st); s; s = s->next1(st)) {
+            for (int voice = 0; voice < VOICES; ++voice) {
+                  int track = voice + staffIdx * VOICES;
+                  Element* e = s->element(track);
+                  if (e && e->isChord())
+                        addChord(toChord(e), voice);
+                  }
+            }
+
+      update();
+      }
+
+//---------------------------------------------------------
+//   clearNoteData
+//---------------------------------------------------------
+
+void NoteTweakerDialog::clearNoteData()
+      {
+      noteList.clear();
+      }
+
+}

--- a/mscore/pianoroll/notetweakerdialog.h
+++ b/mscore/pianoroll/notetweakerdialog.h
@@ -1,8 +1,8 @@
 //=============================================================================
-//  MusE Score
-//  Linux Music Score Editor
+//  MuseScore
+//  Music Composition & Notation
 //
-//  Copyright (C) 2009 Werner Schweer and others
+//  Copyright (C) 2020 MuseScore BVBA and others
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2.
@@ -17,43 +17,50 @@
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
 
-#ifndef __PIANOLEVELSCHOOSER_H__
-#define __PIANOLEVELSCHOOSER_H__
 
-#include "ui_pianolevelschooser.h"
+#ifndef NOTETWEAKERDIALOG_H
+#define NOTETWEAKERDIALOG_H
 
-#include "libmscore/staff.h"
+#include "ui_notetweakerdialog.h"
+
+namespace Ui {
+class NoteTweakerDialog;
+}
 
 namespace Ms {
 
+class Staff;
+class Note;
+class Chord;
 
-//---------------------------------------------------------
-//   PianoLevelsChooser
-//---------------------------------------------------------
-
-class PianoLevelsChooser : public QWidget, public Ui::PianoLevelsChooser
-{
+class NoteTweakerDialog : public QDialog
+      {
       Q_OBJECT
 
-      int _levelsIndex;
       Staff* _staff;
+      QList<Note*> noteList;
 
-public:
-      Staff* staff() { return _staff; }
-      void setStaff(Staff* staff) { _staff = staff; }
+   public:
+      explicit NoteTweakerDialog(QWidget *parent = nullptr);
+      ~NoteTweakerDialog();
 
-signals:
-      void levelsIndexChanged(int);
+      void setStaff(Staff* s);
+
+   signals:
       void notesChanged();
 
-public slots:
-      void setLevelsIndex(int index);
-      void setEventDataPressed();
+   public slots:
+      void setNoteOffTime();
 
-public:
-    explicit PianoLevelsChooser(QWidget *parent = 0);
-};
+   private:
+      void addChord(Chord* chord, int voice);
+      void updateNotes();
+      void clearNoteData();
+
+
+      Ui::NoteTweakerDialog *ui;
+      };
 
 }
 
-#endif // __PIANOLEVELSCHOOSER_H__
+#endif // NOTETWEAKERDIALOG_H

--- a/mscore/pianoroll/notetweakerdialog.ui
+++ b/mscore/pianoroll/notetweakerdialog.ui
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>NoteTweakerDialog</class>
+ <widget class="QDialog" name="NoteTweakerDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>206</width>
+    <height>137</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Note Tweaker</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Note Off Time</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Fraction of beat:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="comboOffTimeFrac">
+        <item>
+         <property name="text">
+          <string>1/2</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>1/4</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>1/8</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>1/16</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>1/32</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>1/64</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPushButton" name="bnSetNoteOffTime">
+        <property name="text">
+         <string>Set</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="bnClose">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/mscore/pianoroll/pianolevelschooser.ui
+++ b/mscore/pianoroll/pianolevelschooser.ui
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PianoLevelsChooser</class>
+ <widget class="QWidget" name="PianoLevelsChooser">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>369</width>
+    <height>288</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QComboBox" name="levelsCombo">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Note Event Data Type</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Set Values</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="2" column="1">
+       <widget class="QPushButton" name="setEventsBn">
+        <property name="toolTip">
+         <string>Set Selected Note Event Data</string>
+        </property>
+        <property name="text">
+         <string>Set</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QSpinBox" name="eventValSpinBox">
+        <property name="minimum">
+         <number>-100000</number>
+        </property>
+        <property name="maximum">
+         <number>100000</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/mscore/pianoroll/pianolevelsfilter.cpp
+++ b/mscore/pianoroll/pianolevelsfilter.cpp
@@ -1,6 +1,7 @@
 #include "pianolevelsfilter.h"
 
 #include "libmscore/note.h"
+#include "libmscore/chord.h"
 #include "libmscore/staff.h"
 #include "libmscore/score.h"
 #include "libmscore/undo.h"
@@ -10,6 +11,7 @@ namespace Ms {
 
 PianoLevelsFilter* PianoLevelsFilter::FILTER_LIST[] = {
       new PianoLevelFilterLen,
+      new PianoLevelFilterLenOfftime,
       new PianoLevelFilterVeloOffset,
       new PianoLevelFilterVeloUser,
       new PianoLevelFilterOnTime,
@@ -60,6 +62,61 @@ void PianoLevelFilterLen::setValue(Staff* staff, Note* note, NoteEvent* evt, int
 
       NoteEvent ne = *evt;
       ne.setLen(value);
+
+      score->startCmd();
+      score->undo(new ChangeNoteEvent(note, evt, ne));
+      score->endCmd();
+      }
+
+
+//---------------------------------------------------------
+//   maxRange
+//---------------------------------------------------------
+
+int PianoLevelFilterLenOfftime::maxRange()
+      {
+      return MScore::division;
+      }
+
+//---------------------------------------------------------
+//   divisionGap
+//---------------------------------------------------------
+
+int PianoLevelFilterLenOfftime::divisionGap()
+      {
+      return MScore::division / 4;
+      }
+
+
+//---------------------------------------------------------
+//   value
+//---------------------------------------------------------
+
+int PianoLevelFilterLenOfftime::value(Staff* /*staff*/, Note* note, NoteEvent* evt)
+      {
+      Chord* chord = note->chord();
+      int ticks = chord->ticks().ticks();
+      int gate = evt->len();
+      int offTicks = ticks - (ticks * gate / 1000);
+
+      return offTicks;
+      }
+
+//---------------------------------------------------------
+//   setValue
+//---------------------------------------------------------
+
+void PianoLevelFilterLenOfftime::setValue(Staff* staff, Note* note, NoteEvent* evt, int value)
+      {
+      Chord* chord = note->chord();
+      int ticks = chord->ticks().ticks();
+      int onTicks = qMax(ticks - value, 1);
+      int gate = 1000 * onTicks / ticks;
+
+      Score* score = staff->score();
+
+      NoteEvent ne = *evt;
+      ne.setLen(gate);
 
       score->startCmd();
       score->undo(new ChangeNoteEvent(note, evt, ne));

--- a/mscore/pianoroll/pianolevelsfilter.h
+++ b/mscore/pianoroll/pianolevelsfilter.h
@@ -20,8 +20,6 @@
 #ifndef __PIANOLEVELSFILTER_H__
 #define __PIANOLEVELSFILTER_H__
 
-#include <QString>
-
 namespace Ms {
 
 class Note;
@@ -34,8 +32,7 @@ class Staff;
 //       Manage note/event data for different views when drawing in the PianoLevels window
 //---------------------------------------------------------
 
-class PianoLevelsFilter
-{
+class PianoLevelsFilter {
 public:
       static PianoLevelsFilter* FILTER_LIST[];
 
@@ -46,24 +43,25 @@ public:
       virtual bool isPerEvent() = 0;
       virtual int value(Staff* staff, Note* note, NoteEvent* evt) = 0;
       virtual void setValue(Staff* staff, Note* note, NoteEvent* evt, int value) = 0;
-};
+      };
 
 
 //---------------------------------------------------------
 //   PianoLevelFilterOnTime
 //---------------------------------------------------------
 
-class PianoLevelFilterOnTime : public PianoLevelsFilter
-{
+class PianoLevelFilterOnTime : public PianoLevelsFilter {
+      Q_DECLARE_TR_FUNCTIONS(PianoLevelFilterOnTime)
+
 public:
-      QString name() override { return "On Time"; }
+      QString name() override { return tr("Note on time", "amount note 'on time' is adjusted by"); }
       int maxRange() override { return 1000; }
       int minRange() override { return -1000; }
       int divisionGap() override { return 250; }
       bool isPerEvent() override { return true; }
       int value(Staff* staff, Note* note, NoteEvent* evt) override;
       void setValue(Staff* staff, Note* note, NoteEvent* evt, int value) override;
-};
+      };
 
 
 //---------------------------------------------------------
@@ -71,17 +69,37 @@ public:
 //---------------------------------------------------------
 
 
-class PianoLevelFilterLen : public PianoLevelsFilter
-{
+class PianoLevelFilterLen : public PianoLevelsFilter {
+      Q_DECLARE_TR_FUNCTIONS(PianoLevelFilterLen)
+
 public:
-      QString name() override { return "Length"; }
+      QString name() override { return tr("Length as note multiplier", "length tweak is interpreted as a scalar to base note length"); }
       int maxRange() override { return 1000; }
       int minRange() override { return 0; }
       int divisionGap() override { return 250; }
       bool isPerEvent() override { return true; }
       int value(Staff* staff, Note* note, NoteEvent* evt) override;
       void setValue(Staff* staff, Note* note, NoteEvent* evt, int value) override;
-};
+      };
+
+
+//---------------------------------------------------------
+//   PianoLevelFilterLenOff
+//---------------------------------------------------------
+
+
+class PianoLevelFilterLenOfftime : public PianoLevelsFilter {
+      Q_DECLARE_TR_FUNCTIONS(PianoLevelFilterLenOfftime)
+
+public:
+      QString name() override { return tr("Length as note off time", "length tweak is interpreted as an offset to the base note length"); }
+      int maxRange() override;
+      int minRange() override { return 0; }
+      int divisionGap() override;
+      bool isPerEvent() override { return true; }
+      int value(Staff* staff, Note* note, NoteEvent* evt) override;
+      void setValue(Staff* staff, Note* note, NoteEvent* evt, int value) override;
+      };
 
 
 //---------------------------------------------------------
@@ -89,17 +107,18 @@ public:
 //---------------------------------------------------------
 
 
-class PianoLevelFilterVeloOffset : public PianoLevelsFilter
-{
+class PianoLevelFilterVeloOffset : public PianoLevelsFilter {
+      Q_DECLARE_TR_FUNCTIONS(PianoLevelFilterVeloOffset)
+
 public:
-      QString name() override { return "Velocity Offset"; }
+      QString name() override { return tr("Velocity as dynamics multiplier", "velocity tweak is interpreted as a scalar relative to the dynamics marking"); }
       int maxRange() override { return 200; }
       int minRange() override { return -200; }
       int divisionGap() override { return 100; }
       bool isPerEvent() override { return false; }
       int value(Staff* staff, Note* note, NoteEvent* evt) override;
       void setValue(Staff* staff, Note* note, NoteEvent* evt, int value) override;
-};
+      };
 
 
 //---------------------------------------------------------
@@ -107,17 +126,18 @@ public:
 //---------------------------------------------------------
 
 
-class PianoLevelFilterVeloUser : public PianoLevelsFilter
-{
+class PianoLevelFilterVeloUser : public PianoLevelsFilter {
+      Q_DECLARE_TR_FUNCTIONS(PianoLevelFilterVeloUser)
+
 public:
-      QString name() override { return "Velocity Absolute"; }
+      QString name() override { return tr("Velocity as absolute MIDI volume", "velocity tweak is intepreted as a MIDI volume level"); }
       int maxRange() override { return 128; }
       int minRange() override { return 0; }
       int divisionGap() override { return 32; }
       bool isPerEvent() override { return false; }
       int value(Staff* staff, Note* note, NoteEvent* evt) override;
       void setValue(Staff* staff, Note* note, NoteEvent* evt, int value) override;
-};
+      };
 
 }
 

--- a/mscore/pianoroll/pianoroll.cmake
+++ b/mscore/pianoroll/pianoroll.cmake
@@ -15,4 +15,11 @@ set(PIANOROLL_SRC
     ${CMAKE_CURRENT_LIST_DIR}/pianoruler.h
     ${CMAKE_CURRENT_LIST_DIR}/pianoview.cpp
     ${CMAKE_CURRENT_LIST_DIR}/pianoview.h
+    ${CMAKE_CURRENT_LIST_DIR}/notetweakerdialog.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/notetweakerdialog.h
+    )
+
+set(PIANOROLL_UI
+      ${CMAKE_CURRENT_LIST_DIR}/pianolevelschooser.ui
+      ${CMAKE_CURRENT_LIST_DIR}/notetweakerdialog.ui
     )

--- a/mscore/pianoroll/pianoroll.cpp
+++ b/mscore/pianoroll/pianoroll.cpp
@@ -22,6 +22,7 @@
 #include "seq.h"
 #include "preferences.h"
 #include "waveview.h"
+#include "notetweakerdialog.h"
 #include "libmscore/staff.h"
 #include "libmscore/measure.h"
 #include "libmscore/note.h"
@@ -50,10 +51,14 @@ PianorollEditor::PianorollEditor(QWidget* parent)
       _score   = 0;
       staff    = 0;
 
+
       QActionGroup* ag = Shortcut::getActionGroupForWidget(MsWidget::PIANO_ROLL_EDITOR);
       ag->setParent(this);
       addActions(ag->actions());
       connect(ag, SIGNAL(triggered(QAction*)), this, SLOT(handleAction(QAction*)));
+
+      noteTweakerDlg = new NoteTweakerDialog(this);
+
 
       QWidget* mainWidget = new QWidget;
       QToolBar* tb = addToolBar("Toolbar 1");
@@ -266,16 +271,19 @@ PianorollEditor::PianorollEditor(QWidget* parent)
       connect(hsb,         SIGNAL(valueChanged(int)),                 SLOT(setXpos(int)));
       connect(pianoView->horizontalScrollBar(), SIGNAL(valueChanged(int)),   SLOT(setXpos(int)));
 
-      connect(ruler,       SIGNAL(locatorMoved(int, const Pos&)), SLOT(moveLocator(int, const Pos&)));
-      connect(pianoLevels, SIGNAL(locatorMoved(int, const Pos&)), SLOT(moveLocator(int, const Pos&)));
-      connect(veloType,    SIGNAL(activated(int)),                SLOT(veloTypeChanged(int)));
-      connect(velocity,    SIGNAL(valueChanged(int)),             SLOT(velocityChanged(int)));
-      connect(onTime,      SIGNAL(valueChanged(int)),             SLOT(onTimeChanged(int)));
-      connect(tickLen,     SIGNAL(valueChanged(int)),             SLOT(tickLenChanged(int)));
-      connect(pianoView,   SIGNAL(selectionChanged()),            SLOT(selectionChanged()));
-      connect(pianoKbd,    SIGNAL(keyPressed(int)),               SLOT(keyPressed(int)));
-      connect(pianoKbd,    SIGNAL(keyReleased(int)),              SLOT(keyReleased(int)));
-      connect(pianoLevels, SIGNAL(noteLevelsChanged()),           SLOT(selectionChanged()));
+      connect(ruler,              SIGNAL(locatorMoved(int, const Pos&)), SLOT(moveLocator(int, const Pos&)));
+      connect(pianoLevels,        SIGNAL(locatorMoved(int, const Pos&)), SLOT(moveLocator(int, const Pos&)));
+      connect(veloType,           SIGNAL(activated(int)),                SLOT(veloTypeChanged(int)));
+      connect(velocity,           SIGNAL(valueChanged(int)),             SLOT(velocityChanged(int)));
+      connect(onTime,             SIGNAL(valueChanged(int)),             SLOT(onTimeChanged(int)));
+      connect(tickLen,            SIGNAL(valueChanged(int)),             SLOT(tickLenChanged(int)));
+      connect(pianoView,          SIGNAL(selectionChanged()),            SLOT(selectionChanged()));
+      connect(pianoView,          SIGNAL(showNoteTweakerRequest()),      SLOT(showNoteTweaker()));
+      connect(pianoKbd,           SIGNAL(keyPressed(int)),               SLOT(keyPressed(int)));
+      connect(pianoKbd,           SIGNAL(keyReleased(int)),              SLOT(keyReleased(int)));
+      connect(pianoLevels,        SIGNAL(noteLevelsChanged()),           SLOT(selectionChanged()));
+      connect(noteTweakerDlg,     SIGNAL(notesChanged()),                SLOT(selectionChanged()));
+      connect(pianoLevelsChooser, SIGNAL(notesChanged()),                SLOT(selectionChanged()));
 
       readSettings();
 
@@ -337,7 +345,16 @@ void PianorollEditor::handleAction(QAction* a)
 
 
 //---------------------------------------------------------
-//   focusOnElement
+//   showNoteTweaker
+//---------------------------------------------------------
+
+void PianorollEditor::showNoteTweaker()
+      {
+      noteTweakerDlg->show();
+      }
+
+//---------------------------------------------------------
+//   focusOnPosition
 //---------------------------------------------------------
 
 void PianorollEditor::focusOnPosition(Position* p)
@@ -393,7 +410,9 @@ void PianorollEditor::setStaff(Staff* st)
       pianoView->setStaff(staff, locator);
       pianoLevels->setScore(_score, locator);
       pianoLevels->setStaff(staff, locator);
+      pianoLevelsChooser->setStaff(staff);
       pianoKbd->setStaff(staff);
+      noteTweakerDlg->setStaff(staff);
 
       updateSelection();
       setEnabled(st);
@@ -670,6 +689,7 @@ void PianorollEditor::cmd(QAction* /*a*/)
       //score()->startCmd();
       pianoView->setStaff(staff, locator);
       pianoLevels->setStaff(staff, locator);
+      pianoLevelsChooser->setStaff(staff);
       pianoKbd->setStaff(staff);
       //score()->endCmd();
       }

--- a/mscore/pianoroll/pianoroll.h
+++ b/mscore/pianoroll/pianoroll.h
@@ -31,6 +31,7 @@ class PianoView;
 class PianoKeyboard;
 class PianoLevels;
 class PianoLevelsChooser;
+class NoteTweakerDialog;
 class Note;
 class PianoRuler;
 class Seq;
@@ -68,6 +69,7 @@ class PianorollEditor : public QMainWindow, public MuseScoreView {
       QList<QAction*> actions;
 
       bool updateScheduled = false;
+      NoteTweakerDialog* noteTweakerDlg;
 
       void updateVelocity(Note* note);
       void updateSelection();
@@ -94,6 +96,7 @@ class PianorollEditor : public QMainWindow, public MuseScoreView {
    public slots:
       void changeSelection(SelState);
       void handleAction(QAction*);
+      void showNoteTweaker();
 
    public:
       PianorollEditor(QWidget* parent = 0);

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -584,7 +584,6 @@ void PianoView::wheelEvent(QWheelEvent* event)
             }
       }
 
-
 //---------------------------------------------------------
 //   showPopupMenu
 //---------------------------------------------------------
@@ -592,10 +591,14 @@ void PianoView::wheelEvent(QWheelEvent* event)
 void PianoView::showPopupMenu(const QPoint& pos)
       {
       QMenu popup(this);
-//      popup.addAction(getAction("cut"));
-//      popup.addAction(getAction("copy"));
+
+      QAction*  act;
+
+      act = new QAction(tr("Note Tweaker"));
+      connect(act, &QAction::triggered, this, &PianoView::showNoteTweaker);
+      popup.addAction(act);
+
       popup.addAction(getAction("paste"));
-//      popup.addAction(getAction("swap"));
       popup.addAction(getAction("delete"));
 
       popup.exec(pos);
@@ -1216,6 +1219,15 @@ QAction* PianoView::getAction(const char* id)
       {
       Shortcut* s = Shortcut::getShortcut(id);
       return s ? s->action() : 0;
+      }
+
+//---------------------------------------------------------
+//   showNoteTweaker
+//---------------------------------------------------------
+
+void PianoView::showNoteTweaker()
+      {
+      emit showNoteTweakerRequest();
       }
 
 //---------------------------------------------------------

--- a/mscore/pianoroll/pianoview.h
+++ b/mscore/pianoroll/pianoview.h
@@ -24,6 +24,7 @@ class ChordRest;
 class Note;
 class NoteEvent;
 class PianoView;
+class NoteTweakerDialog;
 
 enum class NoteSelectType {
       REPLACE = 0,
@@ -133,6 +134,7 @@ private:
       void pitchChanged(int);
       void trackingPosChanged(const Pos&);
       void selectionChanged();
+      void showNoteTweakerRequest();
 
    public slots:
       void moveLocator(int);
@@ -142,6 +144,7 @@ private:
       void setSubdiv(int);
       void setBarPattern(int);
       void togglePitchHighlight(int pitch);
+      void showNoteTweaker();
 
    public:
       PianoView();


### PR DESCRIPTION
Adding dialog to allow user to specify a fraction of a beat that notes should be cutoff at.  Right click in the paino note area and select 'Note Tweaker' to activate dialog.
Can now set note values using levels chooser widget.

Spin box now has better default limits.
