### PR TITLE
fix #293724: added the ability to delete the previous word using ctrl + backspace

### DIFF
--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -265,13 +265,21 @@ bool TextBase::edit(EditData& ed)
                         return true;
 
                   case Qt::Key_Backspace:
-                        if (!deleteSelectedText(ed)) {
-                              if (_cursor->column() == 0 && _cursor->row() != 0)
-                                    score()->undo(new JoinText(_cursor), &ed);
-                              else {
-                                    if (!_cursor->movePosition(QTextCursor::Left))
-                                          return false;
-                                    score()->undo(new RemoveText(_cursor, QString(_cursor->currentCharacter())), &ed);
+                        if (ctrlPressed) {
+                              // delete last word
+                              _cursor->movePosition(QTextCursor::WordLeft, QTextCursor::MoveMode::KeepAnchor);
+                              s.clear();
+                              deleteSelectedText(ed);
+                              }
+                        else {
+                              if (!deleteSelectedText(ed)) {
+                                    if (_cursor->column() == 0 && _cursor->row() != 0)
+                                          score()->undo(new JoinText(_cursor), &ed);
+                                    else {
+                                          if (!_cursor->movePosition(QTextCursor::Left))
+                                                return false;
+                                          score()->undo(new RemoveText(_cursor, QString(_cursor->currentCharacter())), &ed);
+                                          }
                                     }
                               }
                         return true;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/293724

Added the ability to delete the last word using ctrl + backspace.

![delete_word](https://user-images.githubusercontent.com/21060365/79168962-d0184d80-7df3-11ea-8fd5-9b09d4218401.gif)

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made
