### PR TITLE
Fix two problems with ambiti

### DIFF
--- a/libmscore/ambitus.cpp
+++ b/libmscore/ambitus.cpp
@@ -698,10 +698,10 @@ bool Ambitus::setProperty(Pid propertyId, const QVariant& v)
                   setBottomPitch(v.toInt());
                   break;
             case Pid::FBPARENTHESIS3:        // recycled property = octave of _topPitch
-                  setTopPitch(topPitch() % 12 + v.toInt() * 12);
+                  setTopPitch(topPitch() % 12 + (v.toInt() + 1) * 12);
                   break;
             case Pid::FBPARENTHESIS4:        // recycled property = octave of _bottomPitch
-                  setBottomPitch(bottomPitch() % 12 + v.toInt() * 12);
+                  setBottomPitch(bottomPitch() % 12 + (v.toInt() + 1) * 12);
                   break;
             default:
                   return Element::setProperty(propertyId, v);

--- a/libmscore/ambitus.cpp
+++ b/libmscore/ambitus.cpp
@@ -196,7 +196,7 @@ void Ambitus::write(XmlWriter& xml) const
       xml.tag(Pid::HEAD_TYPE,  int(_noteHeadType),  int(NOTEHEADTYPE_DEFAULT));
       xml.tag(Pid::MIRROR_HEAD,int(_dir),           int(DIR_DEFAULT));
       xml.tag("hasLine",    _hasLine,       true);
-      xml.tag(Pid::LINE_WIDTH, _lineWidth,     LINEWIDTH_DEFAULT);
+      xml.tag(Pid::LINE_WIDTH_SPATIUM, _lineWidth, LINEWIDTH_DEFAULT);
       xml.tag("topPitch",   _topPitch);
       xml.tag("topTpc",     _topTpc);
       xml.tag("bottomPitch",_bottomPitch);
@@ -243,7 +243,7 @@ bool Ambitus::readProperties(XmlReader& e)
       else if (tag == "hasLine")
             setHasLine(e.readInt());
       else if (tag == "lineWidth")
-            readProperty(e, Pid::LINE_WIDTH);
+            readProperty(e, Pid::LINE_WIDTH_SPATIUM);
       else if (tag == "topPitch")
             _topPitch = e.readInt();
       else if (tag == "bottomPitch")
@@ -644,7 +644,7 @@ QVariant Ambitus::getProperty(Pid propertyId) const
                   return int(direction());
             case Pid::GHOST:                 // recycled property = _hasLine
                   return hasLine();
-            case Pid::LINE_WIDTH:
+            case Pid::LINE_WIDTH_SPATIUM:
                   return lineWidth();
             case Pid::TPC1:
                   return topTpc();
@@ -682,7 +682,7 @@ bool Ambitus::setProperty(Pid propertyId, const QVariant& v)
             case Pid::GHOST:                 // recycled property = _hasLine
                   setHasLine(v.toBool());
                   break;
-            case Pid::LINE_WIDTH:
+            case Pid::LINE_WIDTH_SPATIUM:
                   setLineWidth(v.value<Spatium>());
                   break;
             case Pid::TPC1:
@@ -725,7 +725,7 @@ QVariant Ambitus::propertyDefault(Pid id) const
                   return int(DIR_DEFAULT);
             case Pid::GHOST:
                   return HASLINE_DEFAULT;
-            case Pid::LINE_WIDTH:
+            case Pid::LINE_WIDTH_SPATIUM:
                   return Spatium(LINEWIDTH_DEFAULT);
             case Pid::TPC1:                  // no defaults for pitches, tpc's and octaves
             case Pid::FBPARENTHESIS1:

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -186,6 +186,7 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::GROUPS,                  false, 0,                       P_TYPE::GROUPS,              DUMMY_QT_TRANSLATE_NOOP("propertyName", "groups")           },
       { Pid::LINE_STYLE,              false, "lineStyle",             P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "line style")       },
       { Pid::LINE_WIDTH,              false, "lineWidth",             P_TYPE::SP_REAL,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "line width")       },
+      { Pid::LINE_WIDTH_SPATIUM,      false, "lineWidth",             P_TYPE::SPATIUM,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "line width (spatium)") },
       { Pid::LASSO_POS,               false, 0,                       P_TYPE::POINT_MM,            DUMMY_QT_TRANSLATE_NOOP("propertyName", "lasso position")   },
       { Pid::LASSO_SIZE,              false, 0,                       P_TYPE::SIZE_MM,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "lasso size")       },
       { Pid::TIME_STRETCH,            true,  "timeStretch",           P_TYPE::REAL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "time stretch")     },

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -193,6 +193,7 @@ enum class Pid {
       GROUPS,
       LINE_STYLE,
       LINE_WIDTH,
+      LINE_WIDTH_SPATIUM,
       LASSO_POS,
       LASSO_SIZE,
       TIME_STRETCH,

--- a/mscore/inspector/inspectorAmbitus.cpp
+++ b/mscore/inspector/inspectorAmbitus.cpp
@@ -85,15 +85,15 @@ InspectorAmbitus::InspectorAmbitus(QWidget* parent)
       item->setFlags(item->flags() & ~(Qt::ItemIsSelectable|Qt::ItemIsEnabled));
 
       const std::vector<InspectorItem> iiList = {
-            { Pid::HEAD_GROUP,     0, r.noteHeadGroup, r.resetNoteHeadGroup },
-            { Pid::HEAD_TYPE,      0, r.noteHeadType,  r.resetNoteHeadType  },
-            { Pid::MIRROR_HEAD,    0, r.direction,     r.resetDirection     },
-            { Pid::GHOST,          0, r.hasLine,       r.resetHasLine       },      // recycled property
-            { Pid::LINE_WIDTH,     0, r.lineWidth,     r.resetLineWidth     },
-            { Pid::TPC1,           0, r.topTpc,        nullptr              },
-            { Pid::FBPARENTHESIS1, 0, r.bottomTpc,     nullptr              },      // recycled property
-            { Pid::FBPARENTHESIS3, 0, r.topOctave,     nullptr              },      // recycled property
-            { Pid::FBPARENTHESIS4, 0, r.bottomOctave,  nullptr              },      // recycled property
+            { Pid::HEAD_GROUP,         0, r.noteHeadGroup, r.resetNoteHeadGroup },
+            { Pid::HEAD_TYPE,          0, r.noteHeadType,  r.resetNoteHeadType  },
+            { Pid::MIRROR_HEAD,        0, r.direction,     r.resetDirection     },
+            { Pid::GHOST,              0, r.hasLine,       r.resetHasLine       },      // recycled property
+            { Pid::LINE_WIDTH_SPATIUM, 0, r.lineWidth,     r.resetLineWidth     },
+            { Pid::TPC1,               0, r.topTpc,        nullptr              },
+            { Pid::FBPARENTHESIS1,     0, r.bottomTpc,     nullptr              },      // recycled property
+            { Pid::FBPARENTHESIS3,     0, r.topOctave,     nullptr              },      // recycled property
+            { Pid::FBPARENTHESIS4,     0, r.bottomOctave,  nullptr              },      // recycled property
 
             { Pid::LEADING_SPACE,  1, s.leadingSpace,  s.resetLeadingSpace  },
             };


### PR DESCRIPTION
Resolves: https://musescore.org/node/285135.

`Pid::LINE_WIDTH` cannot be used, since it's a `qreal` value, but the value used to store the line thickness of an ambitus is a `Spatium` value, so we have to use another `Pid` which is `Spatium` type, a new one `Pid::LINE_WIDTH_SPATIUM`.

Resolves: https://musescore.org/node/305941.