### PR TITLE
Fix #4867: Filling measure with rests be affected by time signature

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -982,35 +982,20 @@ Fraction Score::makeGap(Segment* segment, int track, const Fraction& _sd, Tuplet
                   //
                   accumulated = _sd;
                   Fraction rd = td - sd;
+                  Fraction tick = cr->tick() + actualTicks(sd, tuplet, timeStretch);
 
-                  std::vector<TDuration> dList = toDurationList(rd, false);
+                  std::vector<TDuration> dList = toRhythmicDurationList(rd, true, tick - measure->tick(), sigmap()->timesig(tick).nominal(), measure, 0);
                   if (dList.empty())
                         break;
 
-                  Fraction tick = cr->tick() + actualTicks(sd, tuplet, timeStretch);
-
-                  if ((tuplet == 0) && (((measure->tick() - tick).ticks() % dList[0].ticks().ticks()) == 0)) {
-                        for (TDuration d : dList) {
-                              if (ltuplet) {
-                                    // take care not to recreate tuplet we just deleted
-                                    Rest* r = setRest(tick, track, d.fraction(), false, 0, false);
-                                    tick += r->actualTicks();
-                                    }
-                              else {
-                                    tick += addClone(cr, tick, d)->actualTicks();
-                                    }
+                  for (TDuration d : dList) {
+                        if (ltuplet) {
+                              // take care not to recreate tuplet we just deleted
+                              Rest* r = setRest(tick, track, d.fraction(), false, 0, false);
+                              tick += r->actualTicks();
                               }
-                        }
-                  else {
-                        for (size_t i = dList.size(); i > 0; --i) { // loop needs to be in this reverse order
-                              if (ltuplet) {
-                                    // take care not to recreate tuplet we just deleted
-                                    Rest* r = setRest(tick, track, dList[i-1].fraction(), false, 0, false);
-                                    tick += r->actualTicks();
-                                    }
-                              else {
-                                    tick += addClone(cr, tick, dList[i-1])->actualTicks();
-                                    }
+                        else {
+                              tick += addClone(cr, tick, d)->actualTicks();
                               }
                         }
                   break;

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -333,26 +333,16 @@ Rest* Score::setRest(const Fraction& _tick, int track, const Fraction& _l, bool 
                   //
                   // compute list of durations which will fit l
                   //
-                  std::vector<TDuration> dList = toDurationList(f, useDots);
+                  std::vector<TDuration> dList = toRhythmicDurationList(f, true, tick - measure->tick(), sigmap()->timesig(tick).nominal(), measure, useDots ? 1 : 0);
                   if (dList.empty())
                         return 0;
 
                   Rest* rest = 0;
-                  if (((tick - measure->tick()).ticks() % dList[0].ticks().ticks()) == 0) {
-                        for (const TDuration& d : dList) {
-                              rest = addRest(tick, track, d, tuplet);
-                              if (r == 0)
-                                    r = rest;
-                              tick += rest->actualTicks();
-                              }
-                        }
-                  else {
-                        for (size_t i = dList.size(); i > 0; --i) { // loop needs to be in this reverse order
-                              rest = addRest(tick, track, dList[i-1], tuplet);
-                              if (r == 0)
-                                    r = rest;
-                              tick += rest->actualTicks();
-                              }
+                  for (const TDuration& d : dList) {
+                        rest = addRest(tick, track, d, tuplet);
+                        if (r == 0)
+                              r = rest;
+                        tick += rest->actualTicks();
                         }
                   }
             l -= f;

--- a/mtest/guitarpro/UncompletedMeasure.gpx-ref.mscx
+++ b/mtest/guitarpro/UncompletedMeasure.gpx-ref.mscx
@@ -142,7 +142,10 @@
             </Chord>
           <Rest>
             <linkedMain/>
-            <dots>1</dots>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <linkedMain/>
             <durationType>half</durationType>
             </Rest>
           </voice>
@@ -318,7 +321,11 @@
             <Rest>
               <linked>
                 </linked>
-              <dots>1</dots>
+              <durationType>quarter</durationType>
+              </Rest>
+            <Rest>
+              <linked>
+                </linked>
               <durationType>half</durationType>
               </Rest>
             </voice>
@@ -351,7 +358,11 @@
             <Rest>
               <linked>
                 </linked>
-              <dots>1</dots>
+              <durationType>quarter</durationType>
+              </Rest>
+            <Rest>
+              <linked>
+                </linked>
               <durationType>half</durationType>
               </Rest>
             </voice>

--- a/mtest/testscript/scripts/#294727-navigate-voice-4.mscx
+++ b/mtest/testscript/scripts/#294727-navigate-voice-4.mscx
@@ -350,7 +350,10 @@
               </Note>
             </Chord>
           <Rest>
-            <durationType>half</durationType>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         <voice/>
@@ -364,7 +367,10 @@
               </Note>
             </Chord>
           <Rest>
-            <durationType>half</durationType>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>

--- a/mtest/testscript/scripts/palette.mscx
+++ b/mtest/testscript/scripts/palette.mscx
@@ -119,7 +119,10 @@
               </Note>
             </Chord>
           <Rest>
-            <durationType>half</durationType>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
@@ -136,7 +139,10 @@
               </Note>
             </Chord>
           <Rest>
-            <durationType>half</durationType>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
@@ -170,7 +176,10 @@
               </Note>
             </Chord>
           <Rest>
-            <durationType>half</durationType>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
@@ -185,7 +194,10 @@
               </Note>
             </Chord>
           <Rest>
-            <durationType>half</durationType>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
@@ -210,7 +222,10 @@
               </Note>
             </Chord>
           <Rest>
-            <durationType>half</durationType>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
@@ -244,7 +259,10 @@
               </Note>
             </Chord>
           <Rest>
-            <durationType>half</durationType>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
@@ -388,7 +406,10 @@
               </Note>
             </Chord>
           <Rest>
-            <durationType>half</durationType>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
@@ -407,7 +428,10 @@
               </Note>
             </Chord>
           <Rest>
-            <durationType>half</durationType>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
@@ -428,7 +452,10 @@
               </Note>
             </Chord>
           <Rest>
-            <durationType>half</durationType>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
@@ -484,7 +511,10 @@
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
-            <durationType>half</durationType>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>

--- a/mtest/testscript/scripts/palette_articulations_1.script
+++ b/mtest/testscript/scripts/palette_articulations_1.script
@@ -8,6 +8,9 @@ cmd note-a
 cmd note-a
 cmd note-a
 cmd escape
+cmd next-chord
+cmd pad-note-2
+cmd prev-chord
 cmd prev-chord
 cmd prev-chord
 cmd prev-chord

--- a/mtest/testscript/scripts/timewise-input.mscx
+++ b/mtest/testscript/scripts/timewise-input.mscx
@@ -168,7 +168,10 @@
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <durationType>half</durationType>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
@@ -189,7 +192,10 @@
               </Note>
             </Chord>
           <Rest>
-            <durationType>half</durationType>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
@@ -249,7 +255,10 @@
               </Note>
             </Chord>
           <Rest>
-            <durationType>half</durationType>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
@@ -271,21 +280,26 @@
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <durationType>half</durationType>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
       <Measure len="4/4">
         <voice>
           <Rest>
-            <durationType>whole</durationType>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure len="4/4">
         <voice>
           <Rest>
-            <durationType>whole</durationType>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
@@ -341,31 +355,34 @@
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <durationType>half</durationType>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
       <Measure len="4/4">
         <voice>
           <Rest>
-            <durationType>whole</durationType>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure len="4/4">
         <voice>
           <Rest>
-            <durationType>whole</durationType>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure len="5/4">
         <voice>
           <Rest>
-            <durationType>whole</durationType>
-            </Rest>
-          <Rest>
-            <durationType>quarter</durationType>
+            <durationType>measure</durationType>
+            <duration>5/4</duration>
             </Rest>
           </voice>
         </Measure>

--- a/mtest/testscript/scripts/ux_replace_slurs_on_copy_diffstaves.mscx
+++ b/mtest/testscript/scripts/ux_replace_slurs_on_copy_diffstaves.mscx
@@ -246,7 +246,10 @@
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
-            <durationType>half</durationType>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>

--- a/mtest/testscript/scripts/ux_replace_slurs_on_copy_diffstaves~undo.mscx
+++ b/mtest/testscript/scripts/ux_replace_slurs_on_copy_diffstaves~undo.mscx
@@ -246,7 +246,10 @@
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
-            <durationType>half</durationType>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/4867.

This makes use of the toRhythmicDurationList() function in Score::setRest() and Score::makeGap(). Since the resulting duration list is constructed based on the relative tick within the measure, the rests will never have to be added in the reverse order, which was something that had to be done when using toDurationList().