### PR TITLE
Fix #97376 - Split Measure breaks slurs and ties

### DIFF
--- a/libmscore/splitMeasure.cpp
+++ b/libmscore/splitMeasure.cpp
@@ -66,8 +66,10 @@ void Score::splitMeasure(Segment* segment)
                   start = nullptr;
             if (s->tick2() >= stick && s->tick2() < etick)
                   end = nullptr;
-            if (start != s->startElement() || end != s->endElement())
+            if (start != s->startElement() || end != s->endElement()) {
+                  sl.push_back(std::make_tuple(s, s->tick(), s->ticks()));
                   undo(new ChangeStartEndSpanner(s, start, end));
+                  }
             if (s->tick() < stick && s->tick2() > stick)
                   sl.push_back(std::make_tuple(s, s->tick(), s->ticks()));
             }

--- a/mtest/libmscore/split/split295207-ref.mscx
+++ b/mtest/libmscore/split/split295207-ref.mscx
@@ -182,6 +182,16 @@
                   </location>
                 </next>
               </Spanner>
+            <Spanner type="Slur">
+              <Slur>
+                </Slur>
+              <next>
+                <location>
+                  <measures>1</measures>
+                  <fractions>1/4</fractions>
+                  </location>
+                </next>
+              </Spanner>
             <Note>
               <Spanner type="Tie">
                 <Tie>
@@ -209,15 +219,6 @@
             </TimeSig>
           <Chord>
             <durationType>quarter</durationType>
-            <Spanner type="Slur">
-              <Slur>
-                </Slur>
-              <next>
-                <location>
-                  <fractions>1/4</fractions>
-                  </location>
-                </next>
-              </Spanner>
             <Note>
               <Spanner type="Tie">
                 <prev>
@@ -243,6 +244,7 @@
             <Spanner type="Slur">
               <prev>
                 <location>
+                  <measures>-1</measures>
                   <fractions>-1/4</fractions>
                   </location>
                 </prev>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/97376
Setting the <code>SPANNER_TICK</code>/<code>SPANNER_TICKS</code> properties for <code>Spanners</code> getting a new start or end element adapted.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
