### PR TITLE
fix# 304633 Using QT_TRANSLATE_NOOP to define strings for PianoLevels…

### DIFF
--- a/mscore/pianoroll/pianolevelschooser.cpp
+++ b/mscore/pianoroll/pianolevelschooser.cpp
@@ -19,6 +19,7 @@ PianoLevelsChooser::PianoLevelsChooser(QWidget *parent)
       for (int i = 0; PianoLevelsFilter::FILTER_LIST[i]; ++i) {
             QString name = PianoLevelsFilter::FILTER_LIST[i]->name();
             levelsCombo->addItem(name, i);
+            levelsCombo->setItemData(i, PianoLevelsFilter::FILTER_LIST[i]->tooltip(), Qt::ToolTipRole);
             }
 
       connect(levelsCombo, SIGNAL(activated(int)), SLOT(setLevelsIndex(int)));

--- a/mscore/pianoroll/pianolevelsfilter.cpp
+++ b/mscore/pianoroll/pianolevelsfilter.cpp
@@ -9,6 +9,23 @@
 
 namespace Ms {
 
+
+static const char* STRN_NOTE_ON_NAME = QT_TRANSLATE_NOOP("PianoLevelsFilter", "Note start time");
+static const char* STRN_NOTE_ON_TT = QT_TRANSLATE_NOOP("PianoLevelsFilter", "Add (or subtract) a bit to the start time of a note");
+
+static const char* STRN_LEN_MUL_NAME = QT_TRANSLATE_NOOP("PianoLevelsFilter", "Length (multiplier)");
+static const char* STRN_LEN_MUL_TT = QT_TRANSLATE_NOOP("PianoLevelsFilter", "Multiply the note length by a bit");
+
+static const char* STRN_LEN_OFF_NAME = QT_TRANSLATE_NOOP("PianoLevelsFilter", "Length (offset)");
+static const char* STRN_LEN_OFF_TT = QT_TRANSLATE_NOOP("PianoLevelsFilter", "Add (or subtract) a bit from the end of the note");
+
+static const char* STRN_VEL_DYN_NAME = QT_TRANSLATE_NOOP("PianoLevelsFilter", "Velocity (relative)");
+static const char* STRN_VEL_DYN_TT = QT_TRANSLATE_NOOP("PianoLevelsFilter", "Raise or lower loudness relative to current dynamics value");
+
+static const char* STRN_VEL_ABS_NAME = QT_TRANSLATE_NOOP("PianoLevelsFilter", "Velocity (absolute)");
+static const char* STRN_VEL_ABS_TT = QT_TRANSLATE_NOOP("PianoLevelsFilter", "Ignore dynamic markings and use this as the MIDI output value");
+
+
 PianoLevelsFilter* PianoLevelsFilter::FILTER_LIST[] = {
       new PianoLevelFilterLen,
       new PianoLevelFilterLenOfftime,
@@ -17,6 +34,24 @@ PianoLevelsFilter* PianoLevelsFilter::FILTER_LIST[] = {
       new PianoLevelFilterOnTime,
       0  //end of list indicator
 };
+
+//---------------------------------------------------------
+//   name
+//---------------------------------------------------------
+
+QString PianoLevelFilterOnTime::name()
+      {
+      return qApp->translate("PianoLevelsFilter", STRN_NOTE_ON_NAME);
+      }
+
+//---------------------------------------------------------
+//   tooltip
+//---------------------------------------------------------
+
+QString PianoLevelFilterOnTime::tooltip()
+      {
+      return qApp->translate("PianoLevelsFilter", STRN_NOTE_ON_TT);
+      }
 
 //---------------------------------------------------------
 //   value
@@ -44,6 +79,24 @@ void PianoLevelFilterOnTime::setValue(Staff* staff, Note* note, NoteEvent* evt, 
       }
 
 //---------------------------------------------------------
+//   name
+//---------------------------------------------------------
+
+QString PianoLevelFilterLen::name()
+      {
+      return qApp->translate("PianoLevelsFilter", STRN_LEN_MUL_NAME);
+      }
+
+//---------------------------------------------------------
+//   tooltip
+//---------------------------------------------------------
+
+QString PianoLevelFilterLen::tooltip()
+      {
+      return qApp->translate("PianoLevelsFilter", STRN_LEN_MUL_TT);
+      }
+
+//---------------------------------------------------------
 //   value
 //---------------------------------------------------------
 
@@ -68,6 +121,24 @@ void PianoLevelFilterLen::setValue(Staff* staff, Note* note, NoteEvent* evt, int
       score->endCmd();
       }
 
+
+//---------------------------------------------------------
+//   name
+//---------------------------------------------------------
+
+QString PianoLevelFilterLenOfftime::name()
+      {
+      return qApp->translate("PianoLevelsFilter", STRN_LEN_OFF_NAME);
+      }
+
+//---------------------------------------------------------
+//   tooltip
+//---------------------------------------------------------
+
+QString PianoLevelFilterLenOfftime::tooltip()
+      {
+      return qApp->translate("PianoLevelsFilter", STRN_LEN_OFF_TT);
+      }
 
 //---------------------------------------------------------
 //   maxRange
@@ -124,6 +195,24 @@ void PianoLevelFilterLenOfftime::setValue(Staff* staff, Note* note, NoteEvent* e
       }
 
 //---------------------------------------------------------
+//   name
+//---------------------------------------------------------
+
+QString PianoLevelFilterVeloOffset::name()
+      {
+      return qApp->translate("PianoLevelsFilter", STRN_VEL_DYN_NAME);
+      }
+
+//---------------------------------------------------------
+//   tooltip
+//---------------------------------------------------------
+
+QString PianoLevelFilterVeloOffset::tooltip()
+      {
+      return qApp->translate("PianoLevelsFilter", STRN_VEL_DYN_TT);
+      }
+
+//---------------------------------------------------------
 //   value
 //---------------------------------------------------------
 
@@ -170,6 +259,24 @@ void PianoLevelFilterVeloOffset::setValue(Staff* staff, Note* note, NoteEvent* /
       score->endCmd();
       }
 
+
+//---------------------------------------------------------
+//   name
+//---------------------------------------------------------
+
+QString PianoLevelFilterVeloUser::name()
+      {
+      return qApp->translate("PianoLevelsFilter", STRN_VEL_ABS_NAME);
+      }
+
+//---------------------------------------------------------
+//   tooltip
+//---------------------------------------------------------
+
+QString PianoLevelFilterVeloUser::tooltip()
+      {
+      return qApp->translate("PianoLevelsFilter", STRN_VEL_ABS_TT);
+      }
 
 //---------------------------------------------------------
 //   value

--- a/mscore/pianoroll/pianolevelsfilter.h
+++ b/mscore/pianoroll/pianolevelsfilter.h
@@ -27,6 +27,7 @@ class NoteEvent;
 class Staff;
 
 
+
 //---------------------------------------------------------
 //   PianoLevelsFilter
 //       Manage note/event data for different views when drawing in the PianoLevels window
@@ -37,6 +38,7 @@ public:
       static PianoLevelsFilter* FILTER_LIST[];
 
       virtual QString name() = 0;
+      virtual QString tooltip() = 0;
       virtual int maxRange() = 0;
       virtual int minRange() = 0;
       virtual int divisionGap() = 0;  //Vertical guide line separation gap
@@ -54,7 +56,8 @@ class PianoLevelFilterOnTime : public PianoLevelsFilter {
       Q_DECLARE_TR_FUNCTIONS(PianoLevelFilterOnTime)
 
 public:
-      QString name() override { return tr("Note on time", "amount note 'on time' is adjusted by"); }
+      QString name() override;
+      QString tooltip() override;
       int maxRange() override { return 1000; }
       int minRange() override { return -1000; }
       int divisionGap() override { return 250; }
@@ -73,7 +76,8 @@ class PianoLevelFilterLen : public PianoLevelsFilter {
       Q_DECLARE_TR_FUNCTIONS(PianoLevelFilterLen)
 
 public:
-      QString name() override { return tr("Length as note multiplier", "length tweak is interpreted as a scalar to base note length"); }
+      QString name() override;
+      QString tooltip() override;
       int maxRange() override { return 1000; }
       int minRange() override { return 0; }
       int divisionGap() override { return 250; }
@@ -92,7 +96,8 @@ class PianoLevelFilterLenOfftime : public PianoLevelsFilter {
       Q_DECLARE_TR_FUNCTIONS(PianoLevelFilterLenOfftime)
 
 public:
-      QString name() override { return tr("Length as note off time", "length tweak is interpreted as an offset to the base note length"); }
+      QString name() override;
+      QString tooltip() override;
       int maxRange() override;
       int minRange() override { return 0; }
       int divisionGap() override;
@@ -111,7 +116,8 @@ class PianoLevelFilterVeloOffset : public PianoLevelsFilter {
       Q_DECLARE_TR_FUNCTIONS(PianoLevelFilterVeloOffset)
 
 public:
-      QString name() override { return tr("Velocity as dynamics multiplier", "velocity tweak is interpreted as a scalar relative to the dynamics marking"); }
+      QString name() override;
+      QString tooltip() override;
       int maxRange() override { return 200; }
       int minRange() override { return -200; }
       int divisionGap() override { return 100; }
@@ -130,7 +136,8 @@ class PianoLevelFilterVeloUser : public PianoLevelsFilter {
       Q_DECLARE_TR_FUNCTIONS(PianoLevelFilterVeloUser)
 
 public:
-      QString name() override { return tr("Velocity as absolute MIDI volume", "velocity tweak is intepreted as a MIDI volume level"); }
+      QString name() override;
+      QString tooltip() override;
       int maxRange() override { return 128; }
       int minRange() override { return 0; }
       int divisionGap() override { return 32; }


### PR DESCRIPTION
…Filter

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://musescore.org/en/cla)
- [ ] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [ ] I made sure the code compiles on my machine
- [ ] I made sure there are no unnecessary changes in the code
- [ ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
