### PR TITLE
fix #303983 : MuseScore takes very long on opening some 2.x scores; w…

### DIFF
--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -853,8 +853,6 @@ Score::FileError MasterScore::loadCompressedMsc(QIODevice* io, bool ignoreVersio
                   }
             }
       XmlReader e(dbuf);
-      QBuffer readBuf(&dbuf);
-      e.setDevice(&readBuf);
       e.setDocName(masterScore()->fileInfo()->completeBaseName());
 
       FileError retval = read1(e, ignoreVersionError);
@@ -912,7 +910,6 @@ Score::FileError MasterScore::loadMsc(QString name, QIODevice* io, bool ignoreVe
             return loadCompressedMsc(io, ignoreVersionError);
       else {
             XmlReader r(io);
-            r.setDevice(io);
             return read1(r, ignoreVersionError);
             }
       }

--- a/libmscore/xml.h
+++ b/libmscore/xml.h
@@ -69,10 +69,6 @@ class LinksIndexer {
 class XmlReader : public QXmlStreamReader {
       QString docName;  // used for error reporting
 
-      // For readahead possibility.
-      // If needed, must be explicitly set by setDevice.
-      QIODevice* _readDevice = nullptr;
-
       // Score read context (for read optimizations):
       Fraction _tick             { Fraction(0, 1) };
       Fraction _tickOffset       { Fraction(0, 1) };
@@ -105,6 +101,8 @@ class XmlReader : public QXmlStreamReader {
 
       void addConnectorInfo(std::unique_ptr<ConnectorInfoReader>);
       void removeConnector(const ConnectorInfoReader*); // Removes the whole ConnectorInfo chain from the connectors list.
+
+      qint64 _offsetLines { 0 };
 
    public:
       XmlReader(QFile* f) : QXmlStreamReader(f), docName(f->fileName()) {}
@@ -148,6 +146,7 @@ class XmlReader : public QXmlStreamReader {
 
       Fraction tick()  const            { return _tick + _tickOffset; }
       Fraction rtick()  const ;
+      Fraction tickOffset() const       { return _tickOffset; }
       void setTick(const Fraction& f);
       void incTick(const Fraction& f);
       void setTickOffset(const Fraction& val) { _tickOffset = val; }
@@ -203,13 +202,13 @@ class XmlReader : public QXmlStreamReader {
 
       void checkTuplets();
       Tid addUserTextStyle(const QString& name);
-      Tid lookupUserTextStyle(const QString& name);
-
-      // Ownership on read device is NOT transferred to XmlReader.
-      void setDevice(QIODevice* dev) { if (!dev->isSequential()) _readDevice = dev; }
-      QIODevice* getDevice() { return _readDevice; }
+      Tid lookupUserTextStyle(const QString& name) const;
 
       QList<std::pair<Element*, QPointF>>& fixOffsets() { return  _fixOffsets; }
+
+      // for reading old files (< 3.01)
+      QMap<int, QList<QPair<LinkedElements*, Location>>>& staffLinkedElements() { return _staffLinkedElements; }
+      void setOffsetLines(qint64 val) { _offsetLines = val; }
       };
 
 //---------------------------------------------------------

--- a/libmscore/xmlreader.cpp
+++ b/libmscore/xmlreader.cpp
@@ -207,9 +207,9 @@ void XmlReader::unknown()
             qDebug("%s ", qPrintable(errorString()));
       if (!docName.isEmpty())
             qDebug("tag in <%s> line %lld col %lld: %s",
-               qPrintable(docName), lineNumber(), columnNumber(), name().toUtf8().data());
+               qPrintable(docName), lineNumber() + _offsetLines, columnNumber(), name().toUtf8().data());
       else
-            qDebug("line %lld col %lld: %s", lineNumber(), columnNumber(), name().toUtf8().data());
+            qDebug("line %lld col %lld: %s", lineNumber() + _offsetLines, columnNumber(), name().toUtf8().data());
       skipCurrentElement();
       }
 
@@ -538,7 +538,7 @@ Tid XmlReader::addUserTextStyle(const QString& name)
 //   lookupUserTextStyle
 //---------------------------------------------------------
 
-Tid XmlReader::lookupUserTextStyle(const QString& name)
+Tid XmlReader::lookupUserTextStyle(const QString& name) const
       {
       for (const auto& i : userTextStyles) {
             if (i.name == name)


### PR DESCRIPTION
…ithout breaking #285434

See https://musescore.org/en/node/303983

This rewrites text property reading for 2.x scores, so that "style" tag can be read before the others.
Refactoring of the helper class was done with the precious help of dmitrio95.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
