### PR TITLE
Fix #302388 - Changing the order of the instruments (staves)

### DIFF
--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -318,6 +318,15 @@ PartListItem::PartListItem(const InstrumentTemplate* i, QTreeWidget* lv)
       op   = ListItemOp::ADD;
       setText(0, it->trackName);
       }
+PartListItem::PartListItem(const InstrumentTemplate* i, QTreeWidget* lv, QTreeWidgetItem* prv)
+   : QTreeWidgetItem(lv, prv, PART_LIST_ITEM)
+      {
+      part = 0;
+      it   = i;
+      op   = ListItemOp::ADD;
+      setText(0, it->trackName);
+      }
+
 
 //---------------------------------------------------------
 //   InstrumentTemplateListItem
@@ -385,7 +394,7 @@ InstrumentsWidget::InstrumentsWidget(QWidget* parent)
       downButton->setEnabled(false);
       addStaffButton->setEnabled(false);
       addLinkedStaffButton->setEnabled(false);
-      
+
       upButton->setIcon(*icons[int(Icons::arrowUp_ICON)]);
       downButton->setIcon(*icons[int(Icons::arrowDown_ICON)]);
 
@@ -562,12 +571,17 @@ void InstrumentsWidget::on_instrumentList_itemActivated(QTreeWidgetItem* item, i
 
 void InstrumentsWidget::on_addButton_clicked()
       {
+      QTreeWidgetItem* prvItem = nullptr;
+      QList<QTreeWidgetItem*> wi = partiturList->selectedItems();
+      if (!wi.isEmpty())
+            prvItem = wi.front()->parent() ? wi.front()->parent() : wi.front();
+
       for (QTreeWidgetItem* i : instrumentList->selectedItems()) {
             InstrumentTemplateListItem* item = static_cast<InstrumentTemplateListItem*>(i);
             const InstrumentTemplate* it     = item->instrumentTemplate();
             if (it == 0)
                   continue;
-            PartListItem* pli = new PartListItem(it, partiturList);
+            PartListItem* pli = prvItem ? new PartListItem(it, partiturList, prvItem) : new PartListItem(it, partiturList);
             pli->setFirstColumnSpanned(true);
             pli->op = ListItemOp::ADD;
 

--- a/mscore/instrwidget.h
+++ b/mscore/instrwidget.h
@@ -45,6 +45,7 @@ class PartListItem : public QTreeWidgetItem {
 
       PartListItem(Part* p, QTreeWidget* lv);
       PartListItem(const InstrumentTemplate* i, QTreeWidget* lv);
+      PartListItem(const InstrumentTemplate* i, QTreeWidget* lv, QTreeWidgetItem* prv);
       bool visible() const;
       void setVisible(bool val);
       void updateClefs();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/302388

Implementation is using another <code>QTreeWidgetItem</code> constructor which accepts the preceding item. This makes the implementation straight forward.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n.a.] I created the test (mtest, vtest, script test) to verify the changes I made
