### PR TITLE
Fix #303483: CMake creates Microsoft Visual Studio projects with incorrect settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -930,16 +930,32 @@ add_custom_target(lrelease
 
 add_dependencies(mscore pluginDocumentation)
 
-
 ##
-##  For MSVC: set the startup project to be mscore
-##     (requires CMake 3.6.3+ to work, but should be benign on other versions
-##      as it is just setting the value for a property).
+## Miscellaneous Microsoft Visual Studio settings
 ##
 if (MSVC)
+
+   # Force the "install" and "package" targets not to depend on the "all" target.
    set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY true)
    set(CMAKE_SKIP_PACKAGE_ALL_DEPENDENCY true)
-   set(VS_STARTUP_PROJECT mscore)
+
+   # Set the startup project to "mscore".
+   if (NOT ${CMAKE_VERSION} VERSION_LESS "3.6.0")
+      set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT mscore)
+   endif ()
+
+   # Set the debugging properties for the "mscore" project.
+   file(TO_NATIVE_PATH "${CMAKE_INSTALL_PREFIX}/bin" VS_DEBUGGER_WORKING_DIRECTORY)
+   if (NOT ${CMAKE_VERSION} VERSION_LESS "3.12.0")
+      set_target_properties(mscore PROPERTIES VS_DEBUGGER_COMMAND "${VS_DEBUGGER_WORKING_DIRECTORY}\\${MSCORE_EXECUTABLE_NAME}${CMAKE_EXECUTABLE_SUFFIX}")
+   endif ()
+   if (NOT ${CMAKE_VERSION} VERSION_LESS "3.8.0")
+      set_target_properties(mscore PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${VS_DEBUGGER_WORKING_DIRECTORY}")
+   endif ()
+   if (NOT ${CMAKE_VERSION} VERSION_LESS "3.13.0")
+      set_target_properties(mscore PROPERTIES VS_DEBUGGER_COMMAND_ARGUMENTS "--debug")
+   endif ()
+
 endif (MSVC)
 
 ## TEMP: Display all variables!

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -31,7 +31,7 @@
                "value": "${projectDir}\\dependencies\\libx64"
             }
          ],
-         "buildCommandArgs": "-v",
+         "buildCommandArgs": "",
          "ctestCommandArgs": ""
       }
    ]


### PR DESCRIPTION
Resolves: [#303483](https://musescore.org/en/node/303483)

The `CMakeLists.txt` CMake configuration file for MuseScore applies the following default settings to generated Microsoft Visual Studio projects:

1. Force the `install` and `package` targets not to depend on the `all` target.

2. Set the startup project to `mscore`.

These settings are fine. However, the second setting was applied using incorrect syntax, causing the startup project to end up not getting set at all. (It's possible that this syntax used to work in previous versions of Visual Studio, but it doesn't work in either Visual Studio 2017 or Visual Studio 2019). This is now fixed.

Additionally, the following settings are now applied:

3. Set *Debugging* | *Command* to the full path of the built executable installed by the `INSTALL` project.

4. Set *Debugging* | *Command Arguments* to `--debug` so that MuseScore is run in debug mode while being debugged. (Note: This setting requires CMake 3.13.0 or later, so it won't work in Visual Studio 2017, which comes with CMake 3.12.x.)

5. Set *Debugging* | *Working Directory* to the full path of the location of the built executable installed by the `INSTALL` project.

Prior to this fix, the developer had to manually apply the above settings each and every time the Visual Studio projects were generated or regenerated by CMake. Otherwise, any attempt to debug failed with a series of very confusing error messages (e.g., “MuseScore3.exe - Entry Point Not Found: The procedure entry point `?isNCName@QXmlUtils@@SA_NAEBVQString@@@Z` could not be located in the dynamic link library `C:\Qt\5.9.9\msvc2017_64\bin\Qt5XmlPatterns.dll`.”).

These problems are now fixed, making it possible to start debugging MuseScore in Visual Studio immediately after building.

Finally, in the `CMakeSettings.json` schema file, the `buildCommandArgs` property of the `x64-RelWithDebInfo` configuration was set to `"-v"`. This is a setting for the Ninja generator, but the schema isn't set up for that generator. Instead, it specifies the “Visual Studio 15 2017 Win64” generator, which uses the Microsoft Build Engine (MSBuild). Consequently, building inside Visual Studio using the *CMake* | *Build All* command failed with the following error message: “error MSB1016: Specify the verbosity level.”

In Ninja, the `"-v"` option is used to show all command lines while building. Since MSBuild already shows the command lines by default, the incorrect `"-v"` setting has simply been removed.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made