### PR TITLE
fix #304051: repeat single note in normal mode

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4686,8 +4686,10 @@ void ScoreView::cmdRepeatSelection()
             return;
             }
       if (!selection.isRange()) {
-            qDebug("wrong selection type");
-            return;
+            ChordRest* cr = _score->getSelectedChordRest();
+            if (!cr)
+                  return;
+            _score->select(cr, SelectType::RANGE);
             }
 
       if (!checkCopyOrCut())


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/304051

Lately there has been much discussion of the "R" command
and the fact that it only works on range selections.
In Sibelius, the same command is more general.
While it's not obvious what results might be expected
in each and every case, the most important request here
has been for "R" to work with a single note selected (not a range).

This change implements that very simply by checking for this case
and creating a range selection first.
Currently we generate a debug error message then simply do nothing.
So the change does not change anything about how the command works
except to allow it to do something reasonable
in the case of a single note/rest selected.

Note because a range selection is created, this means
selecting a single note in a chord repeats the whole chord.
That is how the command works in note input mode,
and it is how Sibelius works.