### PR TITLE
fix #298899: work around palette search crash with NVDA on Qt 5.9

### DIFF
--- a/mscore/palette/paletteworkspace.cpp
+++ b/mscore/palette/paletteworkspace.cpp
@@ -979,4 +979,22 @@ bool PaletteWorkspace::read(XmlReader& e)
 
       return true;
       }
+
+//---------------------------------------------------------
+//   PaletteWorkspace::needsItemDestructionAccessibilityWorkaround
+///   Checks whether workaround for palette search crash
+///   with NVDA is needed, see issue #298899.
+//---------------------------------------------------------
+
+bool PaletteWorkspace::needsItemDestructionAccessibilityWorkaround() const
+      {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+      // Qt switched to a new accessibility backend since 5.11
+      // and no crashes are reported for 5.12 so presumably
+      // the workaround is not needed since Qt 5.11.
+      return false;
+#else
+      return QAccessible::isActive();
+#endif
+      }
 } // namespace Ms

--- a/mscore/palette/paletteworkspace.h
+++ b/mscore/palette/paletteworkspace.h
@@ -219,6 +219,8 @@ class PaletteWorkspace : public QObject {
       Q_INVOKABLE bool savePalette(const QModelIndex&);
       Q_INVOKABLE bool loadPalette(const QModelIndex&);
 
+      Q_INVOKABLE bool needsItemDestructionAccessibilityWorkaround() const;
+
       bool paletteChanged() const { return userPalette->paletteTreeChanged(); }
 
       void setUserPaletteTree(std::unique_ptr<PaletteTree> tree);

--- a/mscore/qml/nativemenu.cpp
+++ b/mscore/qml/nativemenu.cpp
@@ -88,4 +88,19 @@ void QmlNativeMenu::popup()
       showMenu(QCursor::pos());
       }
 
+//---------------------------------------------------------
+//   QmlNativeMenu::setVisible
+//---------------------------------------------------------
+
+void QmlNativeMenu::setVisible(bool val)
+      {
+      if (val == _visible)
+            return;
+
+      if (val)
+            open();
+      else
+            Q_ASSERT(false); // trying to hide visible menu: not implemented and (is supposed to be) unused
+      }
+
 } // namespace Ms

--- a/mscore/qml/nativemenu.h
+++ b/mscore/qml/nativemenu.h
@@ -40,7 +40,7 @@ class QmlNativeMenu : public QQuickItem {
       Q_PROPERTY(int x READ x WRITE setX)
       Q_PROPERTY(int y READ y WRITE setY)
 
-      Q_PROPERTY(bool visible READ visible NOTIFY visibleChanged)
+      Q_PROPERTY(bool visible READ visible WRITE setVisible NOTIFY visibleChanged)
 
       QQmlListProperty<QObject> contentData() { return QQmlListProperty<QObject>(this, _contentData); } // TODO: use different QQmlListProperty constructor?
 
@@ -58,7 +58,8 @@ class QmlNativeMenu : public QQuickItem {
       void setX(int val) { pos.setX(val); }
       void setY(int val) { pos.setY(val); }
 
-      bool visible() const { return _visible; };
+      bool visible() const { return _visible; }
+      void setVisible(bool val);
 
       Q_INVOKABLE void open();
       Q_INVOKABLE void popup();

--- a/mscore/qml/palettes/PaletteTree.qml
+++ b/mscore/qml/palettes/PaletteTree.qml
@@ -304,6 +304,11 @@ ListView {
             property int rowIndex: index
             property var modelIndex: paletteTree.model.modelIndex(index, 0)
 
+            Component.onDestruction: {
+                if (paletteTree.paletteWorkspace.needsItemDestructionAccessibilityWorkaround())
+                    Utils.setInvisibleRecursive(this);
+            }
+
             onActiveFocusChanged: {
                 if (activeFocus)
                     paletteTree.currentTreeItem = this;
@@ -606,6 +611,11 @@ ListView {
                     paletteName: model.display
                     paletteIsCustom: model.custom
                     paletteEditingEnabled: model.editable
+
+                    Component.onDestruction: {
+                        if (paletteTree.paletteWorkspace.needsItemDestructionAccessibilityWorkaround())
+                            Utils.setInvisibleRecursive(this);
+                    }
 
                     onVisibleChanged: {
                         // build pool model on first popup appearance

--- a/mscore/qml/palettes/utils.js
+++ b/mscore/qml/palettes/utils.js
@@ -40,3 +40,14 @@ function dropEventMimeData(drag) {
 function removeSelectedItems(paletteController, selectionModel, parentIndex) {
     paletteController.removeSelection(selectionModel.selectedIndexes, parentIndex);
 }
+
+function setInvisibleRecursive(item) {
+    var children = item.children; // list of children if item is Item
+    if (!children)
+        children = item.contentChildren; // list of children if item is Popup
+
+    for (var i = 0; i < children.length; ++i)
+        setInvisibleRecursive(children[i]);
+
+    item.visible = false;
+}


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/298899

### Short description of commit

Added a hack to explicitly set visibility of items to be destroyed
to false to avoid changing it to true and triggering accessibility
events on item destruction.

Added an ability to set `visible` property of Ms::QmlNativeMenu to
avoid special-handling this type in the workaround code.

### More detailed workaround explanation

MSVC shows the following call stack for the crash in question:

<details>
<summary> Call stack (Qt 5.9.8) </summary>

```
Qt5QuickTemplates2.dll!QQuickControlPrivate::accessibilityActiveChanged(bool active=true)Строка 324
	в c:\users\qt\work\qt\qtquickcontrols2\src\quicktemplates2\qquickcontrol.cpp(324)
Qt5Gui.dll!QAccessible::setActive(bool active)Строка 805
	в c:\users\qt\work\qt\qtbase\src\gui\accessible\qaccessible.cpp(805)
qwindows.dll!00007ff96de869cf()
qwindows.dll!00007ff96de508af()
qwindows.dll!00007ff96de515b7()
user32.dll!00007ff9855224fd()
user32.dll!00007ff985523d6b()
opengl32.dll!00007ff969b528fc()
user32.dll!00007ff985523fe0()
user32.dll!00007ff985523af2()
user32.dll!00007ff985523bbe()
ntdll.dll!00007ff9876a25c4()
user32.dll!00007ff98552102a()
user32.dll!00007ff9855252a8()
oleacc.dll!00007ff9802a2620()
oleacc.dll!00007ff9802a2987()
nvdaHelperRemote.dll!00007ff9708cd2b2()
nvdaHelperRemote.dll!00007ff9708b38ad()
user32.dll!00007ff985524dda()
ntdll.dll!00007ff9876a25c4()
user32.dll!00007ff985525ffa()
qwindows.dll!00007ff96de86f1f()
Qt5Gui.dll!QAccessible::updateAccessibility(QAccessibleEvent * event=0x000000000013b698)Строка 876
	в c:\users\qt\work\qt\qtbase\src\gui\accessible\qaccessible.cpp(876)
Qt5Quick.dll!QQuickItemPrivate::setEffectiveVisibleRecur(bool newEffectiveVisible=true)Строка 5896
	в c:\users\qt\work\qt\qtdeclarative\src\quick\items\qquickitem.cpp(5896)
Qt5Quick.dll!QQuickItemPrivate::setEffectiveVisibleRecur(bool newEffectiveVisible)Строка 5888
	в c:\users\qt\work\qt\qtdeclarative\src\quick\items\qquickitem.cpp(5888)
Qt5Quick.dll!QQuickItemPrivate::setEffectiveVisibleRecur(bool newEffectiveVisible)Строка 5888
	в c:\users\qt\work\qt\qtdeclarative\src\quick\items\qquickitem.cpp(5888)
Qt5Quick.dll!QQuickItem::setParentItem(QQuickItem * parentItem=0x0000000000000000)Строка 2744
	в c:\users\qt\work\qt\qtdeclarative\src\quick\items\qquickitem.cpp(2744)
Qt5Quick.dll!QQuickItem::~QQuickItem()Строка 2379
	в c:\users\qt\work\qt\qtdeclarative\src\quick\items\qquickitem.cpp(2379)
Qt5Quick.dll!QQmlPrivate::QQmlElement<QQuickRectangle>::`scalar deleting destructor'(unsigned int)
Qt5Core.dll!QObjectPrivate::deleteChildren()Строка 1990
	в c:\users\qt\work\qt\qtbase\src\corelib\kernel\qobject.cpp(1990)
Qt5Core.dll!QObject::~QObject()Строка 1023
	в c:\users\qt\work\qt\qtbase\src\corelib\kernel\qobject.cpp(1023)
Qt5Quick.dll!QQmlPrivate::QQmlElement<QQuickColumn>::`scalar deleting destructor'(unsigned int)
Qt5Core.dll!QObjectPrivate::deleteChildren()Строка 1990
	в c:\users\qt\work\qt\qtbase\src\corelib\kernel\qobject.cpp(1990)
Qt5Core.dll!QObject::~QObject()Строка 1023
	в c:\users\qt\work\qt\qtbase\src\corelib\kernel\qobject.cpp(1023)
qtquicktemplates2plugin.dll!QQmlPrivate::QQmlElement<QQuickItemDelegate>::`scalar deleting destructor'(unsigned int)
[Внедренный фрейм] Qt5Core.dll!qDeleteInEventHandler(QObject *)Строка 4600
	в c:\users\qt\work\qt\qtbase\src\corelib\kernel\qobject.cpp(4600)
Qt5Core.dll!QObject::event(QEvent * e)Строка 1239
	в c:\users\qt\work\qt\qtbase\src\corelib\kernel\qobject.cpp(1239)
Qt5Widgets.dll!QApplicationPrivate::notify_helper(QObject * receiver=0x000000000f0adc00, QEvent * e=0x0000000008733100)Строка 3723
	в c:\users\qt\work\qt\qtbase\src\widgets\kernel\qapplication.cpp(3723)
Qt5Widgets.dll!QApplication::notify(QObject * receiver=0x000000000f0adc00, QEvent * e=0x0000000008733100)Строка 3564
	в c:\users\qt\work\qt\qtbase\src\widgets\kernel\qapplication.cpp(3564)
Qt5Core.dll!QCoreApplication::notifyInternal2(QObject * receiver=0x000000000f0adc00, QEvent * event=0x0000000008733100)Строка 1024
	в c:\users\qt\work\qt\qtbase\src\corelib\kernel\qcoreapplication.cpp(1024)
[Внедренный фрейм] Qt5Core.dll!QCoreApplication::sendEvent(QObject *)Строка 233
	в c:\users\qt\work\qt\qtbase\src\corelib\kernel\qcoreapplication.h(233)
Qt5Core.dll!QCoreApplicationPrivate::sendPostedEvents(QObject * receiver=0x0000000000000000, int event_type, QThreadData * data=0x00000000001af180)Строка 1699
	в c:\users\qt\work\qt\qtbase\src\corelib\kernel\qcoreapplication.cpp(1699)
qwindows.dll!00007ff96de93fef()
Qt5Core.dll!qt_internal_proc(HWND__ * hwnd=0x0000000000040460, unsigned int message=1025, unsigned __int64 wp=0, __int64 lp=0)Строка 237
	в c:\users\qt\work\qt\qtbase\src\corelib\kernel\qeventdispatcher_win.cpp(237)
user32.dll!00007ff9855224fd()
user32.dll!00007ff985522357()
Qt5Core.dll!QEventDispatcherWin32::processEvents(QFlags<enum QEventLoop::ProcessEventsFlag> flags={...})Строка 635
	в c:\users\qt\work\qt\qtbase\src\corelib\kernel\qeventdispatcher_win.cpp(635)
qwindows.dll!00007ff96de93fc9()
[Внедренный фрейм] Qt5Core.dll!QEventLoop::processEvents(QFlags<enum QEventLoop::ProcessEventsFlag> flags)Строка 134
	в c:\users\qt\work\qt\qtbase\src\corelib\kernel\qeventloop.cpp(134)
Qt5Core.dll!QEventLoop::exec(QFlags<enum QEventLoop::ProcessEventsFlag> flags={...})Строка 212
	в c:\users\qt\work\qt\qtbase\src\corelib\kernel\qeventloop.cpp(212)
Qt5Core.dll!QCoreApplication::exec()Строка 1297
	в c:\users\qt\work\qt\qtbase\src\corelib\kernel\qcoreapplication.cpp(1297)
MuseScore3.exe!Ms::runApplication(int & argc=1, char * * av)Строка 7648
	в e:\projects\musescore\musescore\mscore\musescore.cpp(7648)
MuseScore3.exe!main(int argc=1108755996, char * * argv=0x00007ff5ffff6000)Строка 92
	в e:\projects\musescore\musescore\main\main.cpp(92)
[Внедренный фрейм] MuseScore3.exe!invoke_main()Строка 78
	в d:\agent\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl(78)
MuseScore3.exe!__scrt_common_main_seh()Строка 288
	в d:\agent\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl(288)
kernel32.dll!00007ff984ce13d2()
ntdll.dll!00007ff9876254f4()
```
</details>

It can be noted that `QQuickItem` destructor [sets](https://github.com/qt/qtdeclarative/blob/5.9.8/src/quick/items/qquickitem.cpp#L2380) parent item for children of the destroyed item to null pointer, which, in turn, causes child items to [update](https://github.com/qt/qtdeclarative/blob/5.9.8/src/quick/items/qquickitem.cpp#L2743) their real visibility status. If this happens to change its visibility status it [invokes](https://github.com/qt/qtdeclarative/blob/5.9.8/src/quick/items/qquickitem.cpp#L5895) accessibility support code which finally comes down to a crash somewhere in [`QQuickControlPrivate::accessibilityActiveChanged()`](https://github.com/qt/qtquickcontrols2/blob/5.9.8/src/quicktemplates2/qquickcontrol.cpp#L323) function, possibly due to trying to retrieve pointer for a "non-private" object which is already in the process of being destroyed (or, possibly, has already been destroyed).

The new effective visibilty value being assigned to an item is calculated in [`calcEffectiveVisible()`](https://github.com/qt/qtdeclarative/blob/5.9.8/src/quick/items/qquickitem.cpp#L5856) function. Somewhat surprisingly, it effectively returns `explicitVisible` value if no parent is present for an item, which means that a child of invisible item which has not itself been explicitly marked invisible would change its effective visibility from `false` to `true` in the process of destruction of its parent. As this change is what triggers the calls chain described above, it can be expected that explicitly setting child items visibility to `false` (or any value which wouldn't change effective visibility in the process of destruction) would prevent this issue from happening. This is basically what is implemented in this pull request.

The workaround implemented in this pull request is to recursively mark the palette delegate which is planned to be destroyed and all its descendants invisible before the actual destruction happens. That way when the actual destruction happens no change in effective visibility occurs so the code which produces the crash does not get triggered.

So far I enabled this workaround only for Qt before 5.11 version since 5.11 version contains different accessibility backend (although the code mentioned here seems to be still similar to its 5.9 version). If no crash happens with the new accessibility implementation then there is no need for this workaround in newer versions of Qt, but if it happens to be necessary this approach could possibly be used for those versions as well.