### PR TITLE
Fix a crash when shutting down application before initialisation ends

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7829,7 +7829,6 @@ void MuseScore::init(QStringList& argv)
             sc->setWindowFlags(Qt::FramelessWindowHint);
 #endif
             sc->show();
-            qApp->processEvents();
             }
 
       if (!MScore::noGui)
@@ -8050,15 +8049,13 @@ void MuseScore::init(QStringList& argv)
             //otherwise, welcome tour will appear on closing StartCenter
             }
 
-      if (sc) {
-            sc->close();
-            qApp->processEvents();
-            }
-
       mscore->showPlayPanel(preferences.getBool(PREF_UI_APP_STARTUP_SHOWPLAYPANEL));
       QSettings settings;
       if (settings.value("synthControlVisible", false).toBool())
             mscore->showSynthControl(true);
+
+      if (sc)
+            sc->close();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
prevent crash when trying to redisplay dock widgets after closing the application.

Resolves: May resolve some startup issues, but there's not enough information to prove that this is the root cause.

In Musescore.cpp Musescore::init(args), at the very end, events were processed before the play panel was shown, so if the user exited the application at its earliest stage (when it first appeared), the play panel tried to be redisplayed when the application was shutting down. This caused a crash in redisplayDockWidgets (musescore.cpp)



<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- n/a I created the test (mtest, vtest, script test) to verify the changes I made
