### PR TITLE
fix #287047, fix #290968: update mmrest bbox including the number

### DIFF
--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -109,19 +109,22 @@ void Rest::draw(QPainter* painter) const
             // draw number
             int n = measure()->mmRestCount();
             std::vector<SymId>&& s = toTimeSigString(QString("%1").arg(n));
+            QRectF numberBox = symBbox(s);
             qreal y = _mmRestNumberPos * spatium() - staff()->height() * .5;
-            qreal x = (_mmWidth - symBbox(s).width()) * .5;
+            qreal x = (_mmWidth - numberBox.width()) * .5;
             drawSymbols(s, painter, QPointF(x, y));
 
             // draw horizontal line
-            qreal pw = _spatium * .7;
+            qreal pw = _spatium * .7; // line width
             QPen pen(painter->pen());
             pen.setWidthF(pw);
             painter->setPen(pen);
-            qreal x1 = pw * .5;
+            qreal x1 = pw * .5; // half of the line width
             qreal x2 = _mmWidth - x1;
-            if (_mmRestNumberPos > 0.7 && _mmRestNumberPos < 3.3) { // hack for when number encounters horizontal line
-                  qreal gapDistance = symBbox(s).width() * .5 + _spatium;
+
+            // avoid painting the line when it collides with the number.
+            if ((y + (numberBox.height() * .5 )) > -x1  && (y - (numberBox.height() * .5 )) < x1) {
+                  qreal gapDistance = numberBox.width() * .5 + _spatium;
                   qreal midpoint = (x1 + x2) * .5;
                   painter->drawLine(QLineF(x1, 0.0, midpoint - gapDistance, 0.0));
                   painter->drawLine(QLineF(midpoint + gapDistance, 0.0, x2, 0.0));

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -348,8 +348,25 @@ void Rest::layoutMMRest(qreal val)
       bbox().setRect(0.0, -_spatium, _mmWidth, _spatium * 2);
 
       // text
-//      qreal y  = -_spatium * 2.5 - staff()->height() *.5;
-//      addbbox(QRectF(0, y, w, _spatium * 2));         // approximation
+      addbbox(mmRestNumberRect());
+}
+
+//---------------------------------------------------------
+//   mmRestNumberRect
+///   returns the mmrest number's bounding rectangle
+//---------------------------------------------------------
+
+QRectF Rest::mmRestNumberRect() const
+      {
+      int n = measure()->mmRestCount();
+      std::vector<SymId>&& s = toTimeSigString(QString("%1").arg(n));
+
+      QRectF r = symBbox(s);
+      qreal y = _mmRestNumberPos * spatium() - staff()->height() * .5;
+      qreal x = (_mmWidth - r.width()) * .5;
+
+      r.translate(QPointF(x, y));
+      return r;
       }
 
 //---------------------------------------------------------
@@ -1072,15 +1089,7 @@ Shape Rest::shape() const
                   qreal _spatium = spatium();
                   shape.add(QRectF(0.0, -_spatium, _mmWidth, 2.0 * _spatium));
 
-                  int n = measure()->mmRestCount();
-                  std::vector<SymId>&& s = toTimeSigString(QString("%1").arg(n));
-                  
-                  QRectF r = symBbox(s);
-                  qreal y = _mmRestNumberPos * spatium() - staff()->height() * .5;
-                  qreal x = .5 * (_mmWidth - r.width());
-
-                  r.translate(QPointF(x, y));
-                  shape.add(r);
+                  shape.add(mmRestNumberRect());
                   }
             else
 #ifndef NDEBUG

--- a/libmscore/rest.h
+++ b/libmscore/rest.h
@@ -75,6 +75,7 @@ class Rest : public ChordRest {
       void write(XmlWriter& xml) const override;
 
       void layoutMMRest(qreal val);
+      QRectF mmRestNumberRect() const;
       qreal mmWidth() const        { return _mmWidth; }
       SymId getSymbol(TDuration::DurationType type, int line, int lines,  int* yoffset);
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/287047 (first part) and https://musescore.org/en/node/290968

sorry for the bad quality gif

![1](https://user-images.githubusercontent.com/35939574/82522740-5a8d5480-9af8-11ea-994d-459241041c79.gif)

second commit fixes hardcoded values that were not working properly with special staves. There is no link in the issue tracker for that as i rescolved the bug when i discovered it. 
Steps to reproduce for those curious: 
1) new score with one instrument: triangle (or any single lined staff)
2) press "M" to switch to MMRests. 
3) move number down: the collision detection doesn't work properly.

Result after the second commit
![2](https://user-images.githubusercontent.com/35939574/82524476-05077680-9afd-11ea-8068-557f72280448.gif)


- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n/a] I created the test (mtest, vtest, script test) to verify the changes I made
