### PR TITLE
[MU4] Fix incorrect choice of accidentals on notes with same midi pitches on capx file import.

### DIFF
--- a/importexport/capella/capella.cpp
+++ b/importexport/capella/capella.cpp
@@ -790,7 +790,6 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
 
                               chord->add(note);
                               note->setPitch(pitch);
-                              // TODO: compute tpc from pitch & line
                               note->setTpcFromPitch();
                               if (o->rightTie) {
                                     Tie* tie = new Tie(score);
@@ -963,6 +962,7 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
                   }
             }
       Fraction endTick = tick;
+      score->spell();   //Call respell-pitches to correct accidentals
 
       //
       // pass II

--- a/libmscore/pitchspelling.h
+++ b/libmscore/pitchspelling.h
@@ -36,7 +36,7 @@ enum {
       };
 #endif
 
-// a list of tpc's, with legal ranges, not really an enum, so no way to cnvert into a class
+// a list of tpc's, with legal ranges, not really an enum, so no way to convert into a class
 enum Tpc : signed char {
       TPC_INVALID = -2,
       TPC_F_BB, TPC_C_BB, TPC_G_BB, TPC_D_BB, TPC_A_BB, TPC_E_BB, TPC_B_BB,


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/304625 issue (b)

On importing capx file given in node #304625, accidentals for notes with same midi pitches are incorrectly chosen by the capx importer.
Current fix: I've called respell-pitches after importing all the notes from the file, as discussed earlier that knowledge of staff line can help in determining the correct accidental.
Another alternative would be to rewrite the bits of ```Score::spell()``` while importing the notes at ```readCapVoice(...)``` in ```capella.cpp```, this can eliminate the extra traversal caused by calling ```Score::spell()```.
Before:
![Current](https://user-images.githubusercontent.com/26518513/80923099-00be2800-8d9f-11ea-83be-9c9e83f1430e.png)

After:
![New](https://user-images.githubusercontent.com/26518513/80923107-13d0f800-8d9f-11ea-834e-fbf4854e602e.png)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [n/a] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
