### PR TITLE
Instruments and channels API for plugins

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3650,27 +3650,8 @@ bool Score::switchLayer(const QString& s)
 //   appendPart
 //---------------------------------------------------------
 
-void Score::appendPart(const QString& name)
+void Score::appendPart(const InstrumentTemplate* t)
       {
-      static InstrumentTemplate defaultInstrument;
-      InstrumentTemplate* t;
-
-      t = searchTemplate(name);
-      if (t == 0) {
-            qDebug("appendPart: <%s> not found", qPrintable(name));
-            t = &defaultInstrument;
-            }
-
-      if (t->channel.empty()) {
-            Channel a;
-            a.setChorus(0);
-            a.setReverb(0);
-            a.setName(Channel::DEFAULT_NAME);
-            a.setBank(0);
-            a.setVolume(90);
-            a.setPan(0);
-            t->channel.append(a);
-            }
       Part* part = new Part(this);
       part->initFromInstrTemplate(t);
       int n = nstaves();

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -783,6 +783,7 @@ class Score : public QObject, public ScoreElement {
       const QList<Part*>& parts() const    { return _parts; }
 
       void appendPart(Part* p);
+      void appendPart(const InstrumentTemplate*);
       void updateStaffIndex();
       void sortStaves(QList<int>& dst);
 
@@ -1117,8 +1118,6 @@ class Score : public QObject, public ScoreElement {
 
       QList<Score*> scoreList();
       bool switchLayer(const QString& s);
-      //@ appends to the score a named part as last part
-      void appendPart(const QString&);
       //@ appends to the score a number of measures
       void appendMeasures(int);
 

--- a/mscore/plugin/api/cursor.cpp
+++ b/mscore/plugin/api/cursor.cpp
@@ -710,7 +710,7 @@ void Cursor::nextInTrack()
 
 int Cursor::qmlKeySignature()
       {
-      Staff* staff = _score->staves()[staffIdx()];
+      Ms::Staff* staff = _score->staves()[staffIdx()];
       return static_cast<int>(staff->key(Fraction::fromTicks(tick())));
       }
 

--- a/mscore/plugin/api/elements.cpp
+++ b/mscore/plugin/api/elements.cpp
@@ -12,6 +12,7 @@
 
 #include "elements.h"
 #include "fraction.h"
+#include "part.h"
 #include "libmscore/property.h"
 #include "libmscore/undo.h"
 
@@ -273,6 +274,14 @@ void Chord::remove(Ms::PluginAPI::Element* wrapped)
             chord()->score()->deleteItem(s); // Create undo op and remove the element.
       }
 
+//---------------------------------------------------------
+//   Staff::part
+//---------------------------------------------------------
+
+Part* Staff::part()
+      {
+      return wrap<Part>(staff()->part());
+      }
 
 //---------------------------------------------------------
 //   wrap

--- a/mscore/plugin/api/elements.h
+++ b/mscore/plugin/api/elements.h
@@ -22,6 +22,7 @@
 #include "libmscore/notedot.h"
 #include "libmscore/page.h"
 #include "libmscore/segment.h"
+#include "libmscore/staff.h"
 #include "libmscore/tuplet.h"
 #include "libmscore/accidental.h"
 #include "libmscore/musescoreCore.h"
@@ -35,6 +36,8 @@ namespace PluginAPI {
 
 class FractionWrapper;
 class Element;
+class Part;
+class Staff;
 class Tuplet;
 class Tie;
 extern Tie* tieWrap(Ms::Tie* tie);
@@ -84,6 +87,11 @@ class Element : public Ms::PluginAPI::ScoreElement {
        * \since 3.3
        */
       Q_PROPERTY(Ms::PluginAPI::Element* parent READ parent)
+      /**
+       * Staff which this element belongs to.
+       * \since MuseScore 3.5
+       */
+      Q_PROPERTY(Ms::PluginAPI::Staff* staff READ staff)
       /**
        * X-axis offset from a reference position in spatium units.
        * \see Element::offset
@@ -208,6 +216,7 @@ class Element : public Ms::PluginAPI::ScoreElement {
       API_PROPERTY( beamMode,                BEAM_MODE                 )
       API_PROPERTY( beamNoSlope,             BEAM_NO_SLOPE             )
       API_PROPERTY( userLen,                 USER_LEN                  )
+      /** For spacers: amount of space between staves. */
       API_PROPERTY( space,                   SPACE                     )
       API_PROPERTY( tempo,                   TEMPO                     )
       API_PROPERTY( tempoFollowText,         TEMPO_FOLLOW_TEXT         )
@@ -300,10 +309,6 @@ class Element : public Ms::PluginAPI::ScoreElement {
       API_PROPERTY( dashLineLen,             DASH_LINE_LEN             )
       API_PROPERTY( dashGapLen,              DASH_GAP_LEN              )
 //       API_PROPERTY_READ_ONLY( tick,          TICK                      ) // wasn't available in 2.X, disabled due to fractions transition
-      API_PROPERTY( playbackVoice1,          PLAYBACK_VOICE1           )
-      API_PROPERTY( playbackVoice2,          PLAYBACK_VOICE2           )
-      API_PROPERTY( playbackVoice3,          PLAYBACK_VOICE3           )
-      API_PROPERTY( playbackVoice4,          PLAYBACK_VOICE4           )
       API_PROPERTY( symbol,                  SYMBOL                    )
       API_PROPERTY( playRepeats,             PLAY_REPEATS              )
       API_PROPERTY( createSystemHeader,      CREATE_SYSTEM_HEADER      )
@@ -317,10 +322,6 @@ class Element : public Ms::PluginAPI::ScoreElement {
       API_PROPERTY( staffGenTimesig,         STAFF_GEN_TIMESIG         )
       API_PROPERTY( staffGenKeysig,          STAFF_GEN_KEYSIG          )
       API_PROPERTY( staffYoffset,            STAFF_YOFFSET             )
-      API_PROPERTY( staffUserdist,           STAFF_USERDIST            )
-      API_PROPERTY( staffBarlineSpan,        STAFF_BARLINE_SPAN        )
-      API_PROPERTY( staffBarlineSpanFrom,    STAFF_BARLINE_SPAN_FROM   )
-      API_PROPERTY( staffBarlineSpanTo,      STAFF_BARLINE_SPAN_TO     )
       API_PROPERTY( bracketSpan,             BRACKET_SPAN              )
       API_PROPERTY( bracketColumn,           BRACKET_COLUMN            )
       API_PROPERTY( inameLayoutPosition,     INAME_LAYOUT_POSITION     )
@@ -377,6 +378,7 @@ class Element : public Ms::PluginAPI::ScoreElement {
       QPointF pagePos() const { return element()->pagePos() / element()->spatium(); }
 
       Ms::PluginAPI::Element* parent() const { return wrap(element()->parent()); }
+      Staff* staff() { return wrap<Staff>(element()->staff()); }
 
       QRectF bbox() const;
 
@@ -789,6 +791,59 @@ class Page : public Element {
       const Ms::Page* page() const { return toPage(e); }
 
       int pagenumber() const;
+      /// \endcond
+      };
+
+//---------------------------------------------------------
+//   Staff
+///   \since MuseScore 3.5
+//---------------------------------------------------------
+
+class Staff : public ScoreElement {
+      Q_OBJECT
+
+      API_PROPERTY_T( bool, small,           SMALL                     )
+      API_PROPERTY_T( qreal, mag,            MAG                       )
+      /**
+       * Staff color. See https://doc.qt.io/qt-5/qml-color.html
+       * for the reference on color type in QML.
+       */
+      API_PROPERTY_T( QColor, color,         COLOR                     )
+
+      /** Whether voice 1 participates in playback. */
+      API_PROPERTY_T( bool, playbackVoice1,  PLAYBACK_VOICE1           )
+      /** Whether voice 2 participates in playback. */
+      API_PROPERTY_T( bool, playbackVoice2,  PLAYBACK_VOICE2           )
+      /** Whether voice 3 participates in playback. */
+      API_PROPERTY_T( bool, playbackVoice3,  PLAYBACK_VOICE3           )
+      /** Whether voice 4 participates in playback. */
+      API_PROPERTY_T( bool, playbackVoice4,  PLAYBACK_VOICE4           )
+
+      API_PROPERTY_T( int, staffBarlineSpan,     STAFF_BARLINE_SPAN      )
+      API_PROPERTY_T( int, staffBarlineSpanFrom, STAFF_BARLINE_SPAN_FROM )
+      API_PROPERTY_T( int, staffBarlineSpanTo,   STAFF_BARLINE_SPAN_TO   )
+
+      /**
+       * User-defined amount of additional space before this staff.
+       * It is recommended to consider adding a spacer instead as it
+       * allows adjusting staff spacing locally as opposed to this
+       * property.
+       * \see \ref Element.space
+       */
+      API_PROPERTY_T( qreal, staffUserdist,  STAFF_USERDIST            )
+
+      /** Part which this staff belongs to. */
+      Q_PROPERTY(Ms::PluginAPI::Part* part READ part);
+
+   public:
+      /// \cond MS_INTERNAL
+      Staff(Ms::Staff* staff, Ownership own = Ownership::PLUGIN)
+         : Ms::PluginAPI::ScoreElement(staff, own) {}
+
+      Ms::Staff* staff() { return toStaff(e); }
+      const Ms::Staff* staff() const { return toStaff(e); }
+
+      Part* part();
       /// \endcond
       };
 

--- a/mscore/plugin/api/instrument.cpp
+++ b/mscore/plugin/api/instrument.cpp
@@ -1,0 +1,163 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#include "instrument.h"
+
+#include "audio/midi/midipatch.h"
+#include "libmscore/part.h"
+#include "libmscore/score.h"
+#include "libmscore/undo.h"
+
+namespace Ms {
+namespace PluginAPI {
+
+//---------------------------------------------------------
+//   Channel::activeChannel
+//---------------------------------------------------------
+
+Ms::Channel* Channel::activeChannel()
+      {
+      Ms::Score* score = _part->score();
+      Ms::MasterScore* masterScore = score->masterScore();
+
+      if (masterScore->playbackScore() == score)
+            return masterScore->playbackChannel(_channel);
+      return _channel;
+      }
+
+//---------------------------------------------------------
+//   Channel::setMidiBankAndProgram
+//---------------------------------------------------------
+
+void Channel::setMidiBankAndProgram(int bank, int program, bool setUserBankController)
+      {
+      Ms::Channel* ch = activeChannel();
+
+      MidiPatch patch;
+      // other values are unused in ChangePatch command
+      patch.synti = ch->synti();
+      patch.bank = bank;
+      patch.prog = program;
+
+      Ms::Score* score = _part->score();
+      score->undo(new ChangePatch(score, ch, &patch));
+
+      if (setUserBankController)
+            score->undo(new SetUserBankController(ch, true));
+      }
+
+//---------------------------------------------------------
+//   Channel::setMidiProgram
+//---------------------------------------------------------
+
+void Channel::setMidiProgram(int prog)
+      {
+      prog = qBound(0, prog, 127);
+      setMidiBankAndProgram(activeChannel()->bank(), prog, false);
+      }
+
+//---------------------------------------------------------
+//   Channel::setMidiBank
+//---------------------------------------------------------
+
+void Channel::setMidiBank(int bank)
+      {
+      bank = qBound(0, bank, 255);
+      setMidiBankAndProgram(bank, activeChannel()->program(), true);
+      }
+
+//---------------------------------------------------------
+//   StringData::stringList
+//---------------------------------------------------------
+
+QVariantList StringData::stringList() const
+      {
+      QVariantList pluginStringsList;
+      for (instrString str : _data.stringList()) {
+            QVariantMap pluginStringData;
+            pluginStringData["pitch"] = str.pitch;
+            pluginStringData["open"] = str.open;
+            pluginStringsList.append(pluginStringData);
+            }
+      return pluginStringsList;
+      }
+
+//---------------------------------------------------------
+//   ChannelListProperty
+//---------------------------------------------------------
+
+ChannelListProperty::ChannelListProperty(Instrument* i)
+   : QQmlListProperty<Channel>(i, i, &count, &at) {}
+
+//---------------------------------------------------------
+//   ChannelListProperty::count
+//---------------------------------------------------------
+
+int ChannelListProperty::count(QQmlListProperty<Channel>* l)
+      {
+      return static_cast<int>(static_cast<Instrument*>(l->data)->instrument()->channel().size());
+      }
+
+//---------------------------------------------------------
+//   ChannelListProperty::at
+//---------------------------------------------------------
+
+Channel* ChannelListProperty::at(QQmlListProperty<Channel>* l, int i)
+      {
+      Instrument* instr = static_cast<Instrument*>(l->data);
+
+      if (i < 0 || i >= instr->instrument()->channel().size())
+            return nullptr;
+
+      Ms::Channel* ch = instr->instrument()->channel(i);
+
+      return customWrap<Channel>(ch, instr->part());
+      }
+
+//---------------------------------------------------------
+//   Instrument::longName
+//---------------------------------------------------------
+
+QString Instrument::longName() const
+      {
+      const QList<Ms::StaffName>& names = instrument()->longNames();
+      return names.empty() ? "" : names[0].name();
+      }
+
+//---------------------------------------------------------
+//   Instrument::shortName
+//---------------------------------------------------------
+
+QString Instrument::shortName() const
+      {
+      const QList<Ms::StaffName>& names = instrument()->shortNames();
+      return names.empty() ? "" : names[0].name();
+      }
+
+//---------------------------------------------------------
+//   Instrument::channels
+//---------------------------------------------------------
+
+ChannelListProperty Instrument::channels()
+      {
+      return ChannelListProperty(this);
+      }
+
+} // namespace PluginAPI
+} // namespace Ms

--- a/mscore/plugin/api/instrument.h
+++ b/mscore/plugin/api/instrument.h
@@ -1,0 +1,264 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef __PLUGIN_API_INSTRUMENT_H__
+#define __PLUGIN_API_INSTRUMENT_H__
+
+#include "scoreelement.h"
+#include "libmscore/instrument.h"
+
+namespace Ms {
+
+class Instrument;
+
+namespace PluginAPI {
+
+class Instrument;
+
+//---------------------------------------------------------
+//   Channel
+///   Provides an access to channel properties. Similar to
+///   Mixer, changes to some of the playback-related
+///   properties are not recorded to undo stack and are not
+///   revertable with standard user-visible "undo" action.
+///   Changing MIDI patch though is undoable in normal way
+///   ("dock" type plugins may need to call
+///   \ref Score.startCmd / \ref Score.endCmd for that to
+///   work properly).
+///
+///   Iterating over all channels in the current score can
+///   be done as follows:
+///   \code
+///   var parts = curScore.parts;
+///   for (var i = 0; i < parts.length; ++i) {
+///       var part = parts[i];
+///       var instrs = part.instruments;
+///       for (var j = 0; j < instrs.length; ++j) {
+///           var instr = instrs[j];
+///           var channels = instr.channels;
+///           for (var k = 0; k < channels.length; ++k) {
+///               var channel = channels[k];
+///               channel.volume = 64; // just for example, changing the channel's volume
+///           }
+///       }
+///   }
+///   \endcode
+///   \since MuseScore 3.5
+//---------------------------------------------------------
+
+class Channel : public QObject {
+      Q_OBJECT
+
+      Ms::Channel* _channel;
+      Ms::Part* _part;
+
+      /** Name of this channel */
+      Q_PROPERTY(QString name READ name)
+
+      /**
+       * Channel volume, from 0 to 127.
+       * \note Changing this property is **not** revertable with a standard "undo"
+       * action. Plugins may need to handle reverting this property change if
+       * necessary.
+       */
+      Q_PROPERTY(int volume READ volume WRITE setVolume)
+      /**
+       * Channel pan, from 0 to 127.
+       * \note Changing this property is **not** revertable with a standard "undo"
+       * action. Plugins may need to handle reverting this property change if
+       * necessary.
+       */
+      Q_PROPERTY(int pan READ pan WRITE setPan)
+      /**
+       * Channel chorus, from 0 to 127.
+       * \note Changing this property is **not** revertable with a standard "undo"
+       * action. Plugins may need to handle reverting this property change if
+       * necessary.
+       */
+      Q_PROPERTY(int chorus READ chorus WRITE setChorus)
+      /**
+       * Channel reverb, from 0 to 127.
+       * \note Changing this property is **not** revertable with a standard "undo"
+       * action. Plugins may need to handle reverting this property change if
+       * necessary.
+       */
+      Q_PROPERTY(int reverb READ reverb WRITE setReverb)
+      /**
+       * Whether this channel is muted.
+       * \note Changing this property is **not** revertable with a standard "undo"
+       * action. Plugins may need to handle reverting this property change if
+       * necessary.
+       */
+      Q_PROPERTY(bool mute READ mute WRITE setMute)
+
+      /**
+       * MIDI program number, from 0 to 127. Changing this property is recorded
+       * to the program's undo stack and can be reverted with a standard "undo"
+       * action.
+       */
+      Q_PROPERTY(int midiProgram READ midiProgram WRITE setMidiProgram)
+      /**
+       * MIDI patch bank number. Changing this property is recorded
+       * to the program's undo stack and can be reverted with a standard "undo"
+       * action.
+       */
+      Q_PROPERTY(int midiBank READ midiBank WRITE setMidiBank)
+
+      Ms::Channel* activeChannel();
+
+      void setMidiBankAndProgram(int bank, int program, bool setUserBankController);
+
+   public:
+      /// \cond MS_INTERNAL
+      Channel(Ms::Channel* ch, Ms::Part* p, QObject* parent = nullptr)
+         : QObject(parent), _channel(ch), _part(p) {}
+
+      QString name() const { return _channel->name(); }
+
+      int volume() const { return _channel->volume(); }
+      void setVolume(int val) { activeChannel()->setVolume(qBound(0, val, 127)); }
+      int pan() const { return _channel->pan(); }
+      void setPan(int val) { activeChannel()->setPan(qBound(0, val, 127)); }
+      int chorus() const { return _channel->chorus(); }
+      void setChorus(int val) { activeChannel()->setChorus(qBound(0, val, 127)); }
+      int reverb() const { return _channel->reverb(); }
+      void setReverb(int val) { activeChannel()->setReverb(qBound(0, val, 127)); }
+
+      bool mute() const { return _channel->mute(); }
+      void setMute(bool val) { activeChannel()->setMute(val); }
+
+      int midiProgram() const { return _channel->program(); }
+      void setMidiProgram(int prog);
+      int midiBank() const { return _channel->bank(); }
+      void setMidiBank(int bank);
+      /// \endcond
+      };
+
+//---------------------------------------------------------
+//   StringData
+///   \since MuseScore 3.5
+//---------------------------------------------------------
+
+class StringData : public QObject {
+      Q_OBJECT
+
+      /**
+       * List of strings in this instrument.
+       * \returns A list of objects representing strings. Each
+       * object has the following fields:
+       * - \p pitch - pitch of this string on fret 0 (integer).
+       * - \p open - if \p true, this string is not fretted and
+       *             always open. If \p false, the string **is**
+       *             fretted. For example, for classical guitar
+       *             all strings are fretted, and for them
+       *             \p open value will always be \p false.
+       */
+      Q_PROPERTY(QVariantList strings READ stringList)
+
+      /** Number of frets in this instrument */
+      Q_PROPERTY(int frets READ frets)
+
+      Ms::StringData _data;
+
+   public:
+      /// \cond MS_INTERNAL
+      StringData(const Ms::StringData* d, QObject* parent = nullptr)
+         : QObject(parent), _data(*d) {}
+
+      QVariantList stringList() const;
+      int frets() const { return _data.frets(); }
+      /// \endcond
+      };
+
+//---------------------------------------------------------
+//   ChannelListProperty
+///   \cond PLUGIN_API \private \endcond
+//---------------------------------------------------------
+
+class ChannelListProperty : public QQmlListProperty<Channel> {
+public:
+      ChannelListProperty(Instrument* i);
+
+      static int count(QQmlListProperty<Channel>* l);
+      static Channel* at(QQmlListProperty<Channel>* l, int i);
+      };
+
+//---------------------------------------------------------
+//   Instrument
+///   \since MuseScore 3.5
+//---------------------------------------------------------
+
+class Instrument : public QObject {
+      Q_OBJECT
+
+      /**
+       * The string identifier
+       * ([MusicXML Sound ID](https://www.musicxml.com/for-developers/standard-sounds/))
+       * for this instrument.
+       * \see \ref Ms::PluginAPI::Part::instrumentId "Part.instrumentId"
+       */
+      Q_PROPERTY(QString                        instrumentId         READ instrumentId)
+      // Ms::Instrument supports multiple short/long names (for aeolus instruments?)
+      // but in practice only one is actually used. If this gets changed this API could
+      // be expanded.
+      /** The long name for this instrument. */
+      Q_PROPERTY(QString                        longName             READ longName)
+      /** The short name for this instrument. */
+      Q_PROPERTY(QString                        shortName            READ shortName)
+
+      /**
+       * For fretted instruments, an information about this
+       * instrument's strings.
+       */
+      Q_PROPERTY(Ms::PluginAPI::StringData* stringData READ stringData)
+
+      // TODO: a property for drumset?
+
+      Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::Channel> channels READ channels)
+
+      Ms::Instrument* _instrument;
+      Ms::Part* _part;
+
+   public:
+      /// \cond MS_INTERNAL
+      Instrument(Ms::Instrument* i, Ms::Part* p)
+         : QObject(), _instrument(i), _part(p) {}
+
+      Ms::Instrument* instrument() { return _instrument; };
+      const Ms::Instrument* instrument() const { return _instrument; };
+
+      Ms::Part* part() { return _part; }
+
+      QString instrumentId() const { return instrument()->instrumentId(); }
+      QString longName() const;
+      QString shortName() const;
+
+      StringData* stringData() { return customWrap<StringData>(instrument()->stringData()); }
+
+      ChannelListProperty channels();
+      /// \endcond
+
+      /** Checks whether two variables represent the same object. */
+      Q_INVOKABLE bool is(Ms::PluginAPI::Instrument* other) { return other && instrument() == other->instrument(); }
+      };
+
+} // namespace PluginAPI
+} // namespace Ms
+
+#endif

--- a/mscore/plugin/api/part.cpp
+++ b/mscore/plugin/api/part.cpp
@@ -1,0 +1,78 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#include "part.h"
+#include "instrument.h"
+
+namespace Ms {
+namespace PluginAPI {
+
+//---------------------------------------------------------
+//   InstrumentListProperty
+//---------------------------------------------------------
+
+InstrumentListProperty::InstrumentListProperty(Part* p)
+   : QQmlListProperty<Instrument>(p, p, &count, &at) {}
+
+//---------------------------------------------------------
+//   InstrumentListProperty::count
+//---------------------------------------------------------
+
+int InstrumentListProperty::count(QQmlListProperty<Instrument>* l)
+      {
+      return static_cast<int>(static_cast<Part*>(l->data)->part()->instruments()->size());
+      }
+
+//---------------------------------------------------------
+//   InstrumentListProperty::at
+//---------------------------------------------------------
+
+Instrument* InstrumentListProperty::at(QQmlListProperty<Instrument>* l, int i)
+      {
+      Part* part = static_cast<Part*>(l->data);
+      const Ms::InstrumentList* il = part->part()->instruments();
+
+      if (i < 0 || i >= int(il->size()))
+            return nullptr;
+
+      Ms::Instrument* instr = std::next(il->begin(), i)->second;
+
+      return customWrap<Instrument>(instr, part->part());
+      }
+
+//---------------------------------------------------------
+//   Part::instruments
+//---------------------------------------------------------
+
+InstrumentListProperty Part::instruments()
+      {
+      return InstrumentListProperty(this);
+      }
+
+//---------------------------------------------------------
+//   Part::instrumentAtTick
+//---------------------------------------------------------
+
+Instrument* Part::instrumentAtTick(int tick)
+      {
+      return customWrap<Instrument>(part()->instrument(Ms::Fraction::fromTicks(tick)), part());
+      }
+
+} // namespace PluginAPI
+} // namespace Ms

--- a/mscore/plugin/api/part.h
+++ b/mscore/plugin/api/part.h
@@ -19,6 +19,22 @@
 namespace Ms {
 namespace PluginAPI {
 
+class Instrument;
+class Part;
+
+//---------------------------------------------------------
+//   InstrumentListProperty
+///   \cond PLUGIN_API \private \endcond
+//---------------------------------------------------------
+
+class InstrumentListProperty : public QQmlListProperty<Instrument> {
+public:
+      InstrumentListProperty(Part* p);
+
+      static int count(QQmlListProperty<Instrument>* l);
+      static Instrument* at(QQmlListProperty<Instrument>* l, int i);
+      };
+
 //---------------------------------------------------------
 //   Part
 //---------------------------------------------------------
@@ -68,6 +84,12 @@ class Part : public Ms::PluginAPI::ScoreElement {
       /// \since MuseScore 3.2.1
       Q_PROPERTY(bool                           show                 READ show)
 
+      /**
+       * List of instruments in this part.
+       * \since MuseScore 3.5
+       */
+      Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::Instrument> instruments READ instruments);
+
    public:
       /// \cond MS_INTERNAL
       Part(Ms::Part* p = nullptr, Ownership o = Ownership::SCORE)
@@ -90,7 +112,15 @@ class Part : public Ms::PluginAPI::ScoreElement {
       QString shortName() const { return part()->shortName(); }
       QString partName() const { return part()->partName(); }
       bool show() const { return part()->show(); }
+
+      InstrumentListProperty instruments();
       /// \endcond
+
+      /**
+       * Finds an instrument that is active in this part at the given \p tick.
+       * \since MuseScore 3.5
+       */
+      Q_INVOKABLE Ms::PluginAPI::Instrument* instrumentAtTick(int tick);
       };
 } // namespace PluginAPI
 } // namespace Ms

--- a/mscore/plugin/api/part.h
+++ b/mscore/plugin/api/part.h
@@ -27,7 +27,13 @@ class Part : public Ms::PluginAPI::ScoreElement {
       Q_OBJECT
       Q_PROPERTY(int                            startTrack           READ startTrack)
       Q_PROPERTY(int                            endTrack             READ endTrack)
-      /// The string identifier for the current instrument. \since MuseScore 3.2
+      /**
+       * The string identifier
+       * ([MusicXML Sound ID](https://www.musicxml.com/for-developers/standard-sounds/))
+       * for the first instrument in this part.
+       * \see \ref Ms::PluginAPI::Instrument::instrumentId "Instrument.instrumentId"
+       * \since MuseScore 3.2
+       */
       Q_PROPERTY(QString                        instrumentId         READ instrumentId)
       /// The number of Chord Symbols. \since MuseScore 3.2.1
       Q_PROPERTY(int                            harmonyCount         READ harmonyCount)

--- a/mscore/plugin/api/qmlpluginapi.cpp
+++ b/mscore/plugin/api/qmlpluginapi.cpp
@@ -208,7 +208,7 @@ Score* PluginAPI::newScore(const QString& name, const QString& part, int measure
             msc()->currentScore()->endCmd();
       MasterScore* score = new MasterScore(MScore::defaultStyle());
       score->setName(name);
-      score->appendPart(part);
+      score->appendPart(Score::instrTemplateFromName(part));
       score->appendMeasures(measures);
       score->doLayout();
       const int view = msc()->appendScore(score);

--- a/mscore/plugin/api/qmlpluginapi.cpp
+++ b/mscore/plugin/api/qmlpluginapi.cpp
@@ -14,6 +14,7 @@
 #include "cursor.h"
 #include "elements.h"
 #include "fraction.h"
+#include "instrument.h"
 #include "score.h"
 #include "part.h"
 #include "util.h"
@@ -342,6 +343,9 @@ void PluginAPI::registerQmlTypes()
       qmlRegisterType<Segment>();
       qmlRegisterType<Measure>();
       qmlRegisterType<Part>();
+      qmlRegisterType<Instrument>();
+      qmlRegisterType<Channel>();
+      qmlRegisterType<StringData>();
       qmlRegisterType<Excerpt>();
       qmlRegisterType<Selection>();
       qmlRegisterType<Tie>();

--- a/mscore/plugin/api/score.cpp
+++ b/mscore/plugin/api/score.cpp
@@ -189,6 +189,15 @@ Measure* Score::lastMeasureMM()
       }
 
 //---------------------------------------------------------
+//   Score::staves
+//---------------------------------------------------------
+
+QQmlListProperty<Staff> Score::staves()
+      {
+      return wrapContainerProperty<Staff>(this, score()->staves());
+      }
+
+//---------------------------------------------------------
 //   Score::startCmd
 //---------------------------------------------------------
 

--- a/mscore/plugin/api/score.cpp
+++ b/mscore/plugin/api/score.cpp
@@ -13,6 +13,7 @@
 #include "score.h"
 #include "cursor.h"
 #include "elements.h"
+#include "libmscore/instrtemplate.h"
 #include "libmscore/measure.h"
 #include "libmscore/score.h"
 #include "libmscore/segment.h"
@@ -66,6 +67,72 @@ void Score::addText(const QString& type, const QString& txt)
       text->setParent(measure);
       text->setXmlText(txt);
       score()->undoAddElement(text);
+      }
+
+//---------------------------------------------------------
+//   defaultInstrTemplate
+//---------------------------------------------------------
+
+static const InstrumentTemplate* defaultInstrTemplate()
+      {
+      static InstrumentTemplate defaultInstrument;
+      if (defaultInstrument.channel.empty()) {
+            Channel a;
+            a.setChorus(0);
+            a.setReverb(0);
+            a.setName(Channel::DEFAULT_NAME);
+            a.setBank(0);
+            a.setVolume(90);
+            a.setPan(0);
+            defaultInstrument.channel.append(a);
+            }
+      return &defaultInstrument;
+      }
+
+//---------------------------------------------------------
+//   instrTemplateFromName
+//---------------------------------------------------------
+
+const InstrumentTemplate* Score::instrTemplateFromName(const QString& name)
+      {
+      const InstrumentTemplate* t = searchTemplate(name);
+      if (!t) {
+            qWarning("<%s> not found", qPrintable(name));
+            t = defaultInstrTemplate();
+            }
+      return t;
+      }
+
+//---------------------------------------------------------
+//   Score::appendPart
+//---------------------------------------------------------
+
+void Score::appendPart(const QString& instrumentId)
+      {
+      const InstrumentTemplate* t = searchTemplate(instrumentId);
+
+      if (!t) {
+            qWarning("appendPart: <%s> not found", qPrintable(instrumentId));
+            t = defaultInstrTemplate();
+            }
+
+      score()->appendPart(t);
+      }
+
+//---------------------------------------------------------
+//   Score::appendPartByMusicXmlId
+//---------------------------------------------------------
+
+void Score::appendPartByMusicXmlId(const QString& instrumentMusicXmlId)
+      {
+      const InstrumentTemplate* t = searchTemplateForMusicXmlId(instrumentMusicXmlId);
+
+      if (!t) {
+            qWarning("appendPart: <%s> not found", qPrintable(instrumentMusicXmlId));
+            t = defaultInstrTemplate();
+            }
+
+      score()->appendPart(t);
       }
 
 //---------------------------------------------------------

--- a/mscore/plugin/api/score.h
+++ b/mscore/plugin/api/score.h
@@ -20,6 +20,9 @@
 #include "libmscore/score.h"
 
 namespace Ms {
+
+class InstrumentTemplate;
+
 namespace PluginAPI {
 
 class Cursor;
@@ -129,8 +132,26 @@ class Score : public Ms::PluginAPI::ScoreElement {
       /// Sets the metatag named \p tag to \p val
       Q_INVOKABLE void setMetaTag(const QString& tag, const QString& val) { score()->setMetaTag(tag, val); }
 
-//      //@ appends to the score a named part as last part
-//      Q_INVOKABLE void appendPart(const QString&);
+      /**
+       * Appends a part with the instrument defined by \p instrumentId
+       * to this score.
+       * \param instrumentId - ID of the instrument to be added, as listed in
+       * [`instruments.xml`](https://github.com/musescore/MuseScore/blob/3.x/share/instruments/instruments.xml)
+       * file.
+       * \since MuseScore 3.5
+       */
+      Q_INVOKABLE void appendPart(const QString& instrumentId);
+      /**
+       * Appends a part with the instrument defined by the given MusicXML ID
+       * to this score.
+       * \param instrumentMusicXmlId -
+       * [MusicXML Sound ID](https://www.musicxml.com/for-developers/standard-sounds/)
+       * of the instrument to be added.
+       * \see \ref Ms::PluginAPI::Part::instrumentId, \ref Ms::PluginAPI::Instrument::instrumentId
+       * \since MuseScore 3.5
+       */
+      Q_INVOKABLE void appendPartByMusicXmlId(const QString& instrumentMusicXmlId);
+
       /// Appends a number of measures to this score.
       Q_INVOKABLE void appendMeasures(int n) { score()->appendMeasures(n); }
       Q_INVOKABLE void addText(const QString& type, const QString& text);
@@ -197,6 +218,8 @@ class Score : public Ms::PluginAPI::ScoreElement {
 
       QQmlListProperty<Part> parts() { return wrapContainerProperty<Part>(this, score()->parts());   }
       QQmlListProperty<Excerpt> excerpts() { return wrapExcerptsContainerProperty<Excerpt>(this, score()->excerpts());   }
+
+      static const Ms::InstrumentTemplate* instrTemplateFromName(const QString& name); // used by PluginAPI::newScore()
       /// \endcond
       };
 } // namespace PluginAPI

--- a/mscore/plugin/api/score.h
+++ b/mscore/plugin/api/score.h
@@ -30,6 +30,7 @@ class Segment;
 class Measure;
 class Selection;
 class Score;
+class Staff;
 
 extern Selection* selectionWrap(Ms::Selection* select);
 
@@ -101,6 +102,12 @@ class Score : public Ms::PluginAPI::ScoreElement {
        * \see Page::pagenumber
        */
       Q_PROPERTY(int pageNumberOffset READ pageNumberOffset WRITE setPageNumberOffset)
+
+      /**
+       * List of staves in this score.
+       * \since MuseScore 3.5
+       */
+      Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::Staff> staves    READ staves)
 
    public:
       /// \cond MS_INTERNAL
@@ -218,6 +225,7 @@ class Score : public Ms::PluginAPI::ScoreElement {
 
       QQmlListProperty<Part> parts() { return wrapContainerProperty<Part>(this, score()->parts());   }
       QQmlListProperty<Excerpt> excerpts() { return wrapExcerptsContainerProperty<Excerpt>(this, score()->excerpts());   }
+      QQmlListProperty<Staff> staves();
 
       static const Ms::InstrumentTemplate* instrTemplateFromName(const QString& name); // used by PluginAPI::newScore()
       /// \endcond

--- a/mscore/plugin/api/scoreelement.cpp
+++ b/mscore/plugin/api/scoreelement.cpp
@@ -53,6 +53,15 @@ QString ScoreElement::userName() const
       }
 
 //---------------------------------------------------------
+//   ScoreElement::spatium
+//---------------------------------------------------------
+
+qreal ScoreElement::spatium() const
+      {
+      return e->isElement() ? toElement(e)->spatium() : e->score()->spatium();
+      }
+
+//---------------------------------------------------------
 //   ScoreElement::get
 //---------------------------------------------------------
 
@@ -68,10 +77,11 @@ QVariant ScoreElement::get(Ms::Pid pid) const
                   }
             case P_TYPE::POINT_SP:
             case P_TYPE::POINT_SP_MM:
-                  if (e->isElement())
-                        return val.toPointF() / toElement(e)->spatium();
-                  // TODO: handle Staff and other classes?
-                  break;
+                  return val.toPointF() / spatium();
+            case P_TYPE::SP_REAL:
+                  return val.toReal() / spatium();
+            case P_TYPE::SPATIUM:
+                  return val.value<Spatium>().val();
             default:
                   break;
             }
@@ -99,9 +109,13 @@ void ScoreElement::set(Ms::Pid pid, QVariant val)
                   break;
             case P_TYPE::POINT_SP:
             case P_TYPE::POINT_SP_MM:
-                  if (e->isElement())
-                        val = val.toPointF() * toElement(e)->spatium();
-                  // TODO: handle Staff and other classes?
+                  val = val.toPointF() * spatium();
+                  break;
+            case P_TYPE::SP_REAL:
+                  val = val.toReal() * spatium();
+                  break;
+            case P_TYPE::SPATIUM:
+                  val = QVariant::fromValue(Spatium(val.toReal()));
                   break;
             default:
                   break;

--- a/mscore/plugin/api/scoreelement.cpp
+++ b/mscore/plugin/api/scoreelement.cpp
@@ -153,6 +153,8 @@ ScoreElement* wrap(Ms::ScoreElement* se, Ownership own)
                   return wrap<Score>(toScore(se), own);
             case ElementType::PART:
                   return wrap<Part>(toPart(se), own);
+            case ElementType::STAFF:
+                  return wrap<Staff>(toStaff(se), own);
             default:
                   break;
             }

--- a/mscore/plugin/api/scoreelement.h
+++ b/mscore/plugin/api/scoreelement.h
@@ -55,6 +55,8 @@ class ScoreElement : public QObject {
 
       Ownership _ownership;
 
+      qreal spatium() const;
+
    protected:
       /// \cond MS_INTERNAL
       Ms::ScoreElement* const e;

--- a/mscore/plugin/api/scoreelement.h
+++ b/mscore/plugin/api/scoreelement.h
@@ -105,6 +105,24 @@ Wrapper* wrap(T* t, Ownership own = Ownership::SCORE)
 extern ScoreElement* wrap(Ms::ScoreElement* se, Ownership own = Ownership::SCORE);
 
 //---------------------------------------------------------
+//   customWrap
+///   \cond PLUGIN_API \private \endcond
+///   \internal
+///   Can be used to construct wrappers which do not
+///   support standard ownership logic or require
+///   additional arguments for initialization.
+//---------------------------------------------------------
+
+template <class Wrapper, class T, typename... Args>
+Wrapper* customWrap(T* t, Args... args)
+      {
+      Wrapper* w = t ? new Wrapper(t, std::forward<Args>(args)...) : nullptr;
+      // All wrapper objects should belong to JavaScript code.
+      QQmlEngine::setObjectOwnership(w, QQmlEngine::JavaScriptOwnership);
+      return w;
+      }
+
+//---------------------------------------------------------
 ///   QML access to containers.
 ///   A wrapper which provides read-only access for various
 ///   items containers.

--- a/mscore/plugin/plugin.cmake
+++ b/mscore/plugin/plugin.cmake
@@ -9,6 +9,9 @@ set (PLUGIN_API_SRC
     ${CMAKE_CURRENT_LIST_DIR}/api/excerpt.cpp
     ${CMAKE_CURRENT_LIST_DIR}/api/excerpt.h
     ${CMAKE_CURRENT_LIST_DIR}/api/fraction.h
+    ${CMAKE_CURRENT_LIST_DIR}/api/instrument.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/api/instrument.h
+    ${CMAKE_CURRENT_LIST_DIR}/api/part.cpp
     ${CMAKE_CURRENT_LIST_DIR}/api/part.h
     ${CMAKE_CURRENT_LIST_DIR}/api/playevent.cpp
     ${CMAKE_CURRENT_LIST_DIR}/api/playevent.h


### PR DESCRIPTION
There is no separate issue for this but there are numerous requests for functionality provided here across the forum (the list may be incomplete):
- https://musescore.org/en/node/294183
- https://musescore.org/en/node/295638 (partially)
- https://musescore.org/en/node/294858
- https://musescore.org/en/node/56916

Ability to append instruments to a score and manipulate some playback-related properties were present in MuseScore 2.X but have not yet been implemented in MuseScore 3. This PR implements a somewhat more complete version of that, providing an access to the entire instruments and channels structure which is currently used inside MuseScore. In addition to that, both to provide a link between elements and parts and to expose an ability to mute voices, `Staff` objects are also exposed to plugins in this pull request.