### PR TITLE
Fix #283964 - Linked parts for single voices don't work

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1910,7 +1910,7 @@ void MasterScore::addExcerpt(Excerpt* ex)
                         }
                   }
             }
-      if (ex->tracks().isEmpty()) {                         // SHOULDN'T HAPPEN, protected in the UI
+      if (ex->tracks().isEmpty()) {      // SHOULDN'T HAPPEN, protected in the UI, but it happens during read-in!!!
             QMultiMap<int, int> tracks;
             for (Staff* s : score->staves()) {
                   const LinkedElements* ls = s->links();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/283964

Corrects recognition of linked staves with a part and linked staves over excerpts.

<ocde>Score::undoAddCR()</code> will find all linked staves for the passed <code>ChordRest</code> and iterates over all these staves and decides what to do. The root cause of this issue was this algorithm didn't clearly distinguish between the two different kind of linked staves:

- 1 Linked staves within a part
- 2 Linked staves between master score and scores on excerpt.
This PR now handles creating a <code>ChordRest</code> for the following cases:

- 1 On non-linked staff at the master score.
- 2 On a staff linked, via an excerpt, to another score on another part.
- 3 On a staff linked, via an excerpt, to another score on another part using the voice-to-part feature.
- 4 On a staff linked to another staff on the same score ("linked staves" in the Parts dialog). 
- 5 On a staff linked to another staff on the same score and to another part.
- 6 On a staff linked to another staff on the same score and to another part using the voice-to-part.
All 6 cases are tested by creating a <code>ChordRest</code> on the master score and all, if applicable, on any of the linked staves.

Corrects recognition of linked staves with a part and linked staves over excerpts.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
