### PR TITLE
Fix #305962 - Staff type change in first measure causes a crash

### DIFF
--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -1035,10 +1035,15 @@ void Staff::staffTypeListChanged(const Fraction& tick)
       else
             triggerLayout(Fraction::fromTicks(range.first));
 
-      if (range.second < 0)
-            triggerLayout(score()->lastMeasure()->endTick());
-      else
+      if (range.second < 0) {
+            // When reading a score and there is a Staff Change on the first
+            // measure, there are no measures yet and nothing to layout.
+            if (score()->lastMeasure())
+                  triggerLayout(score()->lastMeasure()->endTick());
+            }
+      else {
             triggerLayout(Fraction::fromTicks(range.second));
+            }
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/305962

This PR is essentially the same [#5318] which got lost by [#5745].

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
