### PR TITLE
fixed collision between drag and cmds next*, prev*

### DIFF
--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -15,6 +15,8 @@
  Implementation of class Selection plus other selection related functions.
 */
 
+#include "log.h"
+
 #include "mscore.h"
 #include "arpeggio.h"
 #include "barline.h"
@@ -321,6 +323,12 @@ static QRectF changeSelection(Element* e, bool b)
 
 void Selection::clear()
       {
+
+      IF_ASSERT_FAILED(!isLocked()) {
+            LOGE() << "selection locked, reason: " << lockReason();
+            return;
+            }
+
       for (Element* e : _el) {
             if (e->isSpanner()) {   // TODO: only visible elements should be selectable?
                   Spanner* sp = toSpanner(e);
@@ -358,6 +366,10 @@ void Selection::remove(Element* el)
 
 void Selection::add(Element* el)
       {
+      IF_ASSERT_FAILED(!isLocked()) {
+            LOGE() << "selection locked, reason: " << lockReason();
+            return;
+            }
       _el.append(el);
       update();
       }
@@ -432,6 +444,10 @@ bool SelectionFilter::canSelectVoice(int track) const
 
 void Selection::appendFiltered(Element* e)
       {
+      IF_ASSERT_FAILED(!isLocked()) {
+            LOGE() << "selection locked, reason: " << lockReason();
+            return;
+            }
       if (selectionFilter().canSelect(e))
             _el.append(e);
       }
@@ -442,6 +458,10 @@ void Selection::appendFiltered(Element* e)
 
 void Selection::appendChord(Chord* chord)
       {
+      IF_ASSERT_FAILED(!isLocked()) {
+            LOGE() << "selection locked, reason: " << lockReason();
+            return;
+            }
       if (chord->beam() && !_el.contains(chord->beam()))
             _el.append(chord->beam());
       if (chord->stem())
@@ -487,6 +507,10 @@ void Selection::appendChord(Chord* chord)
 
 void Selection::updateSelectedElements()
       {
+      IF_ASSERT_FAILED(!isLocked()) {
+            LOGE() << "selection locked, reason: " << lockReason();
+            return;
+            }
       if (_state != SelState::RANGE) {
             update();
             return;

--- a/libmscore/select.h
+++ b/libmscore/select.h
@@ -154,6 +154,8 @@ class Selection {
       Fraction _currentTick;  // tracks the most recent selection
       int _currentTrack;
 
+      QString _lockReason;
+
       QByteArray staffMimeData() const;
       QByteArray symbolListMimeData() const;
       SelectionFilter selectionFilter() const;
@@ -171,6 +173,12 @@ class Selection {
       bool isRange() const             { return _state == SelState::RANGE; }
       bool isList() const              { return _state == SelState::LIST; }
       void setState(SelState s);
+
+      //! NOTE If locked, the selected items should not be changed.
+      void lock(const QString& reason)    { _lockReason = reason; }
+      void unlock(const QString& reason)  { Q_UNUSED(reason); _lockReason.clear(); } // reason for clarity
+      bool isLocked() const               { return  !_lockReason.isEmpty(); }
+      const QString& lockReason() const   { return _lockReason; }
 
       const QList<Element*>& elements() const { return _el; }
       std::vector<Note*> noteList(int track = -1) const;

--- a/mscore/dragelement.cpp
+++ b/mscore/dragelement.cpp
@@ -10,6 +10,8 @@
 //  the file LICENCE.GPL
 //=============================================================================
 
+#include "log.h"
+
 #include "scoreview.h"
 #include "libmscore/score.h"
 #include "musescore.h"
@@ -35,6 +37,8 @@ void ScoreView::startDrag()
 
       for (Element* e : _score->selection().elements())
             e->startDrag(editData);
+
+      _score->selection().lock("drag");
       }
 
 //---------------------------------------------------------
@@ -96,6 +100,8 @@ void ScoreView::endDrag()
             e->endDrag(editData);
             e->triggerLayout();
             }
+
+      _score->selection().unlock("drag");
       setDropTarget(0); // this also resets dropAnchor
       _score->endCmd();
       if (editData.element->normalModeEditBehavior() == Element::EditBehavior::Edit && _score->selection().element() == editData.element)

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -10,6 +10,8 @@
 //  the file LICENCE.GPL
 //=============================================================================
 
+#include "log.h"
+
 #include "scoreview.h"
 
 #include "breaksdialog.h"
@@ -2048,6 +2050,12 @@ void ScoreView::cmd(const char* s)
               "prev-track",
               "next-measure",
               "prev-measure"}, [](ScoreView* cv, const QByteArray& cmd) {
+
+                  if (cv->score()->selection().isLocked()) {
+                        LOGW() << "unable exec cmd: " << cmd << ", selection locked, reason: " << cv->score()->selection().lockReason();
+                        return;
+                        }
+
                   Element* el = cv->score()->selection().element();
                   if (el && (el->isTextBase())) {
                         cv->score()->startCmd();


### PR DESCRIPTION
Resolves: some crashes from CrashReporter

There are several drag crashes in the crash report.
I previously fixed the consequences of the problems.
I investigated the reasons, found that crashes occur if the selected elements are changed during the drag.
Case:
1. Select Note
2. Start drag 
3. Click key right arrow (holding the mouse button) 
4. Try drag Note -> crash
5. Or end drag Note -> crash

The drag function expects that between the start of the drag, the drag, and the end of the drag, the selected elements do not change.  
But commands next-*, prev-* change selection elements.

Added a lock function to Selection

    
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
