### PR TITLE
Try fix crash on Note::drag (from CrashReporter)

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2354,6 +2354,9 @@ void Note::startDrag(EditData& ed)
 QRectF Note::drag(EditData& ed)
       {
       NoteEditData* noteEditData = static_cast<NoteEditData*>(ed.getData(this));
+      IF_ASSERT_FAILED(noteEditData) {
+            return QRectF();
+            }
 
       QPointF delta = ed.pos - ed.lastPos;
       noteEditData->delta = delta;


### PR DESCRIPTION
Resolves: https://sentry.musescore.org/musescore/editor/issues/9719 (from CrashReporter)
evens: 323   
dump:
```
Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ
MuseScore3 0x0001407da318 Ms::Note::drag(Ms::EditData &) c:\musescore\libmscore\note.cpp:2341
MuseScore3 0x000140648490 Ms::ScoreView::doDragElement(QMouseEvent *) c:\musescore\mscore\dragelement.cpp:69
Qt5Gui 0x7ff9c18d4653 <unknown>
MuseScore3 0x00014025fdcd Ms::ScoreView::mouseMoveEvent(QMouseEvent *) c:\musescore\mscore\events.cpp:664
```
   
May crash due to `NoteEditData* noteEditData` is null
Added check and assertions.
There is probably a deeper problem, something like that was already #5847, #5856
    
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
