### PR TITLE
fix #296075: enable showing brackets which span to single stave when empty staves are hidden

### DIFF
--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -143,6 +143,7 @@ static const StyleType styleTypes[] {
       { Sid::repeatBarTips,           "repeatBarTips",           QVariant(false) },
       { Sid::startBarlineSingle,      "startBarlineSingle",      QVariant(false) },
       { Sid::startBarlineMultiple,    "startBarlineMultiple",    QVariant(true) },
+
       { Sid::bracketWidth,            "bracketWidth",            Spatium(0.45) },
       { Sid::bracketDistance,         "bracketDistance",         Spatium(0.1) },
       { Sid::akkoladeWidth,           "akkoladeWidth",           Spatium(1.6) },
@@ -402,7 +403,9 @@ static const StyleType styleTypes[] {
       { Sid::minMMRestWidth,          "minMMRestWidth",          Spatium(4) },
       { Sid::hideEmptyStaves,         "hideEmptyStaves",         QVariant(false) },
       { Sid::dontHideStavesInFirstSystem,
-                                 "dontHidStavesInFirstSystm",         QVariant(true) },
+                                 "dontHidStavesInFirstSystm",    QVariant(true) },
+      { Sid::alwaysShowBracketsWhenEmptyStavesAreHidden,
+                                 "alwaysShowBracketsWhenEmptyStavesAreHidden", QVariant(false) },
       { Sid::hideInstrumentNameIfOneInstrument,
                                  "hideInstrumentNameIfOneInstrument", QVariant(true) },
       { Sid::gateTime,                "gateTime",                QVariant(100) },

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -373,6 +373,7 @@ enum class Sid {
       minMMRestWidth,
       hideEmptyStaves,
       dontHideStavesInFirstSystem,
+      alwaysShowBracketsWhenEmptyStavesAreHidden,
       hideInstrumentNameIfOneInstrument,
       gateTime,
       tenutoGateTime,

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -656,11 +656,13 @@ void System::layout2()
             // if end staff not visible, try prev staff
             while (staffIdx1 <= staffIdx2 && !_staves[staffIdx2]->show())
                   --staffIdx2;
+            // if the score doesn't have "alwaysShowBracketsWhenEmptyStavesAreHidden" as true,
             // the bracket will be shown IF:
             // it spans at least 2 visible staves (staffIdx1 < staffIdx2) OR
             // it spans just one visible staff (staffIdx1 == staffIdx2) but it is required to do so
             // (the second case happens at least when the bracket is initially dropped)
-            bool notHidden = (staffIdx1 < staffIdx2) || (b->span() == 1 && staffIdx1 == staffIdx2);
+            bool notHidden = score()->styleB(Sid::alwaysShowBracketsWhenEmptyStavesAreHidden)
+               ? (staffIdx1 <= staffIdx2) : (staffIdx1 < staffIdx2) || (b->span() == 1 && staffIdx1 == staffIdx2);
             if (notHidden) {                    // set vert. pos. and height to visible spanned staves
                   sy = _staves[staffIdx1]->bbox().top();
                   ey = _staves[staffIdx2]->bbox().bottom();

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -166,7 +166,8 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       { Sid::minEmptyMeasures,        false, minEmptyMeasures,        0 },
       { Sid::minMMRestWidth,          false, minMeasureWidth,         resetMinMMRestWidth },
       { Sid::hideEmptyStaves,         false, hideEmptyStaves,         0 },
-      { Sid::dontHideStavesInFirstSystem, false, dontHideStavesInFirstSystem,             0 },
+      { Sid::dontHideStavesInFirstSystem, false, dontHideStavesInFirstSystem, 0 },
+      { Sid::alwaysShowBracketsWhenEmptyStavesAreHidden, false, alwaysShowBrackets, 0 },
       { Sid::hideInstrumentNameIfOneInstrument, false, hideInstrumentNameIfOneInstrument, 0 },
       { Sid::accidentalNoteDistance,  false, accidentalNoteDistance,  0 },
       { Sid::accidentalDistance,      false, accidentalDistance,      0 },
@@ -501,7 +502,6 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       connect(swingSixteenth,      SIGNAL(toggled(bool)),             SLOT(setSwingParams(bool)));
 
       connect(concertPitch,        SIGNAL(toggled(bool)),             SLOT(concertPitchToggled(bool)));
-      connect(hideEmptyStaves,     SIGNAL(clicked(bool)), dontHideStavesInFirstSystem, SLOT(setEnabled(bool)));
       connect(lyricsDashMinLength, SIGNAL(valueChanged(double)),      SLOT(lyricsDashMinLengthValueChanged(double)));
       connect(lyricsDashMaxLength, SIGNAL(valueChanged(double)),      SLOT(lyricsDashMaxLengthValueChanged(double)));
       connect(minSystemDistance,   SIGNAL(valueChanged(double)),      SLOT(systemMinDistanceValueChanged(double)));
@@ -1090,8 +1090,6 @@ void EditStyle::setValues()
             chordDescriptionGroup->setEnabled(true);
             }
       //formattingGroup->setEnabled(lstyle.chordList()->autoAdjust());
-
-      dontHideStavesInFirstSystem->setEnabled(hideEmptyStaves->isChecked());
 
       // figured bass
       for (int i = 0; i < comboFBFont->count(); i++)

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>912</width>
-    <height>660</height>
+    <height>692</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -481,17 +481,32 @@
             </widget>
            </item>
            <item>
-            <widget class="QCheckBox" name="hideEmptyStaves">
-             <property name="text">
+            <widget class="QGroupBox" name="hideEmptyStaves">
+             <property name="title">
               <string>Hide empty staves within systems</string>
              </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="dontHideStavesInFirstSystem">
-             <property name="text">
-              <string>Don't hide empty staves in first system</string>
+             <property name="checkable">
+              <bool>true</bool>
              </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_2">
+              <item>
+               <widget class="QCheckBox" name="dontHideStavesInFirstSystem">
+                <property name="text">
+                 <string>Don't hide empty staves in first system</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="alwaysShowBrackets">
+                <property name="text">
+                 <string>Always show brackets which span to single staff</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </widget>
            </item>
            <item>
@@ -9354,7 +9369,7 @@
               <item row="1" column="1">
                <widget class="QDoubleSpinBox" name="extensionAdjust">
                 <property name="minimum">
-                 <double>-99.99</double>
+                 <double>-99.989999999999995</double>
                 </property>
                </widget>
               </item>
@@ -9388,7 +9403,7 @@
               <item row="1" column="4">
                <widget class="QDoubleSpinBox" name="modifierAdjust">
                 <property name="minimum">
-                 <double>-99.99</double>
+                 <double>-99.989999999999995</double>
                 </property>
                </widget>
               </item>
@@ -10201,8 +10216,7 @@
                   <number>0</number>
                  </property>
                  <item row="0" column="1">
-                  <widget class="Awl::ColorLabel" name="textStyleFrameForeground">
-                  </widget>
+                  <widget class="Awl::ColorLabel" name="textStyleFrameForeground"/>
                  </item>
                  <item row="2" column="0">
                   <widget class="QLabel" name="label_205">
@@ -10287,8 +10301,7 @@
                   <widget class="QDoubleSpinBox" name="textStyleFramePadding"/>
                  </item>
                  <item row="1" column="1">
-                  <widget class="Awl::ColorLabel" name="textStyleFrameBackground">
-                  </widget>
+                  <widget class="Awl::ColorLabel" name="textStyleFrameBackground"/>
                  </item>
                  <item row="3" column="2">
                   <widget class="QToolButton" name="resetTextStyleFramePadding">
@@ -10348,8 +10361,7 @@
             </widget>
            </item>
            <item row="6" column="1">
-            <widget class="Awl::ColorLabel" name="textStyleColor">
-            </widget>
+            <widget class="Awl::ColorLabel" name="textStyleColor"/>
            </item>
            <item row="7" column="1">
             <widget class="Ms::OffsetSelect" name="textStyleOffset" native="true"/>
@@ -10545,6 +10557,7 @@
   <tabstop>resetMinMMRestWidth</tabstop>
   <tabstop>hideEmptyStaves</tabstop>
   <tabstop>dontHideStavesInFirstSystem</tabstop>
+  <tabstop>alwaysShowBrackets</tabstop>
   <tabstop>crossMeasureValues</tabstop>
   <tabstop>hideInstrumentNameIfOneInstrument</tabstop>
   <tabstop>swingOff</tabstop>


### PR DESCRIPTION
Resolves: https://musescore.org/node/296075.

I ran into this problem again today, and I still think it's necessary to get this option in as soon as possible. This solution may not cover _all_ the cases, or not _very_ convenient, but it is simple and gets _most_ of the cases covered.

The solution: a simple score style option which defaults to the current behaviour but can be turned on to make single-stave brackets visible.