### PR TITLE
fix #289952 : gliss. text is misplaced on exporting the score

### DIFF
--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -118,7 +118,7 @@ void GlissandoSegment::draw(QPainter* painter) const
             f.setBold(glissando()->fontStyle() & FontStyle::Bold);
             f.setItalic(glissando()->fontStyle() & FontStyle::Italic);
             f.setUnderline(glissando()->fontStyle() & FontStyle::Underline);
-            QFontMetricsF fm(f);
+            QFontMetricsF fm(f, painter->device()); // use the QPaintDevice, otherwise calculations will be done in screen metrics
             QRectF r = fm.boundingRect(glissando()->text());
 
             // if text longer than available space, skip it


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/289952

The "gliss." text width was computed by assuming screen metrics, while exporting (as pdf, svg or png) assumes a DPI value usually different from the screen one.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] _(already existing)_ I created the test (mtest, vtest, script test) to verify the changes I made
