### PR TITLE
Fix #304725: Remove “using namespace std” directive

### DIFF
--- a/importexport/guitarpro/importgtp-gp6.cpp
+++ b/importexport/guitarpro/importgtp-gp6.cpp
@@ -380,7 +380,7 @@ void GuitarPro6::readMasterTracks(QDomNode* masterTrack)
                                           curtempo = sa[0].toInt();
                                     auto barnode = currentAutomation.firstChildElement("Bar");
                                     if (!barnode.isNull()) {
-                                          tempoMap[barnode.text().toInt()] = make_pair(curtempo, linearTemp);
+                                          tempoMap[barnode.text().toInt()] = std::make_pair(curtempo, linearTemp);
                                           }
                                     }
                               }

--- a/importexport/guitarpro/importptb.cpp
+++ b/importexport/guitarpro/importptb.cpp
@@ -77,7 +77,7 @@ std::string PowerTab::readString(int length)
 bool PowerTab::readVersion()
       {
       std::string version = readString(4);
-      version += std::string("-") + to_string(readShort());
+      version += std::string("-") + std::to_string(readShort());
       return version == "ptab-4";
       }
 
@@ -372,7 +372,7 @@ void PowerTab::readBarLine(ptSection& sec)
       readTimeSignature(bar);
       readRehearsalSign(sec);
       //sec.getPosition(position).addComponent(bar);
-      sec.bars.push_back(shared_ptr<ptBar>(bar));
+      sec.bars.push_back(std::shared_ptr<ptBar>(bar));
       /*if (bars.empty() || ( bars.back()->measureNo < bar->measureNo ))
             bars.push_back(bar);*/
       }
@@ -440,7 +440,7 @@ void PowerTab::readPosition(int staff, int voice, ptSection& sec)
             else {
                   beat = new ptBeat(staff, voice);
                   beat->position = position;
-                  sec.beats[staff].insert(pos, shared_ptr<ptBeat>(beat));
+                  sec.beats[staff].insert(pos, std::shared_ptr<ptBeat>(beat));
                   }
             }
       auto beaming = readUChar();
@@ -975,7 +975,7 @@ void PowerTab::ptSection::copyTracks(ptTrack* track)
                   while (int(beats.size()) <= staff) {
                         beats.push_back({});
                         }
-                  beats[staff].push_back(shared_ptr<ptBeat>(beat));
+                  beats[staff].push_back(std::shared_ptr<ptBeat>(beat));
                   }
             }
       }
@@ -1038,7 +1038,7 @@ void PowerTab::readSection(ptSection& sec)
 
       auto bar = new ptBar();
       bar->repeatClose = (lastBarData >> 5 == 4) ? lastBarData - 128 : 0;
-      sec.bars.push_back(shared_ptr<ptBar>(bar));
+      sec.bars.push_back(std::shared_ptr<ptBar>(bar));
       //sec.getPosition(sec.getNextPositionNumber()).addComponent(bar);
       }
 
@@ -1194,7 +1194,7 @@ int PowerTab::ptSection::getNextPositionNumber()
 
 void PowerTab::ptPosition::addComponent(ptComponent* c)
       {
-      components.push_back(shared_ptr<ptComponent>(c));
+      components.push_back(std::shared_ptr<ptComponent>(c));
       }
 
 

--- a/importexport/guitarpro/importptb.h
+++ b/importexport/guitarpro/importptb.h
@@ -216,7 +216,7 @@ class PowerTab {
 
             struct ptPosition {
                   int position{ 0 };
-                  std::vector<shared_ptr<ptComponent>> components;
+                  std::vector<std::shared_ptr<ptComponent>> components;
                   void addComponent(ptComponent* c);
                   };
 
@@ -237,7 +237,7 @@ class PowerTab {
                   int notes_count{ 0 };
                   };
 
-            typedef std::list<shared_ptr<ptBeat>> tBeatList;
+            typedef std::list<std::shared_ptr<ptBeat>> tBeatList;
 
             struct ptTrack;
             struct ptSection {
@@ -256,7 +256,7 @@ class PowerTab {
 
                   std::map<int, ptChordText> chordTextMap;
                   std::vector<tBeatList>  beats;
-                  std::list<shared_ptr<ptBar>> bars;
+                  std::list<std::shared_ptr<ptBar>> bars;
                   bool readed { false };
 
                   void copyTracks(ptTrack*);

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -719,7 +719,7 @@ void Chord::addLedgerLines()
       size_t n = _notes.size();
       for (size_t j = 0; j < 2; j++) {             // notes are scanned twice...
             int from, delta;
-            vector<LedgerLineData> vecLines;
+            std::vector<LedgerLineData> vecLines;
             hw = 0.0;
             minX  = maxX = 0;
             minLine = 0;

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -112,7 +112,7 @@ FretDiagram* FretDiagram::fromString(Score* score, const QString &s)
             else {
                   int fret = c.digitValue();
                   if (fret != -1) {
-                        dotsToAdd.push_back(make_pair(i, fret));
+                        dotsToAdd.push_back(std::make_pair(i, fret));
                         if (fret - 3 > 0 && offset < fret - 3)
                             offset = fret - 3;
                         }

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -1400,8 +1400,8 @@ int totalTiedNoteTicks(Note* note)
 //---------------------------------------------------------
 
 bool renderNoteArticulation(NoteEventList* events, Note* note, bool chromatic, int requestedTicksPerNote,
-   const vector<int>& prefix, const vector<int>& body,
-   bool repeatp, bool sustainp, const vector<int>& suffix,
+   const std::vector<int>& prefix, const std::vector<int>& body,
+   bool repeatp, bool sustainp, const std::vector<int>& suffix,
    int fastestFreq=64, int slowestFreq=8 // 64 Hz and 8 Hz
    )
       {
@@ -1443,7 +1443,7 @@ bool renderNoteArticulation(NoteEventList* events, Note* note, bool chromatic, i
                   ticksPerNote = minTicksPerNote;
             }
 
-      ticksPerNote = max(requestedTicksPerNote, minTicksPerNote);
+      ticksPerNote = std::max(requestedTicksPerNote, minTicksPerNote);
 
       if (slowestFreq <= 0) // no slowest freq given such as something silly like glissando with 4 notes over 8 counts.
             ;
@@ -1478,7 +1478,7 @@ bool renderNoteArticulation(NoteEventList* events, Note* note, bool chromatic, i
       // If so, increment the duration by the appropriate note duration, and increment the index, j, to the next note index
       // of a different pitch.
       // The total duration of the tied note is returned, and the index is modified.
-      auto tieForward = [millespernote] (int & j, const vector<int> & vec) {
+      auto tieForward = [millespernote] (int & j, const std::vector<int> & vec) {
             int size = int(vec.size());
             int duration = millespernote;
             while ( j < size-1 && vec[j] == vec[j+1] ) {
@@ -1584,22 +1584,22 @@ bool renderNoteArticulation(NoteEventList* events, Note* note, bool chromatic, i
 
 struct OrnamentExcursion {
       SymId atype;
-      set<MScore::OrnamentStyle> ostyles;
+      std::set<MScore::OrnamentStyle> ostyles;
       int duration;
-      vector<int> prefix;
-      vector<int> body;
+      std::vector<int> prefix;
+      std::vector<int> body;
       bool repeatp;
       bool sustainp;
-      vector<int> suffix;
+      std::vector<int> suffix;
       };
 
-set<MScore::OrnamentStyle> baroque  = {MScore::OrnamentStyle::BAROQUE};
-set<MScore::OrnamentStyle> defstyle = {MScore::OrnamentStyle::DEFAULT};
-set<MScore::OrnamentStyle> any; // empty set has the special meaning of any-style, rather than no-styles.
+std::set<MScore::OrnamentStyle> baroque  = {MScore::OrnamentStyle::BAROQUE};
+std::set<MScore::OrnamentStyle> defstyle = {MScore::OrnamentStyle::DEFAULT};
+std::set<MScore::OrnamentStyle> any; // empty set has the special meaning of any-style, rather than no-styles.
 int _16th = MScore::division / 4;
 int _32nd = _16th / 2;
 
-vector<OrnamentExcursion> excursions = {
+std::vector<OrnamentExcursion> excursions = {
       //  articulation type            set of  duration       body         repeatp      suffix
       //                               styles          prefix                    sustainp
       { SymId::ornamentTurn,                any, _32nd, {},    {1,0,-1,0},   false, true, {}}
@@ -1639,7 +1639,7 @@ bool renderNoteArticulation(NoteEventList* events, Note * note, bool chromatic, 
       if (!note->staff()->isPitchedStaff(note->tick())) // not enough info in tab staff
             return false;
 
-      vector<int> emptypattern = {};
+      std::vector<int> emptypattern = {};
       for (auto& oe : excursions) {
             if (oe.atype == articulationType && ( 0 == oe.ostyles.size()
                   || oe.ostyles.end() != oe.ostyles.find(ornamentStyle))) {
@@ -1656,7 +1656,7 @@ bool renderNoteArticulation(NoteEventList* events, Note * note, bool chromatic, 
 
 bool renderNoteArticulation(NoteEventList* events, Note * note, bool chromatic, Trill::Type trillType, MScore::OrnamentStyle ornamentStyle)
       {
-      map<Trill::Type,SymId> articulationMap = {
+      std::map<Trill::Type,SymId> articulationMap = {
             {Trill::Type::TRILL_LINE,      SymId::ornamentTrill      }
            ,{Trill::Type::UPPRALL_LINE,    SymId::ornamentUpPrall    }
            ,{Trill::Type::DOWNPRALL_LINE,  SymId::ornamentPrecompMordentUpperPrefix  }
@@ -1691,13 +1691,13 @@ bool noteHasGlissando(Note *note)
 
 void renderGlissando(NoteEventList* events, Note *notestart)
       {
-      vector<int> empty = {};
+      std::vector<int> empty = {};
       int Cnote = 60; // pitch of middle C
       int pitchstart = notestart->ppitch();
       int linestart = notestart->line();
 
-      set<int> blacknotes = {  1,  3,    6, 8, 10};
-      set<int> whitenotes = {0,  2, 4, 5, 7,  9, 11};
+      std::set<int> blacknotes = {  1,  3,    6, 8, 10};
+      std::set<int> whitenotes = {0,  2, 4, 5, 7,  9, 11};
 
       for (Spanner* spanner : notestart->spannerFor()) {
             if (spanner->type() == ElementType::GLISSANDO) {
@@ -1706,7 +1706,7 @@ void renderGlissando(NoteEventList* events, Note *notestart)
                   Element* ee = spanner->endElement();
                   // only consider glissando connected to NOTE.
                   if (glissando->playGlissando() && ElementType::NOTE == ee->type()) {
-                        vector<int> body;
+                        std::vector<int> body;
                         Note *noteend  = toNote(ee);
                         int pitchend   = noteend->ppitch();
                         bool direction = pitchend >  pitchstart;

--- a/libmscore/splitMeasure.cpp
+++ b/libmscore/splitMeasure.cpp
@@ -69,7 +69,7 @@ void Score::splitMeasure(Segment* segment)
             if (start != s->startElement() || end != s->endElement())
                   undo(new ChangeStartEndSpanner(s, start, end));
             if (s->tick() < stick && s->tick2() > stick)
-                  sl.push_back(make_tuple(s, s->tick(), s->ticks()));
+                  sl.push_back(std::make_tuple(s, s->tick(), s->ticks()));
             }
 
       // Make sure ties are the beginning the split measure are restored.

--- a/libmscore/textlinebase.cpp
+++ b/libmscore/textlinebase.cpp
@@ -140,7 +140,7 @@ void TextLineBaseSegment::draw(QPainter* painter) const
                   QVector<qreal> nDashes { dash, newGap };
                   if (tl->beginHookType() == HookType::HOOK_45 || tl->beginHookType() == HookType::HOOK_90) {
                         qreal absD = sqrt(QPointF::dotProduct(points[start+1]-points[start], points[start+1]-points[start])) / textlineLineWidth;
-                        numPairs = max(qreal(1), absD / (dash + gap));
+                        numPairs = std::max(qreal(1), absD / (dash + gap));
                         nDashes[1] = (absD - dash * (numPairs + 1)) / numPairs;
                         pen.setDashPattern(nDashes);
                         painter->setPen(pen);
@@ -149,14 +149,14 @@ void TextLineBaseSegment::draw(QPainter* painter) const
                         }
                   if (tl->endHookType() == HookType::HOOK_45 || tl->endHookType() == HookType::HOOK_90) {
                         qreal absD = sqrt(QPointF::dotProduct(points[end]-points[end-1], points[end]-points[end-1])) / textlineLineWidth;
-                        numPairs = max(qreal(1), absD / (dash + gap));
+                        numPairs = std::max(qreal(1), absD / (dash + gap));
                         nDashes[1] = (absD - dash * (numPairs + 1)) / numPairs;
                         pen.setDashPattern(nDashes);
                         painter->setPen(pen);
                         painter->drawLines(&points[end-1], 1);
                         end--;
                         }
-                  numPairs = max(qreal(1), adjustedLineLength / (dash + gap));
+                  numPairs = std::max(qreal(1), adjustedLineLength / (dash + gap));
                   nDashes[1] = (adjustedLineLength - dash * (numPairs + 1)) / numPairs;
                   pen.setDashPattern(nDashes);
                   }

--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -1311,7 +1311,7 @@ void Tuplet::addMissingElements()
                   Fraction f = missingElementsDuration / ratio();
                   Fraction ticksRequired = f;
                   Fraction endTick = elements().front()->tick();
-                  Fraction startTick = max(firstAvailableTick, endTick - ticksRequired);
+                  Fraction startTick = std::max(firstAvailableTick, endTick - ticksRequired);
                   if (expectedTick > startTick)
                         startTick = expectedTick;
                   missingElementsDuration -= addMissingElement(startTick, endTick);

--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -1096,8 +1096,8 @@ void InstrumentsWidget::createInstruments(Score* cs)
 
 void InstrumentsWidget::numberInstrumentNames(Score* cs)
       {
-      vector<QString> names;
-      vector<QString> firsts;
+      std::vector<QString> names;
+      std::vector<QString> firsts;
 
       for (auto i = cs->parts().begin(); i != cs->parts().end(); ++i) {
             auto p = *i;

--- a/mscore/mixer/mixerdetails.cpp
+++ b/mscore/mixer/mixerdetails.cpp
@@ -564,7 +564,7 @@ void MixerDetails::midiChannelChanged(int)
       seq->initInstruments();
 
       // Update MIDI Out ports
-      int maxPort = max(p, part->score()->masterScore()->midiPortCount());
+      int maxPort = std::max(p, part->score()->masterScore()->midiPortCount());
       part->score()->masterScore()->setMidiPortCount(maxPort);
       if (seq->driver() && (preferences.getBool(PREF_IO_JACK_USEJACKMIDI) || preferences.getBool(PREF_IO_ALSA_USEALSAAUDIO)))
             seq->driver()->updateOutPortCount(maxPort + 1);

--- a/mscore/parteditbase.cpp
+++ b/mscore/parteditbase.cpp
@@ -542,7 +542,7 @@ void PartEdit::midiChannelChanged(int)
             }
 
       // Update MIDI Out ports
-      int maxPort = max(p, part->score()->masterScore()->midiPortCount());
+      int maxPort = std::max(p, part->score()->masterScore()->midiPortCount());
       part->score()->masterScore()->setMidiPortCount(maxPort);
       if (seq->driver() && (preferences.getBool(PREF_IO_JACK_USEJACKMIDI) || preferences.getBool(PREF_IO_ALSA_USEALSAAUDIO)))
             seq->driver()->updateOutPortCount(maxPort + 1);

--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -412,7 +412,7 @@ std::pair<int, float> ScoreAccessibility::barbeat(Element *e)
             beat = -1;
             ticks = 0;
             }
-      return pair<int,float>(bar + 1, beat + 1 + ticks / static_cast<float>(ticksB));
+      return std::pair<int,float>(bar + 1, beat + 1 + ticks / static_cast<float>(ticksB));
       }
 
 void ScoreAccessibility::makeReadable(QString& s)

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -367,7 +367,7 @@ void TRowLabels::updateLabels(std::vector<std::pair<QString, bool>> labels, int 
 
             if (row == numMetas - 1)
                   measureWidth = graphicsTextItem->boundingRect().width();
-            maxWidth = max(maxWidth, int(graphicsTextItem->boundingRect().width()));
+            maxWidth = std::max(maxWidth, int(graphicsTextItem->boundingRect().width()));
 
             QFontMetrics f(QApplication::font());
             QString partName = f.elidedText(labels[row].first, Qt::ElideRight, width());
@@ -428,7 +428,7 @@ void TRowLabels::updateLabels(std::vector<std::pair<QString, bool>> labels, int 
             }
       QGraphicsLineItem* graphicsLineItem = new QGraphicsLineItem(0,
                                                     height * numMetas + verticalScrollBar()->value() + 1,
-                                                    max(maxWidth + 20, 70),
+                                                    std::max(maxWidth + 20, 70),
                                                     height * numMetas + verticalScrollBar()->value() + 1);
       graphicsLineItem->setPen(QPen(QColor(150, 150, 150), 4));
       graphicsLineItem->setZValue(0);
@@ -444,7 +444,7 @@ void TRowLabels::updateLabels(std::vector<std::pair<QString, bool>> labels, int 
       _oldItemInfo = tmp;
 
       setMinimumWidth(measureWidth + 9);
-      setMaximumWidth(max(maxWidth + 20, 70));
+      setMaximumWidth(std::max(maxWidth + 20, 70));
       mouseOver(mapToScene(mapFromGlobal(QCursor::pos())));
       }
 

--- a/thirdparty/intervaltree/IntervalTree.h
+++ b/thirdparty/intervaltree/IntervalTree.h
@@ -5,9 +5,6 @@
 #include <algorithm>
 #include <iostream>
 
-using namespace std;
-
-
 template <class T, typename K = int>
 class Interval {
 public:
@@ -32,7 +29,7 @@ int intervalStop(const Interval<T,K>& i) {
 }
 
 template <class T, typename K>
-ostream& operator<<(ostream& out, Interval<T,K>& i) {
+std::ostream& operator<<(std::ostream& out, Interval<T,K>& i) {
     out << "Interval(" << i.start << ", " << i.stop << "): " << i.value;
     return out;
 }
@@ -50,7 +47,7 @@ class IntervalTree {
 
 public:
     typedef Interval<T,K> interval;
-    typedef vector<interval> intervalVector;
+    typedef std::vector<interval> intervalVector;
     typedef IntervalTree<T,K> intervalTree;
 
     intervalVector intervals;
@@ -131,7 +128,7 @@ public:
                 rightp = rightextent;
             } else {
                 leftp = ivals.front().start;
-                vector<K> stops;
+                std::vector<K> stops;
                 stops.resize(ivals.size());
                 transform(ivals.begin(), ivals.end(), stops.begin(), intervalStop<T,K>);
                 rightp = *max_element(stops.begin(), stops.end());


### PR DESCRIPTION
Resolves: [#304725](https://musescore.org/en/node/304725)

Removed a `using namespace std` directive from the file `thirdparty\intervaltree\IntervalTree.h` and added missing `std::` prefixes wherever needed.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made