### PR TITLE
Fix #304238: Prevent crash when using 'Image capture'

### DIFF
--- a/mscore/dragelement.cpp
+++ b/mscore/dragelement.cpp
@@ -98,7 +98,8 @@ void ScoreView::doDragElement(QMouseEvent* ev)
 
       for (Element* e : sel.elements()) {
             QVector<QLineF> elAnchorLines = e->dragAnchorLines();
-            const QPointF pageOffset(e->findAncestor(ElementType::PAGE)->pos());
+            Element* const page = e->findAncestor(ElementType::PAGE);
+            const QPointF pageOffset((page ? page : e)->pos());
 
             if (!elAnchorLines.isEmpty()) {
                   for (QLineF& l : elAnchorLines)

--- a/mscore/editelement.cpp
+++ b/mscore/editelement.cpp
@@ -60,8 +60,8 @@ void ScoreView::updateGrips()
 
             // updateGrips returns grips in page coordinates,
             // transform to view coordinates:
-
-            const QPointF pageOffset(editData.element->findAncestor(ElementType::PAGE)->pos());
+            Element* const page = editData.element->findAncestor(ElementType::PAGE);
+            const QPointF pageOffset((page ? page : editData.element)->pos());
 
             for (QRectF& grip : editData.grip) {
                   grip.translate(pageOffset);


### PR DESCRIPTION
Solves https://musescore.org/en/node/304238

#5980 might be the better fix