### PR TITLE
Fix #304466: The “I/O” tab of the “Preferences” dialog should use radio buttons instead of checkboxes

### DIFF
--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -175,7 +175,7 @@ add_library(mscoreapp STATIC
       pathlistdialog.h piano.h  pianotools.h
       openfilelocation.h
       playpanel.h preferences.h preferenceslistwidget.h prefsdialog.h
-      recordbutton.h resourceManager.h revision.h ruler.h scoreaccessibility.h
+      radiobuttongroupbox.h recordbutton.h resourceManager.h revision.h ruler.h scoreaccessibility.h
       scoreBrowser.h scoreInfo.h scorePreview.h scoretab.h scoreview.h searchComboBox.h
       selectdialog.h selectionwindow.h selectnotedialog.h selinstrument.h
       seq.h shortcut.h shortcutcapturedialog.h simplebutton.h splitstaff.h stafftextproperties.h
@@ -198,7 +198,7 @@ add_library(mscoreapp STATIC
       preferences.cpp measureproperties.cpp
       seq.cpp textpalette.cpp
       timedialog.cpp symboldialog.cpp shortcutcapturedialog.cpp
-      simplebutton.cpp
+      radiobuttongroupbox.cpp simplebutton.cpp
       openfilelocation.cpp
       editdrumset.cpp editstaff.cpp
       timesigproperties.cpp newwizard.cpp transposedialog.cpp

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -2704,7 +2704,7 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_8">
        <item>
-        <widget class="QGroupBox" name="pulseaudioDriver">
+        <widget class="Ms::RadioButtonGroupBox" name="pulseaudioDriver">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -2729,7 +2729,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="portaudioDriver">
+        <widget class="Ms::RadioButtonGroupBox" name="portaudioDriver">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -2909,7 +2909,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="alsaDriver">
+        <widget class="Ms::RadioButtonGroupBox" name="alsaDriver">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -3125,7 +3125,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="jackDriver">
+        <widget class="Ms::RadioButtonGroupBox" name="jackDriver">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -4279,6 +4279,11 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
    <class>Ms::RecordButton</class>
    <extends>QToolButton</extends>
    <header>recordbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Ms::RadioButtonGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>radiobuttongroupbox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/mscore/radiobuttongroupbox.cpp
+++ b/mscore/radiobuttongroupbox.cpp
@@ -1,0 +1,49 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#include "radiobuttongroupbox.h"
+
+namespace Ms {
+
+void RadioButtonGroupBox::paintEvent(QPaintEvent*)
+      {
+      QStylePainter painter(this);
+      QStyleOptionGroupBox styleOption;
+      initStyleOption(&styleOption);
+
+      // Paint the default QGroupBox-style control, which includes an unwanted checkbox that we'll cover up afterwards.
+      painter.drawComplexControl(QStyle::CC_GroupBox, styleOption);
+
+      // Calculate the background color the same way Qt does in QFusionStylePrivate::tabFrameColor().
+      const QColor& buttonColor = styleOption.palette.button().color();
+      QColor bgColor = buttonColor.lighter(100 + std::max(1, (180 - qGray(buttonColor.rgb())) / 6));
+      bgColor.setHsv(bgColor.hue(), 3 * bgColor.saturation() / 4, bgColor.value());
+      bgColor = bgColor.lighter(104);
+
+      // Adjust the style options to use the checkbox's rectangle.
+      styleOption.rect = style()->subControlRect(QStyle::CC_GroupBox, &styleOption, QStyle::SC_GroupBoxCheckBox, this);
+
+      // Cover up the checkbox, making sure to enlarge the rectangle a bit to cover up any anti-aliasing around the edges.
+      painter.fillRect(styleOption.rect.adjusted(-2, -2, 2, 2), bgColor);
+
+      // Paint the radio button.
+      painter.drawPrimitive(QStyle::PE_IndicatorRadioButton, styleOption);
+      }
+
+}

--- a/mscore/radiobuttongroupbox.h
+++ b/mscore/radiobuttongroupbox.h
@@ -1,0 +1,37 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef RADIOBUTTONGROUPBOX_H
+#define RADIOBUTTONGROUPBOX_H
+
+namespace Ms {
+
+class RadioButtonGroupBox : public QGroupBox {
+      Q_OBJECT
+
+      void paintEvent(QPaintEvent* event) override;
+      
+   public:
+      explicit RadioButtonGroupBox(QWidget* parent = nullptr) : QGroupBox(parent) { }
+      explicit RadioButtonGroupBox(const QString& title, QWidget* parent = nullptr) : QGroupBox(title, parent) { }
+      };
+
+}
+
+#endif


### PR DESCRIPTION
Resolves: [#304466](https://musescore.org/en/node/304466)

Fixed a UI problem with the *I/O* tab of the *Preferences* dialog that caused mutually exclusive options to be presented to the user as checkboxes instead of radio buttons.

The underlying technical reason for this was that the Qt framework does not allow group boxes to have radio buttons. This has been worked around by subclassing the `QGroupBox` class and rendering the checkboxes to look like radio buttons. This is sufficient for our purposes because the application already overrides the checkboxes' behavior to work like radio buttons.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made