### PR TITLE
Fix #123141: Playback panel: Turning loop OFF leaves loop in/out buttons ON

### DIFF
--- a/mscore/playpanel.ui
+++ b/mscore/playpanel.ui
@@ -395,9 +395,6 @@
          <iconset resource="musescore.qrc">
           <normaloff>:/data/icons/media-playback-loop-out.svg</normaloff>:/data/icons/media-playback-loop-out.svg</iconset>
         </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
        </widget>
       </item>
       <item row="0" column="4">
@@ -422,9 +419,6 @@
         <property name="icon">
          <iconset resource="musescore.qrc">
           <normaloff>:/data/icons/media-playback-loop-in.svg</normaloff>:/data/icons/media-playback-loop-in.svg</iconset>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2999,8 +2999,7 @@ Shortcut Shortcut::_sc[] = {
          QT_TRANSLATE_NOOP("action","Set loop in position"),
          0,
          Icons::loopIn_ICON,
-         Qt::WindowShortcut,
-         ShortcutFlags::A_CHECKABLE
+         Qt::WindowShortcut
          },
       {
          MsWidget::MAIN_WINDOW,
@@ -3010,8 +3009,7 @@ Shortcut Shortcut::_sc[] = {
          QT_TRANSLATE_NOOP("action","Set loop out position"),
          0,
          Icons::loopOut_ICON,
-         Qt::WindowShortcut,
-         ShortcutFlags::A_CHECKABLE
+         Qt::WindowShortcut
          },
       {
          MsWidget::MAIN_WINDOW,


### PR DESCRIPTION
Resolves: [#123141](https://musescore.org/en/node/123141)

Fixed a problem with the “Loop In” and “Loop Out” buttons in the Play Panel that caused them to visually appear as toggle buttons even though functionally they are actually simple pushbuttons.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made