### PR TITLE
Fixed clipping issue in Note Spelling (edit style ui)

### DIFF
--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -30,6 +30,7 @@
 #include "inspector/alignSelect.h"
 #include "inspector/offsetSelect.h"
 #include "inspector/fontStyleSelect.h"
+#include "preferences.h"
 
 namespace Ms {
 
@@ -556,6 +557,11 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
 
             mapper2->setMapping(sw.widget, int(sw.idx));
             }
+
+      int topBottomMargin = automaticCapitalization->rect().height() - preferences.getInt(PREF_UI_THEME_FONTSIZE);
+      topBottomMargin /= 2;
+      topBottomMargin = topBottomMargin > 4 ? topBottomMargin - 4 : 0;
+      automaticCapitalization->layout()->setContentsMargins(9, topBottomMargin, 9, topBottomMargin);
 
       connect(mapper,  SIGNAL(mapped(int)), SLOT(resetStyleValue(int)));
       connect(mapper2, SIGNAL(mapped(int)), SLOT(valueChanged(int)));


### PR DESCRIPTION
Fixes a small clipping issue in the Note Spelling ui.

Before:
![Screenshot from 2020-04-13 12-24-34](https://user-images.githubusercontent.com/21060365/79111192-b7248380-7d84-11ea-9dbe-81d1a23a2304.png)
After:
![Screenshot from 2020-04-13 12-36-02](https://user-images.githubusercontent.com/21060365/79111206-bc81ce00-7d84-11ea-83fa-d928b36d364e.png)



- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made
