### PR TITLE
fix #291522 : Double-click on drum palette produces wrong note when t…

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -443,7 +443,7 @@ void Palette::mouseMoveEvent(QMouseEvent* ev)
 //   applyDrop
 //---------------------------------------------------------
 
-static void applyDrop(Score* score, ScoreView* viewer, Element* target, Element* e, Qt::KeyboardModifiers modifiers, QPointF pt = QPointF())
+static void applyDrop(Score* score, ScoreView* viewer, Element* target, Element* e, Qt::KeyboardModifiers modifiers, QPointF pt = QPointF(), bool pasteMode = false)
       {
       EditData& dropData = viewer->getEditData();
       dropData.pos         = pt.isNull() ? target->pagePos() : pt;
@@ -458,6 +458,7 @@ static void applyDrop(Score* score, ScoreView* viewer, Element* target, Element*
 //printf("<<%s>>\n", a.data());
 
             XmlReader n(a);
+            n.setPasteMode(pasteMode);
             Fraction duration;  // dummy
             QPointF dragOffset;
             ElementType type = Element::readType(n, &dragOffset, &duration);
@@ -541,7 +542,7 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
                               e = toChord(e)->upNote();
                         // use voice of element being added to (otherwise we can might corrupt the measure)
                         element->setTrack(e->voice());
-                        applyDrop(score, viewer, e, element, modifiers);
+                        applyDrop(score, viewer, e, element, modifiers, QPointF(), true);
                         // continue in same track
                         score->inputState().setTrack(e->track());
                         }


### PR DESCRIPTION
…ransposing instrument at top of score and concert pitch off

Resolves: https://musescore.org/en/node/291522

When the note was read from the drumset palette data, the first staff of the score was considered as the starting note staff for the note to be added, therefore, if this was a transposing instrument staff, the note pitch was adjusted by the transposing properties of such first staff by entering the if condition here https://github.com/musescore/MuseScore/blob/e925ba0e6173689c9598bd45dc399310add72ba9/libmscore/note.cpp#L1338

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
