### PR TITLE
[MU3] fix #303422: lyrics color is preserved when importing mxml + small bugfix and cleanup for isEven

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -788,6 +788,7 @@ static void addLyric(MxmlLogger* logger, const QXmlStreamReader* const xmlreader
             }
       else {
             l->setNo(lyricNo);
+            l->setEvenLyricStyle(lyricNo & 1);
             cr->add(l);
             extendedLyrics.setExtend(lyricNo, cr->track(), cr->tick());
             }

--- a/libmscore/lyrics.h
+++ b/libmscore/lyrics.h
@@ -56,7 +56,7 @@ class Lyrics final : public TextBase {
 
    protected:
       int _no;                ///< row index
-      bool _even;
+      bool _evenLyricStyle;   ///< whether the lyric was even/odd the last time that layout was called
 
    public:
       Lyrics(Score* = 0);
@@ -82,8 +82,9 @@ class Lyrics final : public TextBase {
       int subtype() const override            { return _no; }
       QString subtypeName() const override    { return QObject::tr("Verse %1").arg(_no + 1); }
       void setNo(int n)                               { _no = n; }
+      void setEvenLyricStyle(bool b);
       int no() const                                  { return _no; }
-      bool isEven() const                             { return _no % 1; }
+      bool isEven() const                             { return _no & 1; }
       void setSyllabic(Syllabic s)                    { _syllabic = s; }
       Syllabic syllabic() const                       { return _syllabic; }
       void add(Element*) override;

--- a/mtest/musicxml/io/testLyricColor.xml
+++ b/mtest/musicxml/io/testLyricColor.xml
@@ -185,6 +185,10 @@
           <syllabic>single</syllabic>
           <text>blue.</text>
           </lyric>
+        <lyric number="2" color="#9541E8">
+          <syllabic>single</syllabic>
+          <text>purple.</text>
+          </lyric>
         </note>
       <barline location="right">
         <bar-style>light-heavy</bar-style>


### PR DESCRIPTION
Relates to: https://musescore.org/en/node/303422

I removed the `_even` variable which does not do anything other than creating a bug where there are lyrics that are neither odd nor even (as far as `Lyrics::layout` is concerned). Even `Layout::isEven` uses `_no` instead of `_even`.

This further breaks the behavior of the program when importing lyrics (since now no lyrics have the correct color when imported), but I would think that it is a step in the right direction :^).

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
