### PR TITLE
fix #295156: select-all now highlights text without the need to release ctrl

### DIFF
--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -358,7 +358,8 @@ bool TextBase::edit(EditData& ed)
 
                   case Qt::Key_A:
                         if (ctrlPressed) {
-                              selectAll(_cursor);
+                              _cursor->movePosition(QTextCursor::Start, QTextCursor::MoveMode::MoveAnchor);
+                              _cursor->movePosition(QTextCursor::End, QTextCursor::MoveMode::KeepAnchor);
                               s.clear();
                         }
                         break;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/295156

Added a timer that repaints the ScoreView 200ms after pressing ctrl + a (this is not very 'clean', but it is a very simple and non-destructive way to handle this).

(also fixed some formatting)

edit: Now it looks pretty neat.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ n/a] I created the test (mtest, vtest, script test) to verify the changes I made
