### PR TITLE
fix #305717: chord symbols attached to fret diagrams don't link to parts

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4758,6 +4758,14 @@ void Score::undoAddElement(Element* element)
                 ne->setScore(score);
                 ne->setSelected(false);
                 ne->setTrack(staffIdx * VOICES + element->voice());
+
+                if (ne->isFretDiagram()) {
+                    FretDiagram* fd = toFretDiagram(ne);
+                    Harmony* fdHarmony = fd->harmony();
+                    fdHarmony->setScore(score);
+                    fdHarmony->setSelected(false);
+                    fdHarmony->setTrack(staffIdx * VOICES + element->voice());
+                }
             }
 
             if (element->isArticulation()) {
@@ -4845,8 +4853,7 @@ void Score::undoAddElement(Element* element)
                 if (ne->isHarmony()) {
                     for (Element* segel : segment->annotations()) {
                         if (segel && segel->isFretDiagram() && segel->track() == ntrack) {
-                            ne->setTrack(segel->track());
-                            ne->setParent(segel);
+                            segel->add(ne);
                             break;
                         }
                     }

--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -457,6 +457,22 @@ static void cloneTuplets(ChordRest* ocr, ChordRest* ncr, Tuplet* ot, TupletMap& 
 }
 
 //---------------------------------------------------------
+//   processLinkedClone
+//---------------------------------------------------------
+
+void Excerpt::processLinkedClone(Element* ne, Score* score, int strack)
+{
+    // reset offset as most likely it will not fit
+    PropertyFlags f = ne->propertyFlags(Pid::OFFSET);
+    if (f == PropertyFlags::UNSTYLED) {
+        ne->setPropertyFlags(Pid::OFFSET, PropertyFlags::STYLED);
+        ne->resetProperty(Pid::OFFSET);
+    }
+    ne->setTrack(strack == -1 ? 0 : strack);
+    ne->setScore(score);
+}
+
+//---------------------------------------------------------
 //   cloneStaves
 //---------------------------------------------------------
 
@@ -516,14 +532,7 @@ void Excerpt::cloneStaves(Score* oscore, Score* score, const QList<int>& map, QM
                         }
                         if ((e->track() == srcTrack && strack != -1) || (e->systemFlag() && srcTrack == 0)) {
                             Element* ne = e->linkedClone();
-                            // reset offset as most likely it will not fit
-                            PropertyFlags f = ne->propertyFlags(Pid::OFFSET);
-                            if (f == PropertyFlags::UNSTYLED) {
-                                ne->setPropertyFlags(Pid::OFFSET, PropertyFlags::STYLED);
-                                ne->resetProperty(Pid::OFFSET);
-                            }
-                            ne->setTrack(strack == -1 ? 0 : strack);
-                            ne->setScore(score);
+                            processLinkedClone(ne, score, strack);
                             if (!ns) {
                                 ns = nm->getSegment(oseg->segmentType(), oseg->tick());
                             }
@@ -533,6 +542,12 @@ void Excerpt::cloneStaves(Score* oscore, Score* score, const QList<int>& map, QM
                             if (ne->isHarmony()) {
                                 Harmony* h = toHarmony(ne);
                                 h->render();
+                            } else if (ne->isFretDiagram()) {
+                                Harmony* h = toHarmony(toFretDiagram(ne)->harmony());
+                                if (h) {
+                                    processLinkedClone(h, score, strack);
+                                    h->render();
+                                }
                             }
                         }
                     }

--- a/libmscore/excerpt.h
+++ b/libmscore/excerpt.h
@@ -69,6 +69,7 @@ public:
     static void cloneStaves(Score* oscore, Score* score, const QList<int>& map, QMultiMap<int, int>& allTracks);
     static void cloneStaff(Staff* ostaff, Staff* nstaff);
     static void cloneStaff2(Staff* ostaff, Staff* nstaff, const Fraction& stick, const Fraction& etick);
+    static void processLinkedClone(Element* ne, Score* score, int strack);
 };
 }     // namespace Ms
 #endif

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -84,6 +84,22 @@ FretDiagram::~FretDiagram()
 }
 
 //---------------------------------------------------------
+//   linkedClone
+//---------------------------------------------------------
+
+Element* FretDiagram::linkedClone()
+{
+    FretDiagram* e = clone();
+    e->setAutoplace(true);
+    if (_harmony) {
+        Element* newHarmony = _harmony->linkedClone();
+        e->add(newHarmony);
+    }
+    score()->undo(new Link(e, this));
+    return e;
+}
+
+//---------------------------------------------------------
 //   fromString
 ///   Create diagram from string like "XO-123"
 ///   Always assume barre on the first visible fret

--- a/libmscore/fret.h
+++ b/libmscore/fret.h
@@ -162,6 +162,7 @@ public:
     ~FretDiagram();
 
     void draw(QPainter*) const override;
+    Element* linkedClone() override;
     FretDiagram* clone() const override { return new FretDiagram(*this); }
 
     Segment* segment() { return toSegment(parent()); }


### PR DESCRIPTION
See #6109 - this is a version based on master.