### PR TITLE
Clarify the text for ambitus update range. Add tooltip.

### DIFF
--- a/mscore/inspector/inspector_ambitus.ui
+++ b/mscore/inspector/inspector_ambitus.ui
@@ -846,8 +846,11 @@
         <property name="focusPolicy">
          <enum>Qt::TabFocus</enum>
         </property>
+        <property name="toolTip">
+         <string>Adjust the range of the ambitus to match the range of the notes that are currently on the staff.</string>
+        </property>
         <property name="text">
-         <string>Update Range</string>
+         <string comment="Adjust the range of the ambitus to match the range of the notes that are currently on the staff.">Match Staff</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
The button's text was not clear. After a discussion on telegram (starting [here](https://t.me/musescore_design/1084), and ending [there](https://t.me/musescore_design/1135)), a viable option seemed to be "Match Staff".
The (not set in stone) tooltip is here set to "Search through the staff for lowest and highest notes, and update the ambitus' range accordingly."
As english is not my first langage, I would appreciate feedback on the this.
