### PR TITLE
fix #138266: Merge matching rests in multiple voices

### DIFF
--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -495,7 +495,7 @@ int Rest::computeLineOffset(int lines)
             else if (measure()->isOnlyDeletedRests(track() + 1, tick(), tick() + globalTicks()))
                   offsetVoices = false;
             }
-#if 0
+
       if (offsetVoices && staff()->mergeMatchingRests()) {
             // automatically merge matching rests in voices 1 & 2 if nothing in any other voice
             // this is not always the right thing to do do, but is useful in choral music
@@ -512,7 +512,7 @@ int Rest::computeLineOffset(int lines)
                         // try to find match in other voice (1 or 2)
                         if (e && e->type() == ElementType::REST) {
                               Rest* r = toRest(e);
-                              if (r->globalDuration() == globalDuration()) {
+                              if (r->globalTicks() == globalTicks()) {
                                     matchFound = true;
                                     continue;
                                     }
@@ -531,7 +531,6 @@ int Rest::computeLineOffset(int lines)
             if (matchFound && nothingElse)
                   offsetVoices = false;
             }
-#endif
 
       int lineOffset    = 0;
       int assumedCenter = 4;

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -659,6 +659,8 @@ void Staff::write(XmlWriter& xml) const
             xml.tag("showIfSystemEmpty", showIfEmpty());
       if (_hideSystemBarLine)
             xml.tag("hideSystemBarLine", _hideSystemBarLine);
+      if (_mergeMatchingRests)
+            xml.tag("mergeMatchingRests", _mergeMatchingRests);
 
       for (const BracketItem* i : _brackets) {
             BracketType a = i->bracketType();
@@ -729,6 +731,8 @@ bool Staff::readProperties(XmlReader& e)
             setShowIfEmpty(e.readInt());
       else if (tag == "hideSystemBarLine")
             _hideSystemBarLine = e.readInt();
+      else if (tag == "mergeMatchingRests")
+            _mergeMatchingRests = e.readInt();
       else if (tag == "keylist")
             _keys.read(e, score());
       else if (tag == "bracket") {
@@ -1071,6 +1075,7 @@ void Staff::init(const Staff* s)
       _cutaway           = s->_cutaway;
       _showIfEmpty       = s->_showIfEmpty;
       _hideSystemBarLine = s->_hideSystemBarLine;
+      _mergeMatchingRests = s->_mergeMatchingRests;
       _color             = s->_color;
       _userDist          = s->_userDist;
       }

--- a/libmscore/staff.h
+++ b/libmscore/staff.h
@@ -81,6 +81,7 @@ class Staff final : public ScoreElement {
       bool _cutaway            { false };
       bool _showIfEmpty        { false };       ///< show this staff if system is empty and hideEmptyStaves is true
       bool _hideSystemBarLine  { false };       // no system barline if not preceded by staff with barline
+      bool _mergeMatchingRests { false };       // merge matching rests in multiple voices
       HideMode _hideWhenEmpty  { HideMode::AUTO };    // hide empty staves
 
       QColor _color            { MScore::defaultColor };
@@ -176,6 +177,8 @@ class Staff final : public ScoreElement {
       void setHideSystemBarLine(bool val) { _hideSystemBarLine = val;  }
       HideMode hideWhenEmpty() const      { return _hideWhenEmpty;     }
       void setHideWhenEmpty(HideMode v)   { _hideWhenEmpty = v;        }
+      bool mergeMatchingRests() const     { return _mergeMatchingRests;}
+      void setMergeMatchingRests(bool val){ _mergeMatchingRests = val; }
 
       int barLineSpan() const        { return _barLineSpan; }
       int barLineFrom() const        { return _barLineFrom; }

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1516,7 +1516,8 @@ void SetUserBankController::flip(EditData*)
 //---------------------------------------------------------
 
 ChangeStaff::ChangeStaff(Staff* _staff,  bool _invisible, ClefTypeList _clefType,
-   qreal _userDist, Staff::HideMode _hideMode, bool _showIfEmpty, bool _cutaway, bool hide)
+   qreal _userDist, Staff::HideMode _hideMode, bool _showIfEmpty, bool _cutaway, 
+   bool _hideSystemBarLine, bool  _mergeMatchingRests)
       {
       staff       = _staff;
       invisible   = _invisible;
@@ -1525,7 +1526,8 @@ ChangeStaff::ChangeStaff(Staff* _staff,  bool _invisible, ClefTypeList _clefType
       hideMode    = _hideMode;
       showIfEmpty = _showIfEmpty;
       cutaway     = _cutaway;
-      hideSystemBarLine = hide;
+      hideSystemBarLine  = _hideSystemBarLine;
+      mergeMatchingRests = _mergeMatchingRests;
       }
 
 //---------------------------------------------------------
@@ -1541,7 +1543,8 @@ void ChangeStaff::flip(EditData*)
       Staff::HideMode oldHideMode    = staff->hideWhenEmpty();
       bool oldShowIfEmpty = staff->showIfEmpty();
       bool oldCutaway     = staff->cutaway();
-      bool hide           = staff->hideSystemBarLine();
+      bool oldHideSystemBarLine  = staff->hideSystemBarLine();
+      bool oldMergeMatchingRests = staff->mergeMatchingRests();
 
       staff->setInvisible(invisible);
       staff->setDefaultClefType(clefType);
@@ -1550,6 +1553,7 @@ void ChangeStaff::flip(EditData*)
       staff->setShowIfEmpty(showIfEmpty);
       staff->setCutaway(cutaway);
       staff->setHideSystemBarLine(hideSystemBarLine);
+      staff->setMergeMatchingRests(mergeMatchingRests);
 
       invisible   = oldInvisible;
       clefType    = oldClefType;
@@ -1557,7 +1561,8 @@ void ChangeStaff::flip(EditData*)
       hideMode    = oldHideMode;
       showIfEmpty = oldShowIfEmpty;
       cutaway     = oldCutaway;
-      hideSystemBarLine = hide;
+      hideSystemBarLine  = oldHideSystemBarLine;
+      mergeMatchingRests = oldMergeMatchingRests;
 
       Score* score = staff->score();
       if (invisibleChanged) {

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -625,12 +625,13 @@ class ChangeStaff : public UndoCommand {
       bool     showIfEmpty;
       bool     cutaway;
       bool     hideSystemBarLine;
+      bool     mergeMatchingRests;
 
       void flip(EditData*) override;
 
    public:
       ChangeStaff(Staff*, bool invisible, ClefTypeList _clefType, qreal userDist, Staff::HideMode _hideMode,
-         bool _showIfEmpty, bool _cutaway, bool hide);
+         bool _showIfEmpty, bool _cutaway, bool hide, bool mergeRests);
       UNDO_NAME("ChangeStaff")
       };
 

--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -110,6 +110,7 @@ void EditStaff::setStaff(Staff* s, const Fraction& tick)
       staff->setShowIfEmpty(orgStaff->showIfEmpty());
       stt->setUserMag(orgStaff->staffType(Fraction(0,1))->userMag());
       staff->setHideSystemBarLine(orgStaff->hideSystemBarLine());
+      staff->setMergeMatchingRests(orgStaff->mergeMatchingRests());
 
       // get tick range for instrument
       auto i = part->instruments()->upper_bound(tick.ticks());
@@ -133,6 +134,7 @@ void EditStaff::setStaff(Staff* s, const Fraction& tick)
       hideMode->setCurrentIndex(int(staff->hideWhenEmpty()));
       showIfEmpty->setChecked(staff->showIfEmpty());
       hideSystemBarLine->setChecked(staff->hideSystemBarLine());
+      mergeMatchingRests->setChecked(staff->mergeMatchingRests());
       mag->setValue(stt->userMag() * 100.0);
       updateStaffType();
       updateInstrument();
@@ -359,6 +361,7 @@ void EditStaff::apply()
       qreal userDist = spinExtraDistance->value();
       bool ifEmpty   = showIfEmpty->isChecked();
       bool hideSystemBL = hideSystemBarLine->isChecked();
+      bool mergeRests = mergeMatchingRests->isChecked();
       bool cutAway      = cutaway->isChecked();
       Staff::HideMode hideEmpty = Staff::HideMode(hideMode->currentIndex());
 
@@ -411,8 +414,9 @@ void EditStaff::apply()
          || hideEmpty != orgStaff->hideWhenEmpty()
          || ifEmpty != orgStaff->showIfEmpty()
          || hideSystemBL != orgStaff->hideSystemBarLine()
+         || mergeRests != orgStaff->mergeMatchingRests()
          ) {
-            score->undo(new ChangeStaff(orgStaff, inv, clefType, userDist * score->spatium(), hideEmpty, ifEmpty, cutAway, hideSystemBL));
+            score->undo(new ChangeStaff(orgStaff, inv, clefType, userDist * score->spatium(), hideEmpty, ifEmpty, cutAway, hideSystemBL, mergeRests));
             }
 
       if ( !(*orgStaff->staffType(Fraction(0,1)) == *staff->staffType(Fraction(0,1))) ) {

--- a/mscore/editstaff.ui
+++ b/mscore/editstaff.ui
@@ -298,6 +298,13 @@
           </item>
          </layout>
         </item>
+        <item row="5" column="1">
+         <widget class="QCheckBox" name="mergeMatchingRests">
+          <property name="text">
+           <string>Merge matching rests</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/138266

Marc Sabatella thankfully prepared this functionality 5 years ago. I activated his code and added a staff property "Merge matching rests" which enables the functionality.

Merging rests are common to closed SATB scores. The other way to achieve this is to make all matching voice 2 rests invisible. But this is a error prone and time consuming procedure which is now automated.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
