### PR TITLE
Fix #306333 - Various type of edits change the measure count

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -4530,8 +4530,8 @@ void Score::doLayoutRange(const Fraction& st, const Fraction& et)
                   if (sectionBreak && sectionBreak->startWithMeasureOne())
                         lc.measureNo = 0;
                   else
-                        lc.measureNo = lc.nextMeasure->prevMeasure()->no() + 1; // will be adjusted later with respect
-                                                                                // to the user-defined offset.
+                        lc.measureNo = lc.nextMeasure->prevMeasure()->no()                     // will be adjusted later with respect
+                                       + (lc.nextMeasure->prevMeasure()->irregular() ? 0 : 1); // to the user-defined offset.
                   lc.tick      = lc.nextMeasure->tick();
                   }
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/306333

After a modification, a re-layout is triggered starting at the beginning of the system. The measure number of the first measure of the system is taken adding 1 to the measure number of the last measure of previous system. However it was not taken into account whether that measure was excluded from measure count.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
