### PR TITLE
fix #305078 : Crash on attempting to playback or rewind score

### DIFF
--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -1040,7 +1040,8 @@ void Seq::initInstruments(bool realTime)
 
 void Seq::renderChunk(const MidiRenderer::Chunk& ch, EventMap* eventMap)
       {
-      MidiRenderer::Context ctx(mscore->synthesizerState());
+      SynthesizerState synState = mscore->synthesizerState();
+      MidiRenderer::Context ctx(synState);
       ctx.metronome = true;
       ctx.renderHarmony = preferences.getBool(PREF_SCORE_HARMONY_PLAY);
       midi.renderChunk(ch, eventMap, ctx);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/305078

An analysis with AddressSanitizer shows that the object mscore->synthesizerState() was running out of scope after execution of initialization ctx(mscore->synthesizerState()), so when the synthesizerState stored in ctx was accessed (during midi.renderChunk), a deleted variable was actually accessed.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
