### PR TITLE
fix #57791: Importing chord symbol in capx

### DIFF
--- a/mscore/capella.cpp
+++ b/mscore/capella.cpp
@@ -53,6 +53,7 @@
 #include "libmscore/hairpin.h"
 #include "libmscore/sym.h"
 #include "libmscore/articulation.h"
+#include "libmscore/harmony.h"
 
 extern QString rtf2html(const QString &);
 
@@ -337,7 +338,6 @@ static void processBasicDrawObj(QList<BasicDrawObj*> objects, Segment* s, int tr
                         QPointF p(st->pos());
                         p = p / 32.0 * score->spatium();
                         // text->setUserOff(st->pos());
-                        text->setAutoplace(false);
                         text->setOffset(p);
                         // qDebug("setText %s (%f %f)(%f %f) <%s>",
                         //            qPrintable(st->font().family()),
@@ -361,6 +361,33 @@ static void processBasicDrawObj(QList<BasicDrawObj*> objects, Segment* s, int tr
                         s->add(text);
                         }
                         break;
+                  case CapellaType::TRANSPOSABLE:
+                        {
+                        TransposableObj* to = static_cast<TransposableObj*>(oo);
+                        QString str = "";
+                        for (BasicDrawObj* bdo : to->variants) {
+                              SimpleTextObj* st = static_cast<SimpleTextObj*>(bdo);
+                              if (st->font().family() == "capella3") {
+                                    for (const QChar& ch : st->text()) {
+                                          if (ch == 'Q')
+                                                str += "b";
+                                          else if (ch == 'S')
+                                                str += "#";
+                                          else if (ch == 'R')
+                                                str += "natural";
+                                          else
+                                                str += ch;
+                                          }
+                                    }
+                              else
+                                    str += st->text();
+                              }
+                        Harmony* harmony = new Harmony(score);
+                        harmony->setHarmony(str);
+                        harmony->setTrack(track);
+                        s->add(harmony);
+                        break;
+                        }
                   case CapellaType::TEXT:
                         qDebug("======================Text:");
                         break;

--- a/mscore/capella.h
+++ b/mscore/capella.h
@@ -289,6 +289,7 @@ class TransposableObj : public BasicDrawObj {
    public:
       TransposableObj(Capella* c) : BasicDrawObj(CapellaType::TRANSPOSABLE, c) {}
       void read();
+      void readCapx(XmlReader& e);
 
       QPointF relPos;
       char b { 0 };

--- a/mscore/capxml.cpp
+++ b/mscore/capxml.cpp
@@ -505,6 +505,31 @@ void SimpleTextObj::readCapx(XmlReader& e)
       }
 
 //---------------------------------------------------------
+//   TransposableObj::readCapx -- capx equivalent of TransposableObj::read
+//---------------------------------------------------------
+
+void TransposableObj::readCapx(XmlReader& e)
+      {
+      QString enharmonicNote = e.attribute("base");
+      while (e.readNextStartElement()) {
+            const QStringRef& tag1(e.name());
+            if (tag1 == "drawObj") {
+                  if (e.attribute("base") == enharmonicNote) {
+                        while (e.readNextStartElement()) {
+                              const QStringRef& tag2(e.name());
+                              if (tag2 == "group") {
+                                    variants.append(cap->readCapxDrawObjectArray(e));
+                                    }
+                              }
+                        }
+                  else {
+                        e.skipCurrentElement();
+                        }
+                  }
+            }
+      }
+
+//---------------------------------------------------------
 //   SlurObj::readCapx -- capx equivalent of SlurObj::read
 //---------------------------------------------------------
 
@@ -663,8 +688,10 @@ QList<BasicDrawObj*> Capella::readCapxDrawObjectArray(XmlReader& e)
                               ol.append(o);
                               }
                         else if (tag == "transposable") {
-                              qDebug("readCapxDrawObjectArray: found transposable (skipping)");
-                              e.skipCurrentElement();
+                              TransposableObj* o = new TransposableObj(this);
+                              bdo = o; // save o to handle the "basic" tag (which sometimes follows)
+                              o->readCapx(e);
+                              ol.append(o);
                               }
                         else if (tag == "group") {
                               qDebug("readCapxDrawObjectArray: found group (skipping)");

--- a/mtest/capella/io/testText1.capx-ref.mscx
+++ b/mtest/capella/io/testText1.capx-ref.mscx
@@ -57,11 +57,9 @@
             <sigD>4</sigD>
             </TimeSig>
           <StaffText>
-            <autoplace>0</autoplace>
             <text>Test text 1</text>
             </StaffText>
           <StaffText>
-            <autoplace>0</autoplace>
             <text>This is the subtitle</text>
             </StaffText>
           <Chord>
@@ -178,7 +176,6 @@
               </Note>
             </Chord>
           <StaffText>
-            <autoplace>0</autoplace>
             <text>MuseScore testfile
 Leon Vinken</text>
             </StaffText>

--- a/mtest/capella/io/testVolta1.capx-ref.mscx
+++ b/mtest/capella/io/testVolta1.capx-ref.mscx
@@ -59,11 +59,9 @@
             <sigD>4</sigD>
             </TimeSig>
           <StaffText>
-            <autoplace>0</autoplace>
             <text>Volta 1</text>
             </StaffText>
           <StaffText>
-            <autoplace>0</autoplace>
             <text>MuseScore testfile</text>
             </StaffText>
           <Chord>
@@ -134,7 +132,6 @@
           </LayoutBreak>
         <voice>
           <StaffText>
-            <autoplace>0</autoplace>
             <text>Leon Vinken</text>
             </StaffText>
           <Spanner type="Volta">


### PR DESCRIPTION
PR to find a fix for: #57791

This PR fixes the chord symbols import issue from the music sheet of .capx format.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules]
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
