### PR TITLE
Improve XML indentation, thus optimizing file sizes

### DIFF
--- a/libmscore/xmlwriter.cpp
+++ b/libmscore/xmlwriter.cpp
@@ -112,8 +112,9 @@ void XmlWriter::stag(const QString& name, const ScoreElement* se, const QString&
 
 void XmlWriter::etag()
       {
+      auto const tagToClose = stack.takeLast();
       putLevel();
-      *this << "</" << stack.takeLast() << '>' << endl;
+      *this << "</" << tagToClose << '>' << endl;
       }
 
 //---------------------------------------------------------

--- a/mtest/testutils.cpp
+++ b/mtest/testutils.cpp
@@ -171,9 +171,6 @@ bool MTest::compareFilesFromPaths(const QString& f1, const QString& f2)
       p.start(cmd, args);
       if (!p.waitForFinished() || p.exitCode()) {
             QByteArray ba = p.readAll();
-            //qDebug("%s", qPrintable(ba));
-            //qDebug("   <diff -u %s %s failed", qPrintable(compareWith),
-            //   qPrintable(QString(root + "/" + saveName)));
             QTextStream outputText(stdout);
             outputText << QString(ba);
             outputText << "   <" << cmd << " " << args.join(" ") << " failed" << endl;

--- a/mtest/testutils.cpp
+++ b/mtest/testutils.cpp
@@ -176,7 +176,7 @@ bool MTest::compareFilesFromPaths(const QString& f1, const QString& f2)
             //   qPrintable(QString(root + "/" + saveName)));
             QTextStream outputText(stdout);
             outputText << QString(ba);
-            outputText << QString("   <diff -u %1 %2 failed").arg(f2).arg(f1);
+            outputText << "   <" << cmd << " " << args.join(" ") << " failed" << endl;
             return false;
             }
       return true;

--- a/mtest/testutils.cpp
+++ b/mtest/testutils.cpp
@@ -161,6 +161,7 @@ bool MTest::compareFilesFromPaths(const QString& f1, const QString& f2)
       {
       QString cmd = "diff";
       QStringList args;
+      args.append("-w");  // ignore any whitespace differences
       args.append("-u");
       args.append("--strip-trailing-cr");
       args.append(f2);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/303489

### Description

As described in the linked issue description, closing brackets in any generated XML are rendered on the same indent level as their preceding child nodes, which (a) makes them harder parse visually, (b) unneccessarily bloats file size, and (c) also contradicts the expected MusicXML default formatting (References: [1](https://en.wikipedia.org/wiki/MusicXML), [2](https://wpmedia.musicxml.com/wp-content/uploads/2013/04/MusicXML-Musikmesse-2013.pdf), [3](https://www.musicxml.com/publications/makemusic-recordare/notation-and-analysis/a-sample-musicxml-encoding/)).

### Improvement

File size comparison before and after:

XML file  | master @ c458cc3 | Fix-303489 | Total diff (bytes) | New size (%) | Size Decrease (%)
:-- | --: | --: | --: | --: | --:
All in mtest | 32775316 | 32131202 | 644114 | 98,03 % | **1,97 %**
I.mscx | 107054 | 104638 | 2416 | 97,74 % | **2,26 %**
I.musicxml | 81716 | 80360 | 1356 | 98,34 % | **1,66 %**
I.mscz | 21832 | 21758 | 74 | 99,66 % | **0,34 %**

> * NB: "I.*" is a local test file for a complete musical score of the works of [Zinnschauer](https://kapitaenplatte.bandcamp.com/album/zinnschauer-hunger-stille) that i recently started to work on

**Baseline**: Raw XML size is decreased by ~2%, and even compressed MuseScore files are shrunk by a few bytes :smile: 

### Open Points / Help needed

* it would be nice if someone could help out with a regression test for this change
* [as advised](https://musescore.org/en/node/303489#comment-990051), the score files under mtest are updated via 4dc1c81 to the new format utilizing a [small, idempodent and carefully tested script](https://github.com/Philzen/MuseScore-Xml-Fixer) that also helps rebasing as new commits fly into master. However, there are some issues encountered:
  * `mtest/libmscore/parts/part-image-parts.mscx` and `mtest/libmscore/parts/part-all-insertmeasures.mscx` are invalid XML, as they contain a `</BarLine>` closing tag that is not opened anywhere
  * `mtest/musicxml/io/testMultipleNotations.xml` has some more indentation jumps than expected, however i can adjust this file manually and amend the commit if needed (once everything is good to go)
  * i have a hunch that it may not be wise to reformat `mtest/libmscore/compat114/` and `mtest/libmscore/compat206/` (judging from their name and contents)
  * maybe there are other folder below this that should not be reformatted as well 
  * there are 1449 XML files in `mtest` that are rewritten in 4dc1c81 - however, the whole project contains 2679 XML files (=1230 files untouched), pls advise if you think those should be reformatted as well
* i am still waiting for tests to compile and run, which takes ages (~30m) on my machine - also my local MuseScore 3.2.4 install got overwritten. I followed the [testing instructions in the `mtest` folder](https://github.com/musescore/MuseScore/blob/master/mtest/README.md). Is there any way i can speed up this process, am i looking at the wrong tutorial? Right now i'm doing `make clean` and repeat all the steps there - maybe we can improve on that document to hint what is necessary and what isn't to get a proper test run (and also not overwrite an existing install)
* current master (at c458cc3) only passes 39/40 tests on my machine

### Checklist

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n/a] I created the test (mtest, vtest, script test) to verify the changes I made
