### PR TITLE
fix #305613: add heavy, reverse end and heavy double barlines to Inspector

### DIFF
--- a/inspectors/types/barlinetypes.h
+++ b/inspectors/types/barlinetypes.h
@@ -10,13 +10,23 @@ class BarlineTypes
 public:
     enum class LineType {
         TYPE_NORMAL = 1,
+        TYPE_SINGLE= LineType::TYPE_NORMAL,
         TYPE_DOUBLE = 2,
         TYPE_START_REPEAT = 4,
+        TYPE_LEFT_REPEAT = LineType::TYPE_START_REPEAT,
         TYPE_END_REPEAT = 8,
+        TYPE_RIGHT_REPEAT = LineType::TYPE_END_REPEAT,
         TYPE_DASHED = 0x10,
+        TYPE_BROKEN = LineType::TYPE_DASHED,
         TYPE_FINAL = 0x20,
+        TYPE_END = LineType::TYPE_FINAL,
         TYPE_END_START_REPEAT = 0x40,
-        TYPE_DOTTED = 0x80
+        TYPE_LEFT_RIGHT_REPEAT = LineType::TYPE_END_START_REPEAT,
+        TYPE_DOTTED = 0x80,
+        TYPE_REVERSE_END = 0x100,
+        TYPE_REVERS_FINAL = LineType::TYPE_REVERSE_END,
+        TYPE_HEAVY = 0x200,
+        TYPE_DOUBLE_HEAVY = 0x400,
     };
 
     enum class SpanPreset {
@@ -24,7 +34,7 @@ public:
         PRESET_TICK_1,
         PRESET_TICK_2,
         PRESET_SHORT_1,
-        PRESET_SHORT_2
+        PRESET_SHORT_2,
     };
 
     Q_ENUM(LineType)

--- a/inspectors/view/qml/notation/barlines/BarlinePopup.qml
+++ b/inspectors/view/qml/notation/barlines/BarlinePopup.qml
@@ -36,14 +36,17 @@ StyledPopup {
                 valueRoleName: "value"
 
                 model: [
-                    { text: qsTr("Normal"), value: BarlineTypes.TYPE_NORMAL },
-                    { text: qsTr("Double"), value: BarlineTypes.TYPE_DOUBLE },
-                    { text: qsTr("Start repeat"), value: BarlineTypes.TYPE_START_REPEAT },
-                    { text: qsTr("End repeat"), value: BarlineTypes.TYPE_END_REPEAT },
-                    { text: qsTr("Broken"), value: BarlineTypes.TYPE_DASHED },
-                    { text: qsTr("End"), value: BarlineTypes.TYPE_FINAL },
-                    { text: qsTr("End start repeat"), value: BarlineTypes.TYPE_END_START_REPEAT },
-                    { text: qsTr("Dotted"), value: BarlineTypes.TYPE_DOTTED },
+                    { text: qsTranslate("symUserNames", "Single barline"), value: BarlineTypes.TYPE_NORMAL },
+                    { text: qsTranslate("symUserNames", "Double barline"), value: BarlineTypes.TYPE_DOUBLE },
+                    { text: qsTranslate("symUserNames", "Left (start) repeat sign"), value: BarlineTypes.TYPE_START_REPEAT },
+                    { text: qsTranslate("symUserNames", "Right (end) repeat sign"), value: BarlineTypes.TYPE_END_REPEAT },
+                    { text: qsTranslate("symUserNames", "Right and left repeat sign"), value: BarlineTypes.TYPE_END_START_REPEAT },
+                    { text: qsTranslate("symUserNames", "Dashed barline"), value: BarlineTypes.TYPE_DASHED },
+                    { text: qsTranslate("symUserNames", "Final barline"), value: BarlineTypes.TYPE_FINAL },
+                    { text: qsTranslate("symUserNames", "Dotted barline"), value: BarlineTypes.TYPE_DOTTED },
+                    { text: qsTranslate("symUserNames", "Reverse final barline"), value: BarlineTypes.TYPE_REVERSE_END },
+                    { text: qsTranslate("symUserNames", "Heavy barline"), value: BarlineTypes.TYPE_HEAVY },
+                    { text: qsTranslate("symUserNames", "Heavy double barline"), value: BarlineTypes.TYPE_DOUBLE_HEAVY },
                 ]
 
                 currentIndex: root.barlineSettingsModel && !root.barlineSettingsModel.type.isUndefined ? indexOfValue(root.barlineSettingsModel.type.value) : -1


### PR DESCRIPTION
follow up for PR #6119, to adjust to the new QML based Inspector, also:

* Add alterative names to inspector barlinetypes.h to match those from mscore.h.
* Reuse existing translations for barlines in Inspector, same as the Palettes use (Barlines, Repeats & Jumps, Symbols). (I guess we should use that much more throughout the new Inspector)
* Use the same order of barlines in Inspector as in the Palettes.