### PR TITLE
fix #305253: fix assertion failure on adding text frame with no text

### DIFF
--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -122,16 +122,12 @@ void TextBase::endEdit(EditData& ed)
                   newlyAdded = true;
                   undo->mergeCommands(ted->startUndoIdx - 1);
                   }
-            else {
-                  IF_ASSERT_FAILED(parent()) {
-                      return;
-                  }
-                  
-                  newlyAdded = (Ms::toTBox(parent()) != nullptr);
-                  }
             }
 
-      if (actualPlainText.isEmpty()) {
+      // TBox'es manage their Text themselves and are not removed if text is empty
+      const bool removeTextIfEmpty = !(parent() && parent()->isTBox());
+
+      if (actualPlainText.isEmpty() && removeTextIfEmpty) {
             qDebug("actual text is empty");
 
             // If this assertion fails, no undo command relevant to this text


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/305253

An alternative to 18e625bda704adfc7b0135a626f167e51217ba90 way to
fix the assertion failure. The solution in this commit does not try
to remove the text belonging to text frame (as it is managed by text
frame itself) and does not try to modify undo stack further in case
of adding empty text frame.

This solution has partially been described in https://github.com/musescore/MuseScore/pull/6127#discussion_r431824390 but I implemented only a part with not trying to remove the empty `TBox` text. This seems to be the right thing to do with `TBox`es and is enough to fix both the assertion failure and the potential incorrect behavior of `endEdit()` regarding undo stack entries management.