### PR TITLE
Fixed crash fluids voice noteoff (from CrashReporter)

### DIFF
--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -619,6 +619,9 @@ void Seq::processMessages()
                   case SeqMsgId::SEEK:
                         setPos(msg.intVal);
                         break;
+                  case SeqMsgId::ALL_NOTE_OFF:
+                        _synti->allNotesOff(msg.intVal);
+                        break;
                   default:
                         break;
                   }
@@ -1330,8 +1333,9 @@ void Seq::stopNotes(int channel, bool realTime)
             if (cs->midiChannel(channel) != 9)
                   send(NPlayEvent(ME_PITCHBEND,  channel, 0, 64));
             }
-      if (cachedPrefs.useAlsaAudio || cachedPrefs.useJackAudio || cachedPrefs.usePulseAudio || cachedPrefs.usePortAudio)
-            _synti->allNotesOff(channel);
+      if (cachedPrefs.useAlsaAudio || cachedPrefs.useJackAudio || cachedPrefs.usePulseAudio || cachedPrefs.usePortAudio) {
+            guiToSeq(SeqMsg(SeqMsgId::ALL_NOTE_OFF, channel));
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/seq.h
+++ b/mscore/seq.h
@@ -55,6 +55,7 @@ enum class SeqMsgId : char {
       NO_MESSAGE,
       TEMPO_CHANGE,
       PLAY, SEEK,
+      ALL_NOTE_OFF,
       MIDI_INPUT_EVENT
       };
 


### PR DESCRIPTION
Resolves: https://sentry.musescore.org/musescore/editor/issues/19451/ (from CrashReporter)
  
one of the frequent crash is:  
```
Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ
MuseScore3 0x0001407b1006 FluidS::Voice::noteoff() c:\musescore\fluid\voice.cpp:1444
MuseScore3 0x00014079d112 QList<FluidS::Voice *>::detach_helper c:\musescore\qt\msvc2017_64\include\qtcore\qlist.h:788
MuseScore3 0x00014079c4e5 FluidS::Fluid::allNotesOff(int) c:\musescore\fluid\fluid.cpp:224
MuseScore3 0x000140a7acde Ms::MasterSynthesizer::allNotesOff(int) c:\musescore\synthesizer\msynthesizer.cpp:172
MuseScore3 0x0001402b5a0c Ms::Seq::stopNotes(int,bool) c:\musescore\mscore\seq.cpp:1334
Qt5Core 0x000064df43f8 <unknown>
Qt5Core 0x0000653317e8 <unknown>
```

By stack, a crash occurs when the list changes.
Indeed
```
void Fluid::allNotesOff(int chan)
      {
      for(Voice* v : activeVoices) {
            if (chan == -1 || v->chan == chan)
                  v->noteoff();
            }
      }
```

When the `allNotesOff` method is called directly from the GUI thread, iterating through the list of `activeVoices` is performed, but it may change at that moment in another thread - as a result, we get a crash.

I make that `allNotesOff` is not called directly from the GUI thread.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
