### PR TITLE
fix #301561: Plugin API: restore pagenumber and pagePos properties from MuseScore 2.X

### DIFF
--- a/mscore/plugin/api/elements.cpp
+++ b/mscore/plugin/api/elements.cpp
@@ -220,6 +220,15 @@ void Chord::addInternal(Ms::Chord* chord, Ms::Element* s)
       }
 
 //---------------------------------------------------------
+//   Page::pagenumber
+//---------------------------------------------------------
+
+int Page::pagenumber() const
+      {
+      return page()->no();
+      }
+
+//---------------------------------------------------------
 //   Chord::remove
 //---------------------------------------------------------
 
@@ -259,6 +268,8 @@ Element* wrap(Ms::Element* e, Ownership own)
                   return wrap<Segment>(toSegment(e), own);
             case ElementType::MEASURE:
                   return wrap<Measure>(toMeasure(e), own);
+            case ElementType::PAGE:
+                  return wrap<Page>(toPage(e), own);
             default:
                   break;
             }

--- a/mscore/plugin/api/elements.h
+++ b/mscore/plugin/api/elements.h
@@ -689,7 +689,13 @@ class Page : public Element {
        * \brief Page number, counting from 0.
        * Number of this page in the score counting from 0, i.e.
        * for the first page its \p pagenumber value will be equal to 0.
+       * User-visible page number can be calculated as
+       * \code
+       * page.pagenumber + 1 + score.pageNumberOffset
+       * \endcode
+       * where \p score is the relevant \ref Score object.
        * \since MuseScore 3.5
+       * \see Score::pageNumberOffset
        */
       Q_PROPERTY(int pagenumber READ pagenumber)
 

--- a/mscore/plugin/api/elements.h
+++ b/mscore/plugin/api/elements.h
@@ -20,6 +20,7 @@
 #include "libmscore/measure.h"
 #include "libmscore/note.h"
 #include "libmscore/notedot.h"
+#include "libmscore/page.h"
 #include "libmscore/segment.h"
 #include "libmscore/accidental.h"
 #include "libmscore/musescoreCore.h"
@@ -114,6 +115,11 @@ class Element : public Ms::PluginAPI::ScoreElement {
        * \since MuseScore 3.3
        */
       Q_PROPERTY(qreal posY READ posY)
+      /**
+       * Position of this element in page coordinates, in spatium units.
+       * \since MuseScore 3.5
+       */
+      Q_PROPERTY(QPointF pagePos READ pagePos)
 
       /**
        * Bounding box of this element.
@@ -368,6 +374,8 @@ class Element : public Ms::PluginAPI::ScoreElement {
 
       qreal posX() const { return element()->pos().x() / element()->spatium(); }
       qreal posY() const { return element()->pos().y() / element()->spatium(); }
+
+      QPointF pagePos() const { return element()->pagePos() / element()->spatium(); }
 
       Ms::PluginAPI::Element* parent() const { return wrap(element()->parent()); }
 
@@ -668,6 +676,32 @@ class Measure : public Element {
       Measure* nextMeasure() { return wrap<Measure>(measure()->nextMeasure(), Ownership::SCORE); }
 
       QQmlListProperty<Element> elements() { return wrapContainerProperty<Element>(this, measure()->el()); }
+      /// \endcond
+      };
+
+//---------------------------------------------------------
+//   Page
+//---------------------------------------------------------
+
+class Page : public Element {
+      Q_OBJECT
+      /**
+       * \brief Page number, counting from 0.
+       * Number of this page in the score counting from 0, i.e.
+       * for the first page its \p pagenumber value will be equal to 0.
+       * \since MuseScore 3.5
+       */
+      Q_PROPERTY(int pagenumber READ pagenumber)
+
+   public:
+      /// \cond MS_INTERNAL
+      Page(Ms::Page* p = nullptr, Ownership own = Ownership::SCORE)
+         : Element(p, own) {}
+
+      Ms::Page* page() { return toPage(e); }
+      const Ms::Page* page() const { return toPage(e); }
+
+      int pagenumber() const;
       /// \endcond
       };
 

--- a/mscore/plugin/api/score.h
+++ b/mscore/plugin/api/score.h
@@ -86,6 +86,15 @@ class Score : public Ms::PluginAPI::ScoreElement {
       Q_PROPERTY(QString                        mscoreRevision    READ mscoreRevision)
       /** Current selections for the score. \since MuseScore 3.3 */
       Q_PROPERTY(Ms::PluginAPI::Selection*      selection         READ selection)
+      /**
+       * Page numbering offset. The user-visible number of the given \p page is defined as
+       * \code
+       * page.pagenumber + 1 + score.pageNumberOffset
+       * \endcode
+       * \since MuseScore 3.5
+       * \see Page::pagenumber
+       */
+      Q_PROPERTY(int pageNumberOffset READ pageNumberOffset WRITE setPageNumberOffset)
 
    public:
       /// \cond MS_INTERNAL
@@ -105,6 +114,9 @@ class Score : public Ms::PluginAPI::ScoreElement {
       QString lyricist() { return score()->metaTag("lyricist"); } // not the meanwhile obsolete "poet"
       QString title() { return score()->metaTag("workTitle"); }
       Ms::PluginAPI::Selection* selection() { return selectionWrap(&score()->selection()); }
+
+      int pageNumberOffset() const { return score()->pageNumberOffset(); }
+      void setPageNumberOffset(int offset) { score()->undoChangePageNumberOffset(offset); }
 
       /// \endcond
 


### PR DESCRIPTION
Restores `pagenumber` and `pagePos` properties which were exposed to plugins in MuseScore 2.X, as requested in https://musescore.org/en/node/301561.

Update: also added `Score.pageNumberOffset` property to allow obtaining (and changing) user-visible page numbers.