### PR TITLE
fix #293203 + preference rework: improved responsiveness, ease of adding preferences, UI

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -24,6 +24,7 @@
 // Defines for all preferences
 // Every preference should have a define to ease the usage of the preference
 // Make sure the string key has a sensible grouping - use / for grouping
+// If the preference has to do with the UI/STYLE/THEME, add it under ui (so that the view is updated when apply is pressed)
 //
 #define PREF_APP_AUTOSAVE_AUTOSAVETIME                      "application/autosave/autosaveTime"
 #define PREF_APP_AUTOSAVE_USEAUTOSAVE                       "application/autosave/useAutosave"

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -448,7 +448,7 @@ void updateExternalValuesFromPreferences() {
 //   preferencesChanged
 //---------------------------------------------------------
 
-void MuseScore::preferencesChanged(bool fromWorkspace)
+void MuseScore::preferencesChanged(bool fromWorkspace, bool changeUI)
       {
       updateExternalValuesFromPreferences();
 
@@ -460,7 +460,8 @@ void MuseScore::preferencesChanged(bool fromWorkspace)
       getAction("show-tours")->setChecked(preferences.getBool(PREF_UI_APP_STARTUP_SHOWTOURS));
       _statusBar->setVisible(preferences.getBool(PREF_UI_APP_SHOWSTATUSBAR));
 
-      MuseScore::updateUiStyleAndTheme();
+      if (changeUI)
+            MuseScore::updateUiStyleAndTheme(); // this is a slow operation
       updateIcons();
 
       QString fgWallpaper = preferences.getString(PREF_UI_CANVAS_FG_WALLPAPER);

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -495,7 +495,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void openRecentMenu();
       void selectScore(QAction*);
       void startPreferenceDialog();
-      void preferencesChanged(bool fromWorkspace = false);
+      void preferencesChanged(bool fromWorkspace = false, bool changeUI = true);
       void seqStarted();
       void seqStopped();
       void cmdAppendMeasures();

--- a/mscore/preferenceslistwidget.cpp
+++ b/mscore/preferenceslistwidget.cpp
@@ -52,7 +52,7 @@ void PreferencesListWidget::loadPreferences()
 
 void PreferencesListWidget::updatePreferences()
       {
-      for (PreferenceItem* item : preferenceItems.values())
+      for (PreferenceItem* item : _preferenceItems.values())
             item->update();
       }
 
@@ -60,7 +60,7 @@ void PreferencesListWidget::addPreference(PreferenceItem* item)
       {
       addTopLevelItem(item);
       setItemWidget(item, PREF_VALUE_COLUMN, item->editor());
-      preferenceItems[item->name()] = item;
+      _preferenceItems[item->name()] = item;
       }
 
 void PreferencesListWidget::visit(QString key, IntPreference*)
@@ -99,7 +99,7 @@ std::vector<QString> PreferencesListWidget::save()
       for (int i = 0; i < topLevelItemCount(); ++i) {
             PreferenceItem* item = static_cast<PreferenceItem*>(topLevelItem(i));
             if (item->isModified()) {
-                  item->save();
+                  item->apply();
                   changedPreferences.push_back(item->name());
                   }
             }
@@ -111,10 +111,6 @@ std::vector<QString> PreferencesListWidget::save()
 //   PreferenceItem
 //---------------------------------------------------------
 
-PreferenceItem::PreferenceItem()
-{
-}
-
 PreferenceItem::PreferenceItem(QString name)
       : _name(name)
       {
@@ -122,7 +118,7 @@ PreferenceItem::PreferenceItem(QString name)
       setSizeHint(0, QSize(0, 25));
       }
 
-void PreferenceItem::save(QVariant value)
+void PreferenceItem::apply(QVariant value)
       {
       preferences.setPreference(name(), value);
       }
@@ -131,36 +127,76 @@ void PreferenceItem::save(QVariant value)
 //   ColorPreferenceItem
 //---------------------------------------------------------
 
-ColorPreferenceItem::ColorPreferenceItem(QString name)
+ColorPreferenceItem::ColorPreferenceItem(QString name, std::function<void()> applyFunc, std::function<void()> updateFunc)
       : PreferenceItem(name),
         _initialValue(preferences.getColor(name)),
-        _editor(new Awl::ColorLabel)
+        _editorColorLabel(new Awl::ColorLabel)
       {
-      _editor->setColor(_initialValue);
-      _editor->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+      _editorColorLabel->setColor(_initialValue);
+      _editorColorLabel->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+      connect(_editorColorLabel, &Awl::ColorLabel::colorChanged, this, &PreferenceItem::editorValueModified);
+      _applyFunction = applyFunc;
+      _updateFunction = updateFunc;
       }
 
-void ColorPreferenceItem::save()
+ColorPreferenceItem::ColorPreferenceItem(QString name, Awl::ColorLabel* editor, std::function<void()> applyFunc, std::function<void()> updateFunc)
+      : PreferenceItem(name),
+        _initialValue(preferences.getColor(name)),
+        _editorColorLabel(editor)
       {
-      QColor newValue = _editor->color();
-      _initialValue = newValue;
-      PreferenceItem::save(newValue);
+      _editorColorLabel->setColor(_initialValue);
+      _editorColorLabel->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+      connect(_editorColorLabel, &Awl::ColorLabel::colorChanged, this, &PreferenceItem::editorValueModified);
+      _applyFunction = applyFunc;
+      _updateFunction = updateFunc;
       }
 
-void ColorPreferenceItem::update()
+void ColorPreferenceItem::apply()
       {
-      QColor newValue = preferences.getColor(name());
-      _editor->setColor(newValue);
+      if (_applyFunction) {
+            _applyFunction();
+            _initialValue = preferences.getColor(name());
+            }
+      else {
+            QColor newValue = _editorColorLabel->color();
+            _initialValue = newValue;
+            PreferenceItem::apply(newValue);
+            }
+      }
+
+void ColorPreferenceItem::update(bool setup)
+      {
+      if (_updateFunction) {
+            _updateFunction();
+            }
+      else {
+            QColor newValue = preferences.getColor(name());
+            _editorColorLabel->setColor(newValue);
+            }
+      if (setup)
+            setInitialValueToEditor();
       }
 
 void ColorPreferenceItem::setDefaultValue()
       {
-      _editor->setColor(preferences.defaultValue(name()).value<QColor>());
+      _editorColorLabel->setColor(preferences.defaultValue(name()).value<QColor>());
+      if (_applyFunction)
+            _applyFunction();
+      }
+
+QWidget* ColorPreferenceItem::editor() const
+      {
+      return _editorColorLabel;
       }
 
 bool ColorPreferenceItem::isModified() const
       {
-      return _initialValue != _editor->color();
+      return _initialValue != _editorColorLabel->color();
+      }
+
+void ColorPreferenceItem::setInitialValueToEditor()
+      {
+      _initialValue = _editorColorLabel->color();
       }
 
 
@@ -168,77 +204,293 @@ bool ColorPreferenceItem::isModified() const
 //   IntPreferenceItem
 //---------------------------------------------------------
 
-IntPreferenceItem::IntPreferenceItem(QString name)
+IntPreferenceItem::IntPreferenceItem(QString name, std::function<void()> applyFunc, std::function<void()> updateFunc)
       : PreferenceItem(name),
-        _initialValue(preferences.getInt(name))
-{
-      _editor = new QSpinBox;
-      _editor->setMaximum(INT_MAX);
-      _editor->setMinimum(INT_MIN);
-      _editor->setValue(_initialValue);
-}
-
-void IntPreferenceItem::save()
+        _initialValue(preferences.getInt(name)),
+        _editorSpinBox(new QSpinBox)
       {
-      int newValue = _editor->value();
-      _initialValue = newValue;
-      PreferenceItem::save(newValue);
+      _editorSpinBox->setMaximum(INT_MAX);
+      _editorSpinBox->setMinimum(INT_MIN);
+      _editorSpinBox->setValue(_initialValue);
+      connect(_editorSpinBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &PreferenceItem::editorValueModified);
+      _applyFunction = applyFunc;
+      _updateFunction = updateFunc;
       }
 
-void IntPreferenceItem::update()
+IntPreferenceItem::IntPreferenceItem(QString name, QSpinBox* editor, std::function<void()> applyFunc, std::function<void()> updateFunc)
+      : PreferenceItem(name),
+        _initialValue(preferences.getInt(name)),
+        _editorSpinBox(editor)
       {
-      int newValue = preferences.getInt(name());
-      _editor->setValue(newValue);
+      _editorSpinBox->setValue(_initialValue);
+      connect(_editorSpinBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &PreferenceItem::editorValueModified);
+      _applyFunction = applyFunc;
+      _updateFunction = updateFunc;
+      }
+
+IntPreferenceItem::IntPreferenceItem(QString name, QComboBox* editor, std::function<void()> applyFunc, std::function<void()> updateFunc)
+      : PreferenceItem(name),
+        _initialValue(preferences.getInt(name)),
+        _editorComboBox(editor)
+      {
+      int index = _editorComboBox->findData(preferences.getInt(name));
+      _editorComboBox->setCurrentIndex(index);
+      _initialEditorIndex = index;
+      connect(_editorComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &PreferenceItem::editorValueModified);
+      _applyFunction = applyFunc;
+      _updateFunction = updateFunc;
+      }
+
+void IntPreferenceItem::apply()
+      {
+      if (_applyFunction) {
+            _applyFunction();
+            _initialValue = preferences.getInt(name());
+            }
+      else {
+            if (_editorSpinBox) {
+                  int newValue = _editorSpinBox->value();
+                  _initialValue = newValue;
+                  PreferenceItem::apply(newValue);
+                  }
+            else if (_editorComboBox) {
+                  int newValue = _editorComboBox->currentData().toInt();
+                  _initialValue = newValue;
+                  PreferenceItem::apply(newValue);
+                  _initialEditorIndex = _editorComboBox->currentIndex();
+                  }
+            }
+      }
+
+void IntPreferenceItem::update(bool setup)
+      {
+      if (_updateFunction) {
+            _updateFunction();
+            }
+      else {
+            if (_editorSpinBox) {
+                  int newValue = preferences.getInt(name());
+                  _editorSpinBox->setValue(newValue);
+                  }
+            else if (_editorComboBox) {
+                  int index = _editorComboBox->findData(preferences.getInt(name()));
+                  if (index == -1)
+                        setDefaultValue();
+                  else
+                        _editorComboBox->setCurrentIndex(index);
+                  }
+            }
+      if (setup)
+            setInitialValueToEditor();
       }
 
 void IntPreferenceItem::setDefaultValue()
       {
-      _editor->setValue(preferences.defaultValue(name()).toInt());
+      if (_editorSpinBox) {
+            _editorSpinBox->setValue(preferences.defaultValue(name()).toInt());
+            }
+      else if (_editorComboBox) {
+            int index = _editorComboBox->findData(preferences.defaultValue(name()).toInt());
+            qDebug() << "Preference: " << name() << ":" << index << " != " << "-1" << endl;
+            _editorComboBox->setCurrentIndex(index);
+            }
+      if (_applyFunction)
+            _applyFunction();
+      }
+
+QWidget* IntPreferenceItem::editor() const
+      {
+      if (_editorSpinBox)
+            return _editorSpinBox;
+      else if (_editorComboBox)
+            return _editorComboBox;
+      else
+            Q_ASSERT(false);
+      return nullptr;
       }
 
 
 bool IntPreferenceItem::isModified() const
       {
-      return _initialValue != _editor->value();
+      if (_editorSpinBox)
+            return _initialValue != _editorSpinBox->value();
+      else if (_editorComboBox)
+            return _initialEditorIndex != _editorComboBox->currentIndex();
+      else
+            Q_ASSERT(false);
+      return false;
+      }
+
+void IntPreferenceItem::setInitialValueToEditor()
+      {
+      if (_editorSpinBox)
+            _initialValue = _editorSpinBox->value();
+      else if (_editorComboBox)
+            _initialEditorIndex = _editorComboBox->currentIndex();
       }
 
 //---------------------------------------------------------
 //   DoublePreferenceItem
 //---------------------------------------------------------
 
-DoublePreferenceItem::DoublePreferenceItem(QString name)
+DoublePreferenceItem::DoublePreferenceItem(QString name, std::function<void()> applyFunc, std::function<void()> updateFunc)
       : PreferenceItem(name),
         _initialValue(preferences.getDouble(name)),
-        _editor(new QDoubleSpinBox)
+        _editorDoubleSpinBox(new QDoubleSpinBox)
       {
-      _editor->setMaximum(DBL_MAX);
-      _editor->setMinimum(DBL_MIN);
-      _editor->setValue(_initialValue);
+      _editorDoubleSpinBox->setMaximum(DBL_MAX);
+      _editorDoubleSpinBox->setMinimum(DBL_MIN);
+      _editorDoubleSpinBox->setValue(_initialValue);
       if (qAbs(_initialValue) < 2.0)
-          _editor->setSingleStep(0.1);
+            _editorDoubleSpinBox->setSingleStep(0.1);
+      connect(_editorDoubleSpinBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &PreferenceItem::editorValueModified);
+      _applyFunction = applyFunc;
+      _updateFunction = updateFunc;
       }
 
-void DoublePreferenceItem::save()
+DoublePreferenceItem::DoublePreferenceItem(QString name, QDoubleSpinBox* editor, std::function<void()> applyFunc, std::function<void()> updateFunc)
+      : PreferenceItem(name),
+        _initialValue(preferences.getDouble(name)),
+        _editorDoubleSpinBox(editor)
       {
-      double newValue = _editor->value();
-      _initialValue = newValue;
-      PreferenceItem::save(newValue);
+      _editorDoubleSpinBox->setValue(_initialValue);
+      if (qAbs(_initialValue) < 2.0)
+            _editorDoubleSpinBox->setSingleStep(0.1);
+      connect(_editorDoubleSpinBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &PreferenceItem::editorValueModified);
+      _applyFunction = applyFunc;
+      _updateFunction = updateFunc;
       }
 
-void DoublePreferenceItem::update()
+DoublePreferenceItem::DoublePreferenceItem(QString name, QComboBox* editor, std::function<void()> applyFunc, std::function<void()> updateFunc)
+      : PreferenceItem(name),
+        _initialValue(preferences.getDouble(name)),
+        _editorComboBox(editor)
       {
-      double newValue = preferences.getDouble(name());
-      _editor->setValue(newValue);
+      int index = _editorComboBox->findData(preferences.getDouble(name));
+      _editorComboBox->setCurrentIndex(index);
+      _initialEditorIndex = index;
+      connect(_editorComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &PreferenceItem::editorValueModified);
+      _applyFunction = applyFunc;
+      _updateFunction = updateFunc;
+      }
+
+DoublePreferenceItem::DoublePreferenceItem(QString name, QSpinBox* editor, std::function<void ()> applyFunc, std::function<void ()> updateFunc)
+      : PreferenceItem(name),
+        _initialValue(preferences.getDouble(name)),
+        _editorSpinBox(editor)
+      {
+      _editorSpinBox->setValue(_initialValue);
+      if (qAbs(_initialValue) < 2.0)
+            _editorDoubleSpinBox->setSingleStep(0.1);
+      connect(_editorSpinBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &PreferenceItem::editorValueModified);
+      _applyFunction = applyFunc;
+      _updateFunction = updateFunc;
+      }
+
+void DoublePreferenceItem::apply()
+      {
+      if (_applyFunction) {
+            _applyFunction();
+            _initialValue = preferences.getDouble(name());
+            }
+      else {
+            if (_editorDoubleSpinBox) {
+                  double newValue = _editorDoubleSpinBox->value();
+                  _initialValue = newValue;
+                  PreferenceItem::apply(newValue);
+                  }
+            else if (_editorComboBox) {
+                  double newValue = _editorComboBox->currentData().toDouble();
+                  _initialValue = newValue;
+                  PreferenceItem::apply(newValue);
+                  }
+            else if (_editorSpinBox) {
+                  double newValue = _editorSpinBox->value();
+                  _initialValue = newValue;
+                  PreferenceItem::apply(newValue);
+                  _initialEditorIndex = _editorComboBox->currentIndex();
+                  }
+            }
+      }
+
+void DoublePreferenceItem::update(bool setup)
+      {
+      if (_updateFunction) {
+            _updateFunction();
+            }
+      else {
+            if (_editorDoubleSpinBox) {
+                  double newValue = preferences.getDouble(name());
+                  _editorDoubleSpinBox->setValue(newValue);
+                  }
+            else if (_editorComboBox) {
+                  int index = _editorComboBox->findData(preferences.getDouble(name()));
+                  if (index == -1)
+                        setDefaultValue();
+                  else
+                        _editorComboBox->setCurrentIndex(index);
+                  }
+            else if (_editorSpinBox) {
+                  double newValue = preferences.getDouble(name());
+                  _editorSpinBox->setValue(newValue);
+                  }
+            }
+      if (setup)
+            setInitialValueToEditor();
       }
 
 void DoublePreferenceItem::setDefaultValue()
       {
-      _editor->setValue(preferences.defaultValue(name()).toDouble());
+      if (_editorDoubleSpinBox){
+            _editorDoubleSpinBox->setValue(preferences.defaultValue(name()).toDouble());
+            }
+      else if (_editorComboBox) {
+            int index = _editorComboBox->findData(preferences.defaultValue(name()).toDouble());
+            _editorComboBox->setCurrentIndex(index);
+            }
+      else if (_editorSpinBox){
+            _editorSpinBox->setValue(preferences.defaultValue(name()).toDouble());
+            }
+      if (_applyFunction)
+            _applyFunction();
+      }
+
+QWidget* DoublePreferenceItem::editor() const
+      {
+      if (_editorDoubleSpinBox)
+            return _editorDoubleSpinBox;
+      else if (_editorComboBox)
+            return _editorComboBox;
+      else if (_editorSpinBox)
+            return _editorSpinBox;
+      else
+            Q_ASSERT(false);
+      return nullptr;
       }
 
 bool DoublePreferenceItem::isModified() const
       {
-      return _initialValue != _editor->value();
+      if (_editorDoubleSpinBox)
+            return _initialValue != _editorDoubleSpinBox->value();
+      else if (_editorComboBox)
+            return _initialEditorIndex != _editorComboBox->currentIndex();
+      else if (_editorSpinBox)
+            return _initialValue != _editorSpinBox->value();
+      else
+            Q_ASSERT(false);
+      return false;
+      }
+
+void DoublePreferenceItem::setInitialValueToEditor()
+      {
+      if (_editorDoubleSpinBox)
+            _initialValue = _editorDoubleSpinBox->value();
+      else if (_editorComboBox)
+            _initialEditorIndex = _editorComboBox->currentIndex();
+      else if (_editorSpinBox)
+            _initialValue = _editorSpinBox->value();
+      else
+            Q_ASSERT(false);
       }
 
 
@@ -246,72 +498,410 @@ bool DoublePreferenceItem::isModified() const
 //   BoolPreferenceItem
 //---------------------------------------------------------
 
-BoolPreferenceItem::BoolPreferenceItem(QString name)
+BoolPreferenceItem::BoolPreferenceItem(QString name, std::function<void()> applyFunc, std::function<void()> updateFunc)
       : PreferenceItem(name),
         _initialValue(preferences.getBool(name)),
-        _editor(new QCheckBox)
+        _editorCheckBox(new QCheckBox)
       {
-      _editor->setChecked(_initialValue);
+      _editorCheckBox->setChecked(_initialValue);
+      connect(_editorCheckBox, &QCheckBox::toggled, this, &PreferenceItem::editorValueModified);
+      _applyFunction = applyFunc;
+      _updateFunction = updateFunc;
       }
 
-void BoolPreferenceItem::save()
+BoolPreferenceItem::BoolPreferenceItem(QString name, QCheckBox* editor, std::function<void()> applyFunc, std::function<void()> updateFunc)
+      : PreferenceItem(name),
+        _initialValue(preferences.getBool(name)),
+        _editorCheckBox(editor)
       {
-      bool newValue = _editor->isChecked();
-      _initialValue = newValue;
-      PreferenceItem::save(newValue);
+      _editorCheckBox->setChecked(_initialValue);
+      connect(_editorCheckBox, &QCheckBox::toggled, this, &PreferenceItem::editorValueModified);
+      _applyFunction = applyFunc;
+      _updateFunction = updateFunc;
       }
 
-void BoolPreferenceItem::update()
+BoolPreferenceItem::BoolPreferenceItem(QString name, QGroupBox* editor, std::function<void()> applyFunc, std::function<void()> updateFunc)
+      : PreferenceItem(name),
+        _initialValue(preferences.getBool(name)),
+        _editorGroupBox(editor)
       {
-      bool newValue = preferences.getBool(name());
-      _editor->setChecked(newValue);
+      _editorGroupBox->setChecked(_initialValue);
+      connect(_editorGroupBox, &QGroupBox::toggled, this, &PreferenceItem::editorValueModified);
+      _applyFunction = applyFunc;
+      _updateFunction = updateFunc;
+      }
+
+BoolPreferenceItem::BoolPreferenceItem(QString name, QRadioButton* editor, std::function<void()> applyFunc, std::function<void()> updateFunc)
+      : PreferenceItem(name),
+        _initialValue(preferences.getBool(name)),
+        _editorRadioButton(editor)
+      {
+      _editorRadioButton->setChecked(_initialValue);
+      connect(_editorRadioButton, &QRadioButton::toggled, this, &PreferenceItem::editorValueModified);
+      _applyFunction = applyFunc;
+      _updateFunction = updateFunc;
+      }
+
+void BoolPreferenceItem::apply()
+      {
+      if (_applyFunction) {
+            _applyFunction();
+            _initialValue = preferences.getBool(name());
+            }
+      else {
+            if (_editorCheckBox) {
+                  bool newValue = _editorCheckBox->isChecked();
+                  _initialValue = newValue;
+                  PreferenceItem::apply(newValue);
+                  }
+            else if (_editorGroupBox) {
+                  bool newValue = _editorGroupBox->isChecked();
+                  _initialValue = newValue;
+                  PreferenceItem::apply(newValue);
+                  }
+            else if (_editorRadioButton) {
+                  bool newValue = _editorRadioButton->isChecked();
+                  _initialValue = newValue;
+                  PreferenceItem::apply(newValue);
+                  }
+            }
+      }
+
+void BoolPreferenceItem::update(bool setup)
+      {
+      if (_updateFunction) {
+            _updateFunction();
+            }
+      else {
+            if (_editorCheckBox) {
+                  bool newValue = preferences.getBool(name());
+                  _editorCheckBox->setChecked(newValue);
+                  }
+            else if (_editorGroupBox) {
+                  bool newValue = preferences.getBool(name());
+                  _editorGroupBox->setChecked(newValue);
+                  }
+            else if (_editorRadioButton) {
+                  bool newValue = preferences.getBool(name());
+                  _editorRadioButton->setChecked(newValue);
+                  }
+            }
+      if (setup)
+            setInitialValueToEditor();
       }
 
 void BoolPreferenceItem::setDefaultValue()
       {
-      _editor->setChecked(preferences.defaultValue(name()).toBool());
+      if (_editorCheckBox)
+            _editorCheckBox->setChecked(preferences.defaultValue(name()).toBool());
+      else if (_editorGroupBox)
+            _editorGroupBox->setChecked(preferences.defaultValue(name()).toBool());
+      else if (_editorRadioButton)
+            _editorRadioButton->setChecked(preferences.defaultValue(name()).toBool());
+      if (_applyFunction)
+            _applyFunction();
+      }
+
+QWidget* BoolPreferenceItem::editor() const
+      {
+      if (_editorCheckBox)
+            return _editorCheckBox;
+      else if (_editorGroupBox)
+            return _editorGroupBox;
+      else if (_editorRadioButton)
+            return _editorRadioButton;
+      else
+            Q_ASSERT(false);
+      return nullptr;
       }
 
 bool BoolPreferenceItem::isModified() const
       {
-      return _initialValue != _editor->isChecked();
+      if (_editorCheckBox)
+            return _initialValue != _editorCheckBox->isChecked();
+      else if (_editorGroupBox)
+            return _initialValue != _editorGroupBox->isChecked();
+      else if (_editorRadioButton)
+            return _initialValue != _editorRadioButton->isChecked();
+      else
+            Q_ASSERT(false);
+      return false;
+      }
+
+void BoolPreferenceItem::setInitialValueToEditor()
+      {
+      if (_editorCheckBox)
+            _initialValue = _editorCheckBox->isChecked();
+      else if (_editorGroupBox)
+            _initialValue = _editorGroupBox->isChecked();
+      else if (_editorRadioButton)
+            _initialValue = _editorRadioButton->isChecked();
+      else
+            Q_ASSERT(false);
       }
 
 //---------------------------------------------------------
 //   StringPreferenceItem
 //---------------------------------------------------------
 
-StringPreferenceItem::StringPreferenceItem(QString name)
+StringPreferenceItem::StringPreferenceItem(QString name, std::function<void()> applyFunc, std::function<void()> updateFunc)
       : PreferenceItem(name),
         _initialValue(preferences.getString(name)),
-        _editor(new QLineEdit)
+        _editorLineEdit(new QLineEdit)
       {
-      _editor->setText(_initialValue);
+      _editorLineEdit->setText(_initialValue);
+      connect(_editorLineEdit, &QLineEdit::textChanged, this, &PreferenceItem::editorValueModified);
+      _applyFunction = applyFunc;
+      _updateFunction = updateFunc;
       }
 
-void StringPreferenceItem::save()
+StringPreferenceItem::StringPreferenceItem(QString name, QLineEdit* editor, std::function<void()> applyFunc, std::function<void()> updateFunc)
+      : PreferenceItem(name),
+        _initialValue(preferences.getString(name)),
+        _editorLineEdit(editor)
       {
-      QString newValue = _editor->text();
-      _initialValue = newValue;
-      PreferenceItem::save(newValue);
+      _editorLineEdit->setText(_initialValue);
+      connect(_editorLineEdit, &QLineEdit::textChanged, this, &PreferenceItem::editorValueModified);
+      _applyFunction = applyFunc;
+      _updateFunction = updateFunc;
       }
 
-void StringPreferenceItem::update()
+StringPreferenceItem::StringPreferenceItem(QString name, QFontComboBox* editor, std::function<void()> applyFunc, std::function<void()> updateFunc)
+      : PreferenceItem(name),
+        _initialValue(preferences.getString(name)),
+        _editorFontComboBox(editor)
       {
-      QString newValue = preferences.getString(name());
-      _editor->setText(newValue);
+      _editorFontComboBox->setCurrentFont(QFont(_initialValue));
+      connect(_editorFontComboBox, &QFontComboBox::currentFontChanged, this, &PreferenceItem::editorValueModified);
+      _applyFunction = applyFunc;
+      _updateFunction = updateFunc;
+      }
+
+StringPreferenceItem::StringPreferenceItem(QString name, QComboBox* editor, std::function<void()> applyFunc, std::function<void()> updateFunc)
+      : PreferenceItem(name),
+        _initialValue(preferences.getString(name)),
+        _editorComboBox(editor)
+      {
+      int index = _editorComboBox->findData(preferences.getString(name));
+      _editorComboBox->setCurrentIndex(index);
+      _initialEditorIndex = index;
+      connect(_editorComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &PreferenceItem::editorValueModified);
+      _applyFunction = applyFunc;
+      _updateFunction = updateFunc;
+      }
+
+StringPreferenceItem::StringPreferenceItem(QString name, QRadioButton* editor, std::function<void ()> applyFunc, std::function<void ()> updateFunc)
+      : PreferenceItem(name),
+        _initialValue(""),
+        _editorRadioButton(editor)
+      {
+      connect(_editorRadioButton, &QRadioButton::toggled, this, &PreferenceItem::editorValueModified);
+      Q_ASSERT(applyFunc); // if an apply and an update function are not provided this cannot work
+      _applyFunction = applyFunc;
+      Q_ASSERT(updateFunc);
+      _updateFunction = updateFunc;
+      update(true);
+      }
+
+
+void StringPreferenceItem::apply()
+      {
+      if (_applyFunction) {
+            _applyFunction();
+            _initialValue = preferences.getString(name());
+            }
+      else {
+            if (_editorLineEdit) {
+                  QString newValue = _editorLineEdit->text();
+                  _initialValue = newValue;
+                  PreferenceItem::apply(newValue);
+                  }
+            else if (_editorFontComboBox) {
+                  QString newValue = _editorFontComboBox->currentFont().family();
+                  _initialValue = newValue;
+                  PreferenceItem::apply(newValue);
+                  }
+            else if (_editorComboBox) {
+                  QString newValue = _editorComboBox->currentText();
+                  _initialValue = newValue;
+                  PreferenceItem::apply(newValue);
+                  _initialEditorIndex = _editorComboBox->currentIndex();;
+                  }
+            else if (_editorRadioButton) {
+                  // there must always be a _applyFunction
+                  Q_ASSERT(false);
+                  }
+            }
+      }
+
+void StringPreferenceItem::update( bool setup)
+      {
+      if (_updateFunction) {
+            _updateFunction();
+            }
+      else {
+            if (_editorLineEdit) {
+                  QString newValue = preferences.getString(name());
+                  _editorLineEdit->setText(newValue);
+                  }
+            else if (_editorFontComboBox) {
+                  QString newValue = preferences.getString(name());
+                  _editorFontComboBox->setCurrentFont(QFont(newValue));
+                  }
+            else if (_editorComboBox) {
+                  int index = _editorComboBox->findData(preferences.getString(name()));
+                  if (index == -1)
+                        setDefaultValue();
+                  else
+                        _editorComboBox->setCurrentIndex(index);
+                  }
+            else if (_editorRadioButton) {
+                  // there must always be a _updateFunction
+                  Q_ASSERT(false);
+                  }
+            }
+      if (setup)
+            setInitialValueToEditor();
       }
 
 void StringPreferenceItem::setDefaultValue()
       {
-      _editor->setText(preferences.defaultValue(name()).toString());
+      if (_editorLineEdit) {
+            _editorLineEdit->setText(preferences.defaultValue(name()).toString());
+            }
+      else if (_editorFontComboBox) {
+            _editorFontComboBox->setCurrentFont(QFont(preferences.defaultValue(name()).toString()));
+            }
+      else if (_editorComboBox) {
+            int index = _editorComboBox->findData(preferences.defaultValue(name()).toString());
+            _editorComboBox->setCurrentIndex(index);
+            }
+      else if (_editorRadioButton) {
+            ;
+            }
+      if (_applyFunction)
+            _applyFunction();
+      }
+
+QWidget* StringPreferenceItem::editor() const
+      {
+      if (_editorLineEdit)
+            return _editorLineEdit;
+      else if (_editorFontComboBox)
+            return _editorFontComboBox;
+      else if (_editorComboBox)
+            return _editorComboBox;
+      else if (_editorRadioButton)
+            return _editorRadioButton;
+      else
+            Q_ASSERT(false);
+      return nullptr;
       }
 
 bool StringPreferenceItem::isModified() const
       {
-      return _initialValue != _editor->text();
+      if (_editorLineEdit)
+            return _initialValue != _editorLineEdit->text();
+      else if (_editorFontComboBox)
+            return _initialValue != _editorFontComboBox->currentFont().family();
+      else if (_editorComboBox)
+            return _initialEditorIndex != _editorComboBox->currentIndex();
+      else if (_editorRadioButton)
+            return _initialIsChecked != _editorRadioButton->isChecked();
+      else
+            Q_ASSERT(false);
+      return false;
       }
 
+void StringPreferenceItem::setInitialValueToEditor()
+      {
+      if (_editorLineEdit)
+            _initialValue = _editorLineEdit->text();
+      else if (_editorFontComboBox)
+            _initialValue = _editorFontComboBox->currentFont().family();
+      else if (_editorComboBox)
+            _initialEditorIndex = _editorComboBox->currentIndex();
+      else if (_editorRadioButton)
+             _initialIsChecked = _editorRadioButton->isChecked();
+      else
+            Q_ASSERT(false);
+      }
 
+//---------------------------------------------------------
+//   CustomPreferenceItem
+//---------------------------------------------------------
+
+CustomPreferenceItem::CustomPreferenceItem(QString name, QRadioButton* editor, std::function<void ()> applyFunc, std::function<void ()> updateFunc)
+      : PreferenceItem(name),
+        _editorRadioButton(editor)
+      {
+      Q_ASSERT(applyFunc); // if an apply and an update function are not provided this cannot work
+      _applyFunction = applyFunc;
+      Q_ASSERT(updateFunc);
+      _updateFunction = updateFunc;
+      update(true); // update on creation is the same as assigning an initival value
+      connect(_editorRadioButton, &QRadioButton::toggled, this, &PreferenceItem::editorValueModified);
+      }
+
+CustomPreferenceItem::CustomPreferenceItem(QString name, QComboBox* editor, std::function<void ()> applyFunc, std::function<void ()> updateFunc)
+      : PreferenceItem(name),
+        _editorComboBox(editor)
+      {
+      Q_ASSERT(applyFunc); // if an apply and an update function are not provided this cannot work
+      _applyFunction = applyFunc;
+      Q_ASSERT(updateFunc);
+      _updateFunction = updateFunc;
+      update(true); // update on creation is the same as assigning an initival value
+      connect(_editorComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &PreferenceItem::editorValueModified);
+      }
+
+void CustomPreferenceItem::apply()
+      {
+      _applyFunction();
+      }
+
+void CustomPreferenceItem::update(bool setup)
+      {
+      _updateFunction();
+      if (setup)
+            setInitialValueToEditor();
+      }
+
+void CustomPreferenceItem::setDefaultValue()
+      {
+      Q_ASSERT(false);
+      }
+
+QWidget* CustomPreferenceItem::editor() const
+      {
+      if (_editorRadioButton)
+            return _editorRadioButton;
+      else if (_editorComboBox)
+            return _editorComboBox;
+      else
+            Q_ASSERT(false);
+      return nullptr;
+      }
+
+bool CustomPreferenceItem::isModified() const
+      {
+      if (_editorRadioButton)
+            return _initialIsChecked != _editorRadioButton->isChecked();
+      else if (_editorComboBox)
+            return _initialEditorIndex != _editorComboBox->currentIndex();
+      else
+            Q_ASSERT(false);
+      return false;
+      }
+
+void CustomPreferenceItem::setInitialValueToEditor()
+      {
+      if (_editorRadioButton)
+            _initialIsChecked = _editorRadioButton->isChecked();
+      else if (_editorComboBox)
+            _initialEditorIndex = _editorComboBox->currentIndex();
+      else
+            Q_ASSERT(false);
+      }
 
 } // namespace Ms

--- a/mscore/preferenceslistwidget.h
+++ b/mscore/preferenceslistwidget.h
@@ -30,44 +30,54 @@ namespace Ms {
 //---------------------------------------------------------
 //   PreferenceItem
 //---------------------------------------------------------
-class PreferenceItem : public QTreeWidgetItem, public QObject {
+class PreferenceItem : public QObject, public QTreeWidgetItem {
+
+      Q_OBJECT
 
       QString _name;
 
     protected:
-      void save(QVariant value);
+      void apply(QVariant value);
 
     public:
-      PreferenceItem();
       PreferenceItem(QString name);
 
-      virtual void save() = 0;
-      virtual void update() = 0;
+      virtual void apply() = 0;
+      virtual void update(bool setup = false) = 0;
       virtual void setDefaultValue() = 0;
       virtual QWidget* editor() const = 0;
       virtual bool isModified() const = 0;
+      virtual void setInitialValueToEditor() = 0;
 
       QString name() const {return _name;}
 
+   signals:
+      void editorValueModified();
       };
 
 //---------------------------------------------------------
 //   BoolPreferenceItem
 //---------------------------------------------------------
 class BoolPreferenceItem : public PreferenceItem {
-   private:
       bool _initialValue;
-      QCheckBox* _editor;
+      QCheckBox* _editorCheckBox                { nullptr };
+      QGroupBox* _editorGroupBox                { nullptr };
+      QRadioButton* _editorRadioButton          { nullptr };
+      std::function<void()> _applyFunction      { nullptr };
+      std::function<void()> _updateFunction     { nullptr };
 
    public:
-      BoolPreferenceItem(QString name);
+      BoolPreferenceItem(QString name, std::function<void()> applyFunc = nullptr, std::function<void()> updateFunc = nullptr);
+      BoolPreferenceItem(QString name, QCheckBox* editor, std::function<void()> applyFunc = nullptr, std::function<void()> updateFunc = nullptr);
+      BoolPreferenceItem(QString name, QGroupBox* editor, std::function<void()> applyFunc = nullptr, std::function<void()> updateFunc = nullptr);
+      BoolPreferenceItem(QString name, QRadioButton* editor, std::function<void()> applyFunc = nullptr, std::function<void()> updateFunc = nullptr);
 
-      void save();
-      void update();
-      void setDefaultValue();
-      QWidget* editor() const {return _editor;}
-      bool isModified() const;
-
+      void apply() override;
+      void update(bool setup = false) override;
+      void setDefaultValue() override;
+      QWidget* editor() const override;
+      bool isModified() const override;
+      void setInitialValueToEditor() override;
       };
 
 
@@ -76,50 +86,78 @@ class BoolPreferenceItem : public PreferenceItem {
 //---------------------------------------------------------
 class IntPreferenceItem : public PreferenceItem {
       int _initialValue;
-      QSpinBox* _editor;
+      int _initialEditorIndex                   { -1 };
+      QSpinBox* _editorSpinBox                  { nullptr };
+      QComboBox* _editorComboBox                { nullptr };
+      std::function<void()> _applyFunction      { nullptr };
+      std::function<void()> _updateFunction     { nullptr };
 
    public:
-      IntPreferenceItem(QString name);
+      IntPreferenceItem(QString name, std::function<void()> applyFunc = nullptr, std::function<void()> updateFunc = nullptr);
+      IntPreferenceItem(QString name, QSpinBox* editor, std::function<void()> applyFunc = nullptr, std::function<void()> updateFunc = nullptr);
+      IntPreferenceItem(QString name, QComboBox* editor, std::function<void()> applyFunc = nullptr, std::function<void()> updateFunc = nullptr);
 
-      void save();
-      void update();
-      void setDefaultValue();
-      QWidget* editor() const {return _editor;}
-      bool isModified() const;
+      void apply() override;
+      void update(bool setup = false) override;
+      void setDefaultValue() override;
+      QWidget* editor() const override;
+      bool isModified() const override;
+      void setInitialValueToEditor() override;
       };
 
 //---------------------------------------------------------
 //   DoublePreferenceItem
 //---------------------------------------------------------
 class DoublePreferenceItem : public PreferenceItem {
-      double _initialValue;
-      QDoubleSpinBox* _editor;
+      double _initialValue                      { 0 };
+      int _initialEditorIndex                   { -1 };
+      QDoubleSpinBox* _editorDoubleSpinBox      { nullptr };
+      QComboBox* _editorComboBox                { nullptr };
+      QSpinBox* _editorSpinBox                  { nullptr };
+      std::function<void()> _applyFunction      { nullptr };
+      std::function<void()> _updateFunction     { nullptr };
 
    public:
-      DoublePreferenceItem(QString name);
+      DoublePreferenceItem(QString name, std::function<void()> applyFunc = nullptr, std::function<void()> updateFunc = nullptr);
+      DoublePreferenceItem(QString name, QDoubleSpinBox* editor, std::function<void()> applyFunc = nullptr, std::function<void()> updateFunc = nullptr);
+      DoublePreferenceItem(QString name, QComboBox* editor, std::function<void()> applyFunc = nullptr, std::function<void()> updateFunc = nullptr);
+      DoublePreferenceItem(QString name, QSpinBox* editor, std::function<void()> applyFunc = nullptr, std::function<void()> updateFunc = nullptr);
 
-      void save();
-      void update();
-      void setDefaultValue();
-      QWidget* editor() const {return _editor;}
-      bool isModified() const;
+      void apply() override;
+      void update(bool setup = false) override;
+      void setDefaultValue() override;
+      QWidget* editor() const override;
+      bool isModified() const override;
+      void setInitialValueToEditor() override;
       };
 
 //---------------------------------------------------------
 //   StringPreferenceItem
 //---------------------------------------------------------
 class StringPreferenceItem : public PreferenceItem {
-      QString _initialValue;
-      QLineEdit* _editor;
+      QString _initialValue                     { "" };
+      int _initialEditorIndex                   { -1 };
+      bool _initialIsChecked                    { false };
+      QLineEdit* _editorLineEdit                { nullptr };
+      QFontComboBox* _editorFontComboBox        { nullptr };
+      QComboBox* _editorComboBox                { nullptr };
+      QRadioButton* _editorRadioButton          { nullptr };
+      std::function<void()> _applyFunction      { nullptr };
+      std::function<void()> _updateFunction     { nullptr };
 
    public:
-      StringPreferenceItem(QString name);
+      StringPreferenceItem(QString name, std::function<void()> applyFunc = nullptr, std::function<void()> updateFunc = nullptr);
+      StringPreferenceItem(QString name, QLineEdit* editor, std::function<void()> applyFunc = nullptr, std::function<void()> updateFunc = nullptr);
+      StringPreferenceItem(QString name, QFontComboBox* editor, std::function<void()> applyFunc = nullptr, std::function<void()> updateFunc = nullptr);
+      StringPreferenceItem(QString name, QComboBox* editor, std::function<void()> applyFunc = nullptr, std::function<void()> updateFunc = nullptr);
+      StringPreferenceItem(QString name, QRadioButton* editor, std::function<void()> applyFunc = nullptr, std::function<void()> updateFunc = nullptr); // remove nullptr default since you cannot not have an apply and update func
 
-      void save();
-      void update();
-      void setDefaultValue();
-      QWidget* editor() const {return _editor;}
-      bool isModified() const;
+      void apply() override;
+      void update(bool setup = false) override;
+      void setDefaultValue() override;
+      QWidget* editor() const override;
+      bool isModified() const override;
+      void setInitialValueToEditor() override;
       };
 
 //---------------------------------------------------------
@@ -127,18 +165,44 @@ class StringPreferenceItem : public PreferenceItem {
 //---------------------------------------------------------
 class ColorPreferenceItem : public PreferenceItem {
       QColor _initialValue;
-      Awl::ColorLabel* _editor;
+      Awl::ColorLabel* _editorColorLabel        { nullptr };
+      std::function<void()> _applyFunction      { nullptr };
+      std::function<void()> _updateFunction     { nullptr };
 
    public:
-      ColorPreferenceItem(QString name);
+      ColorPreferenceItem(QString name, std::function<void()> applyFunc = nullptr, std::function<void()> updateFunc = nullptr);
+      ColorPreferenceItem(QString name, Awl::ColorLabel* editor, std::function<void()> applyFunc = nullptr, std::function<void()> updateFunc = nullptr);
 
-      void save();
-      void update();
-      void setDefaultValue();
-      QWidget* editor() const {return _editor;}
-      bool isModified() const;
+      void apply() override;
+      void update(bool setup = false) override;
+      void setDefaultValue() override;
+      QWidget* editor() const override;
+      bool isModified() const override;
+      void setInitialValueToEditor() override;
       };
 
+//---------------------------------------------------------
+//   CustomPreferenceItem
+//---------------------------------------------------------
+class CustomPreferenceItem : public PreferenceItem {
+      int _initialEditorIndex                   { -1 };
+      bool _initialIsChecked                    { false };
+      QRadioButton* _editorRadioButton          { nullptr };
+      QComboBox* _editorComboBox                { nullptr };
+      std::function<void()> _applyFunction      { nullptr };
+      std::function<void()> _updateFunction     { nullptr };
+
+   public:
+      CustomPreferenceItem(QString name, QRadioButton* editor, std::function<void()> applyFunc = nullptr, std::function<void()> updateFunc = nullptr);
+      CustomPreferenceItem(QString name, QComboBox* editor, std::function<void()> applyFunc = nullptr, std::function<void()> updateFunc = nullptr);
+
+      void apply() override;
+      void update(bool setup = false) override;
+      void setDefaultValue() override;
+      QWidget* editor() const override;
+      bool isModified() const override;
+      void setInitialValueToEditor() override;
+      };
 
 //---------------------------------------------------------
 //   PreferencesListWidget
@@ -147,7 +211,7 @@ class ColorPreferenceItem : public PreferenceItem {
 class PreferencesListWidget : public QTreeWidget, public PreferenceVisitor {
       Q_OBJECT
 
-      QHash<QString, PreferenceItem*> preferenceItems;
+      QHash<QString, PreferenceItem*> _preferenceItems;
 
       void addPreference(PreferenceItem* item);
 
@@ -164,7 +228,8 @@ class PreferencesListWidget : public QTreeWidget, public PreferenceVisitor {
       void visit(QString key, StringPreference*);
       void visit(QString key, ColorPreference*);
 
-};
+      QHash<QString, PreferenceItem*> preferenceItems() const { return _preferenceItems; };
+      };
 
 } // namespace Ms
 

--- a/mscore/prefsdialog.h
+++ b/mscore/prefsdialog.h
@@ -39,13 +39,30 @@ class PreferenceDialog : public AbstractDialog, private Ui::PrefsDialogBase {
       QMap<QString, Shortcut*> localShortcuts;
       bool shortcutsChanged;
       QButtonGroup* recordButtons;
+      std::vector<PreferenceItem*> normalWidgets;
+      std::vector<PreferenceItem*> uiRelatedWidgets;
+      std::vector<PreferenceItem*> audioRelatedWidgets;
+      std::vector<PreferenceItem*> modifiedWidgets;
+      std::vector<PreferenceItem*> modifiedUiWidgets;
+      std::vector<PreferenceItem*> modifiedAudioWidgets;
       PreferencesListWidget* advancedWidget;
 
       virtual void hideEvent(QHideEvent*);
       void apply();
       void updateSCListView();
       void setUseMidiOutput(bool);
-      void updateValues(bool useDefaultValues = false);
+      void updateValues(bool useDefaultValues = false, bool setup = false);
+      void checkApplyActivation();
+
+      void applySetActive(bool active);
+      void updateShortestNote();
+      void applyShortestNote();
+      void languageUpdate();
+      void languageApply();
+      void updateCharsetListGP();
+      void updateCharsetListOve();
+      void updateUseLocalAvsOmr();
+      void applyPageVertical();
 
    private slots:
       void buttonBoxClicked(QAbstractButton*);
@@ -82,13 +99,16 @@ class PreferenceDialog : public AbstractDialog, private Ui::PrefsDialogBase {
       void filterAdvancedPreferences(const QString&);
       void resetAdvancedPreferenceToDefault();
       void restartAudioEngine();
+      void widgetModified();
+      void uiWidgetModified();
+      void audioWidgetModified();
+      void applyActivate();
 
       void changeSoundfontPaths();
       void updateTranslationClicked();
 
    signals:
-      void preferencesChanged();
-      void preferencesChangedWithBool(bool b);
+      void preferencesChanged(bool fromWorkspace, bool changeUI);
       void mixerPreferencesChanged(bool showMidiControls);
 
    protected:

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -2503,22 +2503,22 @@
             </property>
             <item>
              <property name="text">
-              <string>Page Width</string>
+              <string notr="true" extracomment="Dummy values. Used for clarity in the Designer. Translated elsewhere.">Page Width</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>Whole Page</string>
+              <string notr="true" extracomment="Dummy values. Used for clarity in the Designer. Translated elsewhere.">Whole Page</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>Two Pages</string>
+              <string notr="true" extracomment="Dummy values. Used for clarity in the Designer. Translated elsewhere.">Two Pages</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>Percentage</string>
+              <string notr="true" extracomment="Dummy values. Used for clarity in the Designer. Translated elsewhere.">Percentage</string>
              </property>
             </item>
            </widget>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/293203

Applying preference changes is pretty slow (even if no changes are made).

Edited (PR reworked):

The preferences dialog has 4 main problems:
- Applying changes is pretty slow (around 1 second even if no changes are made) + all preferences are saved again each time
- The user can press the 'Apply' button even when no changes are made. It can also be pressed multiple times which leads to a huge slowdown that looks like a freeze.
- Adding new preferences in the dialog requires adding code in 2 places (in the apply function and in the update function).
- Advanced preferences are handled differently from normal preferences.

The first problem was caused by: `mscore->changeWorkspace(WorkspacesManager::currentWorkspace(), false);`
and by reapplying the UI theme (even if no ui related changes were made).
The second problem was a result of not knowing which preferences were modified (if any). Each time everything was saved.

In addition to fixing the first problem, I reworked the way that preferences are handled. I expanded the classes used by the advanced preferences and implemented normal preferences using those classes.

There are 2 main std vectors. One for normal widgets (most widgets/preferences) and one for ui widgets. To add a new preference we add a new *PreferenceItem in one of those vectors (exceptions are made for more complicated logic *see audioRelatedWidgets).
A *PreferenceItem takes 2+1+1 arguments. The first 2 are the preference key and the related widget. If the required functionality is just setting and getting the preference this is all that is needed.
The 3rd argument is the `applyFunction`. This function is called when Apply (PreferenceDialog::apply) is pressed. The 4th argument is the `updateFunction`, which is called from PreferenceDialog::update.

Giving nullptr in place of the function is the default (only get or set) and an empty lambda means do nothing.

Speed improvements (Apply/OK):
1s -> 1ms for no changes
1s -> ~50ms for most changes
1s -> ~550ms for UI related changes
(time counted using QElapsedTimer on Linux, Ubuntu 19.10)

As far as the UI is concerned, when no settings are modified the Apply button is greyed/disabled. In addition to that, when Apply is pressed it's text changes to 'Applying' for the duration of the operation.

![preferences](https://user-images.githubusercontent.com/21060365/80291989-2920a380-875b-11ea-88be-2487104a1735.gif)

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
