### PR TITLE
fix: #299697: Repeat play a bar, goes back to first bar briefly

### DIFF
--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -836,8 +836,10 @@ void Seq::process(unsigned framesPerPeriod, float* buffer)
                         if (mscore->loop()) {
                               int loopOutUTick = cs->repeatList().tick2utick(cs->loopOutTick().ticks());
                               if (loopOutUTick < scoreEndUTick) {
-                                    // Also make sure we are not "before" the loop
-                                    if (playPosUTick >= loopOutUTick || cs->repeatList().utick2tick(playPosUTick) < cs->loopInTick().ticks()) {
+                                    qreal framesPerPeriodInTime = static_cast<qreal>(framesPerPeriod) / MScore::sampleRate;
+                                    int framesPerPeriodInTicks = cs->utime2utick(framesPerPeriodInTime);
+                                    // Also make sure we are inside the loop
+                                    if (playPosUTick >= loopOutUTick - 2 * framesPerPeriodInTicks || cs->repeatList().utick2tick(playPosUTick) < cs->loopInTick().ticks()) {
                                           qDebug ("Process: playPosUTick = %d, cs->loopInTick().ticks() = %d, cs->loopOutTick().ticks() = %d, getCurTick() = %d, loopOutUTick = %d, playFrame = %d",
                                                             playPosUTick,      cs->loopInTick().ticks(),      cs->loopOutTick().ticks(),      getCurTick(),      loopOutUTick,    *pPlayFrame);
                                           if (cachedPrefs.useJackTransport) {
@@ -849,7 +851,7 @@ void Seq::process(unsigned framesPerPeriod, float* buffer)
                                                       }
                                                 }
                                           else {
-                                                emit toGui('3');
+                                                emit toGui('3'); // calls loopStart()
                                                 }
                                           // Exit this function to avoid segmentation fault in Scoreview
                                           return;
@@ -1092,7 +1094,7 @@ void Seq::collectEvents(int utick)
             }
 
       updateEventsEnd();
-      playPos = events.cbegin();
+      playPos = mscore->loop() ? events.find(cs->loopInTick().ticks()) : events.cbegin();
       playlistChanged = false;
       mutex.unlock();
       }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/299697

Made cursor rewind earlier in loop play mode and changed rewind target from 0 to loopIn.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue

Resubmission of [this PR](https://github.com/musescore/MuseScore/pull/5684).