### PR TITLE
[WIP] Add shortcuts next-pane (F6) and prev-pane (Shift+F6) +collect_artifacts

### DIFF
--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -571,6 +571,14 @@
     <seq>F10</seq>
     </SC>
   <SC>
+    <key>next-pane</key>
+    <seq>F6</seq>
+    </SC>
+  <SC>
+    <key>prev-pane</key>
+    <seq>Shift+F6</seq>
+    </SC>
+  <SC>
     <key>quit</key>
     <seq>Ctrl+Q</seq>
     </SC>
@@ -757,7 +765,7 @@
     </SC>
   <SC>
     <key>toggle-selection-window</key>
-    <seq>F6</seq>
+    <seq>F7</seq>
     </SC>
 <!--
   <SC>

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -116,6 +116,7 @@ struct PluginDescription;
 enum class SelState : char;
 enum class IconType : signed char;
 enum class MagIdx : char;
+enum class Panes;
 
 extern QString mscoreGlobalShare;
 extern QString revision;
@@ -443,6 +444,10 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void showSelectionWindow(bool);
       void showSearchDialog();
       void showToolbarEditor();
+      Panes widget2pane(QWidget* w);
+      QWidget* pane2widget(Panes p);
+      QWidget* nextPrevPane(QWidget* w, bool next);
+      void focusNextPrevPane(bool next);
       void splitWindow(bool horizontal);
       void removeSessionFile();
       void editChordStyle();
@@ -479,6 +484,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void scoreStateChanged(ScoreState state);
 
    private slots:
+      void focusChanged(QWidget* old, QWidget* now);
       void cmd(QAction* a, const QString& cmd);
       void autoSaveTimerTimeout();
       void helpBrowser1() const;

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1932,6 +1932,24 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_PLAY,
+         "next-pane",
+         QT_TRANSLATE_NOOP("action","Focus next pane"),
+         QT_TRANSLATE_NOOP("action","Give focus to next application pane"),
+         0,
+         Icons::Invalid_ICON
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_PLAY,
+         "prev-pane",
+         QT_TRANSLATE_NOOP("action","Focus previous pane"),
+         QT_TRANSLATE_NOOP("action","Give focus to previous application pane"),
+         0,
+         Icons::Invalid_ICON
+         },
+      {
+         MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT ,
          "toggle-fileoperations",
          QT_TRANSLATE_NOOP("action","File Operations"),


### PR DESCRIPTION
Resolves: *no issue in tracker*

Enables users to quickly move keyboard focus between application panes like
the Inspector, Palettes, Toolbars and ScoreView, etc. F6 is traditionally
used as the shortcut key for this purpose.

The Selection Filter shortcut has been changed to F7.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [ ] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [N/A] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made

__Known issues:__

- Not all panels are included (e.g. Selection Tools, Mixer, etc)
- Tabbing from a pane to its children is unreliable
    - e.g. From File Operations toolbar to the New button.
- Last focus widget within each pane is not remembered