### PR TITLE
fix #101991 Ignore score command shortcuts in menus

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5879,6 +5879,12 @@ void MuseScore::cmd(QAction* a)
                tr("Command %1 not valid in current state").arg(cmdn));
             return;
             }
+      if (sc->assignedWidget() == MsWidget::SCORE_TAB
+         && QApplication::focusWidget()
+         && !ctab->isAncestorOf(QApplication::focusWidget())) {
+            qDebug("MuseScore::cmd(): not on score tab <%s>", qPrintable(cmdn));
+            return;
+            }
       if (cmdn == "toggle-palette") {
             showPalette(a->isChecked());
             if (a->isChecked()) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/101991

Previously, certain keyboard shortcuts were active in menus when they shouldn't be. For example, pressing the letter keys A to G while inside a menu would cause notes to be added to the score, and S would add a slur. This was problematic because letter keys are traditionally used to open menu items (e.g. pressing A in the Help menu should open the About dialog).

This commit prevents unwanted edits from the menus by terminating the edit operation if the score does not have focus. The shortcut is still active, however, so this commit DOES NOT restore the traditional behaviour where pressing letter keys opens menu items. As such, this is a quick fix rather than a long-term solution.

I investigated whether it would be possible to properly disable or override score shortcuts in the menus. I tried various methods:

- Install event filters on the menubar, menus and submenus to accept all Qt::ShortcutOverride events. This worked in a bare-bones Qt project but not in MuseScore for some reason (shortcuts were triggered despite filters).

- Change shortcut context from Qt::WidgetWithChildrenShortcut to the default Qt::WindowShortcut for all score actions. This worked to deactivate shortcuts in the menus, but it made them active in other parts of the program. For example, pressing Spacebar while on a checkbox in the Inspector would cause playback to begin (i.e. it didn't check the checkbox).

The ideal solution would probably combine these methods. I had some success changing the shortcut context to Qt::WindowShortcut and then filtering events on checkboxes and other widgets. However, this would require filtering events on every single widget that implements its own keypress handling, hence I decided to stick with the easy (albeit incomplete) fix for the time being.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
