### PR TITLE
Disable sending all events to telemetry, but the ones responsible for…

### DIFF
--- a/mscore/globals.h
+++ b/mscore/globals.h
@@ -34,6 +34,16 @@ extern int trimMargin;
 extern bool noWebView;
 extern bool ignoreWarnings;
 
+enum TelemetryDataCollectionType : unsigned char {
+      COLLECT_NO_DATA = 0,
+      COLLECT_CRASH_FREE_DATA = 1,
+      COLLECT_INSPECTOR_DATA = 1 << 1,
+      COLLECT_SHORTCUT_AND_MENU_DATA = 1 << 2,
+      COLLECT_ALL_DATA = COLLECT_CRASH_FREE_DATA & COLLECT_INSPECTOR_DATA & COLLECT_SHORTCUT_AND_MENU_DATA
+};
+
+constexpr TelemetryDataCollectionType enabledTelemetryDataTypes = TelemetryDataCollectionType::COLLECT_CRASH_FREE_DATA;
+
 //---------------------------------------------------------
 // MsWidget
 // used to assign actions (shortcuts) to the appropriate

--- a/mscore/inspector/inspectorBase.cpp
+++ b/mscore/inspector/inspectorBase.cpp
@@ -700,31 +700,34 @@ bool InspectorScrollPreventer::eventFilter(QObject* watched, QEvent* event)
 
 void InspectorEventObserver::event(EventType evtType, const InspectorItem& ii, const Element* e)
       {
-#ifdef BUILD_TELEMETRY_MODULE
-      QString evtCategory;
-      switch (evtType) {
-            case EventType::PropertyChange:
-                  evtCategory = QStringLiteral("inspector-property-change");
-                  break;
-            case EventType::PropertyReset:
-                  evtCategory = QStringLiteral("inspector-property-reset");
-                  break;
-            case EventType::PropertySetStyle:
-                  evtCategory = QStringLiteral("inspector-property-set-style");
-                  break;
-            }
+#ifndef TELEMETRY_DISABLED
+      //if inspector data IS the enabled telemetry data
+      if (Ms::enabledTelemetryDataTypes & Ms::TelemetryDataCollectionType::COLLECT_INSPECTOR_DATA) {
+            QString evtCategory;
+            switch (evtType) {
+                  case EventType::PropertyChange:
+                        evtCategory = QStringLiteral("inspector-property-change");
+                        break;
+                  case EventType::PropertyReset:
+                        evtCategory = QStringLiteral("inspector-property-reset");
+                        break;
+                  case EventType::PropertySetStyle:
+                        evtCategory = QStringLiteral("inspector-property-set-style");
+                        break;
+                  }
 
-      const QObject* w = ii.w;
-      const QObject* p = w->parent();
-      while (p && !qobject_cast<const InspectorBase*>(p)) {
-            w = p;
-            p = p->parent();
-            }
-      const QString inspectorName = w->objectName();
+            const QObject* w = ii.w;
+            const QObject* p = w->parent();
+            while (p && !qobject_cast<const InspectorBase*>(p)) {
+                  w = p;
+                  p = p->parent();
+                  }
+            const QString inspectorName = w->objectName();
 
-      const QString evtAction = QStringLiteral("%1/%2").arg(inspectorName).arg(propertyName(ii.t));
-      const QString evtLabel = e ? e->name() : "null";
-      TelemetryManager::telemetryService()->sendEvent(evtCategory, evtAction, evtLabel);
+            const QString evtAction = QStringLiteral("%1/%2").arg(inspectorName).arg(propertyName(ii.t));
+            const QString evtLabel = e ? e->name() : "null";
+            TelemetryManager::telemetryService()->sendEvent(evtCategory, evtAction, evtLabel);
+            }
 #else
       Q_UNUSED(evtType);
       Q_UNUSED(ii);

--- a/mscore/sessionstatusobserver.cpp
+++ b/mscore/sessionstatusobserver.cpp
@@ -25,25 +25,28 @@ namespace Ms {
 
 void SessionStatusObserver::prevSessionStatus(bool sessionFileFound, const QString& sessionFullVersion, bool clean)
       {
-#ifdef BUILD_TELEMETRY_MODULE
-      QString status;
-      QString label;
-      if (mscoreFirstStart)
-            status = QStringLiteral("first-start");
-      else if (!sessionFileFound)
-            status = QStringLiteral("session-file-not-found");
-      else {
-            const bool versionChanged = MuseScore::fullVersion() != sessionFullVersion;
-            if (versionChanged) {
-                  status = QStringLiteral("version-changed");
-                  label = sessionFullVersion;
+#ifndef TELEMETRY_DISABLED
+      //if session status data IS the enabled telemetry data
+      if (Ms::enabledTelemetryDataTypes & Ms::TelemetryDataCollectionType::COLLECT_CRASH_FREE_DATA) {
+            QString status;
+            QString label;
+            if (mscoreFirstStart)
+                  status = QStringLiteral("first-start");
+            else if (!sessionFileFound)
+                  status = QStringLiteral("session-file-not-found");
+            else {
+                  const bool versionChanged = MuseScore::fullVersion() != sessionFullVersion;
+                  if (versionChanged) {
+                        status = QStringLiteral("version-changed");
+                        label = sessionFullVersion;
+                        }
+                  else if (clean)
+                        status = QStringLiteral("clean");
+                  else
+                        status = QStringLiteral("dirty");
                   }
-            else if (clean)
-                  status = QStringLiteral("clean");
-            else
-                  status = QStringLiteral("dirty");
-            }
-      TelemetryManager::telemetryService()->sendEvent("prev-session-status", status, label);
+          TelemetryManager::telemetryService()->sendEvent("prev-session-status", status, label);
+          }
 #else
       Q_UNUSED(sessionFileFound);
       Q_UNUSED(sessionFullVersion);


### PR DESCRIPTION
… Crash Free ratio

Resolves: exceeded number of events Google Analytics can track for us for free. More data costs about $200.000 (sorry, Google).

We decided to leave only the events that indicates Crash Free ratio and drop all other events for now.

I decided to commit the changes to indicate that the solution is permanent for now and cannot be undone using a switch/variable/define, and I don't like `#if 0`, sorry :)

`eventFilter()` should stay in place. Without that, GA doesn't receive any events.