### PR TITLE
[MU4] fix #300958: [WIP] .capx jump instructions and -markers not imported

### DIFF
--- a/importexport/capella/capella.cpp
+++ b/importexport/capella/capella.cpp
@@ -206,11 +206,15 @@ static void processBasicDrawObj(QList<BasicDrawObj*> objects, Segment* s, int tr
                                           case 'u':   // fermata up
                                                 addArticulationText(score, cr, track, SymId::fermataAbove);
                                                 break;
+                                          case 'n':   // segno coda
+                                                addArticulationText(score, cr, track, SymId::coda);
+                                                break;
+                                          case 'y':   // segno
+                                                addArticulationText(score, cr, track, SymId::segno);
+                                                break;
                                           case 'd':   // da capo D.C.
                                           case 'e':   // dal segno D.S.
-                                          case 'n':   // segno coda
                                           case 'o':   // segno coda (smaller)
-                                          case 'y':   // segno
                                           case '$':   // segno variation
                                           case 'a':   // pedal Ped.
                                           case 'b':   // pedal asterisk *
@@ -933,6 +937,8 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
                                     score->sigmap()->add(m->tick() + m->ticks(), ne2);
 #endif
                                     }
+                              Segment* s = pm->getSegment(SegmentType::BarLine, tick);
+                              processBasicDrawObj(o->objects, s, track, nullptr);   //TODO: passing nullptr can cause issues
                               }
                         // qDebug("pm %p", pm);
 

--- a/importexport/capella/capella.h
+++ b/importexport/capella/capella.h
@@ -132,6 +132,7 @@ class CapMeter : public NoteObj, public CapellaObj {
 //   CapExplicitBarline
 //---------------------------------------------------------
 
+class BasicDrawObj;
 class CapExplicitBarline : public NoteObj, public CapellaObj {
       BarLineType _type { BarLineType::NORMAL };
       int _barMode      { 0 };      // 0 = auto, 1 = nur Zeilen, 2 = durchgezogen
@@ -142,7 +143,7 @@ class CapExplicitBarline : public NoteObj, public CapellaObj {
       void readCapx(XmlReader& e);
       BarLineType type() const { return _type; }
       int barMode() const      { return _barMode; }
-
+      QList<BasicDrawObj*> objects;
       };
 
 //---------------------------------------------------------

--- a/importexport/capella/capxml.cpp
+++ b/importexport/capella/capxml.cpp
@@ -172,7 +172,7 @@ void CapExplicitBarline::readCapx(XmlReader& e)
       while (e.readNextStartElement()) {
             const QStringRef& tag(e.name());
             if (tag == "drawObjects") {
-                  e.skipCurrentElement();
+                  objects = cap->readCapxDrawObjectArray(e);
                   }
             else
                   e.unknown();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/300958

This is a WIP fix to import jump instructions and markers from .capx file format.
Current issues:
1. Overlapping coda signs.
2. Improperly formatted "D.S. al Coda" text.
3. Melody is not able to interpret the signs and repeat instructions.

Fixed issues:
Reading jump instructions and markers viz. Segno, Coda, D.S. al Coda using capx importer.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
