### PR TITLE
Fix #305106: Crash when applying preferences with no scores open

### DIFF
--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -965,6 +965,8 @@ void PreferenceDialog::buttonBoxClicked(QAbstractButton* button)
 
 void PreferenceDialog::apply()
       {
+      const auto cv = mscore->currentScoreView();
+
       advancedWidget->save();
 
       if (lastSession->isChecked())
@@ -1123,8 +1125,8 @@ void PreferenceDialog::apply()
                   for (Score* ss : s->scoreList())
                         ss->doLayout();
                   }
-            if (mscore->currentScoreView())
-                  mscore->currentScoreView()->setOffset(0.0, 0.0);
+            if (cv)
+                  cv->setOffset(0.0, 0.0);
             mscore->scorePageLayoutChanged();
             mscore->update();
             }
@@ -1208,10 +1210,11 @@ void PreferenceDialog::apply()
       preferences.save();
       mscore->startAutoSave();
 
-      //Smooth panning
-      SmoothPanSettings* svPanSettings = mscore->currentScoreView()->panSettings();
-      svPanSettings->loadFromPreferences();
-      mscore->currentScoreView()->setControlCursorVisible(preferences.getBool(PREF_PAN_CURSOR_VISIBLE));
+      // Smooth panning
+      if (cv) {
+            cv->panSettings().loadFromPreferences();
+            cv->setControlCursorVisible(preferences.getBool(PREF_PAN_CURSOR_VISIBLE));
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -454,7 +454,7 @@ class ScoreView : public QWidget, public MuseScoreView {
 
       virtual void moveCursor() override;
 
-      SmoothPanSettings* panSettings() { return &_panSettings; }
+      SmoothPanSettings& panSettings() { return _panSettings; }
 
       virtual void layoutChanged();
       virtual void dataChanged(const QRectF&);


### PR DESCRIPTION
Resolves: [#305106](https://musescore.org/en/node/305106)

Added a missing `nullptr` check for `mscore->currentScoreView()` inside `PreferenceDialog::apply()`, fixing a crash that occurred if the user attempted to apply preferences when there were no scores open.

Also changed `ScoreView::panSettings()` to return a reference instead of a pointer, eliminating the need for an unnecessary `nullptr` check.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made