### PR TITLE
fix #16077 part 1: Double click an instrument name to open the corresponding menu

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -729,8 +729,14 @@ void ScoreView::mouseDoubleClickEvent(QMouseEvent* mouseEvent)
 
       Element* clickedElement = elementNear(toLogical(mouseEvent->pos()));
 
-      if (!(clickedElement && clickedElement->isEditable()))
+      if (!clickedElement)
             return;
+
+      if (!clickedElement->isEditable()) {
+            if (clickedElement->isInstrumentName()) // double-click an instrument name to open the edit staff/part properties menu
+                  elementPropertyAction("staff-props", clickedElement);
+            return;
+            }
 
       startEditMode(clickedElement);
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/16077

When the double-click event is created, the program checks if the user double-clicked on an instrument-name and opens the 'Edit Staff/Part Properties' menu if that is the case.

This provides one part of the requested functionality (the other, is to add the same ability for footers, but this should be another PR).

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made
