### PR TITLE
fix #302822: breaks are now accessible via keyboard

### DIFF
--- a/libmscore/navigate.cpp
+++ b/libmscore/navigate.cpp
@@ -641,6 +641,9 @@ Element* Score::nextElement()
                               return mb;
                               }
                         }
+                  case ElementType::LAYOUT_BREAK: {
+                        staffId = 0; // otherwise it will equal -1, which breaks the navigation
+                        }
                   default:
                         break;
                   }
@@ -775,6 +778,9 @@ Element* Score::prevElement()
                         else {
                               return mb;
                               }
+                        }
+                  case ElementType::LAYOUT_BREAK: {
+                        staffId = 0; // otherwise it will equal -1, which breaks the navigation
                         }
                   default:
                         break;

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -1626,6 +1626,8 @@ Element* Segment::nextElement(int activeStaff)
                               return nmb;
                         else if (nme && nme->isTextBase() && nme->staffIdx() == e->staffIdx())
                               return nme;
+                        else if (nme && nme->isLayoutBreak() && e->staffIdx() == 0)
+                              return nme;
                         }
 
                   while (nextSegment) {
@@ -1768,6 +1770,8 @@ Element* Segment::prevElement(int activeStaff)
                          MeasureBase* pmb = measure()->prevMM();
                          Element* me = measure()->el().empty() ? nullptr : measure()->el().back();
                          if (me && me->isTextBase() && me->staffIdx() == e->staffIdx())
+                               return me;
+                         else if (me && me->isLayoutBreak() && e->staffIdx() == 0)
                                return me;
                          else if (psm != pmb)
                               return pmb;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/302822

Added the ability to access breaks via the keyboard.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made
