### PR TITLE
fix Windows nightly build uploads

### DIFF
--- a/build/appveyor/after_build.bat
+++ b/build/appveyor/after_build.bat
@@ -7,8 +7,10 @@ REM the code is used to generate MS version for both nightly and stable releases
 SET MUSESCORE_VERSION=%MUSESCORE_VERSION_FULL%.%APPVEYOR_BUILD_NUMBER%
 
 SET DEBUG_SYMS_FILE=musescore_win%TARGET_PROCESSOR_BITS%.sym
+REM Add one of the directories containing msdia140.dll (x86 version), for dump_syms.exe
+SET PATH=%PATH%;C:\Program Files\dotnet\sdk\3.1.200\TestHost\x86
 @echo on
-C:\MuseScore\breakpad_tools\dump_syms.exe %APPVEYOR_BUILD_FOLDER%\%BUILD_FOLDER%\main\RelWithDebInfo\MuseScore3.pdb > %DEBUG_SYMS_FILE%
+C:\MuseScore\breakpad_tools\dump_syms.exe %APPVEYOR_BUILD_FOLDER%\msvc.build_%PLATFORM%\main\RelWithDebInfo\MuseScore3.pdb > %DEBUG_SYMS_FILE%
 @echo off
 
 :: Test MuseScore stability
@@ -117,8 +119,9 @@ type C:\MuseScore\update_win_nightly.xml
 :UPLOAD
 SET SSH_IDENTITY=C:\MuseScore\build\appveyor\resources\osuosl_nighlies_rsa_nopp
 SET PATH=%OLD_PATH%
+REM Remove OpenSSH from PATH, to force the use of msys64 ssh
+SET PATH=%PATH:C:\Windows\System32\OpenSSH\;=%
 IF DEFINED ENCRYPT_SECRET_SSH (
-  chmod 600 %SSH_IDENTITY%
   scp -oStrictHostKeyChecking=no -C -i %SSH_IDENTITY% %ARTIFACT_NAME% musescore-nightlies@ftp-osl.osuosl.org:~/ftp/windows/
   ssh -oStrictHostKeyChecking=no -i %SSH_IDENTITY% musescore-nightlies@ftp-osl.osuosl.org "cd ~/ftp/windows; ls MuseScoreNightly* -t | tail -n +41 | xargs rm -f"
   rem create and upload index.html and RSS


### PR DESCRIPTION
This is another tentative at fixing Windows nightly uploading when using Appveyor MSVC 2019 image.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [N/A] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
