### PR TITLE
Fix #281666 - Parts Dialog Problem with Voices

### DIFF
--- a/mscore/excerptsdialog.ui
+++ b/mscore/excerptsdialog.ui
@@ -68,6 +68,9 @@
          </item>
          <item>
           <widget class="QToolButton" name="moveUpButton">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -91,6 +94,9 @@
          </item>
          <item>
           <widget class="QToolButton" name="moveDownButton">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -183,6 +189,9 @@
          </item>
          <item>
           <widget class="QPushButton" name="deleteButton">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
            <property name="text">
             <string>Delete</string>
            </property>
@@ -241,6 +250,9 @@
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <item>
             <widget class="QListWidget" name="instrumentList">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
              <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
                <horstretch>0</horstretch>
@@ -272,6 +284,9 @@
              </item>
              <item>
               <widget class="QPushButton" name="addButton">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
                <property name="accessibleDescription">
                 <string>Add instrument</string>
                </property>
@@ -282,6 +297,9 @@
              </item>
              <item>
               <widget class="QPushButton" name="removeButton">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
                <property name="accessibleDescription">
                 <string>Remove instrument</string>
                </property>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/281666

Root case was loosing the first track of a part after the form was built. 
To solve this, the internal structure has to be rewritten to keep track of the mapping of the parts and the first track of each part.

In the last push, all remaining issues are solved:
* It is not possible to deselect all voices of a part.
* If a part, e.g. Flute has two voices, it is possible to create a part with 2 flute staves, one for voice 1 and one voice 2. When reopening the form both staves will show the correct selected voice.
* For instruments with linked staves only one, the first staff can be edited. The linked staves are disabled and will show the same selection as the primary staff.

Besides the issue as reported in [#281666](https://musescore.org/en/node/281666) is solved some other small issues are solved in the form itself:
* The Up/Down button are disabled when first or last Part is selected.
* Instruments list is enabled in when a new part is created only.
* Add/Remove instrument buttons are enabled when they make sense.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n.a.] I created the test (mtest, vtest, script test) to verify the changes I made
