### PR TITLE
fix #291402: added the ability to delete \n using the delete key (duplicate, the old one was automatically closed for some reason)

### DIFF
--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -260,8 +260,20 @@ bool TextBase::edit(EditData& ed)
                         return true;
 
                   case Qt::Key_Delete:
-                        if (!deleteSelectedText(ed))
-                              score()->undo(new RemoveText(_cursor, QString(_cursor->currentCharacter())), &ed);
+                        if (!deleteSelectedText(ed)) {
+                              // check for move down
+                              if (_cursor->column() == _cursor->columns()) { // if you are on the end of the line, delete the newline char
+                                    int cursorRow = _cursor->row();
+                                    _cursor->movePosition(QTextCursor::Down);
+                                    if (_cursor->row() != cursorRow) {
+                                          _cursor->movePosition(QTextCursor::StartOfLine);
+                                          score()->undo(new JoinText(_cursor), &ed);
+                                          }
+                                    }
+                              else {
+                                    score()->undo(new RemoveText(_cursor, QString(_cursor->currentCharacter())), &ed);
+                                    }
+                              }
                         return true;
 
                   case Qt::Key_Backspace:


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/291402

Used the implementation of backspace to implement the expected functionality. The cursor gets moved to the beginning of the next line and the same function as backspace is called.

![delete_new_line](https://user-images.githubusercontent.com/21060365/79563274-27007a00-80b5-11ea-867e-05b189352471.gif)

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made