### PR TITLE
Fix #304843 - Brackets displaced in Continuous View

### DIFF
--- a/libmscore/layoutlinear.cpp
+++ b/libmscore/layoutlinear.cpp
@@ -121,7 +121,7 @@ void Score::resetSystems(bool layoutAll, LayoutContext& lc)
                         m->mmRest()->setSystem(nullptr);
                         }
                   if (firstMeasure) {
-                        system->layoutSystem(0.0);
+                        system->layoutSystem(pos.rx());
                         if (m->repeatStart()) {
                               Segment* s = m->findSegmentR(SegmentType::StartRepeatBarLine, Fraction(0,1));
                               if (!s->enabled())


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/304843

Call to <code>layoutSystem()</code> in <code>Score::collectLinearSystem()</code> didn't take the existence of a <code>HBOX</code> into account. Instead of fixed 0.0, now the shift due to the <code>HBox</code> is passed.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
