### PR TITLE
fix #16077 part 2: Double click a header/footer to open the corresponding menu

### DIFF
--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -79,6 +79,9 @@ inline int trackZeroVoice(int track) { return track & ~3;    }
 
 static const int MAX_TAGS = 32;
 
+static const int MAX_HEADERS = 3;
+static const int MAX_FOOTERS = 3;
+
 static constexpr qreal INCH      = 25.4;
 static constexpr qreal PPI       = 72.0;           // printer points per inch
 static constexpr qreal DPI_F     = 5;

--- a/libmscore/page.cpp
+++ b/libmscore/page.cpp
@@ -151,20 +151,22 @@ void Page::drawHeaderFooter(QPainter* p, int area, const QString& ss) const
             return;
 
       Text* text;
-      if (area < 3) {
-            text = score()->headerText();
+      if (area < MAX_HEADERS) {
+            text = score()->headerText(area);
             if (!text) {
                   text = new Text(score(), Tid::HEADER);
+                  text->setFlag(ElementFlag::GENERATED, true); // set to disable editing
                   text->setLayoutToParentWidth(true);
-                  score()->setHeaderText(text);
+                  score()->setHeaderText(text, area);
                   }
             }
       else {
-            text = score()->footerText();
+            text = score()->footerText(area - MAX_HEADERS); // because they are 3 4 5
             if (!text) {
                   text = new Text(score(), Tid::FOOTER);
+                  text->setFlag(ElementFlag::GENERATED, true); // set to disable editing
                   text->setLayoutToParentWidth(true);
-                  score()->setFooterText(text);
+                  score()->setFooterText(text, area - MAX_HEADERS);
                   }
             }
       text->setParent((Page*)this);

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1234,10 +1234,12 @@ static void updateStyle(void*, Element* e)
 void Score::styleChanged()
       {
       scanElements(0, updateStyle);
-      if (headerText())
-            headerText()->styleChanged();
-      if (footerText())
-            footerText()->styleChanged();
+      for(int i = 0; i < MAX_HEADERS; i++)
+            if (headerText(i))
+                  headerText(i)->styleChanged();
+      for(int i = 0; i < MAX_FOOTERS; i++)
+            if (footerText(i))
+                  footerText(i)->styleChanged();
       setLayoutAll();
       }
 
@@ -4750,7 +4752,7 @@ bool Score::isTopScore() const
 //---------------------------------------------------------
 
 Movements::Movements()
-   : std::vector<MasterScore*>()
+   : std::vector<MasterScore*>(), _headersText(MAX_HEADERS, nullptr), _footersText(MAX_FOOTERS, nullptr)
       {
       _undo = new UndoStack();
       }

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -353,8 +353,8 @@ class Movements : public std::vector<MasterScore*> {
       UndoStack* _undo;
       QList<Page*> _pages;          // pages are build from systems
       MStyle _style;
-      Text* _headerText  { 0 };
-      Text* _footerText  { 0 };
+      std::vector<Text*> _headersText;
+      std::vector<Text*> _footersText;
 
    public:
       Movements();
@@ -366,10 +366,10 @@ class Movements : public std::vector<MasterScore*> {
       UndoStack* undo() const                 { return _undo;                }
       MStyle& style()                         { return _style;               }
       const MStyle& style() const             { return _style;               }
-      Text* headerText() const                { return _headerText;          }
-      Text* footerText() const                { return _footerText;          }
-      void setHeaderText(Text* t)             { _headerText = t;             }
-      void setFooterText(Text* t)             { _footerText = t;             }
+      std::vector<Text*> headersText() const  { return _headersText;         }
+      std::vector<Text*> footersText() const  { return _footersText;         }
+      void setHeaderText(Text* t, int index)  { _headersText[index] = t;     }
+      void setFooterText(Text* t, int index)  { _footersText[index] = t;     }
       };
 
 //---------------------------------------------------------------------------------------
@@ -1207,10 +1207,10 @@ class Score : public QObject, public ScoreElement {
 
       bool isTopScore() const;
 
-      Text* headerText() const                { return movements()->headerText();          }
-      Text* footerText() const                { return movements()->footerText();          }
-      void setHeaderText(Text* t)             { movements()->setHeaderText(t);             }
-      void setFooterText(Text* t)             { movements()->setFooterText(t);             }
+      Text* headerText(int index) const               { return movements()->headersText()[index];     }
+      Text* footerText(int index) const               { return movements()->footersText()[index];     }
+      void setHeaderText(Text* t, int index)          { movements()->setHeaderText(t, index);         }
+      void setFooterText(Text* t, int index)          { movements()->setFooterText(t, index);         }
 
       void cmdAddPitch(int note, bool addFlag, bool insert);
       void forAllLyrics(std::function<void(Lyrics*)> f);

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -769,6 +769,16 @@ void EditStyle::gotoElement(Element* e)
       }
 
 //---------------------------------------------------------
+//   gotoElement
+///   used to go to the correct page when double-clicking on a header/footer
+//---------------------------------------------------------
+
+void EditStyle::gotoHeaderFooterPage()
+      {
+      setPage(pageStack->indexOf(PageHeaderFooter));
+      }
+
+//---------------------------------------------------------
 //   elementHasPage
 ///   check if an element has a style page related to it
 //---------------------------------------------------------

--- a/mscore/editstyle.h
+++ b/mscore/editstyle.h
@@ -104,6 +104,7 @@ class EditStyle : public QDialog, private Ui::EditStyleBase {
       void setScore(Score* s) { cs = s; }
 
       void gotoElement(Element* e);
+      void gotoHeaderFooterPage();
       static bool elementHasPage(Element* e);
       };
 

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -748,6 +748,8 @@ void ScoreView::mouseDoubleClickEvent(QMouseEvent* mouseEvent)
       if (!clickedElement->isEditable()) {
             if (clickedElement->isInstrumentName()) // double-click an instrument name to open the edit staff/part properties menu
                   elementPropertyAction("staff-props", clickedElement);
+            else if (clickedElement->isText() && (toText(clickedElement)->tid() == Tid::FOOTER || toText(clickedElement)->tid() == Tid::HEADER)) // double-click an instrument name to open the edit staff/part properties menu
+                  elementPropertyAction("style-header-footer", clickedElement);
             return;
             }
 

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -377,10 +377,16 @@ void Inspector::update(Score* s)
                               ie = new InspectorNoteDot(this);
                               break;
                         default:
-                              if (element()->isText())
-                                    ie = new InspectorText(this);
-                              else
+                              if (element()->isText()) {
+                                    // don't allow footers/headers to be edited via the inspector
+                                    if (toText(element())->tid() != Tid::FOOTER && toText(element())->tid() != Tid::HEADER)
+                                          ie = new InspectorText(this);
+                                    else
+                                          ie = new InspectorEmpty(this);
+                                    }
+                              else {
                                     ie = new InspectorElement(this);
+                                    }
                               break;
                         }
                   }

--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -435,6 +435,14 @@ void ScoreView::elementPropertyAction(const QString& cmd, Element* e)
             mscore->styleDlg()->gotoElement(e);
             mscore->styleDlg()->exec();
             }
+      else if (cmd == "style-header-footer") { // used to go to the header/footer dialog by double-clicking on a header/footer
+            if (!mscore->styleDlg())
+                  mscore->setStyleDlg(new EditStyle { _score, mscore });
+            else
+                  mscore->styleDlg()->setScore(mscore->currentScore());
+            mscore->styleDlg()->gotoHeaderFooterPage();
+            mscore->styleDlg()->exec();
+            }
       else if (cmd == "ch-instr")
             selectInstrument(toInstrumentChange(e));
       else if (cmd == "staff-props") {

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4779,6 +4779,12 @@ QList<Element*> ScoreView::elementsNear(QPointF p)
       QRectF r(p.x() - w, p.y() - w, 3.0 * w, 3.0 * w);
 
       QList<Element*> el = page->items(r);
+      for (int i = 0; i < MAX_HEADERS; i++)
+            if (score()->headerText(i) != nullptr)      // gives the ability to select the header
+                  el.push_back(score()->headerText(i));
+      for (int i = 0; i < MAX_FOOTERS; i++)
+            if (score()->footerText(i) != nullptr)      // gives the ability to select the footer
+                  el.push_back(score()->footerText(i));
       for (Element* e : el) {
             e->itemDiscovered = 0;
             if (!e->selectable() || e->isPage())


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/16077

Related PR: https://github.com/musescore/MuseScore/pull/5886

Added the ability to double click a header/footer to go their menu (dialog).

First of all, to be able to double click you need to be able to select. Headers/footers were not selectable because they were not in Page->items, which means that they were not in the bspTree. Adding them to the bspTree causes graphical glitches and it requires extensive workarounds to bypass the constness of Page::draw. That's why they are added manually in ScoreView::elementsNear.

After giving them the ability to be selected, they need to be non-editable, which means setting their flag to generated and disabling their inspector. Editing them via the inspector causes more graphical glitches and makes the logic in ScoreView::mouseDoubleClickEvent more complex. If we want the ability to edit them via the inspector, more extensive changes have to be made.

Edited for the latest push: I changed the way headers/footers are stored in the program to enable the ability to click any one of the 3 headers/footers to go to the dialog. While doing that I changed the pointer initialization to nullptr and converted some things to the new representation (which uses vectors).


- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made
