### PR TITLE
[Regression] fix #305007: fix an error of single-note tremolo layout

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1446,9 +1446,9 @@ qreal Chord::minAbsStemLength() const
 
             qreal height;
             if (up())
-                  height = downPos() - _tremolo->pos().y();
+                  height = upPos() - _tremolo->pos().y();
             else
-                  height = _tremolo->pos().y() + _tremolo->height() - upPos();
+                  height = _tremolo->pos().y() + _tremolo->height() - downPos();
             const bool hasHook = beamLvl && !beam();
             if (hasHook)
                   beamLvl += (up() ? 4 : 2); // reserve more space for stem with both hook and tremolo


### PR DESCRIPTION
(Should be in master too)

Before:
![image](https://user-images.githubusercontent.com/46259489/81077926-2aeb2380-8f20-11ea-8c59-4a95bd58b0d8.png)
After:
![image](https://user-images.githubusercontent.com/46259489/81077984-3b030300-8f20-11ea-9179-614b0279fe10.png)
