### PR TITLE
fix some translatable strings

### DIFF
--- a/mscore/metaedit.cpp
+++ b/mscore/metaedit.cpp
@@ -178,7 +178,7 @@ void MetaEditDialog::setDirty(const bool dirty)
             return;
 
       saveButton->setEnabled(dirty);
-      setWindowTitle(tr("Score properties: ") + m_score->title() + (dirty ? "*" : ""));
+      setWindowTitle(tr("Score properties: %1%2").arg(m_score->title()).arg((dirty ? "*" : "")));
 
       m_dirty = dirty;
       }
@@ -223,8 +223,8 @@ bool MetaEditDialog::save()
                         if (map.contains(tagText)) {
                               if (isBuiltinTag(tagText)) {
                                     QMessageBox::warning(this, tr("MuseScore"),
-                                                         tagText + tr(" is a reserved builtin tag.\n"
-                                                                      "It can't be used."),
+                                                         tr("%1 is a reserved builtin tag.\n"
+                                                            "It can't be used.").arg(tagText),
                                                          QMessageBox::Ok, QMessageBox::Ok);
                                     tag->setFocus();
                                     return false;

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4105,33 +4105,31 @@ bool MuseScore::readLanguages(const QString& path)
       //: The default language of the operating system. NOT a music system.
       _languages.append(LanguageItem("system", tr("System")));
       QFile qf(path);
-      if (qf.exists()){
-          QDomDocument doc;
-          int line, column;
-          QString err;
-          if (!doc.setContent(&qf, false, &err, &line, &column)) {
-                QString error;
-                error.sprintf(qPrintable(tr("Error reading language file %s at line %d column %d: %s\n")),
-                   qPrintable(qf.fileName()), line, column, qPrintable(err));
-                QMessageBox::warning(0,
-                   QWidget::tr("Load Languages Failed:"),
-                   error,
-                   QString(), QWidget::tr("Quit"), QString(), 0, 1);
-                return false;
-                }
+      if (qf.exists()) {
+            QDomDocument doc;
+            int line, column;
+            QString err;
+            if (!doc.setContent(&qf, false, &err, &line, &column)) {
+                  QMessageBox::warning(0,
+                     QWidget::tr("Load Languages Failed:"),
+                     tr("Error reading language file %1 at line %2 column %3: %4")
+                        .arg(qf.fileName()).arg(line).arg(column).arg(err),
+                     QString(), QWidget::tr("Quit"), QString(), 0, 1);
+                  return false;
+                  }
 
-          for (QDomElement e = doc.documentElement(); !e.isNull(); e = e.nextSiblingElement()) {
-                if(e.tagName() == "languages") {
-                      for (e = e.firstChildElement(); !e.isNull(); e = e.nextSiblingElement()) {
-                        if (e.tagName() == "language") {
-                              QString code = e.attribute(QString("code"));
-                              QString name = e.attribute(QString("name"));
-                              QString handbook = e.attribute(QString("handbook"));
-                              _languages.append(LanguageItem(code, name, handbook));
+            for (QDomElement e = doc.documentElement(); !e.isNull(); e = e.nextSiblingElement()) {
+                  if(e.tagName() == "languages") {
+                        for (e = e.firstChildElement(); !e.isNull(); e = e.nextSiblingElement()) {
+                              if (e.tagName() == "language") {
+                                    QString code = e.attribute(QString("code"));
+                                    QString name = e.attribute(QString("name"));
+                                    QString handbook = e.attribute(QString("handbook"));
+                                    _languages.append(LanguageItem(code, name, handbook));
+                                    }
                               }
-                          }
-                      }
-                }
+                        }
+                  }
             return true;
             }
       return false;

--- a/mscore/partedit.ui
+++ b/mscore/partedit.ui
@@ -290,7 +290,7 @@
            </size>
           </property>
           <property name="text" >
-           <string>Rev</string>
+           <string>Rev.</string>
           </property>
           <property name="alignment" >
            <set>Qt::AlignCenter</set>
@@ -318,7 +318,7 @@
            </size>
           </property>
           <property name="text" >
-           <string>Cho</string>
+           <string>Cho.</string>
           </property>
           <property name="alignment" >
            <set>Qt::AlignCenter</set>

--- a/mscore/pianoroll/pianoroll.cpp
+++ b/mscore/pianoroll/pianoroll.cpp
@@ -565,7 +565,7 @@ void PianorollEditor::setStaff(Staff* st)
             return;
 
       if (st)
-            partLabel->setText("Part: " + st->partName());
+            partLabel->setText(tr("Part: %1").arg(st->partName()));
 
       if ((st && st->score() != _score) || (!st && _score)) {
             if (_score) {

--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -418,11 +418,11 @@ std::pair<int, float> ScoreAccessibility::barbeat(Element *e)
 void ScoreAccessibility::makeReadable(QString& s)
       {
       static std::vector<std::pair<QString, QString>> unicodeReplacements {
-            { "♭", tr(" flat") },
-            { "♮", tr(" natural") },
-            { "♯", tr(" sharp") },
-            { "𝄫", tr(" double flat") },
-            { "𝄪", tr(" double sharp") },
+            { "♭", " " + tr("flat") },
+            { "♮", " " + tr("natural") },
+            { "♯", " " + tr("sharp") },
+            { "𝄫", " " + tr("double flat") },
+            { "𝄪", " " + tr("double sharp") },
       };
 
       if (!QAccessible::isActive())


### PR DESCRIPTION
String with leading or trailing spaces are difficult to translate right, so should get avoided. using %s and %d in a translatable string is not going to help much I believe, this is what Qt has %1, %2. etc. and .arg() for.
Fix another string to become translatable, see https://musescore.org/en/node/305315