### PR TITLE
[Regression] fix #304834: settings field for multimeasure rests is too small

### DIFF
--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -247,7 +247,7 @@
        </size>
       </property>
       <property name="currentIndex">
-       <number>4</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="PageScore">
        <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -432,6 +432,12 @@
                 </item>
                 <item row="0" column="0">
                  <widget class="QLabel" name="label_15">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
                   <property name="text">
                    <string>Minimum number of empty measures:</string>
                   </property>
@@ -442,6 +448,12 @@
                 </item>
                 <item row="1" column="0">
                  <widget class="QLabel" name="label_16">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
                   <property name="text">
                    <string>Minimum width of measure:</string>
                   </property>
@@ -465,6 +477,12 @@
                 </item>
                 <item row="2" column="0">
                  <widget class="QLabel" name="label_92">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
                   <property name="text">
                    <string>Vertical position of number:</string>
                   </property>


### PR DESCRIPTION
Resolves: https://musescore.org/node/304834.

- Adjust size policies of widgets concerning multimeasure rests
- Fix `currentIndex` property