### PR TITLE
Issue 305135 fretdiagram

### DIFF
--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1379,19 +1379,22 @@ void Harmony::calculateBoundingRect()
                         xx = fd->bbox().width() - bb.width();
                   else if (align() & Align::HCENTER)
                         xx = fd->centerX() - bb.width() / 2.0;
+
+                  setPos(0.0, ypos - yy - score()->styleP(Sid::harmonyFretDist));
                   }
             else {
                   if (align() & Align::RIGHT)
                         xx = -bb.x() -bb.width() + cw;
                   else if (align() & Align::HCENTER)
                         xx = -bb.x() -bb.width() / 2.0 + cw / 2.0;
+
+                  setPos(0.0, ypos);
                   }
 
             for (TextSegment* ts : textList)
                   ts->offset = QPointF(xx, yy);
 
             setbbox(bb.translated(xx, yy));
-            setPos(0.0, fd ? rypos() : ypos);
             _harmonyHeight = bbox().height();
 
             for (int i = 0; i < rows(); ++i) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/305135

Placement of <code>Harmony</code> above a <code>FretDiagram</code> didn't take the style parameter <code>harmonyFretDist</code> into account. This issue is introduced in PR #5876 .

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n.a.] I created the test (mtest, vtest, script test) to verify the changes I made
