### PR TITLE
Fix #304446: "Continue last session" (from Preferences > General) doesn't work anymore, starts empty instead

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -366,18 +366,16 @@ void MuseScore::closeEvent(QCloseEvent* ev)
       unloadPlugins();
       QList<MasterScore*> removeList;
       for (MasterScore* score : scoreList) {
-            if (!score->created() && !score->dirty())
-                  removeList.append(score);
-            else {
-                  if (checkDirty(score)) {      // ask user if file is dirty
-                        ev->ignore();
-                        return;
-                        }
-                  // If the score has never been saved or is still dirty (or both), the user has discarded the score and we can remove it from the list.
-                  // Note that it's necessary to consider either flag in case we're dealing with a newly created score that hasn't been edited at all.
-                  if (score->created() || score->dirty())
-                        removeList.append(score);
+            // Prompt the user to save the score if it's "dirty" (has unsaved changes) or if it's newly created.
+            if (checkDirty(score)) {
+                  // The user has canceled out entirely, so ignore the close event.
+                  ev->ignore();
+                  return;
                   }
+            // If the score is still flagged as newly created at this point, it means that the user has just chosen to discard it,
+            // so we need to remove it from the list of scores to be saved to the session file.
+            if (score->created())
+                  removeList.append(score);
             }
 
       // remove all new created/not save score so they are


### PR DESCRIPTION
Resolves: [#304446](https://musescore.org/en/node/304446)

Fixed a problem introduced in PR #5784 that caused some open scores to fail to be written to the session file on application close, breaking the “continue last session” functionality for those scores.

This affected all open scores that had previously been saved but hadn't been modified since being saved. It did not affect scores that had been modified or that were newly created and had never been saved.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made