### PR TITLE
Change to MSVC 2019

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: C:\MuseScore
 # set clone depth
 clone_depth: 50                      # clone entire repository history if not defined
 
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 branches:
   only:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,7 +265,7 @@ else (APPLE)
       if (BUILD_64 STREQUAL "ON")
          set(USE_SSE FALSE)
       endif(BUILD_64 STREQUAL "ON")
-   # Set compiler options for VS2017 toolchain.
+   # Set compiler options for VS2017/19 toolchain.
    # Note: /D_CRT_SECURE_NO WARNINGS disables warnings when using "non-secure" library functions like sscanf...
       set(CMAKE_CXX_FLAGS                "/MP /DWIN32 /D_WINDOWS /GR /EHsc /D_UNICODE /DUNICODE /D_CRT_SECURE_NO_WARNINGS /execution-charset:utf-8 /source-charset:utf-8")
       set(CMAKE_C_FLAGS                  "/MP /DWIN32 /D_WINDOWS /D_CRT_SECURE_NO_WARNINGS")

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -3,7 +3,7 @@
    "configurations": [
       {
          "name": "x64-RelWithDebInfo",
-         "generator": "Visual Studio 15 2017 Win64",
+         "generator": "Visual Studio 16 2019 Win64",
          "configurationType": "RelWithDebInfo",
          "inheritEnvironments": [ "msvc_x64_x64" ],
          "buildRoot": "${projectDir}\\msvc.build_x64", // "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}", 


### PR DESCRIPTION
Let's see whether AppVeyor plays along..

Edit: and it does! See this from the AppVeyor log:
[00:01:06] -- The C compiler identification is MSVC 19.25.28610.4
[00:01:07] -- The CXX compiler identification is MSVC 19.25.28610.4
[00:01:07] -- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.25.28610/bin/Hostx64/x64/cl.exe
[00:01:08] -- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.25.28610/bin/Hostx64/x64/cl.exe -- works

Edit 2: seems now I got it working for the 32-bit build too
