### PR TITLE
Fix #303799 - Crash when starting MuseScore after compare score

### DIFF
--- a/mscore/scoretab.cpp
+++ b/mscore/scoretab.cpp
@@ -146,7 +146,7 @@ ScoreView* ScoreTab::view(int n) const
 QSplitter* ScoreTab::viewSplitter(int n) const
       {
       const TabScoreView* tsv = tabScoreView(n);
-      IF_ASSERT_FAILED(tsv) {
+      if(!tsv) {
             return nullptr;
             }
 
@@ -188,12 +188,12 @@ void ScoreTab::clearTab2()
 
 TabScoreView* ScoreTab::tabScoreView(int idx)
       {
-      IF_ASSERT_FAILED(tab) {
+      if (!tab) {
             return nullptr;
             }
 
       QVariant tabData = tab->tabData(idx);
-      IF_ASSERT_FAILED(tabData.isValid()) {
+      if (!tabData.isValid()) {
             return nullptr;
             }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/303799

Removed three <code>IF_ASSERTS_FAILED</code> because in these situations a failed
assertion is a valid condition which happens when MuseScore is started with the Score Comparison tool open. In this case there are even no files loaded so the assertions cannot be met.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
