### PR TITLE
fix #302603: Changing "Direction" has no effect on bowing symbols

### DIFF
--- a/libmscore/articulation.cpp
+++ b/libmscore/articulation.cpp
@@ -76,6 +76,8 @@ int Articulation::subtype() const
       QString s = Sym::id2name(_symId);
       if (s.endsWith("Below"))
             return int(Sym::name2id(s.left(s.size() - 5) + "Above"));
+      else if (s.endsWith("Turned"))
+            return int(Sym::name2id(s.left(s.size() - 6)));
       else
             return int(_symId);
       }
@@ -92,6 +94,16 @@ void Articulation::setUp(bool val)
       if (s.endsWith(!dup ? "Above" : "Below")) {
             QString s2 = s.left(s.size() - 5) + (dup ? "Above" : "Below");
             _symId = Sym::name2id(s2);
+            }
+      else if (s.endsWith("Turned")) {
+            QString s2 = dup ? s.left(s.size() - 6) : s;
+            _symId = Sym::name2id(s2);
+            }
+      else if (!dup) {
+            QString s2 = s + "Turned";
+            SymId sym = Sym::name2id(s2);
+            if (sym != SymId::noSym)
+                  _symId = sym;
             }
       }
 

--- a/mtest/libmscore/compat206/articulations-ref.mscx
+++ b/mtest/libmscore/compat206/articulations-ref.mscx
@@ -1008,7 +1008,7 @@
             <durationType>quarter</durationType>
             <Articulation>
               <direction>down</direction>
-              <subtype>stringsUpBow</subtype>
+              <subtype>stringsUpBowTurned</subtype>
               </Articulation>
             <Note>
               <pitch>60</pitch>
@@ -1057,7 +1057,7 @@
             <durationType>quarter</durationType>
             <Articulation>
               <direction>down</direction>
-              <subtype>stringsDownBow</subtype>
+              <subtype>stringsDownBowTurned</subtype>
               </Articulation>
             <Note>
               <pitch>60</pitch>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/302603.

Many articulations have names like "fermataAbove" and "fermataBelow". The flipping mechanism currently only supports articulations with names in this form. But some articulations have names like "stringsUpBow" and "stringsUpBowTurned". This commit adds the ability to flip articulations with names in this form also.