### PR TITLE
WIP: Core Audio Backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ SET(JACK_MIN_VERSION "0.98.0")
 option(BUILD_JACK    "Build with support for ${JACK_LONGNAME} audio backend. JACK >= ${JACK_MIN_VERSION} will be needed." ON)
 option(BUILD_PULSEAUDIO "Build with support for PulseAudio audio backend." ON)
 option(BUILD_ALSA "Build with support for ALSA audio backend." ON)
+option(BUILD_COREAUDIO "Build with support for CoreAudio audio backend." ON)
 option(BUILD_PORTAUDIO "Build with support for PortAudio audio backend." ON)
 option(BUILD_PORTMIDI "Build with support for PortAudio's MIDI features." ${BUILD_PORTAUDIO}) # PortAudio required
 option(BUILD_PCH "Build using precompiled headers." ON)
@@ -512,6 +513,16 @@ ELSE(BUILD_JACK)
      MESSAGE(STATUS "${JACK_LONGNAME} support disabled")
 ENDIF(BUILD_JACK)
 
+##
+## CoreAudio
+##
+
+if (BUILD_COREAUDIO)
+    if (APPLE)
+        message("Including CoreAudio support.")
+        set(USE_COREAUDIO 1)
+    endif (APPLE)
+endif (BUILD_COREAUDIO)
 
 ##
 ## PortAudio

--- a/audio/drivers/coreaudio.cpp
+++ b/audio/drivers/coreaudio.cpp
@@ -1,0 +1,474 @@
+//=============================================================================
+//  MusE Score
+//  Linux Music Score Editor
+//
+//  Copyright (C) 2020 Musescore BVBA
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+/*
+ * Thanks to PortAudio, whose CoreAudio implementation inspired portions of this code.
+ */
+
+#include "mididriver.h"
+
+#include "libmscore/score.h"
+
+#include "mscore/preferences.h"
+#include "mscore/seq.h"
+#include "audio/midi/msynthesizer.h"
+
+#include "coreaudio.h"
+
+#include <CoreAudio/CoreAudio.h>
+#include <AudioUnit/AudioUnit.h>
+#include <AudioToolbox/AudioToolbox.h>
+
+namespace Ms {
+AudioUnit audioUnit = NULL;
+
+//---------------------------------------------------------
+//   CoreAudio
+//---------------------------------------------------------
+
+CoreAudio::CoreAudio(Seq* s)
+    : Driver(s)
+{
+    _sampleRate = 48000;      // will be replaced by device default sample rate
+    initialized = false;
+    state       = Transport::STOP;
+    seekflag    = false;
+    pos = 0;
+    startTime = 0.0;
+    midiDriver  = 0;
+}
+
+//---------------------------------------------------------
+//   ~CoreAudio
+//---------------------------------------------------------
+
+CoreAudio::~CoreAudio()
+{
+    if (initialized) {
+        OSStatus status = AudioUnitUninitialize(audioUnit);
+        if (status != noErr) {
+            qDebug("CoreAudio uninitialize failed: %d", status);
+        }
+
+        AudioComponentInstanceDispose(audioUnit);
+    }
+}
+
+OSStatus getDefaultOutputDevice(AudioDeviceID* deviceId)
+{
+    if (deviceId == nullptr) {
+        return kAudio_ParamError;
+    }
+
+    UInt32 size = sizeof(AudioDeviceID);
+
+    AudioObjectPropertyAddress devAddress = {
+        kAudioHardwarePropertyDefaultOutputDevice,
+        kAudioObjectPropertyScopeGlobal,
+        kAudioObjectPropertyElementMaster
+    };
+
+    return AudioObjectGetPropertyData(kAudioObjectSystemObject, &devAddress, 0, nullptr, &size, deviceId);
+}
+
+Float64 getSampleRate(AudioDeviceID devId)
+{
+    Float64 sampleRate;
+    UInt32 size = sizeof(Float64);
+
+    AudioObjectPropertyAddress theAddress = {
+        kAudioDevicePropertyActualSampleRate,
+        kAudioObjectPropertyScopeInput,
+        kAudioObjectPropertyElementMaster
+    };
+
+    OSStatus status = AudioObjectGetPropertyData(devId, &theAddress, 0, NULL, &size, &sampleRate);
+
+    if (status == noErr) {
+        return sampleRate;
+    } else {
+        return 0.0f;
+    }
+}
+
+static OSStatus CoreAudioIOProc(void* inRefCon,AudioUnitRenderActionFlags* ioActionFlags,const AudioTimeStamp* inTimeStamp,
+                                UInt32 inBusNumber,UInt32 inNumberFrames,AudioBufferList* ioData);
+
+static OSStatus changeDesiredStreamFormat(AudioUnit* audioUnit, float sampleRate)
+{
+    AudioStreamBasicDescription desiredFormat;
+
+    qDebug("Setting sample rate of %f, %d", sampleRate, seq->canStart());
+
+    MScore::sampleRate = sampleRate;
+
+    if (seq->canStart()) {
+        seq->synti()->setSampleRate(sampleRate);
+    }
+
+    memset(&desiredFormat, 0, sizeof(AudioStreamBasicDescription));
+    desiredFormat.mFormatID = kAudioFormatLinearPCM;
+    desiredFormat.mFormatFlags = kAudioFormatFlagsNativeFloatPacked;
+    desiredFormat.mFramesPerPacket = 1;
+    desiredFormat.mBitsPerChannel = sizeof(float) * 8;
+    desiredFormat.mSampleRate = sampleRate;
+    desiredFormat.mBytesPerPacket = sizeof(float) * 2;
+    desiredFormat.mBytesPerFrame = sizeof(float) * 2;
+    desiredFormat.mChannelsPerFrame = 2;
+    return AudioUnitSetProperty(*audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &desiredFormat,
+                                sizeof(desiredFormat));
+}
+
+// Substantial portions of this taken from Portaudio.
+bool openAudioUnit(AudioUnit* audioUnit, AudioDeviceID* audioDevice, CoreAudio* ca)
+{
+    AudioComponent comp;
+    AudioComponentDescription desc;
+    AURenderCallbackStruct renderCallbackData;
+    UInt32 converterQuality;
+
+    desc.componentType = kAudioUnitType_Output;
+    desc.componentSubType = kAudioUnitSubType_HALOutput;
+    desc.componentManufacturer = kAudioUnitManufacturer_Apple;
+    desc.componentFlags = 0;
+    desc.componentFlagsMask = 0;
+
+    comp = AudioComponentFindNext(NULL, &desc);
+    if (!comp) {
+        qDebug("AUHAL component not found.");
+        *audioUnit = NULL;
+        *audioDevice = kAudioDeviceUnknown;
+        return false;
+    }
+
+    OSStatus status = AudioComponentInstanceNew(comp, audioUnit);
+    if (status) {
+        qDebug("Failed to open AUHAL component.");
+        *audioUnit = NULL;
+        *audioDevice = kAudioDeviceUnknown;
+        return false;
+    }
+
+    status
+        = AudioUnitSetProperty(*audioUnit, kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global, 0, audioDevice,
+                               sizeof(AudioDeviceID));
+    if (status) {
+        qDebug("Failed to set current device.");
+        goto error;
+    }
+
+    converterQuality = kAudioConverterQuality_Max;
+    status
+        = AudioUnitSetProperty(*audioUnit, kAudioUnitProperty_RenderQuality, kAudioUnitScope_Global, 0, &converterQuality,
+                               sizeof(converterQuality));
+    if (status) {
+        qDebug("Failed to set render quality");
+        goto error;
+    }
+
+    status = changeDesiredStreamFormat(audioUnit, ca->sampleRate());
+    if (status) {
+        qDebug("Failed to set stream format");
+        goto error;
+    }
+
+    renderCallbackData.inputProc = CoreAudioIOProc;
+    renderCallbackData.inputProcRefCon = ca;
+
+    status
+        = AudioUnitSetProperty(*audioUnit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Output, 0, &renderCallbackData,
+                               sizeof(renderCallbackData));
+    if (status) {
+        qDebug("Failed to set render callback");
+        goto error;
+    }
+
+    AudioUnitInitialize(*audioUnit);
+
+    return true;
+error:
+    if (*audioUnit) {
+        AudioComponentInstanceDispose(*audioUnit);
+        *audioUnit = NULL;
+    }
+
+    *audioDevice = kAudioDeviceUnknown;
+    return false;
+}
+
+static OSStatus CoreAudioIOProc(void* inRefCon,
+                                AudioUnitRenderActionFlags* ioActionFlags,
+                                const AudioTimeStamp* inTimeStamp,
+                                UInt32 inBusNumber,
+                                UInt32 inNumberFrames,
+                                AudioBufferList* ioData)
+{
+    Q_UNUSED(inRefCon);
+    Q_UNUSED(ioActionFlags);
+    Q_UNUSED(inTimeStamp);
+    Q_UNUSED(inBusNumber);
+    Q_UNUSED(inNumberFrames);
+
+    seq->setInitialMillisecondTimestampWithLatency();
+
+    UInt32 bytesPerFrame = sizeof(float) * ioData->mBuffers[0].mNumberChannels;
+
+    float* buffer = static_cast<float*>(ioData->mBuffers[0].mData);
+    UInt32 frames = ioData->mBuffers[0].mDataByteSize / bytesPerFrame;
+
+    if (seq->driver()) {
+        seq->process(frames, buffer);
+    }
+
+    return noErr;
+}
+
+bool CoreAudio::init(bool)
+{
+    CFRunLoopRef theRunLoop = NULL;
+    AudioObjectPropertyAddress theAddress
+        = { kAudioHardwarePropertyRunLoop, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMaster };
+    OSStatus osErr = AudioObjectSetPropertyData(kAudioObjectSystemObject, &theAddress, 0, NULL, sizeof(CFRunLoopRef), &theRunLoop);
+    if (osErr != noErr) {
+        initialized = false;
+        return false;
+    }
+
+    AudioObjectPropertyAddress outputDeviceAddress = {
+        kAudioHardwarePropertyDefaultOutputDevice,
+        kAudioObjectPropertyScopeGlobal,
+        kAudioObjectPropertyElementMaster
+    };
+
+    AudioObjectAddPropertyListener(kAudioObjectSystemObject, &outputDeviceAddress, &CoreAudio::onDefaultOutputDeviceChanged, this);
+
+    AudioDeviceID deviceId = 0;
+    OSStatus status = getDefaultOutputDevice(&deviceId);
+    if (status != noErr) {
+        qDebug("Error occurred while getting default output device: %d", status);
+        return false;
+    }
+
+    this->currentOutputDevice = deviceId;
+
+    outputDeviceAddress = {
+        kAudioDevicePropertyActualSampleRate,
+        kAudioObjectPropertyScopeInput,
+        kAudioObjectPropertyElementMaster
+    };
+
+    AudioObjectAddPropertyListener(deviceId, &outputDeviceAddress, &CoreAudio::onSampleRateChanged, this);
+
+    return openAudioUnit(&audioUnit, &deviceId, this);
+}
+
+bool CoreAudio::start(bool)
+{
+    OSStatus status = AudioOutputUnitStart(audioUnit);
+    if (status) {
+        return false;
+    } else {
+        return true;
+    }
+}
+
+bool CoreAudio::stop()
+{
+    OSStatus status = AudioOutputUnitStop(audioUnit);
+
+    if (status) {
+        return false;
+    } else {
+        return true;
+    }
+}
+
+void CoreAudio::stopTransport()
+{
+    state = Transport::STOP;
+}
+
+void CoreAudio::startTransport()
+{
+    state = Transport::PLAY;
+}
+
+Transport CoreAudio::getState()
+{
+    return state;
+}
+
+void CoreAudio::midiRead()
+{
+    return;
+}
+
+// FIXME: Do we want to keep this around? Will there be a need to give people the option to switch devices in the CoreAudio back end?
+QStringList CoreAudio::deviceList()
+{
+    QStringList dl;
+
+    AudioObjectPropertyAddress deviceListAddress = {
+        kAudioHardwarePropertyDevices,
+        kAudioObjectPropertyScopeGlobal,
+        kAudioObjectPropertyElementMaster
+    };
+
+    UInt32 dataSize = 0;
+
+    OSStatus status = AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &deviceListAddress, 0, NULL, &dataSize);
+    if (status != kAudioHardwareNoError) {
+        qDebug("AudioObjectGetPropertyDataSize (kAudioHardwarePropertyDevices) failed: %i\n", status);
+        return dl;
+    }
+
+    UInt32 deviceCount = static_cast<UInt32>(dataSize / sizeof(AudioDeviceID));
+
+    AudioDeviceID* audioDevices = static_cast<AudioDeviceID*>(malloc(dataSize));
+    if (audioDevices == nullptr) {
+        qDebug("Could not allocate enough memory for audioDevices");
+        return dl;
+    }
+
+    status = AudioObjectGetPropertyData(kAudioObjectSystemObject, &deviceListAddress, 0, NULL, &dataSize, audioDevices);
+    if (status != kAudioHardwareNoError) {
+        qDebug("AudioObjectGetPropertyData (kAudioHardwarePropertyDevices) failed: %i\n", status);
+        free(audioDevices);
+        audioDevices = nullptr;
+        return dl;
+    }
+
+    CFMutableArrayRef inputDeviceArray = CFArrayCreateMutable(kCFAllocatorDefault, deviceCount, &kCFTypeArrayCallBacks);
+    if (NULL == inputDeviceArray) {
+        qDebug("CFArrayCreateMutable failed");
+        free(audioDevices), audioDevices = nullptr;
+        return dl;
+    }
+
+    // Iterate through all the devices and determine which are input-capable
+    deviceListAddress.mScope = kAudioDevicePropertyScopeOutput;
+    for (UInt32 i = 0; i < deviceCount; i++) {
+        // Query device UID
+        CFStringRef deviceUID = NULL;
+        dataSize = sizeof(deviceUID);
+        deviceListAddress.mSelector = kAudioDevicePropertyDeviceUID;
+        status = AudioObjectGetPropertyData(audioDevices[i], &deviceListAddress, 0, NULL, &dataSize, &deviceUID);
+        if (kAudioHardwareNoError != status) {
+            qDebug("AudioObjectGetPropertyData (kAudioDevicePropertyDeviceUID) failed: %i\n", status);
+            continue;
+        }
+
+        // Query device name
+        CFStringRef deviceName = NULL;
+        dataSize = sizeof(deviceName);
+        deviceListAddress.mSelector = kAudioDevicePropertyDeviceNameCFString;
+        status = AudioObjectGetPropertyData(audioDevices[i], &deviceListAddress, 0, NULL, &dataSize, &deviceName);
+        if (kAudioHardwareNoError != status) {
+            qDebug("AudioObjectGetPropertyData (kAudioDevicePropertyDeviceNameCFString) failed: %i\n", status);
+            continue;
+        }
+
+        if (deviceName != nullptr) {
+            dl.append(QString::fromCFString(deviceName));
+        }
+    }
+
+    return dl;
+}
+
+OSStatus CoreAudio::onSampleRateChanged(AudioObjectID objId, UInt32 inNumberAddresses, const AudioObjectPropertyAddress inAddresses[],
+                                        void* paVoid)
+{
+    Q_UNUSED(inNumberAddresses);
+    Q_UNUSED(paVoid);
+
+    Float64 sampleRate = 0.0f;
+    UInt32 size = sizeof(Float64);
+
+    OSStatus status;
+    if ((status = AudioObjectGetPropertyData(objId, inAddresses, 0, nullptr, &size, &sampleRate)) != 0) {
+        qDebug("Error happened while fetching sample rate: %d\n", status);
+        return status;
+    }
+
+    status = changeDesiredStreamFormat(&audioUnit, sampleRate);
+    if (!status) {
+        qDebug("Error occurred while setting new sample rate: %d\n", status);
+    }
+
+    return status;
+}
+
+OSStatus CoreAudio::onDefaultOutputDeviceChanged(AudioObjectID inObjectID, UInt32 inNumberAddresses,
+                                                 const AudioObjectPropertyAddress inAddresses[], void* paVoid)
+{
+    Q_UNUSED(inNumberAddresses);
+
+    CoreAudio* ca = static_cast<CoreAudio*>(paVoid);
+
+    UInt32 defaultOut = 0;
+    UInt32 size = sizeof(UInt32);
+
+    AudioObjectPropertyAddress addr = {
+        kAudioDevicePropertyActualSampleRate,
+        kAudioObjectPropertyScopeInput,
+        kAudioObjectPropertyElementMaster
+    };
+
+    OSStatus status;
+
+    // Need to keep the property listener updated for the default output device.
+    status = AudioObjectRemovePropertyListener(ca->currentOutputDevice, &addr, &CoreAudio::onSampleRateChanged, paVoid);
+    if (status) {
+        qDebug("Error occurred while removing property listener: %d", status);
+        return status;
+    }
+
+    if ((status = AudioObjectGetPropertyData(inObjectID, inAddresses, 0, nullptr, &size, &defaultOut)) != 0) {
+        qDebug("Error occurred while fetching default output device: %d", status);
+        return status;
+    }
+
+    ca->_sampleRate = getSampleRate(defaultOut);
+    ca->currentOutputDevice = defaultOut;
+
+    // Need to keep the property listener updated for the default output device.
+    status = AudioObjectAddPropertyListener(ca->currentOutputDevice, &addr, &CoreAudio::onSampleRateChanged, paVoid);
+    if (status) {
+        qDebug("Error occurred while adding property listener: %d", status);
+        return status;
+    }
+
+    status
+        = AudioUnitSetProperty(audioUnit, kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global, 0, &defaultOut,
+                               sizeof(AudioDeviceID));
+    if (status) {
+        qDebug("Failed to set current device: %d", status);
+        return status;
+    }
+
+    status = changeDesiredStreamFormat(&audioUnit, ca->_sampleRate);
+    if (status) {
+        qDebug("Failed to change desired stream format: %d", status);
+        return status;
+    }
+
+    return noErr;
+}
+}

--- a/audio/drivers/coreaudio.h
+++ b/audio/drivers/coreaudio.h
@@ -1,0 +1,83 @@
+//=============================================================================
+//  MuseScore
+//  Linux Music Score Editor
+//
+//  Copyright (C) 2020 Musescore BVBA
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef __COREAUDIO_H__
+#define __COREAUDIO_H__
+
+#include "config.h"
+#include "driver.h"
+
+#include <CoreAudio/CoreAudio.h>
+#include <AudioUnit/AudioUnit.h>
+#include <AudioToolbox/AudioToolbox.h>
+
+namespace Ms {
+class Synth;
+class Seq;
+class MidiDriver;
+
+enum class Transport : char;
+
+//---------------------------------------------------------
+//   CoreAudio
+//---------------------------------------------------------
+
+class CoreAudio : public Driver
+{
+    bool initialized;
+    float _sampleRate;
+
+    Transport state;
+    bool seekflag;
+    unsigned pos;
+    double startTime;
+
+    MidiDriver* midiDriver;
+
+    UInt32 currentOutputDevice;
+
+    static OSStatus onDefaultOutputDeviceChanged(AudioObjectID inObjectID, UInt32 inNumberAddresses,
+                                                 const AudioObjectPropertyAddress inAddresses[], void* paVoid);
+    static OSStatus onSampleRateChanged(AudioObjectID inObjectID, UInt32 inNumberAddresses, const AudioObjectPropertyAddress inAddresses[],
+                                        void* paVoid);
+
+public:
+    CoreAudio(Seq*);
+    virtual ~CoreAudio();
+    virtual bool init(bool hot = false);
+    virtual bool start(bool hotPlug = false);
+    virtual bool stop();
+    virtual void startTransport();
+    virtual void stopTransport();
+    virtual Transport getState() override;
+    virtual int sampleRate() const { return static_cast<int>(_sampleRate); }
+    virtual void midiRead();
+
+    int framePos() const;
+    float* getLBuffer(long n);
+    float* getRBuffer(long n);
+    virtual bool isRealtime() const { return false; }
+
+    QStringList deviceList();
+    int currentDevice() const;
+    MidiDriver* mididriver() { return midiDriver; }
+};
+}
+
+#endif // __COREAUDIO_H__

--- a/audio/drivers/drivers.cmake
+++ b/audio/drivers/drivers.cmake
@@ -12,6 +12,10 @@ if ( NOT MINGW AND NOT MSVC )
     endif (USE_ALSA)
 endif ( NOT MINGW AND NOT MSVC )
 
+if (USE_COREAUDIO)
+    set (DRIVERS_SRC ${DRIVERS_SRC} ${DRIVERS_DIR}/coreaudio.cpp ${DRIVERS_DIR}/coreaudio.h)
+endif (USE_COREAUDIO)
+
 if (USE_PORTAUDIO)
     set (DRIVERS_SRC ${DRIVERS_SRC} ${DRIVERS_DIR}/pa.cpp ${DRIVERS_DIR}/pa.h)
 endif (USE_PORTAUDIO)

--- a/build/config.h.in
+++ b/build/config.h.in
@@ -22,6 +22,7 @@
 
 #cmakedefine USE_ALSA
 #cmakedefine USE_JACK
+#cmakedefine USE_COREAUDIO
 #cmakedefine USE_PORTAUDIO
 #cmakedefine USE_PORTMIDI
 #cmakedefine USE_PULSEAUDIO

--- a/framework/preferencekeys.h
+++ b/framework/preferencekeys.h
@@ -100,6 +100,7 @@
 #define PREF_IO_PORTMIDI_OUTPUTDEVICE                       "io/portMidi/outputDevice"
 #define PREF_IO_PORTMIDI_OUTPUTLATENCYMILLISECONDS          "io/portMidi/outputLatencyMilliseconds"
 #define PREF_IO_PULSEAUDIO_USEPULSEAUDIO                    "io/pulseAudio/usePulseAudio"
+#define PREF_IO_COREAUDIO_USECOREAUDIO                      "io/coreAudio/useCoreAudio"
 #define PREF_SCORE_CHORD_PLAYONADDNOTE                      "score/chord/playOnAddNote"
 #define PREF_SCORE_HARMONY_PLAY_ONEDIT                      "score/harmony/play/onedit"
 #define PREF_SCORE_MAGNIFICATION                            "score/magnification"

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -189,6 +189,7 @@ void Preferences::init(bool storeInMemoryOnly)
             { PREF_IO_MIDI_USEREMOTECONTROL,                        new BoolPreference(false, false) },
             { PREF_IO_OSC_PORTNUMBER,                               new IntPreference(5282, false) },
             { PREF_IO_OSC_USEREMOTECONTROL,                         new BoolPreference(false, false) },
+            { PREF_IO_COREAUDIO_USECOREAUDIO,                       new BoolPreference(false, false) },
             { PREF_IO_PORTAUDIO_DEVICE,                             new IntPreference(-1, false) },
             { PREF_IO_PORTAUDIO_USEPORTAUDIO,                       new BoolPreference(defaultUsePortAudio, false) },
             { PREF_IO_PORTMIDI_INPUTBUFFERCOUNT,                    new IntPreference(100) },

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -2683,6 +2683,22 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_8">
        <item>
+        <widget class="Ms::RadioButtonGroupBox" name="coreAudioDriver">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>30</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Core Audio</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="Ms::RadioButtonGroupBox" name="pulseaudioDriver">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -4375,6 +4391,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>partStyleButton</tabstop>
   <tabstop>scale</tabstop>
   <tabstop>showMidiControls</tabstop>
+  <tabstop>coreAudioDriver</tabstop>
   <tabstop>pulseaudioDriver</tabstop>
   <tabstop>portaudioDriver</tabstop>
   <tabstop>portaudioApi</tabstop>

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -248,6 +248,7 @@ void Seq::CachedPreferences::update()
     useJackAudio = preferences.getBool(PREF_IO_JACK_USEJACKAUDIO);
     useAlsaAudio = preferences.getBool(PREF_IO_ALSA_USEALSAAUDIO);
     usePortAudio = preferences.getBool(PREF_IO_PORTAUDIO_USEPORTAUDIO);
+    useCoreAudio = preferences.getBool(PREF_IO_COREAUDIO_USECOREAUDIO);
     usePulseAudio = preferences.getBool(PREF_IO_PULSEAUDIO_USEPULSEAUDIO);
 }
 
@@ -1396,7 +1397,8 @@ void Seq::stopNotes(int channel, bool realTime)
             send(NPlayEvent(ME_PITCHBEND,  channel, 0, 64));
         }
     }
-    if (cachedPrefs.useAlsaAudio || cachedPrefs.useJackAudio || cachedPrefs.usePulseAudio || cachedPrefs.usePortAudio) {
+    if (cachedPrefs.useAlsaAudio || cachedPrefs.useJackAudio || cachedPrefs.usePulseAudio || cachedPrefs.usePortAudio
+        || cachedPrefs.useCoreAudio) {
         guiToSeq(SeqMsg(SeqMsgId::ALL_NOTE_OFF, channel));
     }
 }
@@ -1622,7 +1624,7 @@ void Seq::putEvent(const NPlayEvent& event, unsigned framePos)
     _synti->play(event, syntiIdx);
 
     // midi
-    if (_driver != 0 && (cachedPrefs.useJackMidi || cachedPrefs.useAlsaAudio || cachedPrefs.usePortAudio)) {
+    if (_driver != 0 && (cachedPrefs.useJackMidi || cachedPrefs.useAlsaAudio || cachedPrefs.usePortAudio || cachedPrefs.useCoreAudio)) {
         _driver->putEvent(event, framePos);
     }
 }

--- a/mscore/seq.h
+++ b/mscore/seq.h
@@ -184,6 +184,7 @@ class Seq : public QObject, public Sequencer
         bool useJackAudio = false;
         bool useAlsaAudio = false;
         bool usePortAudio = false;
+        bool useCoreAudio = false;
         bool usePulseAudio = false;
 
         void update();


### PR DESCRIPTION
I added a basic Driver class for a Core Audio backend, and added a RadioGroupBox to the preference dialog for selecting Core Audio.

Why did I want to add this code/What are the benefits?
I wanted MuseScore to switch output devices automatically if I were to plug one in. PortAudio required me to mess with the I/O tab in the Preferences dialog to switch output devices. PortAudio has no API for tracking output device changes.

Using Core Audio directly has another benefit, which is a lower "Energy Impact" score. My not-so-scientific test yielded a difference between 5 and 2.5 when playback was stopped. It's not groundbreaking, but it is a small improvement.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [ ] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
