### PR TITLE
Show messages on splash screen

### DIFF
--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -297,7 +297,7 @@ add_library(mscoreapp STATIC
       keycanvas.h keyedit.h layer.h licence.h
       magbox.h masterpalette.h
       measureproperties.h mediadialog.h metaedit.h miconengine.h
-      musescore.h navigator.h newwizard.h noteGroups.h
+      mssplashscreen.h musescore.h navigator.h newwizard.h noteGroups.h
       omrpanel.h pagesettings.h palette.h partedit.h parteditbase.h
       pathlistdialog.h piano.h  pianotools.h
       playpanel.h preferences.h preferenceslistwidget.h prefsdialog.h
@@ -317,7 +317,7 @@ add_library(mscoreapp STATIC
       icons.cpp
       instrdialog.cpp instrwidget.cpp
       debugger/debugger.cpp menus.cpp
-      musescore.cpp musescoredialogs.cpp navigator.cpp pagesettings.cpp palette.cpp
+      mssplashscreen.cpp musescore.cpp musescoredialogs.cpp navigator.cpp pagesettings.cpp palette.cpp
       sessionstatusobserver.cpp
       timeline.cpp
       parteditbase.cpp playpanel.cpp selectionwindow.cpp

--- a/mscore/mssplashscreen.cpp
+++ b/mscore/mssplashscreen.cpp
@@ -1,0 +1,49 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#include "mssplashscreen.h"
+
+namespace Ms {
+
+//---------------------------------------------------------
+//   drawContents
+//---------------------------------------------------------
+
+void MsSplashScreen::drawContents(QPainter* painter)
+      {
+      qreal width  = static_cast<qreal>(pixmap().width());
+      qreal height = static_cast<qreal>(pixmap().height());
+      QRectF rect  = QRectF(0.0, 0.65 * height, width, 0.35 * height);
+
+      painter->setPen(QColor(255, 255, 255, 255 * 0.8));
+      painter->drawText(rect, Qt::AlignTop | Qt::AlignHCenter, _message);
+      }
+
+//---------------------------------------------------------
+//   showMessage
+//---------------------------------------------------------
+
+void MsSplashScreen::showMessage(const QString& message)
+      {
+      _message = message;
+      // The align flags and color don't matter here as drawContents() is overwritten
+      QSplashScreen::showMessage(message, Qt::AlignTop | Qt::AlignHCenter, QColor(255, 255, 255, 255 * 0.8));
+      }
+
+}

--- a/mscore/mssplashscreen.h
+++ b/mscore/mssplashscreen.h
@@ -1,0 +1,40 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+namespace Ms {
+
+//---------------------------------------------------------
+//   MsSplashScreen
+//---------------------------------------------------------
+
+class MsSplashScreen : public QSplashScreen {
+      QString _message;
+
+   public:
+      MsSplashScreen(const QPixmap& pixmap) : QSplashScreen(pixmap) {}
+
+      void setMessage(QString& message) { _message = message; }
+
+      void drawContents(QPainter* painter) override;
+
+   public slots:
+      void showMessage(const QString& message);
+      };
+
+}

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -101,6 +101,7 @@
 #include "scoreaccessibility.h"
 #include "startupWizard.h"
 #include "tourhandler.h"
+#include "mssplashscreen.h"
 
 #include "libmscore/mscore.h"
 #include "libmscore/system.h"
@@ -7743,6 +7744,18 @@ int runApplication(int& argc, char** av)
       }
 
 //---------------------------------------------------------
+//   showSplashMessage
+//---------------------------------------------------------
+
+inline static void showSplashMessage(MsSplashScreen* sc, QString&& message)
+      {
+      if (sc)
+            sc->showMessage(message);
+      else
+            qInfo(message.toStdString().c_str());
+      }
+
+//---------------------------------------------------------
 //   init
 //---------------------------------------------------------
 
@@ -7830,13 +7843,13 @@ void MuseScore::init(QStringList& argv)
       if (!MScore::testMode)
             MScore::readDefaultStyle(preferences.getString(PREF_SCORE_STYLE_DEFAULTSTYLEFILE));
 
-      QSplashScreen* sc = 0;
+      MsSplashScreen* sc = nullptr;
       if (!MScore::noGui && preferences.getBool(PREF_UI_APP_STARTUP_SHOWSPLASHSCREEN)) {
             QString pictureScaling;
             if (QGuiApplication::primaryScreen()->devicePixelRatio() >= 2)
                   pictureScaling = "@2x";
             QPixmap pm(":/data/splash" + pictureScaling + ".png");
-            sc = new QSplashScreen(pm);
+            sc = new MsSplashScreen(pm);
             sc->setWindowTitle(QString("MuseScore Startup"));
 #ifdef Q_OS_MAC // to have session dialog on top of splashscreen on mac
             sc->setWindowFlags(Qt::FramelessWindowHint);
@@ -7845,8 +7858,12 @@ void MuseScore::init(QStringList& argv)
             qApp->processEvents();
             }
 
-      if (!MScore::noGui)
+      // Best not to show this since the font used to display the message
+      // isn't updated till updateUiStyleAndTheme()
+      // showSplashMessage(sc, tr("Updating user interface and theme…"));
+      if (!MScore::noGui) {
             MuseScore::updateUiStyleAndTheme();
+            }
       else {
             genIcons(); // in GUI mode generated in updateUiStyleAndTheme()
             noSeq = true;
@@ -7854,6 +7871,7 @@ void MuseScore::init(QStringList& argv)
 
       // Do not create sequencer and audio drivers if run with '-s'
       if (!noSeq) {
+            showSplashMessage(sc, tr("Initializing sequencer and audio driver…"));
             seq            = new Seq();
             MScore::seq    = seq;
             Driver* driver = driverFactory(seq, audioDriver);
@@ -7861,6 +7879,8 @@ void MuseScore::init(QStringList& argv)
             if (driver) {
                   MScore::sampleRate = driver->sampleRate();
                   synti->setSampleRate(MScore::sampleRate);
+
+                  showSplashMessage(sc, tr("Loading SoundFonts…"));
                   synti->init();
 
                   seq->setDriver(driver);
@@ -7903,9 +7923,11 @@ void MuseScore::init(QStringList& argv)
 #ifndef Q_OS_MAC
             qApp->setWindowIcon(*icons[int(Icons::window_ICON)]);
 #endif
+            showSplashMessage(sc, tr("Initializing workspace…"));
             WorkspacesManager::initCurrentWorkspace();
             }
 
+      showSplashMessage(sc, tr("Creating main window…"));
       mscore = new MuseScore();
       // create a score for internal use
       gscore = new MasterScore();
@@ -7922,12 +7944,14 @@ void MuseScore::init(QStringList& argv)
       tryToRequestTelemetryPermission();
 #endif
 
+      showSplashMessage(sc, tr("Reading translations…"));
       //read languages list
       mscore->readLanguages(mscoreGlobalShare + "locale/languages.xml");
 
       if (!MScore::noGui) {
             if (preferences.getBool(PREF_APP_STARTUP_FIRSTSTART)) {
                   mscoreFirstStart = true;
+                  showSplashMessage(sc, tr("Initializing startup wizard…"));
                   StartupWizard* sw = new StartupWizard;
                   sw->exec();
                   preferences.setPreference(PREF_APP_STARTUP_FIRSTSTART, false);
@@ -7943,6 +7967,7 @@ void MuseScore::init(QStringList& argv)
                   preferences.setPreference(PREF_UI_APP_STARTUP_SHOWTOURS, sw->showTours());
                   delete sw;
 
+                  showSplashMessage(sc, tr("Initializing preferences…"));
                   // reinitialize preferences so some default values are calculated based on chosen language
                   preferences.init();
                   // store preferences with locale-dependent default values
@@ -7982,6 +8007,7 @@ void MuseScore::init(QStringList& argv)
       if (MScore::noGui)
             return;
       else {
+            showSplashMessage(sc, tr("Initializing main window…"));
             mscore->readSettings();
             QObject::connect(qApp, SIGNAL(messageReceived(const QString&)),
                mscore, SLOT(handleMessage(const QString&)));
@@ -8006,6 +8032,7 @@ void MuseScore::init(QStringList& argv)
             //
             // TODO: delete old session backups
             //
+            showSplashMessage(sc, tr("Restoring session…"));
             restoredSession = mscore->restoreSession((preferences.sessionStart() == SessionStart::LAST && (files == 0)));
             }
 
@@ -8027,9 +8054,11 @@ void MuseScore::init(QStringList& argv)
 
       mscore->changeState(mscore->noScore() ? STATE_DISABLED : STATE_NORMAL);
       mscore->show();
-
-      if (!restoredSession || files)
+      
+      if (!restoredSession || files) {
+            showSplashMessage(sc, tr("Loading scores…"));
             loadScores(argv);
+            }
 
       if (mscore->hasToCheckForExtensionsUpdate())
             mscore->checkForExtensionsUpdate();
@@ -8038,11 +8067,12 @@ void MuseScore::init(QStringList& argv)
             TourHandler::addWidgetToTour("welcome", menubar, "menubar");
 
       if (!scoresOnCommandline && preferences.getBool(PREF_UI_APP_STARTUP_SHOWSTARTCENTER) && (!restoredSession || mscore->scores().size() == 0)) {
+            showSplashMessage(sc, tr("Initializing start center…"));
 #ifdef Q_OS_MAC
 // ugly, but on mac we get an event when a file is open.
 // We can't get the event when the startcenter is shown.
 // So we let the event loop run a bit before showing the start center.
-            QTimer *timer = new QTimer();
+            QTimer* timer = new QTimer();
             timer->setSingleShot(true);
             QObject::connect(timer, &QTimer::timeout, [=]() {
                   if (!scoresOnCommandline) {
@@ -8059,6 +8089,7 @@ void MuseScore::init(QStringList& argv)
 #endif
             }
       else {
+            showSplashMessage(sc, tr("Initializing tours…"));
             mscore->tourHandler()->startTour("welcome");
             //otherwise, welcome tour will appear on closing StartCenter
             }


### PR DESCRIPTION
Making MuseScore a bit cooler ;-)
Also tells user what's going on during startup.

__Note:__ The font is consistent with what font you have for the main UI. For me it's High Tower Text. If you haven't changed the default font, then the font the messages use is also the default.

__Note 2:__ The position of the messages was changed, because there will be a new splash screen designed by @Tantacrul. The gif below however hasn't been changed. If you pull this PR now and build it, the position is not going to look good, but it will be on the new splash screen.

![splash-screen](https://user-images.githubusercontent.com/46259489/79306445-cbed4c80-7f27-11ea-99d0-1e18864377f5.gif)

Forum topic: https://musescore.org/en/node/303903.