### PR TITLE
Fix #302714: make chord symbol playback settings available in Edit Style dialog

### DIFF
--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -259,6 +259,10 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       { Sid::maxHarmonyBarDistance,   false, maxHarmonyBarDistance,   0 },
       { Sid::maxChordShiftAbove,      false, maxChordShiftAbove,      resetMaxChordShiftAbove   },
       { Sid::maxChordShiftBelow,      false, maxChordShiftBelow,      resetMaxChordShiftBelow   },
+      { Sid::harmonyPlay,             false, harmonyPlay,             0 },
+      { Sid::harmonyVoiceLiteral,     false, voicingSelectWidget->interpretBox, 0 },
+      { Sid::harmonyVoicing,          false, voicingSelectWidget->voicingBox, 0 },
+      { Sid::harmonyDuration,         false, voicingSelectWidget->durationBox, 0 },
 
       { Sid::tupletVHeadDistance,     false, tupletVHeadDistance,     resetTupletVHeadDistance      },
       { Sid::tupletVStemDistance,     false, tupletVStemDistance,     resetTupletVStemDistance      },
@@ -436,6 +440,27 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
             comboFBFont->addItem(family);
       comboFBFont->setCurrentIndex(0);
       connect(comboFBFont, SIGNAL(currentIndexChanged(int)), SLOT(on_comboFBFont_currentIndexChanged(int)));
+
+      // chord symbol init
+      harmonyPlay->setChecked(true);
+
+      voicingSelectWidget->interpretBox->clear();
+      voicingSelectWidget->interpretBox->addItem(tr("Jazz"), int(0)); // two-item combobox for boolean style variant
+      voicingSelectWidget->interpretBox->addItem(tr("Literal"), int(1)); // true = literal
+
+      voicingSelectWidget->voicingBox->clear();
+      voicingSelectWidget->voicingBox->addItem(tr("Automatic"), int(Voicing::AUTO));
+      voicingSelectWidget->voicingBox->addItem(tr("Root Only"), int(Voicing::ROOT_ONLY));
+      voicingSelectWidget->voicingBox->addItem(tr("Close"), int(Voicing::CLOSE));
+      voicingSelectWidget->voicingBox->addItem(tr("Drop 2"), int(Voicing::DROP_2));
+      voicingSelectWidget->voicingBox->addItem(tr("Six Note"), int(Voicing::SIX_NOTE));
+      voicingSelectWidget->voicingBox->addItem(tr("Four Note"), int(Voicing::FOUR_NOTE));
+      voicingSelectWidget->voicingBox->addItem(tr("Three Note"), int(Voicing::THREE_NOTE));
+
+      voicingSelectWidget->durationBox->clear();
+      voicingSelectWidget->durationBox->addItem(tr("Until Next Chord Symbol"), int(HDuration::UNTIL_NEXT_CHORD_SYMBOL));
+      voicingSelectWidget->durationBox->addItem(tr("Until End of Measure"), int(HDuration::STOP_AT_MEASURE_END));
+      voicingSelectWidget->durationBox->addItem(tr("Chord/Rest Duration"), int(HDuration::SEGMENT_DURATION));
 
       // keep in sync with implementation in Page::replaceTextMacros (page.cpp)
       // jumping thru hoops here to make the job of translators easier, yet have a nice display
@@ -921,9 +946,16 @@ QVariant EditStyle::getValue(Sid idx)
             return v;
             }
       else if (!strcmp("bool", type)) {
-            QVariant v = sw.widget->property("checked");
-            if (!v.isValid())
-                  unhandledType(&sw);
+            QVariant v;
+            if (sw.idx == Sid::harmonyVoiceLiteral) { // special case for bool represented by a two-item combobox
+                  QComboBox* cb = qobject_cast<QComboBox*>(sw.widget);
+                  v = cb->currentIndex();
+                  }
+            else {
+                  v = sw.widget->property("checked");
+                  if (!v.isValid())
+                        unhandledType(&sw);
+                  }
             return v;
             }
       else if (!strcmp("int", type)) {
@@ -1010,10 +1042,15 @@ void EditStyle::setValues()
                         unhandledType(&sw);
                   }
             else if (!strcmp("bool", type)) {
-                  if (!sw.widget->setProperty("checked", val))
-                        unhandledType(&sw);
-                  if (sw.idx == Sid::measureNumberSystem && !val.toBool())
-                        showIntervalMeasureNumber->setChecked(true);
+                  if (sw.idx == Sid::harmonyVoiceLiteral) { // special case for bool represented by a two-item combobox
+                        voicingSelectWidget->interpretBox->setCurrentIndex(val.toBool());
+                        }
+                  else {
+                        if (!sw.widget->setProperty("checked", val))
+                              unhandledType(&sw);
+                        if (sw.idx == Sid::measureNumberSystem && !val.toBool())
+                              showIntervalMeasureNumber->setChecked(true);
+                        }
                   }
             else if (!strcmp("int", type)) {
                   if (qobject_cast<QComboBox*>(sw.widget)) {

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -247,7 +247,7 @@
        </size>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>31</number>
       </property>
       <widget class="QWidget" name="PageScore">
        <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -2285,7 +2285,7 @@
               <string>Reset 'Position below' value</string>
              </property>
              <property name="text">
-             <string notr="true"/>
+              <string notr="true"/>
              </property>
              <property name="icon">
               <iconset resource="musescore.qrc">
@@ -9357,174 +9357,67 @@
           <property name="title">
            <string>Chord Symbols</string>
           </property>
-          <layout class="QVBoxLayout" name="verticalLayout_36">
-           <item>
-            <widget class="QGroupBox" name="groupBox_25">
+          <layout class="QGridLayout" name="gridLayout_13">
+           <item row="1" column="2" colspan="2">
+            <widget class="QGroupBox" name="harmonyPlay">
              <property name="title">
-              <string>Appearance</string>
+              <string>Play</string>
              </property>
-             <layout class="QHBoxLayout" name="horizontalLayout">
-              <item>
-               <widget class="QRadioButton" name="chordsStandard">
-                <property name="text">
-                 <string>Standard</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QRadioButton" name="chordsJazz">
-                <property name="text">
-                 <string>Jazz</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QRadioButton" name="chordsCustom">
-                <property name="text">
-                 <string>Custom</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QWidget" name="chordDescriptionGroup" native="true">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <layout class="QGridLayout" name="chordDescriptionLayout">
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
-                 <item row="0" column="1">
-                  <widget class="QToolButton" name="chordDescriptionFileButton">
-                   <property name="text">
-                    <string notr="true"/>
-                   </property>
-                   <property name="icon">
-                    <iconset resource="musescore.qrc">
-                     <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QCheckBox" name="chordsXmlFile">
-                   <property name="text">
-                    <string>Load chords.xml</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="0">
-                  <widget class="QLineEdit" name="chordDescriptionFile"/>
-                 </item>
-                </layout>
-               </widget>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_47">
+              <item row="0" column="0">
+               <widget class="Ms::VoicingSelect" name="voicingSelectWidget" native="true"/>
               </item>
              </layout>
             </widget>
            </item>
-           <item>
-            <widget class="QGroupBox" name="formattingGroup">
+           <item row="2" column="2">
+            <widget class="QLabel" name="label_60">
+             <property name="text">
+              <string extracomment="Capodastro">Capo fret position:</string>
+             </property>
+             <property name="buddy">
+              <cstring>capoPosition</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0" colspan="4">
+            <widget class="QGroupBox" name="groupBox_25">
              <property name="title">
-              <string>Formatting</string>
+              <string>Appearance</string>
              </property>
              <layout class="QGridLayout" name="gridLayout_45">
-              <item row="0" column="0">
-               <widget class="QLabel" name="labelExtensionMag">
-                <property name="text">
-                 <string>Extension scaling:</string>
-                </property>
-                <property name="buddy">
-                 <cstring>extensionMag</cstring>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QDoubleSpinBox" name="extensionMag">
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <widget class="QToolButton" name="resetExtensionMag">
-                <property name="toolTip">
-                 <string>Reset to default</string>
-                </property>
-                <property name="accessibleName">
-                 <string>Reset 'Extension scaling' value</string>
-                </property>
-                <property name="text">
-                 <string notr="true"/>
-                </property>
-                <property name="icon">
-                 <iconset resource="musescore.qrc">
-                  <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="3">
-               <widget class="QLabel" name="labelModifierMag">
-                <property name="text">
-                 <string>Modifier scaling:</string>
-                </property>
-                <property name="buddy">
-                 <cstring>modifierMag</cstring>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="4">
+              <item row="1" column="4">
                <widget class="QDoubleSpinBox" name="modifierMag">
                 <property name="singleStep">
                  <double>0.100000000000000</double>
                 </property>
                </widget>
               </item>
-              <item row="0" column="5">
-               <widget class="QToolButton" name="resetModifierMag">
-                <property name="toolTip">
-                 <string>Reset to default</string>
-                </property>
-                <property name="accessibleName">
-                 <string>Reset 'Modifier scaling' value</string>
-                </property>
-                <property name="text">
-                 <string notr="true"/>
-                </property>
-                <property name="icon">
-                 <iconset resource="musescore.qrc">
-                  <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="labelExtensionAdjust">
-                <property name="text">
-                 <string>Extension vertical offset:</string>
-                </property>
-                <property name="buddy">
-                 <cstring>extensionAdjust</cstring>
+              <item row="2" column="4">
+               <widget class="QDoubleSpinBox" name="modifierAdjust">
+                <property name="minimum">
+                 <double>-99.989999999999995</double>
                 </property>
                </widget>
               </item>
               <item row="1" column="1">
+               <widget class="QDoubleSpinBox" name="extensionMag">
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
                <widget class="QDoubleSpinBox" name="extensionAdjust">
                 <property name="minimum">
                  <double>-99.989999999999995</double>
                 </property>
                </widget>
               </item>
-              <item row="1" column="2">
+              <item row="2" column="2">
                <widget class="QToolButton" name="resetExtensionAdjust">
                 <property name="toolTip">
                  <string>Reset to default</string>
@@ -9541,7 +9434,131 @@
                 </property>
                </widget>
               </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="labelExtensionAdjust">
+                <property name="text">
+                 <string>Extension vertical offset:</string>
+                </property>
+                <property name="buddy">
+                 <cstring>extensionAdjust</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0" colspan="6">
+               <layout class="QHBoxLayout" name="horizontalLayout_7">
+                <item>
+                 <widget class="QLabel" name="label_147">
+                  <property name="text">
+                   <string>Style:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QRadioButton" name="chordsStandard">
+                  <property name="text">
+                   <string>Standard</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QRadioButton" name="chordsJazz">
+                  <property name="text">
+                   <string>Jazz</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QRadioButton" name="chordsCustom">
+                  <property name="text">
+                   <string>Custom</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLineEdit" name="chordDescriptionFile"/>
+                </item>
+                <item>
+                 <widget class="QWidget" name="chordDescriptionGroup" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <layout class="QGridLayout" name="chordDescriptionLayout">
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>0</number>
+                   </property>
+                   <item row="0" column="1">
+                    <widget class="QToolButton" name="chordDescriptionFileButton">
+                     <property name="text">
+                      <string notr="true"/>
+                     </property>
+                     <property name="icon">
+                      <iconset resource="musescore.qrc">
+                       <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="0" column="2">
+                    <widget class="QCheckBox" name="chordsXmlFile">
+                     <property name="text">
+                      <string>Load XML</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="labelExtensionMag">
+                <property name="text">
+                 <string>Extension scaling:</string>
+                </property>
+                <property name="buddy">
+                 <cstring>extensionMag</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="2">
+               <widget class="QToolButton" name="resetExtensionMag">
+                <property name="toolTip">
+                 <string>Reset to default</string>
+                </property>
+                <property name="accessibleName">
+                 <string>Reset 'Extension scaling' value</string>
+                </property>
+                <property name="text">
+                 <string notr="true"/>
+                </property>
+                <property name="icon">
+                 <iconset resource="musescore.qrc">
+                  <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                </property>
+               </widget>
+              </item>
               <item row="1" column="3">
+               <widget class="QLabel" name="labelModifierMag">
+                <property name="text">
+                 <string>Modifier scaling:</string>
+                </property>
+                <property name="buddy">
+                 <cstring>modifierMag</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="3">
                <widget class="QLabel" name="labelModifierAdjust">
                 <property name="text">
                  <string>Modifier vertical offset:</string>
@@ -9551,14 +9568,24 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="4">
-               <widget class="QDoubleSpinBox" name="modifierAdjust">
-                <property name="minimum">
-                 <double>-99.989999999999995</double>
+              <item row="1" column="5">
+               <widget class="QToolButton" name="resetModifierMag">
+                <property name="toolTip">
+                 <string>Reset to default</string>
+                </property>
+                <property name="accessibleName">
+                 <string>Reset 'Modifier scaling' value</string>
+                </property>
+                <property name="text">
+                 <string notr="true"/>
+                </property>
+                <property name="icon">
+                 <iconset resource="musescore.qrc">
+                  <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
                 </property>
                </widget>
               </item>
-              <item row="1" column="5">
+              <item row="2" column="5">
                <widget class="QToolButton" name="resetModifierAdjust">
                 <property name="toolTip">
                  <string>Reset to default</string>
@@ -9575,30 +9602,61 @@
                 </property>
                </widget>
               </item>
-              <item row="0" column="6">
-               <spacer name="horizontalSpacer_13">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+              <item row="4" column="0" colspan="6">
+               <widget class="QGroupBox" name="automaticCapitalization">
+                <property name="title">
+                 <string>Automatic Capitalization</string>
                 </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
+                <property name="checkable">
+                 <bool>true</bool>
                 </property>
-               </spacer>
+                <layout class="QHBoxLayout" name="horizontalLayout_12">
+                 <item>
+                  <widget class="QCheckBox" name="lowerCaseMinorChords">
+                   <property name="text">
+                    <string>Lower case minor chords</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QCheckBox" name="lowerCaseBassNotes">
+                   <property name="text">
+                    <string>Lower case bass notes</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QCheckBox" name="allCapsNoteNames">
+                   <property name="text">
+                    <string>All caps note names</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_17">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </widget>
               </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="groupBox_23">
-             <property name="title">
-              <string>Note Spelling</string>
-             </property>
-             <layout class="QVBoxLayout" name="verticalLayout_37">
-              <item>
+              <item row="3" column="0" colspan="5">
                <layout class="QHBoxLayout" name="horizontalLayout_6">
+                <item>
+                 <widget class="QLabel" name="label_148">
+                  <property name="text">
+                   <string>Spelling:</string>
+                  </property>
+                 </widget>
+                </item>
                 <item>
                  <widget class="QRadioButton" name="useStandardNoteNames">
                   <property name="toolTip">
@@ -9664,68 +9722,110 @@
                 </item>
                </layout>
               </item>
-              <item>
-               <widget class="QGroupBox" name="automaticCapitalization">
-                <property name="title">
-                 <string>Automatic Capitalization</string>
-                </property>
-                <property name="checkable">
-                 <bool>true</bool>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_12">
-                 <item>
-                  <widget class="QCheckBox" name="lowerCaseMinorChords">
-                   <property name="text">
-                    <string>Lower case minor chords</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="lowerCaseBassNotes">
-                   <property name="text">
-                    <string>Lower case bass notes</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="allCapsNoteNames">
-                   <property name="text">
-                    <string>All caps note names</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_17">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </widget>
-              </item>
              </layout>
             </widget>
            </item>
-           <item>
+           <item row="2" column="3">
+            <widget class="QSpinBox" name="capoPosition">
+             <property name="maximum">
+              <number>11</number>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="3">
+            <spacer name="verticalSpacer_34">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="1" column="0" rowspan="3" colspan="2">
             <widget class="QGroupBox" name="groupBox_24">
              <property name="title">
               <string>Positioning</string>
              </property>
              <layout class="QGridLayout" name="gridLayout_15">
+              <item row="4" column="0">
+               <widget class="QLabel" name="label_146">
+                <property name="text">
+                 <string>Maximum shift below:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="2">
+               <widget class="QToolButton" name="resetMaxChordShiftAbove">
+                <property name="text">
+                 <string notr="true">…</string>
+                </property>
+                <property name="icon">
+                 <iconset>
+                  <normalon>data/icons/edit-reset.svg</normalon>
+                 </iconset>
+                </property>
+               </widget>
+              </item>
               <item row="0" column="0">
                <widget class="QLabel" name="label_79">
                 <property name="text">
                  <string>Distance to fretboard diagram:</string>
                 </property>
-                <property name="buddy">
-                 <cstring>harmonyFretDist</cstring>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLabel" name="label_123">
+                <property name="text">
+                 <string>Maximum shift above:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QDoubleSpinBox" name="maxHarmonyBarDistance">
+                <property name="suffix">
+                 <string>sp</string>
+                </property>
+                <property name="minimum">
+                 <double>-50.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>50.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.500000000000000</double>
+                </property>
+                <property name="value">
+                 <double>3.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_1001">
+                <property name="text">
+                 <string>Minimum chord spacing:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="label_1002">
+                <property name="text">
+                 <string>Maximum barline distance:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="2">
+               <widget class="QToolButton" name="resetMaxChordShiftBelow">
+                <property name="text">
+                 <string notr="true">…</string>
+                </property>
+                <property name="icon">
+                 <iconset>
+                  <normalon>data/icons/edit-reset.svg</normalon>
+                 </iconset>
                 </property>
                </widget>
               </item>
@@ -9751,16 +9851,6 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_1001">
-                <property name="text">
-                 <string>Minimum chord spacing:</string>
-                </property>
-                <property name="buddy">
-                 <cstring>minHarmonyDistance</cstring>
-                </property>
-               </widget>
-              </item>
               <item row="1" column="1">
                <widget class="QDoubleSpinBox" name="minHarmonyDistance">
                 <property name="suffix">
@@ -9780,88 +9870,7 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="2">
-               <widget class="QLabel" name="label_123">
-                <property name="text">
-                 <string>Maximum shift above:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="3">
-               <widget class="QDoubleSpinBox" name="maxChordShiftAbove">
-                <property name="suffix">
-                 <string>sp</string>
-                </property>
-                <property name="singleStep">
-                 <double>0.500000000000000</double>
-                </property>
-                <property name="value">
-                 <double>0.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="4">
-               <widget class="QToolButton" name="resetMaxChordShiftAbove">
-                <property name="text">
-                 <string notr="true">…</string>
-                </property>
-                <property name="icon">
-                 <iconset>
-                  <normalon>data/icons/edit-reset.svg</normalon>
-                 </iconset>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="5">
-               <spacer name="horizontalSpacer_11">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="label_1002">
-                <property name="text">
-                 <string>Maximum barline distance:</string>
-                </property>
-                <property name="buddy">
-                 <cstring>maxHarmonyBarDistance</cstring>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QDoubleSpinBox" name="maxHarmonyBarDistance">
-                <property name="suffix">
-                 <string>sp</string>
-                </property>
-                <property name="minimum">
-                 <double>-50.000000000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>50.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.500000000000000</double>
-                </property>
-                <property name="value">
-                 <double>3.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="2">
-               <widget class="QLabel" name="label_146">
-                <property name="text">
-                 <string>Maximum shift below:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="3">
+              <item row="4" column="1">
                <widget class="QDoubleSpinBox" name="maxChordShiftBelow">
                 <property name="suffix">
                  <string>sp</string>
@@ -9871,54 +9880,16 @@
                 </property>
                </widget>
               </item>
-              <item row="2" column="4">
-               <widget class="QToolButton" name="resetMaxChordShiftBelow">
-                <property name="text">
-                 <string notr="true">…</string>
+              <item row="3" column="1">
+               <widget class="QDoubleSpinBox" name="maxChordShiftAbove">
+                <property name="suffix">
+                 <string>sp</string>
                 </property>
-                <property name="icon">
-                 <iconset>
-                  <normalon>data/icons/edit-reset.svg</normalon>
-                 </iconset>
+                <property name="singleStep">
+                 <double>0.500000000000000</double>
                 </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="groupBox_27">
-             <property name="title">
-              <string extracomment="Capodastro">Capo</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_13">
-              <item row="0" column="1">
-               <widget class="QSpinBox" name="capoPosition">
-                <property name="maximum">
-                 <number>11</number>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <spacer name="horizontalSpacer_6">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>496</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_60">
-                <property name="text">
-                 <string extracomment="Capodastro">Capo fret position:</string>
-                </property>
-                <property name="buddy">
-                 <cstring>capoPosition</cstring>
+                <property name="value">
+                 <double>0.000000000000000</double>
                 </property>
                </widget>
               </item>
@@ -10789,9 +10760,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>Awl::ColorLabel</class>
-   <extends>QPushButton</extends>
-   <header>awl/colorlabel.h</header>
+   <class>Ms::OffsetSelect</class>
+   <extends>QWidget</extends>
+   <header>inspector/offsetSelect.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -10801,15 +10772,21 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>Awl::ColorLabel</class>
+   <extends>QPushButton</extends>
+   <header>awl/colorlabel.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>Ms::AlignSelect</class>
    <extends>QWidget</extends>
    <header>inspector/alignSelect.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>Ms::OffsetSelect</class>
+   <class>Ms::VoicingSelect</class>
    <extends>QWidget</extends>
-   <header>inspector/offsetSelect.h</header>
+   <header>inspector/voicingSelect.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -11163,12 +11140,7 @@
   <tabstop>radioFBBottom</tabstop>
   <tabstop>radioFBModern</tabstop>
   <tabstop>radioFBHistoric</tabstop>
-  <tabstop>chordsStandard</tabstop>
-  <tabstop>chordsJazz</tabstop>
-  <tabstop>chordsCustom</tabstop>
-  <tabstop>chordDescriptionFile</tabstop>
   <tabstop>chordDescriptionFileButton</tabstop>
-  <tabstop>chordsXmlFile</tabstop>
   <tabstop>extensionMag</tabstop>
   <tabstop>resetExtensionMag</tabstop>
   <tabstop>extensionAdjust</tabstop>
@@ -11182,14 +11154,9 @@
   <tabstop>useFullGermanNoteNames</tabstop>
   <tabstop>useSolfeggioNoteNames</tabstop>
   <tabstop>useFrenchNoteNames</tabstop>
-  <tabstop>automaticCapitalization</tabstop>
   <tabstop>lowerCaseMinorChords</tabstop>
   <tabstop>lowerCaseBassNotes</tabstop>
   <tabstop>allCapsNoteNames</tabstop>
-  <tabstop>harmonyFretDist</tabstop>
-  <tabstop>minHarmonyDistance</tabstop>
-  <tabstop>maxHarmonyBarDistance</tabstop>
-  <tabstop>capoPosition</tabstop>
   <tabstop>fretY</tabstop>
   <tabstop>fretMag</tabstop>
   <tabstop>fretNumMag</tabstop>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/302714

![Screen Shot 2020-03-29 at 9 10 15 PM](https://user-images.githubusercontent.com/11616153/77866614-cdb5d100-7201-11ea-8f86-fd6a1b9a4f70.png)

As suggested by @Jojo-Schmitz in his PR #5852, this reuses voicing_select.ui from the Inspector. This creates no merge conflicts, and it will work perfectly well if merged independently, but it will look a lot nicer (as in the above screenshot) if his PR is merged first.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
