### PR TITLE
fix compiler warnings and a string typo

### DIFF
--- a/libmscore/arpeggio.cpp
+++ b/libmscore/arpeggio.cpp
@@ -25,7 +25,7 @@ namespace Ms {
 
 const std::array<const char*, 6> Arpeggio::arpeggioTypeNames = {
       QT_TRANSLATE_NOOP("Palette", "Arpeggio"),
-      QT_TRANSLATE_NOOP("Palette", "Up Arpgeggio"),
+      QT_TRANSLATE_NOOP("Palette", "Up arpeggio"),
       QT_TRANSLATE_NOOP("Palette", "Down arpeggio"),
       QT_TRANSLATE_NOOP("Palette", "Bracket arpeggio"),
       QT_TRANSLATE_NOOP("Palette", "Up arpeggio straight"),

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -503,7 +503,7 @@ void FretDiagram::layout()
                   }
             }
 
-      qreal mainWidth;
+      qreal mainWidth = 0.0;
       if (_orientation == Orientation::VERTICAL)
             mainWidth = stringDist * (_strings - 1);
       else if (_orientation == Orientation::HORIZONTAL)

--- a/mscore/inspector/inspector_fret.ui
+++ b/mscore/inspector/inspector_fret.ui
@@ -105,16 +105,6 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Fret number:</string>
-        </property>
-        <property name="buddy">
-         <cstring>fretNumber</cstring>
-        </property>
-       </widget>
-      </item>
       <item row="14" column="0" colspan="3">
        <widget class="Ms::FretCanvas" name="diagram">
         <property name="sizePolicy">
@@ -214,22 +204,6 @@
          <string>Show nut</string>
         </property>
         <property name="minimum" stdset="0">
-         <number>1</number>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="QSpinBox" name="fretNumber">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Fret number</string>
-        </property>
-        <property name="minimum">
          <number>1</number>
         </property>
        </widget>

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -1865,12 +1865,12 @@ void PianoView::cutNotes()
 
 void PianoView::copyNotes()
       {
-      QString data = serializeSelectedNotes();
-      if (data.isEmpty())
+      QString copiedNotes = serializeSelectedNotes();
+      if (copiedNotes.isEmpty())
           return;
 
       QMimeData* mimeData = new QMimeData;
-      mimeData->setData(PIANO_NOTE_MIME_TYPE, data.toUtf8());
+      mimeData->setData(PIANO_NOTE_MIME_TYPE, copiedNotes.toUtf8());
       QApplication::clipboard()->setMimeData(mimeData);
       }
 
@@ -1902,10 +1902,10 @@ void PianoView::pasteNotesAtCursor()
 
       if (ms->hasFormat(PIANO_NOTE_MIME_TYPE)) {
             //Decode our XML format and recreate the notes
-            QByteArray data = ms->data(PIANO_NOTE_MIME_TYPE);
+            QByteArray copiedNotes = ms->data(PIANO_NOTE_MIME_TYPE);
 
             score->startCmd();
-            pasteNotes(data, pasteStartTick, 0);
+            pasteNotes(copiedNotes, pasteStartTick, 0);
             score->endCmd();
             }
 
@@ -1953,10 +1953,10 @@ void PianoView::finishNoteGroupDrag() {
 //   pasteNotes
 //---------------------------------------------------------
 
-void PianoView::pasteNotes(const QString& data, Fraction pasteStartTick, int pitchOffset, bool xIsOffset)
+void PianoView::pasteNotes(const QString& copiedNotes, Fraction pasteStartTick, int pitchOffset, bool xIsOffset)
       {
 
-      QXmlStreamReader xml(data);
+      QXmlStreamReader xml(copiedNotes);
       Fraction firstTick;
 
       while (!xml.atEnd()) {
@@ -2063,6 +2063,7 @@ void PianoView::drawDraggedNotes(QPainter* painter)
 
 void PianoView::drawDraggedNote(QPainter* painter, Fraction startTick, Fraction frac, int pitch, int track, QColor color)
       {
+      Q_UNUSED(track);
       painter->setBrush(color);
 
       painter->setPen(QPen(color.darker(250)));

--- a/mscore/pianoroll/pianoview.h
+++ b/mscore/pianoroll/pianoview.h
@@ -175,7 +175,7 @@ private:
       void setNotesToVoice(int voice);
 
       QString serializeSelectedNotes();
-      void pasteNotes(const QString& data, Fraction pasteStartTick, int pitchOffset, bool xIsOffset = false);
+      void pasteNotes(const QString& copiedNotes, Fraction pasteStartTick, int pitchOffset, bool xIsOffset = false);
       void drawDraggedNotes(QPainter* painter);
       void drawDraggedNote(QPainter* painter, Fraction startTick, Fraction frac, int pitch, int track, QColor color);
 


### PR DESCRIPTION
Resolves https://musescore.org/en/node/304830 and https://musescore.org/en/node/304826