### PR TITLE
Extend vtests and collect artifacts (Linux and Mac) to 3.x branch

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,6 +9,7 @@ image: Visual Studio 2019
 branches:
   only:
   - master
+  - 3.x
 
 # build cache to preserve files/folders between builds
 cache:

--- a/.github/workflows/collect_artifacts.yml
+++ b/.github/workflows/collect_artifacts.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
     - master
+    - 3.x
 
 jobs:
   collect_artifacts_Linux:

--- a/.github/workflows/vtests.yml
+++ b/.github/workflows/vtests.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
     - master
+    - 3.x
   push:
     branches:
     - master
+    - 3.x
 
 jobs:
   run_vtests:


### PR DESCRIPTION
Vtest check was originally done only for master branch and PR targeting master branch. The same also for "collect artifacts" tag. This PR extends to behavior also to branch 3.x
It also enables Appveyor CI for 3.x branch.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [N/A] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
