### PR TITLE
Fix #279773 - Articulations are duplicated on adding linked staves, c…

### DIFF
--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -886,6 +886,10 @@ void Excerpt::cloneStaff(Staff* srcStaff, Staff* dstStaff)
                               ncr->lyrics().clear();
 
                               for (Element* e : seg->annotations()) {
+                                    if (!e) {
+                                          qDebug("cloneStaff: corrupted annotation found.");
+                                          continue;
+                                          }
                                     if (e->generated() || e->systemFlag())
                                           continue;
                                     if (e->track() != srcTrack)
@@ -901,6 +905,17 @@ void Excerpt::cloneStaff(Staff* srcStaff, Staff* dstStaff)
                                           case ElementType::DYNAMIC:
                                           case ElementType::LYRICS:   // not normally segment-attached
                                                 continue;
+                                          case ElementType::FERMATA:
+                                                {
+                                                // Fermatas are special since the belong to a segment but should
+                                                // be created and linked on each staff.
+                                                Element* ne1 = e->linkedClone();
+                                                ne1->setTrack(dstTrack);
+                                                ne1->setParent(seg);
+                                                ne1->setScore(score);
+                                                score->undo(new AddElement(ne1));
+                                                continue;
+                                                }
                                           default:
                                                 Element* ne1 = e->clone();
                                                 ne1->setTrack(dstTrack);
@@ -931,7 +946,7 @@ void Excerpt::cloneStaff(Staff* srcStaff, Staff* dstStaff)
                                                       tie->setEndNote(nn);
                                                       }
                                                 else {
-                                                      qDebug("cloneStave: cannot find tie");
+                                                      qDebug("cloneStaff: cannot find tie");
                                                       }
                                                 }
                                           // add back spanners (going back from end to start spanner element
@@ -945,7 +960,7 @@ void Excerpt::cloneStaff(Staff* srcStaff, Staff* dstStaff)
                                                       score->addElement(newSp);
                                                       }
                                                 else {
-                                                      qDebug("cloneStave: cannot find spanner start note");
+                                                      qDebug("cloneStaff: cannot find spanner start note");
                                                       }
                                                 }
                                           }
@@ -1138,7 +1153,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& stic
                                                       tie->setEndNote(nn);
                                                       }
                                                 else {
-                                                      qDebug("cloneStave: cannot find tie");
+                                                      qDebug("cloneStaff2: cannot find tie");
                                                       }
                                                 }
                                           }

--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -295,7 +295,6 @@ void MuseScore::editInstrList()
                   masterScore->undo(new InsertPart(part, staffIdx));
 
                   pli->part = part;
-                  QList<Staff*> linked;
                   for (int cidx = 0; pli->child(cidx); ++cidx) {
                         StaffListItem* sli = static_cast<StaffListItem*>(pli->child(cidx));
                         Staff* staff       = new Staff(masterScore);
@@ -311,10 +310,8 @@ void MuseScore::editInstrList()
                         ++staffIdx;
 
                         Staff* linkedStaff = part->staves()->front();
-                        if (sli->linked() && linkedStaff != staff) {
+                        if (sli->linked() && linkedStaff != staff)
                               Excerpt::cloneStaff(linkedStaff, staff);
-                              linked.append(staff);
-                              }
                         }
 
                   //insert keysigs


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/279773

When creating a linked staff, <code>closeStaff()</code> will create a new <code>Fermata</code> element and add it using <code>undoAddElement()</code> which will create a clone on each staff but this doesn't take an exiting <code>Fermata</code> into account. As a result a second <code>Fermata</code> appears at the original staff.
This is solved by creating a linked clone from the original <code>Fermata</code> and copy this clone to the linked staff.

This solves also the crash. The crash was caused by a corrupted returned annotation in line 888 of <code>Excerpt::cloneStaff()</code>.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n.a.] I created the test (mtest, vtest, script test) to verify the changes I made
