### PR TITLE
fix #304957: moving headers/footers causes a crash

### DIFF
--- a/libmscore/page.cpp
+++ b/libmscore/page.cpp
@@ -155,6 +155,7 @@ void Page::drawHeaderFooter(QPainter* p, int area, const QString& ss) const
             text = score()->headerText(area);
             if (!text) {
                   text = new Text(score(), Tid::HEADER);
+                  text->setFlag(ElementFlag::MOVABLE, false);
                   text->setFlag(ElementFlag::GENERATED, true); // set to disable editing
                   text->setLayoutToParentWidth(true);
                   score()->setHeaderText(text, area);
@@ -164,6 +165,7 @@ void Page::drawHeaderFooter(QPainter* p, int area, const QString& ss) const
             text = score()->footerText(area - MAX_HEADERS); // because they are 3 4 5
             if (!text) {
                   text = new Text(score(), Tid::FOOTER);
+                  text->setFlag(ElementFlag::MOVABLE, false);
                   text->setFlag(ElementFlag::GENERATED, true); // set to disable editing
                   text->setLayoutToParentWidth(true);
                   score()->setFooterText(text, area - MAX_HEADERS);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/304957

The proper way to make sure that an element cannot be moved is to set its`ElementFlag::MOVABLE` flag to `false`.