### PR TITLE
fix #304057: fixed harmony being reset when loading

### DIFF
--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -822,7 +822,7 @@ void FretDiagram::read(XmlReader& e)
         } else if (tag == "Harmony") {
             Harmony* h = new Harmony(score());
             h->read(e);
-            add(h);
+            addLoaded(h);
         } else if (!Element::readProperties(e)) {
             e.unknown();
         }
@@ -1213,6 +1213,23 @@ void FretDiagram::add(Element* e)
     } else {
         qWarning("FretDiagram: cannot add <%s>\n", e->name());
     }
+}
+
+//---------------------------------------------------------
+//   addLoaded
+//    used to add harmonies in read()
+//---------------------------------------------------------
+
+void FretDiagram::addLoaded(Element* e)
+{
+    e->setParent(this);
+    if (e->isHarmony()) {
+        _harmony = toHarmony(e);
+        _harmony->setTrack(track());
+        }
+    else {
+        qWarning("FretDiagram: cannot add <%s>\n", e->name());
+        }
 }
 
 //---------------------------------------------------------

--- a/libmscore/fret.h
+++ b/libmscore/fret.h
@@ -225,7 +225,7 @@ public:
     Harmony* harmony() const { return _harmony; }
 
     void init(Ms::StringData*, Chord*);
-
+    void addLoaded(Element*);
     void add(Element*) override;
     void remove(Element*) override;
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/304057

When reading(loading) the fretboard would call FretDiagram::add method to add the harmony. The problem with that is, that FretDiagram::add resets the offset of the harmony. I created a new method that adds the harmony, without resetting it's offset.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made
