### PR TITLE
fix #305739: Realize chord symbols dialog won't open, even though the…

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6329,8 +6329,6 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             changeScore(-1);
       else if (cmd == "transpose")
             transpose();
-      else if (cmd == "realize-chord-symbols")
-            realizeChordSymbols();
       else if (cmd == "save-style") {
             QString name = getStyleFilename(false);
             if (!name.isEmpty()) {

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -369,6 +369,13 @@ void ScoreView::objectPopup(const QPoint& pos, Element* obj)
             mscore->selectSimilarInRange(obj);
       else if (cmd == "select-dialog")
             mscore->selectElementDialog(obj);
+      else if (cmd == "realize-chord-symbols") {
+            if (obj->isEditable()) {
+                  if (obj->score())
+                        obj->score()->select(obj, SelectType::ADD);
+                  mscore->realizeChordSymbols();
+                  }
+            }
       else {
             _score->startCmd();
             elementPropertyAction(cmd, obj);


### PR DESCRIPTION
… option is displayed in the menu

The context menu item was implemented incorrectly (the related cmd was called in the wrong place).