### PR TITLE
fix #297446: shift+click empty space clears selection

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -450,10 +450,10 @@ void ScoreView::mousePressEventNormal(QMouseEvent* ev)
                         _score->select(m, st, staffIdx);
                         _score->setUpdateAll();
                         }
-                  else if (st != SelectType::ADD)
+                  else if (st == SelectType::SINGLE)
                         modifySelection = true;
                   }
-            else if (st != SelectType::ADD)
+            else if (st == SelectType::SINGLE)
                   modifySelection = true;
             }
       _score->update();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/297446

Currently if you have a selection and try to shift+click to extend it
but accidentally click too far above or below where you intended,
the existing selection is lost.
There is no benefit to this behavior, since the way to clear a selection
is to *click*, not shift+click, an empty space.
Shift+click an empty space should be harmless, as ctrl+click is.
I previously implemented the check for ctrl+click,
I simply negeclted to include shift+click.
This is fixed by changing the two tests that were detecting ctrl+click
and skipping the usual clear selection in the case,
so they instead skip the clear for both ctrl & shift click
(actually, for anything but plain click).