### PR TITLE
[MU3] fix #296528: Footers now appear inside page margins

### DIFF
--- a/libmscore/page.cpp
+++ b/libmscore/page.cpp
@@ -172,6 +172,7 @@ void Page::drawHeaderFooter(QPainter* p, int area, const QString& ss) const
                   text->setLayoutToParentWidth(true);
                   score()->setFooterText(text, area - MAX_HEADERS);
                   }
+            text->setLayoutRelativeToBottom(score()->styleB(Sid::footerInsideMargins));
             }
       text->setParent((Page*)this);
       Align flags = Align::LEFT;

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -473,6 +473,7 @@ static const StyleType styleTypes[] {
 
       { Sid::footerFirstPage,         "footerFirstPage",         QVariant(true) },
       { Sid::footerOddEven,           "footerOddEven",           QVariant(true) },
+      { Sid::footerInsideMargins,     "footerInsideMargins",     QVariant(false) },
       { Sid::evenFooterL,             "evenFooterL",             QVariant(QString()) },
       { Sid::evenFooterC,             "evenFooterC",             QVariant(QString("$:copyright:")) },
       { Sid::evenFooterR,             "evenFooterR",             QVariant(QString()) },

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -455,6 +455,7 @@ enum class Sid {
       showFooter,
       footerFirstPage,
       footerOddEven,
+      footerInsideMargins,
       evenFooterL,
       evenFooterC,
       evenFooterR,

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -1830,7 +1830,7 @@ void TextBase::layout1()
                   else if (parent()->isPage()) {
                         Page* p = toPage(parent());
                         h = p->height() - p->tm() - p->bm();
-                        yoff = p->tm();
+                        yoff = _layoutRelativeToBottom ? -p->bm() : p->tm(); // used to keep footers inside page margins
                         }
                   else if (parent()->isMeasure())
                         ;

--- a/libmscore/textbase.h
+++ b/libmscore/textbase.h
@@ -252,6 +252,7 @@ class TextBase : public Element {
 
       QString preEdit;              // move to EditData?
       bool _layoutToParentWidth     { false };
+      bool _layoutRelativeToBottom  { false }; // used to keep footers inside page margins
 
       int  hexState                 { -1    };
       bool _primed                  { 0 };
@@ -298,11 +299,12 @@ class TextBase : public Element {
       qreal lineHeight() const;
       virtual qreal baseLine() const override;
 
-      bool empty() const                  { return xmlText().isEmpty(); }
-      void clear()                        { setXmlText(QString());      }
+      bool empty() const                        { return xmlText().isEmpty();   }
+      void clear()                              { setXmlText(QString());        }
 
-      bool layoutToParentWidth() const    { return _layoutToParentWidth; }
-      void setLayoutToParentWidth(bool v) { _layoutToParentWidth = v;   }
+      bool layoutToParentWidth() const          { return _layoutToParentWidth;  }
+      void setLayoutToParentWidth(bool v)       { _layoutToParentWidth = v;     }
+      void setLayoutRelativeToBottom(bool v)    { _layoutRelativeToBottom = v ; }
 
       virtual void startEdit(EditData&) override;
       virtual bool edit(EditData&) override;

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -342,6 +342,7 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       { Sid::showFooter,               false, showFooter,                   0 },
       { Sid::footerFirstPage,          false, showFooterFirstPage,          0 },
       { Sid::footerOddEven,            false, footerOddEven,                0 },
+      { Sid::footerInsideMargins,      false, footerInsideMargins,          0 },
       { Sid::evenFooterL,              false, evenFooterL,                  0 },
       { Sid::evenFooterC,              false, evenFooterC,                  0 },
       { Sid::evenFooterR,              false, evenFooterR,                  0 },

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -2699,6 +2699,26 @@
                    </property>
                   </spacer>
                  </item>
+                 <item>
+                  <widget class="QCheckBox" name="footerInsideMargins">
+                   <property name="text">
+                    <string>Inside margins</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_7">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
                 </layout>
                </item>
                <item>
@@ -4886,6 +4906,12 @@ By default, they will be placed such as that their right end are at the same lev
                 <spacer name="verticalSpacer_11">
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
                  </property>
                 </spacer>
                </item>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/296528

Added the ability to layout a textbase using the bottom margin (the old way used the top margin in every case). This change fixes the issue.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made
