### PR TITLE
fix #303422: imported lyric colors from MusicXML

### DIFF
--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -271,8 +271,10 @@ void Lyrics::layout()
             styleDidChange    = true;
             }
 
+      QColor oldColor = _color;
       if (styleDidChange)
             styleChanged();
+      setColor(oldColor);
 
       if (isMelisma() || hasNumber)
             if (isStyled(Pid::ALIGN)) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/303422

This is a very simple fix to save the color of even-numbered lyrics.

The layout function behaves differently for odd and even lyrics. For odd-numbered lyrics the function returns almost immediately (using the first return statement). Even-numbered lyrics run through the entire function, one part of which sets the properties of the lyric to the defaults. I don't know if this is the desired behavior or a bug.

If it is a bug, that means that there are probably more problems than the colors not being imported, which might require some bigger changes. If that's the case I'll keep looking for a better solution to this problem.

edit: There are, indeed, more problems with importing (e.g. the font behaves weirdly). I will continue looking into this.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made
