### PR TITLE
fix #280244 : [Workaround] User fonts not visible to MuseScore 3 (Windows 10)

### DIFF
--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -376,6 +376,19 @@ void MScore::init()
                   }
             }
 #endif
+// Workaround for QTBUG-73241 (solved in Qt 5.12.2) in Windows 10, see https://musescore.org/en/node/280244
+#if defined(Q_OS_WIN) && (QT_VERSION < QT_VERSION_CHECK(5, 12, 2))
+if (QOperatingSystemVersion::current().majorVersion() >= 10) {
+      const QDir additionalFontsDir(QString("%1/Microsoft/Windows/Fonts").arg(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)));
+      if (additionalFontsDir.exists()) {
+            QFileInfoList fileList = additionalFontsDir.entryInfoList();
+            for (int i = 0; i < fileList.size(); ++i) {
+                  QFileInfo fileInfo = fileList.at(i);
+                  QFontDatabase::addApplicationFont(fileInfo.filePath());
+                  }
+            }
+      }
+#endif
       initScoreFonts();
       StaffType::initStaffTypes();
       initDrumset();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/280244

Because of QTBUG-73241 ( https://bugreports.qt.io/browse/QTBUG-73241 ), when using freetype engine under Windows 10 (after update 1809), fonts installed in the user-specific folder C:\Users\UserName\AppData\Local\Microsoft\Windows\Fonts cannot be found by Qt. This is solved for Qt 5.12.2. However, current MuseScore build still uses Qt 5.9.
This is a workaround to add those user-specific fonts to the application.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
