### PR TITLE
Use palette background color for keysig chooser in the New Score Wizard

### DIFF
--- a/mscore/palette/palettelistview.cpp
+++ b/mscore/palette/palettelistview.cpp
@@ -12,6 +12,7 @@
 #include "palettelistview.h"
 
 #include "palettemodel.h"
+#include "preferences.h"
 
 namespace Ms {
 
@@ -36,6 +37,8 @@ PaletteListView::PaletteListView(PalettePanel* panel, QWidget* parent)
 
       setModel(model);
       setRootIndex(parentCategory);
+
+      setupStyle();
       }
 
 //---------------------------------------------------------
@@ -105,4 +108,38 @@ void PaletteListView::keyPressEvent(QKeyEvent* event)
                         QListView::keyPressEvent(event);
             }
       }
-}
+
+//---------------------------------------------------------
+//   PaletteListView::setupStyle
+//---------------------------------------------------------
+
+void PaletteListView::setupStyle()
+      {
+      QPalette pal = palette(); // color palette
+      QColor c;
+      if (preferences.getBool(PREF_UI_CANVAS_FG_USECOLOR)
+         && preferences.getBool(PREF_UI_CANVAS_FG_USECOLOR_IN_PALETTES))
+            c = preferences.getColor(PREF_UI_CANVAS_FG_COLOR);
+      else
+            c = preferences.defaultValue(PREF_UI_CANVAS_FG_COLOR).value<QColor>();
+      pal.setColor(QPalette::Base, c);
+      setPalette(pal);
+      }
+
+//---------------------------------------------------------
+//   PaletteListView::changeEvent
+//---------------------------------------------------------
+
+void PaletteListView::changeEvent(QEvent* event)
+      {
+      QListView::changeEvent(event);
+      switch (event->type()) {
+            case QEvent::StyleChange:
+                  setupStyle();
+                  break;
+            default:
+                  break;
+            }
+      }
+
+} // namespace Ms

--- a/mscore/palette/palettelistview.h
+++ b/mscore/palette/palettelistview.h
@@ -53,7 +53,10 @@ class PaletteListView : public QListView // see also QListWidget
 
    protected:
       virtual void keyPressEvent(QKeyEvent* event) override;
+      virtual void changeEvent(QEvent* event) override;
 
+   private:
+      void setupStyle();
       };
 }
 


### PR DESCRIPTION
Resolves: *no issue in tracker*

This PR makes the background the same almost-white colour as is used in the palettes. Previously, the keysig chooser was using Qt's default background color, which is dark when the Dark Theme is loaded. This made the icons difficult to see.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [N/A] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
