### PR TITLE
fix #299788 Crash when deleting a local Time Signature (removed assert)

### DIFF
--- a/libmscore/range.cpp
+++ b/libmscore/range.cpp
@@ -289,7 +289,7 @@ void TrackList::read(const Segment* fs, const Segment* es)
                         s  = skipTuplet(t);    // continue with first chord/rest after tuplet
                         de = t;
                         }
-                  Q_ASSERT(gap >= Fraction(0,1));
+
                   if (gap.isNotZero()) {
                         appendGap(gap);
                         tick += gap;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/299788

In fact, it’s not a crash, but about assert in the debug build.
I did not find the reasons why this assert was added, until the last change (before the transition to `Fraction`) it was not. 

I think it should not be, but I can be wrong, anyone has any information why this assert was added?

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue