### PR TITLE
Get splash screen messages to appear on macOS

### DIFF
--- a/mscore/mssplashscreen.cpp
+++ b/mscore/mssplashscreen.cpp
@@ -27,8 +27,8 @@ namespace Ms {
 
 void MsSplashScreen::drawContents(QPainter* painter)
       {
-      qreal width  = static_cast<qreal>(pixmap().width());
-      qreal height = static_cast<qreal>(pixmap().height());
+      qreal width  = static_cast<qreal>(QWidget::width());
+      qreal height = static_cast<qreal>(QWidget::height());
       QRectF rect  = QRectF(0.0, 0.65 * height, width, 0.35 * height);
 
       painter->setPen(QColor(255, 255, 255, 255 * 0.8));

--- a/mscore/mssplashscreen.cpp
+++ b/mscore/mssplashscreen.cpp
@@ -27,23 +27,11 @@ namespace Ms {
 
 void MsSplashScreen::drawContents(QPainter* painter)
       {
-      qreal width  = static_cast<qreal>(QWidget::width());
-      qreal height = static_cast<qreal>(QWidget::height());
-      QRectF rect  = QRectF(0.0, 0.65 * height, width, 0.35 * height);
+      static const QRectF rect(0.0, 0.65 * height(), width(), 0.35 * height());
+      static const QColor color(255, 255, 255, 255 * 0.8);
 
-      painter->setPen(QColor(255, 255, 255, 255 * 0.8));
-      painter->drawText(rect, Qt::AlignTop | Qt::AlignHCenter, _message);
-      }
-
-//---------------------------------------------------------
-//   showMessage
-//---------------------------------------------------------
-
-void MsSplashScreen::showMessage(const QString& message)
-      {
-      _message = message;
-      // The align flags and color don't matter here as drawContents() is overwritten
-      QSplashScreen::showMessage(message, Qt::AlignTop | Qt::AlignHCenter, QColor(255, 255, 255, 255 * 0.8));
+      painter->setPen(color);
+      painter->drawText(rect, Qt::AlignTop | Qt::AlignHCenter, message());
       }
 
 }

--- a/mscore/mssplashscreen.h
+++ b/mscore/mssplashscreen.h
@@ -24,17 +24,9 @@ namespace Ms {
 //---------------------------------------------------------
 
 class MsSplashScreen : public QSplashScreen {
-      QString _message;
-
    public:
       MsSplashScreen(const QPixmap& pixmap) : QSplashScreen(pixmap) {}
-
-      void setMessage(QString& message) { _message = message; }
-
       void drawContents(QPainter* painter) override;
-
-   public slots:
-      void showMessage(const QString& message);
       };
 
 }

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7783,7 +7783,7 @@ inline static void showSplashMessage(MsSplashScreen* sc, QString&& message)
       if (sc)
             sc->showMessage(message);
       else
-            qInfo(message.toStdString().c_str());
+            qInfo("%s", qPrintable(message));
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
The splash screen image used on macOS is @2x resolution, which means that
the width and height of the pixmap are twice the width and height of the
splash screen, which meant that the message text was being drawn outside
of its window. It is better to just use the widget's own width and height
properties to determine the placement of the message text.

The first commit solves the issue of messages not appearing on the splash screen on macOS.

The second commit simplifies the MsSplashScreen class so that it contains no more code than what is necessary for displaying a message in a custom location, which is really the only thing that the MsSplashScreen class offers in the first place.