### PR TITLE
fix CI builds

### DIFF
--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -17,7 +17,7 @@
 #  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #=============================================================================
 
-VERSION = `cmake -P config.cmake | grep -oP "VERSION\s+\K.*"`
+VERSION = `cmake -P config.cmake | sed -n -e "s/^.*VERSION  *//p"`
 BUILD_NUMBER=""
 CPUS = %NUMBER_OF_PROCESSORS%
 BUILD_FOR_WINSTORE="OFF"     # Override with "ON" to enable.

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -17,7 +17,7 @@
 #  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #=============================================================================
 
-VERSION = `cmake -P config.cmake | grep -oP "VERSION\s+\K.*"`
+VERSION = `cmake -P config.cmake | sed -n -e "s/^.*VERSION  *//p"`
 BUILD_NUMBER = ""
 PREFIX=../applebuild
 TELEMETRY_TRACK_ID=""

--- a/build/appveyor/before_build.bat
+++ b/build/appveyor/before_build.bat
@@ -47,8 +47,8 @@ START " " /wait "7z" x -y %TOOLS_ARCHIVE% > nul
 CD C:\MuseScore
 
 :: is MuseScore stable? Check here, no grep in PATH later on
-for /f "delims=" %%i in ('bash -c "cmake -P config.cmake | grep -P 'MSCORE_UNSTABLE\s+TRUE'"') do set NIGHTLY_BUILD=%%i
-for /f %%i in ('bash -c "cmake -P config.cmake | grep -oP 'MUSESCORE_VERSION_FULL\s+\K.*'"') do set MUSESCORE_VERSION_FULL=%%i
+for /f "delims=" %%i in ('bash -c "cmake -P config.cmake | grep -o 'MSCORE_UNSTABLE  *TRUE'"') do set NIGHTLY_BUILD=%%i
+for /f %%i in ('bash -c "cmake -P config.cmake | sed -n -e 's/^.*MUSESCORE_VERSION_FULL  *//p'"') do set MUSESCORE_VERSION_FULL=%%i
 
 :: get revision number
 SET "PATH=%QTDIR%\bin;%PATH%"

--- a/build/appveyor/winsparkle_appcast_generator.sh
+++ b/build/appveyor/winsparkle_appcast_generator.sh
@@ -3,7 +3,7 @@
 # $3 - MuseScore version
 # $4 - Revision hash
 
-export MSCORE_RELEASE_CHANNEL=$(cmake -P config.cmake | grep -oP 'MSCORE_RELEASE_CHANNEL\s+\K.*')
+export MSCORE_RELEASE_CHANNEL=$(cmake -P config.cmake | sed -n -e 's/^.*MSCORE_RELEASE_CHANNEL  *//p')
 RSS_DATE="$(LANG=C date +'%a, %d %b %Y %H:%M:%S %z')"
 FILESIZE="$(wc -c $1 | awk '{print $1}')"
 APPCAST_URL="https://sparkle.musescore.org/$MSCORE_RELEASE_CHANNEL/3/win/appcast.xml"

--- a/build/package_mac
+++ b/build/package_mac
@@ -13,7 +13,7 @@ else
     LONGER_NAME="MuseScore 3"
 
     SCRIPT_DIR=$(cd "$(dirname ${BASH_SOURCE[0]})" && pwd)
-    VERSION=$(cmake -P "$SCRIPT_DIR/../config.cmake" | grep -oP 'VERSION\s+\K.*')
+    VERSION=$(cmake -P "$SCRIPT_DIR/../config.cmake" | sed -n -e "s/^.*VERSION  *//p")
 fi
 
 

--- a/build/travis/job_macos/before_install.sh
+++ b/build/travis/job_macos/before_install.sh
@@ -26,11 +26,11 @@ expect << EOF
 EOF
 
 # Set NIGHTLY_BUILD variable if MSCORE_UNSTABLE is TRUE
-if [ "$(cmake -P config.cmake | grep -P 'MSCORE_UNSTABLE\s+TRUE')" ]
+if [ "$(cmake -P config.cmake | grep -o 'MSCORE_UNSTABLE  *TRUE')" ]
 then
 export NIGHTLY_BUILD=TRUE
 fi
 
-export MSCORE_RELEASE_CHANNEL=$(cmake -P config.cmake | grep -oP 'MSCORE_RELEASE_CHANNEL\s+\K.*')
+export MSCORE_RELEASE_CHANNEL=$(cmake -P config.cmake | sed -n -e 's/^.*MSCORE_RELEASE_CHANNEL  *//p')
 
 fi

--- a/build/travis/job_macos/script.sh
+++ b/build/travis/job_macos/script.sh
@@ -64,7 +64,7 @@ scp -C -i $SSH_INDENTITY build/travis/job_macos/web/nightly.xml musescore-nightl
 ssh -i $SSH_INDENTITY musescore-nightlies@ftp-osl.osuosl.org "~/trigger-musescore-nightlies"
 
 # send nightly update to S3
-MUSESCORE_VERSION_FULL=$(cmake -P config.cmake | grep -oP 'MUSESCORE_VERSION_FULL\s+\K.*')
+MUSESCORE_VERSION_FULL=$(cmake -P config.cmake | sed -n -e 's/^.*MUSESCORE_VERSION_FULL  *//p')
 BUILD_NUMBER=${TRAVIS_BUILD_NUMBER}
 MUSESCORE_VERSION=${MUSESCORE_VERSION_FULL}.${BUILD_NUMBER}
 SHORT_DATE="$(date -u +%Y-%m-%d)"

--- a/build/travis/job_macos_lupdate/before_install.sh
+++ b/build/travis/job_macos_lupdate/before_install.sh
@@ -6,9 +6,9 @@ export QT_MACOS=$QT_PATH/$QT_SHORT_VERSION/clang_64
 export PATH=$PATH:$QT_MACOS/bin
 
 # Set NIGHTLY_BUILD variable if MSCORE_UNSTABLE is TRUE
-if [ "$(cmake -P config.cmake | grep -P 'MSCORE_UNSTABLE\s+TRUE')" ]
+if [ "$(cmake -P config.cmake | grep -o 'MSCORE_UNSTABLE  *TRUE')" ]
 then
 export NIGHTLY_BUILD=TRUE
 fi
 
-export MSCORE_RELEASE_CHANNEL=$(cmake -P config.cmake | grep -oP 'MSCORE_RELEASE_CHANNEL\s+\K.*')
+export MSCORE_RELEASE_CHANNEL=$(cmake -P config.cmake | sed -n -e 's/^.*MSCORE_RELEASE_CHANNEL  *//p')


### PR DESCRIPTION
This should solve the issue of nightly builds not properly generated for Windows.
"grep -P" was causing an error in Appveyor build chain (I checked by connecting via Remote Desktop to one of Appveyor builds).
I added the same modifications also for Mac to test if the absence of Mac nightly builds is due to the same cause.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [only Win checked] I made sure the code compiles on my machine
- [Mac to be tested] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [N/A] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
