### PR TITLE
fix #305293: crash on load of score with missing drumset

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -879,8 +879,18 @@ SymId Note::noteHead() const
 
       if (_headGroup == NoteHead::Group::HEAD_CUSTOM) {
             if (st) {
-                  if (st->staffTypeForElement(chord())->isDrumStaff())
-                        return st->part()->instrument(chord()->tick())->drumset()->noteHeads(_pitch, ht);
+                  if (st->staffTypeForElement(chord())->isDrumStaff()) {
+                        Fraction t = chord()->tick();
+                        Instrument* inst = st->part()->instrument(t);
+                        Drumset* d = inst->drumset();
+                        if (d) {
+                              return d->noteHeads(_pitch, ht);
+                              }
+                        else {
+                              qDebug("no drumset");
+                              return noteHead(up, NoteHead::Group::HEAD_NORMAL, ht);
+                              }
+                        }
                   }
             else {
                   return _cachedNoteheadSym;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/305293

We have many crashes with a stack trace showing a bad drumset
when calculating a custom notehead.
I don't know how these scores got into this state
(unless the user deliberately unchecked Drumset in the Mixer),
but I know we can prevent the crash
by returning a default notehead when the drumset is missing.
The drumset will still be missing,
so the user will need to do a change isntrument to set it up again,
but it beats a crash.