### PR TITLE
Fix #297482 - Score layout shifts when saved with fingering on acciaccatura

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -40,6 +40,7 @@
 #include "slur.h"
 #include "staff.h"
 #include "stem.h"
+#include "stemslash.h"
 #include "sticking.h"
 #include "style.h"
 #include "sym.h"
@@ -878,6 +879,9 @@ void Score::layoutChords3(std::vector<Note*>& notes, const Staff* staff, Segment
 
             Chord* chord = note->chord();
             bool _up     = chord->up();
+
+            if (chord->stemSlash())
+                  chord->stemSlash()->layout();
 
             qreal overlapMirror;
             Stem* stem = chord->stem();


### PR DESCRIPTION
…catura

Resolves: https://musescore.org/en/node/297482#comment-984598

Solves the shift of the fingering on the grace note, and therefor the shift of the line above the fingering.

The root cause was <code>StemSlash</code>. Shapes for the <code>StemSlash</code> are created during the layout of the beams of the grace notes and the layout of these beams is with the layout of the complete <code>Chord</code> to which the grace notes belong. As a result, the shapes of <code>StemSlash</code> are added to the skyline after the layout of the <code>Fingering</code> so the layout of the <code>Fingering</code> was based of the layout of the <code>Stem</code> only.
After a re-layout the <code>StemSlash</code> is included in the skyline so the re-layout will move
the Fingering and, in this case, also the line.
The solution was a extra layout of the <code>StemSlash</code> in <code>Score::layoutChords3() </code>so its <code>StemSlash</code> is included in the skyline in time.

Although this issue is very similar to #302316 and fix #297501, the root cause is different.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
