### PR TITLE
Try fix crash on TextBase::endEdit (from CrashReporter)

### DIFF
--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -10,6 +10,7 @@
 //  the file LICENCE.GPL
 //=============================================================================
 
+#include "log.h"
 #include "textedit.h"
 #include "score.h"
 
@@ -83,9 +84,17 @@ void TextBase::startEdit(EditData& ed)
 void TextBase::endEdit(EditData& ed)
       {
       TextEditData* ted = static_cast<TextEditData*>(ed.getData(this));
+      IF_ASSERT_FAILED(ted) {
+            return;
+            }
+
+      UndoStack* undo = score()->undoStack();
+      IF_ASSERT_FAILED(undo) {
+            return;
+            }
+
       const QString actualXmlText = xmlText();
       const QString actualPlainText = plainText();
-      UndoStack* undo = score()->undoStack();
 
       // replace all undo/redo records collected during text editing with
       // one property change


### PR DESCRIPTION
Resolves: https://sentry.musescore.org/musescore/editor/issues/21706 (from CrashReporter)
evens: 245   
dump:
```
Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ
MuseScore3 0x0001409cd948 Ms::TextBase::endEdit(Ms::EditData &) c:\musescore\libmscore\textedit.cpp:75
MuseScore3 0x0001407cda16 Ms::Element::canvasPos() c:\musescore\libmscore\element.cpp:462
MuseScore3 0x0001408050b2 Ms::Score::addRefresh(QRectF const &) c:\musescore\libmscore\score.cpp:4613
MuseScore3 0x0001405fdee2 Ms::ScoreView::endEdit() c:\musescore\mscore\editelement.cpp:162
Qt5Core 0x00005a5ad160 <unknown>
MuseScore3 0x0001407cda16 Ms::Element::canvasPos() c:\musescore\libmscore\element.cpp:462
MuseScore3 0x00014025e466 Ms::ScoreView::changeState(Ms::ViewState) c:\musescore\mscore\events.cpp:1127
MuseScore3 0x000140260491 Ms::ScoreView::mousePressEvent(QMouseEvent *) c:\musescore\mscore\events.cpp:556
```
   
I could not reproduce, so I could not find the true cause of the error.
But now at least there will be no crash for the user, with data loss.
    
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
