### PR TITLE
Fix #305724: Disable save prompt for empty scores

### DIFF
--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -456,6 +456,7 @@ class Score : public QObject, public ScoreElement {
       MStyle _style;
 
       bool _created { false };            ///< file is never saved, has generated name
+      bool _startedEmpty { false };       ///< The score was created from an empty template (typically ":/data/My_First_Score.mscx") during this session, so it doesn't need to be saved if it hasn't been modified.
       QString _tmpName;                   ///< auto saved with this name if not empty
       QString _importedFilePath;          // file from which the score was imported, or empty
 
@@ -853,6 +854,8 @@ class Score : public QObject, public ScoreElement {
       ScoreContentState state() const;
       void setCreated(bool val)      { _created = val;        }
       bool created() const           { return _created;       }
+      void setStartedEmpty(bool val) { _startedEmpty = val;   }
+      bool startedEmpty() const      { return _startedEmpty;  }
       bool savedCapture() const      { return _savedCapture;  }
       bool saved() const             { return _saved;         }
       void setSaved(bool v)          { _saved = v;            }

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -252,7 +252,7 @@ static bool readScoreError(const QString& name, Score::FileError error, bool ask
 
 bool MuseScore::checkDirty(MasterScore* s)
       {
-      if (s->dirty() || s->created()) {
+      if (s->dirty() || (s->created() && !s->startedEmpty())) {
             QMessageBox::StandardButton n = QMessageBox::warning(this, tr("MuseScore"),
                tr("Save changes to the score \"%1\"\n"
                "before closing?").arg(s->fileInfo()->completeBaseName()),

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -366,14 +366,14 @@ void MuseScore::closeEvent(QCloseEvent* ev)
       unloadPlugins();
       QList<MasterScore*> removeList;
       for (MasterScore* score : scoreList) {
-            // Prompt the user to save the score if it's "dirty" (has unsaved changes) or if it's newly created.
+            // Prompt the user to save the score if it's "dirty" (has unsaved changes) or if it's newly created but non-empty.
             if (checkDirty(score)) {
                   // The user has canceled out entirely, so ignore the close event.
                   ev->ignore();
                   return;
                   }
-            // If the score is still flagged as newly created at this point, it means that the user has just chosen to discard it,
-            // so we need to remove it from the list of scores to be saved to the session file.
+            // If the score is still flagged as newly created at this point, it means that either it's empty or the user has just
+            // chosen to discard it, so we need to remove it from the list of scores to be saved to the session file.
             if (score->created())
                   removeList.append(score);
             }
@@ -3491,7 +3491,7 @@ static void loadScores(const QStringList& argv)
                                     score->setName(mscore->createDefaultName());
                                     // TODO score->setPageFormat(*MScore::defaultStyle().pageFormat());
                                     score->doLayout();
-                                    score->setCreated(true);
+                                    score->setStartedEmpty(true);
                                     }
                               if (score == 0) {
                                     score = mscore->readScore(":/data/My_First_Score.mscx");
@@ -3502,7 +3502,7 @@ static void loadScores(const QStringList& argv)
                                           score->setName(mscore->createDefaultName());
                                           // TODO score->setPageFormat(*MScore::defaultStyle().pageFormat());
                                           score->doLayout();
-                                          score->setCreated(true);
+                                          score->setStartedEmpty(true);
                                           }
                                     }
                               if (score)


### PR DESCRIPTION
Resolves: [#305724](https://musescore.org/en/node/305724)

Added logic to disable the save prompt for empty scores; i.e., scores that were automatically created at startup using the “Start with score” feature and that don't contain any modifications.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made