### PR TITLE
Fixed some issues from PVS-Studio report (step3)

### DIFF
--- a/libmscore/beam.h
+++ b/libmscore/beam.h
@@ -80,24 +80,24 @@ class Beam final : public Element {
       Beam(Score* = 0);
       Beam(const Beam&);
       ~Beam();
-      virtual Beam* clone() const override         { return new Beam(*this); }
-      virtual ElementType type() const override    { return ElementType::BEAM; }
-      virtual QPointF pagePos() const override;    ///< position in page coordinates
-      virtual QPointF canvasPos() const override;  ///< position in page coordinates
+      Beam* clone() const override         { return new Beam(*this); }
+      ElementType type() const override    { return ElementType::BEAM; }
+      QPointF pagePos() const override;    ///< position in page coordinates
+      QPointF canvasPos() const override;  ///< position in page coordinates
 
-      virtual bool isEditable() const override { return true; }
-      virtual void startEdit(EditData&) override;
-      virtual void endEdit(EditData&) override;
-      virtual void editDrag(EditData&) override;
+      bool isEditable() const override { return true; }
+      void startEdit(EditData&) override;
+      void endEdit(EditData&) override;
+      void editDrag(EditData&) override;
 
-      virtual Fraction tick() const override;
-      virtual Fraction rtick() const override;
+      Fraction tick() const override;
+      Fraction rtick() const override;
 
-      virtual void write(XmlWriter& xml) const override;
-      virtual void read(XmlReader&) override;
-      virtual void spatiumChanged(qreal /*oldValue*/, qreal /*newValue*/) override;
+      void write(XmlWriter& xml) const override;
+      void read(XmlReader&) override;
+      void spatiumChanged(qreal /*oldValue*/, qreal /*newValue*/) override;
 
-      virtual void reset() override;
+      void reset() override;
 
       System* system() const { return toSystem(parent()); }
 
@@ -110,11 +110,11 @@ class Beam final : public Element {
       bool empty() const                { return _elements.empty(); }
       bool contains(const ChordRest* cr) const { return std::find(_elements.begin(), _elements.end(), cr) != _elements.end(); }
 
-      virtual void add(Element*) override;
-      virtual void remove(Element*) override;
+      void add(Element*) override;
+      void remove(Element*) override;
 
-      virtual void move(const QPointF&) override;
-      virtual void draw(QPainter*) const override;
+      void move(const QPointF&) override;
+      void draw(QPainter*) const override;
 
       bool up() const                     { return _up; }
       void setUp(bool v)                  { _up = v;    }
@@ -126,8 +126,8 @@ class Beam final : public Element {
       void setBeamDirection(Direction d);
       Direction beamDirection() const     { return _direction; }
 
-      virtual bool acceptDrop(EditData&) const override;
-      virtual Element* drop(EditData&) override;
+      bool acceptDrop(EditData&) const override;
+      Element* drop(EditData&) override;
 
       qreal growLeft() const              { return _grow1; }
       qreal growRight() const             { return _grow2; }
@@ -145,16 +145,16 @@ class Beam final : public Element {
 
       qreal beamDist() const              { return _beamDist; }
 
-      virtual QVariant getProperty(Pid propertyId) const override;
-      virtual bool setProperty(Pid propertyId, const QVariant&) override;
-      virtual QVariant propertyDefault(Pid id) const override;
+      QVariant getProperty(Pid propertyId) const override;
+      bool setProperty(Pid propertyId, const QVariant&) override;
+      QVariant propertyDefault(Pid id) const override;
 
       bool isGrace() const { return _isGrace; }  // for debugger
       bool cross() const   { return _cross; }
 
       void addSkyline(Skyline&);
 
-      virtual void triggerLayout() const override;
+      void triggerLayout() const override;
 
       EditBehavior normalModeEditBehavior() const override { return EditBehavior::Edit; }
       int gripsCount() const override { return 3; }

--- a/libmscore/clef.h
+++ b/libmscore/clef.h
@@ -139,21 +139,21 @@ class Clef final : public Element {
 
    public:
       Clef(Score*);
-      virtual Clef* clone() const        { return new Clef(*this); }
-      virtual ElementType type() const { return ElementType::CLEF; }
-      virtual qreal mag() const;
+      Clef* clone() const override       { return new Clef(*this); }
+      ElementType type() const override  { return ElementType::CLEF; }
+      qreal mag() const override;
 
       Segment* segment() const           { return (Segment*)parent(); }
       Measure* measure() const           { return (Measure*)parent()->parent(); }
 
-      virtual bool acceptDrop(EditData&) const override;
-      virtual Element* drop(EditData&);
-      virtual void layout();
-      virtual void draw(QPainter*) const;
-      virtual void read(XmlReader&);
-      virtual void write(XmlWriter&) const;
+      bool acceptDrop(EditData&) const override;
+      Element* drop(EditData&) override;
+      void layout() override;
+      void draw(QPainter*) const override;
+      void read(XmlReader&) override;
+      void write(XmlWriter&) const override;
 
-      virtual bool isEditable() const  { return false; }
+      bool isEditable() const override { return false; }
 
       bool small() const               { return _small; }
       void setSmall(bool val);
@@ -179,14 +179,14 @@ class Clef final : public Element {
       void setConcertClef(ClefType val);
       void setTransposingClef(ClefType val);
       void setClefType(const ClefTypeList& ctl) { _clefTypes = ctl; }
-      virtual void spatiumChanged(qreal oldValue, qreal newValue) override;
+      void spatiumChanged(qreal oldValue, qreal newValue) override;
 
-      QVariant getProperty(Pid propertyId) const;
-      bool setProperty(Pid propertyId, const QVariant&);
-      QVariant propertyDefault(Pid id) const;
+      QVariant getProperty(Pid propertyId) const override;
+      bool setProperty(Pid propertyId, const QVariant&) override;
+      QVariant propertyDefault(Pid id) const override;
 
-      virtual Element* nextSegmentElement() override;
-      virtual Element* prevSegmentElement() override;
+      Element* nextSegmentElement() override;
+      Element* prevSegmentElement() override;
       QString accessibleInfo() const override;
       void clear();
       };

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -142,8 +142,8 @@ class NoteHead final : public Symbol {
 
       NoteHead(Score* s = 0) : Symbol(s) {}
       NoteHead &operator=(const NoteHead&) = delete;
-      virtual NoteHead* clone() const override    { return new NoteHead(*this); }
-      virtual ElementType type() const override { return ElementType::NOTEHEAD; }
+      NoteHead* clone() const override    { return new NoteHead(*this); }
+      ElementType type() const override { return ElementType::NOTEHEAD; }
 
       Group headGroup() const;
 
@@ -295,16 +295,16 @@ class Note final : public Element {
       virtual Note* clone() const override  { return new Note(*this, false); }
       ElementType type() const override   { return ElementType::NOTE; }
 
-      virtual void undoUnlink() override;
+      void undoUnlink() override;
 
-      virtual qreal mag() const override;
+      qreal mag() const override;
 
-      void layout();
+      void layout() override;
       void layout2();
       //setter is used only in drumset tools to setup the notehead preview in the drumset editor and the palette
       void setCachedNoteheadSym(SymId i) { _cachedNoteheadSym = i; };
-      void scanElements(void* data, void (*func)(void*, Element*), bool all=true);
-      void setTrack(int val);
+      void scanElements(void* data, void (*func)(void*, Element*), bool all = true) override;
+      void setTrack(int val) override;
 
       int playTicks() const;
 
@@ -324,8 +324,8 @@ class Note final : public Element {
       void setHeadGroup(NoteHead::Group val);
       void setHeadType(NoteHead::Type t);
 
-      virtual int subtype() const override { return int(_headGroup); }
-      virtual QString subtypeName() const override;
+      int subtype() const override { return int(_headGroup); }
+      QString subtypeName() const override;
 
       void setPitch(int val);
       void setPitch(int pitch, int tpc1, int tpc2);
@@ -374,8 +374,8 @@ class Note final : public Element {
       bool fretConflict() const       { return _fretConflict; }
       void setFretConflict(bool val)  { _fretConflict = val; }
 
-      virtual void add(Element*) override;
-      virtual void remove(Element*) override;
+      void add(Element*) override;
+      void remove(Element*) override;
 
       bool mirror() const             { return _mirror;  }
       void setMirror(bool val)        { _mirror = val;   }
@@ -399,15 +399,15 @@ class Note final : public Element {
 
       Chord* chord() const            { return (Chord*)parent(); }
       void setChord(Chord* a)         { setParent((Element*)a);  }
-      virtual void draw(QPainter*) const override;
+      void draw(QPainter*) const override;
 
-      virtual void read(XmlReader&) override;
-      virtual bool readProperties(XmlReader&) override;
-      virtual void readAddConnector(ConnectorInfoReader* info, bool pasteMode) override;
-      virtual void write(XmlWriter&) const override;
+      void read(XmlReader&) override;
+      bool readProperties(XmlReader&) override;
+      void readAddConnector(ConnectorInfoReader* info, bool pasteMode) override;
+      void write(XmlWriter&) const override;
 
       bool acceptDrop(EditData&) const override;
-      Element* drop(EditData&);
+      Element* drop(EditData&) override;
 
       bool hidden() const                       { return _hidden; }
       void setHidden(bool val)                  { _hidden = val;  }
@@ -430,7 +430,7 @@ class Note final : public Element {
       void setUserDotPosition(Direction d)      { _userDotPosition = d;    }
       bool dotIsUp() const;               // actual dot position
 
-      void reset();
+      void reset() override;
 
       ValueType veloType() const            { return _veloType;          }
       void setVeloType(ValueType v)         { _veloType = v;             }
@@ -464,16 +464,16 @@ class Note final : public Element {
 
       void transposeDiatonic(int interval, bool keepAlterations, bool useDoubleAccidentals);
 
-      virtual void localSpatiumChanged(qreal oldValue, qreal newValue) override;
-      virtual QVariant getProperty(Pid propertyId) const override;
-      virtual bool setProperty(Pid propertyId, const QVariant&) override;
+      void localSpatiumChanged(qreal oldValue, qreal newValue) override;
+      QVariant getProperty(Pid propertyId) const override;
+      bool setProperty(Pid propertyId, const QVariant&) override;
       void undoChangeDotsVisible(bool v);
-      virtual QVariant propertyDefault(Pid) const override;
-      virtual QString propertyUserValue(Pid) const override;
+      QVariant propertyDefault(Pid) const override;
+      QString propertyUserValue(Pid) const override;
 
       bool mark() const               { return _mark;   }
       void setMark(bool v) const      { _mark = v;   }
-      virtual void setScore(Score* s) override;
+      void setScore(Score* s) override;
       void setDotY(Direction);
 
       void addParentheses();
@@ -484,17 +484,17 @@ class Note final : public Element {
 
       Element* nextInEl(Element* e);
       Element* prevInEl(Element* e);
-      virtual Element* nextElement() override;
-      virtual Element* prevElement() override;
+      Element* nextElement() override;
+      Element* prevElement() override;
       virtual Element* lastElementBeforeSegment();
-      virtual Element* nextSegmentElement() override;
-      virtual Element* prevSegmentElement() override;
+      Element* nextSegmentElement() override;
+      Element* prevSegmentElement() override;
 
-      virtual QString accessibleInfo() const override;
-      virtual QString screenReaderInfo() const override;
-      virtual QString accessibleExtraInfo() const override;
+      QString accessibleInfo() const override;
+      QString screenReaderInfo() const override;
+      QString accessibleExtraInfo() const override;
 
-      virtual Shape shape() const override;
+      Shape shape() const override;
       std::vector<Note*> tiedNotes() const;
 
       void setOffTimeType(int v) { _offTimeType = v; }

--- a/libmscore/stafftype.h
+++ b/libmscore/stafftype.h
@@ -429,13 +429,13 @@ class TabDurationSymbol final : public Element {
       TabDurationSymbol(Score* s);
       TabDurationSymbol(Score* s, const StaffType* tab, TDuration::DurationType type, int dots);
       TabDurationSymbol(const TabDurationSymbol&);
-      virtual TabDurationSymbol* clone() const  { return new TabDurationSymbol(*this); }
-      virtual void draw(QPainter*) const;
-      virtual bool isEditable() const           { return false; }
-      virtual void layout();
-      virtual ElementType type() const        { return ElementType::TAB_DURATION_SYMBOL; }
+      TabDurationSymbol* clone() const override  { return new TabDurationSymbol(*this); }
+      void draw(QPainter*) const override;
+      bool isEditable() const override           { return false; }
+      void layout() override;
+      ElementType type() const override          { return ElementType::TAB_DURATION_SYMBOL; }
 
-      TabBeamGrid beamGrid()                    { return _beamGrid; }
+      TabBeamGrid beamGrid()                     { return _beamGrid; }
       void layout2();               // second step of layout: after horiz. pos. are defined, compute width of 'grid beams'
       void setDuration(TDuration::DurationType type, int dots, const StaffType* tab) {
             _tab = tab;

--- a/libmscore/symbol.h
+++ b/libmscore/symbol.h
@@ -39,22 +39,22 @@ class Symbol : public BSymbol {
 
       Symbol &operator=(const Symbol&) = delete;
 
-      virtual Symbol* clone() const      { return new Symbol(*this); }
-      virtual ElementType type() const   { return ElementType::SYMBOL; }
+      Symbol* clone() const override     { return new Symbol(*this); }
+      ElementType type() const override  { return ElementType::SYMBOL; }
 
       void setSym(SymId s, const ScoreFont* sf = nullptr) { _sym  = s; _scoreFont = sf;    }
       SymId sym() const                  { return _sym;  }
       QString symName() const;
 
-      virtual void draw(QPainter*) const override;
-      virtual void write(XmlWriter& xml) const override;
-      virtual void read(XmlReader&) override;
-      virtual void layout() override;
+      void draw(QPainter*) const override;
+      void write(XmlWriter& xml) const override;
+      void read(XmlReader&) override;
+      void layout() override;
 
-      virtual QVariant getProperty(Pid) const override;
-      virtual bool setProperty(Pid, const QVariant&) override;
+      QVariant getProperty(Pid) const override;
+      bool setProperty(Pid, const QVariant&) override;
 
-      virtual qreal baseLine() const     { return 0.0; }
+      qreal baseLine() const override    { return 0.0; }
       virtual Segment* segment() const   { return (Segment*)parent(); }
       };
 
@@ -71,15 +71,15 @@ class FSymbol final : public BSymbol {
       FSymbol(Score* s);
       FSymbol(const FSymbol&);
 
-      virtual FSymbol* clone() const    { return new FSymbol(*this); }
-      virtual ElementType type() const  { return ElementType::FSYMBOL; }
+      FSymbol* clone() const override   { return new FSymbol(*this); }
+      ElementType type() const override { return ElementType::FSYMBOL; }
 
-      virtual void draw(QPainter*) const;
-      virtual void write(XmlWriter& xml) const;
-      virtual void read(XmlReader&);
-      virtual void layout();
+      void draw(QPainter*) const override;
+      void write(XmlWriter& xml) const override;
+      void read(XmlReader&) override;
+      void layout() override;
 
-      virtual qreal baseLine() const { return 0.0; }
+      qreal baseLine() const override{ return 0.0; }
       Segment* segment() const       { return (Segment*)parent(); }
       QFont font() const             { return _font; }
       int code() const               { return _code; }

--- a/libmscore/text.h
+++ b/libmscore/text.h
@@ -26,10 +26,10 @@ class Text final : public TextBase {
    public:
       Text(Score* s = 0, Tid tid = Tid::DEFAULT);
 
-      virtual ElementType type() const override    { return ElementType::TEXT; }
-      virtual Text* clone() const override         { return new Text(*this); }
-      virtual void read(XmlReader&) override;
-      virtual QVariant propertyDefault(Pid id) const override;
+      ElementType type() const override    { return ElementType::TEXT; }
+      Text* clone() const override         { return new Text(*this); }
+      void read(XmlReader&) override;
+      QVariant propertyDefault(Pid id) const override;
       };
 
 }     // namespace Ms

--- a/libmscore/tremolo.h
+++ b/libmscore/tremolo.h
@@ -55,10 +55,10 @@ class Tremolo final : public Element {
       Tremolo(Score*);
       Tremolo(const Tremolo&);
       Tremolo &operator=(const Tremolo&) = delete;
-      virtual Tremolo* clone() const       { return new Tremolo(*this); }
-      virtual ElementType type() const     { return ElementType::TREMOLO; }
-      virtual int subtype() const override { return static_cast<int>(_tremoloType); }
-      virtual QString subtypeName() const override;
+      Tremolo* clone() const override      { return new Tremolo(*this); }
+      ElementType type() const override    { return ElementType::TREMOLO; }
+      int subtype() const override         { return static_cast<int>(_tremoloType); }
+      QString subtypeName() const override;
 
       QString tremoloTypeName() const;
       void setTremoloType(const QString& s);
@@ -70,12 +70,12 @@ class Tremolo final : public Element {
       void setTremoloType(TremoloType t);
       TremoloType tremoloType() const      { return _tremoloType; }
 
-      virtual qreal mag() const;
-      virtual void draw(QPainter*) const;
-      virtual void layout();
+      qreal mag() const override;
+      void draw(QPainter*) const override;
+      void layout() override;
       void layout2();
-      virtual void write(XmlWriter& xml) const;
-      virtual void read(XmlReader&);
+      void write(XmlWriter& xml) const override;
+      void read(XmlReader&) override;
 
       Chord* chord1() const { return _chord1; }
       Chord* chord2() const { return _chord2; }
@@ -93,16 +93,16 @@ class Tremolo final : public Element {
 
       bool placeMidStem() const;
 
-      virtual void spatiumChanged(qreal oldValue, qreal newValue) override;
-      virtual void localSpatiumChanged(qreal oldValue, qreal newValue) override;
-      virtual void styleChanged() override;
+      void spatiumChanged(qreal oldValue, qreal newValue) override;
+      void localSpatiumChanged(qreal oldValue, qreal newValue) override;
+      void styleChanged() override;
 
-      virtual QString accessibleInfo() const override;
+      QString accessibleInfo() const override;
 
-      virtual QVariant getProperty(Pid propertyId) const override;
-      virtual bool setProperty(Pid propertyId, const QVariant&) override;
-      virtual Pid propertyId(const QStringRef& xmlName) const override;
-      virtual QString propertyUserValue(Pid) const override;
+      QVariant getProperty(Pid propertyId) const override;
+      bool setProperty(Pid propertyId, const QVariant&) override;
+      Pid propertyId(const QStringRef& xmlName) const override;
+      QString propertyUserValue(Pid) const override;
       };
 
 


### PR DESCRIPTION
Resolves: from PVS-Studio report 
  
We analyzed the MuseScore code using PVS-Studio, get a report with warnings and errors.
  
Issues:
```
V1052 Declaring virtual methods in a class marked as 'final' is pointless. Consider inspecting the 'ClassName' class.
```
  
The `virtual` specifier shows - this method can be overridden. 
The `override` specifier shows - this is an overriding method.

Adding a `virtual` qualifier for overriding methods is semantically incorrect, and can also cause problems.

One such problem is in the code:
```
MuseScore/mscore/exampleview.h:69: error: V762 It is possible a virtual function was overridden incorrectly. See third argument of function 'adjustCanvasPosition' in derived class 'ExampleView' and base class 'MuseScoreView'.  
```

If there was a class inherited from ExampleView, and it redefined the adjustCanvasPosition method, it was not clear whether it should redefine the virtual function from MuseScoreView :: adjustCanvasPosition, or it should redefine the virtual function from ExampleView :: adjustCanvasPosition. Both are marked as `virtual`, meaning semantically that both are for redefinition.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
