### PR TITLE
[Regression] Fix file type filter sometimes not shown when saving

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -458,12 +458,14 @@ bool MuseScore::saveFile(MasterScore* score)
                   fname = QFileInfo(fname).baseName() + ".msmr";
                   filter = msmrType + ";;" + mscxType + ";;" + msczType;
                   }
-            else
+            else {
 #endif
-            if (QFileInfo(fname).suffix().isEmpty()) {
+            filter = msczType + ";;" + mscxType;
+            if (QFileInfo(fname).suffix().isEmpty())
                   fname += ".mscz";
-                  filter = msczType + ";;" + mscxType;
-                  }
+#ifdef AVSOMR
+            }
+#endif
 
             fn = mscore->getSaveScoreName(tr("Save Score"), fname, filter);
             if (fn.isEmpty())


### PR DESCRIPTION
For example when importing a 2.x score