### PR TITLE
remove unused mixer and synth code, followup to PR #4140

### DIFF
--- a/mscore/synthcontrol.cpp
+++ b/mscore/synthcontrol.cpp
@@ -173,10 +173,7 @@ void MuseScore::showSynthControl(bool val)
             mscore->stackUnder(synthControl);
             synthControl->setScore(cs);
             connect(synti,        SIGNAL(gainChanged(float)), synthControl, SLOT(setGain(float)));
-            connect(synthControl, SIGNAL(gainChanged(float)), synti, SLOT(setGain(float)));
             connect(synthControl, SIGNAL(closed(bool)), a,     SLOT(setChecked(bool)));
-            if (mixer)
-                  connect(synthControl, SIGNAL(soundFontChanged()), mixer, SLOT(patchListChanged()));
             }
       synthControl->setVisible(val);
       }


### PR DESCRIPTION
Resolves: none
Related to: https://github.com/musescore/MuseScore/pull/4140

Removed a couple of unused connections.

![Screenshot from 2020-04-28 23-46-22](https://user-images.githubusercontent.com/21060365/80537526-e3f3b000-89ac-11ea-938b-58d16ffb932e.png)

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made
