### PR TITLE
Fix #304333: Using Edit > Preferences causes crash when no score is open

### DIFF
--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -1757,6 +1757,9 @@ void Timeline::changeSelection(SelState)
 
 void Timeline::drawSelection()
       {
+      if (!_score)
+            return;
+
       _selectionPath = QPainterPath();
       _selectionPath.setFillRule(Qt::WindingFill);
 
@@ -2882,11 +2885,10 @@ const TimelineTheme& Timeline::activeTheme() const
 
 void Timeline::updateTimelineTheme()
       {
-      scene()->setBackgroundBrush(QBrush(activeTheme().backgroundColor));
-      updateView();
+      const QBrush backgroundBrush = QBrush(activeTheme().backgroundColor);
+      scene()->setBackgroundBrush(backgroundBrush);
+      _rowNames->scene()->setBackgroundBrush(backgroundBrush);
       updateGrid();
-      drawSelection();
-      // does not change the bottom left box, restart for changes to apply fully :^)
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/304333.

It is unnecessary for `Timeline::updateTimelineTheme()` to call `updateView()`
and `drawSelection()` since it calls `updateGrid()` which already calls both
of these methods. However, `Timeline::updateTimelineTheme()` does need to set
the background brush for the `_rownames` object in order to ensure that the
new theme applies to the whole timeline.