### PR TITLE
fix #304880: wrong beam positions when changing spatium

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -2005,7 +2005,7 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
 
 void Beam::spatiumChanged(qreal oldValue, qreal newValue)
       {
-      int idx = (_direction == Direction::AUTO || _direction == Direction::DOWN) ? 0 : 1;
+      int idx = (!_up) ? 0 : 1;
       if (_userModified[idx]) {
             qreal diff = newValue / oldValue;
             for (BeamFragment* f : fragments) {


### PR DESCRIPTION
for custom positioned beams of down stem notes.
Resolves https://musescore.org/en/node/304880