### PR TITLE
fix #305018: fix a crash on adding a note with unrewound Cursor

### DIFF
--- a/mscore/plugin/api/cursor.cpp
+++ b/mscore/plugin/api/cursor.cpp
@@ -378,6 +378,10 @@ void Cursor::addNote(int pitch, bool addToChord)
             qWarning("Cursor::addNote: invalid pitch: %d", pitch);
             return;
             }
+      if (!segment()) {
+            qWarning("Cursor::addNote: cursor location is undefined, use rewind() to define its location");
+            return;
+            }
       if (!inputState().duration().isValid())
             setDuration(1, 4);
       NoteVal nval(pitch);

--- a/mscore/plugin/api/cursor.h
+++ b/mscore/plugin/api/cursor.h
@@ -38,7 +38,15 @@ class Score;
 
 //---------------------------------------------------------
 //   @@ Cursor
-///   Cursor can be used by plugins to manipulate the score
+///   Cursor can be used by plugins to manipulate the score.
+///   Cursor object for a score can be obtained with
+///   \ref Score.newCursor method. After creating a cursor
+///   it does not point to any location in a score. To define
+///   its initial location use \ref rewind or \ref rewindToTick
+///   methods. Alternatively, you can set its
+///   \ref inputStateMode to \ref INPUT_STATE_SYNC_WITH_SCORE "Cursor.INPUT_STATE_SYNC_WITH_SCORE"
+///   to make cursor location be synchronized with
+///   user-visible note input state.
 //---------------------------------------------------------
 
 class Cursor : public QObject {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/305018

In addition to fixing a crash also expands a bit `Cursor` documentation to make its usage (hopefully) more clear.