### PR TITLE
Fix #304918: Channel lists contain bad values after an instrument change

### DIFF
--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -165,9 +165,10 @@ void Score::updateChannel()
       for (Segment* s = fm->first(SegmentType::ChordRest); s; s = s->next1(SegmentType::ChordRest)) {
             for (const Element* e : s->annotations()) {
                   if (e->isInstrumentChange()) {
-                        Staff* staff = Score::staff(e->staffIdx());
-                        for (int voice = 0; voice < VOICES; ++voice)
-                              staff->insertIntoChannelList(voice, s->tick(), 0);
+                        for (Staff* staff : *e->part()->staves()) {
+                              for (int voice = 0; voice < VOICES; ++voice)
+                                    staff->insertIntoChannelList(voice, s->tick(), 0);
+                              }
                         continue;
                         }
                   if (!e->isStaffTextBase())


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/304918.

Since an instrument change applies to an entire part rather than a single
staff, it is necessary to update the channel lists for all staves belonging
to the part when an instrument change occurs, and not just the staff where
the instrument change is placed.