### PR TITLE
AppImage: give execute permission on scripts to Group and World

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -643,11 +643,10 @@ if (NOT MINGW AND NOT MSVC AND NOT APPLE)
       # Prepare portable scripts:
       configure_file(build/Linux+BSD/portable/AppRun.in          AppRun         @ONLY)
       configure_file(build/Linux+BSD/portable/portable-utils.in  portable-utils @ONLY)
-      set(SCRIPT_PERMS PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ WORLD_READ)
-      install(PROGRAMS ${PROJECT_BINARY_DIR}/AppRun     DESTINATION .   COMPONENT portable ${SCRIPT_PERMS})
+      install(PROGRAMS ${PROJECT_BINARY_DIR}/AppRun     DESTINATION .   COMPONENT portable)
       install(PROGRAMS ${PROJECT_BINARY_DIR}/portable-utils
                        build/Linux+BSD/portable/ldd-recursive
-                       build/rm-empty-dirs              DESTINATION bin COMPONENT portable ${SCRIPT_PERMS})
+                       build/rm-empty-dirs              DESTINATION bin COMPONENT portable)
       install(FILES    build/Linux+BSD/portable/qt.conf DESTINATION bin COMPONENT portable)
     else (${MSCORE_INSTALL_SUFFIX} MATCHES "portable")
       set(MAN_PORTABLE .\\\") # comment out lines in man page that are only relevant to the portable version


### PR DESCRIPTION
Resolves: *no issue in tracker*

**Old permissions:** `rwxr--r--` (Owner can execute)
**New permissions:** `rwxr-xr-x` (Owner, Group and World can execute)

Owner execute is not enough because the files are owned by root at runtime
(the AppImage is mounted this way by FUSE). Normally the permissions are
ignored, but they matter when trying to run the AppImage inside a sandbox
with an application like Firejail.

See AppImage/appimage.github.io#1943

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [N/A] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
