### PR TITLE
fix #302372: Palette Search filters palettes but not items

### DIFF
--- a/mscore/palette/palettemodel.cpp
+++ b/mscore/palette/palettemodel.cpp
@@ -253,8 +253,8 @@ QVariant PaletteTreeModel::data(const QModelIndex& index, int role) const
       if (const PalettePanel* pp = findPalettePanel(index)) {
             switch (role) {
                   case Qt::DisplayRole:
-                        return pp->translatedName();
                   case Qt::ToolTipRole:
+                        return pp->translatedName();
                   case Qt::AccessibleTextRole:
                         return QString("%1 palette").arg(pp->translatedName());
                   case VisibleRole:
@@ -1018,6 +1018,16 @@ bool FilterPaletteTreeModel::filterAcceptsRow(int sourceRow, const QModelIndex& 
       if (!cell) // a palette panel or just an unrelated model
             return true;
       return cellFilter->accept(*cell);
+      }
+
+//---------------------------------------------------------
+//   PaletteCellFilterProxyModel::PaletteCellFilterProxyModel
+//---------------------------------------------------------
+
+PaletteCellFilterProxyModel::PaletteCellFilterProxyModel(QObject* parent)
+      : QSortFilterProxyModel(parent)
+      {
+      setFilterRole(Qt::ToolTipRole); // palette cells have no data for DisplayRole
       }
 
 //---------------------------------------------------------

--- a/mscore/palette/palettemodel.h
+++ b/mscore/palette/palettemodel.h
@@ -200,7 +200,7 @@ class FilterPaletteTreeModel : public QSortFilterProxyModel {
 class PaletteCellFilterProxyModel : public QSortFilterProxyModel {
       Q_OBJECT
    public:
-      PaletteCellFilterProxyModel(QObject* parent = nullptr) : QSortFilterProxyModel(parent) {}
+      PaletteCellFilterProxyModel(QObject* parent = nullptr);
 
       bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const override;
       };

--- a/mscore/qml/palettes/Palette.qml
+++ b/mscore/qml/palettes/Palette.qml
@@ -412,7 +412,7 @@ GridView {
     function focusNextMatchingItem(str) {
         const nextIndex = (currentIndex === count - 1) ? 0 : currentIndex + 1;
         const modelIndex = paletteModel.index(nextIndex, 0, paletteRootIndex);
-        const matchedIndexList = paletteModel.match(modelIndex, Qt.DisplayRole, str);
+        const matchedIndexList = paletteModel.match(modelIndex, Qt.ToolTipRole, str);
         if (matchedIndexList.length) {
             currentIndex = matchedIndexList[0].row;
             currentItem.forceActiveFocus();

--- a/mscore/qml/palettes/PaletteTree.qml
+++ b/mscore/qml/palettes/PaletteTree.qml
@@ -261,7 +261,7 @@ ListView {
     function focusNextMatchingItem(str) {
         const nextIndex = (currentIndex < count - 1) ? currentIndex + 1 : 0;
         const modelIndex = paletteModel.index(nextIndex, 0);
-        const matchedIndexList = paletteModel.match(modelIndex, Qt.DisplayRole, str);
+        const matchedIndexList = paletteModel.match(modelIndex, Qt.ToolTipRole, str);
         if (matchedIndexList.length) {
             currentIndex = matchedIndexList[0].row;
             currentItem.forceActiveFocus();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/302372

Replace Qt::DisplayRole with Qt::ToolTipRole when accessing data for palette
cells. Necessitated by [changes to palettemodel.cpp](https://github.com/musescore/MuseScore/pull/5729/files#diff-50d614a92cd54767059e16f57d24670a) in PR #5729.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
