### PR TITLE
Fix #305705: part 2, gp[345] mtest failures

### DIFF
--- a/libmscore/instrtemplate.cpp
+++ b/libmscore/instrtemplate.cpp
@@ -790,9 +790,9 @@ ClefTypeList InstrumentTemplate::clefType(int staffIdx) const
 
 ClefType defaultClef(int program)
       {
-      if (program >= 25 && program < 32)              // this are guitars
+      if (program >= 24 && program < 32)              // this are guitars
             return ClefType::G8_VB;
-      else if (program >= 33 && program < 41)         // this is bass
+      else if (program >= 32 && program < 40)         // this is bass
             return ClefType::F8_VB;
 
       for (InstrumentGroup* g : instrumentGroups) {


### PR DESCRIPTION
apparently Guitar Pro picks the clefs for the first instrument from instruments.xml with a matching sound of nylon strings, which now fails as Bouzouki just got changed to use a regular G clef in #6101, the real issue gets solved by fixing off-by-one errors in ínstrtemplate.cpp, detecting Guitars (and G8vb clefs) only starting with steel strings!