### PR TITLE
[MU4] make hook installation work via symlinks instead of copying

### DIFF
--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -2,4 +2,5 @@
 
 HOOKSDIR=./.git/hooks/
 
-cp ./hooks/pre-commit "$HOOKSDIR/pre-commit"
+rm -f "$HOOKSDIR/pre-commit"
+ln ./hooks/pre-commit "$HOOKSDIR/pre-commit"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+CODESTYLE_LOCATION="./tools/codestyle/"
+
+if [ ! -d "$CODESTYLE_LOCATION" ]; then
+      echo "Not uncrustifying, since new code style is not set up in this branch"
+      exit 0
+fi
+
 echo "Uncrustifying staged files..."
 
 RELPATH=../..


### PR DESCRIPTION
This changes how hook installation works so that any changes to the hook should be reflected in the `.git` directory. It also prevents the hook from failing if a branch pre-4.0 is checked out.