### PR TITLE
fix #293017: add a possibility to change selection from plugins

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -482,6 +482,11 @@ void UndoStack::redo(EditData* ed)
 //   UndoMacro
 //---------------------------------------------------------
 
+bool UndoMacro::canRecordSelectedElement(const Element* e)
+      {
+      return e->isNote() || (e->isChordRest() && !e->isChord()) || (e->isTextBase() && !e->isInstrumentName()) || e->isFretDiagram();
+      }
+
 void UndoMacro::fillSelectionInfo(SelectionInfo& info, const Selection& sel)
       {
       info.staffStart = info.staffEnd = -1;
@@ -489,7 +494,7 @@ void UndoMacro::fillSelectionInfo(SelectionInfo& info, const Selection& sel)
 
       if (sel.isList()) {
             for (Element* e : sel.elements()) {
-                  if (e->isNote() || e->isChordRest() || (e->isTextBase() && !e->isInstrumentName()) || e->isFretDiagram())
+                  if (canRecordSelectedElement(e))
                         info.elements.push_back(e);
                   else {
                         // don't remember selection we are unable to restore

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -165,6 +165,8 @@ class UndoMacro : public UndoCommand {
       bool empty() const { return childCount() == 0; }
       void append(UndoMacro&& other);
 
+      static bool canRecordSelectedElement(const Element* e);
+
       UNDO_NAME("UndoMacro");
       };
 

--- a/mscore/plugin/api/selection.cpp
+++ b/mscore/plugin/api/selection.cpp
@@ -13,6 +13,8 @@
 #include "selection.h"
 #include "score.h"
 
+#include "libmscore/undo.h"
+
 namespace Ms {
 namespace PluginAPI {
 
@@ -28,5 +30,141 @@ Selection* selectionWrap(Ms::Selection* select)
       return w;
       }
 
+//---------------------------------------------------------
+//   Selection::checkSelectionIsNotLocked
+//---------------------------------------------------------
+
+bool Selection::checkSelectionIsNotLocked() const
+      {
+      if (_select->isLocked()) {
+            qWarning("Cannot change selection: %s", qPrintable(_select->lockReason()));
+            return false;
+            }
+      return true;
+      }
+
+//---------------------------------------------------------
+//   Selection::select
+///   Selects the given element. At this point only a
+///   limited number of element types is supported, like
+///   notes, rests and most of text elements.
+///   \param e element to select
+///   \param add if \p true, appends an element to already
+///   existing selection. If \p false (default), deselects
+///   all other elements and selects this element.
+///   \return \p true on success, \p false if selection
+///   cannot be changed, e.g. due to the ongoing operation
+///   on a score (like dragging elements) or incorrect
+///   arguments to this function.
+///   \since MuseScore 3.5
+//---------------------------------------------------------
+
+bool Selection::select(Element* elWrapper, bool add)
+      {
+      if (!checkSelectionIsNotLocked())
+            return false;
+
+      if (!elWrapper)
+            return false;
+
+      Ms::Element* e = elWrapper->element();
+
+      // Check whether it's safe to select this element:
+      // use types list from UndoMacro for now
+      if (!Ms::UndoMacro::canRecordSelectedElement(e)) {
+            qWarning("Cannot select element of type %s", e->name());
+            return false;
+            }
+
+      if (e->score() != _select->score() || elWrapper->ownership() != Ownership::SCORE) {
+            qWarning("Selection::select: element does not belong to score");
+            return false;
+            }
+
+      const SelectType selType = add ? SelectType::ADD : SelectType::SINGLE;
+      e->score()->select(e, selType);
+
+      return true;
+      }
+
+//---------------------------------------------------------
+//   Selection::selectRange
+///   Selects a range in a score
+///   \param startTick start tick to be included in selection
+///   \param endTick end tick of selection, excluded from selection
+///   \param startStaff start staff index, included in selection
+///   \param endStaff end staff index, excluded from seleciton
+///   \return \p true on success, \p false if selection
+///   cannot be changed, e.g. due to the ongoing operation
+///   on a score (like dragging elements) or incorrect
+///   arguments to this function.
+///   \since MuseScore 3.5
+//---------------------------------------------------------
+
+bool Selection::selectRange(int startTick, int endTick, int startStaff, int endStaff)
+      {
+      if (!checkSelectionIsNotLocked())
+            return false;
+
+      const int nstaves = _select->score()->nstaves();
+
+      startStaff = qBound(0, startStaff, nstaves - 1);
+      endStaff = qBound(1, endStaff, nstaves);
+
+      if (startStaff >= endStaff)
+            return false;
+
+      Ms::Segment* segStart = _select->score()->tick2leftSegmentMM(Ms::Fraction::fromTicks(startTick));
+      Ms::Segment* segEnd = _select->score()->tick2leftSegmentMM(Ms::Fraction::fromTicks(endTick));
+
+      if (!segStart || (segEnd && !((*segEnd) > (*segStart))))
+            return false;
+
+      if (segEnd && _select->score()->undoStack()->active())
+            _select->setRangeTicks(segStart->tick(), segEnd->tick(), startStaff, endStaff);
+      else
+            _select->setRange(segStart, segEnd, startStaff, endStaff);
+
+      return true;
+      }
+
+//---------------------------------------------------------
+//   Selection::deselect
+///   Deselects the given element.
+///   \return \p true on success, \p false if selection
+///   cannot be changed, e.g. due to the ongoing operation
+///   on a score (like dragging elements).
+///   \since MuseScore 3.5
+//---------------------------------------------------------
+
+bool Selection::deselect(Element* elWrapper)
+      {
+      if (!checkSelectionIsNotLocked())
+            return false;
+
+      if (!elWrapper)
+            return false;
+
+      _select->score()->deselect(elWrapper->element());
+      return true;
+      }
+
+//---------------------------------------------------------
+//   Selection::clear
+///   Clears the selection.
+///   \return \p true on success, \p false if selection
+///   cannot be changed, e.g. due to the ongoing operation
+///   on a score (like dragging elements).
+///   \since MuseScore 3.5
+//---------------------------------------------------------
+
+bool Selection::clear()
+      {
+      if (!checkSelectionIsNotLocked())
+            return false;
+
+      _select->deselectAll();
+      return true;
+      }
 }
 }

--- a/mscore/plugin/api/selection.h
+++ b/mscore/plugin/api/selection.h
@@ -31,20 +31,68 @@ class Selection : public QObject {
       /// \since MuseScore 3.3
       Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::Element> elements READ elements)
 
-      /// \cond MS_INTERNAL
+      /**
+       * Whether this selection covers a range of a score, as opposed to
+       * a list of distinct elements.
+       * \since MuseScore 3.5
+       */
+      Q_PROPERTY(bool isRange READ isRange)
+      /**
+       * Start segment of selection, included. This property is valid
+       * only for range selection.
+       * \since MuseScore 3.5
+       * \see \ref isRange
+       */
+      Q_PROPERTY(Ms::PluginAPI::Segment* startSegment READ startSegment)
+      /**
+       * End segment of selection, excluded. This property is valid
+       * only for range selection.
+       * \since MuseScore 3.5
+       * \see \ref isRange
+       */
+      Q_PROPERTY(Ms::PluginAPI::Segment* endSegment READ endSegment)
+      /**
+       * First staff of selection, included. This property is valid
+       * only for range selection.
+       * \since MuseScore 3.5
+       * \see \ref isRange
+       */
+      Q_PROPERTY(int startStaff READ startStaff)
+      /**
+       * End staff of selection, included. This property is valid
+       * only for range selection.
+       * \since MuseScore 3.5
+       * \see \ref isRange
+       */
+      Q_PROPERTY(int endStaff READ endStaff)
 
    protected:
+      /// \cond MS_INTERNAL
       Ms::Selection* _select;
 
-   public:
+      bool checkSelectionIsNotLocked() const;
+      /// \endcond
 
+   public:
+      /// \cond MS_INTERNAL
       Selection(Ms::Selection* select) : QObject(), _select(select) {}
       virtual ~Selection() { }
 
       QQmlListProperty<Element> elements()
             { return wrapContainerProperty<Element>(this, _select->elements()); }
 
+      bool isRange() const { return _select->isRange(); }
+
+      Segment* startSegment() const { return wrap<Segment>(_select->startSegment()); }
+      Segment* endSegment() const { return wrap<Segment>(_select->endSegment()); }
+      int startStaff() const { return _select->staffStart(); }
+      int endStaff() const { return _select->staffEnd(); }
       /// \endcond
+
+      Q_INVOKABLE bool select(Ms::PluginAPI::Element* e, bool add = false);
+      Q_INVOKABLE bool selectRange(int startTick, int endTick, int startStaff, int endStaff);
+      Q_INVOKABLE bool deselect(Ms::PluginAPI::Element* e);
+      Q_INVOKABLE bool clear();
 };
 
 extern Selection* selectionWrap(Ms::Selection* select);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/293017

Allows selecting elements from plugins to extent described in [this issue comment](https://musescore.org/en/node/293017#comment-949195). This PR provides a different way of selecting elements from what has been proposed in #5259 (separate `select()`, `deselect()`, `selectRange()` and `clear()` methods instead of inserting elements directly to `Selection.elements` list) and includes some extra safety checks for changing a selection. These checks include restricting element types which are allowed to be selected from plugins and take the recently added selection lock mechanism (from #5866) into account.

In addition to that, range selection properties are also added to Selection object here.