### PR TITLE
ColorLabel::setColor should emit colorChanged

### DIFF
--- a/awl/colorlabel.cpp
+++ b/awl/colorlabel.cpp
@@ -43,8 +43,11 @@ ColorLabel::~ColorLabel()
 
 void ColorLabel::setColor(const QColor& c)
       {
+      const bool changed = _color != c;
       _color = c;
       update();
+      if (changed)
+            emit this->colorChanged(_color);
       }
 
 //---------------------------------------------------------

--- a/mscore/mixer/mixerdetails.cpp
+++ b/mscore/mixer/mixerdetails.cpp
@@ -101,7 +101,9 @@ void MixerDetails::updateFromTrack()
             chorusSpinBox->setValue(0);
             portSpinBox->setValue(0);
             channelSpinBox->setValue(0);
+            trackColorLabel->blockSignals(true);
             trackColorLabel->setColor(QColor());
+            trackColorLabel->blockSignals(false);
 
             drumkitCheck->setEnabled(false);
             patchCombo->setEnabled(false);


### PR DESCRIPTION
Resolves: none
Related to: https://github.com/musescore/MuseScore/pull/5922

ColorLabel should emit a colorChanged signal in setColor ( required for PR #5922 )
Without the signal blocks, MuseScore crashes.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made
