### PR TITLE
[MU4] Fixes a bug where the cursor forgets it's font when editing with empty lines.

### DIFF
--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -1035,7 +1035,7 @@ void TextFragment::changeFormat(FormatId id, QVariant data)
 //   split
 //---------------------------------------------------------
 
-TextBlock TextBlock::split(int column)
+TextBlock TextBlock::split(int column, TextCursor* tc)
       {
       TextBlock tl;
 
@@ -1066,7 +1066,10 @@ TextBlock TextBlock::split(int column)
       TextFragment tf("");
       if (_fragments.size() > 0)
             tf.format = _fragments.last().format;
+      else
+            tf.format = *(tc->format());
       tl._fragments.append(tf);
+
       return tl;
       }
 

--- a/libmscore/textbase.h
+++ b/libmscore/textbase.h
@@ -196,7 +196,7 @@ class TextBlock {
       QString remove(int column);
       QString remove(int start, int n);
       int column(qreal x, TextBase*) const;
-      TextBlock split(int column);
+      TextBlock split(int column, TextCursor* tc);
       qreal xpos(int col, const TextBase*) const;
       const CharFormat* formatAt(int) const;
       const TextFragment* fragment(int col) const;

--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -483,10 +483,12 @@ void SplitJoinText::join(EditData* ed)
       if (line < lines)
             t->textBlock(line).setEol(eol);
       t->textBlockList().removeAt(line);
+
       c.setRow(line-1);
       c.setColumn(col);
       c.setFormat(*charFmt);             // restore orig. format at new line
       c.clearSelection();
+
       if (ed)
             *t->cursor(*ed) = c;
       c.text()->setTextInvalid();
@@ -500,7 +502,7 @@ void SplitJoinText::split(EditData* ed)
       t->triggerLayout();
 
       CharFormat* charFmt = c.format();         // take current format
-      t->textBlockList().insert(line + 1, c.curLine().split(c.column()));
+      t->textBlockList().insert(line + 1, c.curLine().split(c.column(), &c));
       c.curLine().setEol(true);
 
       c.setRow(line+1);


### PR DESCRIPTION
I believe that this PR fixes this problem: https://github.com/musescore/MuseScore/pull/5881
This is a backup solution in case the above PR does not work.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
