### PR TITLE
fix #305871: Tuplets submenu has been added to right click menu.

### DIFF
--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -642,6 +642,14 @@ void PianoView::showPopupMenu(const QPoint& posGlobal)
       connect(act, &QAction::triggered, this, [=](){this->setNotesToVoice(3);});
       popup.addAction(act);
 
+      popup.addSeparator();
+
+      QMenu* menuTuplet = new QMenu(tr("Tuplets"));
+      for (auto i : { "duplet", "triplet", "quadruplet", "quintuplet", "sextuplet",
+            "septuplet", "octuplet", "nonuplet", "tuplet-dialog" })
+            menuTuplet->addAction(getAction(i));
+      popup.addMenu(menuTuplet);
+
       popup.exec(posGlobal);
       }
 


### PR DESCRIPTION
Tuplets submenu has been added to right click menu.

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://musescore.org/en/cla)
- [ ] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [ ] I made sure the code compiles on my machine
- [ ] I made sure there are no unnecessary changes in the code
- [ ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
