### PR TITLE
fix #306096: fix incorrect anchor lines coordinates for some element types

### DIFF
--- a/libmscore/arpeggio.cpp
+++ b/libmscore/arpeggio.cpp
@@ -17,6 +17,7 @@
 #include "score.h"
 #include "staff.h"
 #include "part.h"
+#include "page.h"
 #include "segment.h"
 #include "property.h"
 #include "xml.h"
@@ -308,7 +309,7 @@ QVector<QLineF> Arpeggio::dragAnchorLines() const
 
       Chord* c = chord();
       if (c)
-            result << QLineF(pagePos(), c->upNote()->pagePos());
+            result << QLineF(canvasPos(), c->upNote()->canvasPos());
       return QVector<QLineF>();
       }
 
@@ -324,17 +325,20 @@ QVector<QLineF> Arpeggio::gripAnchorLines(Grip grip) const
       if (!_chord)
             return result;
 
-      QPointF gripPosition = gripsPositions()[static_cast<int>(grip)];
+      const Page* p = toPage(findAncestor(ElementType::PAGE));
+      const QPointF pageOffset = p ? p->pos() : QPointF();
+
+      const QPointF gripCanvasPos = gripsPositions()[static_cast<int>(grip)] + pageOffset;
 
       if (grip == Grip::START)
-            result << QLineF(_chord->upNote()->pagePos(), gripPosition);
+            result << QLineF(_chord->upNote()->canvasPos(), gripCanvasPos);
       else if (grip == Grip::END) {
             Note* downNote = _chord->downNote();
             int btrack  = track() + (_span - 1) * VOICES;
             Element* e = _chord->segment()->element(btrack);
             if (e && e->isChord())
                   downNote = toChord(e)->downNote();
-            result << QLineF(downNote->pagePos(), gripPosition);
+            result << QLineF(downNote->canvasPos(), gripCanvasPos);
             }
       return result;
       }

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -306,7 +306,7 @@ class Element : public ScoreElement {
       virtual void startDrag(EditData&);
       virtual QRectF drag(EditData&);
       virtual void endDrag(EditData&);
-      /** Returns anchor lines displayed while dragging element in page coordinates. */
+      /** Returns anchor lines displayed while dragging element in canvas coordinates. */
       virtual QVector<QLineF> dragAnchorLines() const       { return QVector<QLineF>(); }
       /**
        * A generic \ref dragAnchorLines() implementation which can be used in
@@ -334,7 +334,7 @@ class Element : public ScoreElement {
       void updateGrips(EditData&) const;
       virtual bool nextGrip(EditData&) const;
       virtual bool prevGrip(EditData&) const;
-      /** Returns anchor lines displayed while dragging element's grip in page coordinates. */
+      /** Returns anchor lines displayed while dragging element's grip in canvas coordinates. */
       virtual QVector<QLineF> gripAnchorLines(Grip) const     { return QVector<QLineF>(); }
 
       virtual EditBehavior normalModeEditBehavior() const { return EditBehavior::SelectOnly; }

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -18,6 +18,7 @@
 #include "measure.h"
 #include "note.h"
 #include "part.h"
+#include "page.h"
 #include "score.h"
 #include "segment.h"
 #include "staff.h"
@@ -154,16 +155,19 @@ QVector<QLineF> LineSegment::gripAnchorLines(Grip grip) const
                   y += system()->staff(stIdx)->bbox().height();
             }
 
+      const Page* p = system()->page();
+      const QPointF pageOffset = p ? p->pos() : QPointF();
+
       switch (grip) {
       case Grip::START:
-            result << QLineF(leftAnchorPosition(y), gripsPositions().at(static_cast<int>(Grip::START)));
+            result << QLineF(leftAnchorPosition(y), gripsPositions().at(static_cast<int>(Grip::START))).translated(pageOffset);
             break;
       case Grip::END:
-            result << QLineF(rightAnchorPosition(y), gripsPositions().at(static_cast<int>(Grip::END)));
+            result << QLineF(rightAnchorPosition(y), gripsPositions().at(static_cast<int>(Grip::END))).translated(pageOffset);
             break;
       case Grip::MIDDLE:
-            result << QLineF(leftAnchorPosition(y), gripsPositions().at(static_cast<int>(Grip::START)));
-            result << QLineF(rightAnchorPosition(y), gripsPositions().at(static_cast<int>(Grip::END)));
+            result << QLineF(leftAnchorPosition(y), gripsPositions().at(static_cast<int>(Grip::START))).translated(pageOffset);
+            result << QLineF(rightAnchorPosition(y), gripsPositions().at(static_cast<int>(Grip::END))).translated(pageOffset);
             break;
       default:
             break;

--- a/libmscore/slurtie.cpp
+++ b/libmscore/slurtie.cpp
@@ -19,6 +19,7 @@
 #include "slurtie.h"
 #include "tie.h"
 #include "chord.h"
+#include "page.h"
 
 namespace Ms {
 
@@ -79,7 +80,10 @@ QVector<QLineF> SlurTieSegment::gripAnchorLines(Grip grip) const
                   break;
             }
 
-      result << QLineF(anchorPosition, gripsPositions().at(gripIndex));
+      const Page* p = system()->page();
+      const QPointF pageOffset = p ? p->pos() : QPointF();
+
+      result << QLineF(anchorPosition, gripsPositions().at(gripIndex)).translated(pageOffset);
 
       return result;
       }

--- a/mscore/dragelement.cpp
+++ b/mscore/dragelement.cpp
@@ -98,12 +98,8 @@ void ScoreView::doDragElement(QMouseEvent* ev)
 
       for (Element* e : sel.elements()) {
             QVector<QLineF> elAnchorLines = e->dragAnchorLines();
-            Element* const page = e->findAncestor(ElementType::PAGE);
-            const QPointF pageOffset((page ? page : e)->pos());
 
             if (!elAnchorLines.isEmpty()) {
-                  for (QLineF& l : elAnchorLines)
-                        l.translate(pageOffset);
                   anchorLines.append(elAnchorLines);
                   }
             }

--- a/mscore/editelement.cpp
+++ b/mscore/editelement.cpp
@@ -72,8 +72,6 @@ void ScoreView::updateGrips()
             QVector<QLineF> anchorLines = editData.element->gripAnchorLines(anchorLinesGrip);
 
             if (!anchorLines.isEmpty()) {
-                  for (QLineF& l : anchorLines)
-                        l.translate(pageOffset);
                   setDropAnchorLines(anchorLines);
                   }
             else


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/306096

In the process of anchor lines reworking some elements appeared to use
page coordinate system to describe their anchor lines coordinates while
others continued using canvas coordinate system. 4c5e9ed fixed this
issue wrongly effectively swapping element types having the incorrect
coordinates issue. This PR fixes this inconsistency by ensuring using
canvas coordinates for this purpose.