### PR TITLE
fix mtests under Windows MSVC

### DIFF
--- a/mtest/mscore/palette/CMakeLists.txt
+++ b/mtest/mscore/palette/CMakeLists.txt
@@ -22,3 +22,11 @@ set(TARGET tst_palette)
 set(MTEST_LINK_MSCOREAPP TRUE)
 
 include(${PROJECT_SOURCE_DIR}/mtest/cmake.inc)
+
+if (MSVC)
+      install(DIRECTORY
+            ${CMAKE_INSTALL_PREFIX}/workspaces
+            USE_SOURCE_PERMISSIONS
+            DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+            )
+endif (MSVC)

--- a/mtest/testscript/CMakeLists.txt
+++ b/mtest/testscript/CMakeLists.txt
@@ -16,3 +16,11 @@ include(${PROJECT_SOURCE_DIR}/mtest/cmake.inc)
 
 add_dependencies(tst_runscripts mscore)
 add_definitions(-DMSCORE_EXECUTABLE_PATH="$<TARGET_FILE:mscore>")
+
+if (MSVC)
+      install(DIRECTORY
+            ${CMAKE_INSTALL_PREFIX}/workspaces
+            USE_SOURCE_PERMISSIONS
+            DESTINATION $<TARGET_FILE_DIR:mscore>/..
+            )
+endif (MSVC)


### PR DESCRIPTION
Fixes running of mtests under Windows, when compiled with MSVC.
The "workspaces" folder was missing for the new palette tests, and the executable used for scripting tests was searching for "workspaces" folder as well.
No changes in the mtest instructions.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [N/A] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
