### PR TITLE
Try fix crash on get tabScoreView (from CrashReporter)

### DIFF
--- a/mscore/scoretab.h
+++ b/mscore/scoretab.h
@@ -46,14 +46,14 @@ struct TabScoreView {
 
 class ScoreTab : public QWidget {
       Q_OBJECT
-      QList<MasterScore*>* scoreList;
-      QTabBar* tab;                 // list of scores
-      QTabBar* tab2;                // list of excerpts for current score
-      QStackedLayout* stack;
-      MuseScore* mainWindow;
+      QList<MasterScore*>* scoreList { nullptr };
+      QTabBar* tab  { nullptr };                 // list of scores
+      QTabBar* tab2 { nullptr };                 // list of excerpts for current score
+      QStackedLayout* stack { nullptr };
+      MuseScore* mainWindow { nullptr };;
       void clearTab2();
-      TabScoreView* tabScoreView(int idx) { return static_cast<TabScoreView*>(tab->tabData(idx).value<void*>()); }
-      const TabScoreView* tabScoreView(int idx) const { return const_cast<ScoreTab*>(this)->tabScoreView(idx); }
+      TabScoreView* tabScoreView(int idx);
+      const TabScoreView* tabScoreView(int idx) const;
 
    signals:
       void currentScoreViewChanged(ScoreView*);


### PR DESCRIPTION
Resolves: https://sentry.musescore.org/musescore/editor/issues/9171 (from CrashReporter)
evens: 508   
dump:
```
Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ
MuseScore3 0x000140363167 Ms::ScoreTab::tabScoreView(int) c:\musescore\mscore\scoretab.h:54
Qt5Core 0x7ffaacc93180 <unknown>
Qt5Core 0x7ffaac953993 <unknown>
MuseScore3 0x000140363602 Ms::ScoreTab::viewSplitter(int) c:\musescore\mscore\scoretab.cpp:107
MuseScore3 0x0001403635b9 Ms::ScoreTab::view(int) c:\musescore\mscore\scoretab.cpp:95
MuseScore3 0x000140362069 Ms::ScoreTab::initScoreView(int,double,Ms::MagIdx,double,double) c:\musescore\mscore\scoretab.cpp:464
Qt5Core 0x7ffaac7b5287 <unknown>
MuseScore3 0x00014028496a Ms::MuseScore::restoreSession(bool) c:\musescore\mscore\musescore.cpp:5216
```
   
The single-line methods in the .h files do not motivate us to do state checks and do not allow us to see exactly which action failed.
Rewrote the code, added assertions.
  
    
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
