### PR TITLE
Proll rands

### DIFF
--- a/mscore/pianoroll/pianolevelschooser.cpp
+++ b/mscore/pianoroll/pianolevelschooser.cpp
@@ -49,23 +49,34 @@ void PianoLevelsChooser::setEventDataPressed()
       PianoLevelsFilter* filter = PianoLevelsFilter::FILTER_LIST[_levelsIndex];
 
       int val = eventValSpinBox->value();
+      int randVal = 0; // initializing randVal as 0
       QList<Note*> noteList = _staff->getNotes();
 
       Score* score = _staff->score();
 
       score->startCmd();
 
+      // initialize random seed:
+      std::srand(eventSeedSpinBox->value());
+
       for (Note* note: noteList) {
             if (!note->selected())
                   continue;
 
+            // Generating a random integer from 0 to eventRandSpinBox->value()
+            if (eventRandSpinBox->value() > 0) // else it remains 0, as initialized
+            {
+                randVal = std::rand()/((RAND_MAX + 1u)/eventRandSpinBox->value());
+            }
+
+            // applying set to selected notes:
             if (filter->isPerEvent()) {
                   for (NoteEvent& e : note->playEvents()) {
-                        filter->setValue(_staff, note, &e, val);
-                        }
-                  }
-                  else
-                        filter->setValue(_staff, note, nullptr, val);
+                      filter->setValue(_staff, note, &e, val + randVal);
+                   }
+            }
+            else
+                      filter->setValue(_staff, note, nullptr, val + randVal);
 
             }
 

--- a/mscore/pianoroll/pianolevelschooser.cpp
+++ b/mscore/pianoroll/pianolevelschooser.cpp
@@ -64,8 +64,7 @@ void PianoLevelsChooser::setEventDataPressed()
                   continue;
 
             // Generating a random integer from 0 to eventRandSpinBox->value()
-            if (eventRandSpinBox->value() > 0) // else it remains 0, as initialized
-            {
+            if (eventRandSpinBox->value() > 0) { // else it remains 0, as initialized
                 randVal = std::rand()/((RAND_MAX + 1u)/eventRandSpinBox->value());
             }
 

--- a/mscore/pianoroll/pianolevelschooser.ui
+++ b/mscore/pianoroll/pianolevelschooser.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>159</width>
-    <height>155</height>
+    <width>135</width>
+    <height>220</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -31,7 +31,17 @@
    <item>
     <widget class="QGroupBox" name="groupBox">
      <layout class="QGridLayout" name="gridLayout">
-      <item row="2" column="1">
+      <item row="1" column="0" colspan="2">
+       <widget class="QSpinBox" name="eventRandSpinBox">
+        <property name="toolTip">
+         <string>Random: an integer from 0 to this number will be added into the value</string>
+        </property>
+        <property name="maximum">
+         <number>999</number>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
        <widget class="QPushButton" name="setEventsBn">
         <property name="toolTip">
          <string>Set selected note event data</string>
@@ -41,7 +51,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="4" column="0">
        <spacer name="horizontalSpacer">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -54,8 +64,21 @@
         </property>
        </spacer>
       </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QSpinBox" name="eventSeedSpinBox">
+        <property name="toolTip">
+         <string>Seed for pseudo random number generation.</string>
+        </property>
+        <property name="maximum">
+         <number>10000</number>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0" colspan="2">
        <widget class="QSpinBox" name="eventValSpinBox">
+        <property name="toolTip">
+         <string>Value</string>
+        </property>
         <property name="minimum">
          <number>-100000</number>
         </property>


### PR DESCRIPTION
Piano roll – set with random component. It is one way for the user to get a more humanized playback, making it possible to add a random component to velocity, starting time or length of a group of nomes.

Is one way to resolve many requests on humanized playback regarding velocities, start times and lengths of the notes. An alternative way that can also allow for more humanized playback is to implement random-related op codes in Zerberus. The two methods shouldn't be treated exclusively, but as an extension of each other. The method here is deterministic and the one that can be implemented in Zerberus is neither deterministic nor customizable, but might involve other paramenters beyond velocities, start times and lengths. This method takes effect in non-Zerberus instruments as well.

Changes:
File `pianolevelschooser.ui` - 2 extra spinboxes created and all supplied with a tooltip.
File `pianolevelschooser.cpp` calls `std::srand()` to initialize with a seed and `std::rand()` to generate a random value.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
