### PR TITLE
Fix 302571: Disappearing beam while editing slur node

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2264,7 +2264,7 @@ int LayoutContext::adjustMeasureNo(MeasureBase* m)
 //    helper function
 //---------------------------------------------------------
 
-void Score::createBeams(Measure* measure)
+void Score::createBeams(LayoutContext& lc, Measure* measure)
       {
       bool crossMeasure = styleB(Sid::crossMeasureValues);
 
@@ -2322,6 +2322,7 @@ void Score::createBeams(Measure* measure)
                                     const Measure* pm = prevCR->measure();
                                     if (!beamNoContinue(prevCR->beamMode())
                                         && !pm->lineBreak() && !pm->pageBreak() && !pm->sectionBreak()
+                                        && lc.prevMeasure
                                         && prevCR->durationType().type() >= TDuration::DurationType::V_EIGHTH
                                         && prevCR->durationType().type() <= TDuration::DurationType::V_1024TH) {
                                           beam = prevCR->beam();
@@ -2694,7 +2695,7 @@ void Score::getNextMeasure(LayoutContext& lc)
                   }
             }
 
-      createBeams(measure);
+      createBeams(lc, measure);
 
       for (int staffIdx = 0; staffIdx < score()->nstaves(); ++staffIdx) {
             for (Segment& segment : measure->segments()) {

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -1213,7 +1213,7 @@ class Score : public QObject, public ScoreElement {
       System* getNextSystem(LayoutContext&);
       void hideEmptyStaves(System* system, bool isFirstSystem);
       void layoutLyrics(System*);
-      void createBeams(Measure*);
+      void createBeams(LayoutContext&, Measure*);
 
       constexpr static double defaultTempo()  { return _defaultTempo; }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/302571

The cross measure beaming algorithm takes system breaks into account, but only when the
first chord of the cross measure beam was part of layout range.
When the layout range starts with measure contains mid/end notes of the cross measure
beam, the break in the cross measure beam due to a system break was recognized when this
was an explicit system break only (e.g. by placing System or Page Break element). Any
system breaks generated by the auto-placer were ignored. As a result a partial layout
(e.g. triggered by an edit) would remove the hook of the "broken" cross measure beam because
the auto-placer assumed it was beamed to a note in the previous measure.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n.a.] I created the test (mtest, vtest, script test) to verify the changes I made
