### PR TITLE
fix #306371: wrong input position if last selected cR in voice >1

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2935,10 +2935,18 @@ void ScoreView::startNoteEntry()
                   intersect.translate(-p->x(), -p->y());
                   QList<Element*> el = p->items(intersect);
                   ChordRest* lastSelected = score()->selection().currentCR();
+                  if (lastSelected && lastSelected->voice()) {
+                        // if last selected CR was not in voice 1,
+                        // find CR in voice 1 instead
+                        int track = trackZeroVoice(lastSelected->track());
+                        Segment* s = lastSelected->segment();
+                        if (s)
+                              lastSelected = s->nextChordRest(track, true);
+                        }
                   for (Element* e : el) {
                         // loop through visible elements
                         // looking for the CR in voice 1 with earliest tick and highest staff position
-                        // but stop we find the last selected CR
+                        // but stop if we find the last selected CR
                         ElementType et = e->type();
                         if (et == ElementType::NOTE || et == ElementType::REST) {
                               if (e->voice())


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/306371

When entering note input mode with no selection,
we try to find a good location to start.
Originally this was the top left visible CR of voice 1.
A while ago I added code to favor the last selected CR,
but since we were looking in voice 1 only, we never found it.
Fix here is to check for voice >1 in lastSelected, and if so,
find a CR in voice 0 instead.
Alternative would be to go ahead and start note entry in voice 2,
but to me this felt too surprising given we are talking about a case
where nothing is in fact currently selected.
People generally expect note input to start in voice 1
unless they explicitly selected something in voice 2.
