### PR TITLE
Fix #306092: Adding bracket when nothing selected sets its span to 0

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1426,7 +1426,10 @@ Element* Measure::drop(EditData& data)
                         firstStaff++;
                         }
                   Selection sel = score()->selection();
-                  score()->undoAddBracket(staff, level, b->bracketType(), sel.staffEnd() - sel.staffStart());
+                  if (sel.isRange())
+                        score()->undoAddBracket(staff, level, b->bracketType(), sel.staffEnd() - sel.staffStart());
+                  else
+                        score()->undoAddBracket(staff, level, b->bracketType(), 1);
                   delete b;
                   }
                   break;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/305265
Fixes regression for adding bracket from palette without range selection.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
