### PR TITLE
Fix #305125: Crash in debug build when dragging selected notes

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -333,7 +333,7 @@ void Score::update(bool resetCmdState)
             if (resetCmdState)
                   cs.reset();
             }
-      if (_selection.isRange())
+      if (_selection.isRange() && !_selection.isLocked())
             _selection.updateSelectedElements();
       }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/305125