### PR TITLE
fix #306317: Multi-page scores yield invalid MusicXML

### DIFF
--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -5395,11 +5395,7 @@ void ExportMusicXml::print(const Measure* const m, const int partNr, const int f
                         _xml.tag("right-margin", QString("%1").arg(QString::number(systemRM,'f',2)) );
                         _xml.etag();
 
-                        if (mpc.pageStart || mpc.scoreStart) {
-                              const double topSysDist = getTenthsFromDots(mmR1->pagePos().y()) - tm;
-                              _xml.tag("top-system-distance", QString("%1").arg(QString::number(topSysDist,'f',2)) );
-                              }
-                        if (mpc.systemStart && !mpc.scoreStart) {
+                        if (mpc.systemStart && !mpc.pageStart) {
                               // see System::layout2() for the factor 2 * score()->spatium()
                               const double sysDist = getTenthsFromDots(mmR1->pagePos().y()
                                                                        - mpc.prevMeasure->pagePos().y()
@@ -5409,6 +5405,10 @@ void ExportMusicXml::print(const Measure* const m, const int partNr, const int f
                               _xml.tag("system-distance",
                                        QString("%1").arg(QString::number(sysDist,'f',2)));
                               }
+                        if (mpc.pageStart || mpc.scoreStart) {
+                              const double topSysDist = getTenthsFromDots(mmR1->pagePos().y()) - tm;
+                              _xml.tag("top-system-distance", QString("%1").arg(QString::number(topSysDist,'f',2)) );
+                        }
 
                         _xml.etag();
                         }

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -3749,7 +3749,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
           <item>
            <widget class="QRadioButton" name="exportAllLayouts">
             <property name="text">
-             <string>Export all layouts</string>
+             <string>Export all layout</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/306317

Restores the MusicXML output to what is was in commit 2e6e53b (the last one before pull request 5775 was merged). Also fixes the spurious "s" in the export preferences dialog.

No new test file was created for this fix, as we currently do not have a trivial way to check MusicXML output when "export all layout" is selected. Note that the output depends on the exact behaviour of the layout algorithm and would be prone to change regularly.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
