### PR TITLE
Fix #303902: Export to SVG with trim via command line results in blank image

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -2957,8 +2957,6 @@ bool MuseScore::saveSvg(Score* score, QIODevice* device, int pageNumber, bool dr
       if (trimMargin >= 0 && score->npages() == 1)
             p.translate(-r.topLeft());
       MScore::pixelRatio = DPI / printer.logicalDpiX();
-      if (trimMargin >= 0)
-             p.translate(-r.topLeft());
 
       if (drawPageBackground)
             p.fillRect(r, Qt::white);


### PR DESCRIPTION
The removed translation moves the elements out of the viewport and repeats an identical translation 2 lines before.

Resolves: https://musescore.org/en/node/303902

This change simply removes what is probably a typo. The typo effectively doubled a translation that should only appear once.

I would like to add a test but unable to find test suite for comparing svg output with musicxml/mscx input. I have tested by hand and confirm the fix works.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made