### PR TITLE
Fix #305869: MuseScore crashes when playing MusicXML file with chord symbols

### DIFF
--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -52,6 +52,7 @@
 #include "utils.h"
 #include "sym.h"
 #include "synthesizerstate.h"
+#include "log.h"
 
 #include "audio/midi/event.h"
 #include "mscore/preferences.h"
@@ -537,7 +538,8 @@ static void renderHarmony(EventMap* events, Measure* m, Harmony* h, int tickOffs
             return;
       Staff* staff = m->score()->staff(h->track() / VOICES);
       const Channel* channel = staff->part()->harmonyChannel();
-      Q_ASSERT(channel);
+      IF_ASSERT_FAILED(channel)
+            return;
 
       events->registerChannel(channel->channel());
       if (!staff->primaryStaff())

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -2479,6 +2479,9 @@ Score::FileError readScore(MasterScore* score, QString name, bool ignoreVersionE
                   score->setCreated(true); // force save as for imported files
             }
 
+      for (Part* p : score->parts()) {
+            p->updateHarmonyChannels(false);
+            }
       score->rebuildMidiMapping();
       score->setSoloMute();
       for (Score* s : score->scoreList()) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/305869.