### PR TITLE
Fix #304238: Crash when using 'Image capture'

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1414,21 +1414,21 @@ bool Element::isPrintable() const
       }
 
 //---------------------------------------------------------
-//   findAncestor
+//   findOldestAncestor
 //---------------------------------------------------------
 
-Element* Element::findAncestor(ElementType t)
+Element* Element::findOldestAncestor()
       {
       Element* e = this;
-      while (e && e->type() != t)
+      while (e->parent())
             e = e->parent();
       return e;
       }
 
-const Element* Element::findAncestor(ElementType t) const
+const Element* Element::findOldestAncestor() const
       {
       const Element* e = this;
-      while (e && e->type() != t)
+      while (e->parent())
             e = e->parent();
       return e;
       }

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -198,8 +198,8 @@ class Element : public ScoreElement {
       Element* parent() const                 { return _parent;     }
       void setParent(Element* e)              { _parent = e;        }
 
-      Element* findAncestor(ElementType t);
-      const Element* findAncestor(ElementType t) const;
+      Element* findOldestAncestor();
+      const Element* findOldestAncestor() const;
 
       Measure* findMeasure();
       const Measure* findMeasure() const;

--- a/mscore/dragelement.cpp
+++ b/mscore/dragelement.cpp
@@ -98,7 +98,7 @@ void ScoreView::doDragElement(QMouseEvent* ev)
 
       for (Element* e : sel.elements()) {
             QVector<QLineF> elAnchorLines = e->dragAnchorLines();
-            const QPointF pageOffset(e->findAncestor(ElementType::PAGE)->pos());
+            const QPointF pageOffset(e->findOldestAncestor()->pos());
 
             if (!elAnchorLines.isEmpty()) {
                   for (QLineF& l : elAnchorLines)

--- a/mscore/editelement.cpp
+++ b/mscore/editelement.cpp
@@ -61,7 +61,7 @@ void ScoreView::updateGrips()
             // updateGrips returns grips in page coordinates,
             // transform to view coordinates:
 
-            const QPointF pageOffset(editData.element->findAncestor(ElementType::PAGE)->pos());
+            const QPointF pageOffset(editData.element->findOldestAncestor()->pos());
 
             for (QRectF& grip : editData.grip) {
                   grip.translate(pageOffset);


### PR DESCRIPTION
Resolves: [#304238](https://musescore.org/en/node/304238)

Fixed two crashes that occurred while using the “image capture” feature: the first immediately after the user activated the feature, and the second when the user tried to drag the image capture region with the mouse.

These crashes were caused by an incorrect assumption that any element with drag handles is always part of the score and is thus part of the page hierarchy. This is not true for image capture regions, which float over the score and are never part of the page.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made