### PR TITLE
fix #278538: Implement collision avoidance between rests and notes

### DIFF
--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -586,12 +586,12 @@ int Rest::computeLineOffset(int lines)
                               }
                         else {
                               lineOffset = up ? -4 : 6;     // whole symbol
-                              lineOffset += up ? (line < 3 ? line - 3 : 0) : (line > 6 ? line - 5 : 0);
+                              lineOffset += up ? (line < 3 ? line - 2 : 0) : (line > 6 ? line - 5 : 0);
                               }
                         break;
                   case TDuration::DurationType::V_WHOLE:
                         lineOffset = up ? -4 : 6;
-                        lineOffset += up ? (line < 3 ? line - 3 : 0) : (line > 6 ? line - 5 : 0);
+                        lineOffset += up ? (line < 3 ? line - 2 : 0) : (line > 6 ? line - 5 : 0);
                         break;
                   case TDuration::DurationType::V_HALF:
                         lineOffset = up ? -4 : 4;

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -539,47 +539,93 @@ int Rest::computeLineOffset(int lines)
       if (offsetVoices) {
             // move rests in a multi voice context
             bool up = (voice() == 0) || (voice() == 2);     // TODO: use style values
+            
+            // Calculate extra offset to move rests above the highest resp. below the lowest note
+            // of this segment (for measure rests, of the whole measure) in all opposite voices. 
+            // Ignore stems and articulations, because which multi-voice they are at the opposite end.
+            int upOffset = up ? 1 : 0;
+            int firstTrack = staffIdx() * 4;
+            int line = up ? 10 : -10;
+            bool isMeasureRest = durationType().type() == TDuration::DurationType::V_MEASURE;
+            Segment* seg = isMeasureRest ? measure()->first() : s;
+            while (seg) {
+                  for (const int& track : { firstTrack + upOffset, firstTrack + 2 + upOffset }) {
+                        Element* e = seg->element(track);
+                        if (e && e->isChord()) {
+                              for (Note* note : toChord(e)->notes()) {
+                                    int nline = note->line();
+                                    if (up && nline <= line) {
+                                          line = nline;
+                                          if (note->accidentalType() != AccidentalType::NONE)
+                                                line--;
+                                          }
+                                    else if (!up && nline >= line) {
+                                          line = nline;
+                                          if (note->accidentalType() != AccidentalType::NONE)
+                                                line++;
+                                          }
+                                    }
+                              }
+                        }
+                  seg = isMeasureRest ? seg->next() : nullptr;
+                  }
+
             switch(durationType().type()) {
                   case TDuration::DurationType::V_LONG:
                         lineOffset = up ? -3 : 5;
+                        lineOffset += up ? (line < 5 ? line - 5 : 0) : (line > 5 ? line - 5 : 0);
                         break;
                   case TDuration::DurationType::V_BREVE:
                         lineOffset = up ? -3 : 5;
+                        lineOffset += up ? (line < 3 ? line - 3 : 0) : (line > 5 ? line - 5 : 0);
                         break;
                   case TDuration::DurationType::V_MEASURE:
-                        if (ticks() >= Fraction(2, 1))   // breve symbol
+                        if (ticks() >= Fraction(2, 1)) {  // breve symbol
                               lineOffset = up ? -3 : 5;
-                        else
+                              lineOffset += up ? (line < 3 ? line - 3 : 0) : (line > 5 ? line - 4 : 0);
+                              }
+                        else {
                               lineOffset = up ? -4 : 6;     // whole symbol
+                              lineOffset += up ? (line < 3 ? line - 3 : 0) : (line > 6 ? line - 5 : 0);
+                              }
                         break;
                   case TDuration::DurationType::V_WHOLE:
                         lineOffset = up ? -4 : 6;
+                        lineOffset += up ? (line < 3 ? line - 3 : 0) : (line > 6 ? line - 5 : 0);
                         break;
                   case TDuration::DurationType::V_HALF:
                         lineOffset = up ? -4 : 4;
+                        lineOffset += up ? (line < 2 ? line - 3 : 0) : (line > 5 ? line - 4 : 0);
                         break;
                   case TDuration::DurationType::V_QUARTER:
                         lineOffset = up ? -4 : 4;
+                        lineOffset += up ? (line < 5 ? line - 4 : 0) : (line > 3 ? line - 3 : 0);
                         break;
                   case TDuration::DurationType::V_EIGHTH:
                         lineOffset = up ? -4 : 4;
+                        lineOffset += up ? (line < 4 ? line - 4 : 0) : (line > 4 ? line - 4 : 0);
                         break;
                   case TDuration::DurationType::V_16TH:
                         lineOffset = up ? -6 : 4;
+                        lineOffset += up ? (line < 4 ? line - 4 : 0) : (line > 4 ? line - 4 : 0);
                         break;
                   case TDuration::DurationType::V_32ND:
                         lineOffset = up ? -6 : 6;
+                        lineOffset += up ? (line < 4 ? line - 4 : 0) : (line > 4 ? line - 4 : 0);
                         break;
                   case TDuration::DurationType::V_64TH:
                         lineOffset = up ? -8 : 6;
+                        lineOffset += up ? (line < 4 ? line - 4 : 0) : (line > 4 ? line - 4 : 0);
                         break;
                   case TDuration::DurationType::V_128TH:
                         lineOffset = up ? -8 : 8;
+                        lineOffset += up ? (line < 4 ? line - 4 : 0) : (line > 4 ? line - 4 : 0);
                         break;
                   case TDuration::DurationType::V_1024TH:
                   case TDuration::DurationType::V_512TH:
                   case TDuration::DurationType::V_256TH:
                         lineOffset = up ? -10 : 6;
+                        lineOffset += up ? (line < 4 ? line - 4 : 0) : (line > 4 ? line - 4 : 0);
                         break;
                   default:
                         break;


### PR DESCRIPTION
This PR does implement collision avoidance between rests and notes in opposite voices. For measure rests, between all notes in the measure.

Resolves: https://musescore.org/en/node/278538

Rests already get a vertical offset if there are multiple voices. This works in a restricted range of pitches. But if the notes get very low or high, they will collide with rests of other voices. This often happens when transposing SATB scores. 

To avoid this the PR determines, depending of the rests voice, the highest or lowest note in the chords of opposite voices at the same segment (or all segments of the measure in case of measure rests). 

If there is a accident at the note, the offset is incremented because b requires some additional space above and # some more space below.

Stems or articulations are not taken into account, because in multi-voice measures they are at the opposite side.

The highest resp. lowest line is now used to add some extra offset if the rest is nearby, depending on the rest type. 

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
