### PR TITLE
Added Edit Header/Footer as 4th option in context menu of score

### DIFF
--- a/mscore/editstyle.h
+++ b/mscore/editstyle.h
@@ -75,6 +75,8 @@ class EditStyle : public QDialog, private Ui::EditStyleBase {
 
       static const std::map<ElementType, EditStylePage> PAGES;
 
+      friend class MuseScore;
+
    private slots:
       void selectChordDescriptionFile();
       void setChordStyle(bool);

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -997,6 +997,7 @@ void ScoreView::contextMenuEvent(QContextMenuEvent* ev)
                   popup->addAction(getAction("edit-style"));
                   popup->addAction(getAction("page-settings"));
                   popup->addAction(getAction("load-style"));
+                  popup->addAction(getAction("edit-header-footer"));
                   _score->update();
                   popup->popup(gp);
                   }

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6314,6 +6314,14 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
                   _styleDlg->setScore(cs);
             _styleDlg->exec();
             }
+      else if (cmd == "edit-header-footer") {
+            if (!_styleDlg)
+                  _styleDlg = new EditStyle { cs, this };
+            else
+                  _styleDlg->setScore(cs);
+            _styleDlg->setPage(_styleDlg->pageStack->indexOf(_styleDlg->PageHeaderFooter));
+            _styleDlg->exec();
+            }
       else if (cmd == "edit-info") {
             MetaEditDialog med(cs, 0);
             med.exec();

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -3741,6 +3741,16 @@ Shortcut Shortcut::_sc[] = {
          Icons::mail_ICON,
          Qt::ApplicationShortcut
          },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
+         "edit-header-footer",
+         QT_TRANSLATE_NOOP("action","Edit Header/Footer…"),
+         QT_TRANSLATE_NOOP("action","Edit header/footer"),
+         0,
+         Icons::Invalid_ICON,
+         Qt::WindowShortcut
+         },
 #ifdef MSCORE_UNSTABLE
       {
          MsWidget::MAIN_WINDOW,


### PR DESCRIPTION
Resolves: Issue wasn't created, it's just a good-first-feature

Added the 4th option in the context menu (appears after right clicking in empty area of the score). It takes user directly to the "Header, Footer" page of "Style" menu.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
