### PR TITLE
Fix #302114: Wrong default GUI font under Windows

### DIFF
--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -38,6 +38,29 @@ void Preferences::init(bool storeInMemoryOnly)
             _settings = new QSettings();
             }
 
+#if defined(Q_OS_WIN)
+      // Use the correct default GUI font on Windows. Qt 5 and below use the deprecated function GetStockObject() with
+      // DEFAULT_GUI_FONT, which returns MS Shell Dlg 2 in 8 pt. MS Shell Dlg 2 is a virtual font that maps to Tahoma, which has
+      // not been the default Windows GUI font since 2006.
+      //
+      // The correct way to determine the default GUI font is to call SystemParametersInfoW() with SPI_GETNONCLIENTMETRICS and use
+      // the returned lfMessageFont structure. On all versions of Windows from Windows Vista through Windows 10, this typically
+      // returns Segoe UI in 9 pt.
+      //
+      // This problem is slated to be fixed in Qt 6. For details, see: https://bugreports.qt.io/browse/QTBUG-58610
+      //
+      // In the meantime, we can work around the problem by having Qt use the "QMessageBox" font instead, which is already being
+      // initialized the correct way.
+      QApplication::setFont(QApplication::font("QMessageBox"));
+
+      // If the current settings file is using the deprecated default GUI font, reset it so that the correct default font can be
+      // picked up automatically.
+      if (_settings && _settings->value(PREF_UI_THEME_FONTFAMILY) == "MS Shell Dlg 2") {
+            _settings->remove(PREF_UI_THEME_FONTFAMILY);
+            _settings->remove(PREF_UI_THEME_FONTSIZE);
+            }
+#endif
+
       _storeInMemoryOnly = storeInMemoryOnly;
 
 #if defined(Q_OS_MAC) || (defined(Q_OS_WIN) && !defined(FOR_WINSTORE))


### PR DESCRIPTION
Resolves: [#302114](https://musescore.org/en/node/302114)

Worked around a problem in Qt that caused MuseScore to use the wrong default GUI font on Windows. Qt 5.x and below use the deprecated function `GetStockObject()` with `DEFAULT_GUI_FONT`, which returns MS Shell Dlg 2 in 8 pt. MS Shell Dlg 2 is a virtual font that maps to Tahoma, which has not been the default Windows GUI font since 2006.

The correct way to determine the default GUI font is to call `SystemParametersInfoW()` with `SPI_GETNONCLIENTMETRICS` and use the returned `lfMessageFont` structure. On all versions of Windows from Windows Vista through Windows 10, this typically returns Segoe UI in 9 pt.

This problem is slated to be fixed in Qt 6. For details, see [QTBUG-58610](https://bugreports.qt.io/browse/QTBUG-58610).

In the meantime, we can work around the problem by having Qt use the `"QMessageBox"` font instead, which is already being initialized the correct way.

There are two parts to this fix:

1. Override Qt's detection of the default GUI font. To do this, we ask Qt for the `"QMessageBox"` font and then tell Qt to use that as the default GUI font as well.

2. Detect existing settings files that have been saved with the incorrect default GUI font, and reset the incorrect font settings so that the correct font can be picked up automatically by existing MuseScore installations. Note that this will have the side effect of making the MS Shell Dlg 2 font no longer “stick” if the user explicitly selects it. However, this is a virtual placeholder font that shouldn't be explicitly selected anyway, and any users who prefer its look can always explicitly select the actual underlying font, Tahoma.

[Note: This is a corrected version of [PR #5791](https://github.com/musescore/MuseScore/pull/5791).]

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made