### PR TITLE
fix #101991 Ignore shortcuts in menus

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5895,6 +5895,12 @@ void MuseScore::cmd(QAction* a)
                tr("Command %1 not valid in current state").arg(cmdn));
             return;
             }
+      if (qApp->focusWidget()
+         && (!isAncestorOf(qApp->focusWidget()) || menuBar()->isAncestorOf(qApp->focusWidget()))
+         ) {
+            qDebug("MuseScore::cmd(): not on main window <%s>", qPrintable(cmdn));
+            return;
+            }
       if (cmdn == "toggle-palette") {
             showPalette(a->isChecked());
             if (a->isChecked()) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/101991

Slightly better fix than originally attempted in PR #5890. This time editing is terminated if the main window does not have focus, which means that it is safe to use toolbar buttons that take focus away from the score, such as the buttons for Voices 1 to 4.

As with PR #5890, these changes do not allow letter keys to open menu items. That would require substantial changes to the shortcut system as discussed in PR #5890.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
