### PR TITLE
fix #293141: Missing ToolTip for timsig wizard pickup measure unit

### DIFF
--- a/mscore/timesigwizard.ui
+++ b/mscore/timesigwizard.ui
@@ -268,6 +268,9 @@
       </item>
       <item>
        <widget class="QComboBox" name="pickupTimesigN">
+        <property name="toolTip">
+         <string>Beat unit</string>
+        </property>
         <property name="statusTip">
          <string>Beat unit for the pickup measure</string>
         </property>


### PR DESCRIPTION
resolves https://musescore.org/en/node/293141