### PR TITLE
fix #305717: chord symbols attached to fret diagrams don't link to parts

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4579,6 +4579,14 @@ void Score::undoAddElement(Element* element)
                         ne->setScore(score);
                         ne->setSelected(false);
                         ne->setTrack(staffIdx * VOICES + element->voice());
+
+                        if (ne->isFretDiagram()) {
+                              FretDiagram* fd = toFretDiagram(ne);
+                              Harmony* fdHarmony = fd->harmony();
+                              fdHarmony->setScore(score);
+                              fdHarmony->setSelected(false);
+                              fdHarmony->setTrack(staffIdx * VOICES + element->voice());
+                              }
                         }
 
                   if (element->isArticulation()) {
@@ -4664,8 +4672,7 @@ void Score::undoAddElement(Element* element)
                         if (ne->isHarmony()) {
                               for (Element* segel : segment->annotations()) {
                                     if (segel && segel->isFretDiagram() && segel->track() == ntrack) {
-                                          ne->setTrack(segel->track());
-                                          ne->setParent(segel);
+                                          segel->add(ne);
                                           break;
                                           }
                                     }

--- a/libmscore/excerpt.h
+++ b/libmscore/excerpt.h
@@ -71,6 +71,7 @@ class Excerpt : public QObject {
       static void cloneStaves(Score* oscore, Score* score, const QList<int>& map, QMultiMap<int, int>& allTracks);
       static void cloneStaff(Staff* ostaff, Staff* nstaff);
       static void cloneStaff2(Staff* ostaff, Staff* nstaff, const Fraction& stick, const Fraction& etick);
+      static void processLinkedClone(Element* ne, Score* score, int strack);
       };
 
 }     // namespace Ms

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -84,6 +84,22 @@ FretDiagram::~FretDiagram()
       }
 
 //---------------------------------------------------------
+//   linkedClone
+//---------------------------------------------------------
+
+Element* FretDiagram::linkedClone()
+      {
+      FretDiagram* e = clone();
+      e->setAutoplace(true);
+      if (_harmony) {
+            Element* newHarmony = _harmony->linkedClone();
+            e->add(newHarmony);
+            }
+      score()->undo(new Link(e, this));
+      return e;
+      }
+
+//---------------------------------------------------------
 //   fromString
 ///   Create diagram from string like "XO-123"
 ///   Always assume barre on the first visible fret

--- a/libmscore/fret.h
+++ b/libmscore/fret.h
@@ -164,6 +164,7 @@ class FretDiagram final : public Element {
       ~FretDiagram();
 
       void draw(QPainter*) const override;
+      Element* linkedClone() override;
       FretDiagram* clone() const override { return new FretDiagram(*this); }
 
       Segment* segment() { return toSegment(parent()); }


### PR DESCRIPTION
resolves https://musescore.org/en/node/305717

This issue mainly comes from a linked version of the harmony not being created when a linked version of a fret diagram is created. To fix this, a few bits of special case logic, plus the implementation of this linked child harmony, needed to be added.