### PR TITLE
Fix #305814: Adding Intervals via "alt + number" command

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2387,7 +2387,16 @@ void ScoreView::cmd(const char* s)
               "interval8", "interval-8",
               "interval9", "interval-9"}, [](ScoreView* cv, const QByteArray& cmd) {
                   int n = cmd.mid(8).toInt();
-                  std::vector<Note*> nl = cv->score()->selection().noteList();
+                  std::vector<Note*> nl;
+                  if (cv->score()->selection().isRange()) {
+                        for (ChordRest* cr : cv->score()->getSelectedChordRests()) {
+                              if (cr->isChord())
+                                    nl.push_back(n > 0 ? toChord(cr)->upNote() : toChord(cr)->downNote());
+                              }
+                        }
+                  else {
+                        nl = cv->score()->selection().noteList();
+                        }
                   if (!nl.empty()) {
                         //if (!noteEntryMode())
                         //      ;     // TODO: state    sm->postEvent(new CommandEvent("note-input"));


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/305814.

Currently when adding an interval to a selection, the interval is added to each note within the selection. This commit changes this behavior so that in the case of a range selection, only one note is added to each chord within the selection.