### PR TITLE
fix #303678: increase tuning offset of Note Inspector to allow for triple flat/sharp

### DIFF
--- a/mscore/inspector/inspector_note.ui
+++ b/mscore/inspector/inspector_note.ui
@@ -489,10 +489,10 @@
             <string>Tuning</string>
            </property>
            <property name="minimum">
-            <double>-200.000000000000000</double>
+            <double>-300.000000000000000</double>
            </property>
            <property name="maximum">
-            <double>200.000000000000000</double>
+            <double>300.000000000000000</double>
            </property>
            <property name="singleStep">
             <double>10.000000000000000</double>


### PR DESCRIPTION
Should solve https://musescore.org/en/node/303678

Without this change programatically set offsets outside the (old) range are not even shown, but capped at that range setting.