### PR TITLE
Fix url loss after the save online operation

### DIFF
--- a/mscore/cloud/uploadscoredialog.cpp
+++ b/mscore/cloud/uploadscoredialog.cpp
@@ -126,13 +126,18 @@ void UploadScoreDialog::uploadSuccess(const QString& url, const QString& nid, co
 
       _newScore = !(oldScoreID && oldScoreID == _nid);
 
-      Score* score = mscore->currentScore()->masterScore();
+      MasterScore* score = mscore->currentScore()->masterScore();
       QMap<QString, QString>  metatags = score->metaTags();
       if (metatags.value("source") != url) {
             metatags.insert("source", url);
             score->startCmd();
             score->undo(new ChangeMetaTags(score, metatags));
             score->endCmd();
+
+            //!Note Automatically save score file with received web-link if file already exists
+            if (!score->created()) {
+                mscore->saveFile();
+            }
       }
       if (uploadAudio->isChecked())
             _loginManager->getMediaUrl(nid, vid, "mp3");

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -428,7 +428,6 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void editInstrList();
       void symbolMenu();
       void showKeyEditor();
-      bool saveFile();
       bool saveFile(MasterScore* score);
       void fingeringMenu();
 
@@ -622,6 +621,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QString lastSaveCopyFormat;
       QString lastSaveDirectory;
       QString lastSaveCaptureName;
+      bool saveFile();
       SynthControl* getSynthControl() const       { return synthControl; }
       void editInPianoroll(Staff* staff, Position* p = 0);
       void editInDrumroll(Staff* staff);


### PR DESCRIPTION
Prevent the loss of the user's score URL by automatically saving the local score file when receiving the URL from the web server during the “Save Online” operation.

We found out that some users lost links to their scores after they saved the score online.

It turned out that the current process requires from the user not quite obvious additional steps to save:

- the user saves his score locally
- the user clicks the "Save online" button
- the editor receives a new link to the score and modifies the .mscz file, adding a meta tag with a link to the score
- the file is modified and the user must save it again locally so as not to lose the link. Otherwise, the next time he goes to the editor and opens his score locally, there will be no link in it. So the next time he'll try to save online, duplicates will form on the server-side.

