### PR TITLE
Fix #303194: Wrong working directory when MuseScore is launched via a file association under Windows

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7715,6 +7715,8 @@ int runApplication(int& argc, char** av)
             return ok ? EXIT_SUCCESS : EXIT_FAILURE;
             }
 
+      QDir::setCurrent(app->applicationDirPath());
+
       return qApp->exec();
       }
 


### PR DESCRIPTION
Resolves: [#303194](https://musescore.org/en/node/303194)

Worked around a problem that caused MuseScore to start up with the working directory set to the score directory instead of the application directory when launched via a file association under Windows (e.g., when the user double-clicks a score in File Explorer).

This problem made it impossible to delete or rename the score directory without closing MuseScore.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made