### PR TITLE
[MU4] fix #96986: Added the ability to disable SHIFT+Space shortcut in the …

### DIFF
--- a/mscore/editlyrics.cpp
+++ b/mscore/editlyrics.cpp
@@ -13,6 +13,7 @@
 #include "musescore.h"
 #include "scoreview.h"
 #include "texttools.h"
+#include "shortcut.h"
 #include "libmscore/chordrest.h"
 #include "libmscore/lyrics.h"
 #include "libmscore/score.h"
@@ -36,8 +37,12 @@ bool ScoreView::editKeyLyrics()
                   if (!editData.control(textEditing)) {
                         if (editData.s == "_")
                               lyricsUnderscore();
-                        else // TODO: shift+tab events are filtered by qt
-                              lyricsTab(editData.modifiers & Qt::ShiftModifier, true, false);
+                        else { // TODO: shift+tab events are filtered by qt
+                              Shortcut* mySC = Shortcut::getShortcut("prev-lyric");
+                              for (auto& ks : mySC->keys())
+                                    if (ks == QKeySequence(Qt::SHIFT + Qt::Key_Space))
+                                          lyricsTab(editData.modifiers & Qt::ShiftModifier, true, false);
+                              }
                         }
                   else
                         return false;


### PR DESCRIPTION
…lyrics editor. There was an old archived PR for this and there was a request to recreate it

Resolves: https://musescore.org/en/node/96986

There is an archived PR (https://github.com/musescore/MuseScore/pull/2416) for this issue. Since there was a request to reimplement it, here it is.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n/a] I created the test (mtest, vtest, script test) to verify the changes I made
