### PR TITLE
[MU4] exclude accidentals etc. from chord shape if autoplace disabled

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -3303,6 +3303,14 @@ QString Chord::accessibleExtraInfo() const
 
 Shape Chord::shape() const
       {
+      // the chord shape will always contain the basic elements of note/stem/hook
+      // however, other elements are only added to the shape if the chord itself has autoplace set
+      // thus, disabling autoplace for the chord removes ledger lines, accidentals, arpeggios, etc. from the shape
+      // this allows the spacing algorithm to do basic spacing of notes according to duration with or without autoplace
+      // by default, with autoplace on, you get space for the other elements too
+      // this avoid collisions, but it can produce noticeably uneven spacing once the measure is stretched
+      // by turning autoplace off, no space is allocated for the other elements
+      // this can produce collisions if spacing is tight, but if the measure is wide enough, spacing can be made more even
       Shape shape;
       if (_hook && _hook->addToSkyline())
             shape.add(_hook->shape().translated(_hook->pos()));
@@ -3313,30 +3321,34 @@ Shape Chord::shape() const
             }
       if (_stemSlash && _stemSlash->addToSkyline())
             shape.add(_stemSlash->shape().translated(_stemSlash->pos()));
-      if (_arpeggio && _arpeggio->addToSkyline())
-            shape.add(_arpeggio->shape().translated(_arpeggio->pos()));
-//      if (_tremolo)
-//            shape.add(_tremolo->shape().translated(_tremolo->pos()));
       for (Note* note : _notes) {
             shape.add(note->shape().translated(note->pos()));
-            for (Element* e : note->el()) {
-                  if (!e->addToSkyline())
-                        continue;
-                  if (e->isFingering() && toFingering(e)->layoutType() == ElementType::CHORD && e->bbox().isValid())
-                        shape.add(e->bbox().translated(e->pos() + note->pos()));
+            if (addToSkyline()) {
+                  for (Element* e : note->el()) {
+                        if (!e->addToSkyline())
+                              continue;
+                        if (e->isFingering() && toFingering(e)->layoutType() == ElementType::CHORD && e->bbox().isValid())
+                              shape.add(e->bbox().translated(e->pos() + note->pos()));
+                        }
                   }
             }
-      for (Element* e : el()) {
-            if (e->addToSkyline())
-                  shape.add(e->shape().translated(e->pos()));
-            }
-      for (Chord* chord : _graceNotes)    // process grace notes last, needed for correct shape calculation
-            shape.add(chord->shape().translated(chord->pos()));
       shape.add(ChordRest::shape());      // add lyrics
-      for (LedgerLine* l = _ledgerLines; l; l = l->next())
-            shape.add(l->shape().translated(l->pos()));
-      if (_spaceLw || _spaceRw)
-            shape.addHorizontalSpacing(Shape::SPACING_GENERAL, -_spaceLw, _spaceRw);
+      if (addToSkyline()) {
+            if (_arpeggio && _arpeggio->addToSkyline())
+                  shape.add(_arpeggio->shape().translated(_arpeggio->pos()));
+            //if (_tremolo)
+            //      shape.add(_tremolo->shape().translated(_tremolo->pos()));
+            for (Element* e : el()) {
+                  if (e->addToSkyline())
+                        shape.add(e->shape().translated(e->pos()));
+                  }
+            for (Chord* chord : _graceNotes)    // process grace notes last, needed for correct shape calculation
+                  shape.add(chord->shape().translated(chord->pos()));
+            for (LedgerLine* l = _ledgerLines; l; l = l->next())
+                  shape.add(l->shape().translated(l->pos()));
+            if (_spaceLw != 0.0 || _spaceRw != 0.0)
+                  shape.addHorizontalSpacing(Shape::SPACING_GENERAL, -_spaceLw, _spaceRw);
+            }
       return shape;
       }
 

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3701,7 +3701,7 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                                           }
 
                                     // add element to skyline
-                                    if (e->addToSkyline())
+                                    if (e->addToSkyline() || e->isChord())
                                           skyline.add(e->shape().translated(e->pos() + p));
 
                                     // add tremolo to skyline

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2670,6 +2670,8 @@ QVariant Note::getProperty(Pid propertyId) const
                   return fixed();
             case Pid::FIXED_LINE:
                   return fixedLine();
+            case Pid::AUTOPLACE:
+                  return chord() ? chord()->autoplace() : autoplace();
             default:
                   break;
             }
@@ -2749,6 +2751,12 @@ bool Note::setProperty(Pid propertyId, const QVariant& v)
                   break;
             case Pid::FIXED_LINE:
                   setFixedLine(v.toInt());
+                  break;
+            case Pid::AUTOPLACE:
+                  if (chord())
+                        chord()->setAutoplace(v.toBool());
+                  else
+                        setAutoplace(v.toBool());
                   break;
             default:
                   if (!Element::setProperty(propertyId, v))

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -1979,7 +1979,7 @@ void Segment::createShape(int staffIdx)
             int effectiveTrack = e->vStaffIdx() * VOICES + e->voice();
             if (effectiveTrack >= strack && effectiveTrack < etrack) {
                   setVisible(true);
-                  if (e->addToSkyline())
+                  if (e->addToSkyline() || e->isChord())
                         s.add(e->shape().translated(e->pos()));
                   }
             }


### PR DESCRIPTION
There are a number of spacing issues that stem (pun not intended)
from the inclusion of things other than the notes themselves
in chord shapes:
    - despite the best intentions of "smart layout" changes for 3.0,
      accidentals can't tuck under the previous note
    - accidentals in a measure result in increased note spacing,
      even if the measure ie wider enough to not need extra space
    - for the latter, similar for arpeggios, fingering, etc

There has been good discussion and proposals for ways of fixing this,
but they require relatively significant changes to the layout,
probably require new options to support, etc.
And the tucking issue might not be solvable at all for beamed notes
without changes to the beaming algorithm as well.

This commit provides a manual workaround:
allowing the user to disable autoplace for a note,
which results in the accidentals and other attached symbols
being excluded from the chord shape.
The note itself is still added to the chord shape,
so the note is spaced as it normally would be
if it didn't have accidentals etc.
That means you will get collisions if spacing is tight,
so don't disable autoplace unless there is definitely room.
And in that case, the spacing automatically improves,
plus accidentals will tuck under previous notes where appropriate.

I'm not calling this a fix because eventually this should be automatic.
But see:

https://musescore.org/en/node/289446
https://musescore.org/en/node/299741
https://musescore.org/en/node/285591

I have not yet created vtests because I'm not sure we're ready for that, I expect the possibility of further changes based on review.  I'm therefore marking this WIP, and not necessarily recommending this be included in 3.5 unless there is strong agreement it makes sense to do this now while we await a good autoamtic solution.