### PR TITLE
fix #293129: shift+left/right now highlights the text without releasing shift

### DIFF
--- a/mscore/editlyrics.cpp
+++ b/mscore/editlyrics.cpp
@@ -51,6 +51,8 @@ bool ScoreView::editKeyLyrics()
                         bool kl = editData.key == Qt::Key_Left;
                         lyricsTab(kl, kl, true);      // go to previous/next lyrics
                         }
+                  if (editData.modifiers & Qt::ShiftModifier)
+                        _score->update(); // draw updated selection
                   break;
 
             case Qt::Key_Up:


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/293129

In the lyrics editor, pressing shift+left/right did not highlight the new selection. I added a repaint event (by calling _score->update()) every time this happens. I believe that it fits the rest of the codebase because, most (if not all) lyrics editor selection changes call _score->update(). Also, the current workaround (releasing shift and pressing shift again) calls the update function.

For the above reasons, I don't think that this change will cause a noticeable performance penalty.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made
