### PR TITLE
Try fix crash on SlurTieSegment::startEditDrag (from CrashReporter)

### DIFF
--- a/libmscore/slurtie.cpp
+++ b/libmscore/slurtie.cpp
@@ -10,6 +10,8 @@
 //  the file LICENCE.GPL
 //=============================================================================
 
+#include "log.h"
+
 #include "measure.h"
 #include "score.h"
 #include "system.h"
@@ -115,6 +117,9 @@ std::vector<QPointF> SlurTieSegment::gripsPositions(const EditData&) const
 void SlurTieSegment::startEditDrag(EditData& ed)
       {
       ElementEditData* eed = ed.getData(this);
+      IF_ASSERT_FAILED(eed) {
+            return;
+            }
       for (auto i : { Pid::SLUR_UOFF1, Pid::SLUR_UOFF2, Pid::SLUR_UOFF3, Pid::SLUR_UOFF4, Pid::OFFSET })
             eed->pushProperty(i);
       }


### PR DESCRIPTION
Resolves: https://sentry.musescore.org/musescore/editor/issues/9171 (from CrashReporter)
evens: 364   
dump:
```
Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ
MuseScore3 0x0001409e8ac6 Ms::SlurTieSegment::startEditDrag(Ms::EditData &) c:\musescore\libmscore\slurtie.cpp:119
MuseScore3 0x0001408b561d Ms::UndoStack::beginMacro(Ms::Score *) c:\musescore\libmscore\undo.cpp:216
Qt5Core 0x000061396f00 <unknown> 
MuseScore3 0x00014025fd4d Ms::ScoreView::mouseMoveEvent(QMouseEvent *) c:\musescore\mscore\events.cpp:696
```
   
May crash due to `ElementEditData* eed` is null
Added check and assertions.
There is probably a deeper problem, something like that was already #5847 
    
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
