### PR TITLE
fix #290430: Crash on certain operations involving file containing ve…

### DIFF
--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -237,6 +237,11 @@ void Glissando::layout()
       GlissandoSegment* segm1 = toGlissandoSegment(frontSegment());
       GlissandoSegment* segm2 = toGlissandoSegment(backSegment());
 
+      if (!cr2->segment()->system()) {
+            qDebug("no system: %s  start %s chord parent %s", name(), cr2->name(), cr2->parent()->name());
+            return;
+            }
+
       // Note: line segments are defined by
       // initial point: ipos() (relative to system origin)
       // ending point:  pos2() (relative to initial point)

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -711,7 +711,7 @@ QPointF SLine::linePos(Grip grip, System** sys) const
                   Note* n = toNote(e);
                   System* s = n->chord()->segment()->system();
                   if (s == 0) {
-                        qDebug("no system: %s  start %s chord parent %s\n", name(), n->name(), n->chord()->parent()->name());
+                        qDebug("no system: %s  start %s chord parent %s", name(), n->name(), n->chord()->parent()->name());
                         return QPointF();
                         }
                   *sys = s;

--- a/mscore/importmxmlpass2.cpp
+++ b/mscore/importmxmlpass2.cpp
@@ -1628,10 +1628,12 @@ void MusicXMLParserPass2::part()
                   sp->setTick(tick1);
                   sp->setTick2(tick2);
                   sp->score()->addElement(sp);
+                  //qDebug("spanner %p added to score", sp);
                   }
             else {
                   // incomplete spanner -> cleanup
                   delete sp;
+                  //qDebug("spanner %p cleaned (deleted)", sp);
                   }
             ++i;
             }
@@ -5705,7 +5707,7 @@ static void addGlissandoSlide(const Notation& notation, Note* note,
                   gliss->setText(glissandoText);
                   gliss->setGlissandoType(glissandoTag == 0 ? GlissandoType::STRAIGHT : GlissandoType::WAVY);
                   spanners[gliss] = QPair<int, int>(tick.ticks(), -1);
-                  // qDebug("glissando/slide=%p inserted at first tick %d", gliss, tick);
+                  //qDebug("glissando/slide=%p inserted at first tick %s", gliss, qPrintable(tick.print()));
                   }
             }
       else if (glissandoType == "stop") {
@@ -5720,7 +5722,7 @@ static void addGlissandoSlide(const Notation& notation, Note* note,
                   gliss->setEndElement(note);
                   gliss->setTick2(tick);
                   gliss->setTrack2(track);
-                  // qDebug("glissando/slide=%p second tick %d", gliss, tick);
+                  //qDebug("glissando/slide=%p second tick %s", gliss, qPrintable(tick.print()));
                   gliss = nullptr;
                   }
             }


### PR DESCRIPTION
…ry large slide elements spanning multiple pages

Resolves: https://musescore.org/en/node/290430

Add nullptr check to glissando layout to prevent crashes in corner cases. Also removed a spurious newline in a debug message in line.cpp and changed debug messages in importmxmlpass2.cpp.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [see above] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n/a] I created the test (mtest, vtest, script test) to verify the changes I made