### PR TITLE
fix #305696 Glissando not centered in palette

### DIFF
--- a/mscore/palette/palettetree.cpp
+++ b/mscore/palette/palettetree.cpp
@@ -986,7 +986,10 @@ static void paintScoreElement(QPainter& p, Element* e, qreal spatium, bool align
       p.scale(sizeRatio, sizeRatio); // scale coordinates so element is drawn at correct size
 
       e->layout(); // calculate bbox
-      QPointF origin = e->bbox().center();
+
+      //! NOTE `static_cast<const Element*>(e)` is needed for the `const QRectF& bbox() const` method to be called
+      //! This method is overridden for some elements, in particular for Glissando
+      QPointF origin = static_cast<const Element* >(e)->bbox().center();
 
       if (alignToStaff) {
             origin.setY(0.0); // y = 0 is position of the element's parent.


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/305696

When drawing an element in a palette, the `e->bbox()` method is called.
This will call the method: 

```
virtual QRectF& bbox()                      { return _bbox;              }
```

But for Glissando at the moment, `_bbox` is zero.
For Glissando, `_bbox` will be set if you call the method

```
virtual const QRectF& bbox() const          { return _bbox;              }
```

Because it is overridden `const QRectF& SLine::bbox() const`
(but the `QRectF& bbox()` method is not overridden)

Previously, before the [2fdc875f02b](https://github.com/musescore/MuseScore/commit/2fdc875f02b7f84ea18202d558b18a6add69f5a9 ) commit, it worked because the `e->width()` method was called, which calls `const QRectF& bbox() const `

I think, this is a very precarious situation that can lead to problems, I think we need to remove methods like `QRectF& bbox()`. They are also very difficult to debug, to find places where the value changes. Only setters should be left and used.



