### PR TITLE
fix #306438: wrong default offset for chord symbols on fret diagrams

### DIFF
--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -814,7 +814,7 @@ void FretDiagram::read(XmlReader& e)
             else if (tag == "Harmony") {
                   Harmony* h = new Harmony(score());
                   h->read(e);
-                  addLoaded(h);
+                  add(h);
                   }
             else if (!Element::readProperties(e))
                   e.unknown();
@@ -1195,26 +1195,10 @@ void FretDiagram::add(Element* e)
       if (e->isHarmony()) {
             _harmony = toHarmony(e);
             _harmony->setTrack(track());
-            _harmony->resetProperty(Pid::OFFSET);
+            if (_harmony->propertyFlags(Pid::OFFSET) == PropertyFlags::STYLED)
+                  _harmony->resetProperty(Pid::OFFSET);
             _harmony->setProperty(Pid::ALIGN, int(Align::HCENTER | Align::TOP));
             _harmony->setPropertyFlags(Pid::ALIGN, PropertyFlags::UNSTYLED);
-            }
-      else {
-            qWarning("FretDiagram: cannot add <%s>\n", e->name());
-            }
-      }
-
-//---------------------------------------------------------
-//   addLoaded
-//    used to add harmonies in read()
-//---------------------------------------------------------
-
-void FretDiagram::addLoaded(Element* e)
-      {
-      e->setParent(this);
-      if (e->isHarmony()) {
-            _harmony = toHarmony(e);
-            _harmony->setTrack(track());
             }
       else {
             qWarning("FretDiagram: cannot add <%s>\n", e->name());

--- a/libmscore/fret.h
+++ b/libmscore/fret.h
@@ -227,7 +227,6 @@ class FretDiagram final : public Element {
       void init(Ms::StringData*, Chord*);
 
       void add(Element*) override;
-      void addLoaded(Element*);
       void remove(Element*) override;
 
       bool acceptDrop(EditData&) const override;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/306438

The issue was introduced with a fix for
https://musescore.org/en/node/304057,
but the fix was too broad: it eliminated all reset of offset
for harmony objects on fret diagrams.
The original problem was we *always* reset it,
the fix was to *never* reset it.
The right answer is to reset it if styled.
Then manual adjustments are preserved,
but if no manual adjustments are present,
we reset it - which is to say, set is to the style default.