### PR TITLE
fix #303078: Fixed a bug where the cursor would be on the wrong height after deleting all chars in a line

### DIFF
--- a/libmscore/textbase.h
+++ b/libmscore/textbase.h
@@ -193,9 +193,9 @@ class TextBlock {
       QRectF boundingRect(int col1, int col2, const TextBase*) const;
       int columns() const;
       void insert(TextCursor*, const QString&);
-      void insertEmptyFragment(TextCursor*);
-      QString remove(int column);
-      QString remove(int start, int n);
+      void insertEmptyFragmentIfNeeded(TextCursor*);
+      QString remove(int column, TextCursor*);
+      QString remove(int start, int n, TextCursor*);
       int column(qreal x, TextBase*) const;
       TextBlock split(int column);
       qreal xpos(int col, const TextBase*) const;

--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -477,7 +477,7 @@ void ChangeText::removeText(EditData* ed)
       int column    = c.column();
 
       for (int n = 0; n < s.size(); ++n)
-            l.remove(column);
+            l.remove(column, &c);
       c.text()->triggerLayout();
       if (ed)
             *c.text()->cursor(*ed) = tc;
@@ -679,7 +679,7 @@ void TextBase::inputTransition(EditData& ed, QInputMethodEvent* ie)
       while (n--) {
             if (_cursor->movePosition(QTextCursor::Left)) {
                   TextBlock& l  = _cursor->curLine();
-                   l.remove(_cursor->column());
+                   l.remove(_cursor->column(), _cursor);
                   _cursor->text()->triggerLayout();
                   _cursor->text()->setTextInvalid();
                   }
@@ -743,7 +743,7 @@ void TextBase::endHexState(EditData& ed)
                   int c1 = c2 - (hexState + 1);
 
                   TextBlock& t = _layout[_cursor->row()];
-                  QString ss   = t.remove(c1, hexState + 1);
+                  QString ss   = t.remove(c1, hexState + 1, _cursor);
                   bool ok;
                   int code     = ss.mid(1).toInt(&ok, 16);
                   _cursor->setColumn(c1);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/303078

If you delete all characters in a line cursorRect (used to calculate the text cursor's shape) will have no TextFragments to get formatting information from. This leads the cursor to be offset vertically. This fix adds an empty TextFragment when you remove all characters from a line, so that information about the format of the TextBlock is preserved.

Before:
![cursor_wrong_height](https://user-images.githubusercontent.com/21060365/79573493-69cb4d80-80c7-11ea-80f1-77165f3e01ac.gif)
After:
![cursor_correct_height](https://user-images.githubusercontent.com/21060365/79572856-4fdd3b00-80c6-11ea-8d4f-635ed4c9ddbd.gif)

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made
