### PR TITLE
fix #302711: chord symbol playback channel in Mixer is shown as "harmony"

### DIFF
--- a/libmscore/instrtemplate.cpp
+++ b/libmscore/instrtemplate.cpp
@@ -511,7 +511,7 @@ void InstrumentTemplate::read(XmlReader& e)
             Channel a;
             a.setChorus(0);
             a.setReverb(0);
-            a.setName("normal");
+            a.setName(Channel::DEFAULT_NAME);
             a.setProgram(0);
             a.setBank(0);
             a.setVolume(90);

--- a/libmscore/instrument.cpp
+++ b/libmscore/instrument.cpp
@@ -25,8 +25,8 @@
 
 namespace Ms {
 
-const char* Channel::DEFAULT_NAME = "normal";
-const char* Channel::HARMONY_NAME = "harmony";
+const char* Channel::DEFAULT_NAME = QT_TRANSLATE_NOOP("channel", "Normal");
+const char* Channel::HARMONY_NAME = QT_TRANSLATE_NOOP("channel", "Chord symbols");
 
 Instrument InstrumentList::defaultInstrument;
 const std::initializer_list<Channel::Prop> PartChannelSettingsLink::excerptProperties {

--- a/libmscore/part.cpp
+++ b/libmscore/part.cpp
@@ -583,7 +583,7 @@ void Part::updateHarmonyChannels(bool isDoOnInstrumentChanged, bool checkRemoval
             //~OPTIM~
             if (harmonyCount() == 0) {
                   Instrument* instr = instrument();
-                  int hChIdx= instr->channelIdx(Channel::HARMONY_NAME);
+                  int hChIdx = instr->channelIdx(Channel::HARMONY_NAME);
                   if (hChIdx != -1) {
                         Channel* hChan = instr->channel(hChIdx);
                         instr->removeChannel(hChan);
@@ -598,7 +598,7 @@ void Part::updateHarmonyChannels(bool isDoOnInstrumentChanged, bool checkRemoval
       if (!harmonyChannel() && harmonyCount() > 0) {
             Instrument* instr = instrument();
             Channel* c = new Channel(*instr->channel(0));
-            c->setName(Channel::HARMONY_NAME);
+            c->setName(qApp->translate("channel", Channel::HARMONY_NAME));
             instr->appendChannel(c);
             onInstrumentChanged();
             }

--- a/mscore/articulationprop.cpp
+++ b/mscore/articulationprop.cpp
@@ -58,7 +58,7 @@ ArticulationProperties::ArticulationProperties(Articulation* na, QWidget* parent
 
             for (const Channel* a : instrument->channel()) {
                   if (a->name().isEmpty() || a->name() == Channel::DEFAULT_NAME) {
-                        channelList->addItem(tr(Channel::DEFAULT_NAME));
+                        channelList->addItem(qApp->translate("channel", Channel::DEFAULT_NAME));
                         channelList->item(channelList->count() - 1)->setData(Qt::UserRole, Channel::DEFAULT_NAME);
                         }
                   else {

--- a/mscore/inspector/voicing_select.ui
+++ b/mscore/inspector/voicing_select.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>331</width>
-    <height>174</height>
+    <width>221</width>
+    <height>72</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -16,10 +16,7 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QGridLayout" name="gridLayout">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -32,38 +29,54 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item>
-    <widget class="QLabel" name="label_2">
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_3">
      <property name="text">
-      <string>Interpretation</string>
+      <string>Duration:</string>
+     </property>
+     <property name="buddy">
+      <cstring>durationBox</cstring>
      </property>
     </widget>
    </item>
-   <item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Interpretation:</string>
+     </property>
+     <property name="buddy">
+      <cstring>interpretBox</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Voicing:</string>
+     </property>
+     <property name="buddy">
+      <cstring>voicingBox</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
     <widget class="QComboBox" name="interpretBox">
      <property name="currentIndex">
       <number>1</number>
      </property>
      <item>
       <property name="text">
-       <string>Jazz</string>
+       <string extracomment="adding 9th and 13th as desired">Jazz</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>Literal</string>
+       <string extracomment="Literally following the chord symbols text">Literal</string>
       </property>
      </item>
     </widget>
    </item>
-   <item>
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Voicing</string>
-     </property>
-    </widget>
-   </item>
-   <item>
+   <item row="2" column="1">
     <widget class="QComboBox" name="voicingBox">
      <item>
       <property name="text">
@@ -77,53 +90,46 @@
      </item>
      <item>
       <property name="text">
-       <string>Close</string>
+       <string extracomment="all notes within an octave">Close</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>Drop 2</string>
+       <string extracomment="2nd note an octave down">Drop Two</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>Six Note</string>
+       <string extracomment="6 note chord">Six Note</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>Four Note</string>
+       <string extracomment="4 note chord">Four Note</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>Three Note</string>
+       <string extracomment="3 note chord">Three Note</string>
       </property>
      </item>
     </widget>
    </item>
-   <item>
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Duration</string>
-     </property>
-    </widget>
-   </item>
-   <item>
+   <item row="4" column="1">
     <widget class="QComboBox" name="durationBox">
      <item>
       <property name="text">
-       <string>Until next chord symbol</string>
+       <string>Until Next Chord Symbol</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>Stop at measure</string>
+       <string>Until Measure End</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>Segment duration</string>
+       <string>Chord/Rest Duration</string>
       </property>
      </item>
     </widget>

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5809,7 +5809,7 @@ void MuseScore::realizeChordSymbols()
             return;
       if (!cs->selection().isList()) {
             QErrorMessage err;
-            err.showMessage(tr("Invalid selection. Cannot realize chord"));
+            err.showMessage(tr("Invalid selection. Cannot realize chord symbol"));
             err.exec();
             return;
             }
@@ -5825,7 +5825,7 @@ void MuseScore::realizeChordSymbols()
             }
       else {
             QErrorMessage err;
-            err.showMessage(tr("No chord selected. Cannot realize chord"));
+            err.showMessage(tr("No chord symbol selected. Cannot realize chord symbol"));
             err.exec();
             return;
             }

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -1339,7 +1339,7 @@
           <bool>true</bool>
          </property>
          <property name="title">
-          <string>Play Harmony</string>
+          <string>Play Chord Symbols</string>
          </property>
          <property name="checkable">
           <bool>true</bool>
@@ -1347,11 +1347,11 @@
          <property name="checked">
           <bool>false</bool>
          </property>
-         <layout class="QGridLayout" name="gridLayout_4">
+         <layout class="QGridLayout" name="gridLayout_41">
           <item row="0" column="0">
            <widget class="QCheckBox" name="playHarmonyOnEdit">
             <property name="text">
-             <string>Play harmony when editing</string>
+             <string>Play chord symbol when editing</string>
             </property>
             <property name="checked">
              <bool>true</bool>

--- a/mscore/realizeharmonydialog.cpp
+++ b/mscore/realizeharmonydialog.cpp
@@ -49,7 +49,7 @@ void RealizeHarmonyDialog::toggleChordTable()
       {
       int visible = chordTable->isVisible();
       chordTable->setVisible(!visible);
-      showButton->setText(!visible ? tr("Show less...") : tr("Show more..."));
+      showButton->setText(!visible ? tr("Show less…") : tr("Show more…"));
       }
 
 //---------------------------------------------------------

--- a/mscore/realizeharmonydialog.ui
+++ b/mscore/realizeharmonydialog.ui
@@ -13,6 +13,9 @@
   <property name="windowTitle">
    <string>Realize Chord Symbols</string>
   </property>
+  <property name="toolTip">
+   <string>Convert chord symbols to notes</string>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
     <widget class="QWidget" name="widget" native="true">
@@ -67,7 +70,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>chordLabel</string>
+            <string notr="true">chordLabel</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -166,7 +169,7 @@
          <item>
           <widget class="QPushButton" name="showButton">
            <property name="text">
-            <string>Show more...</string>
+            <string>Show more…</string>
            </property>
           </widget>
          </item>

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -3567,7 +3567,7 @@ Shortcut Shortcut::_sc[] = {
          "realize-chord-symbols",
          QT_TRANSLATE_NOOP("action","Realize Chord Symbols"),
          QT_TRANSLATE_NOOP("action","Realize chord symbols"),
-         0,
+         QT_TRANSLATE_NOOP("action","Convert chord symbols into notes"),
          Icons::Invalid_ICON,
          Qt::WindowShortcut
          },

--- a/mscore/stafftextproperties.cpp
+++ b/mscore/stafftextproperties.cpp
@@ -39,7 +39,7 @@ static void initChannelCombo(QComboBox* cb, StaffTextBase* st)
       Fraction tick = static_cast<Segment*>(st->parent())->tick();
       for (const Channel* a : part->instrument(tick)->channel()) {
             if (a->name().isEmpty() || a->name() == Channel::DEFAULT_NAME)
-                  cb->addItem(QObject::tr(Channel::DEFAULT_NAME));
+                  cb->addItem(qApp->translate("channel", Channel::DEFAULT_NAME));
             else
                   cb->addItem(qApp->translate("InstrumentsXML", a->name().toUtf8().data()));
             }
@@ -185,7 +185,7 @@ StaffTextProperties::StaffTextProperties(const StaffTextBase* st, QWidget* paren
             QTreeWidgetItem* item = new QTreeWidgetItem(channelList);
             item->setData(0, Qt::UserRole, i);
             if (a->name().isEmpty() || a->name() == Channel::DEFAULT_NAME)
-                  item->setText(0, tr(Channel::DEFAULT_NAME));
+                  item->setText(0, qApp->translate("channel", Channel::DEFAULT_NAME));
             else
                   item->setText(0, qApp->translate("InstrumentsXML", a->name().toUtf8().data()));
             item->setText(1, qApp->translate("InstrumentsXML", a->descr().toUtf8().data()));
@@ -389,7 +389,7 @@ void StaffTextProperties::channelItemChanged(QTreeWidgetItem* item, QTreeWidgetI
       for (const NamedEventList& e : part->instrument(tick)->midiActions()) {
             QTreeWidgetItem* ti = new QTreeWidgetItem(actionList);
             if (e.name.isEmpty() || e.name == Channel::DEFAULT_NAME) {
-                  ti->setText(0, tr(Channel::DEFAULT_NAME));
+                  ti->setText(0, qApp->translate("channel", Channel::DEFAULT_NAME));
                   ti->setData(0, Qt::UserRole, Channel::DEFAULT_NAME);
                   }
             else {
@@ -401,7 +401,7 @@ void StaffTextProperties::channelItemChanged(QTreeWidgetItem* item, QTreeWidgetI
       for (const NamedEventList& e : channel->midiActions) {
             QTreeWidgetItem* ti = new QTreeWidgetItem(actionList);
             if (e.name.isEmpty() || e.name == Channel::DEFAULT_NAME) {
-                  ti->setText(0, tr(Channel::DEFAULT_NAME));
+                  ti->setText(0, qApp->translate("channel", Channel::DEFAULT_NAME));
                   ti->setData(0, Qt::UserRole, Channel::DEFAULT_NAME);
                   }
             else {

--- a/mtest/libmscore/chordsymbol/add-link-ref.mscx
+++ b/mtest/libmscore/chordsymbol/add-link-ref.mscx
@@ -70,7 +70,7 @@
         <Channel>
           <program value="24"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="24"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/chordsymbol/add-part-ref.mscx
+++ b/mtest/libmscore/chordsymbol/add-part-ref.mscx
@@ -63,7 +63,7 @@
         <Channel>
           <program value="24"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="24"/>
           </Channel>
         </Instrument>
@@ -161,7 +161,7 @@
           <Channel>
             <program value="24"/>
             </Channel>
-          <Channel name="harmony">
+          <Channel name="Chord symbols">
             <program value="24"/>
             </Channel>
           </Instrument>

--- a/mtest/libmscore/chordsymbol/clear.mscx
+++ b/mtest/libmscore/chordsymbol/clear.mscx
@@ -63,7 +63,7 @@
         <Channel>
           <program value="27"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="27"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/chordsymbol/extend-ref.mscx
+++ b/mtest/libmscore/chordsymbol/extend-ref.mscx
@@ -63,7 +63,7 @@
         <Channel>
           <program value="27"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="27"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/chordsymbol/no-system-ref.mscx
+++ b/mtest/libmscore/chordsymbol/no-system-ref.mscx
@@ -94,7 +94,7 @@
         <Channel>
           <program value="65"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="65"/>
           </Channel>
         </Instrument>
@@ -357,7 +357,7 @@
           <Channel>
             <program value="65"/>
             </Channel>
-          <Channel name="harmony">
+          <Channel name="Chord symbols">
             <program value="65"/>
             </Channel>
           </Instrument>

--- a/mtest/libmscore/chordsymbol/realize-3note-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-3note-ref.mscx
@@ -86,7 +86,7 @@
         <Channel>
           <program value="0"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="0"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/chordsymbol/realize-4note-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-4note-ref.mscx
@@ -86,7 +86,7 @@
         <Channel>
           <program value="0"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="0"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/chordsymbol/realize-6note-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-6note-ref.mscx
@@ -86,7 +86,7 @@
         <Channel>
           <program value="0"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="0"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/chordsymbol/realize-close-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-close-ref.mscx
@@ -86,7 +86,7 @@
         <Channel>
           <program value="0"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="0"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/chordsymbol/realize-concert-pitch-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-concert-pitch-ref.mscx
@@ -87,7 +87,7 @@
         <Channel>
           <program value="0"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="0"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/chordsymbol/realize-drop2-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-drop2-ref.mscx
@@ -86,7 +86,7 @@
         <Channel>
           <program value="0"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="0"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/chordsymbol/realize-duration-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-duration-ref.mscx
@@ -84,7 +84,7 @@
         <Channel>
           <program value="0"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="0"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/chordsymbol/realize-duration.mscx
+++ b/mtest/libmscore/chordsymbol/realize-duration.mscx
@@ -84,7 +84,7 @@
         <Channel>
           <program value="0"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="0"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/chordsymbol/realize-jazz-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-jazz-ref.mscx
@@ -90,7 +90,7 @@
           <controller ctrl="32" value="0"/>
           <program value="4"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <controller ctrl="0" value="0"/>
           <controller ctrl="32" value="0"/>
           <program value="4"/>

--- a/mtest/libmscore/chordsymbol/realize-jazz.mscx
+++ b/mtest/libmscore/chordsymbol/realize-jazz.mscx
@@ -90,7 +90,7 @@
           <controller ctrl="32" value="0"/>
           <program value="4"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <controller ctrl="0" value="0"/>
           <controller ctrl="32" value="0"/>
           <program value="4"/>

--- a/mtest/libmscore/chordsymbol/realize-override-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-override-ref.mscx
@@ -84,7 +84,7 @@
         <Channel>
           <program value="0"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="0"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/chordsymbol/realize-override.mscx
+++ b/mtest/libmscore/chordsymbol/realize-override.mscx
@@ -84,7 +84,7 @@
         <Channel>
           <program value="0"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="0"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/chordsymbol/realize-transpose-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-transpose-ref.mscx
@@ -68,7 +68,7 @@
         <Channel>
           <program value="73"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="73"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/chordsymbol/realize-triplet-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-triplet-ref.mscx
@@ -84,7 +84,7 @@
         <Channel>
           <program value="0"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="0"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/chordsymbol/realize-triplet.mscx
+++ b/mtest/libmscore/chordsymbol/realize-triplet.mscx
@@ -84,7 +84,7 @@
         <Channel>
           <program value="0"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="0"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/chordsymbol/transpose-part-ref.mscx
+++ b/mtest/libmscore/chordsymbol/transpose-part-ref.mscx
@@ -68,7 +68,7 @@
         <Channel>
           <program value="73"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="73"/>
           </Channel>
         </Instrument>
@@ -181,7 +181,7 @@
           <Channel>
             <program value="73"/>
             </Channel>
-          <Channel name="harmony">
+          <Channel name="Chord symbols">
             <program value="73"/>
             </Channel>
           </Instrument>

--- a/mtest/libmscore/chordsymbol/transpose-ref.mscx
+++ b/mtest/libmscore/chordsymbol/transpose-ref.mscx
@@ -68,7 +68,7 @@
         <Channel>
           <program value="73"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="73"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/compat114/chord_symbol-ref.mscx
+++ b/mtest/libmscore/compat114/chord_symbol-ref.mscx
@@ -79,7 +79,7 @@
           <controller ctrl="93" value="30"/>
           <controller ctrl="91" value="30"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="73"/>
           <controller ctrl="93" value="30"/>
           <controller ctrl="91" value="30"/>

--- a/mtest/libmscore/compat114/text_scaling-ref.mscx
+++ b/mtest/libmscore/compat114/text_scaling-ref.mscx
@@ -79,7 +79,7 @@
           <controller ctrl="93" value="30"/>
           <controller ctrl="91" value="30"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="73"/>
           <controller ctrl="93" value="30"/>
           <controller ctrl="91" value="30"/>

--- a/mtest/libmscore/compat206/lidemptytext-ref.mscx
+++ b/mtest/libmscore/compat206/lidemptytext-ref.mscx
@@ -178,7 +178,7 @@
         <Channel name="tremolo">
           <program value="44"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="43"/>
           </Channel>
         </Instrument>
@@ -350,7 +350,7 @@
           <Channel name="tremolo">
             <program value="44"/>
             </Channel>
-          <Channel name="harmony">
+          <Channel name="Chord symbols">
             <program value="43"/>
             </Channel>
           </Instrument>

--- a/mtest/libmscore/copypaste/copypaste19-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste19-ref.mscx
@@ -53,7 +53,7 @@
           </Articulation>
         <Channel>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           </Channel>
         </Instrument>
       </Part>

--- a/mtest/libmscore/copypastesymbollist/copypastesymbollist-chordnames-01-ref.mscx
+++ b/mtest/libmscore/copypastesymbollist/copypastesymbollist-chordnames-01-ref.mscx
@@ -54,7 +54,7 @@
         <Channel>
           <program value="73"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="73"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/copypastesymbollist/copypastesymbollist-chordnames-ref.mscx
+++ b/mtest/libmscore/copypastesymbollist/copypastesymbollist-chordnames-ref.mscx
@@ -54,7 +54,7 @@
         <Channel>
           <program value="52"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="52"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/midi/testVoltaStaffText.mscx
+++ b/mtest/libmscore/midi/testVoltaStaffText.mscx
@@ -249,7 +249,7 @@
               </Note>
             </Chord>
           <StaffText>
-            <channelSwitch voice="0" name="normal"/>
+            <channelSwitch voice="0" name="Normal"/>
             <text>arco</text>
             </StaffText>
           <Beam>
@@ -337,7 +337,7 @@
               </Note>
             </Chord>
           <StaffText>
-            <channelSwitch voice="0" name="normal"/>
+            <channelSwitch voice="0" name="Normal"/>
             <text>arco</text>
             </StaffText>
           <Chord>

--- a/mtest/libmscore/parts/part-all-appendmeasures.mscx
+++ b/mtest/libmscore/parts/part-all-appendmeasures.mscx
@@ -57,7 +57,7 @@
           <midiPort>0</midiPort>
           <midiChannel>0</midiChannel>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <midiPort>0</midiPort>
           <midiChannel>2</midiChannel>
           </Channel>
@@ -1120,7 +1120,7 @@
             </Articulation>
           <Channel>
             </Channel>
-          <Channel name="harmony">
+          <Channel name="Chord symbols">
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/libmscore/parts/part-all-parts.mscx
+++ b/mtest/libmscore/parts/part-all-parts.mscx
@@ -57,7 +57,7 @@
           <midiPort>0</midiPort>
           <midiChannel>0</midiChannel>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <midiPort>0</midiPort>
           <midiChannel>2</midiChannel>
           </Channel>
@@ -1102,7 +1102,7 @@
             </Articulation>
           <Channel>
             </Channel>
-          <Channel name="harmony">
+          <Channel name="Chord symbols">
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/libmscore/parts/part-all-uappendmeasures.mscx
+++ b/mtest/libmscore/parts/part-all-uappendmeasures.mscx
@@ -57,7 +57,7 @@
           <midiPort>0</midiPort>
           <midiChannel>0</midiChannel>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <midiPort>0</midiPort>
           <midiChannel>2</midiChannel>
           </Channel>
@@ -1102,7 +1102,7 @@
             </Articulation>
           <Channel>
             </Channel>
-          <Channel name="harmony">
+          <Channel name="Chord symbols">
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/libmscore/parts/part-all-uinsertmeasures.mscx
+++ b/mtest/libmscore/parts/part-all-uinsertmeasures.mscx
@@ -57,7 +57,7 @@
           <midiPort>0</midiPort>
           <midiChannel>0</midiChannel>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <midiPort>0</midiPort>
           <midiChannel>2</midiChannel>
           </Channel>
@@ -1102,7 +1102,7 @@
             </Articulation>
           <Channel>
             </Channel>
-          <Channel name="harmony">
+          <Channel name="Chord symbols">
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/libmscore/parts/part-all.mscx
+++ b/mtest/libmscore/parts/part-all.mscx
@@ -57,7 +57,7 @@
           <midiPort>0</midiPort>
           <midiChannel>0</midiChannel>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <midiPort>0</midiPort>
           <midiChannel>2</midiChannel>
           </Channel>

--- a/mtest/libmscore/parts/voices-ref.mscx
+++ b/mtest/libmscore/parts/voices-ref.mscx
@@ -81,7 +81,7 @@
           <midiPort>0</midiPort>
           <midiChannel>2</midiChannel>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="0"/>
           <midiPort>0</midiPort>
           <midiChannel>1</midiChannel>
@@ -987,7 +987,7 @@
           <Channel>
             <program value="0"/>
             </Channel>
-          <Channel name="harmony">
+          <Channel name="Chord symbols">
             <program value="0"/>
             </Channel>
           </Instrument>

--- a/mtest/libmscore/selectionrangedelete/selectionrangedelete05-ref.mscx
+++ b/mtest/libmscore/selectionrangedelete/selectionrangedelete05-ref.mscx
@@ -69,7 +69,7 @@
         <Channel name="tremolo">
           <program value="44"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="40"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/timesig/timesig-03-ref.mscx
+++ b/mtest/libmscore/timesig/timesig-03-ref.mscx
@@ -54,7 +54,7 @@
         <Channel>
           <program value="73"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="73"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/timesig/timesig-05-ref.mscx
+++ b/mtest/libmscore/timesig/timesig-05-ref.mscx
@@ -57,7 +57,7 @@
         <Channel>
           <program value="73"/>
           </Channel>
-        <Channel name="harmony">
+        <Channel name="Chord symbols">
           <program value="73"/>
           </Channel>
         </Instrument>


### PR DESCRIPTION
* fixing the harmony channel name
* make channel names translatable, 
* some text changes: using ellipsis, deleting/untranslating some, adding :
* adjusting mtests
* compacting the chord symbols voicing dialog in Inspector. This compacter dialog now might also get reused in the chord symbols section of the Edit Style dialog.

Resolves https://musescore.org/en/node/302711