### PR TITLE
fix #305017: Cursor.addNote fails to add notes to existing chords in INPUT_STATE_INDEPENDENT mode

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -369,8 +369,10 @@ Rest* Score::setRest(const Fraction& _tick, int track, const Fraction& _l, bool 
 //   addNote from NoteVal
 //---------------------------------------------------------
 
-Note* Score::addNote(Chord* chord, const NoteVal& noteVal, bool forceAccidental)
+Note* Score::addNote(Chord* chord, const NoteVal& noteVal, bool forceAccidental, InputState* externalInputState)
       {
+      InputState& is = externalInputState ? (*externalInputState) : _is;
+
       Note* note = new Note(this);
       note->setParent(chord);
       note->setTrack(chord->track());
@@ -388,11 +390,20 @@ Note* Score::addNote(Chord* chord, const NoteVal& noteVal, bool forceAccidental)
             }
       setPlayNote(true);
       setPlayChord(true);
-      select(note, SelectType::SINGLE, 0);
+
+      if (externalInputState) {
+            is.setTrack(note->track());
+            is.setLastSegment(is.segment());
+            is.setSegment(note->chord()->segment());
+            }
+      else {
+            select(note, SelectType::SINGLE, 0);
+            }
+
       if (!chord->staff()->isTabStaff(chord->tick())) {
-            NoteEntryMethod entryMethod = _is.noteEntryMethod();
+            NoteEntryMethod entryMethod = is.noteEntryMethod();
             if (entryMethod != NoteEntryMethod::REALTIME_AUTO && entryMethod != NoteEntryMethod::REALTIME_MANUAL)
-                  _is.moveToNextInputPos();
+                  is.moveToNextInputPos();
             }
       return note;
       }

--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -126,13 +126,13 @@ Note* Score::addPitch(NoteVal& nval, bool addFlag, InputState* externalInputStat
       InputState& is = externalInputState ? (*externalInputState) : _is;
 
       if (addFlag) {
-            Chord* c = toChord(is.lastSegment()->element(is.track()));
+            ChordRest* c = toChordRest(is.lastSegment()->element(is.track()));
 
             if (c == 0 || !c->isChord()) {
                   qDebug("Score::addPitch: cr %s", c ? c->name() : "zero");
                   return 0;
                   }
-            Note* note = addNote(c, nval);
+            Note* note = addNote(toChord(c), nval, /* forceAccidental */ false, externalInputState);
             if (is.lastSegment() == is.segment()) {
                   NoteEntryMethod entryMethod = is.noteEntryMethod();
                   if (entryMethod != NoteEntryMethod::REALTIME_AUTO && entryMethod != NoteEntryMethod::REALTIME_MANUAL)
@@ -140,7 +140,7 @@ Note* Score::addPitch(NoteVal& nval, bool addFlag, InputState* externalInputStat
                   }
             return note;
             }
-      expandVoice();
+      expandVoice(is.segment(), is.track());
 
       // insert note
       Direction stemDirection = Direction::AUTO;
@@ -152,7 +152,7 @@ Note* Score::addPitch(NoteVal& nval, bool addFlag, InputState* externalInputStat
             stemDirection     = ds->stemDirection(nval.pitch);
             track             = ds->voice(nval.pitch) + (is.track() / VOICES) * VOICES;
             is.setTrack(track);
-            expandVoice();
+            expandVoice(is.segment(), is.track());
             }
       if (!is.cr())
             return 0;
@@ -235,7 +235,7 @@ Note* Score::addPitch(NoteVal& nval, bool addFlag, InputState* externalInputStat
             select(lastTiedNote);
             }
       else if (!is.usingNoteEntryMethod(NoteEntryMethod::REPITCH)) {
-            Segment* seg = setNoteRest(is.segment(), track, nval, duration, stemDirection);
+            Segment* seg = setNoteRest(is.segment(), track, nval, duration, stemDirection, /* forceAccidental */ false, /* rhythmic */ false, externalInputState);
             if (seg) {
                   note = toChord(seg->element(track))->upNote();
                   }

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -689,7 +689,7 @@ class Score : public QObject, public ScoreElement {
 
       Note* setGraceNote(Chord*,  int pitch, NoteType type, int len);
 
-      Segment* setNoteRest(Segment*, int track, NoteVal nval, Fraction, Direction stemDirection = Direction::AUTO, bool forceAccidental = false, bool rhythmic = false);
+      Segment* setNoteRest(Segment*, int track, NoteVal nval, Fraction, Direction stemDirection = Direction::AUTO, bool forceAccidental = false, bool rhythmic = false, InputState* externalInputState = nullptr);
       Segment* setChord(Segment*, int track, Chord* chord, Fraction, Direction stemDirection = Direction::AUTO);
       void changeCRlen(ChordRest* cr, const TDuration&);
       void changeCRlen(ChordRest* cr, const Fraction&, bool fillWithRest=true);
@@ -724,7 +724,7 @@ class Score : public QObject, public ScoreElement {
       void addPitch(int pitch, bool addFlag, bool insert);
       Note* addTiedMidiPitch(int pitch, bool addFlag, Chord* prevChord);
       Note* addMidiPitch(int pitch, bool addFlag);
-      Note* addNote(Chord*, const NoteVal& noteVal, bool forceAccidental = false);
+      Note* addNote(Chord*, const NoteVal& noteVal, bool forceAccidental = false, InputState* externalInputState = nullptr);
 
       NoteVal noteValForPosition(Position pos, AccidentalType at, bool &error);
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/305017 (regression after #5657)

The issue appeared after bd979cf23bd6478330990ed103df3fa85bd89c21 which
attempted to decouple the logic behind Cursor.addNote() from InputState
in Score::_is to make it possible to choose whether Cursor should
be synchronized with score input state. However Score::addNote implicitly
contained more dependencies on Score::_is which were not covered by
the previous change. This commit is intended to remove this dependency
and fix behavior of "independent" mode of Cursor in QML plugins.