### PR TITLE
fix #301259: wrong text offset for non-default text styles

### DIFF
--- a/libmscore/dynamic.cpp
+++ b/libmscore/dynamic.cpp
@@ -517,17 +517,6 @@ QString Dynamic::propertyUserValue(Pid pid) const
       }
 
 //---------------------------------------------------------
-//   getPropertyStyle
-//---------------------------------------------------------
-
-Sid Dynamic::getPropertyStyle(Pid pid) const
-      {
-      if (pid == Pid::OFFSET)
-            return placeAbove() ? Sid::dynamicsPosAbove : Sid::dynamicsPosBelow;
-      return TextBase::getPropertyStyle(pid);
-      }
-
-//---------------------------------------------------------
 //   accessibleInfo
 //---------------------------------------------------------
 

--- a/libmscore/dynamic.h
+++ b/libmscore/dynamic.h
@@ -89,7 +89,6 @@ class Dynamic final : public TextBase {
       Speed _velChangeSpeed         { Speed::NORMAL };
 
       QRectF drag(EditData&) override;
-      Sid getPropertyStyle(Pid) const override;
 
    public:
       Dynamic(Score*);

--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -575,17 +575,6 @@ QVariant Lyrics::propertyDefault(Pid id) const
       }
 
 //---------------------------------------------------------
-//   getPropertyStyle
-//---------------------------------------------------------
-
-Sid Lyrics::getPropertyStyle(Pid pid) const
-      {
-      if (pid == Pid::OFFSET)
-            return placeAbove() ? Sid::lyricsPosAbove : Sid::lyricsPosBelow;
-      return TextBase::getPropertyStyle(pid);
-      }
-
-//---------------------------------------------------------
 //   forAllLyrics
 //---------------------------------------------------------
 

--- a/libmscore/lyrics.h
+++ b/libmscore/lyrics.h
@@ -101,7 +101,6 @@ class Lyrics final : public TextBase {
       QVariant getProperty(Pid propertyId) const override;
       bool setProperty(Pid propertyId, const QVariant&) override;
       QVariant propertyDefault(Pid id) const override;
-      Sid getPropertyStyle(Pid) const override;
       };
 
 //---------------------------------------------------------

--- a/libmscore/rehearsalmark.cpp
+++ b/libmscore/rehearsalmark.cpp
@@ -96,16 +96,5 @@ QVariant RehearsalMark::propertyDefault(Pid id) const
             }
       }
 
-//---------------------------------------------------------
-//   getPropertyStyle
-//---------------------------------------------------------
-
-Sid RehearsalMark::getPropertyStyle(Pid pid) const
-      {
-      if (pid == Pid::OFFSET)
-            return placeAbove() ? Sid::rehearsalMarkPosAbove : Sid::rehearsalMarkPosBelow;
-      return TextBase::getPropertyStyle(pid);
-      }
-
 } // namespace Ms
 

--- a/libmscore/rehearsalmark.h
+++ b/libmscore/rehearsalmark.h
@@ -22,7 +22,6 @@ namespace Ms {
 //---------------------------------------------------------
 
 class RehearsalMark final : public TextBase  {
-      Sid getPropertyStyle(Pid) const override;
 
    public:
       RehearsalMark(Score* score);

--- a/libmscore/stafftext.cpp
+++ b/libmscore/stafftext.cpp
@@ -62,16 +62,5 @@ QVariant StaffText::propertyDefault(Pid id) const
             }
       }
 
-//---------------------------------------------------------
-//   getPropertyStyle
-//---------------------------------------------------------
-
-Sid StaffText::getPropertyStyle(Pid pid) const
-      {
-      if (pid == Pid::OFFSET)
-            return placeAbove() ? Sid::staffTextPosAbove : Sid::staffTextPosBelow;
-      return TextBase::getPropertyStyle(pid);
-      }
-
 }
 

--- a/libmscore/stafftext.h
+++ b/libmscore/stafftext.h
@@ -26,7 +26,6 @@ namespace Ms {
 
 class StaffText final : public StaffTextBase  {
 
-      Sid getPropertyStyle(Pid) const override;
       QVariant propertyDefault(Pid id) const override;
 
    public:

--- a/libmscore/sticking.cpp
+++ b/libmscore/sticking.cpp
@@ -91,15 +91,5 @@ QVariant Sticking::propertyDefault(Pid id) const
             }
       }
 
-//---------------------------------------------------------
-//   getPropertyStyle
-//---------------------------------------------------------
-
-Sid Sticking::getPropertyStyle(Pid pid) const
-      {
-      if (pid == Pid::OFFSET)
-            return placeAbove() ? Sid::stickingPosAbove : Sid::stickingPosBelow;
-      return TextBase::getPropertyStyle(pid);
-      }
 }
 

--- a/libmscore/sticking.h
+++ b/libmscore/sticking.h
@@ -30,7 +30,6 @@ namespace Ms {
 //-----------------------------------------------------------------------------
 
 class Sticking final : public TextBase {
-      Sid getPropertyStyle(Pid) const override;
       QVariant propertyDefault(Pid id) const override;
 
    public:

--- a/libmscore/systemtext.cpp
+++ b/libmscore/systemtext.cpp
@@ -57,16 +57,5 @@ void SystemText::layout()
       autoplaceSegmentElement();
       }
 
-//---------------------------------------------------------
-//   getPropertyStyle
-//---------------------------------------------------------
-
-Sid SystemText::getPropertyStyle(Pid pid) const
-      {
-      if (pid == Pid::OFFSET)
-            return placeAbove() ? Sid::systemTextPosAbove : Sid::systemTextPosBelow;
-      return TextBase::getPropertyStyle(pid);
-      }
-
 } // namespace Ms
 

--- a/libmscore/systemtext.h
+++ b/libmscore/systemtext.h
@@ -23,7 +23,6 @@ namespace Ms {
 
 class SystemText final : public StaffTextBase  {
       void layout() override;
-      Sid getPropertyStyle(Pid) const override;
       QVariant propertyDefault(Pid id) const override;
 
    public:

--- a/libmscore/tempotext.cpp
+++ b/libmscore/tempotext.cpp
@@ -474,16 +474,5 @@ QString TempoText::accessibleInfo() const
             return TextBase::accessibleInfo();
       }
 
-//---------------------------------------------------------
-//   getPropertyStyle
-//---------------------------------------------------------
-
-Sid TempoText::getPropertyStyle(Pid pid) const
-      {
-      if (pid == Pid::OFFSET)
-            return placeAbove() ? Sid::tempoPosAbove : Sid::tempoPosBelow;
-      return TextBase::getPropertyStyle(pid);
-      }
-
 }
 

--- a/libmscore/tempotext.h
+++ b/libmscore/tempotext.h
@@ -69,7 +69,6 @@ class TempoText final : public TextBase  {
       QVariant getProperty(Pid propertyId) const override;
       bool setProperty(Pid propertyId, const QVariant&) override;
       QVariant propertyDefault(Pid id) const override;
-      Sid getPropertyStyle(Pid) const override;
       QString accessibleInfo() const override;
       };
 

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -2477,7 +2477,7 @@ int TextBase::getPropertyFlagsIdx(Pid id) const
       }
 
 //---------------------------------------------------------
-//   offsetTid
+//   offsetSid
 //---------------------------------------------------------
 
 Sid TextBase::offsetSid() const

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -2480,24 +2480,28 @@ int TextBase::getPropertyFlagsIdx(Pid id) const
 //   offsetTid
 //---------------------------------------------------------
 
-Sid offsetTid(Tid tid, bool placeAbove)
+Sid TextBase::offsetSid() const
       {
-      switch (tid) {
+      Tid defaultTid = Tid(propertyDefault(Pid::SUB_STYLE).toInt());
+      if (tid() != defaultTid)
+            return Sid::NOSTYLE;
+      bool above = placeAbove();
+      switch (tid()) {
             case Tid::DYNAMICS:
-                  return placeAbove ? Sid::dynamicsPosAbove : Sid::dynamicsPosBelow;
+                  return above ? Sid::dynamicsPosAbove : Sid::dynamicsPosBelow;
             case Tid::LYRICS_ODD:
             case Tid::LYRICS_EVEN:
-                  return placeAbove ? Sid::lyricsPosAbove : Sid::lyricsPosBelow;
+                  return above ? Sid::lyricsPosAbove : Sid::lyricsPosBelow;
             case Tid::REHEARSAL_MARK:
-                  return placeAbove ? Sid::rehearsalMarkPosAbove : Sid::rehearsalMarkPosBelow;
+                  return above ? Sid::rehearsalMarkPosAbove : Sid::rehearsalMarkPosBelow;
             case Tid::STAFF:
-                  return placeAbove ? Sid::staffTextPosAbove : Sid::staffTextPosBelow;
+                  return above ? Sid::staffTextPosAbove : Sid::staffTextPosBelow;
             case Tid::STICKING:
-                  return placeAbove ? Sid::stickingPosAbove : Sid::stickingPosBelow;
+                  return above ? Sid::stickingPosAbove : Sid::stickingPosBelow;
             case Tid::SYSTEM:
-                  return placeAbove ? Sid::systemTextPosAbove : Sid::systemTextPosBelow;
+                  return above ? Sid::systemTextPosAbove : Sid::systemTextPosBelow;
             case Tid::TEMPO:
-                  return placeAbove ? Sid::tempoPosAbove : Sid::tempoPosBelow;
+                  return above ? Sid::tempoPosAbove : Sid::tempoPosBelow;
             default:
                   break;
             }
@@ -2511,12 +2515,9 @@ Sid offsetTid(Tid tid, bool placeAbove)
 Sid TextBase::getPropertyStyle(Pid id) const
       {
       if (id == Pid::OFFSET) {
-            Tid defaultTid = Tid(propertyDefault(Pid::SUB_STYLE).toInt());
-            if (tid() == defaultTid) {
-                  Sid sid = offsetTid(defaultTid, placeAbove());
-                  if (sid != Sid::NOSTYLE)
-                        return sid;
-                  }
+            Sid sid = offsetSid();
+            if (sid != Sid::NOSTYLE)
+                  return sid;
             }
       for (const StyledProperty& p : *_elementStyle) {
             if (p.pid == id)

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -2477,11 +2477,47 @@ int TextBase::getPropertyFlagsIdx(Pid id) const
       }
 
 //---------------------------------------------------------
+//   offsetTid
+//---------------------------------------------------------
+
+Sid offsetTid(Tid tid, bool placeAbove)
+      {
+      switch (tid) {
+            case Tid::DYNAMICS:
+                  return placeAbove ? Sid::dynamicsPosAbove : Sid::dynamicsPosBelow;
+            case Tid::LYRICS_ODD:
+            case Tid::LYRICS_EVEN:
+                  return placeAbove ? Sid::lyricsPosAbove : Sid::lyricsPosBelow;
+            case Tid::REHEARSAL_MARK:
+                  return placeAbove ? Sid::rehearsalMarkPosAbove : Sid::rehearsalMarkPosBelow;
+            case Tid::STAFF:
+                  return placeAbove ? Sid::staffTextPosAbove : Sid::staffTextPosBelow;
+            case Tid::STICKING:
+                  return placeAbove ? Sid::stickingPosAbove : Sid::stickingPosBelow;
+            case Tid::SYSTEM:
+                  return placeAbove ? Sid::systemTextPosAbove : Sid::systemTextPosBelow;
+            case Tid::TEMPO:
+                  return placeAbove ? Sid::tempoPosAbove : Sid::tempoPosBelow;
+            default:
+                  break;
+            }
+      return Sid::NOSTYLE;
+      }
+
+//---------------------------------------------------------
 //   getPropertyStyle
 //---------------------------------------------------------
 
 Sid TextBase::getPropertyStyle(Pid id) const
       {
+      if (id == Pid::OFFSET) {
+            Tid defaultTid = Tid(propertyDefault(Pid::SUB_STYLE).toInt());
+            if (tid() == defaultTid) {
+                  Sid sid = offsetTid(defaultTid, placeAbove());
+                  if (sid != Sid::NOSTYLE)
+                        return sid;
+                  }
+            }
       for (const StyledProperty& p : *_elementStyle) {
             if (p.pid == id)
                   return p.sid;

--- a/libmscore/textbase.h
+++ b/libmscore/textbase.h
@@ -248,6 +248,7 @@ class TextBase : public Element {
       void genText() const;
       virtual int getPropertyFlagsIdx(Pid id) const override;
       QString stripText(bool, bool, bool) const;
+      Sid offsetSid() const;
 
    protected:
       QColor textColor() const;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/301259

See also https://github.com/musescore/MuseScore/pull/5728/

The problem occurs in several different overrides to
getPropertyStyle() for various different text classes.
The function is supposed to determine
which Sid to use for Pid::OFFSET, based on placement above/below.
But that calculation should only be relevant
if the element is using the default text style for its type.
Otherwise it should use the offset in the current text style.

This code removes the overrides for getPropertyStyle() in each class,
instead modifying TextBase::getPropertyStyle() to check
if the element is using its default text style or not,
and then only if so does it use the placement to select a Sid.
Otherwise it uses the offset of the current text style.