### PR TITLE
fix translatable texts

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -3006,7 +3006,7 @@ QString Note::accessibleInfo() const
       else if (staff()->isDrumStaff(tick()) && drumset)
             pitchName = qApp->translate("drumset", drumset->name(pitch()).toUtf8().constData());
       else if (staff()->isTabStaff(tick()))
-            pitchName = QObject::tr("%1; String %2; Fret %3").arg(tpcUserName(false)).arg(QString::number(string() + 1)).arg(QString::number(fret()));
+            pitchName = QObject::tr("%1; String: %2; Fret: %3").arg(tpcUserName(false)).arg(QString::number(string() + 1)).arg(QString::number(fret()));
       else
             pitchName = tpcUserName(false);
       return QObject::tr("%1; Pitch: %2; Duration: %3%4").arg(noteTypeUserName()).arg(pitchName).arg(duration).arg((chord()->isGrace() ? "" : QString("; %1").arg(voice)));
@@ -3029,7 +3029,7 @@ QString Note::screenReaderInfo() const
       else if (staff()->isDrumStaff(tick()) && drumset)
             pitchName = qApp->translate("drumset", drumset->name(pitch()).toUtf8().constData());
       else if (staff()->isTabStaff(tick()))
-            pitchName = QObject::tr("%1 String %2 Fret %3").arg(tpcUserName(true)).arg(QString::number(string() + 1)).arg(QString::number(fret()));
+            pitchName = QObject::tr("%1; String: %2; Fret: %3").arg(tpcUserName(true)).arg(QString::number(string() + 1)).arg(QString::number(fret()));
       else
             pitchName = tpcUserName(true);
       return QString("%1 %2 %3%4").arg(noteTypeUserName()).arg(pitchName).arg(duration).arg((chord()->isGrace() ? "" : QString("; %1").arg(voice)));

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -9731,7 +9731,7 @@
               <item row="1" column="4">
                <widget class="QToolButton" name="resetMaxChordShiftAbove">
                 <property name="text">
-                 <string>...</string>
+                 <string notr="true">…</string>
                 </property>
                 <property name="icon">
                  <iconset>
@@ -9802,7 +9802,7 @@
               <item row="2" column="4">
                <widget class="QToolButton" name="resetMaxChordShiftBelow">
                 <property name="text">
-                 <string>...</string>
+                 <string notr="true">…</string>
                 </property>
                 <property name="icon">
                  <iconset>
@@ -10136,7 +10136,7 @@
            <item row="7" column="2">
             <widget class="QToolButton" name="resetMaxFretShiftAbove">
              <property name="text">
-              <string>...</string>
+              <string notr="true">…</string>
              </property>
              <property name="icon">
               <iconset>
@@ -10147,7 +10147,7 @@
            <item row="8" column="0">
             <widget class="QLabel" name="label_145">
              <property name="text">
-              <string>Maximum shift below</string>
+              <string>Maximum shift below:</string>
              </property>
             </widget>
            </item>
@@ -10164,7 +10164,7 @@
            <item row="8" column="2">
             <widget class="QToolButton" name="resetMaxFretShiftBelow">
              <property name="text">
-              <string>...</string>
+              <string notr="true">…</string>
              </property>
              <property name="icon">
               <iconset>

--- a/mscore/mixer/mixerdetails.cpp
+++ b/mscore/mixer/mixerdetails.cpp
@@ -276,7 +276,7 @@ void MixerDetails::updateFromTrack()
                   tb->setText(QString("%1").arg(voice + 1));
                   tb->setCheckable(true);
                   tb->setChecked(!staff->playbackVoice(voice));
-                  tb->setToolTip(QString(tr("Staff #%1")).arg(staffIdx + 1));
+                  tb->setToolTip(QString(tr("Staff %1")).arg(staffIdx + 1));
 
                   mutePerVoiceGrid->addWidget(tb, staffIdx, voice);
                   MixerDetailsVoiceButtonHandler* handler =

--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -275,7 +275,7 @@ void ScoreAccessibility::currentInfoChanged()
             QString optimizedStaff = "";
             if (e->staffIdx() + 1) {
                   _oldStaff = e->staffIdx();
-                  staff = tr("Staff %1").arg(QString::number(e->staffIdx() + 1));
+                  staff = tr("Staff: %1").arg(QString::number(e->staffIdx() + 1));
                   QString staffName = e->staff()->part()->longName(e->tick());
                   if (staffName.isEmpty())
                         staffName = e->staff()->partName();


### PR DESCRIPTION
No new strings added, just one reused and others removed.
So not affected by any string freeze...

Well, now there are some very are minor changes, should result in at least one string less to translate, resolves https://musescore.org/en/node/306480