### PR TITLE
Fix #303619: MuseScore crashing when entering font name

### DIFF
--- a/mscore/inspector/inspectorBase.cpp
+++ b/mscore/inspector/inspectorBase.cpp
@@ -351,7 +351,7 @@ void InspectorBase::checkDifferentValues(const InspectorItem& ii)
                   if (valuesAreDifferent)
                         break;
                   }
-            ii.w->setStyleSheet(valuesAreDifferent ? QString("* { color: %1; } QToolTip { color: palette(tooltiptext); }").arg(c.name()) : "");
+            ii.w->setStyleSheet(valuesAreDifferent ? QString("* { color: %1; } QToolTip { color: palette(tooltiptext); }").arg(c.name()) : " ");
             }
 
       //deal with reset if only one element, or if values are the same
@@ -366,12 +366,12 @@ void InspectorBase::checkDifferentValues(const InspectorItem& ii)
                         enableReset = false;
                         break;
                   case PropertyFlags::UNSTYLED:
-                        ii.w->setStyleSheet("");
+                        ii.w->setStyleSheet(" ");
                         enableReset = true;
                         break;
                   case PropertyFlags::NOSTYLE:
                         enableReset = !isDefault(ii);
-                        ii.w->setStyleSheet("");
+                        ii.w->setStyleSheet(" ");
                         break;
                   }
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/303619.

Passing an empty string to QWidget::setStyleSheet() causes the widget's
current style sheet to be removed, thus causing the widget's style to be
inherited from its parent. This creates a problem in QComboBox::showPopup(),
where it becomes possible that a pointer to a QStyle object could used after
the object itself has been destroyed. A style sheet of " " can be used to
override any previous style sheet without invalidating the current QStyle
object.