### PR TITLE
fix #302447: Crash on space in score part id

### DIFF
--- a/importexport/musicxml/importmxmlpass1.cpp
+++ b/importexport/musicxml/importmxmlpass1.cpp
@@ -1657,7 +1657,7 @@ void MusicXMLParserPass1::scorePart()
       {
       Q_ASSERT(_e.isStartElement() && _e.name() == "score-part");
       _logger->logDebugTrace("MusicXMLParserPass1::scorePart", &_e);
-      QString id = _e.attributes().value("id").toString();
+      QString id = _e.attributes().value("id").toString().trimmed();
 
       if (_parts.contains(id)) {
             _logger->logError(QString("duplicate part id '%1'").arg(id), &_e);
@@ -1886,7 +1886,7 @@ void MusicXMLParserPass1::part()
       {
       Q_ASSERT(_e.isStartElement() && _e.name() == "part");
       _logger->logDebugTrace("MusicXMLParserPass1::part", &_e);
-      const QString id = _e.attributes().value("id").toString();
+      const QString id = _e.attributes().value("id").toString().trimmed();
 
       if (!_parts.contains(id)) {
             _logger->logError(QString("cannot find part '%1'").arg(id), &_e);

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -1551,7 +1551,7 @@ void MusicXMLParserPass2::scorePart()
 void MusicXMLParserPass2::part()
       {
       Q_ASSERT(_e.isStartElement() && _e.name() == "part");
-      const QString id = _e.attributes().value("id").toString();
+      const QString id = _e.attributes().value("id").toString().trimmed();
 
       if (!_pass1.hasPart(id)) {
             _logger->logError(QString("MusicXMLParserPass2::part cannot find part '%1'").arg(id), &_e);


### PR DESCRIPTION
fixed by trimming leading and trailing whitespace for score-part id and, for consistency, for part id too.

Resolves https://musescore.org/en/node/302447