### PR TITLE
fix# 306180: Adding notes to a tuplet now adds them with respect to t…

### DIFF
--- a/libmscore/fraction.h
+++ b/libmscore/fraction.h
@@ -90,6 +90,9 @@ class Fraction {
       Fraction absValue() const  {
             return Fraction(qAbs(_numerator), _denominator); }
 
+      Fraction inverse() const  {
+            return Fraction(_denominator, _numerator); }
+
 
       // --- reduction --- //
 

--- a/libmscore/tuplet.h
+++ b/libmscore/tuplet.h
@@ -26,12 +26,11 @@ enum class TupletBracketType : char;
 //------------------------------------------------------------------------
 //   @@ Tuplet
 //!     Example of 1/8 triplet:
-//!       _baseLen     = 1/8
-//!       _actualNotes = 3
-//!       _normalNotes = 2     (3 notes played in the time of 2/8)
+//!       _baseLen     = 1/8  (tuplet is measured in eighth notes)
+//!       _ratio       = 3/2  (3 eighth tuplet notes played in the space of 2 regular eighth notes)
 //!
-//!    The tuplet has a  len of _baseLen * _normalNotes.
-//!    A tuplet note has len of _baseLen * _normalNotes / _actualNotes.
+//!    Entire tuplet has a duration of _baseLen * _ratio.denominator().
+//!    A single tuplet note has duration of _baseLen * _ratio.denominator() / _ratio.numerator().
 //------------------------------------------------------------------------
 
 class Tuplet final : public DurationElement {

--- a/mscore/pianoroll/pianoview.h
+++ b/mscore/pianoroll/pianoview.h
@@ -127,7 +127,7 @@ private:
       void selectNotes(int startTick, int endTick, int lowPitch, int highPitch, NoteSelectType selType);
       void showPopupMenu(const QPoint& pos);
       bool cutChordRest(ChordRest* targetCr, int track, Fraction cutTick, ChordRest*& cr0, ChordRest*& cr1);
-      void addNote(Fraction startTick, Fraction duration, int pitch, int track, bool command = true);
+      void addNote(Fraction startTick, Fraction duration, int pitch, int track);
       void handleSelectionClick();
       void insertNote(int modifiers);
       Fraction roundToStartBeat(int tick) const;


### PR DESCRIPTION


Resolves: https://musescore.org/en/node/306180

Adding notes to a tuplet in piano roll editor now adds them with respect to the tuplet's space.

Adding a method to Fraction to return the inverse.

Updating header comment in tuplet.h


<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://musescore.org/en/cla)
- [ ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [ ] I made sure the code compiles on my machine
- [ ] I made sure there are no unnecessary changes in the code
- [ ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
