### PR TITLE
removed double call to _score->update() in lyricsTab

### DIFF
--- a/mscore/editlyrics.cpp
+++ b/mscore/editlyrics.cpp
@@ -143,7 +143,6 @@ void ScoreView::lyricsUpDown(bool up, bool end)
             }
 
       _score->setLayoutAll();
-      _score->update();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
If you compare lyricsTab with lyricsUpDown you see an extra _score->update() on the very end. I believe that it is needless since startEdit(lyrics, Grip::NO_GRIP);  calls _score->update().

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made
