### PR TITLE
Fix #105936: Move tempo selection to timesig page of New Wizard

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -798,10 +798,71 @@ MasterScore* MuseScore::getNewFile()
             delete nvb;
             }
 
-      if (newWizard->createTempo()) {
-            double tempo = newWizard->tempo();
+      double tempo = Score::defaultTempo() * 60; // quarter notes per minute
+      if (newWizard->tempo(&tempo)) {
+
+            Fraction timesig = newWizard->timesig();
+
+            QString text("<sym>metNoteQuarterUp</sym> = %1");
+            double bpm = tempo;
+            switch (timesig.denominator()) {
+                  case 1:
+                        text = "<sym>metNoteWhole</sym> = %1";
+                        bpm /= 4;
+                        break;
+                  case 2:
+                        text = "<sym>metNoteHalfUp</sym> = %1";
+                        bpm /= 2;
+                        break;
+                  case 4:
+                        text = "<sym>metNoteQuarterUp</sym> = %1";
+                        break;
+                  case 8:
+                        if (timesig.numerator() % 3 == 0) {
+                              text = "<sym>metNoteQuarterUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = %1";
+                              bpm /= 1.5;
+                              }
+                        else {
+                              text = "<sym>metNote8thUp</sym> = %1";
+                              bpm *= 2;
+                              }
+                        break;
+                  case 16:
+                        if (timesig.numerator() % 3 == 0) {
+                              text = "<sym>metNote8thUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = %1";
+                              bpm *= 1.5;
+                              }
+                        else {
+                              text = "<sym>metNote16thUp</sym> = %1";
+                              bpm *= 4;
+                              }
+                        break;
+                  case 32:
+                        if (timesig.numerator() % 3 == 0) {
+                              text = "<sym>metNote16thUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = %1";
+                              bpm *= 3;
+                              }
+                        else {
+                              text = "<sym>metNote32ndUp</sym> = %1";
+                              bpm *= 8;
+                              }
+                        break;
+                  case 64:
+                        if (timesig.numerator() % 3 == 0) {
+                              text = "<sym>metNote32ndUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = %1";
+                              bpm *= 6;
+                              }
+                        else {
+                              text = "<sym>metNote64thUp</sym> = %1";
+                              bpm *= 16;
+                              }
+                        break;
+                  default:
+                        break;
+                  }
+
             TempoText* tt = new TempoText(score);
-            tt->setXmlText(QString("<sym>metNoteQuarterUp</sym> = %1").arg(tempo));
+            tt->setXmlText(text.arg(bpm));
             tempo /= 60;      // bpm -> bps
 
             tt->setTempo(tempo);

--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -97,6 +97,16 @@ bool TimesigWizard::pickup(int* z, int* n) const
       }
 
 //---------------------------------------------------------
+//   tempo
+//---------------------------------------------------------
+
+bool TimesigWizard::tempo(double* t) const
+    {
+    *t = spinboxTempo->value();
+    return tempoGroup->isChecked();
+    }
+
+//---------------------------------------------------------
 //   type
 //---------------------------------------------------------
 
@@ -256,7 +266,7 @@ NewWizardTimesigPage::NewWizardTimesigPage(QWidget* parent)
       {
       setFinalPage(true);
       setTitle(tr("Create New Score"));
-      setSubTitle(tr("Choose time signature:"));
+      setSubTitle(tr("Choose time signature and tempo:"));
       setAccessibleName(title());
       setAccessibleDescription(subTitle());
 
@@ -375,7 +385,7 @@ NewWizardKeysigPage::NewWizardKeysigPage(QWidget* parent)
       {
       setFinalPage(true);
       setTitle(tr("Create New Score"));
-      setSubTitle(tr("Choose key signature and tempo:"));
+      setSubTitle(tr("Choose key signature:"));
       setAccessibleName(title());
       setAccessibleDescription(subTitle());
 
@@ -391,28 +401,8 @@ NewWizardKeysigPage::NewWizardKeysigPage(QWidget* parent)
       l1->addWidget(_plv);
       _plv->setCurrentRow(14); // C Major
 
-      tempoGroup = new QGroupBox;
-      tempoGroup->setCheckable(true);
-      tempoGroup->setChecked(false);
-      tempoGroup->setTitle(tr("Tempo"));
-      tempoGroup->setAccessibleName(tempoGroup->title());
-      tempoGroup->setAccessibleDescription(tr("Add tempo marking to score"));
-      QLabel* bpm = new QLabel;
-      bpm->setText(tr("BPM:"));
-      _tempo = new QDoubleSpinBox;
-      _tempo->setAccessibleName(tr("Beats per minute"));
-      _tempo->setRange(20.0, 400.0);
-      _tempo->setValue(120.0);
-      _tempo->setDecimals(1);
-      QHBoxLayout* l2 = new QHBoxLayout;
-      l2->addWidget(bpm);
-      l2->addWidget(_tempo);
-      l2->addStretch(100);
-      tempoGroup->setLayout(l2);
-
       QVBoxLayout* l3 = new QVBoxLayout;
       l3->addWidget(b1);
-      l3->addWidget(tempoGroup);
       l3->addStretch(100);
       setLayout(l3);
       setFocusPolicy(Qt::StrongFocus);

--- a/mscore/newwizard.h
+++ b/mscore/newwizard.h
@@ -54,6 +54,7 @@ class TimesigWizard : public QWidget, private Ui::TimesigWizard {
       int measures() const;
       Fraction timesig() const;
       bool pickup(int* z, int* n) const;
+      bool tempo(double* t) const;
       TimeSigType type() const;
       };
 
@@ -125,6 +126,7 @@ class NewWizardTimesigPage : public QWizardPage {
       Fraction timesig() const                 { return w->timesig();    }
       bool pickupMeasure(int* z, int* n) const { return w->pickup(z, n); }
       TimeSigType timesigType() const          { return w->type();       }
+      bool tempo(double* t) const              { return w->tempo(t);     }
       };
 
 //---------------------------------------------------------
@@ -159,15 +161,11 @@ class NewWizardKeysigPage : public QWizardPage {
       Q_OBJECT
 
       PaletteListView* _plv;
-      QDoubleSpinBox* _tempo;
-      QGroupBox* tempoGroup;
 
    public:
       NewWizardKeysigPage(QWidget* parent = 0);
       virtual bool isComplete() const override { return true; }
       KeySigEvent keysig() const;
-      double tempo() const            { return _tempo->value(); }
-      bool createTempo() const        { return tempoGroup->isChecked(); }
       void init();
       };
 
@@ -206,11 +204,10 @@ class NewWizard : public QWizard {
       QString composer() const           { return infoPage->composer();    }
       QString poet() const               { return infoPage->poet();        }
       QString copyright() const          { return infoPage->copyright();   }
-      KeySigEvent keysig() const         { return keysigPage->keysig();      }
+      KeySigEvent keysig() const         { return keysigPage->keysig();    }
       bool pickupMeasure(int* z, int* n) const { return timesigPage->pickupMeasure(z, n); }
-      TimeSigType timesigType() const     { return timesigPage->timesigType();       }
-      double tempo() const                { return keysigPage->tempo();       }
-      bool createTempo() const            { return keysigPage->createTempo(); }
+      TimeSigType timesigType() const    { return timesigPage->timesigType();}
+      bool tempo(double* t) const        { return timesigPage->tempo(t);   }
       bool emptyScore() const;
       void updateValues() const;
       };

--- a/mscore/timesigwizard.ui
+++ b/mscore/timesigwizard.ui
@@ -412,6 +412,66 @@
      </layout>
     </widget>
    </item>
+   <item>
+    <widget class="QGroupBox" name="tempoGroup">
+     <property name="accessibleName">
+      <string>Tempo</string>
+     </property>
+     <property name="title">
+      <string>Tempo</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QHBoxLayout">
+      <item>
+       <widget class="QLabel" name="labelBpm">
+        <property name="text">
+         <string>BPM:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QDoubleSpinBox" name="spinboxTempo">
+        <property name="toolTip">
+         <string>Quarter notes per minute</string>
+        </property>
+        <property name="accessibleName">
+         <string>Quarter notes per minute</string>
+        </property>
+        <property name="decimals">
+         <number>1</number>
+        </property>
+        <property name="minimum">
+         <double>20.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>400.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>120.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <tabstops>
@@ -424,6 +484,8 @@
   <tabstop>pickupTimesigZ</tabstop>
   <tabstop>pickupTimesigN</tabstop>
   <tabstop>measureCount</tabstop>
+  <tabstop>tempoGroup</tabstop>
+  <tabstop>spinboxTempo</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
shamelessly stolen from PR #3671 (but crediting the author, @JGreenlee, if you don't want that, just let me know), rebased and modified as per the discussion in the other PR.