### PR TITLE
fix #305079: fret diagrams shifted upwards compared to 3.4.2

### DIFF
--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -168,7 +168,7 @@ struct StyleVal2 {
       { Sid::capoPosition,                QVariant(0) },
       { Sid::fretNumMag,                  QVariant(2.0) },
       { Sid::fretNumPos,                  QVariant(0) },
-      { Sid::fretY,                       QVariant(2.0) },
+      { Sid::fretY,                       QVariant(1.0) },
       { Sid::showPageNumber,              QVariant(true) },
       { Sid::showPageNumberOne,           QVariant(false) },
       { Sid::pageNumberOddEven,           QVariant(true) },

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -348,7 +348,7 @@ static const StyleType styleTypes[] {
       { Sid::capoPosition,            "capoPosition",            QVariant(0) },
       { Sid::fretNumMag,              "fretNumMag",              QVariant(2.0) },
       { Sid::fretNumPos,              "fretNumPos",              QVariant(0) },
-      { Sid::fretY,                   "fretY",                   Spatium(2.0) },
+      { Sid::fretY,                   "fretY",                   Spatium(1.0) },
       { Sid::fretMinDistance,         "fretMinDistance",         Spatium(0.5) },
       { Sid::fretMag,                 "fretMag",                 QVariant(1.0) },
       { Sid::fretPlacement,           "fretPlacement",           int(Placement::ABOVE) },


### PR DESCRIPTION
resolves https://musescore.org/en/node/305079

Fixed by changing a default style value. The layout code for fret diagrams was fixed fairly significantly between the last versions, and I thoroughly checked it to make sure it is correct. So, that can only mean that the problem is an incorrect default style value which previously compensated for layout errors.
