### PR TITLE
fix #304959: fix clipping and scaling of Key Signatures palette in New Score wizard

### DIFF
--- a/mscore/palette/palettelistview.cpp
+++ b/mscore/palette/palettelistview.cpp
@@ -26,8 +26,9 @@ PaletteListView::PaletteListView(PalettePanel* panel, QWidget* parent)
       setViewMode(QListView::IconMode);
       setMovement(QListView::Static);
       setResizeMode(QListView::Adjust);
-      setIconSize(panel->gridSize());
-      setSpacing(-5); // zero spacing still has a large gap between icons
+      const QSize gridSize = panel->scaledGridSize();
+      setIconSize(gridSize);
+      setGridSize(gridSize);
 
       PaletteTree* tree = new PaletteTree();
       tree->append(panel);

--- a/mscore/palette/palettemodel.cpp
+++ b/mscore/palette/palettemodel.cpp
@@ -264,7 +264,7 @@ QVariant PaletteTreeModel::data(const QModelIndex& index, int role) const
                   case EditableRole:
                         return pp->editable();
                   case GridSizeRole:
-                        return pp->gridSize() * Palette::guiMag();
+                        return pp->scaledGridSize();
                   case DrawGridRole:
                         return pp->drawGrid();
                   case PaletteExpandedRole:

--- a/mscore/palette/palettetree.cpp
+++ b/mscore/palette/palettetree.cpp
@@ -21,6 +21,7 @@
 
 #include "globals.h"
 #include "musescore.h"
+#include "palette.h"
 #include "preferences.h"
 #include "shortcut.h"
 
@@ -703,6 +704,15 @@ bool PalettePanel::insertCell(int idx, PaletteCellPtr cell)
       cells.insert(cells.begin() + idx, std::move(cell));
 
       return true;
+      }
+
+//---------------------------------------------------------
+//   PalettePanel::scaledGridSize
+//---------------------------------------------------------
+
+QSize PalettePanel::scaledGridSize() const
+      {
+      return gridSize() * Palette::guiMag();
       }
 
 //---------------------------------------------------------

--- a/mscore/palette/palettetree.h
+++ b/mscore/palette/palettetree.h
@@ -167,6 +167,8 @@ class PalettePanel {
       void setGrid(QSize s) { _gridSize = s; }
       void setGrid(int w, int h) { _gridSize = QSize(w, h); }
 
+      QSize scaledGridSize() const;
+
       qreal mag() const { return _mag; }
       void setMag(qreal val) { _mag = val; }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/304959

Ensures accounting for GUI scaling in PaletteListView and uses a
different approach to prevent large gaps between palette cells
(using setGridSize() call instead of setting negative spacing).
This approach prevents clipping of some cells in that palette.

Collaboratively developed in the Telegram chat discussion with @MarcSabatella so I put a co-authorsip in the commit :)