### PR TITLE
fix #279304: disable buttons after last instrument delete

### DIFF
--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -385,7 +385,7 @@ InstrumentsWidget::InstrumentsWidget(QWidget* parent)
       downButton->setEnabled(false);
       addStaffButton->setEnabled(false);
       addLinkedStaffButton->setEnabled(false);
-      
+
       upButton->setIcon(*icons[int(Icons::arrowUp_ICON)]);
       downButton->setIcon(*icons[int(Icons::arrowDown_ICON)]);
 
@@ -508,6 +508,7 @@ void InstrumentsWidget::on_partiturList_itemSelectionChanged()
             downButton->setEnabled(false);
             addLinkedStaffButton->setEnabled(false);
             addStaffButton->setEnabled(false);
+            completeChanged(false);
             return;
             }
       QTreeWidgetItem* item = wi.front();
@@ -538,7 +539,7 @@ void InstrumentsWidget::on_partiturList_itemSelectionChanged()
       bool first = (witems.first() == item);
       bool last = (witems.last() == item);
 
-      removeButton->setEnabled(flag && !onlyOne);
+      removeButton->setEnabled(flag /*&& !onlyOne*/);
       upButton->setEnabled(flag && !onlyOne && !first);
       downButton->setEnabled(flag && !onlyOne && !last);
       addLinkedStaffButton->setEnabled(item && item->type() == STAFF_LIST_ITEM);
@@ -605,11 +606,6 @@ void InstrumentsWidget::on_removeButton_clicked()
       QTreeWidgetItem* parent = item->parent();
 
       if (parent) {
-            if (parent->childCount() == 1) {
-                  Q_ASSERT(false); // shouldn't get here (remove button disabled when one item left)
-                  removeButton->setEnabled(false); // nevertheless, handle gracefully in release builds
-                  return;
-                  }
             if (((StaffListItem*)item)->op() == ListItemOp::ADD) {
                   if (parent->childCount() == 1) {
                         partiturList->takeTopLevelItem(partiturList->indexOfTopLevelItem(parent));
@@ -640,12 +636,6 @@ void InstrumentsWidget::on_removeButton_clicked()
             partiturList->setCurrentItem(parent);
             }
       else {
-            if (partiturList->topLevelItemCount() == 1) {
-                  Q_ASSERT(false); // shouldn't get here as (remove button disabled when one item left)
-                  removeButton->setEnabled(false); // nevertheless, handle gracefully in release builds
-                  emit completeChanged(false);
-                  return;
-                  }
             int idx = partiturList->indexOfTopLevelItem(item);
             if (((PartListItem*)item)->op == ListItemOp::ADD) {
                   partiturList->blockSignals(true);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/279304

*(short description of the changes and the motivation to make the changes)*
Changes in mscore/instrwidget.cpp
in `void InstrumentsWidget::on_removeButton_clicked()` remove button is no longer disabled when 1 instrument is left
in `void InstrumentsWidget::on_partiturList_itemSelectionChanged()` signal to disable Next and Finish buttons

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
