### PR TITLE
fix #303189: Staff/Part properties > Advanced Style Properties > Stemless crashes MuseScore

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -1786,7 +1786,7 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
                               crBase[i1] = bl;
                         }
 
-                  qreal stemWidth  = cr1->isChord() ? toChord(cr1)->stem()->lineWidthMag() : 0.0;
+                  qreal stemWidth  = (cr1->isChord() && toChord(cr1)->stem()) ? toChord(cr1)->stem()->lineWidthMag() : 0.0;
                   qreal x2         = cr1->stemPosX() + cr1->pageX() - _pagePos.x();
                   qreal x3;
 
@@ -1803,7 +1803,7 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
                               if (cr1->up())
                                     x2 -= stemWidth;
                               if (!chordRest2->up())
-                                    x3 += chordRest2->isChord() ? toChord(chordRest2)->stem()->lineWidthMag() : 0.0;
+                                    x3 += (chordRest2->isChord() && toChord(chordRest2)->stem()) ? toChord(chordRest2)->stem()->lineWidthMag() : 0.0;
                               }
                         }
                   else {


### PR DESCRIPTION
resolves [#303189](https://musescore.org/en/node/303189)

The problem is that a stem's `lineWidthMag()` was asked for even if there is no stem (anymore).

Apparently caused by the changes in #5669 / 57d8a1841 for fixing [#291699](https://musescore.org/en/node/291699)