### PR TITLE
Fix #305265: Bracket added from palette only spans one staff regardless of selection

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1425,7 +1425,8 @@ Element* Measure::drop(EditData& data)
                               }
                         firstStaff++;
                         }
-                  score()->undoAddBracket(staff, level, b->bracketType(), 1);
+                  Selection sel = score()->selection();
+                  score()->undoAddBracket(staff, level, b->bracketType(), sel.staffEnd() - sel.staffStart());
                   delete b;
                   }
                   break;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/305265

Small usability/workflow improvement so that newly added bracket spans all selected staves. Previously, only the top staff of the selection would get the bracket.

Submitted against 3.x, but should also be cherry-picked to master.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
