### PR TITLE
fix #305876: Display note drag overlay property for all tools in PRE.

### DIFF
--- a/mscore/pianoroll/pianoview.h
+++ b/mscore/pianoroll/pianoview.h
@@ -140,6 +140,11 @@ private:
       void toggleTie(Note*);
       void dragSelectionNoteGroup();
       void finishNoteGroupDrag();
+      bool toolCanDragNotes() const {
+            return _editNoteTool == PianoRollEditTool::SELECT || _editNoteTool == PianoRollEditTool::INSERT_NOTE ||
+                  _editNoteTool == PianoRollEditTool::APPEND_NOTE || _editNoteTool == PianoRollEditTool::CUT_CHORD ||
+                  _editNoteTool == PianoRollEditTool::TIE;
+            }
 
       QAction* getAction(const char* id);
 


### PR DESCRIPTION
Display note drag overlay property for all tools in PRE.

Resolves: https://musescore.org/en/node/305876

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
