### PR TITLE
Added notation view skeleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -940,8 +940,11 @@ if (MSVC)
 endif (MSVC)
 
 add_subdirectory(framework)
-add_subdirectory(mu4)
 add_subdirectory(global) #todo remove
+
+if (BUILD_UI_MU4)
+    add_subdirectory(mu4)
+endif(BUILD_UI_MU4)
 
 ## TEMP: Display all variables!
 ### message(STATUS "===========================================================")

--- a/build/module.cmake
+++ b/build/module.cmake
@@ -18,12 +18,14 @@
 #=============================================================================
 
 ## Setup
-# set(MODULE somename)
-# set(MODULE_INCLUDE ...)
-# set(MODULE_QRC somename.qrc)
-# set(MODULE_QML_IMPORT ...)
-# set(MODULE_SRC ...)
-# set(MODULE_LINK ...)
+# set(MODULE somename)          - set module (target) name
+# set(MODULE_INCLUDE ...)       - set include (by default see below include_directories)
+# set(MODULE_SRC ...)           - set sources and headers files
+# set(MODULE_LINK ...)          - set libraries for link
+# set(MODULE_QRC somename.qrc)  - set resource (qrc) file
+# set(MODULE_QML_IMPORT ...)    - set Qml import for QtCreator (so that there is code highlighting, jump, etc.)
+
+# After all the settings you need to do:
 # include(${PROJECT_SOURCE_DIR}/build/module.cmake)
 
 message(STATUS "Configuring " ${MODULE})

--- a/framework/global/CMakeLists.txt
+++ b/framework/global/CMakeLists.txt
@@ -26,6 +26,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/log.h
     ${CMAKE_CURRENT_LIST_DIR}/dataformatter.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dataformatter.h
+    ${CMAKE_CURRENT_LIST_DIR}/interfaces/iinteractive.h
     )
 
 include(${PROJECT_SOURCE_DIR}/build/module.cmake)

--- a/framework/global/interfaces/iinteractive.h
+++ b/framework/global/interfaces/iinteractive.h
@@ -1,0 +1,40 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_FRAMEWORK_IINTERACTIVE_H
+#define MU_FRAMEWORK_IINTERACTIVE_H
+
+#include <QString>
+
+#include "modularity/imoduleexport.h"
+
+namespace mu {
+namespace framework {
+class IInteractive : MODULE_EXPORT_INTERFACE
+{
+    INTERFACE_ID(IInteractive)
+
+public:
+    virtual ~IInteractive() = default;
+
+    virtual QString selectOpeningFile(const QString& title, const QString& dir, const QString& filter) = 0;
+};
+}
+}
+
+#endif // MU_FRAMEWORK_IINTERACTIVE_H

--- a/framework/ui/CMakeLists.txt
+++ b/framework/ui/CMakeLists.txt
@@ -28,6 +28,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/qmltheme.cpp
     ${CMAKE_CURRENT_LIST_DIR}/qmltheme.h
     ${CMAKE_CURRENT_LIST_DIR}/iconcodes.h
+    ${CMAKE_CURRENT_LIST_DIR}/uiinteractive.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/uiinteractive.h
     )
 
 include(${PROJECT_SOURCE_DIR}/build/module.cmake)

--- a/framework/ui/uiinteractive.cpp
+++ b/framework/ui/uiinteractive.cpp
@@ -1,0 +1,28 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "uiinteractive.h"
+
+#include <QFileDialog>
+
+using namespace mu::framework;
+
+QString UiInteractive::selectOpeningFile(const QString& title, const QString& dir, const QString& filter)
+{
+    return QFileDialog::getOpenFileName(nullptr /*parent*/, title, dir, filter);
+}

--- a/framework/ui/uiinteractive.h
+++ b/framework/ui/uiinteractive.h
@@ -1,0 +1,37 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_FRAMEWORK_UIINTERACTIVE_H
+#define MU_FRAMEWORK_UIINTERACTIVE_H
+
+#include "interfaces/iinteractive.h"
+
+namespace mu {
+namespace framework {
+class UiInteractive : public IInteractive
+{
+public:
+
+    UiInteractive() = default;
+
+    QString selectOpeningFile(const QString& title, const QString& dir, const QString& filter) override;
+};
+}
+}
+
+#endif // MU_FRAMEWORK_UIINTERACTIVE_H

--- a/framework/ui/uimodule.cpp
+++ b/framework/ui/uimodule.cpp
@@ -8,6 +8,8 @@
 #include "qmltheme.h"
 #include "iconcodes.h"
 
+#include "uiinteractive.h"
+
 using namespace mu::framework;
 
 std::string UiModule::moduleName() const
@@ -19,6 +21,7 @@ std::string UiModule::moduleName() const
 void UiModule::registerExports()
 {
     ioc()->registerExport<IUiEngine>(moduleName(), UiEngine::instance());
+    ioc()->registerExport<IInteractive>(moduleName(), new UiInteractive());
 }
 
 void UiModule::registerUiTypes()

--- a/framework/uicomponents/CMakeLists.txt
+++ b/framework/uicomponents/CMakeLists.txt
@@ -33,4 +33,3 @@ set(MODULE_SRC
 include(${PROJECT_SOURCE_DIR}/build/module.cmake)
 
 
-

--- a/libmscore/CMakeLists.txt
+++ b/libmscore/CMakeLists.txt
@@ -103,9 +103,16 @@ add_library (
       unrollrepeats.cpp
       )
 
+set (LINK_LIBS )
 if (AVSOMR)
-    target_link_libraries(libmscore avsomr)
+    set(LINK_LIBS ${LINK_LIBS} avsomr)
 endif (AVSOMR)
+
+if (BUILD_UI_MU4)
+    set(LINK_LIBS ${LINK_LIBS} audio)
+endif(BUILD_UI_MU4)
+
+target_link_libraries(libmscore ${LINK_LIBS})
 
 ##
 ## Code coverage. Only affects DEBUG builds.

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -77,17 +77,19 @@ target_include_directories(mscore PRIVATE
       ${PROJECT_SOURCE_DIR}/thirdparty
       )
 
-target_link_libraries(mscore
-    mscoreapp
-    global
-    global_old #todo remove
-    ui
-    uicomponents
-    appshell
-    scores
-    extensions
-)
 
+set(LINK_LIB mscoreapp global global_old ui uicomponents)
+if (BUILD_UI_MU4)
+    set(LINK_LIB ${LINK_LIB}
+        appshell
+        scores
+        extensions
+        notation
+        notation_scene
+        )
+endif(BUILD_UI_MU4)
+
+target_link_libraries(mscore ${LINK_LIB} )
 
 if (APPLE)
       set_target_properties (mscore

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -60,7 +60,15 @@ int main(int argc, char** argv)
 
     initResources();
 
+#ifndef BUILD_UI_MU4
     ModulesSetup::instance()->setup();
+#else
+    //! HACK A temporary hack is required because some modules
+    //! can only be initialized after the creation of the QApplication
+    auto moduleSetup = []() {
+                           ModulesSetup::instance()->setup();
+                       };
+#endif
 
 #if (defined (_MSCVER) || defined (_MSC_VER))
     // On MSVC under Windows, we need to manually retrieve the command-line arguments and convert them from UTF-16 to UTF-8.
@@ -98,7 +106,7 @@ int main(int argc, char** argv)
 
 #ifdef BUILD_UI_MU4
     mu::appshell::AppShell app;
-    return app.run(argcFinal, argvFinal);
+    return app.run(argcFinal, argvFinal, moduleSetup);
 #else
     return Ms::runApplication(argcFinal, argvFinal);
 #endif

--- a/main/modulessetup.cpp
+++ b/main/modulessetup.cpp
@@ -25,6 +25,8 @@
 #include "mu4/appshell/appshellmodule.h"
 #include "mu4/scores/scoresmodule.h"
 #include "mu4/extensions/extensionsmodule.h"
+#include "mu4/domain/notation/notationdomainmodule.h"
+#include "mu4/scenes/notation/notationscenemodule.h"
 
 #ifdef BUILD_TELEMETRY_MODULE
 #include "framework/telemetry/telemetrysetup.h"
@@ -43,11 +45,15 @@
 ModulesSetup::ModulesSetup()
 {
     m_modulesSetupList
+#ifdef BUILD_UI_MU4
         << new mu::framework::UiModule()
         << new mu::framework::UiComponentsModule()
         << new mu::appshell::AppShellModule()
         << new mu::scores::ScoresModule()
         << new mu::extensions::ExtensionsModule()
+        << new mu::domain::notation::NotationDomainModule()
+        << new mu::scene::notation::NotationSceneModule()
+#endif
 
 #ifdef BUILD_TELEMETRY_MODULE
         << new TelemetrySetup()

--- a/mu4/CMakeLists.txt
+++ b/mu4/CMakeLists.txt
@@ -2,7 +2,12 @@
 
 add_subdirectory(appshell)
 
+# Domain
+add_subdirectory(domain/notation)
+
 # Home
 add_subdirectory(scores)
 add_subdirectory(extensions)
 
+# Notation
+add_subdirectory(scenes/notation)

--- a/mu4/appshell/appshell.cpp
+++ b/mu4/appshell/appshell.cpp
@@ -32,7 +32,7 @@ AppShell::AppShell()
 {
 }
 
-int AppShell::run(int argc, char** argv)
+int AppShell::run(int argc, char** argv, std::function<void()> moduleSetup)
 {
     LOGI() << "start run";
 
@@ -40,6 +40,8 @@ int AppShell::run(int argc, char** argv)
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 
     QApplication app(argc, argv);
+
+    moduleSetup();
 
     QQmlApplicationEngine* engine = new QQmlApplicationEngine();
     //! NOTE Move ownership to UiEngine

--- a/mu4/appshell/appshell.h
+++ b/mu4/appshell/appshell.h
@@ -29,7 +29,7 @@ class AppShell
 public:
     AppShell();
 
-    int run(int argc, char** argv);
+    int run(int argc, char** argv, std::function<void()> moduleSetup);
 };
 }
 }

--- a/mu4/appshell/appshell.qrc
+++ b/mu4/appshell/appshell.qrc
@@ -7,5 +7,6 @@
         <file>qml/HomePage/HomePage.qml</file>
         <file>qml/HomePage/HomeMenu.qml</file>
         <file>qml/NotationPage/NotationPage.qml</file>
+        <file>qml/NotationPage/NotationToolBar.qml</file>
     </qresource>
 </RCC>

--- a/mu4/appshell/dockwindow/qmllistproperty.h
+++ b/mu4/appshell/dockwindow/qmllistproperty.h
@@ -44,9 +44,9 @@ template<typename T>
 class QmlListProperty
 {
 public:
+
     explicit QmlListProperty(QObject* parent)
-        : _parent(parent),
-        _notifier(new QmlListPropertyNotifier())
+        : _parent(parent), _notifier(new QmlListPropertyNotifier())
     {}
     ~QmlListProperty() { delete _notifier; }
 

--- a/mu4/appshell/qml/HomePage/HomeMenu.qml
+++ b/mu4/appshell/qml/HomePage/HomeMenu.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.9
+import QtQuick 2.7
 import QtQuick.Controls 2.2
 
 Rectangle {

--- a/mu4/appshell/qml/HomePage/HomePage.qml
+++ b/mu4/appshell/qml/HomePage/HomePage.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.9
+import QtQuick 2.7
 import MuseScore.Ui 1.0
 import MuseScore.Dock 1.0
 

--- a/mu4/appshell/qml/Main.qml
+++ b/mu4/appshell/qml/Main.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.9
+import QtQuick 2.7
 import MuseScore.Dock 1.0
 
 import "./HomePage"
@@ -12,7 +12,7 @@ DockWindow {
 
     color: ui.theme.window
 
-    currentPageName: "notation"
+    currentPageName: "home"
 
     toolbar: DockToolBar {
 

--- a/mu4/appshell/qml/MainToolBar.qml
+++ b/mu4/appshell/qml/MainToolBar.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.9
+import QtQuick 2.7
 
 Rectangle {
 

--- a/mu4/appshell/qml/NotationPage/NotationPage.qml
+++ b/mu4/appshell/qml/NotationPage/NotationPage.qml
@@ -1,13 +1,28 @@
-import QtQuick 2.9
+import QtQuick 2.7
 import QtQuick.Controls 2.2
 import MuseScore.Ui 1.0
 import MuseScore.Dock 1.0
+import MuseScore.NotationScene 1.0
 
 DockPage {
     id: notationPage
     objectName: "notation"
 
     property var color: ui.theme.window
+
+    //! NOTE Temporary solution
+    QtObject {
+        id: observer
+
+        property var _callbacks: ({})
+        function register(target, callback) {
+            _callbacks[target] = callback;
+        }
+
+        function call(target, cmd) {
+            _callbacks[target](cmd)
+        }
+    }
 
     toolbar: DockToolBar {
         id: notationToolBar
@@ -17,14 +32,8 @@ DockPage {
         width: 400
         color: notationPage.color
 
-        Rectangle {
-            color: notationPage.color
-
-            Text {
-                anchors.fill: parent
-                verticalAlignment: Text.AlignVCenter
-                text: "Notation toolbar"
-            }
+        NotationToolBar {
+            onClicked: observer.call("view", cmd)
         }
     }
 
@@ -77,13 +86,11 @@ DockPage {
         id: notationCentral
         objectName: "notationCentral"
 
-        Rectangle {
+        NotationView {
+            id: notationView
 
-            Text {
-                anchors.fill: parent
-                verticalAlignment: Text.AlignVCenter
-                horizontalAlignment: Text.AlignHCenter
-                text: "Notation"
+            Component.onCompleted: {
+                observer.register("view", notationView.cmd)
             }
         }
     }

--- a/mu4/appshell/qml/NotationPage/NotationToolBar.qml
+++ b/mu4/appshell/qml/NotationPage/NotationToolBar.qml
@@ -1,0 +1,18 @@
+import QtQuick 2.7
+import QtQuick.Controls 2.2
+import QtQuick.Layouts 1.3
+
+ToolBar {
+    id: root
+
+    signal clicked(string cmd)
+
+    RowLayout {
+        anchors.fill: parent
+
+        ToolButton {
+            text: "Open"
+            onClicked: root.clicked("open")
+        }
+    }
+}

--- a/mu4/appshell/qml/PublishPage.qml
+++ b/mu4/appshell/qml/PublishPage.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.9
+import QtQuick 2.7
 import MuseScore.Ui 1.0
 import MuseScore.Dock 1.0
 

--- a/mu4/appshell/qml/SequencerPage.qml
+++ b/mu4/appshell/qml/SequencerPage.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.9
+import QtQuick 2.7
 import MuseScore.Ui 1.0
 import MuseScore.Dock 1.0
 

--- a/mu4/domain/notation/CMakeLists.txt
+++ b/mu4/domain/notation/CMakeLists.txt
@@ -1,0 +1,44 @@
+#=============================================================================
+#  MuseScore
+#  Music Composition & Notation
+#
+#  Copyright (C) 2020 MuseScore BVBA and others
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#=============================================================================
+
+set(MODULE notation)
+
+find_package(Qt5 COMPONENTS Svg REQUIRED)
+
+set(MODULE_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/notationdomainmodule.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/notationdomainmodule.h
+    ${CMAKE_CURRENT_LIST_DIR}/interfaces/inotation.h
+    ${CMAKE_CURRENT_LIST_DIR}/interfaces/inotationcreator.h
+    ${CMAKE_CURRENT_LIST_DIR}/notation.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/notation.h
+    ${CMAKE_CURRENT_LIST_DIR}/notationcreator.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/notationcreator.h
+    )
+
+set(MODULE_LINK
+    Qt5::Svg
+    freetype
+    qzip
+    z
+    libmscore
+    )
+
+include(${PROJECT_SOURCE_DIR}/build/module.cmake)
+

--- a/mu4/domain/notation/interfaces/inotation.h
+++ b/mu4/domain/notation/interfaces/inotation.h
@@ -1,0 +1,54 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_DOMAIN_INOTATION_H
+#define MU_DOMAIN_INOTATION_H
+
+#include <QRect>
+#include <string>
+
+#include "modularity/imoduleexport.h"
+
+class QPainter;
+namespace mu {
+namespace domain {
+namespace notation {
+class INotation : MODULE_EXPORT_INTERFACE
+{
+    INTERFACE_ID(mu::domain::notation::INotation)
+
+public:
+    ~INotation() = default;
+
+    struct PageSize {
+        int width = -1;
+        int height = -1;
+    };
+
+    struct Params {
+        PageSize pageSize;
+    };
+
+    virtual bool load(const std::string& path, const Params& params) = 0;
+    virtual void paint(QPainter* p, const QRect& r) = 0;
+};
+}
+}
+}
+
+#endif // MU_DOMAIN_INOTATION_H

--- a/mu4/domain/notation/interfaces/inotationcreator.h
+++ b/mu4/domain/notation/interfaces/inotationcreator.h
@@ -1,0 +1,42 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_DOMAIN_INOTATIONCREATOR_H
+#define MU_DOMAIN_INOTATIONCREATOR_H
+
+#include <memory>
+#include "inotation.h"
+#include "modularity/imoduleexport.h"
+
+namespace mu {
+namespace domain {
+namespace notation {
+class INotationCreator : MODULE_EXPORT_INTERFACE
+{
+    INTERFACE_ID(mu::domain::notation::INotationCreator)
+
+public:
+    ~INotationCreator() = default;
+
+    virtual std::shared_ptr<INotation> newNotation() = 0;
+};
+}
+}
+}
+
+#endif // MU_DOMAIN_INOTATIONCREATOR_H

--- a/mu4/domain/notation/notation.cpp
+++ b/mu4/domain/notation/notation.cpp
@@ -1,0 +1,112 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "notation.h"
+
+#include <QPointF>
+#include <QPainter>
+
+#include "config.h"
+#include "libmscore/score.h"
+#include "libmscore/page.h"
+
+#ifdef BUILD_UI_MU4
+//! HACK Temporary hack to link libmscore
+Q_LOGGING_CATEGORY(undoRedo, "undoRedo", QtCriticalMsg)
+
+namespace Ms {
+QString revision;
+MasterSynthesizer* synti;
+QString dataPath;
+QString mscoreGlobalShare;
+}
+//! ---------
+#endif
+
+using namespace mu::domain::notation;
+using namespace Ms;
+
+Notation::Notation()
+{
+    m_scoreGlobal = new MScore();
+    m_score = new MasterScore(m_scoreGlobal->baseStyle());
+}
+
+void Notation::init()
+{
+    MScore::init();         // initialize libmscore
+}
+
+bool Notation::load(const std::string& path, const Params& params)
+{
+    Score::FileError rv = m_score->loadMsc(QString::fromStdString(path), true);
+    if (rv != Score::FileError::FILE_NO_ERROR) {
+        return false;
+    }
+
+//    Ms::MStyle& styleRef = m_score->style();
+//    styleRef.set(Ms::Sid::pageWidth, params.pageSize.width / Ms::DPI);
+// styleRef.set(Ms::Sid::pageHeight, params.pageSize.height / Ms::DPI);
+
+//    styleRef.set(Ms::Sid::pagePrintableWidth, (pageSize.pageWidth - pageSize.margingLeft
+//                                               - pageSize.margingRight) / Ms::DPI);
+//    styleRef.set(Ms::Sid::pageEvenLeftMargin, pageSize.margingLeft / Ms::DPI);
+//    styleRef.set(Ms::Sid::pageOddLeftMargin, pageSize.margingLeft / Ms::DPI);
+
+//    styleRef.set(Ms::Sid::pageEvenTopMargin, pageSize.margingTop / Ms::DPI);
+//    styleRef.set(Ms::Sid::pageOddTopMargin, pageSize.margingTop / Ms::DPI);
+//    styleRef.set(Ms::Sid::pageEvenBottomMargin, pageSize.margingBottom / Ms::DPI);
+//    styleRef.set(Ms::Sid::pageOddBottomMargin, pageSize.margingBottom / Ms::DPI);
+
+    m_score->setUpdateAll();
+    m_score->doLayout();
+
+    return true;
+}
+
+void Notation::paint(QPainter* p, const QRect& r)
+{
+    const QList<Ms::Page*>& mspages = m_score->pages();
+
+    if (mspages.isEmpty()) {
+        p->drawText(10, 10, "no pages");
+        return;
+    }
+
+    Ms::Page* page = mspages.first();
+    page->draw(p);
+
+    p->fillRect(page->bbox(), QColor("#ffffff"));
+
+    QList<Ms::Element*> ell = page->elements();
+    for (const Ms::Element* e : ell) {
+        if (!e->visible()) {
+            continue;
+        }
+
+        e->itemDiscovered = false;
+        QPointF pos(e->pagePos());
+        //LOGI() << e->name() << ", x: " << pos.x() << ", y: " << pos.y() << "\n";
+
+        p->translate(pos);
+
+        e->draw(p);
+
+        p->translate(-pos);
+    }
+}

--- a/mu4/domain/notation/notation.h
+++ b/mu4/domain/notation/notation.h
@@ -1,0 +1,52 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_DOMAIN_NOTATION_H
+#define MU_DOMAIN_NOTATION_H
+
+#include "interfaces/inotation.h"
+
+namespace Ms {
+class MScore;
+class MasterScore;
+}
+
+namespace mu {
+namespace domain {
+namespace notation {
+class Notation : public INotation
+{
+public:
+    Notation();
+
+    //! NOTE Needed at the moment to initialize libmscore
+    static void init();
+
+    bool load(const std::string& path, const Params& params) override;
+    void paint(QPainter* p, const QRect& r) override;
+
+private:
+
+    Ms::MScore* m_scoreGlobal = nullptr;
+    Ms::MasterScore* m_score = nullptr;
+};
+}
+}
+}
+
+#endif // MU_DOMAIN_NOTATION_H

--- a/mu4/domain/notation/notationcreator.cpp
+++ b/mu4/domain/notation/notationcreator.cpp
@@ -1,0 +1,28 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "notationcreator.h"
+
+#include "notation.h"
+
+using namespace mu::domain::notation;
+
+std::shared_ptr<INotation> NotationCreator::newNotation()
+{
+    return std::make_shared<Notation>();
+}

--- a/mu4/domain/notation/notationcreator.h
+++ b/mu4/domain/notation/notationcreator.h
@@ -1,0 +1,38 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_DOMAIN_NOTATIONCREATOR_H
+#define MU_DOMAIN_NOTATIONCREATOR_H
+
+#include "interfaces/inotationcreator.h"
+
+namespace mu {
+namespace domain {
+namespace notation {
+class NotationCreator : public INotationCreator
+{
+public:
+    NotationCreator() = default;
+
+    std::shared_ptr<INotation> newNotation() override;
+};
+}
+}
+}
+
+#endif // MU_DOMAIN_NOTATIONCREATOR_H

--- a/mu4/domain/notation/notationdomainmodule.cpp
+++ b/mu4/domain/notation/notationdomainmodule.cpp
@@ -1,0 +1,40 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "notationdomainmodule.h"
+
+#include "modularity/ioc.h"
+#include "notationcreator.h"
+#include "notation.h"
+
+using namespace mu::domain::notation;
+
+std::string NotationDomainModule::moduleName() const
+{
+    return "notation";
+}
+
+void NotationDomainModule::registerExports()
+{
+    framework::ioc()->registerExport<INotationCreator>(moduleName(), new NotationCreator());
+}
+
+void NotationDomainModule::onInit()
+{
+    Notation::init();
+}

--- a/mu4/domain/notation/notationdomainmodule.h
+++ b/mu4/domain/notation/notationdomainmodule.h
@@ -1,0 +1,40 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_DOMAIN_NOTATIONMODULE_H
+#define MU_DOMAIN_NOTATIONMODULE_H
+
+#include "modularity/imodulesetup.h"
+
+namespace mu {
+namespace domain {
+namespace notation {
+class NotationDomainModule : public framework::IModuleSetup
+{
+public:
+
+    std::string moduleName() const;
+
+    void registerExports() override;
+    void onInit() override;
+};
+}
+}
+}
+
+#endif // MU_DOMAIN_NOTATIONMODULE_H

--- a/mu4/extensions/qml/MuseScore/Extensions/ExtensionsModule.qml
+++ b/mu4/extensions/qml/MuseScore/Extensions/ExtensionsModule.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.9
+import QtQuick 2.7
 
 Rectangle {
     Text {

--- a/mu4/scenes/notation/CMakeLists.txt
+++ b/mu4/scenes/notation/CMakeLists.txt
@@ -1,0 +1,40 @@
+#=============================================================================
+#  MuseScore
+#  Music Composition & Notation
+#
+#  Copyright (C) 2020 MuseScore BVBA and others
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#=============================================================================
+
+set(MODULE notation_scene)
+
+set(MODULE_QRC
+    ${CMAKE_CURRENT_LIST_DIR}/view/notation_view.qrc
+    )
+
+set(MODULE_QML_IMPORT ${CMAKE_CURRENT_LIST_DIR}/view/qml)
+
+include(${CMAKE_CURRENT_LIST_DIR}/view/notationview.cmake)
+
+set(MODULE_SRC
+    ${NOTATIONVIEW_SRC}
+    ${CMAKE_CURRENT_LIST_DIR}/notationscenemodule.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/notationscenemodule.h
+    )
+
+include(${PROJECT_SOURCE_DIR}/build/module.cmake)
+
+
+
+

--- a/mu4/scenes/notation/notationscenemodule.cpp
+++ b/mu4/scenes/notation/notationscenemodule.cpp
@@ -1,0 +1,59 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "notationscenemodule.h"
+
+#include "view/notationpaintview.h"
+
+using namespace mu::scene::notation;
+
+static void notation_view_init_qrc()
+{
+    Q_INIT_RESOURCE(notation_view);
+}
+
+NotationSceneModule::NotationSceneModule()
+{
+
+}
+
+std::string NotationSceneModule::moduleName() const
+{
+    return "notation_scene";
+}
+
+void NotationSceneModule::registerExports()
+{
+
+}
+
+void NotationSceneModule::resolveImports()
+{
+
+}
+
+void NotationSceneModule::registerResources()
+{
+    notation_view_init_qrc();
+}
+
+void NotationSceneModule::registerUiTypes()
+{
+    qmlRegisterType<NotationPaintView>("MuseScore.NotationScene", 1, 0, "NotationPaintView");
+}
+

--- a/mu4/scenes/notation/notationscenemodule.h
+++ b/mu4/scenes/notation/notationscenemodule.h
@@ -1,0 +1,45 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_NOTATION_NOTATIONSCENEMODULE_H
+#define MU_NOTATION_NOTATIONSCENEMODULE_H
+
+#include "modularity/imodulesetup.h"
+
+namespace mu {
+namespace scene {
+namespace notation {
+class NotationSceneModule : public framework::IModuleSetup
+{
+public:
+
+    NotationSceneModule();
+
+    std::string moduleName() const override;
+
+    void registerExports() override;
+    void resolveImports() override;
+
+    void registerResources() override;
+    void registerUiTypes() override;
+};
+}
+}
+}
+
+#endif // MU_NOTATION_NOTATIONSCENEMODULE_H

--- a/mu4/scenes/notation/view/notation_view.qrc
+++ b/mu4/scenes/notation/view/notation_view.qrc
@@ -1,0 +1,6 @@
+<RCC>
+    <qresource prefix="/">
+        <file>qml/MuseScore/NotationScene/NotationView.qml</file>
+        <file>qml/MuseScore/NotationScene/qmldir</file>
+    </qresource>
+</RCC>

--- a/mu4/scenes/notation/view/notationpaintview.cpp
+++ b/mu4/scenes/notation/view/notationpaintview.cpp
@@ -1,0 +1,170 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "notationpaintview.h"
+
+#include <QPainter>
+#include <cmath>
+
+#include "log.h"
+#include "notationviewinputcontroller.h"
+
+using namespace mu::scene::notation;
+
+static constexpr int PREF_UI_CANVAS_MISC_SELECTIONPROXIMITY = 6;
+
+NotationPaintView::NotationPaintView() :
+    QQuickPaintedItem()
+{
+    setFlag(ItemHasContents, true);
+    setAcceptedMouseButtons(Qt::AllButtons);
+
+    //! TODO
+    double mag  = 0.267;//preferences.getDouble(PREF_SCORE_MAGNIFICATION) * (mscore->physicalDotsPerInch() / DPI);
+    m_matrix = QTransform::fromScale(mag, mag);
+
+    m_inputController = new NotationViewInputController(this);
+}
+
+void NotationPaintView::cmd(const QString& name)
+{
+    //! NOTE Temporary
+    if ("open" == name) {
+        open();
+    }
+}
+
+//! NOTE Temporary method for tests
+void NotationPaintView::open()
+{
+    QString filePath = interactive()->selectOpeningFile("Score", "", "");
+    if (filePath.isEmpty()) {
+        return;
+    }
+
+    m_notation = notationCreator()->newNotation();
+    IF_ASSERT_FAILED(m_notation) {
+        return;
+    }
+
+    domain::notation::INotation::Params params;
+    params.pageSize.width = width();
+    params.pageSize.height = height();
+    bool ok = m_notation->load(filePath.toStdString(), params);
+    if (!ok) {
+        LOGE() << "failed load: " << filePath;
+    }
+
+    update();
+}
+
+void NotationPaintView::paint(QPainter* p)
+{
+    QRect rect(0, 0, width(), height());
+    p->fillRect(rect, QColor("#D6E0E9"));
+
+    p->setTransform(m_matrix);
+
+    if (m_notation) {
+        m_notation->paint(p, rect);
+    } else {
+        p->drawText(10, 10, "no notation");
+    }
+}
+
+void NotationPaintView::moveScene(int dx, int dy)
+{
+    m_matrix.translate(dx, dy);
+    update();
+}
+
+void NotationPaintView::scrollVertical(int dy)
+{
+    m_matrix.translate(0, dy);
+    update();
+}
+
+void NotationPaintView::scrollHorizontal(int dx)
+{
+    m_matrix.translate(dx, 0);
+    update();
+}
+
+void NotationPaintView::zoomStep(qreal step, const QPoint& pos)
+{
+    qreal mag = m_matrix.m11();
+    mag *= qPow(1.1, step);
+    zoom(mag, pos);
+}
+
+void NotationPaintView::zoom(qreal mag, const QPoint& pos)
+{
+    //! TODO Zoom to point not completed
+    mag = qBound(0.05, mag, 16.0);
+
+    qreal cmag = m_matrix.m11();
+    if (qFuzzyCompare(mag, cmag)) {
+        return;
+    }
+
+    qreal deltamag = mag / mag;
+
+    QPointF p1 = m_matrix.inverted().map(pos);
+
+    m_matrix.setMatrix(mag, m_matrix.m12(), m_matrix.m13(), m_matrix.m21(),
+                       mag, m_matrix.m23(), m_matrix.dx() * deltamag, m_matrix.dy() * deltamag, m_matrix.m33());
+
+    QPointF p2 = m_matrix.inverted().map(pos);
+    QPointF p3 = p2 - p1;
+    int dx = std::lrint(p3.x() * cmag);
+    int dy = std::lrint(p3.y() * cmag);
+
+    m_matrix.translate(dx, dy);
+
+    update();
+}
+
+void NotationPaintView::wheelEvent(QWheelEvent* ev)
+{
+    m_inputController->wheelEvent(ev);
+}
+
+void NotationPaintView::mousePressEvent(QMouseEvent* ev)
+{
+    m_inputController->mousePressEvent(ev);
+}
+
+void NotationPaintView::mouseMoveEvent(QMouseEvent* ev)
+{
+    m_inputController->mouseMoveEvent(ev);
+}
+
+void NotationPaintView::mouseReleaseEvent(QMouseEvent* ev)
+{
+    m_inputController->mouseReleaseEvent(ev);
+}
+
+QPoint NotationPaintView::toLogical(const QPoint& p) const
+{
+    return m_matrix.inverted().map(p);
+}
+
+QPoint NotationPaintView::toPhysical(const QPoint& p) const
+{
+    return m_matrix.map(p);
+}

--- a/mu4/scenes/notation/view/notationpaintview.h
+++ b/mu4/scenes/notation/view/notationpaintview.h
@@ -1,0 +1,80 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_NOTATIONSCENE_NOTATIONPAINTVIEW_H
+#define MU_NOTATIONSCENE_NOTATIONPAINTVIEW_H
+
+#include <QObject>
+#include <QQuickPaintedItem>
+#include <QTransform>
+
+#include "modularity/ioc.h"
+#include "interfaces/iinteractive.h"
+#include "domain/notation/interfaces/inotationcreator.h"
+
+namespace mu {
+namespace scene {
+namespace notation {
+class NotationViewInputController;
+class NotationPaintView : public QQuickPaintedItem
+{
+    Q_OBJECT
+
+    INJECT(notation, framework::IInteractive, interactive)
+    INJECT(notation, domain::notation::INotationCreator, notationCreator)
+
+public:
+    NotationPaintView();
+
+    Q_INVOKABLE void cmd(const QString& name);
+
+    void open();
+
+    // Draw
+    void paint(QPainter* painter) override;
+
+    // Input
+    void wheelEvent(QWheelEvent*) override;
+    void mousePressEvent(QMouseEvent*) override;
+    void mouseMoveEvent(QMouseEvent*) override;
+    void mouseReleaseEvent(QMouseEvent*) override;
+
+private:
+
+    friend class NotationViewInputController;
+
+    QPoint toLogical(const QPoint& p) const;
+    QPoint toPhysical(const QPoint& p) const;
+
+    void moveScene(int dx, int dy);
+    void scrollVertical(int dy);
+    void scrollHorizontal(int dx);
+    void zoomStep(qreal step, const QPoint& pos);
+    void zoom(qreal mag, const QPoint& pos);
+
+    // ---
+
+    std::shared_ptr<domain::notation::INotation> m_notation;
+    QTransform m_matrix;
+    NotationViewInputController* m_inputController = nullptr;
+};
+}
+}
+}
+
+#endif // MU_NOTATIONSCENE_NOTATIONPAINTVIEW_H

--- a/mu4/scenes/notation/view/notationview.cmake
+++ b/mu4/scenes/notation/view/notationview.cmake
@@ -1,0 +1,7 @@
+
+set (NOTATIONVIEW_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/notationpaintview.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/notationpaintview.h
+    ${CMAKE_CURRENT_LIST_DIR}/notationviewinputcontroller.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/notationviewinputcontroller.h
+    )

--- a/mu4/scenes/notation/view/notationviewinputcontroller.cpp
+++ b/mu4/scenes/notation/view/notationviewinputcontroller.cpp
@@ -1,0 +1,85 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "notationviewinputcontroller.h"
+
+#include "log.h"
+#include "notationpaintview.h"
+
+using namespace mu::scene::notation;
+
+static constexpr int PIXELSSTEPSFACTOR = 5;
+
+NotationViewInputController::NotationViewInputController(NotationPaintView* view) :
+    m_view(view)
+{
+}
+
+void NotationViewInputController::wheelEvent(QWheelEvent* ev)
+{
+    QPoint pixelsScrolled = ev->pixelDelta();
+    QPoint stepsScrolled  = ev->angleDelta();
+
+    int dx = 0;
+    int dy = 0;
+    qreal steps = 0.0;
+
+    if (!pixelsScrolled.isNull()) {
+        dx = pixelsScrolled.x();
+        dy = pixelsScrolled.y();
+        steps = static_cast<qreal>(dy) / static_cast<qreal>(PIXELSSTEPSFACTOR);
+    } else if (!stepsScrolled.isNull()) {
+        dx = (stepsScrolled.x() * qMax(2.0, m_view->width() / 10.0)) / 120;
+        dy = (stepsScrolled.y() * qMax(2.0, m_view->height() / 10.0)) / 120;
+        steps = static_cast<qreal>(stepsScrolled.y()) / 120.0;
+    }
+
+    // Windows touch pad pinches also execute this
+    if (ev->modifiers() & Qt::ControlModifier) {
+        m_view->zoomStep(steps, m_view->toLogical(ev->pos()));
+    } else if (ev->modifiers() & Qt::ShiftModifier && dx == 0) {
+        dx = dy;
+        m_view->scrollHorizontal(dx);
+    } else {
+        m_view->scrollVertical(dy);
+    }
+}
+
+void NotationViewInputController::mousePressEvent(QMouseEvent* ev)
+{
+    QPoint logicPos = m_view->toLogical(ev->pos());
+    m_interactData.beginPoint = logicPos;
+}
+
+void NotationViewInputController::mouseMoveEvent(QMouseEvent* ev)
+{
+    QPoint pos = m_view->toLogical(ev->pos());
+    QPoint d = pos - m_interactData.beginPoint;
+    int dx = d.x();
+    int dy = d.y();
+
+    if (dx == 0 && dy == 0) {
+        return;
+    }
+
+    m_view->moveScene(dx, dy);
+}
+
+void NotationViewInputController::mouseReleaseEvent(QMouseEvent* /*ev*/)
+{
+}

--- a/mu4/scenes/notation/view/notationviewinputcontroller.h
+++ b/mu4/scenes/notation/view/notationviewinputcontroller.h
@@ -1,0 +1,50 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_NOTATIONSCENE_NOTATIONVIEWINPUTCONTROLLER_H
+#define MU_NOTATIONSCENE_NOTATIONVIEWINPUTCONTROLLER_H
+
+#include <QWheelEvent>
+
+namespace mu {
+namespace scene {
+namespace notation {
+class NotationPaintView;
+class NotationViewInputController
+{
+public:
+    NotationViewInputController(NotationPaintView* view);
+
+    void wheelEvent(QWheelEvent* ev);
+    void mousePressEvent(QMouseEvent* ev);
+    void mouseMoveEvent(QMouseEvent* ev);
+    void mouseReleaseEvent(QMouseEvent* ev);
+
+private:
+
+    struct InteractData {
+        QPoint beginPoint;
+    };
+
+    NotationPaintView* m_view = nullptr;
+    InteractData m_interactData;
+};
+}
+}
+}
+#endif // MU_NOTATIONSCENE_NOTATIONVIEWINPUTCONTROLLER_H

--- a/mu4/scenes/notation/view/qml/MuseScore/NotationScene/NotationView.qml
+++ b/mu4/scenes/notation/view/qml/MuseScore/NotationScene/NotationView.qml
@@ -1,0 +1,17 @@
+import QtQuick 2.7
+import MuseScore.NotationScene 1.0
+
+Rectangle {
+
+    id: root
+
+    function cmd(name) {
+        console.info("cmd: " + name)
+        view.cmd(name);
+    }
+
+    NotationPaintView {
+        id: view
+        anchors.fill: parent
+    }
+}

--- a/mu4/scenes/notation/view/qml/MuseScore/NotationScene/qmldir
+++ b/mu4/scenes/notation/view/qml/MuseScore/NotationScene/qmldir
@@ -1,0 +1,2 @@
+module MuseScore.NotationScene
+NotationView 1.0 NotationView.qml

--- a/mu4/scores/qml/MuseScore/Scores/ScoresModule.qml
+++ b/mu4/scores/qml/MuseScore/Scores/ScoresModule.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.9
+import QtQuick 2.7
 
 Rectangle {
     Text {


### PR DESCRIPTION
This is the skeleton of a new view for notation.
Technically, this is a widget for Qml, but as before, most of the code is C++.

Conceptually, this view is no different from the current ScoreView.
Why then do new things?
The reason is that the current ScoreView is a very complex implementation that contains a lot of code and implements responsibilities that are not related to the view. 
Probably the reason is that simply added different code many times, without revising its structure.

At the moment, after the decision to implement MuseScore 4 with a different user interface, we have a great opportunity to rewrite view notations in order to make it simpler and more structured.


