### PR TITLE
Fixes for (translabable) texts

### DIFF
--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -2117,7 +2117,7 @@
            <item row="1" column="4">
             <widget class="QLabel" name="label_93">
              <property name="text">
-              <string>Horizontal placement</string>
+              <string>Horizontal placement:</string>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
* fix #304613: Add missing colon after Format > Style > Measure > Horizontal placement

(I expect more of those to be found)