### PR TITLE
Fix #306370: Status bar should display playback pitch of selected note

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -808,11 +808,31 @@ int Note::tpc() const
 //   tpcUserName
 //---------------------------------------------------------
 
-QString Note::tpcUserName(bool explicitAccidental) const
+QString Note::tpcUserName(const int tpc, const int pitch, const bool explicitAccidental)
       {
-      QString pitchName = tpc2name(tpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, explicitAccidental);
-      QString octaveName = QString::number(((epitch() + ottaveCapoFret() - static_cast<int>(tpc2alter(tpc()))) / 12) - 1);
-      return pitchName + (explicitAccidental ? " " : "") + octaveName;
+      const auto pitchStr = tpc2name(tpc, NoteSpellingType::STANDARD, NoteCaseType::AUTO, explicitAccidental);
+      const auto octaveStr = QString::number(((pitch - static_cast<int>(tpc2alter(tpc))) / PITCH_DELTA_OCTAVE) - 1);
+
+      return pitchStr + (explicitAccidental ? " " : "") + octaveStr;
+      };
+
+//---------------------------------------------------------
+//   tpcUserName
+//---------------------------------------------------------
+
+QString Note::tpcUserName(const bool explicitAccidental) const
+      {
+      const auto playbackPitch = ppitch();
+      const auto tpc1Str = tpcUserName(tpc1(), playbackPitch, explicitAccidental);
+
+      if ((tpc1() == tpc2()) || concertPitch()) {
+            return tpc1Str;
+            }
+      else {
+            // Return both the written pitch and the playback pitch since they currently differ.
+            const auto tpc2Str = tpcUserName(tpc2(), playbackPitch - transposition(), explicitAccidental);
+            return QObject::tr("%1 (%2 concert)").arg(tpc2Str).arg(tpc1Str);
+            }
       }
 
 //---------------------------------------------------------

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -310,6 +310,8 @@ class Note final : public Element {
 
       void normalizeLeftDragDelta(Segment* seg, EditData &ed, NoteEditData* ned);
 
+      static QString tpcUserName(int tpc, int pitch, bool explicitAccidental);
+
    public:
       Note(Score* s = 0);
       Note(const Note&, bool link = false);


### PR DESCRIPTION
Resolves: [#306370](https://musescore.org/en/node/306370)

Enhanced the status bar so that whenever a note is selected, the playback pitch is displayed in addition to the written pitch if they differ; i.e., if the note belongs to a transposing instrument and the “concert pitch” option is not currently enabled.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made