### PR TITLE
add auto code formatting hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,9 @@ To run the debug version, type:
 See [mtest/README.md](/mtest/README.md) or [the developer handbook](https://musescore.org/handbook/developers-handbook/finding-your-way-around/automated-tests) for instructions on how to run the test suite.
 
 The new [script testing facility](https://musescore.org/node/278278) is also available to create your own automated tests. Please try it out!
+
+### Code Formatting
+
+Run `./hooks/install.sh` to install a pre-commit hook that will format your staged files. Requires that you install `uncrustify`.
+
+If you have problems, please report them. To uninstall, run `./hooks/uninstall.sh`.

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+HOOKSDIR=./.git/hooks/
+
+cp ./hooks/pre-commit "$HOOKSDIR/pre-commit"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+echo "Uncrustifying staged files..."
+
+RELPATH=../..
+staged=$(git diff --name-only --cached)
+
+cd ./tools/codestyle/
+while IFS= read -r file; do
+	ext="${file##*.}"
+	if [ $ext != "cpp" ] && [ $ext != "h" ]; then
+		continue
+	fi
+	cp "$RELPATH/$file" "$RELPATH/$file.bak" 
+	if $( ./uncrustify_run_file.sh "$RELPATH/$file" ); then
+		mv "$RELPATH/$file.uncrustify" "$RELPATH/$file"
+		rm "$RELPATH/$file.bak"
+		git add "$RELPATH/$file"
+	else
+		echo $?
+		mv "$RELPATH/$file.bak" "$RELPATH/$file"
+		rm "$RELPATH/$file.uncrustify"
+		echo "Uncrustify failed for $file"
+	fi
+done <<< "$staged"
+
+echo "Finished uncrustifying"
+
+exit 0

--- a/hooks/uninstall.sh
+++ b/hooks/uninstall.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+HOOKSDIR=./.git/hooks/
+
+rm "$HOOKSDIR/pre-commit"

--- a/tools/codestyle/uncrustify_musescore.cfg
+++ b/tools/codestyle/uncrustify_musescore.cfg
@@ -248,7 +248,7 @@ sp_assign                                = ignore   # ignore/add/remove/force
 sp_cpp_lambda_assign                     = remove   # ignore/add/remove/force
 
 # Add or remove space after the capture specification in C++11 lambda.
-sp_cpp_lambda_square_paren               = ignore   # ignore/add/remove/force
+# sp_cpp_lambda_square_paren               = ignore   # ignore/add/remove/force
 
 # Add or remove space around assignment operator '=' in a prototype
 sp_assign_default                        = ignore   # ignore/add/remove/force


### PR DESCRIPTION
This needs to be installed with a script in the new `hooks` directory.

Please also note that a line in the config which is not available in the version of Uncrustify in the Ubuntu package repo has been commented out. That shouldn't be a problem, because it was the default value anyway. 