### PR TITLE
Fixed crash on Measure write (from CrashReporter)

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1923,7 +1923,9 @@ void Measure::write(XmlWriter& xml, int staff, bool writeSystemElements, bool fo
             }
       Q_ASSERT(first());
       Q_ASSERT(last());
-      score()->writeSegments(xml, strack, etrack, first(), last()->next1(), writeSystemElements, forceTimeSig);
+      if (first() && last())
+            score()->writeSegments(xml, strack, etrack, first(), last()->next1(), writeSystemElements, forceTimeSig);
+
       xml.etag();
       }
 


### PR DESCRIPTION
Resolves: https://sentry.musescore.org/musescore/editor/issues/16454/ (from CrashReporter)
   
one of the frequent crash is:  
```
Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ
MuseScore3 0x000140882de4 Ms::Segment::next1() c:\musescore\libmscore\segment.cpp:225
MuseScore3 0x00014093b515 Ms::Measure::write(Ms::XmlWriter &,int,bool,bool) c:\musescore\libmscore\measure.cpp:1926
MuseScore3 0x00014083f003 Ms::writeMeasure c:\musescore\libmscore\scorefile.cpp:67
Qt5Core 0x000064fed160 <unknown> 
MuseScore3 0x0001407f2928 Ms::XmlWriter::stag(Ms::ScoreElement const *,QString const &) c:\musescore\libmscore\xmlwriter.cpp:94
MuseScore3 0x0001408400af Ms::Score::writeMovement(Ms::XmlWriter &,bool) c:\musescore\libmscore\scorefile.cpp:231
```
   
   
I think we are faced with a frequent development problem here - we added assertions, but did not add ifs.
In the debug build, we find the wrong state, but in the release the user will crash.
  
    
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
