### PR TITLE
Fix #291688, Fix: #285855

### DIFF
--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -519,7 +519,7 @@ void Excerpt::cloneStaves(Score* oscore, Score* score, const QList<int>& map, QM
                               for (int track : t) {
                                     //Clone KeySig TimeSig and Clefs if voice 1 of source staff is not mapped to a track
                                     Element* oef = oseg->element(srcTrack & ~3);
-                                    if (oef && (oef->isTimeSig() || oef->isKeySig()) && oef->tick().isZero()
+                                    if (oef && (oef->isTimeSig() || oef->isKeySig()) && oseg->rtick().isZero()
                                         && !(trackList.size() == (score->excerpt()->parts().size() * VOICES))) {
                                           Element* ne = oef->linkedClone();
                                           ne->setTrack(track & ~3);

--- a/mtest/libmscore/parts/tst_parts.cpp
+++ b/mtest/libmscore/parts/tst_parts.cpp
@@ -225,6 +225,26 @@ void TestParts::voicesExcerpt()
       Excerpt::createExcerpt(ex);
       QVERIFY(nscore);
 
+      //
+      // create second part
+      //
+      parts.clear();
+      parts.append(score->parts().at(1));
+      nscore = new Score(score);
+
+      trackList.clear();
+      trackList.insert(8, 0);
+
+      ex = new Excerpt(score);
+      ex->setPartScore(nscore);
+      nscore->setExcerpt(ex);
+      score->excerpts().append(ex);
+      ex->setTitle(parts.front()->longName());
+      ex->setParts(parts);
+      ex->setTracks(trackList);
+      Excerpt::createExcerpt(ex);
+      QVERIFY(nscore);
+
 //      nscore->setName(parts.front()->partName());
 
       score->setExcerptsChanged(true);

--- a/mtest/libmscore/parts/voices-ref.mscx
+++ b/mtest/libmscore/parts/voices-ref.mscx
@@ -135,6 +135,8 @@
           <gateTime>100</gateTime>
           </Articulation>
         <Channel>
+          <controller ctrl="0" value="0"/>
+          <controller ctrl="32" value="17"/>
           <program value="57"/>
           <midiPort>0</midiPort>
           <midiChannel>0</midiChannel>
@@ -420,9 +422,14 @@
         </Measure>
       <Measure>
         <voice>
+          <TimeSig>
+            <linkedMain/>
+            <sigN>2</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
           <Rest>
             <durationType>measure</durationType>
-            <duration>4/4</duration>
+            <duration>2/4</duration>
             </Rest>
           </voice>
         <voice>
@@ -435,7 +442,8 @@
                 </Slur>
               <next>
                 <location>
-                  <fractions>3/4</fractions>
+                  <measures>1</measures>
+                  <fractions>1/4</fractions>
                   </location>
                 </next>
               </Spanner>
@@ -454,6 +462,16 @@
               <tpc>11</tpc>
               </Note>
             </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>2/4</duration>
+            </Rest>
+          </voice>
+        <voice>
           <Chord>
             <linkedMain/>
             <durationType>quarter</durationType>
@@ -469,7 +487,8 @@
             <Spanner type="Slur">
               <prev>
                 <location>
-                  <fractions>-3/4</fractions>
+                  <measures>-1</measures>
+                  <fractions>-1/4</fractions>
                   </location>
                 </prev>
               </Spanner>
@@ -480,19 +499,16 @@
               </Note>
             </Chord>
           </voice>
-        <voice>
-          <Rest>
-            <linkedMain/>
-            <durationType>measure</durationType>
-            <duration>4/4</duration>
-            </Rest>
-          </voice>
         </Measure>
       <Measure>
         <voice>
+          <KeySig>
+            <linkedMain/>
+            <accidental>1</accidental>
+            </KeySig>
           <Rest>
             <durationType>measure</durationType>
-            <duration>4/4</duration>
+            <duration>2/4</duration>
             </Rest>
           </voice>
         <voice>
@@ -501,6 +517,9 @@
             <durationType>quarter</durationType>
             <Note>
               <linkedMain/>
+              <Accidental>
+                <subtype>accidentalFlat</subtype>
+                </Accidental>
               <Spanner type="Tie">
                 <Tie>
                   <linkedMain/>
@@ -531,6 +550,25 @@
               <tpc>11</tpc>
               </Note>
             </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <KeySig>
+            <linkedMain/>
+            <accidental>-3</accidental>
+            </KeySig>
+          <TimeSig>
+            <linkedMain/>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        <voice>
           <Chord>
             <linkedMain/>
             <durationType>quarter</durationType>
@@ -542,14 +580,11 @@
             </Chord>
           <Rest>
             <linkedMain/>
-            <durationType>quarter</durationType>
+            <durationType>half</durationType>
             </Rest>
-          </voice>
-        <voice>
           <Rest>
             <linkedMain/>
-            <durationType>measure</durationType>
-            <duration>4/4</duration>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
@@ -615,15 +650,51 @@
         </Measure>
       <Measure>
         <voice>
+          <TimeSig>
+            <linkedMain/>
+            <sigN>2</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
           <Rest>
             <linkedMain/>
             <durationType>measure</durationType>
-            <duration>4/4</duration>
+            <duration>2/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
         <voice>
+          <Rest>
+            <linkedMain/>
+            <durationType>measure</durationType>
+            <duration>2/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <KeySig>
+            <linkedMain/>
+            <accidental>1</accidental>
+            </KeySig>
+          <Rest>
+            <linkedMain/>
+            <durationType>measure</durationType>
+            <duration>2/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <KeySig>
+            <linkedMain/>
+            <accidental>-3</accidental>
+            </KeySig>
+          <TimeSig>
+            <linkedMain/>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
           <Rest>
             <linkedMain/>
             <durationType>measure</durationType>
@@ -641,6 +712,7 @@
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <linkedMain/>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -684,6 +756,7 @@
       <Measure>
         <voice>
           <Rest>
+            <linkedMain/>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -740,10 +813,24 @@
         </Measure>
       <Measure>
         <voice>
-          <Rest>
-            <durationType>measure</durationType>
-            <duration>4/4</duration>
-            </Rest>
+          <Chord>
+            <linkedMain/>
+            <durationType>half</durationType>
+            <Note>
+              <linkedMain/>
+              <pitch>55</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <linkedMain/>
+            <durationType>half</durationType>
+            <Note>
+              <linkedMain/>
+              <pitch>55</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
           </voice>
         <voice/>
         <voice/>
@@ -788,10 +875,20 @@
         </Measure>
       <Measure>
         <voice>
-          <Rest>
-            <durationType>measure</durationType>
-            <duration>4/4</duration>
-            </Rest>
+          <TimeSig>
+            <linkedMain/>
+            <sigN>2</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <linkedMain/>
+            <durationType>half</durationType>
+            <Note>
+              <linkedMain/>
+              <pitch>59</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
           </voice>
         <voice/>
         <voice/>
@@ -805,7 +902,8 @@
                 </Slur>
               <next>
                 <location>
-                  <fractions>3/4</fractions>
+                  <measures>1</measures>
+                  <fractions>1/4</fractions>
                   </location>
                 </next>
               </Spanner>
@@ -824,6 +922,19 @@
               <tpc>15</tpc>
               </Note>
             </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <linkedMain/>
+            <durationType>measure</durationType>
+            <duration>2/4</duration>
+            </Rest>
+          </voice>
+        <voice/>
+        <voice/>
+        <voice>
           <Chord>
             <linkedMain/>
             <durationType>quarter</durationType>
@@ -839,7 +950,8 @@
             <Spanner type="Slur">
               <prev>
                 <location>
-                  <fractions>-3/4</fractions>
+                  <measures>-1</measures>
+                  <fractions>-1/4</fractions>
                   </location>
                 </prev>
               </Spanner>
@@ -853,9 +965,14 @@
         </Measure>
       <Measure>
         <voice>
+          <KeySig>
+            <linkedMain/>
+            <accidental>1</accidental>
+            </KeySig>
           <Rest>
+            <linkedMain/>
             <durationType>measure</durationType>
-            <duration>4/4</duration>
+            <duration>2/4</duration>
             </Rest>
           </voice>
         <voice/>
@@ -896,6 +1013,28 @@
               <tpc>15</tpc>
               </Note>
             </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <KeySig>
+            <linkedMain/>
+            <accidental>-3</accidental>
+            </KeySig>
+          <TimeSig>
+            <linkedMain/>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <linkedMain/>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        <voice/>
+        <voice/>
+        <voice>
           <Chord>
             <linkedMain/>
             <durationType>quarter</durationType>
@@ -905,6 +1044,10 @@
               <tpc>15</tpc>
               </Note>
             </Chord>
+          <Rest>
+            <linkedMain/>
+            <durationType>half</durationType>
+            </Rest>
           <Rest>
             <linkedMain/>
             <durationType>quarter</durationType>
@@ -1418,6 +1561,12 @@
           </Measure>
         <Measure>
           <voice>
+            <TimeSig>
+              <linked>
+                </linked>
+              <sigN>2</sigN>
+              <sigD>4</sigD>
+              </TimeSig>
             <Chord>
               <linked>
                 <location>
@@ -1435,7 +1584,8 @@
                   </Slur>
                 <next>
                   <location>
-                    <fractions>3/4</fractions>
+                    <measures>1</measures>
+                    <fractions>1/4</fractions>
                     </location>
                   </next>
                 </Spanner>
@@ -1466,6 +1616,10 @@
                 <tpc>11</tpc>
                 </Note>
               </Chord>
+            </voice>
+          </Measure>
+        <Measure>
+          <voice>
             <Chord>
               <linked>
                 <location>
@@ -1493,7 +1647,8 @@
               <Spanner type="Slur">
                 <prev>
                   <location>
-                    <fractions>-3/4</fractions>
+                    <measures>-1</measures>
+                    <fractions>-1/4</fractions>
                     </location>
                   </prev>
                 </Spanner>
@@ -1508,20 +1663,14 @@
                 </Note>
               </Chord>
             </voice>
-          <voice>
-            <Rest>
-              <linked>
-                <location>
-                  <voices>1</voices>
-                  </location>
-                </linked>
-              <durationType>measure</durationType>
-              <duration>4/4</duration>
-              </Rest>
-            </voice>
           </Measure>
         <Measure>
           <voice>
+            <KeySig>
+              <linked>
+                </linked>
+              <accidental>1</accidental>
+              </KeySig>
             <Chord>
               <linked>
                 <location>
@@ -1535,6 +1684,9 @@
                     <voices>1</voices>
                     </location>
                   </linked>
+                <Accidental>
+                  <subtype>accidentalFlat</subtype>
+                  </Accidental>
                 <Spanner type="Tie">
                   <Tie>
                     <linked>
@@ -1577,6 +1729,21 @@
                 <tpc>11</tpc>
                 </Note>
               </Chord>
+            </voice>
+          </Measure>
+        <Measure>
+          <voice>
+            <KeySig>
+              <linked>
+                </linked>
+              <accidental>-3</accidental>
+              </KeySig>
+            <TimeSig>
+              <linked>
+                </linked>
+              <sigN>4</sigN>
+              <sigD>4</sigD>
+              </TimeSig>
             <Chord>
               <linked>
                 <location>
@@ -1600,18 +1767,15 @@
                   <voices>1</voices>
                   </location>
                 </linked>
-              <durationType>quarter</durationType>
+              <durationType>half</durationType>
               </Rest>
-            </voice>
-          <voice>
             <Rest>
               <linked>
                 <location>
                   <voices>1</voices>
                   </location>
                 </linked>
-              <durationType>measure</durationType>
-              <duration>4/4</duration>
+              <durationType>quarter</durationType>
               </Rest>
             </voice>
           </Measure>
@@ -1687,16 +1851,58 @@
           </Measure>
         <Measure>
           <voice>
+            <TimeSig>
+              <linked>
+                </linked>
+              <sigN>2</sigN>
+              <sigD>4</sigD>
+              </TimeSig>
             <Rest>
               <linked>
                 </linked>
               <durationType>measure</durationType>
-              <duration>4/4</duration>
+              <duration>2/4</duration>
               </Rest>
             </voice>
           </Measure>
         <Measure>
           <voice>
+            <Rest>
+              <linked>
+                </linked>
+              <durationType>measure</durationType>
+              <duration>2/4</duration>
+              </Rest>
+            </voice>
+          </Measure>
+        <Measure>
+          <voice>
+            <KeySig>
+              <linked>
+                </linked>
+              <accidental>1</accidental>
+              </KeySig>
+            <Rest>
+              <linked>
+                </linked>
+              <durationType>measure</durationType>
+              <duration>2/4</duration>
+              </Rest>
+            </voice>
+          </Measure>
+        <Measure>
+          <voice>
+            <KeySig>
+              <linked>
+                </linked>
+              <accidental>-3</accidental>
+              </KeySig>
+            <TimeSig>
+              <linked>
+                </linked>
+              <sigN>4</sigN>
+              <sigD>4</sigD>
+              </TimeSig>
             <Rest>
               <linked>
                 </linked>
@@ -1771,6 +1977,8 @@
             <gateTime>100</gateTime>
             </Articulation>
           <Channel>
+            <controller ctrl="0" value="0"/>
+            <controller ctrl="32" value="17"/>
             <program value="57"/>
             </Channel>
           </Instrument>
@@ -2029,6 +2237,12 @@
           </Measure>
         <Measure>
           <voice>
+            <TimeSig>
+              <linked>
+                </linked>
+              <sigN>2</sigN>
+              <sigD>4</sigD>
+              </TimeSig>
             <Chord>
               <linked>
                 <location>
@@ -2046,7 +2260,8 @@
                   </Slur>
                 <next>
                   <location>
-                    <fractions>3/4</fractions>
+                    <measures>1</measures>
+                    <fractions>1/4</fractions>
                     </location>
                   </next>
                 </Spanner>
@@ -2077,6 +2292,10 @@
                 <tpc>15</tpc>
                 </Note>
               </Chord>
+            </voice>
+          </Measure>
+        <Measure>
+          <voice>
             <Chord>
               <linked>
                 <location>
@@ -2104,7 +2323,8 @@
               <Spanner type="Slur">
                 <prev>
                   <location>
-                    <fractions>-3/4</fractions>
+                    <measures>-1</measures>
+                    <fractions>-1/4</fractions>
                     </location>
                   </prev>
                 </Spanner>
@@ -2122,6 +2342,11 @@
           </Measure>
         <Measure>
           <voice>
+            <KeySig>
+              <linked>
+                </linked>
+              <accidental>1</accidental>
+              </KeySig>
             <Chord>
               <linked>
                 <location>
@@ -2177,6 +2402,21 @@
                 <tpc>15</tpc>
                 </Note>
               </Chord>
+            </voice>
+          </Measure>
+        <Measure>
+          <voice>
+            <KeySig>
+              <linked>
+                </linked>
+              <accidental>-3</accidental>
+              </KeySig>
+            <TimeSig>
+              <linked>
+                </linked>
+              <sigN>4</sigN>
+              <sigD>4</sigD>
+              </TimeSig>
             <Chord>
               <linked>
                 <location>
@@ -2200,7 +2440,244 @@
                   <voices>3</voices>
                   </location>
                 </linked>
+              <durationType>half</durationType>
+              </Rest>
+            <Rest>
+              <linked>
+                <location>
+                  <voices>3</voices>
+                  </location>
+                </linked>
               <durationType>quarter</durationType>
+              </Rest>
+            </voice>
+          </Measure>
+        </Staff>
+      <name>Trombone</name>
+      </Score>
+    <Score>
+      <Tracklist sTrack="8" dstTrack="0"/>
+      <LayerTag id="0" tag="default"></LayerTag>
+      <currentLayer>0</currentLayer>
+      <Division>480</Division>
+      <Style>
+        <lastSystemFillLimit>0</lastSystemFillLimit>
+        <createMultiMeasureRests>1</createMultiMeasureRests>
+        <Spatium>1.76389</Spatium>
+        </Style>
+      <showInvisible>1</showInvisible>
+      <showUnprintable>1</showUnprintable>
+      <showFrames>1</showFrames>
+      <showMargins>0</showMargins>
+      <metaTag name="partName">Trombone</metaTag>
+      <Part>
+        <Staff id="1">
+          <linkedTo>3</linkedTo>
+          <StaffType group="pitched">
+            <name>stdNormal</name>
+            </StaffType>
+          <defaultClef>F</defaultClef>
+          </Staff>
+        <trackName>Trombone</trackName>
+        <Instrument>
+          <longName>Trombone</longName>
+          <shortName>Tbn.</shortName>
+          <trackName>Trombone</trackName>
+          <minPitchP>35</minPitchP>
+          <maxPitchP>74</maxPitchP>
+          <minPitchA>35</minPitchA>
+          <maxPitchA>70</maxPitchA>
+          <instrumentId>brass.trombone</instrumentId>
+          <clef>F</clef>
+          <Articulation>
+            <velocity>100</velocity>
+            <gateTime>100</gateTime>
+            </Articulation>
+          <Articulation name="staccatissimo">
+            <velocity>100</velocity>
+            <gateTime>33</gateTime>
+            </Articulation>
+          <Articulation name="staccato">
+            <velocity>100</velocity>
+            <gateTime>50</gateTime>
+            </Articulation>
+          <Articulation name="portato">
+            <velocity>100</velocity>
+            <gateTime>67</gateTime>
+            </Articulation>
+          <Articulation name="tenuto">
+            <velocity>100</velocity>
+            <gateTime>100</gateTime>
+            </Articulation>
+          <Articulation name="marcato">
+            <velocity>120</velocity>
+            <gateTime>67</gateTime>
+            </Articulation>
+          <Articulation name="sforzato">
+            <velocity>120</velocity>
+            <gateTime>100</gateTime>
+            </Articulation>
+          <Channel>
+            <controller ctrl="0" value="0"/>
+            <controller ctrl="32" value="17"/>
+            <program value="57"/>
+            </Channel>
+          </Instrument>
+        </Part>
+      <Staff id="1">
+        <VBox>
+          <height>10</height>
+          <linked>
+            <location>
+              <staves>-2</staves>
+              </location>
+            </linked>
+          <Text>
+            <linked>
+              <location>
+                <staves>-2</staves>
+                </location>
+              </linked>
+            <style>Title</style>
+            <text>voices</text>
+            </Text>
+          <Text>
+            <style>Instrument Name (Part)</style>
+            <text>Trombone</text>
+            </Text>
+          </VBox>
+        <Measure>
+          <voice>
+            <TimeSig>
+              <linked>
+                </linked>
+              <sigN>4</sigN>
+              <sigD>4</sigD>
+              </TimeSig>
+            <Rest>
+              <linked>
+                </linked>
+              <durationType>measure</durationType>
+              <duration>4/4</duration>
+              </Rest>
+            </voice>
+          </Measure>
+        <Measure len="8/4">
+          <multiMeasureRest>2</multiMeasureRest>
+          <voice>
+            <TimeSig>
+              <linked>
+                <indexDiff>-2</indexDiff>
+                </linked>
+              <sigN>4</sigN>
+              <sigD>4</sigD>
+              </TimeSig>
+            <Rest>
+              <durationType>measure</durationType>
+              <duration>8/4</duration>
+              </Rest>
+            </voice>
+          </Measure>
+        <Measure>
+          <voice>
+            <Rest>
+              <linked>
+                </linked>
+              <durationType>measure</durationType>
+              <duration>4/4</duration>
+              </Rest>
+            </voice>
+          </Measure>
+        <Measure>
+          <voice>
+            <Chord>
+              <linked>
+                </linked>
+              <durationType>half</durationType>
+              <Note>
+                <linked>
+                  </linked>
+                <pitch>55</pitch>
+                <tpc>15</tpc>
+                </Note>
+              </Chord>
+            <Chord>
+              <linked>
+                </linked>
+              <durationType>half</durationType>
+              <Note>
+                <linked>
+                  </linked>
+                <pitch>55</pitch>
+                <tpc>15</tpc>
+                </Note>
+              </Chord>
+            </voice>
+          </Measure>
+        <Measure>
+          <voice>
+            <TimeSig>
+              <linked>
+                </linked>
+              <sigN>2</sigN>
+              <sigD>4</sigD>
+              </TimeSig>
+            <Chord>
+              <linked>
+                </linked>
+              <durationType>half</durationType>
+              <Note>
+                <linked>
+                  </linked>
+                <pitch>59</pitch>
+                <tpc>19</tpc>
+                </Note>
+              </Chord>
+            </voice>
+          </Measure>
+        <Measure>
+          <voice>
+            <Rest>
+              <linked>
+                </linked>
+              <durationType>measure</durationType>
+              <duration>2/4</duration>
+              </Rest>
+            </voice>
+          </Measure>
+        <Measure>
+          <voice>
+            <KeySig>
+              <linked>
+                </linked>
+              <accidental>1</accidental>
+              </KeySig>
+            <Rest>
+              <linked>
+                </linked>
+              <durationType>measure</durationType>
+              <duration>2/4</duration>
+              </Rest>
+            </voice>
+          </Measure>
+        <Measure>
+          <voice>
+            <KeySig>
+              <linked>
+                </linked>
+              <accidental>-3</accidental>
+              </KeySig>
+            <TimeSig>
+              <linked>
+                </linked>
+              <sigN>4</sigN>
+              <sigD>4</sigD>
+              </TimeSig>
+            <Rest>
+              <linked>
+                </linked>
+              <durationType>measure</durationType>
+              <duration>4/4</duration>
               </Rest>
             </voice>
           </Measure>

--- a/mtest/libmscore/parts/voices.mscx
+++ b/mtest/libmscore/parts/voices.mscx
@@ -81,6 +81,11 @@
           <midiPort>0</midiPort>
           <midiChannel>2</midiChannel>
           </Channel>
+        <Channel name="Chord symbols">
+          <program value="0"/>
+          <midiPort>0</midiPort>
+          <midiChannel>1</midiChannel>
+          </Channel>
         </Instrument>
       </Part>
     <Part>
@@ -130,6 +135,8 @@
           <gateTime>100</gateTime>
           </Articulation>
         <Channel>
+          <controller ctrl="0" value="0"/>
+          <controller ctrl="32" value="17"/>
           <program value="57"/>
           <midiPort>0</midiPort>
           <midiChannel>0</midiChannel>
@@ -268,7 +275,7 @@
             <durationType>quarter</durationType>
             <Note>
               <Fingering>
-                <pos x="1.05809" y="-4.67501"/>
+                <offset x="1.05809" y="-4.67501"/>
                 <text>2</text>
                 </Fingering>
               <pitch>63</pitch>
@@ -278,7 +285,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Articulation>
-              <subtype>articAccentAbove</subtype>
+              <subtype>articAccentBelow</subtype>
               </Articulation>
             <Note>
               <pitch>63</pitch>
@@ -298,7 +305,7 @@
           <Harmony>
             <root>11</root>
             <name>7</name>
-            <pos x="0" y="-3.22581"/>
+            <offset x="0" y="-3.22581"/>
             </Harmony>
           <Rest>
             <durationType>measure</durationType>
@@ -368,9 +375,13 @@
         </Measure>
       <Measure>
         <voice>
+          <TimeSig>
+            <sigN>2</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
           <Rest>
             <durationType>measure</durationType>
-            <duration>4/4</duration>
+            <duration>2/4</duration>
             </Rest>
           </voice>
         <voice>
@@ -381,7 +392,8 @@
                 </Slur>
               <next>
                 <location>
-                  <fractions>3/4</fractions>
+                  <measures>1</measures>
+                  <fractions>1/4</fractions>
                   </location>
                 </next>
               </Spanner>
@@ -397,6 +409,16 @@
               <tpc>11</tpc>
               </Note>
             </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>2/4</duration>
+            </Rest>
+          </voice>
+        <voice>
           <Chord>
             <durationType>quarter</durationType>
             <Note>
@@ -409,7 +431,8 @@
             <Spanner type="Slur">
               <prev>
                 <location>
-                  <fractions>-3/4</fractions>
+                  <measures>-1</measures>
+                  <fractions>-1/4</fractions>
                   </location>
                 </prev>
               </Spanner>
@@ -419,24 +442,24 @@
               </Note>
             </Chord>
           </voice>
-        <voice>
-          <Rest>
-            <durationType>measure</durationType>
-            <duration>4/4</duration>
-            </Rest>
-          </voice>
         </Measure>
       <Measure>
         <voice>
+          <KeySig>
+            <accidental>1</accidental>
+            </KeySig>
           <Rest>
             <durationType>measure</durationType>
-            <duration>4/4</duration>
+            <duration>2/4</duration>
             </Rest>
           </voice>
         <voice>
           <Chord>
             <durationType>quarter</durationType>
             <Note>
+              <Accidental>
+                <subtype>accidentalFlat</subtype>
+                </Accidental>
               <Spanner type="Tie">
                 <Tie>
                   </Tie>
@@ -464,6 +487,23 @@
               <tpc>11</tpc>
               </Note>
             </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <KeySig>
+            <accidental>-3</accidental>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        <voice>
           <Chord>
             <durationType>quarter</durationType>
             <Note>
@@ -472,13 +512,10 @@
               </Note>
             </Chord>
           <Rest>
-            <durationType>quarter</durationType>
+            <durationType>half</durationType>
             </Rest>
-          </voice>
-        <voice>
           <Rest>
-            <durationType>measure</durationType>
-            <duration>4/4</duration>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
@@ -534,14 +571,44 @@
         </Measure>
       <Measure>
         <voice>
+          <TimeSig>
+            <sigN>2</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
           <Rest>
             <durationType>measure</durationType>
-            <duration>4/4</duration>
+            <duration>2/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
         <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>2/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <KeySig>
+            <accidental>1</accidental>
+            </KeySig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>2/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <KeySig>
+            <accidental>-3</accidental>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
           <Rest>
             <durationType>measure</durationType>
             <duration>4/4</duration>
@@ -618,7 +685,7 @@
             <durationType>quarter</durationType>
             <Note>
               <Fingering>
-                <pos x="1.05809" y="-4.67501"/>
+                <offset x="1.05809" y="-4.67501"/>
                 <text>2</text>
                 </Fingering>
               <pitch>43</pitch>
@@ -628,7 +695,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Articulation>
-              <subtype>articAccentAbove</subtype>
+              <subtype>articAccentBelow</subtype>
               </Articulation>
             <Note>
               <pitch>43</pitch>
@@ -639,10 +706,20 @@
         </Measure>
       <Measure>
         <voice>
-          <Rest>
-            <durationType>measure</durationType>
-            <duration>4/4</duration>
-            </Rest>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <pitch>55</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <pitch>55</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
           </voice>
         <voice/>
         <voice/>
@@ -679,10 +756,17 @@
         </Measure>
       <Measure>
         <voice>
-          <Rest>
-            <durationType>measure</durationType>
-            <duration>4/4</duration>
-            </Rest>
+          <TimeSig>
+            <sigN>2</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <pitch>59</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
           </voice>
         <voice/>
         <voice/>
@@ -694,7 +778,8 @@
                 </Slur>
               <next>
                 <location>
-                  <fractions>3/4</fractions>
+                  <measures>1</measures>
+                  <fractions>1/4</fractions>
                   </location>
                 </next>
               </Spanner>
@@ -710,6 +795,18 @@
               <tpc>15</tpc>
               </Note>
             </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>2/4</duration>
+            </Rest>
+          </voice>
+        <voice/>
+        <voice/>
+        <voice>
           <Chord>
             <durationType>quarter</durationType>
             <Note>
@@ -722,7 +819,8 @@
             <Spanner type="Slur">
               <prev>
                 <location>
-                  <fractions>-3/4</fractions>
+                  <measures>-1</measures>
+                  <fractions>-1/4</fractions>
                   </location>
                 </prev>
               </Spanner>
@@ -735,9 +833,12 @@
         </Measure>
       <Measure>
         <voice>
+          <KeySig>
+            <accidental>1</accidental>
+            </KeySig>
           <Rest>
             <durationType>measure</durationType>
-            <duration>4/4</duration>
+            <duration>2/4</duration>
             </Rest>
           </voice>
         <voice/>
@@ -773,6 +874,25 @@
               <tpc>15</tpc>
               </Note>
             </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <KeySig>
+            <accidental>-3</accidental>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        <voice/>
+        <voice/>
+        <voice>
           <Chord>
             <durationType>quarter</durationType>
             <Note>
@@ -780,6 +900,9 @@
               <tpc>15</tpc>
               </Note>
             </Chord>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
           <Rest>
             <durationType>quarter</durationType>
             </Rest>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/291688
Resolves: https://musescore.org/en/node/285855

In <code>Excerpt::cloneStaves()</code> clones TimeSig's and KeySig's if source staff 1 is not mapped to a track. To prevent copying of precaution segments only TimeSig's and KeySig's at the beginning of the measure are copied. This is done by getting the <code>tick</code> and clone the element when it is at the start of the measure only.
However, the test was using <code>element->tick()</code> instead of <code>segment->rtick()</code>.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
