### PR TITLE
fix  #292652: Empty lines become smaller.

### DIFF
--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -818,6 +818,16 @@ void TextBlock::insert(TextCursor* cursor, const QString& s)
       }
 
 //---------------------------------------------------------
+//   insertEmptyFragment
+//---------------------------------------------------------
+
+void TextBlock::insertEmptyFragment(TextCursor* cursor)
+      {
+      if (_fragments.size() == 0 || _fragments.at(0).text != "")
+            _fragments.insert(0, TextFragment(cursor, ""));
+      }
+
+//---------------------------------------------------------
 //   fragment
 //    inputs:
 //      column is the column relative to the start of the TextBlock.
@@ -1248,6 +1258,8 @@ void TextBase::createLayout()
                   else if (c == '\n') {
                         if (rows() <= cursor.row())
                               _layout.append(TextBlock());
+                        if(_layout[cursor.row()].fragments().size() == 0)
+                              _layout[cursor.row()].insertEmptyFragment(&cursor); // used to preserve the Font size of the line (font info is held in TextFragments, see PR #5881)
                         _layout[cursor.row()].setEol(true);
                         cursor.setRow(cursor.row() + 1);
                         cursor.setColumn(0);

--- a/libmscore/textbase.h
+++ b/libmscore/textbase.h
@@ -193,6 +193,7 @@ class TextBlock {
       QRectF boundingRect(int col1, int col2, const TextBase*) const;
       int columns() const;
       void insert(TextCursor*, const QString&);
+      void insertEmptyFragment(TextCursor*);
       QString remove(int column);
       QString remove(int start, int n);
       int column(qreal x, TextBase*) const;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/292652

After the user is done editing a text object endEdit is called. This function unifies all previous commands (edits) into a single one so that the user can undo all changes with a single action. The problem is that UndoChangeProperty leads to a call of setXmlText, and in turn that leads to a call to createLayout(). 

In createLayout() a new line character adds a new TextBlock, but if no letters are inserted into that TextBlock (that is, if the line is empty) the TextBlock has no TextFragments (which hold information about the format, fontSize included). That leads to the TextBlock using the default font, which leads to smaller empty lines. I add an empty TextFragment to every TextBlock. I probably can improve on this, by deleting empty TextBlocks when they are not needed.

This PR also seems to take care of a problem while editing, where the cursor could "forget" it's font options and reset to the defaults. If in fact, this PR does not fix that issue, I'll upload a related PR that fixes it.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made
