### PR TITLE
fix #304906 Update Piano Levels Filter to shift to the new Fraction based note measurement system

### DIFF
--- a/libmscore/duration.h
+++ b/libmscore/duration.h
@@ -59,6 +59,7 @@ class DurationElement : public Element {
 
       Fraction actualTicks() const;
 
+      //Length expressed as a fraction of a whole note
       virtual Fraction ticks() const { return _duration; }
       Fraction globalTicks() const;
       void setTicks(const Fraction& f) { _duration = f;    }

--- a/libmscore/fraction.h
+++ b/libmscore/fraction.h
@@ -188,20 +188,26 @@ class Fraction {
             return *this;
             }
 
-      #if 0
+
       Fraction& operator/=(int val)
             {
             _denominator *= val;
+            if (_denominator < 0) {
+                  _denominator = -_denominator;
+                  _numerator = -_numerator;
+                  }
+            reduce();
             return *this;
             }
-      #endif
+
+
 
       Fraction operator+(const Fraction& v) const { return Fraction(*this) += v; }
       Fraction operator-(const Fraction& v) const { return Fraction(*this) -= v; }
       Fraction operator-() const                  { return Fraction(-_numerator, _denominator); }
       Fraction operator*(const Fraction& v) const { return Fraction(*this) *= v; }
       Fraction operator/(const Fraction& v) const { return Fraction(*this) /= v; }
-      //      Fraction operator/(int v)             const { return Fraction(*this) /= v; }
+      Fraction operator/(int v)             const { return Fraction(*this) /= v; }
 
 
       //---------------------------------------------------------

--- a/mscore/pianoroll/pianolevels.cpp
+++ b/mscore/pianoroll/pianolevels.cpp
@@ -183,9 +183,6 @@ void PianoLevels::paintEvent(QPaintEvent* e)
       //Round down to first bar to be a multiple of barSkip
       bar1 = (bar1 / barSkip) * barSkip;
 
-//      int subExp = qMin((int)floor(log2(pixPerBeat / minBeatGap)), _subBeats);
-//      int numSubBeats = pow(2, subExp);
-
       for (int bar = bar1; bar <= bar2; bar += barSkip) {
             Pos stick(_score->tempomap(), _score->sigmap(), bar, 0, 0);
 
@@ -222,12 +219,12 @@ void PianoLevels::paintEvent(QPaintEvent* e)
       //draw horiz lines
       PianoLevelsFilter* filter = PianoLevelsFilter::FILTER_LIST[_levelsIndex];
 
-      QFont f("FreeSans", 7);
-      p.setFont(f);
-
       int div = filter->divisionGap();
       int minGuide = (int)floor(filter->minRange() / (qreal)div);
       int maxGuide = (int)ceil(filter->maxRange() / (qreal)div);
+
+      QFont f("FreeSans", 7);
+      p.setFont(f);
 
       for (int i = minGuide; i <= maxGuide; ++i) {
             p.setPen(i == 0 || i == minGuide || i == maxGuide ? penLineMajor : penLineMinor);

--- a/mscore/pianoroll/pianolevelschooser.cpp
+++ b/mscore/pianoroll/pianolevelschooser.cpp
@@ -1,5 +1,6 @@
 #include "pianolevelschooser.h"
 #include "pianolevelsfilter.h"
+#include "pianoview.h"
 
 #include "libmscore/score.h"
 
@@ -11,7 +12,7 @@ namespace Ms {
 
 PianoLevelsChooser::PianoLevelsChooser(QWidget *parent)
       : QWidget(parent)
-{
+      {
       setupUi(this);
 
       _levelsIndex = 0;
@@ -24,24 +25,55 @@ PianoLevelsChooser::PianoLevelsChooser(QWidget *parent)
 
       connect(levelsCombo, SIGNAL(activated(int)), SLOT(setLevelsIndex(int)));
       connect(setEventsBn, SIGNAL(clicked(bool)), SLOT(setEventDataPressed()));
-}
+      }
+
+//---------------------------------------------------------
+//   setPianoView
+//---------------------------------------------------------
+
+void PianoLevelsChooser::setPianoView(PianoView* pianoView)
+      {
+      _pianoView = pianoView;
+      }
+
+//---------------------------------------------------------
+//   updateSetboxValue
+//---------------------------------------------------------
+
+void PianoLevelsChooser::updateSetboxValue()
+      {
+      QList<PianoItem*> items = _pianoView->getSelectedItems();
+
+      if (items.size() == 1) {
+            PianoLevelsFilter* filter = PianoLevelsFilter::FILTER_LIST[_levelsIndex];
+
+            PianoItem* item = items[0];
+            Note* note = item->note();
+
+            NoteEvent* event = item->getTweakNoteEvent();
+            int value = filter->value(_staff, note, event);
+            eventValSpinBox->setValue(value);
+            }
+
+      }
 
 
 //---------------------------------------------------------
-//   PianoLevelsChooser
+//   setLevelsIndex
 //---------------------------------------------------------
 
 void PianoLevelsChooser::setLevelsIndex(int index)
-{
+      {
       if (_levelsIndex != index) {
             _levelsIndex = index;
+            updateSetboxValue();
             emit levelsIndexChanged(index);
             }
-}
+      }
 
 
 //---------------------------------------------------------
-//   PianoLevelsChooser
+//   setEventDataPressed
 //---------------------------------------------------------
 
 void PianoLevelsChooser::setEventDataPressed()

--- a/mscore/pianoroll/pianolevelschooser.h
+++ b/mscore/pianoroll/pianolevelschooser.h
@@ -26,6 +26,7 @@
 
 namespace Ms {
 
+class PianoView;
 
 //---------------------------------------------------------
 //   PianoLevelsChooser
@@ -37,16 +38,19 @@ class PianoLevelsChooser : public QWidget, public Ui::PianoLevelsChooser
 
       int _levelsIndex;
       Staff* _staff;
+      PianoView* _pianoView = nullptr;
 
 public:
       Staff* staff() { return _staff; }
       void setStaff(Staff* staff) { _staff = staff; }
+      void setPianoView(PianoView* pianoView);
 
 signals:
       void levelsIndexChanged(int);
       void notesChanged();
 
 public slots:
+      void updateSetboxValue();
       void setLevelsIndex(int index);
       void setEventDataPressed();
 

--- a/mscore/pianoroll/pianolevelsfilter.h
+++ b/mscore/pianoroll/pianolevelsfilter.h
@@ -72,7 +72,7 @@ public:
 //---------------------------------------------------------
 
 
-class PianoLevelFilterLen : public PianoLevelsFilter {
+class PianoLevelFilterLenMultiplier : public PianoLevelsFilter {
       Q_DECLARE_TR_FUNCTIONS(PianoLevelFilterLen)
 
 public:
@@ -92,15 +92,15 @@ public:
 //---------------------------------------------------------
 
 
-class PianoLevelFilterLenOfftime : public PianoLevelsFilter {
+class PianoLevelFilterLenWholenote : public PianoLevelsFilter {
       Q_DECLARE_TR_FUNCTIONS(PianoLevelFilterLenOfftime)
 
 public:
       QString name() override;
       QString tooltip() override;
-      int maxRange() override;
-      int minRange() override { return 0; }
-      int divisionGap() override;
+      int maxRange() override { return 1000; }
+      int minRange() override { return -1000; }
+      int divisionGap() override { return 1000 / 4; }
       bool isPerEvent() override { return true; }
       int value(Staff* staff, Note* note, NoteEvent* evt) override;
       void setValue(Staff* staff, Note* note, NoteEvent* evt, int value) override;

--- a/mscore/pianoroll/pianoroll.cpp
+++ b/mscore/pianoroll/pianoroll.cpp
@@ -359,6 +359,7 @@ PianorollEditor::PianorollEditor(QWidget* parent)
 
       // levels area
       pianoLevelsChooser = new PianoLevelsChooser;
+      pianoLevelsChooser->setPianoView(pianoView);
       pianoLevelsChooser->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
       pianoLevelsChooser->setFixedWidth(PIANO_KEYBOARD_WIDTH);
 
@@ -692,6 +693,7 @@ void PianorollEditor::updateSelection()
       veloType->setEnabled(enabled);
       onTime->setEnabled(enabled);
       tickLen->setEnabled(enabled);
+      pianoLevelsChooser->updateSetboxValue();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Upgrading the Piano Levels Filter system to use Fration of whole note instead of ticks.
Selecting a single note now updates the Set box.
Changes to tooltip descriptions of filters.
Can now use negative values for specifying note lengths.


Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
