### PR TITLE
fix #301304: Update text styles on dialog open

### DIFF
--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -1050,6 +1050,8 @@ void EditStyle::setValues()
                   sw.widget->blockSignals(false);
             }
 
+      textStyleChanged(textStyles->currentRow());
+
       //TODO: convert the rest:
 
       QString unit(lstyle.value(Sid::swingUnit).toString());


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/301304

Fixes a bug where the text style parameters were not getting updated on opening the "Styles..." dialog. Added the code to set the parameters in EditStyles::setValues() function which is called when the dialog is shown.