### PR TITLE
fix vtest artifact when failing to generate images and add the possib…

### DIFF
--- a/.github/workflows/vtests.yml
+++ b/.github/workflows/vtests.yml
@@ -5,6 +5,7 @@ on:
     branches:
     - master
     - 3.x
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches:
     - master
@@ -100,14 +101,14 @@ jobs:
       with:
         name: compare
         path: ./vtest/compare
-    - name: Comment PR
-      if: github.event_name == 'pull_request' && contains( env.found, '1') && contains( env.VTEST_DIFF_FOUND, 'true')
-      uses: thollander/actions-comment-pull-request@1.0.0
-      with:
-        message: 'This is an automatic message. This PR appears to change some of the visual tests.
-          Please carefully review the new visual test results in the uploaded artifact that can be found
-          [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})'
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Skip failure signal if PR is labeled 'vtests'
+      if: github.event_name == 'pull_request' && contains( env.found, '1') && contains( env.VTEST_DIFF_FOUND, 'true') && contains(github.event.pull_request.labels.*.name, 'vtests')
+      run: |
+        echo "This PR appears to change some of the visual tests."
+        echo "Please carefully review the new visual test results in the uploaded artifact that can be found here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        echo "Failure signal skipped because 'vtests' label is applied to the PR"
+        export VTEST_DIFF_FOUND=false
+        echo "::set-env name=VTEST_DIFF_FOUND::${VTEST_DIFF_FOUND}"
     - name: Emit failure signal for PR if differences are found
       if: github.event_name == 'pull_request' && contains( env.found, '1') && contains( env.VTEST_DIFF_FOUND, 'true')
       run: |

--- a/vtest/gen_compare
+++ b/vtest/gen_compare
@@ -58,6 +58,9 @@ for src in $SRC; do
                   fi
       else
             echo "There were errors generating image $src"
+            if test -f $src-1.png; then
+                  mv $src-1.png $src-ref.png 2>/dev/null
+                  fi
             export VTEST_DIFF_FOUND=true
             echo "    <h2 id=\"$src\">$src <a class=\"toc-anchor\" href=\"#$src\">#</a></h2>" >> $F
             echo "    <div>" >> $F


### PR DESCRIPTION
…ility to skip the failure signal for approved vtest changes

Resolves: N/A

This PR properly renames the ref images even in the case in which the PR vtests cannot be generated.
Moreover, this PR adds the possibility of having the "green check" also for PRs that change vtests.
This is done when the label 'vtests' is applied to the PR, for example when vtests have been reviewed and approved by a person with the correct permissions for adding such a label.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [N/A] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
