### PR TITLE
fix #303585 added return from restore session if failed read score

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5221,6 +5221,11 @@ bool MuseScore::restoreSession(bool always)
                                                 appendScore(score);
                                                 score->setCreated(created);
                                                 }
+                                          else {
+                                                //! NOTE Return true so that there is no attempt to open this file again
+                                                //! See: static void loadScores(const QStringList& argv)
+                                                return true;
+                                                }
                                           }
                                     else {
                                           e.unknown();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/303585

Problem: trying to get a view that is not exists and assert is triggered.
this happens when restoring a session if there is no score file

```
bool MuseScore::restoreSession(bool always)
{
...
    MasterScore* score = readScore(e.readElementText());
    if (score) {
        ...
        appendScore(score);  <= 1
   
    ...
   (tab3 == 0 ? tab1 : tab2)->initScoreView(idx1, vmag, magIdx, x, y);   <= 2
}
```

1 - Here should be added a view with score, but not added, because score is missing.
2 - Here get a view that does not exist

Fix: Added return from `restoreSession` if no score

Problem2: The procedure for opening the last file is done in 2 places - `restoreSession` and `loadScores`. 

Therefore, if the session cannot be restored, then there will be another attempt to open the last file, and the user will be shown a second time a message stating that the file is missing (the first message was shown in `restoreSession`)

I don’t know why the opening of the last file was implemented in two places ... maybe for backward compatibility when the session functionality was introduced.

In order not to show the second message, if the file could not be read in `restoreSession`, then `true` is returned



<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue

