### PR TITLE
fix #302690: crash after copying chord symbol

### DIFF
--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -202,7 +202,9 @@ Harmony::Harmony(const Harmony& h)
       _textName   = h._textName;
       _userName   = h._userName;
       _function   = h._function;
+      _play       = h._play;
       _realizedHarmony = h._realizedHarmony;
+      _realizedHarmony.setHarmony(this);
       for (const TextSegment* s : h.textList) {
             TextSegment* ns = new TextSegment();
             ns->set(s->text, s->font, s->x, s->y);

--- a/libmscore/realizedharmony.h
+++ b/libmscore/realizedharmony.h
@@ -83,10 +83,12 @@ class RealizedHarmony {
       void setDuration(HDuration);
       void setLiteral(bool);
       void setDirty(bool dirty) { cascadeDirty(dirty); } //set dirty flag and cascade
+      void setHarmony(Harmony* h) { _harmony = h; }
 
       Voicing voicing() const { return _voicing; }
       HDuration duration() const { return _duration; }
       bool literal() const { return _literal; }
+      Harmony* harmony() { return _harmony; }
 
       bool valid() const { return !_dirty && _harmony; }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/302690

Currently, a crash can occur after copying a chord symbol.
The Harmony object contains a RealizedHarmony object,
which contains a pointer back to the Harmony object,
but the copy constructor for Harmony does not set the pointer.
This ends up yielding an invalid pointer by the time the copy completes.
This fix makes sure to set the pointer correctly.
It also copies the "_play" property,
otherwise copied chord symbols would not play by default.