### PR TITLE
Try fix crash on Note::endDrag (from CrashReporter)

### DIFF
--- a/libmscore/CMakeLists.txt
+++ b/libmscore/CMakeLists.txt
@@ -35,6 +35,7 @@ endif (NOT MSVC)
 
 include_directories(
       ${PROJECT_SOURCE_DIR}/thirdparty/dtl
+      ${PROJECT_SOURCE_DIR}/global
       )
 
 add_library (

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -17,6 +17,8 @@
 
 #include <assert.h>
 
+#include "log.h"
+
 #include "note.h"
 #include "score.h"
 #include "chord.h"
@@ -2375,8 +2377,11 @@ QRectF Note::drag(EditData& ed)
 void Note::endDrag(EditData& ed)
       {
       NoteEditData* ned = static_cast<NoteEditData*>(ed.getData(this));
+      IF_ASSERT_FAILED(ned) {
+            return;
+            }
       for (Note* nn : tiedNotes()) {
-            for (PropertyData pd : ned->propertyData) {
+            for (const PropertyData& pd : ned->propertyData) {
                   setPropertyFlags(pd.id, pd.f); // reset initial property flags state
                   score()->undoPropertyChanged(nn, pd.id, pd.data);
                   }


### PR DESCRIPTION
Resolves: https://sentry.musescore.org/musescore/editor/issues/9777 (from CrashReporter)
evens: 431   
dump:
```
Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ
MuseScore3 0x0001407d55f3 Ms::Note::endDrag(Ms::EditData &) c:\musescore\libmscore\note.cpp:1565
Qt5Core 0x00006e496f00 <unknown>
MuseScore3 0x00014000bfe1 <unknown>
Qt5Core 0x00006e496f00 <unknown>
MuseScore3 0x00014000bfe1 <unknown>
MuseScore3 0x00014056a6a6 Ms::ScoreView::endDrag() c:\musescore\mscore\dragelement.cpp:88
MuseScore3 0x000140171030 Ms::ScoreView::changeState(Ms::ViewState) c:\musescore\mscore\events.cpp:988
MuseScore3 0x0001401736db Ms::ScoreView::mouseReleaseEvent(QMouseEvent *) c:\musescore\mscore\events.cpp:265
```
   
May crash due to `NoteEditData * ned` is null
Added check and assertions.
  
    
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
