### PR TITLE
Plugin API: add basic access to score style settings

### DIFF
--- a/Doxyfile.plugins
+++ b/Doxyfile.plugins
@@ -798,6 +798,7 @@ INPUT                  = doc/plugins.md \
                          doc/tpc.md \
                          mscore/plugin/api \
                          libmscore/types.h \
+                         libmscore/style.h \
                          libmscore/note.h \
                          libmscore/mscore.h \
                          libmscore/lyrics.h \
@@ -2112,7 +2113,9 @@ INCLUDE_FILE_PATTERNS  =
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
 PREDEFINED             = Q_ENUM(...)= \
-                         Q_DECLARE_METATYPE(...)=
+                         Q_DECLARE_METATYPE(...)= \
+                         BEGIN_QT_REGISTERED_ENUM(...)= \
+                         END_QT_REGISTERED_ENUM(...)= \
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -16,7 +16,6 @@
 namespace Ms {
 
 class XmlReader;
-enum class Sid : int;
 
 //------------------------------------------------------------------------
 //    M_PROPERTY (type, getter_name, setter_name)

--- a/libmscore/scoreElement.h
+++ b/libmscore/scoreElement.h
@@ -137,7 +137,6 @@ class StaffTextBase;
 
 enum class Pid : int;
 enum class PropertyFlags : char;
-enum class Sid : int;
 
 //---------------------------------------------------------
 //   LinkedElements

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -24,13 +24,30 @@ struct ChordDescription;
 class Element;
 class Score;
 
+#ifdef SCRIPT_INTERFACE
+#define BEGIN_QT_REGISTERED_ENUM(Name) \
+class MSQE_##Name { \
+      Q_GADGET \
+   public:
+#define END_QT_REGISTERED_ENUM(Name) \
+      Q_ENUM(Name); \
+      }; \
+using Name = MSQE_##Name::Name;
+#else
+#define BEGIN_QT_REGISTERED_ENUM(Name)
+#define END_QT_REGISTERED_ENUM(Name)
+#endif
+
 //---------------------------------------------------------
 //   Sid
+///   Enumerates the list of score style settings
 //
 //    Keep in sync with styleTypes[] in style.cpp
 //---------------------------------------------------------
 
+BEGIN_QT_REGISTERED_ENUM(Sid)
 enum class Sid {
+      ///.\{
       NOSTYLE = -1,
 
       pageWidth,
@@ -1291,10 +1308,13 @@ enum class Sid {
       autoplaceEnabled,
 
       STYLES
+      ///\}
       };
+END_QT_REGISTERED_ENUM(Sid)
 
 //---------------------------------------------------------
 //   MStyle
+///   \cond PLUGIN_API \private \endcond
 //    the name "Style" gives problems with some microsoft
 //    header files...
 //---------------------------------------------------------
@@ -1338,6 +1358,7 @@ class MStyle {
 
 //---------------------------------------------------------
 //   StyledProperty
+///   \cond PLUGIN_API \private \endcond
 //---------------------------------------------------------
 
 struct StyledProperty {

--- a/libmscore/sym.h
+++ b/libmscore/sym.h
@@ -14,13 +14,12 @@
 #define __SYM_H__
 
 #include "config.h"
+#include "style.h"
 
 #include "ft2build.h"
 #include FT_FREETYPE_H
 
 namespace Ms {
-
-enum class Sid;
 
 //---------------------------------------------------------
 //   SymId

--- a/mscore/plugin/api/score.h
+++ b/mscore/plugin/api/score.h
@@ -15,6 +15,7 @@
 
 #include "scoreelement.h"
 #include "part.h"
+#include "style.h"
 #include "excerpt.h"
 #include "libmscore/score.h"
 
@@ -86,6 +87,8 @@ class Score : public Ms::PluginAPI::ScoreElement {
       Q_PROPERTY(QString                        mscoreRevision    READ mscoreRevision)
       /** Current selections for the score. \since MuseScore 3.3 */
       Q_PROPERTY(Ms::PluginAPI::Selection*      selection         READ selection)
+      /** Style settings for this score. \since MuseScore 3.5 */
+      Q_PROPERTY(Ms::PluginAPI::MStyle*         style             READ style)
       /**
        * Page numbering offset. The user-visible number of the given \p page is defined as
        * \code
@@ -114,6 +117,7 @@ class Score : public Ms::PluginAPI::ScoreElement {
       QString lyricist() { return score()->metaTag("lyricist"); } // not the meanwhile obsolete "poet"
       QString title() { return score()->metaTag("workTitle"); }
       Ms::PluginAPI::Selection* selection() { return selectionWrap(&score()->selection()); }
+      MStyle* style() { return wrap(&score()->style(), score()); }
 
       int pageNumberOffset() const { return score()->pageNumberOffset(); }
       void setPageNumberOffset(int offset) { score()->undoChangePageNumberOffset(offset); }

--- a/mscore/plugin/api/style.cpp
+++ b/mscore/plugin/api/style.cpp
@@ -1,0 +1,120 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#include "style.h"
+
+#include "libmscore/score.h"
+
+namespace Ms {
+namespace PluginAPI {
+
+//---------------------------------------------------------
+//   wrap
+//---------------------------------------------------------
+
+MStyle* wrap(Ms::MStyle* style, Ms::Score* score)
+      {
+      MStyle* st = new MStyle(style, score);
+      // All wrapper objects should belong to JavaScript code.
+      QQmlEngine::setObjectOwnership(st, QQmlEngine::JavaScriptOwnership);
+      return st;
+      }
+
+//---------------------------------------------------------
+//   MStyle::keyToSid
+//---------------------------------------------------------
+
+Sid MStyle::keyToSid(const QString& key) {
+      static QMetaEnum sidEnum = QMetaEnum::fromType<Sid>();
+
+      bool ok;
+      int val = sidEnum.keyToValue(key.toLatin1().constData(), &ok);
+
+      if (ok) {
+            return static_cast<Sid>(val);
+            }
+      else {
+            qWarning("Invalid style key: %s", qPrintable(key));
+            return Sid::NOSTYLE;
+            }
+      }
+
+//---------------------------------------------------------
+//   MStyle::value
+///   Returns a value of style setting named \p key.
+///   Key should be one of \ref Sid values. Type of the
+///   returned value depends on type of the corresponding
+///   style setting.
+//---------------------------------------------------------
+
+QVariant MStyle::value(const QString& key) const {
+      const Sid sid = keyToSid(key);
+
+      if (sid == Sid::NOSTYLE)
+            return QVariant();
+
+      const QVariant val = _style->value(sid);
+
+      if (!strcmp(Ms::MStyle::valueType(sid), "Ms::Spatium"))
+            return val.value<Ms::Spatium>().val();
+
+      return val;
+      }
+
+//---------------------------------------------------------
+//   MStyle::setValue
+///   Sets the value of style setting named \p key to \p value.
+///   Key should be one of \ref Sid values.
+//---------------------------------------------------------
+
+void MStyle::setValue(const QString& key, QVariant value) {
+      const Sid sid = keyToSid(key);
+
+      if (sid == Sid::NOSTYLE)
+            return;
+
+      if (!strcmp(Ms::MStyle::valueType(sid), "Ms::Spatium"))
+            value = QVariant::fromValue(Ms::Spatium(value.toReal()));
+
+      if (_score) {
+            // Style belongs to actual score: change style value in undoable way
+            switch (sid) {
+                  case Sid::spatium: {
+                        const qreal oldSpatium = _score->spatium();
+                        const qreal newSpatium = value.toReal();
+
+                        if (newSpatium > 0.0 && oldSpatium != newSpatium) {
+                              _score->undoChangeStyleVal(Sid::spatium, newSpatium);
+                              _score->spatiumChanged(oldSpatium, newSpatium);
+                              }
+                        }
+                        break;
+                  default:
+                        _score->undoChangeStyleVal(sid, value);
+                        break;
+                  }
+            }
+      else {
+            // Style is not bound to a score: change the value directly
+            _style->set(sid, value);
+            }
+      }
+
+} // namespace PluginAPI
+} // namespace Ms

--- a/mscore/plugin/api/style.h
+++ b/mscore/plugin/api/style.h
@@ -1,0 +1,70 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef __PLUGIN_API_STYLE_H__
+#define __PLUGIN_API_STYLE_H__
+
+#include "libmscore/style.h"
+
+namespace Ms {
+
+class Score;
+
+namespace PluginAPI {
+
+//---------------------------------------------------------
+//   MStyle
+///   Provides an access to score style settings.
+///   Style settings for a score can be obtained by
+///   querying the \ref Score.style property.
+///
+///   Usage example:
+///   \code
+///   var style = curScore.style;
+///   var genClef = style.value("genClef"); // retrieves style setting on clefs generation, true by default
+///   style.setValue("genClef", false); // disables generating clefs for this score
+///   \endcode
+///   \since MuseScore 3.5
+///   \see \ref Sid
+//---------------------------------------------------------
+
+class MStyle : public QObject {
+      Q_OBJECT
+
+      Ms::MStyle* _style;
+      Ms::Score* _score;
+
+      static Sid keyToSid(const QString& key);
+
+   public:
+      /// \cond MS_INTERNAL
+      MStyle(Ms::MStyle* style, Ms::Score* score)
+         : QObject(), _style(style), _score(score) {}
+      /// \endcond
+
+      Q_INVOKABLE QVariant value(const QString& key) const;
+      Q_INVOKABLE void setValue(const QString& key, QVariant value);
+      };
+
+extern MStyle* wrap(Ms::MStyle*, Ms::Score*);
+
+} // namespace PluginAPI
+} // namespace Ms
+
+#endif

--- a/mscore/plugin/plugin.cmake
+++ b/mscore/plugin/plugin.cmake
@@ -20,6 +20,8 @@ set (PLUGIN_API_SRC
     ${CMAKE_CURRENT_LIST_DIR}/api/score.h
     ${CMAKE_CURRENT_LIST_DIR}/api/selection.cpp
     ${CMAKE_CURRENT_LIST_DIR}/api/selection.h
+    ${CMAKE_CURRENT_LIST_DIR}/api/style.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/api/style.h
     ${CMAKE_CURRENT_LIST_DIR}/api/tie.cpp
     ${CMAKE_CURRENT_LIST_DIR}/api/tie.h
     ${CMAKE_CURRENT_LIST_DIR}/api/util.cpp


### PR DESCRIPTION
Provides a basic access to score style settings to plugins. As discussed in [this issue](https://musescore.org/en/node/289326#comment-963145), this would be needed to implement some basic subset of Album feature which might be of use while the full implementation of Albums is not available. Still an access to score style settings should certainly be useful for many other applications.

As for the technical side, to avoid large changes involving moving or rewriting the entire `Sid` enum I added something similar to what has been used for some enumerations in 2.X: see https://github.com/musescore/MuseScore/commit/456c26e461651979623ca4ea4e6876b239c49559. Unlike the solution in the linked commit, the solution proposed here does not require massive formatting changes to the enumeration but only requires to wrap it inside two `BEGIN_QT_REGISTERED_ENUM` and `END_QT_REGISTERED_ENUM` macros. The downside of this implementation is that it doesn't really play well with forward declarations of enumerations but this doesn't seem to be a real issue in this case. Perhaps the same technique could be used in the future to work with some other large enumerations like `SymId` with meta-object system in a similar way.