### PR TITLE
fix #101991, fix #304586: fix menu mnemonics colliding with note input shortcuts

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4020,6 +4020,20 @@ bool MuseScore::eventFilter(QObject *obj, QEvent *event)
                         }
                   break;
                   }
+            case QEvent::ShortcutOverride:
+                  if (qobject_cast<QMenu*>(obj)) {
+                        // Disable one-letter shortcuts while in menu
+                        // to prevent blocking menu mnemonics
+                        QKeyEvent* ke = static_cast<QKeyEvent*>(event);
+                        const QString evtText = ke->text();
+                        const bool letterOrNumber = !ke->modifiers() && evtText.size() == 1 && evtText.at(0).isLetterOrNumber();
+
+                        if (letterOrNumber) {
+                              ke->accept();
+                              return true;
+                              }
+                        }
+                  break;
             default:
                   return QMainWindow::eventFilter(obj, event);
             }
@@ -5894,12 +5908,6 @@ void MuseScore::cmd(QAction* a)
             QMessageBox::warning(0,
                tr("Invalid Command"),
                tr("Command %1 not valid in current state").arg(cmdn));
-            return;
-            }
-      if (qApp->focusWidget()
-         && (!isAncestorOf(qApp->focusWidget()) || menuBar()->isAncestorOf(qApp->focusWidget()))
-         ) {
-            qDebug("MuseScore::cmd(): not on main window <%s>", qPrintable(cmdn));
             return;
             }
       if (cmdn == "toggle-palette") {


### PR DESCRIPTION
Resolves:
 - https://musescore.org/en/node/304586 — a regression introduced in #5982;
 - https://musescore.org/en/node/101991 — the original issue which is attempted to be fixed more completely here.

This commit reverts dbb79fad3e0df676556aa737a65fd39fada84f6e to avoid
interfering with cmd() invokations made not by pressing a letter key
in menu (e.g. from a Piano Roll Editor window). The solution applied
in this commit also makes menu mnemonics actually working thus
restoring their expected behavior.