### PR TITLE
[MU4] fix #276526: position of play panel saved in floating mode

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -503,7 +503,7 @@ void MuseScore::preferencesChanged(bool fromWorkspace)
       // change workspace
       if (!fromWorkspace && preferences.getString(PREF_APP_WORKSPACE) != WorkspacesManager::currentWorkspace()->name()) {
             Workspace* workspace = WorkspacesManager::findByName(preferences.getString(PREF_APP_WORKSPACE));
-            
+
             if (workspace)
                   mscore->changeWorkspace(workspace);
             }
@@ -764,7 +764,7 @@ bool MuseScore::importExtension(QString path)
 
                   if (!sfzs.isEmpty())
                         synti->storeState();
-                  
+
                   s->gui()->synthesizerChanged();
                   }
 
@@ -787,7 +787,7 @@ bool MuseScore::importExtension(QString path)
                         }
                   if (!sfs.isEmpty())
                         synti->storeState();
-                  
+
                   s->gui()->synthesizerChanged();
                   }
             };
@@ -854,7 +854,7 @@ bool MuseScore::uninstallExtension(QString extensionId)
                   }
             if (found)
                   synti->storeState();
-            
+
             s->gui()->synthesizerChanged();
             }
       bool refreshWorkspaces = false;
@@ -884,7 +884,7 @@ bool MuseScore::uninstallExtension(QString extensionId)
             bool curWorkspaceDisappeared = false;
             if (WorkspacesManager::findByName(curWorkspaceName))
                   curWorkspaceDisappeared = true;
-            
+
             if (curWorkspaceDisappeared)
                   changeWorkspace(WorkspacesManager::workspaces().last());
             }
@@ -1241,7 +1241,7 @@ MuseScore::MuseScore()
       {
       feedbackTools = addToolBar("");
       feedbackTools->setObjectName("feedback-tools");
-	  // Forbid to move or undock the toolbar...
+     // Forbid to move or undock the toolbar...
       feedbackTools->setMovable(false);
       feedbackTools->setFloatable(false);
       // Add a spacer to align the buttons to the right side.
@@ -2056,7 +2056,7 @@ void MuseScore::retranslate()
       if (paletteWorkspace)
           paletteWorkspace->retranslate();
       }
-      
+
 //---------------------------------------------------------
 //   setMenuTitles
 //---------------------------------------------------------
@@ -2156,7 +2156,7 @@ void MuseScore::updateMenus()
       addPluginMenuEntries();
 #endif
       }
-      
+
 //---------------------------------------------------------
 //   resizeEvent
 //---------------------------------------------------------
@@ -2999,12 +2999,13 @@ void MuseScore::showPlayPanel(bool visible)
             connect(synti,     SIGNAL(gainChanged(float)), playPanel, SLOT(setGain(float)));
             playPanel->setGain(synti->gain());
             playPanel->setScore(cs);
-            addDockWidget(Qt::RightDockWidgetArea, playPanel);
+            addDockWidget(Qt::RightDockWidgetArea, playPanel); //comment this out to allow for saving the position on both floating and docked mode (you must provide a default position)
 
             // The play panel must be set visible before being set floating for positioning
             // and window geometry reasons.
             playPanel->setVisible(visible);
-            playPanel->setFloating(false);
+            restoreDockWidget(playPanel);
+            playPanel->setFloating(settings.value("MainWindow/playPanelFloating").toBool());
             }
       else
             reDisplayDockWidget(playPanel, visible);
@@ -4504,6 +4505,7 @@ void MuseScore::writeSettings()
       settings.setValue("debuggerSplitter", mainWindow->saveState());
       settings.setValue("split", _horizontalSplit);
       settings.setValue("splitter", splitter->saveState());
+      settings.setValue("playPanelFloating", playPanel->isFloating());
       settings.endGroup();
 
       WorkspacesManager::currentWorkspace()->save();
@@ -6992,7 +6994,7 @@ bool MuseScore::saveMp3(Score* score, QIODevice* device, bool& wasCanceled)
                                           continue;
                                     e.setChannel(a->channel());
                                     int syntiIdx= synth->index(score->masterScore()->midiMapping(a->channel())->articulation()->synti());
-									synth->play(e, syntiIdx);
+                                    synth->play(e, syntiIdx);
                                     }
                               }
                         }
@@ -7845,7 +7847,7 @@ void MuseScore::init(QStringList& argv)
                   Workspace* targetWorkspace = WorkspacesManager::visibleWorkspaces()[0];
                   if (targetWorkspace)
                         mscore->changeWorkspace(targetWorkspace, true);
-                  
+
                   preferences.setPreference(PREF_UI_APP_STARTUP_SHOWTOURS, sw->showTours());
                   delete sw;
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/276526 

The requested feature is pretty simple, save the position of the play panel after exiting the program. I implemented this feature only for floating mode (actually implemented it for both floating and dock modes but then reversed the changes). There is a discussion to be had about whether it should extend to dock mode (in this case give the ability to dock the play panel wherever you want and to save this position) and if yes, should there be similar functionality in similar tools (like the mixer).

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
