### PR TITLE
Corrects tst_palette.cpp after merge of PR6019.

### DIFF
--- a/mtest/mscore/palette/tst_palette.cpp
+++ b/mtest/mscore/palette/tst_palette.cpp
@@ -10,6 +10,7 @@
 //  the file LICENCE.GPL
 //=============================================================================
 
+#include <vector>
 #include <QtTest/QtTest>
 #include "mtest/testutils.h"
 #include "mscore/musescore.h"
@@ -24,7 +25,7 @@ class TestPaletteModel : public QObject, public MTest
       Q_OBJECT
 
       PaletteTreeModel* paletteModel;
-      QMap<QString, vector<QString>> paletteItemNames;
+      QMap<QString, std::vector<QString>> paletteItemNames;
 
       void initMuseScore();
       void iterateOverModel(QAbstractItemModel *model, QModelIndex parent = QModelIndex());
@@ -84,7 +85,7 @@ void TestPaletteModel::iterateOverModel(QAbstractItemModel* model, QModelIndex p
             QString parentName = model->data(parent, Qt::AccessibleTextRole).toString();
 
             paletteItemNames[name].push_back(parentName);
-            
+
             if (model->hasChildren(index))
                   iterateOverModel(model, index);
             }


### PR DESCRIPTION
PR #6019 removed <code>using namespace std;</code> but PR #5760 introduced <code>tst_palette.cpp</code> which was created before the merge of PR #6019 and used <cod>vector>/code> without the <code>std::</code> prefix.

Resolves: no issue

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [n.a.] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n.a.] I created the test (mtest, vtest, script test) to verify the changes I made
