### PR TITLE
Now keeping length, ontime and velocity data when copying notes.

### DIFF
--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -30,6 +30,7 @@
 #include "libmscore/tuplet.h"
 #include "libmscore/segment.h"
 #include "libmscore/noteevent.h"
+#include "libmscore/undo.h"
 #include "libmscore/utils.h"
 
 namespace Ms {
@@ -891,14 +892,34 @@ void PianoView::dragSelectionNoteGroup() {
 
 
 //---------------------------------------------------------
+//   getSegmentNotes
+//---------------------------------------------------------
+
+QVector<Note*> PianoView::getSegmentNotes(Segment* seg, int track)
+      {
+      QVector<Note*> notes;
+
+      ChordRest* cr = seg->cr(track);
+      if (cr && cr->isChord()) {
+            Chord* chord = toChord(cr);
+            notes.append(QVector<Note*>::fromStdVector(chord->notes()));
+            }
+
+      return notes;
+      }
+
+
+//---------------------------------------------------------
 //   addNote
 //---------------------------------------------------------
 
-void PianoView::addNote(Fraction startTick, Fraction duration, int pitch, int track)
+QVector<Note*> PianoView::addNote(Fraction startTick, Fraction duration, int pitch, int track)
       {
       NoteVal nv(pitch);
 
       Score* score = _staff->score();
+
+      QVector<Note*> addedNotes;
 
       ChordRest* curCr = score->findCR(startTick, track);
       if (curCr) {
@@ -919,23 +940,34 @@ void PianoView::addNote(Fraction startTick, Fraction duration, int pitch, int tr
                   cutChordRest(cr1, track, startTick + duration, crMid, crEnd);
                   if (crMid->isChord()) {
                         Chord* ch = toChord(crMid);
-                        score->addNote(ch, nv);
+                        addedNotes.append(score->addNote(ch, nv));
                         }
-                  else
-                        score->setNoteRest(crMid->segment(), track, nv, duration);
+                  else {
+                        Segment* newSeg = score->setNoteRest(crMid->segment(), track, nv, duration);
+                        if (newSeg)
+                              addedNotes.append(getSegmentNotes(newSeg, track));
+                        }
                   }
             else if (cr1End == startTick + duration) {
                   if (cr1->isChord()) {
                         Chord* ch = toChord(cr1);
-                        score->addNote(ch, nv);
+                        addedNotes.append(score->addNote(ch, nv));
                         }
-                  else
-                        score->setNoteRest(cr1->segment(), track, nv, duration);
+                  else {
+                        Segment* newSeg = score->setNoteRest(cr1->segment(), track, nv, duration);
+                        if (newSeg)
+                              addedNotes.append(getSegmentNotes(newSeg, track));
+                        }
                   }
-            else
-                  score->setNoteRest(cr1->segment(), track, nv, duration);
+            else {
+                  Segment* newSeg = score->setNoteRest(cr1->segment(), track, nv, duration);
+                  if (newSeg)
+                        addedNotes.append(getSegmentNotes(newSeg, track));
+                  }
 
             }
+
+      return addedNotes;
       }
 
 
@@ -1850,6 +1882,9 @@ QString PianoView::serializeSelectedNotes()
 
                   int voice = note->voice();
 
+                  int veloOff = note->veloOffset();
+                  Note::ValueType veloType = note->veloType();
+
                   xml.writeStartElement("note");
                   xml.writeAttribute("startN", QString::number(startTick.numerator()));
                   xml.writeAttribute("startD", QString::number(startTick.denominator()));
@@ -1857,6 +1892,19 @@ QString PianoView::serializeSelectedNotes()
                   xml.writeAttribute("lenD", QString::number(len.denominator()));
                   xml.writeAttribute("pitch", QString::number(pitch));
                   xml.writeAttribute("voice", QString::number(voice));
+                  xml.writeAttribute("veloOff", QString::number(veloOff));
+                  xml.writeAttribute("veloType", veloType == Note::ValueType::OFFSET_VAL ? "o" : "u");
+
+                  for (NoteEvent& evt : note->playEvents()) {
+                        int ontime = evt.ontime();
+                        int len = evt.len();
+
+                        xml.writeStartElement("evt");
+                        xml.writeAttribute("ontime", QString::number(ontime));
+                        xml.writeAttribute("len", QString::number(len));
+                        xml.writeEndElement();
+                        }
+
                   xml.writeEndElement();
                   }
             }
@@ -1983,6 +2031,7 @@ void PianoView::pasteNotes(const QString& copiedNotes, Fraction pasteStartTick, 
 
       QXmlStreamReader xml(copiedNotes);
       Fraction firstTick;
+      QVector<Note*> addedNotes;
 
       while (!xml.atEnd()) {
             QXmlStreamReader::TokenType tt = xml.readNext();
@@ -2004,11 +2053,34 @@ void PianoView::pasteNotes(const QString& copiedNotes, Fraction pasteStartTick, 
                         int pitch = xml.attributes().value("pitch").toString().toInt();
                         int voice = xml.attributes().value("voice").toString().toInt();
 
+                        int veloOff = xml.attributes().value("veloOff").toString().toInt();
+                        QString veloTypeStrn = xml.attributes().value("veloType").toString();
+                        Note::ValueType veloType = veloTypeStrn == "o" ? Note::ValueType::OFFSET_VAL : Note::ValueType::USER_VAL;
+
                         int track = _staff->idx() * VOICES + voice;
 
                         Fraction pos = xIsOffset ? startTick + pasteStartTick : startTick - firstTick + pasteStartTick;
 
-                        addNote(pos, tickLen, pitch + pitchOffset, track);
+                        addedNotes = addNote(pos, tickLen, pitch + pitchOffset, track);
+                        for (Note* note: addedNotes) {
+                              note->setVeloOffset(veloOff);
+                              note->setVeloType(veloType);
+                              }
+                        }
+                  if (xml.name().toString() == "evt") {
+                        int ontime = xml.attributes().value("ontime").toString().toInt();
+                        int len = xml.attributes().value("len").toString().toInt();
+
+                        NoteEvent ne;
+                        ne.setOntime(ontime);
+                        ne.setLen(len);
+                        for (Note* note: addedNotes) {
+                              NoteEventList& evtList = note->playEvents();
+                              if (!evtList.isEmpty()) {
+                                    NoteEvent* evt = note->noteEvent(evtList.length() - 1);
+                                    _staff->score()->undo(new ChangeNoteEvent(note, evt, ne));
+                                    }
+                              }
                         }
                   }
             }

--- a/mscore/pianoroll/pianoview.h
+++ b/mscore/pianoroll/pianoview.h
@@ -22,6 +22,7 @@ class Score;
 class Staff;
 class Chord;
 class ChordRest;
+class Segment;
 class Note;
 class NoteEvent;
 class PianoView;
@@ -122,12 +123,13 @@ private:
       virtual void drawBackground(QPainter* painter, const QRectF& rect);
 
       void addChord(Chord* _chord, int voice);
+      QVector<Note*> getSegmentNotes(Segment* seg, int track);
       void updateBoundingSize();
       void clearNoteData();
       void selectNotes(int startTick, int endTick, int lowPitch, int highPitch, NoteSelectType selType);
       void showPopupMenu(const QPoint& pos);
       bool cutChordRest(ChordRest* targetCr, int track, Fraction cutTick, ChordRest*& cr0, ChordRest*& cr1);
-      void addNote(Fraction startTick, Fraction duration, int pitch, int track);
+      QVector<Note*> addNote(Fraction startTick, Fraction duration, int pitch, int track);
       void handleSelectionClick();
       void insertNote(int modifiers);
       Fraction roundToStartBeat(int tick) const;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/305694

Now keeping length, ontime and velocity data when copying notes in PRE.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
