### PR TITLE
[MU4] fix 280260: added an option to set the default font for all text types

### DIFF
--- a/mscore/editstyle.h
+++ b/mscore/editstyle.h
@@ -75,7 +75,7 @@ class EditStyle : public QDialog, private Ui::EditStyleBase {
 
       static const std::map<ElementType, EditStylePage> PAGES;
 
-   private slots:
+private slots:
       void selectChordDescriptionFile();
       void setChordStyle(bool);
       void toggleHeaderOddEven(bool);
@@ -90,6 +90,7 @@ class EditStyle : public QDialog, private Ui::EditStyleBase {
       void resetStyleValue(int);
       void valueChanged(int);
       void textStyleChanged(int);
+      void changeChosenTextFonts(const QFont&);
       void resetTextStyle(Pid);
       void textStyleValueChanged(Pid, QVariant);
       void on_comboFBFont_currentIndexChanged(int index);
@@ -97,8 +98,9 @@ class EditStyle : public QDialog, private Ui::EditStyleBase {
       void editUserStyleName();
       void endEditUserStyleName();
       void resetUserStyleName();
+      void setFromFontToMostUsed();
 
-   public:
+public:
       EditStyle(Score*, QWidget*);
       void setPage(int no);
       void setScore(Score* s) { cs = s; }

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -262,16 +262,25 @@
           <layout class="QVBoxLayout" name="verticalLayout_6">
            <item>
             <layout class="QGridLayout" name="gridLayout">
-             <item row="0" column="2">
-              <widget class="QCheckBox" name="optimizeStyleCheckbox">
-               <property name="toolTip">
-                <string>MuseScore will change the style to suit the font better</string>
-               </property>
-               <property name="text">
-                <string>Automatically load style settings based on font</string>
-               </property>
-               <property name="checked">
+             <item row="2" column="1">
+              <widget class="QFontComboBox" name="textFromComboBox">
+               <property name="enabled">
                 <bool>true</bool>
+               </property>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="font">
+                <font>
+                 <family>FreeSerif</family>
+                 <pointsize>12</pointsize>
+                </font>
+               </property>
+               <property name="currentText">
+                <string>FreeSerif</string>
                </property>
               </widget>
              </item>
@@ -285,6 +294,26 @@
                </property>
               </widget>
              </item>
+             <item row="0" column="2">
+              <widget class="QCheckBox" name="optimizeStyleCheckbox">
+               <property name="toolTip">
+                <string>MuseScore will change the style to suit the font better</string>
+               </property>
+               <property name="text">
+                <string>Automatically load style settings based on font</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="label_92">
+               <property name="text">
+                <string>Text font (from-&gt;to):</string>
+               </property>
+              </widget>
+             </item>
              <item row="1" column="0">
               <widget class="QLabel" name="label_4">
                <property name="text">
@@ -293,36 +322,6 @@
                <property name="buddy">
                 <cstring>musicalTextFont</cstring>
                </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QComboBox" name="musicalSymbolFont">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <item>
-                <property name="text">
-                 <string notr="true">Bravura</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string notr="true">Emmentaler</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string notr="true">Gonville</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string notr="true">MuseJazz</string>
-                </property>
-               </item>
               </widget>
              </item>
              <item row="1" column="1">
@@ -366,6 +365,39 @@
                 </size>
                </property>
               </spacer>
+             </item>
+             <item row="0" column="1">
+              <widget class="QComboBox" name="musicalSymbolFont">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <item>
+                <property name="text">
+                 <string notr="true">Bravura</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string notr="true">Emmentaler</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string notr="true">Gonville</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string notr="true">MuseJazz</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+             <item row="2" column="2">
+              <widget class="QFontComboBox" name="textToComboBox"/>
              </item>
             </layout>
            </item>
@@ -9981,6 +10013,29 @@
       </widget>
       <widget class="QWidget" name="PageTextStyles">
        <layout class="QGridLayout" name="gridLayout_41">
+        <item row="0" column="0" rowspan="2">
+         <widget class="QListWidget" name="textStyles">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <spacer name="verticalSpacer_32">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
         <item row="0" column="1">
          <widget class="QGroupBox" name="showMeasureNumber_8">
           <property name="sizePolicy">
@@ -9993,10 +10048,148 @@
            <string>Edit Text Style</string>
           </property>
           <layout class="QGridLayout" name="_12">
+           <item row="7" column="1">
+            <widget class="Ms::OffsetSelect" name="textStyleOffset" native="true"/>
+           </item>
+           <item row="2" column="1">
+            <widget class="QDoubleSpinBox" name="textStyleFontSize">
+             <property name="suffix">
+              <string>pt</string>
+             </property>
+             <property name="minimum">
+              <double>1.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="2">
+            <widget class="QToolButton" name="resetTextStyleFontSize">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Font size' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="1">
+            <widget class="Ms::AlignSelect" name="textStyleAlign" native="true"/>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_208">
+             <property name="text">
+              <string>Font:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_207">
+             <property name="text">
+              <string>Size:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLineEdit" name="styleName"/>
+           </item>
+           <item row="4" column="1">
+            <widget class="Ms::FontStyleSelect" name="textStyleFontStyle" native="true"/>
+           </item>
+           <item row="6" column="2">
+            <widget class="QToolButton" name="resetTextStyleColor">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Color' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="1">
+            <widget class="Awl::ColorLabel" name="textStyleColor"/>
+           </item>
+           <item row="7" column="2">
+            <widget class="QToolButton" name="resetTextStyleOffset">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Offset' values</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="QToolButton" name="resetTextStyleName">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Name' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="2">
+            <widget class="QToolButton" name="resetTextStyleFontFace">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Font face' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="labelStyleName">
+             <property name="text">
+              <string>Name:</string>
+             </property>
+            </widget>
+           </item>
            <item row="4" column="0">
             <widget class="QLabel" name="label_209">
              <property name="text">
               <string>Style:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="label_210">
+             <property name="text">
+              <string>Align:</string>
              </property>
             </widget>
            </item>
@@ -10034,114 +10227,29 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="2">
-            <widget class="QToolButton" name="resetTextStyleFontSize">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Font size' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="2">
-            <widget class="QToolButton" name="resetTextStyleName">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Name' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="0">
-            <widget class="QLabel" name="labelStyleName">
-             <property name="text">
-              <string>Name:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="1">
-            <widget class="Ms::AlignSelect" name="textStyleAlign" native="true"/>
-           </item>
-           <item row="1" column="2">
-            <widget class="QToolButton" name="resetTextStyleFontFace">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Font face' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="2">
-            <widget class="QToolButton" name="resetTextStyleOffset">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Offset' values</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="0">
-            <widget class="QLabel" name="label_210">
-             <property name="text">
-              <string>Align:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="2">
-            <widget class="QToolButton" name="resetTextStyleColor">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Color' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
            <item row="9" column="0" colspan="3">
             <widget class="QGroupBox" name="groupBox_40">
              <property name="title">
               <string/>
              </property>
              <layout class="QGridLayout" name="gridLayout_38">
+              <item row="0" column="2">
+               <widget class="QToolButton" name="resetTextStyleFrameType">
+                <property name="toolTip">
+                 <string>Reset to default</string>
+                </property>
+                <property name="accessibleName">
+                 <string>Reset 'Frame' value</string>
+                </property>
+                <property name="text">
+                 <string notr="true"/>
+                </property>
+                <property name="icon">
+                 <iconset resource="musescore.qrc">
+                  <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                </property>
+               </widget>
+              </item>
               <item row="0" column="0">
                <widget class="QLabel" name="label_202">
                 <property name="text">
@@ -10168,23 +10276,6 @@
                 </item>
                </widget>
               </item>
-              <item row="0" column="2">
-               <widget class="QToolButton" name="resetTextStyleFrameType">
-                <property name="toolTip">
-                 <string>Reset to default</string>
-                </property>
-                <property name="accessibleName">
-                 <string>Reset 'Frame' value</string>
-                </property>
-                <property name="text">
-                 <string notr="true"/>
-                </property>
-                <property name="icon">
-                 <iconset resource="musescore.qrc">
-                  <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-                </property>
-               </widget>
-              </item>
               <item row="1" column="0" colspan="3">
                <widget class="QWidget" name="frameWidget" native="true">
                 <layout class="QGridLayout" name="gridLayout_43">
@@ -10201,8 +10292,7 @@
                   <number>0</number>
                  </property>
                  <item row="0" column="1">
-                  <widget class="Awl::ColorLabel" name="textStyleFrameForeground">
-                  </widget>
+                  <widget class="Awl::ColorLabel" name="textStyleFrameForeground"/>
                  </item>
                  <item row="2" column="0">
                   <widget class="QLabel" name="label_205">
@@ -10287,8 +10377,7 @@
                   <widget class="QDoubleSpinBox" name="textStyleFramePadding"/>
                  </item>
                  <item row="1" column="1">
-                  <widget class="Awl::ColorLabel" name="textStyleFrameBackground">
-                  </widget>
+                  <widget class="Awl::ColorLabel" name="textStyleFrameBackground"/>
                  </item>
                  <item row="3" column="2">
                   <widget class="QToolButton" name="resetTextStyleFramePadding">
@@ -10347,12 +10436,15 @@
              </layout>
             </widget>
            </item>
-           <item row="6" column="1">
-            <widget class="Awl::ColorLabel" name="textStyleColor">
+           <item row="1" column="1">
+            <widget class="QFontComboBox" name="textStyleFontFace">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
             </widget>
-           </item>
-           <item row="7" column="1">
-            <widget class="Ms::OffsetSelect" name="textStyleOffset" native="true"/>
            </item>
            <item row="5" column="2">
             <widget class="QToolButton" name="resetTextStyleAlign">
@@ -10371,41 +10463,17 @@
              </property>
             </widget>
            </item>
-           <item row="7" column="0">
-            <widget class="QLabel" name="label_186">
-             <property name="text">
-              <string>Offset:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QFontComboBox" name="textStyleFontFace">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="label_208">
-             <property name="text">
-              <string>Font:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="label_207">
-             <property name="text">
-              <string>Size:</string>
-             </property>
-            </widget>
-           </item>
            <item row="6" column="0">
             <widget class="QLabel" name="textStyleColorLabel">
              <property name="text">
               <string>Color:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="0">
+            <widget class="QLabel" name="label_186">
+             <property name="text">
+              <string>Offset:</string>
              </property>
             </widget>
            </item>
@@ -10416,46 +10484,7 @@
              </property>
             </widget>
            </item>
-           <item row="4" column="1">
-            <widget class="Ms::FontStyleSelect" name="textStyleFontStyle" native="true"/>
-           </item>
-           <item row="0" column="1">
-            <widget class="QLineEdit" name="styleName"/>
-           </item>
-           <item row="2" column="1">
-            <widget class="QDoubleSpinBox" name="textStyleFontSize">
-             <property name="suffix">
-              <string>pt</string>
-             </property>
-             <property name="minimum">
-              <double>1.000000000000000</double>
-             </property>
-            </widget>
-           </item>
           </layout>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <spacer name="verticalSpacer_32">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="0" column="0" rowspan="2">
-         <widget class="QListWidget" name="textStyles">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
          </widget>
         </item>
        </layout>
@@ -10509,12 +10538,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>Awl::ColorLabel</class>
-   <extends>QPushButton</extends>
-   <header>awl/colorlabel.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>Ms::FontStyleSelect</class>
    <extends>QWidget</extends>
    <header>inspector/fontStyleSelect.h</header>
@@ -10530,6 +10553,12 @@
    <class>Ms::OffsetSelect</class>
    <extends>QWidget</extends>
    <header>inspector/offsetSelect.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>Awl::ColorLabel</class>
+   <extends>QPushButton</extends>
+   <header>awl/colorlabel.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/280260

Added the ability to change all the text fonts as requested. The option is at  Settings > Style > Score below Musical Text Font.

Edit: Improved the UI, excluded RNA and added a way for the program to give some reasonable default values to the UI elements. Right now the change happens when you change the 2nd box, but I will probably add a button because this is not very intuitive.

![image](https://user-images.githubusercontent.com/21060365/79620299-20571e80-8118-11ea-8e05-457204ea0bf7.png)

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
