### PR TITLE
fix #297423: allow ctrl+click to modify range selection

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -399,6 +399,11 @@ void ScoreView::mousePressEventNormal(QMouseEvent* ev)
                   }
             else {
                   if (st == SelectType::ADD) {
+                        // convert range to list
+                        if (e->score()->selection().isRange()) {
+                              e->score()->selection().setState(SelState::LIST);
+                              e->score()->setUpdateAll();   // needed to clear selection rectangle
+                              }
                         // e is the top element in stacking order,
                         // but we want to replace it with "first non-measure element after a selected element"
                         // (if such an element exists)


### PR DESCRIPTION
This partially resolves https://musescore.org/en/node/297423,
and addresses a common request:
the ability to add or subtract an element from a range selection.
We currently allow building list selections with ctrl+click,
but ctrl+click does nothing interesting with a range selected.
While some might want a new "magic" range selection
that has random elements added or removed from it,
that is beyond the scope of what I am doing here.
This change simply converts the range to a list
before processing the ctrl+click.
So the end result is a list selection that consists of
everything that was formerly in the range selection,
plus or minus what you just ctrl+clicked.