### PR TITLE
Document initial version for notehead scheme properties in plugins API

### DIFF
--- a/mscore/plugin/api/elements.h
+++ b/mscore/plugin/api/elements.h
@@ -142,7 +142,10 @@ class Element : public Ms::PluginAPI::ScoreElement {
       API_PROPERTY( fixedLine,               FIXED_LINE                )
       /** Notehead type, one of PluginAPI::PluginAPI::NoteHeadType values */
       API_PROPERTY( headType,                HEAD_TYPE                 )
-      /** Notehead scheme, one of PluginAPI::PluginAPI::NoteHeadScheme values */
+      /**
+       * Notehead scheme, one of PluginAPI::PluginAPI::NoteHeadScheme values.
+       * \since MuseScore 3.5
+       */
       API_PROPERTY( headScheme,              HEAD_SCHEME               )
       /** Notehead group, one of PluginAPI::PluginAPI::NoteHeadGroup values */
       API_PROPERTY( headGroup,               HEAD_GROUP                )

--- a/mscore/plugin/api/qmlpluginapi.h
+++ b/mscore/plugin/api/qmlpluginapi.h
@@ -139,6 +139,7 @@ class PluginAPI : public Ms::QmlPlugin {
       /// NoteHead class (e.g. NoteHead.HEAD_QUARTER).
       DECLARE_API_ENUM( NoteHeadType,     noteHeadTypeEnum        )
       /// Contains Ms::NoteHead::Scheme enumeration values
+      /// \since MuseScore 3.5
       DECLARE_API_ENUM( NoteHeadScheme,   noteHeadSchemeEnum      )
       /// Contains Ms::NoteHead::Group enumeration values
       /// \note In MuseScore 2.X this enumeration was available in


### PR DESCRIPTION
Adds `\since` statements to documentation of properties related to notehead scheme exposed to plugins API. There properties have been added in the recently merged PR #5332 so they will be available only since 3.5 version.