### PR TITLE
fix #279926: shift+click to select similar

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3133,6 +3133,38 @@ void Score::selectRange(Element* e, int staffIdx)
                   _selection.setStartSegment(cr->segment());
             }
       else {
+            // try to select similar in range
+            Element* selectedElement = _selection.element();
+            if (selectedElement && e->type() == selectedElement->type()) {
+                  int idx1 = selectedElement->staffIdx();
+                  int idx2 = e->staffIdx();
+                  if (idx1 >= 0 && idx2 >= 0) {
+                        Fraction t1 = selectedElement->tick();
+                        Fraction t2 = e->tick();
+                        if (t1 > t2) {
+                              Fraction temp = t1;
+                              t1 = t2;
+                              t2 = temp;
+                              }
+                        Segment* s1 = tick2segmentMM(t1, true, SegmentType::ChordRest);
+                        Segment* s2 = tick2segmentMM(t2, true, SegmentType::ChordRest);
+                        if (s2)
+                              s2 = s2->next1MM(SegmentType::ChordRest);
+                        if (s1 && s2) {
+                              _selection.setRange(s1, s2, idx1, idx2 + 1);
+                              selectSimilarInRange(e);
+                              if (selectedElement->track() == e->track()) {
+                                    // limit to this voice only
+                                    const QList<Element*>& list = _selection.elements();
+                                    for (Element* el : list) {
+                                          if (el->track() != e->track())
+                                                _selection.remove(el);
+                                          }
+                                    }
+                              return;
+                              }
+                        }
+                  }
             select(e, SelectType::SINGLE, staffIdx);
             return;
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/279926

A common request is for click/shift+click to select similar elements.
So for example, click one lyric, shift+click another,
would select all lyrics in that range.

Currently, shift+click of anything but a note or rest
simply selects the elements and loses the previous selection.
This change catches that case, and if there is an element selected,
and the selected element and the shift+clicked elements are same type,
we build a range selection that encompasses thenm both,
then run selectSimilarInRange.
I also check if the two elements are in the same voice,
and if so, I limit the selection to just that voice
rather than all elements on that staff as would normally be the case.
But aside from that, it also allows for selection across staves,
so you can click an articulation on one staff,
shift+click another on another staff,
and all intervening articulations are selected.