### PR TITLE
Fix #304292 - Invisible beams influence lyrics distance from staff

### DIFF
--- a/libmscore/chordrest.h
+++ b/libmscore/chordrest.h
@@ -18,6 +18,7 @@
 #include "duration.h"
 #include "beam.h"
 #include "shape.h"
+#include "measure.h"
 
 namespace Ms {
 
@@ -89,7 +90,7 @@ class ChordRest : public DurationElement {
       Beam::Mode beamMode() const               { return _beamMode; }
 
       void setBeam(Beam* b);
-      virtual Beam* beam() const final          { return _beam; }
+      virtual Beam* beam() const final          { return  !(measure() && measure()->stemless(staffIdx())) ? _beam : nullptr; }
       int beams() const                         { return _durationType.hooks(); }
       virtual qreal upPos()   const = 0;
       virtual qreal downPos() const = 0;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/304292

Reason of the issue was beam were created when the measure was stemless. It is solved by modifying <code>ChordRest::beam()</code> which now also returns a <code>nullptr</code> when the measure is stemless.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
