### PR TITLE
Palettes: Implement Type-Ahead Find with incremental search

### DIFF
--- a/mscore/qml/palettes/Palette.qml
+++ b/mscore/qml/palettes/Palette.qml
@@ -150,7 +150,20 @@ GridView {
 
         onClicked: paletteView.moreButtonClicked()
 
+        Keys.onShortcutOverride: {
+            // Intercept all keys that we want to use with Keys.onPressed
+            // in case they are assigned as shortcuts in Preferences.
+            event.accepted = true; // intercept everything
+            switch (event.key) {
+                case Qt.Key_Up:
+                case Qt.Key_Down:
+                    return;
+            }
+            event.accepted = false; // allow key to function as shortcut (don't intercept)
+        }
+
         Keys.onPressed: {
+            // NOTE: All keys must be intercepted with Keys.onShortcutOverride.
             switch (event.key) {
                 case Qt.Key_Up:
                     focusPreviousItem();
@@ -455,7 +468,24 @@ GridView {
             selectionModel.setCurrentIndex(currentItem.modelIndex, ItemSelectionModel.Select);
     }
 
+    Keys.onShortcutOverride: {
+        // Intercept all keys that we want to use with Keys.onPressed
+        // in case they are assigned as shortcuts in Preferences.
+        event.accepted = true; // intercept everything
+        switch (event.key) {
+            case Qt.Key_Up:
+            case Qt.Key_Down:
+            case Qt.Key_Left:
+            case Qt.Key_Right:
+            case Qt.Key_Backspace:
+            case Qt.Key_Delete:
+                return;
+        }
+        event.accepted = false; // allow key to function as shortcut (don't intercept)
+    }
+
     Keys.onPressed: {
+        // NOTE: All keys must be intercepted with Keys.onShortcutOverride.
         switch (event.key) {
             case Qt.Key_Up:
                 focusPreviousItem();
@@ -582,7 +612,27 @@ GridView {
             Accessible.selectable: true;
             Accessible.selected: selected;
 
+            Keys.onShortcutOverride: {
+                // Intercept all keys that we want to use with Keys.onPressed
+                // in case they are assigned as shortcuts in Preferences.
+                event.accepted = true; // intercept everything
+                switch (event.key) {
+                    case Qt.Key_Space:
+                    case Qt.Key_Enter:
+                    case Qt.Key_Return:
+                    case Qt.Key_Menu:
+                    case Qt.Key_Asterisk:
+                        return;
+                }
+                if (event.key === Qt.Key_F10 && event.modifiers & Qt.ShiftModifier)
+                    return;
+                if (event.text.match(/[^\x00-\x20\x7F]+$/) !== null)
+                    return;
+                event.accepted = false; // allow key to function as shortcut (don't intercept)
+            }
+
             Keys.onPressed: {
+                // NOTE: All keys must be intercepted with Keys.onShortcutOverride.
                 const shiftHeld = event.modifiers & Qt.ShiftModifier;
                 const ctrlHeld = event.modifiers & Qt.ControlModifier;
                 switch (event.key) {

--- a/mscore/qml/palettes/PaletteTree.qml
+++ b/mscore/qml/palettes/PaletteTree.qml
@@ -114,7 +114,26 @@ ListView {
         Utils.removeSelectedItems(paletteController, paletteSelectionModel, parentIndex);
     }
 
+    Keys.onShortcutOverride: {
+        // Intercept all keys that we want to use with Keys.onPressed
+        // in case they are assigned as shortcuts in Preferences.
+        event.accepted = true; // intercept everything
+        switch (event.key) {
+            case Qt.Key_Down:
+            case Qt.Key_Up:
+            case Qt.Key_Home:
+            case Qt.Key_End:
+            case Qt.Key_PageUp:
+            case Qt.Key_PageDown:
+            case Qt.Key_Backspace:
+            case Qt.Key_Delete:
+                return;
+        }
+        event.accepted = false; // allow key to function as shortcut (don't intercept)
+    }
+
     Keys.onPressed: {
+        // NOTE: All keys must be intercepted with Keys.onShortcutOverride.
         switch (event.key) {
             case Qt.Key_Down:
                 focusNextItem();
@@ -407,7 +426,31 @@ ListView {
                 paletteTree.paletteController.remove(modelIndex);
             }
 
+            Keys.onShortcutOverride: {
+                // Intercept all keys that we want to use with Keys.onPressed
+                // in case they are assigned as shortcuts in Preferences.
+                event.accepted = true; // intercept everything
+                switch (event.key) {
+                    case Qt.Key_Right:
+                    case Qt.Key_Plus:
+                    case Qt.Key_Left:
+                    case Qt.Key_Minus:
+                    case Qt.Key_Space:
+                    case Qt.Key_Enter:
+                    case Qt.Key_Return:
+                    case Qt.Key_Menu:
+                    case Qt.Key_Asterisk:
+                        return;
+                }
+                if (event.key === Qt.Key_F10 && event.modifiers & Qt.ShiftModifier)
+                    return;
+                if (event.text.match(/[^\x00-\x20\x7F]+$/) !== null)
+                    return;
+                event.accepted = false; // allow key to function as shortcut (don't intercept)
+            }
+
             Keys.onPressed: {
+                // NOTE: All keys must be intercepted with Keys.onShortcutOverride.
                 switch (event.key) {
                     case Qt.Key_Right:
                     case Qt.Key_Plus:


### PR DESCRIPTION
Resolves: *no issue in tracker*

If the user presses a letter key while in the Palettes tree then a matching palette or cell gains focus. E.g. Press 'L' to jump to the Lines palette.

Pressing multiple keys in quick succession enables incremental search. E.g. Press 'A' shortly followed by 'R' to skip Accidentals and go straight to Articulations.

Pressing the same key repeatedly cycles through matching items. E.g. 'T' => Time Signatures, 'T' => Text, 'T' => Tempo, 'T' => Time Signatures, etc.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [N/A] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
