### PR TITLE
Fix #282670 - rename parts -> missing GUI refresh in tabbar

### DIFF
--- a/mscore/excerptsdialog.cpp
+++ b/mscore/excerptsdialog.cpp
@@ -136,7 +136,7 @@ ExcerptsDialog::ExcerptsDialog(MasterScore* s, QWidget* parent)
 
       moveUpButton->setIcon(*icons[int(Icons::arrowUp_ICON)]);
       moveDownButton->setIcon(*icons[int(Icons::arrowDown_ICON)]);
-      
+
       for (int i = 1; i <= VOICES; i++) {
             //partList->model()->setHeaderData(i, Qt::Horizontal, MScore::selectColor[i-1], Qt::BackgroundRole);
             partList->header()->resizeSection(i, 30);
@@ -410,6 +410,7 @@ void ExcerptsDialog::titleChanged(const QString& s)
             return;
       cur->excerpt()->setTitle(s);
       cur->setText(s);
+      score->masterScore()->setExcerptsChanged(true);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/282670

Force redraw by setting setExcerptsChanged when title changes.
- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n.a.] I created the test (mtest, vtest, script test) to verify the changes I made
