### PR TITLE
[MU4] Note input

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -3,6 +3,7 @@
 add_subdirectory(global)
 add_subdirectory(ui)
 add_subdirectory(uicomponents)
+add_subdirectory(actions)
 
 if (BUILD_TELEMETRY_MODULE)
       add_subdirectory(telemetry)

--- a/framework/actions/CMakeLists.txt
+++ b/framework/actions/CMakeLists.txt
@@ -1,0 +1,31 @@
+#=============================================================================
+#  MuseScore
+#  Music Composition & Notation
+#
+#  Copyright (C) 2020 MuseScore BVBA and others
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#=============================================================================
+
+set(MODULE actions)
+
+set(MODULE_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/actionsmodule.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/actionsmodule.h
+    ${CMAKE_CURRENT_LIST_DIR}/iactionsdispatcher.h
+    ${CMAKE_CURRENT_LIST_DIR}/action.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/actionsdispatcher.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/actionsdispatcher.h
+    )
+
+include(${PROJECT_SOURCE_DIR}/build/module.cmake)

--- a/framework/actions/action.h
+++ b/framework/actions/action.h
@@ -1,0 +1,115 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_ACTIONS_ACTION_H
+#define MU_ACTIONS_ACTION_H
+
+#include <functional>
+#include <string>
+#include <vector>
+#include <memory>
+#include <QString>
+
+namespace mu {
+namespace actions {
+using ActionName = std::string;
+
+inline static ActionName namefromQString(const QString& s)
+{
+    return s.toStdString();
+}
+
+struct Action {
+    ActionName name;
+    std::string title;
+
+    bool isValid() const { return !name.empty(); }
+};
+
+class ActionData
+{
+public:
+
+    template<typename T>
+    static ActionData make_arg1(const T& val)
+    {
+        ActionData d;
+        d.setArg<T>(0, val);
+        return d;
+    }
+
+    template<typename T1, typename T2>
+    static ActionData make_arg2(const T1& val1, const T2& val2)
+    {
+        ActionData d;
+        d.setArg<T1>(0, val1);
+        d.setArg<T2>(1, val2);
+        return d;
+    }
+
+    template<typename T1, typename T2, typename T3>
+    static ActionData make_arg3(const T1& val1, const T2& val2, const T3& val3)
+    {
+        ActionData d;
+        d.setArg<T1>(0, val1);
+        d.setArg<T2>(1, val2);
+        d.setArg<T3>(2, val3);
+        return d;
+    }
+
+    template<typename T>
+    void setArg(int i, const T& val)
+    {
+        IArg* p = new Arg<T>(val);
+        m_args.insert(m_args.begin() + i, std::shared_ptr<IArg>(p));
+    }
+
+    template<typename T>
+    T arg(int i = 0) const
+    {
+        IArg* p = m_args.at(i).get();
+        if (!p) {
+            return T();
+        }
+        Arg<T>* d = reinterpret_cast<Arg<T>*>(p);
+        return d->val;
+    }
+
+    int count() const
+    {
+        return m_args.size();
+    }
+
+    struct IArg {
+        virtual ~IArg() = default;
+    };
+
+    template<typename T>
+    struct Arg : public IArg {
+        T val;
+        Arg(const T& v)
+            : IArg(), val(v) {}
+    };
+
+private:
+    std::vector<std::shared_ptr<IArg> > m_args;
+};
+}
+}
+
+#endif // MU_ACTIONS_ACTION_H

--- a/framework/actions/actionsmodule.cpp
+++ b/framework/actions/actionsmodule.cpp
@@ -23,10 +23,6 @@
 
 using namespace mu::actions;
 
-ActionsModule::ActionsModule()
-{
-}
-
 std::string ActionsModule::moduleName() const
 {
     return "actions";

--- a/framework/actions/actionsmodule.cpp
+++ b/framework/actions/actionsmodule.cpp
@@ -16,35 +16,23 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
+#include "actionsmodule.h"
 
-#ifndef MU_FRAMEWORK_LOG_H
-#define MU_FRAMEWORK_LOG_H
+#include "modularity/ioc.h"
+#include "internal/actionsdispatcher.h"
 
-#include <QDebug>
+using namespace mu::actions;
 
-inline QDebug operator<<(QDebug debug, const std::string& s)
+ActionsModule::ActionsModule()
 {
-    debug << s.c_str();
-    return debug;
 }
 
-#define LOGD() qDebug()
-#define LOGI() qInfo()
-#define LOGW() qWarning()
-#define LOGE() qCritical()
+std::string ActionsModule::moduleName() const
+{
+    return "actions";
+}
 
-#define IF_ASSERT_FAILED_X(cond, msg) if (!(cond)) { \
-        LOGE() << "\"ASSERT FAILED!\":" << msg << __FILE__ << __LINE__; \
-        Q_ASSERT(cond); \
-} \
-    if (!(cond)) \
-
-#define IF_ASSERT_FAILED(cond) IF_ASSERT_FAILED_X(cond, #cond)
-
-#define IF_FAILED(cond) if (!(cond)) { \
-        LOGE() << "\"FAILED!\":" << #cond << __FILE__ << __LINE__; \
-} \
-    if (!(cond)) \
-
-
-#endif // MU_FRAMEWORK_LOG_H
+void ActionsModule::registerExports()
+{
+    framework::ioc()->registerExport<IActionsDispatcher>("actions", new ActionsDispatcher());
+}

--- a/framework/actions/actionsmodule.h
+++ b/framework/actions/actionsmodule.h
@@ -16,35 +16,23 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
+#ifndef MU_ACTIONS_ACTIONSMODULE_H
+#define MU_ACTIONS_ACTIONSMODULE_H
 
-#ifndef MU_FRAMEWORK_LOG_H
-#define MU_FRAMEWORK_LOG_H
+#include "modularity/imodulesetup.h"
 
-#include <QDebug>
-
-inline QDebug operator<<(QDebug debug, const std::string& s)
+namespace mu {
+namespace actions {
+class ActionsModule : public framework::IModuleSetup
 {
-    debug << s.c_str();
-    return debug;
+public:
+    ActionsModule();
+
+    std::string moduleName() const override;
+
+    void registerExports() override;
+};
+}
 }
 
-#define LOGD() qDebug()
-#define LOGI() qInfo()
-#define LOGW() qWarning()
-#define LOGE() qCritical()
-
-#define IF_ASSERT_FAILED_X(cond, msg) if (!(cond)) { \
-        LOGE() << "\"ASSERT FAILED!\":" << msg << __FILE__ << __LINE__; \
-        Q_ASSERT(cond); \
-} \
-    if (!(cond)) \
-
-#define IF_ASSERT_FAILED(cond) IF_ASSERT_FAILED_X(cond, #cond)
-
-#define IF_FAILED(cond) if (!(cond)) { \
-        LOGE() << "\"FAILED!\":" << #cond << __FILE__ << __LINE__; \
-} \
-    if (!(cond)) \
-
-
-#endif // MU_FRAMEWORK_LOG_H
+#endif // MU_ACTIONS_ACTIONSMODULE_H

--- a/framework/actions/actionsmodule.h
+++ b/framework/actions/actionsmodule.h
@@ -26,10 +26,8 @@ namespace actions {
 class ActionsModule : public framework::IModuleSetup
 {
 public:
-    ActionsModule();
 
     std::string moduleName() const override;
-
     void registerExports() override;
 };
 }

--- a/framework/actions/iactionsdispatcher.h
+++ b/framework/actions/iactionsdispatcher.h
@@ -31,20 +31,20 @@ class IActionsDispatcher : MODULE_EXPORT_INTERFACE
 public:
     ~IActionsDispatcher() = default;
 
-    using ActionCallBack1 = std::function<void ()>;
-    using ActionCallBack2 = std::function<void (const ActionName&)>;
-    using ActionCallBack3 = std::function<void (const ActionName&, const ActionData& data)>;
+    using ActionCallBack = std::function<void ()>;
+    using ActionCallBackWithName = std::function<void (const ActionName&)>;
+    using ActionCallBackWithNameAndData = std::function<void (const ActionName&, const ActionData& data)>;
 
     virtual void dispatch(const ActionName& a) = 0;
     virtual void dispatch(const ActionName& a, const ActionData& data) = 0;
-    virtual void reg(const ActionName& action, const ActionCallBack3& call) = 0;
+    virtual void reg(const ActionName& action, const ActionCallBackWithNameAndData& call) = 0;
 
-    void reg(const ActionName& action, const ActionCallBack1& call)
+    void reg(const ActionName& action, const ActionCallBack& call)
     {
         reg(action, [call](const ActionName&, const ActionData&) { call(); });
     }
 
-    void reg(const ActionName& action, const ActionCallBack2& call)
+    void reg(const ActionName& action, const ActionCallBackWithName& call)
     {
         reg(action, [call](const ActionName& action, const ActionData&) { call(action); });
     }

--- a/framework/actions/internal/actionsdispatcher.cpp
+++ b/framework/actions/internal/actionsdispatcher.cpp
@@ -1,0 +1,71 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "actionsdispatcher.h"
+#include "log.h"
+
+using namespace mu::actions;
+
+ActionsDispatcher::ActionsDispatcher()
+{
+}
+
+void ActionsDispatcher::dispatch(const ActionName& action)
+{
+    auto it = m_callbacks.find(action);
+    if (it == m_callbacks.end()) {
+        LOGW() << "not registred action: " << action;
+        return;
+    }
+
+    ActionCallBack3& callback = it->second;
+    LOGI() << "try call action: " << action;
+
+    static ActionData dummy;
+    callback(action, dummy);
+}
+
+void ActionsDispatcher::dispatch(const ActionName& action, const ActionData& data)
+{
+    auto it = m_callbacks.find(action);
+    if (it == m_callbacks.end()) {
+        LOGW() << "not registred action: " << action;
+        return;
+    }
+
+    ActionCallBack3& callback = it->second;
+    LOGI() << "try call action: " << action;
+    callback(action, data);
+}
+
+bool ActionsDispatcher::isRegistred(const ActionName& action) const
+{
+    auto it = m_callbacks.find(action);
+    if (it != m_callbacks.end()) {
+        return true;
+    }
+    return false;
+}
+
+void ActionsDispatcher::reg(const ActionName& action, const ActionCallBack3& call)
+{
+    IF_ASSERT_FAILED_X(!isRegistred(action), std::string("already registred action: ") + action) {
+        return;
+    }
+    m_callbacks.insert({ action, call });
+}

--- a/framework/actions/internal/actionsdispatcher.cpp
+++ b/framework/actions/internal/actionsdispatcher.cpp
@@ -33,7 +33,7 @@ void ActionsDispatcher::dispatch(const ActionName& action)
         return;
     }
 
-    ActionCallBack3& callback = it->second;
+    ActionCallBackWithNameAndData& callback = it->second;
     LOGI() << "try call action: " << action;
 
     static ActionData dummy;
@@ -48,7 +48,7 @@ void ActionsDispatcher::dispatch(const ActionName& action, const ActionData& dat
         return;
     }
 
-    ActionCallBack3& callback = it->second;
+    ActionCallBackWithNameAndData& callback = it->second;
     LOGI() << "try call action: " << action;
     callback(action, data);
 }
@@ -62,7 +62,7 @@ bool ActionsDispatcher::isRegistred(const ActionName& action) const
     return false;
 }
 
-void ActionsDispatcher::reg(const ActionName& action, const ActionCallBack3& call)
+void ActionsDispatcher::reg(const ActionName& action, const ActionCallBackWithNameAndData& call)
 {
     IF_ASSERT_FAILED_X(!isRegistred(action), std::string("already registred action: ") + action) {
         return;

--- a/framework/actions/internal/actionsdispatcher.h
+++ b/framework/actions/internal/actionsdispatcher.h
@@ -33,13 +33,13 @@ public:
     void dispatch(const ActionName& a) override;
     void dispatch(const ActionName& action, const ActionData& data) override;
 
-    void reg(const ActionName& action, const ActionCallBack3& call) override;
+    void reg(const ActionName& action, const ActionCallBackWithNameAndData& call) override;
 
 private:
 
     bool isRegistred(const ActionName& action) const;
 
-    std::map<ActionName, ActionCallBack3> m_callbacks;
+    std::map<ActionName, ActionCallBackWithNameAndData> m_callbacks;
 };
 }
 }

--- a/framework/actions/internal/actionsdispatcher.h
+++ b/framework/actions/internal/actionsdispatcher.h
@@ -16,35 +16,32 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
+#ifndef MU_ACTIONS_ACTIONSDISPATCHER_H
+#define MU_ACTIONS_ACTIONSDISPATCHER_H
 
-#ifndef MU_FRAMEWORK_LOG_H
-#define MU_FRAMEWORK_LOG_H
+#include <map>
 
-#include <QDebug>
+#include "../iactionsdispatcher.h"
 
-inline QDebug operator<<(QDebug debug, const std::string& s)
+namespace mu {
+namespace actions {
+class ActionsDispatcher : public IActionsDispatcher
 {
-    debug << s.c_str();
-    return debug;
+public:
+    ActionsDispatcher();
+
+    void dispatch(const ActionName& a) override;
+    void dispatch(const ActionName& action, const ActionData& data) override;
+
+    void reg(const ActionName& action, const ActionCallBack3& call) override;
+
+private:
+
+    bool isRegistred(const ActionName& action) const;
+
+    std::map<ActionName, ActionCallBack3> m_callbacks;
+};
+}
 }
 
-#define LOGD() qDebug()
-#define LOGI() qInfo()
-#define LOGW() qWarning()
-#define LOGE() qCritical()
-
-#define IF_ASSERT_FAILED_X(cond, msg) if (!(cond)) { \
-        LOGE() << "\"ASSERT FAILED!\":" << msg << __FILE__ << __LINE__; \
-        Q_ASSERT(cond); \
-} \
-    if (!(cond)) \
-
-#define IF_ASSERT_FAILED(cond) IF_ASSERT_FAILED_X(cond, #cond)
-
-#define IF_FAILED(cond) if (!(cond)) { \
-        LOGE() << "\"FAILED!\":" << #cond << __FILE__ << __LINE__; \
-} \
-    if (!(cond)) \
-
-
-#endif // MU_FRAMEWORK_LOG_H
+#endif // MU_ACTIONS_ACTIONSDISPATCHER_H

--- a/framework/global/CMakeLists.txt
+++ b/framework/global/CMakeLists.txt
@@ -20,9 +20,11 @@
 set(MODULE global)
 
 include(${CMAKE_CURRENT_LIST_DIR}/modularity/modularity.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/async/async.cmake)
 
 set(MODULE_SRC
     ${MODULARITY_SRC}
+    ${ASYNC_SRC}
     ${CMAKE_CURRENT_LIST_DIR}/log.h
     ${CMAKE_CURRENT_LIST_DIR}/dataformatter.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dataformatter.h

--- a/framework/global/async/async.cmake
+++ b/framework/global/async/async.cmake
@@ -5,5 +5,6 @@ include(${PROJECT_SOURCE_DIR}/thirdparty/deto_async/async/async.cmake)
 set(ASYNC_SRC
     ${ASYNC_SRC}
     ${CMAKE_CURRENT_LIST_DIR}/asyncable.h
-    ${CMAKE_CURRENT_LIST_DIR}/notify.h
+    ${CMAKE_CURRENT_LIST_DIR}/notification.h
+    ${CMAKE_CURRENT_LIST_DIR}/channel.h
     )

--- a/framework/global/async/async.cmake
+++ b/framework/global/async/async.cmake
@@ -1,0 +1,9 @@
+
+
+include(${PROJECT_SOURCE_DIR}/thirdparty/deto_async/async/async.cmake)
+
+set(ASYNC_SRC
+    ${ASYNC_SRC}
+    ${CMAKE_CURRENT_LIST_DIR}/asyncable.h
+    ${CMAKE_CURRENT_LIST_DIR}/notify.h
+    )

--- a/framework/global/async/asyncable.h
+++ b/framework/global/async/asyncable.h
@@ -1,0 +1,29 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_ASYNC_ASYNCABLE_H
+#define MU_ASYNC_ASYNCABLE_H
+
+#include "thirdparty/deto_async/async/asyncable.h"
+namespace mu {
+namespace async {
+using Asyncable = deto::async::Asyncable;
+}
+}
+
+#endif // MU_ASYNC_ASYNCABLE_H

--- a/framework/global/async/channel.h
+++ b/framework/global/async/channel.h
@@ -1,0 +1,29 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_ASYNC_CHANNEL_H
+#define MU_ASYNC_CHANNEL_H
+
+#include "thirdparty/deto_async/async/channel.h"
+namespace mu {
+namespace async {
+using Channel = deto::async::Channel;
+}
+}
+
+#endif // MU_ASYNC_CHANNEL_H

--- a/framework/global/async/notification.h
+++ b/framework/global/async/notification.h
@@ -19,10 +19,10 @@
 #ifndef MU_ASYNC_NOTIFY_H
 #define MU_ASYNC_NOTIFY_H
 
-#include "thirdparty/deto_async/async/notify.h"
+#include "thirdparty/deto_async/async/notification.h"
 namespace mu {
 namespace async {
-using Notify = deto::async::Notify;
+using Notification = deto::async::Notification;
 }
 }
 

--- a/framework/global/async/notify.h
+++ b/framework/global/async/notify.h
@@ -1,0 +1,29 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_ASYNC_NOTIFY_H
+#define MU_ASYNC_NOTIFY_H
+
+#include "thirdparty/deto_async/async/notify.h"
+namespace mu {
+namespace async {
+using Notify = deto::async::Notify;
+}
+}
+
+#endif // MU_ASYNC_NOTIFY_H

--- a/libmscore/mscoreview.h
+++ b/libmscore/mscoreview.h
@@ -34,7 +34,7 @@ protected:
     Score* _score;
 
 public:
-    MuseScoreView() {}
+    virtual ~MuseScoreView() = default;
     Page* point2page(const QPointF&);
     Element* elementAt(const QPointF& p);
     const QList<Element*> elementsAt(const QPointF&);

--- a/libmscore/musescoreCore.h
+++ b/libmscore/musescoreCore.h
@@ -30,6 +30,7 @@ protected:
 public:
     static MuseScoreCore* mscoreCore;
     MuseScoreCore() { mscoreCore = this; }
+    virtual ~MuseScoreCore() = default;
     Score* currentScore() const { return cs; }
     void setCurrentScore(Score* score) { cs = score; }
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -28,6 +28,14 @@
 #include "layoutbreak.h"
 #include "property.h"
 
+namespace mu {
+namespace domain {
+namespace notation {
+class Notation;
+}
+}
+}
+
 namespace Ms {
 namespace Avs {
 class AvsOmr;
@@ -500,6 +508,8 @@ private:
     QString accInfo;                      ///< information used by the screen-reader
 
     //------------------
+
+    friend class mu::domain::notation::Notation;
 
     ChordRest* nextMeasure(ChordRest* element, bool selectBehavior = false, bool mmRest = false);
     ChordRest* prevMeasure(ChordRest* element, bool mmRest = false);

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -81,6 +81,7 @@ target_include_directories(mscore PRIVATE
 set(LINK_LIB mscoreapp global global_old ui uicomponents)
 if (BUILD_UI_MU4)
     set(LINK_LIB ${LINK_LIB}
+        actions
         appshell
         scores
         extensions

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -83,6 +83,7 @@ if (BUILD_UI_MU4)
     set(LINK_LIB ${LINK_LIB}
         actions
         appshell
+        context
         scores
         extensions
         notation

--- a/main/modulessetup.cpp
+++ b/main/modulessetup.cpp
@@ -24,6 +24,7 @@
 #include "framework/uicomponents/uicomponentsmodule.h"
 #include "framework/actions/actionsmodule.h"
 #include "mu4/appshell/appshellmodule.h"
+#include "mu4/context/contextmodule.h"
 #include "mu4/scores/scoresmodule.h"
 #include "mu4/extensions/extensionsmodule.h"
 #include "mu4/domain/notation/notationdomainmodule.h"
@@ -51,6 +52,7 @@ ModulesSetup::ModulesSetup()
         << new mu::framework::UiComponentsModule()
         << new mu::actions::ActionsModule()
         << new mu::appshell::AppShellModule()
+        << new mu::context::ContextModule()
         << new mu::scores::ScoresModule()
         << new mu::extensions::ExtensionsModule()
         << new mu::domain::notation::NotationDomainModule()

--- a/main/modulessetup.cpp
+++ b/main/modulessetup.cpp
@@ -22,6 +22,7 @@
 
 #include "framework/ui/uimodule.h"
 #include "framework/uicomponents/uicomponentsmodule.h"
+#include "framework/actions/actionsmodule.h"
 #include "mu4/appshell/appshellmodule.h"
 #include "mu4/scores/scoresmodule.h"
 #include "mu4/extensions/extensionsmodule.h"
@@ -48,6 +49,7 @@ ModulesSetup::ModulesSetup()
 #ifdef BUILD_UI_MU4
         << new mu::framework::UiModule()
         << new mu::framework::UiComponentsModule()
+        << new mu::actions::ActionsModule()
         << new mu::appshell::AppShellModule()
         << new mu::scores::ScoresModule()
         << new mu::extensions::ExtensionsModule()

--- a/mu4/CMakeLists.txt
+++ b/mu4/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 
 add_subdirectory(appshell)
+add_subdirectory(context)
 
 # Domain
 add_subdirectory(domain/notation)

--- a/mu4/appshell/qml/NotationPage/NotationPage.qml
+++ b/mu4/appshell/qml/NotationPage/NotationPage.qml
@@ -10,20 +10,6 @@ DockPage {
 
     property var color: ui.theme.window
 
-    //! NOTE Temporary solution
-    QtObject {
-        id: observer
-
-        property var _callbacks: ({})
-        function register(target, callback) {
-            _callbacks[target] = callback;
-        }
-
-        function call(target, cmd) {
-            _callbacks[target](cmd)
-        }
-    }
-
     toolbar: DockToolBar {
         id: notationToolBar
         objectName: "notationToolBar"
@@ -33,7 +19,7 @@ DockPage {
         color: notationPage.color
 
         NotationToolBar {
-            onClicked: observer.call("view", cmd)
+            color: notationToolBar.color
         }
     }
 
@@ -88,10 +74,6 @@ DockPage {
 
         NotationView {
             id: notationView
-
-            Component.onCompleted: {
-                observer.register("view", notationView.cmd)
-            }
         }
     }
 

--- a/mu4/appshell/qml/NotationPage/NotationToolBar.qml
+++ b/mu4/appshell/qml/NotationPage/NotationToolBar.qml
@@ -1,18 +1,30 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import MuseScore.NotationScene 1.0
 
-ToolBar {
+Rectangle {
     id: root
 
-    signal clicked(string cmd)
-
-    RowLayout {
+    Row {
         anchors.fill: parent
 
-        ToolButton {
-            text: "Open"
-            onClicked: root.clicked("open")
+        Repeater {
+            anchors.fill: parent
+            model: toolModel
+            delegate: ToolButton {
+                text: titleRole
+                enabled: enabledRole
+                down: checkedRole
+                onClicked: toolModel.click(nameRole)
+            }
         }
+    }
+
+    NotationToolBarModel {
+        id: toolModel
+    }
+
+    Component.onCompleted: {
+        toolModel.load()
     }
 }

--- a/mu4/context/CMakeLists.txt
+++ b/mu4/context/CMakeLists.txt
@@ -1,0 +1,32 @@
+#=============================================================================
+#  MuseScore
+#  Music Composition & Notation
+#
+#  Copyright (C) 2020 MuseScore BVBA and others
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#=============================================================================
+
+# This module stores global state
+set(MODULE context)
+
+set(MODULE_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/contextmodule.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/contextmodule.h
+    ${CMAKE_CURRENT_LIST_DIR}/iglobalcontext.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/globalcontext.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/globalcontext.h
+    )
+
+include(${PROJECT_SOURCE_DIR}/build/module.cmake)
+

--- a/mu4/context/contextmodule.cpp
+++ b/mu4/context/contextmodule.cpp
@@ -1,0 +1,34 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "contextmodule.h"
+
+#include "modularity/ioc.h"
+#include "internal/globalcontext.h"
+
+using namespace mu::context;
+
+std::string ContextModule::moduleName() const
+{
+    return "context";
+}
+
+void ContextModule::registerExports()
+{
+    framework::ioc()->registerExport<IGlobalContext>("context", new GlobalContext());
+}

--- a/mu4/context/contextmodule.h
+++ b/mu4/context/contextmodule.h
@@ -1,0 +1,36 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_CONTEXT_CONTEXTMODULE_H
+#define MU_CONTEXT_CONTEXTMODULE_H
+
+#include "modularity/imodulesetup.h"
+
+namespace mu {
+namespace context {
+class ContextModule : public framework::IModuleSetup
+{
+public:
+
+    std::string moduleName() const override;
+    void registerExports() override;
+};
+}
+}
+
+#endif // MU_CONTEXT_CONTEXTMODULE_H

--- a/mu4/context/iglobalcontext.h
+++ b/mu4/context/iglobalcontext.h
@@ -21,7 +21,7 @@
 
 #include "modularity/imoduleexport.h"
 #include "domain/notation/inotation.h"
-#include "async/notify.h"
+#include "async/notification.h"
 
 namespace mu {
 namespace context {
@@ -34,7 +34,7 @@ public:
 
     virtual void setCurrentNotation(const std::shared_ptr<domain::notation::INotation>& notation) = 0;
     virtual std::shared_ptr<domain::notation::INotation> currentNotation() const = 0;
-    virtual async::Notify currentNotationChanged() const = 0;
+    virtual async::Notification currentNotationChanged() const = 0;
 };
 }
 }

--- a/mu4/context/iglobalcontext.h
+++ b/mu4/context/iglobalcontext.h
@@ -20,7 +20,7 @@
 #define MU_CONTEXT_IGLOBALCONTEXT_H
 
 #include "modularity/imoduleexport.h"
-#include "domain/notation/interfaces/inotation.h"
+#include "domain/notation/inotation.h"
 #include "async/notify.h"
 
 namespace mu {

--- a/mu4/context/iglobalcontext.h
+++ b/mu4/context/iglobalcontext.h
@@ -1,0 +1,42 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_CONTEXT_IGLOBALCONTEXT_H
+#define MU_CONTEXT_IGLOBALCONTEXT_H
+
+#include "modularity/imoduleexport.h"
+#include "domain/notation/interfaces/inotation.h"
+#include "async/notify.h"
+
+namespace mu {
+namespace context {
+class IGlobalContext : MODULE_EXPORT_INTERFACE
+{
+    INTERFACE_ID(mu::context::IGlobalContext)
+
+public:
+    ~IGlobalContext() = default;
+
+    virtual void setCurrentNotation(const std::shared_ptr<domain::notation::INotation>& notation) = 0;
+    virtual std::shared_ptr<domain::notation::INotation> currentNotation() const = 0;
+    virtual async::Notify currentNotationChanged() const = 0;
+};
+}
+}
+
+#endif // MU_CONTEXT_IGLOBALCONTEXT_H

--- a/mu4/context/internal/globalcontext.cpp
+++ b/mu4/context/internal/globalcontext.cpp
@@ -1,0 +1,38 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "globalcontext.h"
+
+using namespace mu::context;
+using namespace mu::domain::notation;
+
+void GlobalContext::setCurrentNotation(const std::shared_ptr<domain::notation::INotation>& notation)
+{
+    m_notation = notation;
+    m_notationChanged.notify();
+}
+
+std::shared_ptr<INotation> GlobalContext::currentNotation() const
+{
+    return m_notation;
+}
+
+mu::async::Notify GlobalContext::currentNotationChanged() const
+{
+    return m_notationChanged;
+}

--- a/mu4/context/internal/globalcontext.cpp
+++ b/mu4/context/internal/globalcontext.cpp
@@ -32,7 +32,7 @@ std::shared_ptr<INotation> GlobalContext::currentNotation() const
     return m_notation;
 }
 
-mu::async::Notify GlobalContext::currentNotationChanged() const
+mu::async::Notification GlobalContext::currentNotationChanged() const
 {
     return m_notationChanged;
 }

--- a/mu4/context/internal/globalcontext.h
+++ b/mu4/context/internal/globalcontext.h
@@ -1,0 +1,44 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_CONTEXT_GLOBALCONTEXT_H
+#define MU_CONTEXT_GLOBALCONTEXT_H
+
+#include <map>
+#include "../iglobalcontext.h"
+
+namespace mu {
+namespace context {
+class GlobalContext : public IGlobalContext
+{
+public:
+    GlobalContext() = default;
+
+    void setCurrentNotation(const std::shared_ptr<domain::notation::INotation>& notation) override;
+    std::shared_ptr<domain::notation::INotation> currentNotation() const override;
+    async::Notify currentNotationChanged() const override;
+
+private:
+
+    std::shared_ptr<domain::notation::INotation> m_notation;
+    async::Notify m_notationChanged;
+};
+}
+}
+
+#endif // MU_CONTEXT_GLOBALCONTEXT_H

--- a/mu4/context/internal/globalcontext.h
+++ b/mu4/context/internal/globalcontext.h
@@ -31,12 +31,12 @@ public:
 
     void setCurrentNotation(const std::shared_ptr<domain::notation::INotation>& notation) override;
     std::shared_ptr<domain::notation::INotation> currentNotation() const override;
-    async::Notify currentNotationChanged() const override;
+    async::Notification currentNotationChanged() const override;
 
 private:
 
     std::shared_ptr<domain::notation::INotation> m_notation;
-    async::Notify m_notationChanged;
+    async::Notification m_notationChanged;
 };
 }
 }

--- a/mu4/domain/notation/CMakeLists.txt
+++ b/mu4/domain/notation/CMakeLists.txt
@@ -24,12 +24,29 @@ find_package(Qt5 COMPONENTS Svg REQUIRED)
 set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/notationdomainmodule.cpp
     ${CMAKE_CURRENT_LIST_DIR}/notationdomainmodule.h
-    ${CMAKE_CURRENT_LIST_DIR}/interfaces/inotation.h
-    ${CMAKE_CURRENT_LIST_DIR}/interfaces/inotationcreator.h
-    ${CMAKE_CURRENT_LIST_DIR}/notation.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/notation.h
-    ${CMAKE_CURRENT_LIST_DIR}/notationcreator.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/notationcreator.h
+    ${CMAKE_CURRENT_LIST_DIR}/inotation.h
+    ${CMAKE_CURRENT_LIST_DIR}/inotationcreator.h
+    ${CMAKE_CURRENT_LIST_DIR}/inotationinputstate.h
+    ${CMAKE_CURRENT_LIST_DIR}/inotationselection.h
+    ${CMAKE_CURRENT_LIST_DIR}/inotationinputcontroller.h
+    ${CMAKE_CURRENT_LIST_DIR}/notationtypes.h
+    ${CMAKE_CURRENT_LIST_DIR}/notationactions.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/notationactions.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/notation.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/notation.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/notationcreator.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/notationcreator.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/scorecallbacks.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/scorecallbacks.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/notationinputstate.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/notationinputstate.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/notationselection.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/notationselection.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/notationactioncontroller.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/notationactioncontroller.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/igetscore.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/notationinputcontroller.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/notationinputcontroller.h
     )
 
 set(MODULE_LINK

--- a/mu4/domain/notation/inotation.h
+++ b/mu4/domain/notation/inotation.h
@@ -1,0 +1,76 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FIT-0NESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_DOMAIN_INOTATION_H
+#define MU_DOMAIN_INOTATION_H
+
+#include <QRect>
+#include <string>
+
+#include "modularity/imoduleexport.h"
+#include "actions/action.h"
+#include "async/notify.h"
+#include "inotationinputstate.h"
+#include "inotationselection.h"
+#include "inotationinputcontroller.h"
+#include "notationtypes.h"
+
+class QPainter;
+namespace mu {
+namespace domain {
+namespace notation {
+class INotation : MODULE_EXPORT_INTERFACE
+{
+    INTERFACE_ID(mu::domain::notation::INotation)
+
+public:
+    ~INotation() = default;
+
+    virtual bool load(const std::string& path) = 0;
+    virtual void setViewSize(const QSizeF& vs) = 0;
+    virtual void paint(QPainter* p, const QRect& r) = 0;
+
+    // Edit
+    virtual INotationInputState* inputState() const = 0;
+    virtual void startNoteEntry() = 0;
+    virtual void endNoteEntry() = 0;
+    virtual void padNote(const Pad& pad) = 0;
+    virtual void putNote(const QPointF& pos, bool replace, bool insert) = 0;
+
+    // shadow note
+    virtual void showShadowNote(const QPointF& p) = 0;
+    virtual void hideShadowNote() = 0;
+    virtual void paintShadowNote(QPainter* p) = 0;
+
+    // Select
+    virtual INotationSelection* selection() const = 0;
+    virtual void select(Element* e, SelectType type, int staffIdx = 0) = 0;
+
+    // Input (mouse)
+    virtual INotationInputController* inputController() const = 0;
+
+    // notify
+    virtual async::Notify notationChanged() const = 0;
+    virtual async::Notify inputStateChanged() const = 0;
+    virtual async::Notify selectionChanged() const = 0;
+};
+}
+}
+}
+
+#endif // MU_DOMAIN_INOTATION_H

--- a/mu4/domain/notation/inotation.h
+++ b/mu4/domain/notation/inotation.h
@@ -24,7 +24,7 @@
 
 #include "modularity/imoduleexport.h"
 #include "actions/action.h"
-#include "async/notify.h"
+#include "async/notification.h"
 #include "inotationinputstate.h"
 #include "inotationselection.h"
 #include "inotationinputcontroller.h"
@@ -65,9 +65,9 @@ public:
     virtual INotationInputController* inputController() const = 0;
 
     // notify
-    virtual async::Notify notationChanged() const = 0;
-    virtual async::Notify inputStateChanged() const = 0;
-    virtual async::Notify selectionChanged() const = 0;
+    virtual async::Notification notationChanged() const = 0;
+    virtual async::Notification inputStateChanged() const = 0;
+    virtual async::Notification selectionChanged() const = 0;
 };
 }
 }

--- a/mu4/domain/notation/inotationcreator.h
+++ b/mu4/domain/notation/inotationcreator.h
@@ -16,27 +16,27 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#include "notationdomainmodule.h"
+#ifndef MU_DOMAIN_INOTATIONCREATOR_H
+#define MU_DOMAIN_INOTATIONCREATOR_H
 
-#include "modularity/ioc.h"
-#include "internal/notationcreator.h"
-#include "internal/notation.h"
-#include "internal/notationactioncontroller.h"
+#include <memory>
+#include "inotation.h"
+#include "modularity/imoduleexport.h"
 
-using namespace mu::domain::notation;
-
-std::string NotationDomainModule::moduleName() const
+namespace mu {
+namespace domain {
+namespace notation {
+class INotationCreator : MODULE_EXPORT_INTERFACE
 {
-    return "notation";
+    INTERFACE_ID(mu::domain::notation::INotationCreator)
+
+public:
+    ~INotationCreator() = default;
+
+    virtual std::shared_ptr<INotation> newNotation() = 0;
+};
+}
+}
 }
 
-void NotationDomainModule::registerExports()
-{
-    framework::ioc()->registerExport<INotationCreator>(moduleName(), new NotationCreator());
-}
-
-void NotationDomainModule::onInit()
-{
-    Notation::init();
-    NotationActionController::instance(); //! NOTE Only need to create
-}
+#endif // MU_DOMAIN_INOTATIONCREATOR_H

--- a/mu4/domain/notation/inotationinputcontroller.h
+++ b/mu4/domain/notation/inotationinputcontroller.h
@@ -16,27 +16,24 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#include "notationdomainmodule.h"
+#ifndef MU_DOMAIN_INOTATIONINPUTCONTROLLER_H
+#define MU_DOMAIN_INOTATIONINPUTCONTROLLER_H
 
-#include "modularity/ioc.h"
-#include "internal/notationcreator.h"
-#include "internal/notation.h"
-#include "internal/notationactioncontroller.h"
+#include <QPointF>
+#include "notationtypes.h"
 
-using namespace mu::domain::notation;
-
-std::string NotationDomainModule::moduleName() const
+namespace mu {
+namespace domain {
+namespace notation {
+class INotationInputController
 {
-    return "notation";
+public:
+    virtual ~INotationInputController() = default;
+
+    virtual Element* hitElement(const QPointF& pos, float width) const = 0;
+};
+}
+}
 }
 
-void NotationDomainModule::registerExports()
-{
-    framework::ioc()->registerExport<INotationCreator>(moduleName(), new NotationCreator());
-}
-
-void NotationDomainModule::onInit()
-{
-    Notation::init();
-    NotationActionController::instance(); //! NOTE Only need to create
-}
+#endif // MU_DOMAIN_INOTATIONINPUTCONTROLLER_H

--- a/mu4/domain/notation/inotationinputstate.h
+++ b/mu4/domain/notation/inotationinputstate.h
@@ -16,27 +16,25 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#include "notationdomainmodule.h"
+#ifndef MU_DOMAIN_INOTATIONINPUTSTATE_H
+#define MU_DOMAIN_INOTATIONINPUTSTATE_H
 
-#include "modularity/ioc.h"
-#include "internal/notationcreator.h"
-#include "internal/notation.h"
-#include "internal/notationactioncontroller.h"
+#include "async/notify.h"
+#include "notationtypes.h"
 
-using namespace mu::domain::notation;
-
-std::string NotationDomainModule::moduleName() const
+namespace mu {
+namespace domain {
+namespace notation {
+class INotationInputState
 {
-    return "notation";
+public:
+    virtual ~INotationInputState() = default;
+
+    virtual bool isNoteEnterMode() const = 0;
+    virtual DurationType duration() const = 0;
+};
+}
+}
 }
 
-void NotationDomainModule::registerExports()
-{
-    framework::ioc()->registerExport<INotationCreator>(moduleName(), new NotationCreator());
-}
-
-void NotationDomainModule::onInit()
-{
-    Notation::init();
-    NotationActionController::instance(); //! NOTE Only need to create
-}
+#endif // MU_DOMAIN_INOTATIONINPUTSTATE_H

--- a/mu4/domain/notation/inotationinputstate.h
+++ b/mu4/domain/notation/inotationinputstate.h
@@ -19,7 +19,7 @@
 #ifndef MU_DOMAIN_INOTATIONINPUTSTATE_H
 #define MU_DOMAIN_INOTATIONINPUTSTATE_H
 
-#include "async/notify.h"
+#include "async/notification.h"
 #include "notationtypes.h"
 
 namespace mu {

--- a/mu4/domain/notation/inotationselection.h
+++ b/mu4/domain/notation/inotationselection.h
@@ -16,27 +16,26 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#include "notationdomainmodule.h"
+#ifndef MU_DOMAIN_INOTATIONSELECTION_H
+#define MU_DOMAIN_INOTATIONSELECTION_H
 
-#include "modularity/ioc.h"
-#include "internal/notationcreator.h"
-#include "internal/notation.h"
-#include "internal/notationactioncontroller.h"
+#include <QRectF>
+#include "async/notify.h"
 
-using namespace mu::domain::notation;
-
-std::string NotationDomainModule::moduleName() const
+namespace mu {
+namespace domain {
+namespace notation {
+class INotationSelection
 {
-    return "notation";
+public:
+    virtual ~INotationSelection() = default;
+
+    virtual bool isNone() const = 0;
+
+    virtual QRectF canvasBoundingRect() const = 0;
+};
+}
+}
 }
 
-void NotationDomainModule::registerExports()
-{
-    framework::ioc()->registerExport<INotationCreator>(moduleName(), new NotationCreator());
-}
-
-void NotationDomainModule::onInit()
-{
-    Notation::init();
-    NotationActionController::instance(); //! NOTE Only need to create
-}
+#endif // MU_DOMAIN_INOTATIONSELECTION_H

--- a/mu4/domain/notation/internal/igetscore.h
+++ b/mu4/domain/notation/internal/igetscore.h
@@ -16,27 +16,25 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#include "notationdomainmodule.h"
+#ifndef MU_DOMAIN_IGETSCORE_H
+#define MU_DOMAIN_IGETSCORE_H
 
-#include "modularity/ioc.h"
-#include "internal/notationcreator.h"
-#include "internal/notation.h"
-#include "internal/notationactioncontroller.h"
-
-using namespace mu::domain::notation;
-
-std::string NotationDomainModule::moduleName() const
-{
-    return "notation";
+namespace Ms {
+class Score;
 }
 
-void NotationDomainModule::registerExports()
+namespace mu {
+namespace domain {
+namespace notation {
+class IGetScore
 {
-    framework::ioc()->registerExport<INotationCreator>(moduleName(), new NotationCreator());
+public:
+    virtual ~IGetScore() = default;
+
+    virtual Ms::Score* score() const = 0;
+};
+}
+}
 }
 
-void NotationDomainModule::onInit()
-{
-    Notation::init();
-    NotationActionController::instance(); //! NOTE Only need to create
-}
+#endif // MU_DOMAIN_IGETSCORE_H

--- a/mu4/domain/notation/internal/notation.cpp
+++ b/mu4/domain/notation/internal/notation.cpp
@@ -337,17 +337,17 @@ void Notation::putNote(const QPointF& pos, bool replace, bool insert)
     m_notationChanged.notify();
 }
 
-mu::async::Notify Notation::notationChanged() const
+mu::async::Notification Notation::notationChanged() const
 {
     return m_notationChanged;
 }
 
-mu::async::Notify Notation::inputStateChanged() const
+mu::async::Notification Notation::inputStateChanged() const
 {
     return m_inputStateChanged;
 }
 
-mu::async::Notify Notation::selectionChanged() const
+mu::async::Notification Notation::selectionChanged() const
 {
     return m_selectionChanged;
 }

--- a/mu4/domain/notation/internal/notation.cpp
+++ b/mu4/domain/notation/internal/notation.cpp
@@ -1,0 +1,451 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "notation.h"
+
+#include <QPointF>
+#include <QPainter>
+
+#include "config.h"
+#include "libmscore/score.h"
+#include "libmscore/page.h"
+#include "libmscore/shadownote.h"
+#include "libmscore/staff.h"
+#include "libmscore/measure.h"
+#include "libmscore/part.h"
+#include "libmscore/drumset.h"
+#include "libmscore/rest.h"
+#include "libmscore/slur.h"
+#include "libmscore/system.h"
+#include "libmscore/chord.h"
+
+#include "scorecallbacks.h"
+
+#ifdef BUILD_UI_MU4
+//! HACK Temporary hack to link libmscore
+Q_LOGGING_CATEGORY(undoRedo, "undoRedo", QtCriticalMsg)
+
+namespace Ms {
+QString revision;
+MasterSynthesizer* synti;
+QString dataPath;
+QString mscoreGlobalShare;
+}
+//! ---------
+#endif
+
+using namespace mu::domain::notation;
+using namespace Ms;
+
+Notation::Notation()
+{
+    m_scoreGlobal = new MScore(); //! TODO May be static?
+    m_score = new MasterScore(m_scoreGlobal->baseStyle());
+    m_scoreCallbacks = new ScoreCallbacks();
+
+    m_shadowNote = new ShadowNote(m_score);
+    m_shadowNote->setVisible(false);
+
+    m_inputState = new NotationInputState(this);
+    m_selection = new NotationSelection(this);
+    m_inputController = new NotationInputController(this);
+}
+
+Notation::~Notation()
+{
+    delete m_inputState;
+    delete m_selection;
+    delete m_shadowNote;
+    delete m_scoreCallbacks;
+    delete m_score;
+}
+
+void Notation::init()
+{
+    MScore::init();         // initialize libmscore
+}
+
+bool Notation::load(const std::string& path)
+{
+    Score::FileError rv = m_score->loadMsc(QString::fromStdString(path), true);
+    if (rv != Score::FileError::FILE_NO_ERROR) {
+        return false;
+    }
+
+    m_score->setUpdateAll();
+    m_score->doLayout();
+
+    return true;
+}
+
+void Notation::setViewSize(const QSizeF& vs)
+{
+    m_viewSize = vs;
+}
+
+void Notation::paint(QPainter* p, const QRect& r)
+{
+    const QList<Ms::Page*>& mspages = m_score->pages();
+
+    if (mspages.isEmpty()) {
+        p->drawText(10, 10, "no pages");
+        return;
+    }
+
+    Ms::Page* page = mspages.first();
+    page->draw(p);
+
+    p->fillRect(page->bbox(), QColor("#ffffff"));
+
+    QList<Ms::Element*> ell = page->elements();
+    for (const Ms::Element* e : ell) {
+        if (!e->visible()) {
+            continue;
+        }
+
+        e->itemDiscovered = false;
+        QPointF pos(e->pagePos());
+        //LOGI() << e->name() << ", x: " << pos.x() << ", y: " << pos.y() << "\n";
+
+        p->translate(pos);
+
+        e->draw(p);
+
+        p->translate(-pos);
+    }
+}
+
+INotationInputState* Notation::inputState() const
+{
+    return m_inputState;
+}
+
+void Notation::startNoteEntry()
+{
+    //! NOTE Coped from `void ScoreView::startNoteEntry()`
+    Ms::InputState& is = score()->inputState();
+    is.setSegment(0);
+
+    if (score()->selection().isNone()) {
+        selectFirstTopLeftOrLast();
+    }
+
+    //! TODO Find out what does and why.
+    Element* el = score()->selection().element();
+    if (!el) {
+        el = score()->selection().firstChordRest();
+    }
+
+    if (el == nullptr
+        || (el->type() != ElementType::CHORD && el->type() != ElementType::REST && el->type() != ElementType::NOTE)) {
+        // if no note/rest is selected, start with voice 0
+        int track = is.track() == -1 ? 0 : (is.track() / VOICES) * VOICES;
+        // try to find an appropriate measure to start in
+        Fraction tick = el ? el->tick() : Fraction(0,1);
+        el = score()->searchNote(tick, track);
+        if (!el) {
+            el = score()->searchNote(Fraction(0,1), track);
+        }
+    }
+
+    if (!el) {
+        return;
+    }
+
+    if (el->type() == ElementType::CHORD) {
+        Chord* c = static_cast<Chord*>(el);
+        Note* note = c->selectedNote();
+        if (note == 0) {
+            note = c->upNote();
+        }
+        el = note;
+    }
+    //! ---
+
+    TDuration d(is.duration());
+    if (!d.isValid() || d.isZero() || d.type() == TDuration::DurationType::V_MEASURE) {
+        is.setDuration(TDuration(TDuration::DurationType::V_QUARTER));
+    }
+    is.setAccidentalType(AccidentalType::NONE);
+
+    select(el, SelectType::SINGLE, 0);
+
+    is.setRest(false);
+    is.setNoteEntryMode(true);
+
+    //! TODO Find out why.
+    score()->setUpdateAll();
+    score()->update();
+    //! ---
+
+    Staff* staff = score()->staff(is.track() / VOICES);
+    switch (staff->staffType(is.tick())->group()) {
+    case StaffGroup::STANDARD:
+        break;
+    case StaffGroup::TAB: {
+        int strg = 0;                           // assume topmost string as current string
+        // if entering note entry with a note selected and the note has a string
+        // set InputState::_string to note physical string
+        if (el->type() == ElementType::NOTE) {
+            strg = (static_cast<Note*>(el))->string();
+        }
+        is.setString(strg);
+        break;
+    }
+    case StaffGroup::PERCUSSION:
+        break;
+    }
+
+    m_inputStateChanged.notify();
+}
+
+void Notation::selectFirstTopLeftOrLast()
+{
+    // choose page in current view (favor top left quadrant if possible)
+    // select first (top/left) chordrest of that page in current view
+    // or, CR at last selected position if that is in view
+    Page* page = nullptr;
+    QList<QPointF> points;
+    points.append(QPoint(m_viewSize.width() * 0.25, m_viewSize.height() * 0.25));
+    points.append(QPoint(0.0, 0.0));
+    points.append(QPoint(0.0, m_viewSize.height()));
+    points.append(QPoint(m_viewSize.width(), 0.0));
+    points.append(QPoint(m_viewSize.width(), m_viewSize.height()));
+    for (const QPointF& point : points) {
+        page = m_inputController->point2page(point);
+        if (page) {
+            break;
+        }
+    }
+
+    if (page) {
+        ChordRest* topLeft = nullptr;
+        qreal tlY = 0.0;
+        Fraction tlTick = Fraction(0,1);
+        QRectF viewRect  = QRectF(0.0, 0.0, m_viewSize.width(), m_viewSize.height());
+        QRectF pageRect  = page->bbox().translated(page->x(), page->y());
+        QRectF intersect = viewRect & pageRect;
+        intersect.translate(-page->x(), -page->y());
+        QList<Element*> el = page->items(intersect);
+        ChordRest* lastSelected = score()->selection().currentCR();
+        for (Element* e : el) {
+            // loop through visible elements
+            // looking for the CR in voice 1 with earliest tick and highest staff position
+            // but stop we find the last selected CR
+            ElementType et = e->type();
+            if (et == ElementType::NOTE || et == ElementType::REST) {
+                if (e->voice()) {
+                    continue;
+                }
+                ChordRest* cr;
+                if (et == ElementType::NOTE) {
+                    cr = static_cast<ChordRest*>(e->parent());
+                    if (!cr) {
+                        continue;
+                    }
+                } else {
+                    cr = static_cast<ChordRest*>(e);
+                }
+                if (cr == lastSelected) {
+                    topLeft = cr;
+                    break;
+                }
+                // compare ticks rather than x position
+                // to make sure we favor earlier rather than later systems
+                // even though later system might have note farther to left
+                Fraction crTick = Fraction(0,1);
+                if (cr->segment()) {
+                    crTick = cr->segment()->tick();
+                } else {
+                    continue;
+                }
+                // compare staff Y position rather than note Y position
+                // to be sure we do not reject earliest note
+                // just because it is lower in pitch than subsequent notes
+                qreal crY = 0.0;
+                if (cr->measure() && cr->measure()->system()) {
+                    crY = cr->measure()->system()->staffYpage(cr->staffIdx());
+                } else {
+                    continue;
+                }
+                if (topLeft) {
+                    if (crTick <= tlTick && crY <= tlY) {
+                        topLeft = cr;
+                        tlTick = crTick;
+                        tlY = crY;
+                    }
+                } else {
+                    topLeft = cr;
+                    tlTick = crTick;
+                    tlY = crY;
+                }
+            }
+        }
+
+        if (topLeft) {
+            select(topLeft, SelectType::SINGLE);
+        }
+    }
+}
+
+void Notation::endNoteEntry()
+{
+    InputState& is = score()->inputState();
+    is.setNoteEntryMode(false);
+    if (is.slur()) {
+        const std::vector<SpannerSegment*>& el = is.slur()->spannerSegments();
+        if (!el.empty()) {
+            el.front()->setSelected(false);
+        }
+        is.setSlur(0);
+    }
+
+    hideShadowNote();
+    m_inputStateChanged.notify();
+}
+
+void Notation::padNote(const Pad& pad)
+{
+    Ms::EditData ed;
+    ed.view = m_scoreCallbacks;
+    score()->startCmd();
+    score()->padToggle(pad, ed);
+    score()->endCmd();
+    m_inputStateChanged.notify();
+}
+
+void Notation::putNote(const QPointF& pos, bool replace, bool insert)
+{
+    score()->startCmd();
+    score()->putNote(pos, replace, insert);
+    score()->endCmd();
+    m_notationChanged.notify();
+}
+
+mu::async::Notify Notation::notationChanged() const
+{
+    return m_notationChanged;
+}
+
+mu::async::Notify Notation::inputStateChanged() const
+{
+    return m_inputStateChanged;
+}
+
+mu::async::Notify Notation::selectionChanged() const
+{
+    return m_selectionChanged;
+}
+
+Ms::Score* Notation::score() const
+{
+    return m_score;
+}
+
+void Notation::showShadowNote(const QPointF& p)
+{
+    //! NOTE This method coped from ScoreView::setShadowNote
+
+    const InputState& is = score()->inputState();
+    Position pos;
+    if (!score()->getPosition(&pos, p, is.voice())) {
+        m_shadowNote->setVisible(false);
+        return;
+    }
+
+    // in any empty measure, pos will be right next to barline
+    // so pad this by barNoteDistance
+    qreal mag = score()->staff(pos.staffIdx)->staffMag(Fraction(0,1));
+    qreal relX = pos.pos.x() - pos.segment->measure()->canvasPos().x();
+    pos.pos.rx() -= qMin(relX - score()->styleP(Sid::barNoteDistance) * mag, 0.0);
+
+    m_shadowNote->setVisible(true);
+
+    Staff* staff = score()->staff(pos.staffIdx);
+    m_shadowNote->setMag(staff->staffMag(Fraction(0,1)));
+    const Instrument* instr = staff->part()->instrument();
+    NoteHead::Group noteheadGroup = NoteHead::Group::HEAD_NORMAL;
+    int line = pos.line;
+    NoteHead::Type noteHead = is.duration().headType();
+
+    if (instr->useDrumset()) {
+        const Drumset* ds  = instr->drumset();
+        int pitch    = is.drumNote();
+        if (pitch >= 0 && ds->isValid(pitch)) {
+            line     = ds->line(pitch);
+            noteheadGroup = ds->noteHead(pitch);
+        }
+    }
+
+    m_shadowNote->setLine(line);
+
+    int voice;
+    if (is.drumNote() != -1 && is.drumset() && is.drumset()->isValid(is.drumNote())) {
+        voice = is.drumset()->voice(is.drumNote());
+    } else {
+        voice = is.voice();
+    }
+
+    SymId symNotehead;
+    TDuration d(is.duration());
+
+    if (is.rest()) {
+        int yo;
+        Rest rest(gscore, d.type());
+        rest.setTicks(d.fraction());
+        symNotehead = rest.getSymbol(is.duration().type(), 0, staff->lines(pos.segment->tick()), &yo);
+        m_shadowNote->setState(symNotehead, voice, d, true);
+    } else {
+        if (NoteHead::Group::HEAD_CUSTOM == noteheadGroup) {
+            symNotehead = instr->drumset()->noteHeads(is.drumNote(), noteHead);
+        } else {
+            symNotehead = Note::noteHead(0, noteheadGroup, noteHead);
+        }
+
+        m_shadowNote->setState(symNotehead, voice, d);
+    }
+
+    m_shadowNote->layout();
+    m_shadowNote->setPos(pos.pos);
+}
+
+void Notation::hideShadowNote()
+{
+    m_shadowNote->setVisible(false);
+}
+
+void Notation::paintShadowNote(QPainter* p)
+{
+    m_shadowNote->draw(p);
+}
+
+INotationSelection* Notation::selection() const
+{
+    return m_selection;
+}
+
+void Notation::select(Element* e, SelectType type, int staffIdx)
+{
+    score()->select(e, type, staffIdx);
+    m_selectionChanged.notify();
+}
+
+INotationInputController* Notation::inputController() const
+{
+    return m_inputController;
+}

--- a/mu4/domain/notation/internal/notation.h
+++ b/mu4/domain/notation/internal/notation.h
@@ -68,9 +68,9 @@ public:
     INotationInputController* inputController() const override;
 
     // notify
-    async::Notify notationChanged() const override;
-    async::Notify inputStateChanged() const override;
-    async::Notify selectionChanged() const override;
+    async::Notification notationChanged() const override;
+    async::Notification inputStateChanged() const override;
+    async::Notification selectionChanged() const override;
 
     // internal
     Ms::Score* score() const;
@@ -88,9 +88,9 @@ private:
     NotationSelection* m_selection = nullptr;
     NotationInputController* m_inputController = nullptr;
 
-    async::Notify m_notationChanged;
-    async::Notify m_inputStateChanged;
-    async::Notify m_selectionChanged;
+    async::Notification m_notationChanged;
+    async::Notification m_inputStateChanged;
+    async::Notification m_selectionChanged;
 };
 }
 }

--- a/mu4/domain/notation/internal/notation.h
+++ b/mu4/domain/notation/internal/notation.h
@@ -1,0 +1,99 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_DOMAIN_NOTATION_H
+#define MU_DOMAIN_NOTATION_H
+
+#include "../inotation.h"
+#include "actions/action.h"
+
+#include "igetscore.h"
+#include "notationinputstate.h"
+#include "notationselection.h"
+#include "notationinputcontroller.h"
+
+namespace Ms {
+class MScore;
+class MasterScore;
+class ShadowNote;
+class Page;
+}
+
+namespace mu {
+namespace domain {
+namespace notation {
+class ScoreCallbacks;
+class Notation : public INotation, public IGetScore
+{
+public:
+    Notation();
+    ~Notation();
+
+    //! NOTE Needed at the moment to initialize libmscore
+    static void init();
+
+    bool load(const std::string& path) override;
+    void setViewSize(const QSizeF& vs) override;
+    void paint(QPainter* p, const QRect& r) override;
+
+    INotationInputState* inputState() const override;
+    void startNoteEntry() override;
+    void endNoteEntry() override;
+    void padNote(const Pad& pad) override;
+    void putNote(const QPointF& pos, bool replace, bool insert) override;
+
+    // shadow note
+    void showShadowNote(const QPointF& p) override;
+    void hideShadowNote() override;
+    void paintShadowNote(QPainter* p) override;
+
+    INotationSelection* selection() const override;
+    void select(Element* e, SelectType type, int staffIdx = 0) override;
+
+    INotationInputController* inputController() const override;
+
+    // notify
+    async::Notify notationChanged() const override;
+    async::Notify inputStateChanged() const override;
+    async::Notify selectionChanged() const override;
+
+    // internal
+    Ms::Score* score() const;
+
+private:
+
+    void selectFirstTopLeftOrLast();
+
+    QSizeF m_viewSize;
+    Ms::MScore* m_scoreGlobal = nullptr;
+    Ms::MasterScore* m_score = nullptr;
+    ScoreCallbacks* m_scoreCallbacks = nullptr;
+    Ms::ShadowNote* m_shadowNote = nullptr;
+    NotationInputState* m_inputState = nullptr;
+    NotationSelection* m_selection = nullptr;
+    NotationInputController* m_inputController = nullptr;
+
+    async::Notify m_notationChanged;
+    async::Notify m_inputStateChanged;
+    async::Notify m_selectionChanged;
+};
+}
+}
+}
+
+#endif // MU_DOMAIN_NOTATION_H

--- a/mu4/domain/notation/internal/notationactioncontroller.cpp
+++ b/mu4/domain/notation/internal/notationactioncontroller.cpp
@@ -1,0 +1,80 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "notationactioncontroller.h"
+#include "log.h"
+#include <QPoint>
+
+using namespace mu::domain::notation;
+using namespace mu::actions;
+
+NotationActionController::NotationActionController()
+{
+    dispatcher()->reg("domain/notation/note-input", this, &NotationActionController::toggleNoteInput);
+    dispatcher()->reg("domain/notation/pad-note-4", [this]() { padNote(Pad::NOTE4); });
+    dispatcher()->reg("domain/notation/pad-note-8", [this]() { padNote(Pad::NOTE8); });
+    dispatcher()->reg("domain/notation/pad-note-16", [this]() { padNote(Pad::NOTE16); });
+    dispatcher()->reg("domain/notation/put-note", this, &NotationActionController::putNote);
+}
+
+std::shared_ptr<INotation> NotationActionController::currentNotation() const
+{
+    return globalContext()->currentNotation();
+}
+
+void NotationActionController::toggleNoteInput()
+{
+    auto notation = currentNotation();
+    if (!notation) {
+        return;
+    }
+
+    if (notation->inputState()->isNoteEnterMode()) {
+        notation->endNoteEntry();
+    } else {
+        notation->startNoteEntry();
+    }
+}
+
+void NotationActionController::padNote(const Pad& pad)
+{
+    auto notation = currentNotation();
+    if (!notation) {
+        return;
+    }
+
+    notation->padNote(pad);
+}
+
+void NotationActionController::putNote(const actions::ActionData& data)
+{
+    auto notation = currentNotation();
+    if (!notation) {
+        return;
+    }
+
+    IF_ASSERT_FAILED(data.count() > 2) {
+        return;
+    }
+
+    QPoint pos = data.arg<QPoint>(0);
+    bool replace = data.arg<bool>(1);
+    bool insert = data.arg<bool>(2);
+
+    notation->putNote(pos, replace, insert);
+}

--- a/mu4/domain/notation/internal/notationactioncontroller.h
+++ b/mu4/domain/notation/internal/notationactioncontroller.h
@@ -16,27 +16,41 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#include "notationdomainmodule.h"
+#ifndef MU_DOMAIN_NOTATIONACTIONCONTROLLER_H
+#define MU_DOMAIN_NOTATIONACTIONCONTROLLER_H
 
 #include "modularity/ioc.h"
-#include "internal/notationcreator.h"
-#include "internal/notation.h"
-#include "internal/notationactioncontroller.h"
+#include "actions/iactionsdispatcher.h"
+#include "context/iglobalcontext.h"
+#include "../inotation.h"
 
-using namespace mu::domain::notation;
-
-std::string NotationDomainModule::moduleName() const
+namespace mu {
+namespace domain {
+namespace notation {
+class NotationActionController
 {
-    return "notation";
+    INJECT(notation, actions::IActionsDispatcher, dispatcher)
+    INJECT(notation, context::IGlobalContext, globalContext)
+
+public:
+
+    static NotationActionController* instance()
+    {
+        static NotationActionController c;
+        return &c;
+    }
+
+private:
+    NotationActionController();
+
+    std::shared_ptr<INotation> currentNotation() const;
+
+    void toggleNoteInput();
+    void padNote(const Pad& pad);
+    void putNote(const actions::ActionData& data);
+};
+}
+}
 }
 
-void NotationDomainModule::registerExports()
-{
-    framework::ioc()->registerExport<INotationCreator>(moduleName(), new NotationCreator());
-}
-
-void NotationDomainModule::onInit()
-{
-    Notation::init();
-    NotationActionController::instance(); //! NOTE Only need to create
-}
+#endif // MU_DOMAIN_NOTATIONACTIONCONTROLLER_H

--- a/mu4/domain/notation/internal/notationcreator.cpp
+++ b/mu4/domain/notation/internal/notationcreator.cpp
@@ -16,27 +16,13 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#include "notationdomainmodule.h"
+#include "notationcreator.h"
 
-#include "modularity/ioc.h"
-#include "internal/notationcreator.h"
-#include "internal/notation.h"
-#include "internal/notationactioncontroller.h"
+#include "notation.h"
 
 using namespace mu::domain::notation;
 
-std::string NotationDomainModule::moduleName() const
+std::shared_ptr<INotation> NotationCreator::newNotation()
 {
-    return "notation";
-}
-
-void NotationDomainModule::registerExports()
-{
-    framework::ioc()->registerExport<INotationCreator>(moduleName(), new NotationCreator());
-}
-
-void NotationDomainModule::onInit()
-{
-    Notation::init();
-    NotationActionController::instance(); //! NOTE Only need to create
+    return std::make_shared<Notation>();
 }

--- a/mu4/domain/notation/internal/notationcreator.h
+++ b/mu4/domain/notation/internal/notationcreator.h
@@ -16,27 +16,23 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#include "notationdomainmodule.h"
+#ifndef MU_DOMAIN_NOTATIONCREATOR_H
+#define MU_DOMAIN_NOTATIONCREATOR_H
 
-#include "modularity/ioc.h"
-#include "internal/notationcreator.h"
-#include "internal/notation.h"
-#include "internal/notationactioncontroller.h"
+#include "../inotationcreator.h"
 
-using namespace mu::domain::notation;
-
-std::string NotationDomainModule::moduleName() const
+namespace mu {
+namespace domain {
+namespace notation {
+class NotationCreator : public INotationCreator
 {
-    return "notation";
+public:
+    NotationCreator() = default;
+
+    std::shared_ptr<INotation> newNotation() override;
+};
+}
+}
 }
 
-void NotationDomainModule::registerExports()
-{
-    framework::ioc()->registerExport<INotationCreator>(moduleName(), new NotationCreator());
-}
-
-void NotationDomainModule::onInit()
-{
-    Notation::init();
-    NotationActionController::instance(); //! NOTE Only need to create
-}
+#endif // MU_DOMAIN_NOTATIONCREATOR_H

--- a/mu4/domain/notation/internal/notationinputcontroller.cpp
+++ b/mu4/domain/notation/internal/notationinputcontroller.cpp
@@ -1,0 +1,155 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "notationinputcontroller.h"
+
+#include <QRectF>
+#include "libmscore/page.h"
+#include "libmscore/notedot.h"
+
+using namespace mu::domain::notation;
+
+NotationInputController::NotationInputController(IGetScore* getScore)
+    : m_getScore(getScore)
+{
+}
+
+Ms::Score* NotationInputController::score() const
+{
+    return m_getScore->score();
+}
+
+Element* NotationInputController::hitElement(const QPointF& pos, float width) const
+{
+    QList<Ms::Element*> ll = hitElements(pos, width);
+    if (ll.isEmpty()) {
+        return nullptr;
+    }
+    return ll.first();
+}
+
+Ms::Page* NotationInputController::point2page(const QPointF& p) const
+{
+    if (score()->layoutMode() == Ms::LayoutMode::LINE) {
+        return score()->pages().isEmpty() ? 0 : score()->pages().front();
+    }
+    foreach (Ms::Page* page, score()->pages()) {
+        if (page->bbox().translated(page->pos()).contains(p)) {
+            return page;
+        }
+    }
+    return nullptr;
+}
+
+QList<Ms::Element*> NotationInputController::hitElements(const QPointF& p_in, float w) const
+{
+    Ms::Page* page = point2page(p_in);
+    if (!page) {
+        return QList<Ms::Element*>();
+    }
+
+    QList<Ms::Element*> ll;
+
+    QPointF p = p_in - page->pos();
+
+    QRectF r(p.x() - w, p.y() - w, 3.0 * w, 3.0 * w);
+
+    QList<Ms::Element*> el = page->items(r);
+    //! TODO
+    //    for (int i = 0; i < MAX_HEADERS; i++)
+    //        if (score()->headerText(i) != nullptr)      // gives the ability to select the header
+    //            el.push_back(score()->headerText(i));
+    //    for (int i = 0; i < MAX_FOOTERS; i++)
+    //        if (score()->footerText(i) != nullptr)      // gives the ability to select the footer
+    //            el.push_back(score()->footerText(i));
+    //! -------
+
+    for (Ms::Element* e : el) {
+        e->itemDiscovered = 0;
+        if (!e->selectable() || e->isPage()) {
+            continue;
+        }
+        if (e->contains(p)) {
+            ll.append(e);
+        }
+    }
+
+    int n = ll.size();
+    if ((n == 0) || ((n == 1) && (ll[0]->isMeasure()))) {
+        //
+        // if no relevant element hit, look nearby
+        //
+        for (Ms::Element* e : el) {
+            if (e->isPage() || !e->selectable()) {
+                continue;
+            }
+            if (e->intersects(r)) {
+                ll.append(e);
+            }
+        }
+    }
+
+    if (!ll.empty()) {
+        std::sort(ll.begin(), ll.end(), NotationInputController::elementIsLess);
+    }
+
+    return ll;
+}
+
+bool NotationInputController::elementIsLess(const Ms::Element* e1, const Ms::Element* e2)
+{
+    if (!e1->selectable()) {
+        return false;
+    }
+    if (!e2->selectable()) {
+        return true;
+    }
+    if (e1->isNote() && e2->isStem()) {
+        return true;
+    }
+    if (e2->isNote() && e1->isStem()) {
+        return false;
+    }
+    if (e1->z() == e2->z()) {
+        // same stacking order, prefer non-hidden elements
+        if (e1->type() == e2->type()) {
+            if (e1->type() == Ms::ElementType::NOTEDOT) {
+                const Ms::NoteDot* n1 = static_cast<const Ms::NoteDot*>(e1);
+                const Ms::NoteDot* n2 = static_cast<const Ms::NoteDot*>(e2);
+                if (n1->note() && n1->note()->hidden()) {
+                    return false;
+                } else if (n2->note() && n2->note()->hidden()) {
+                    return true;
+                }
+            } else if (e1->type() == Ms::ElementType::NOTE) {
+                const Ms::Note* n1 = static_cast<const Ms::Note*>(e1);
+                const Ms::Note* n2 = static_cast<const Ms::Note*>(e2);
+                if (n1->hidden()) {
+                    return false;
+                } else if (n2->hidden()) {
+                    return true;
+                }
+            }
+        }
+        // different types, or same type but nothing hidden - use track
+        return e1->track() <= e2->track();
+    }
+
+    // default case, use stacking order
+    return e1->z() <= e2->z();
+}

--- a/mu4/domain/notation/internal/notationinputcontroller.h
+++ b/mu4/domain/notation/internal/notationinputcontroller.h
@@ -16,27 +16,35 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#include "notationdomainmodule.h"
+#ifndef MU_DOMAIN_NOTATIONINPUTCONTROLLER_H
+#define MU_DOMAIN_NOTATIONINPUTCONTROLLER_H
 
-#include "modularity/ioc.h"
-#include "internal/notationcreator.h"
-#include "internal/notation.h"
-#include "internal/notationactioncontroller.h"
+#include "../inotationinputcontroller.h"
+#include "igetscore.h"
 
-using namespace mu::domain::notation;
-
-std::string NotationDomainModule::moduleName() const
+namespace mu {
+namespace domain {
+namespace notation {
+class NotationInputController : public INotationInputController
 {
-    return "notation";
+public:
+    NotationInputController(IGetScore* getScore);
+
+    Element* hitElement(const QPointF& pos, float width) const override;
+
+    Ms::Page* point2page(const QPointF& p) const;
+
+private:
+
+    Ms::Score* score() const;
+    QList<Element*> hitElements(const QPointF& p_in, float w) const;
+
+    static bool elementIsLess(const Ms::Element* e1, const Ms::Element* e2);
+
+    IGetScore* m_getScore;
+};
+}
+}
 }
 
-void NotationDomainModule::registerExports()
-{
-    framework::ioc()->registerExport<INotationCreator>(moduleName(), new NotationCreator());
-}
-
-void NotationDomainModule::onInit()
-{
-    Notation::init();
-    NotationActionController::instance(); //! NOTE Only need to create
-}
+#endif // MU_DOMAIN_NOTATIONINPUTCONTROLLER_H

--- a/mu4/domain/notation/internal/notationinputstate.cpp
+++ b/mu4/domain/notation/internal/notationinputstate.cpp
@@ -16,27 +16,29 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#include "notationdomainmodule.h"
+#include "notationinputstate.h"
 
-#include "modularity/ioc.h"
-#include "internal/notationcreator.h"
-#include "internal/notation.h"
-#include "internal/notationactioncontroller.h"
+#include "libmscore/score.h"
+#include "libmscore/input.h"
 
 using namespace mu::domain::notation;
 
-std::string NotationDomainModule::moduleName() const
+NotationInputState::NotationInputState(IGetScore* getScore)
+    : m_getScore(getScore)
 {
-    return "notation";
 }
 
-void NotationDomainModule::registerExports()
+Ms::Score* NotationInputState::score() const
 {
-    framework::ioc()->registerExport<INotationCreator>(moduleName(), new NotationCreator());
+    return m_getScore->score();
 }
 
-void NotationDomainModule::onInit()
+bool NotationInputState::isNoteEnterMode() const
 {
-    Notation::init();
-    NotationActionController::instance(); //! NOTE Only need to create
+    return score()->inputState().noteEntryMode();
+}
+
+DurationType NotationInputState::duration() const
+{
+    return score()->inputState().duration().type();
 }

--- a/mu4/domain/notation/internal/notationinputstate.h
+++ b/mu4/domain/notation/internal/notationinputstate.h
@@ -16,27 +16,37 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#include "notationdomainmodule.h"
+#ifndef MU_DOMAIN_NOTATIONINPUTSTATE_H
+#define MU_DOMAIN_NOTATIONINPUTSTATE_H
 
-#include "modularity/ioc.h"
-#include "internal/notationcreator.h"
-#include "internal/notation.h"
-#include "internal/notationactioncontroller.h"
+#include <map>
+#include "../inotationinputstate.h"
 
-using namespace mu::domain::notation;
+#include "igetscore.h"
 
-std::string NotationDomainModule::moduleName() const
-{
-    return "notation";
+namespace Ms {
+class Score;
 }
 
-void NotationDomainModule::registerExports()
+namespace mu {
+namespace domain {
+namespace notation {
+class NotationInputState : public INotationInputState
 {
-    framework::ioc()->registerExport<INotationCreator>(moduleName(), new NotationCreator());
+public:
+    NotationInputState(IGetScore* getScore);
+
+    bool isNoteEnterMode() const override;
+    DurationType duration() const override;
+
+private:
+
+    Ms::Score* score() const;
+
+    IGetScore* m_getScore = nullptr;
+};
+}
+}
 }
 
-void NotationDomainModule::onInit()
-{
-    Notation::init();
-    NotationActionController::instance(); //! NOTE Only need to create
-}
+#endif // MU_DOMAIN_NOTATIONINPUTSTATE_H

--- a/mu4/domain/notation/internal/notationselection.cpp
+++ b/mu4/domain/notation/internal/notationselection.cpp
@@ -1,0 +1,68 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "notationselection.h"
+#include "log.h"
+
+#include "libmscore/score.h"
+
+using namespace mu::domain::notation;
+
+NotationSelection::NotationSelection(IGetScore* getScore)
+    : m_getScore(getScore)
+{
+}
+
+Ms::Score* NotationSelection::score() const
+{
+    return m_getScore->score();
+}
+
+bool NotationSelection::isNone() const
+{
+    return score()->selection().isNone();
+}
+
+QRectF NotationSelection::canvasBoundingRect() const
+{
+    if (isNone()) {
+        return QRectF();
+    }
+
+    Ms::Element* el = score()->selection().element();
+    if (el) {
+        return el->canvasBoundingRect();
+    }
+
+    QList<Ms::Element*> els = score()->selection().elements();
+    if (els.isEmpty()) {
+        LOGW() << "selection not none, but no elements";
+        return QRectF();
+    }
+
+    QRectF rect;
+    for (const Ms::Element* el: els) {
+        if (rect.isNull()) {
+            rect = el->canvasBoundingRect();
+        } else {
+            rect = rect.united(el->canvasBoundingRect());
+        }
+    }
+
+    return rect;
+}

--- a/mu4/domain/notation/internal/notationselection.h
+++ b/mu4/domain/notation/internal/notationselection.h
@@ -16,27 +16,37 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#include "notationdomainmodule.h"
+#ifndef MU_DOMAIN_NOTATIONSELECTION_H
+#define MU_DOMAIN_NOTATIONSELECTION_H
 
-#include "modularity/ioc.h"
-#include "internal/notationcreator.h"
-#include "internal/notation.h"
-#include "internal/notationactioncontroller.h"
+#include "../inotationselection.h"
+#include "../notationtypes.h"
 
-using namespace mu::domain::notation;
+#include "igetscore.h"
 
-std::string NotationDomainModule::moduleName() const
-{
-    return "notation";
+namespace Ms {
+class Score;
 }
 
-void NotationDomainModule::registerExports()
+namespace mu {
+namespace domain {
+namespace notation {
+class NotationSelection : public INotationSelection
 {
-    framework::ioc()->registerExport<INotationCreator>(moduleName(), new NotationCreator());
+public:
+    NotationSelection(IGetScore* getScore);
+
+    bool isNone() const override;
+    QRectF canvasBoundingRect() const override;
+
+private:
+
+    Ms::Score* score() const;
+
+    IGetScore* m_getScore = nullptr;
+};
+}
+}
 }
 
-void NotationDomainModule::onInit()
-{
-    Notation::init();
-    NotationActionController::instance(); //! NOTE Only need to create
-}
+#endif // MU_DOMAIN_NOTATIONSELECTION_H

--- a/mu4/domain/notation/internal/scorecallbacks.cpp
+++ b/mu4/domain/notation/internal/scorecallbacks.cpp
@@ -16,27 +16,23 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#include "notationdomainmodule.h"
-
-#include "modularity/ioc.h"
-#include "internal/notationcreator.h"
-#include "internal/notation.h"
-#include "internal/notationactioncontroller.h"
+#include "scorecallbacks.h"
 
 using namespace mu::domain::notation;
 
-std::string NotationDomainModule::moduleName() const
+void ScoreCallbacks::dataChanged(const QRectF&)
 {
-    return "notation";
 }
 
-void NotationDomainModule::registerExports()
+void ScoreCallbacks::updateAll()
 {
-    framework::ioc()->registerExport<INotationCreator>(moduleName(), new NotationCreator());
 }
 
-void NotationDomainModule::onInit()
+void ScoreCallbacks::drawBackground(QPainter*, const QRectF&) const
 {
-    Notation::init();
-    NotationActionController::instance(); //! NOTE Only need to create
+}
+
+const QRect ScoreCallbacks::geometry() const
+{
+    return QRect();
 }

--- a/mu4/domain/notation/internal/scorecallbacks.h
+++ b/mu4/domain/notation/internal/scorecallbacks.h
@@ -16,27 +16,31 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#include "notationdomainmodule.h"
+#ifndef MU_DOMAIN_SCORECALLBACKS_H
+#define MU_DOMAIN_SCORECALLBACKS_H
 
-#include "modularity/ioc.h"
-#include "internal/notationcreator.h"
-#include "internal/notation.h"
-#include "internal/notationactioncontroller.h"
+#include <QRectF>
+#include <QRect>
+class QPainter;
 
-using namespace mu::domain::notation;
+#include "libmscore/mscoreview.h"
+#include "libmscore/musescoreCore.h"
 
-std::string NotationDomainModule::moduleName() const
+namespace mu {
+namespace domain {
+namespace notation {
+class ScoreCallbacks : public Ms::MuseScoreView, public Ms::MuseScoreCore
 {
-    return "notation";
+public:
+    ScoreCallbacks() = default;
+
+    void dataChanged(const QRectF&) override;
+    void updateAll() override;
+    void drawBackground(QPainter*, const QRectF&) const override;
+    const QRect geometry() const override;
+};
+}
+}
 }
 
-void NotationDomainModule::registerExports()
-{
-    framework::ioc()->registerExport<INotationCreator>(moduleName(), new NotationCreator());
-}
-
-void NotationDomainModule::onInit()
-{
-    Notation::init();
-    NotationActionController::instance(); //! NOTE Only need to create
-}
+#endif // MU_DOMAIN_SCORECALLBACKS_H

--- a/mu4/domain/notation/notationactions.cpp
+++ b/mu4/domain/notation/notationactions.cpp
@@ -23,38 +23,38 @@
 using namespace mu::domain::notation;
 using namespace mu::actions;
 
-//! NOTO Only actions processed by notation
+//! NOTE Only actions processed by notation
 
-static const std::vector<Action> _actions = {
+static const std::vector<Action> m_actions = {
     {
         "domain/notation/file-open",
         QT_TRANSLATE_NOOP("action", "Open...")
     },
     {
         "domain/notation/note-input",
-        QT_TRANSLATE_NOOP("action", "Note input")
+        QT_TRANSLATE_NOOP("action", "Note Input")
     },
     {
         "domain/notation/pad-note-4",
-        QT_TRANSLATE_NOOP("action", "Note 4")
+        QT_TRANSLATE_NOOP("action", "Quarter Note")
     },
     {
         "domain/notation/pad-note-8",
-        QT_TRANSLATE_NOOP("action", "Note 8")
+        QT_TRANSLATE_NOOP("action", "8th Note")
     },
     {
         "domain/notation/pad-note-16",
-        QT_TRANSLATE_NOOP("action", "Note 16")
+        QT_TRANSLATE_NOOP("action", "16th Note")
     },
     {
         "domain/notation/put-note", // args: QPoint pos, bool replace, bool insert
-        QT_TRANSLATE_NOOP("action", "Put note")
+        QT_TRANSLATE_NOOP("action", "Put Note")
     }
 };
 
 const Action& NotationActions::action(const ActionName& name)
 {
-    for (const Action& a : _actions) {
+    for (const Action& a : m_actions) {
         if (a.name == name) {
             return a;
         }

--- a/mu4/domain/notation/notationactions.cpp
+++ b/mu4/domain/notation/notationactions.cpp
@@ -1,0 +1,65 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "notationactions.h"
+
+#include <vector>
+
+using namespace mu::domain::notation;
+using namespace mu::actions;
+
+//! NOTO Only actions processed by notation
+
+static const std::vector<Action> _actions = {
+    {
+        "domain/notation/file-open",
+        QT_TRANSLATE_NOOP("action", "Open...")
+    },
+    {
+        "domain/notation/note-input",
+        QT_TRANSLATE_NOOP("action", "Note input")
+    },
+    {
+        "domain/notation/pad-note-4",
+        QT_TRANSLATE_NOOP("action", "Note 4")
+    },
+    {
+        "domain/notation/pad-note-8",
+        QT_TRANSLATE_NOOP("action", "Note 8")
+    },
+    {
+        "domain/notation/pad-note-16",
+        QT_TRANSLATE_NOOP("action", "Note 16")
+    },
+    {
+        "domain/notation/put-note", // args: QPoint pos, bool replace, bool insert
+        QT_TRANSLATE_NOOP("action", "Put note")
+    }
+};
+
+const Action& NotationActions::action(const ActionName& name)
+{
+    for (const Action& a : _actions) {
+        if (a.name == name) {
+            return a;
+        }
+    }
+
+    static Action null;
+    return null;
+}

--- a/mu4/domain/notation/notationactions.h
+++ b/mu4/domain/notation/notationactions.h
@@ -16,27 +16,22 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#include "notationdomainmodule.h"
+#ifndef MU_DOMAIN_NOTATIONACTIONS_H
+#define MU_DOMAIN_NOTATIONACTIONS_H
 
-#include "modularity/ioc.h"
-#include "internal/notationcreator.h"
-#include "internal/notation.h"
-#include "internal/notationactioncontroller.h"
+#include "actions/action.h"
 
-using namespace mu::domain::notation;
-
-std::string NotationDomainModule::moduleName() const
+namespace mu {
+namespace domain {
+namespace notation {
+class NotationActions
 {
-    return "notation";
+public:
+
+    static const actions::Action& action(const actions::ActionName& name);
+};
+}
+}
 }
 
-void NotationDomainModule::registerExports()
-{
-    framework::ioc()->registerExport<INotationCreator>(moduleName(), new NotationCreator());
-}
-
-void NotationDomainModule::onInit()
-{
-    Notation::init();
-    NotationActionController::instance(); //! NOTE Only need to create
-}
+#endif // MU_DOMAIN_NOTATIONACTIONS_H

--- a/mu4/domain/notation/notationtypes.h
+++ b/mu4/domain/notation/notationtypes.h
@@ -16,27 +16,23 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#include "notationdomainmodule.h"
+#ifndef MU_DOMAIN_NOTATIONTYPES_H
+#define MU_DOMAIN_NOTATIONTYPES_H
 
-#include "modularity/ioc.h"
-#include "internal/notationcreator.h"
-#include "internal/notation.h"
-#include "internal/notationactioncontroller.h"
+#include "libmscore/element.h"
+#include "libmscore/durationtype.h"
+#include "libmscore/mscore.h"
+#include "libmscore/score.h"
 
-using namespace mu::domain::notation;
-
-std::string NotationDomainModule::moduleName() const
-{
-    return "notation";
+namespace mu {
+namespace domain {
+namespace notation {
+using Element = Ms::Element;
+using DurationType = Ms::TDuration::DurationType;
+using SelectType = Ms::SelectType;
+using Pad = Ms::Pad;
+}
+}
 }
 
-void NotationDomainModule::registerExports()
-{
-    framework::ioc()->registerExport<INotationCreator>(moduleName(), new NotationCreator());
-}
-
-void NotationDomainModule::onInit()
-{
-    Notation::init();
-    NotationActionController::instance(); //! NOTE Only need to create
-}
+#endif // MU_DOMAIN_NOTATIONTYPES_H

--- a/mu4/scenes/notation/CMakeLists.txt
+++ b/mu4/scenes/notation/CMakeLists.txt
@@ -31,6 +31,12 @@ set(MODULE_SRC
     ${NOTATIONVIEW_SRC}
     ${CMAKE_CURRENT_LIST_DIR}/notationscenemodule.cpp
     ${CMAKE_CURRENT_LIST_DIR}/notationscenemodule.h
+    ${CMAKE_CURRENT_LIST_DIR}/toolbar/notationtoolbarmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/toolbar/notationtoolbarmodel.h
+    )
+
+set(MODULE_LINK
+    notation
     )
 
 include(${PROJECT_SOURCE_DIR}/build/module.cmake)

--- a/mu4/scenes/notation/notationscenemodule.cpp
+++ b/mu4/scenes/notation/notationscenemodule.cpp
@@ -19,6 +19,7 @@
 #include "notationscenemodule.h"
 
 #include "view/notationpaintview.h"
+#include "toolbar/notationtoolbarmodel.h"
 
 using namespace mu::scene::notation;
 
@@ -29,7 +30,6 @@ static void notation_view_init_qrc()
 
 NotationSceneModule::NotationSceneModule()
 {
-
 }
 
 std::string NotationSceneModule::moduleName() const
@@ -39,12 +39,10 @@ std::string NotationSceneModule::moduleName() const
 
 void NotationSceneModule::registerExports()
 {
-
 }
 
 void NotationSceneModule::resolveImports()
 {
-
 }
 
 void NotationSceneModule::registerResources()
@@ -55,5 +53,5 @@ void NotationSceneModule::registerResources()
 void NotationSceneModule::registerUiTypes()
 {
     qmlRegisterType<NotationPaintView>("MuseScore.NotationScene", 1, 0, "NotationPaintView");
+    qmlRegisterType<NotationToolBarModel>("MuseScore.NotationScene", 1, 0, "NotationToolBarModel");
 }
-

--- a/mu4/scenes/notation/toolbar/notationtoolbarmodel.cpp
+++ b/mu4/scenes/notation/toolbar/notationtoolbarmodel.cpp
@@ -98,17 +98,20 @@ NotationToolBarModel::ActionItem& NotationToolBarModel::item(const actions::Acti
 
 void NotationToolBarModel::onNotationChanged()
 {
-    updateState();
     std::shared_ptr<INotation> notation = globalContext()->currentNotation();
+
+    //! NOTE Unsubscribe from previous notation, if it was
+    m_notationChanged.resetOnNotify(this);
+    m_inputStateChanged.resetOnNotify(this);
+
     if (notation) {
         m_inputStateChanged = notation->inputStateChanged();
         m_inputStateChanged.onNotify(this, [this]() {
             updateState();
         });
-    } else {
-        m_notationChanged.resetOnNotify(this);
-        m_inputStateChanged.resetOnNotify(this);
     }
+
+    updateState();
 }
 
 void NotationToolBarModel::updateState()

--- a/mu4/scenes/notation/toolbar/notationtoolbarmodel.cpp
+++ b/mu4/scenes/notation/toolbar/notationtoolbarmodel.cpp
@@ -1,0 +1,150 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "notationtoolbarmodel.h"
+
+#include "log.h"
+#include "domain/notation/notationactions.h"
+
+using namespace mu::scene::notation;
+using namespace mu::domain::notation;
+using namespace mu::actions;
+
+NotationToolBarModel::NotationToolBarModel(QObject* parent)
+    : QAbstractListModel(parent)
+{
+}
+
+QVariant NotationToolBarModel::data(const QModelIndex& index, int role) const
+{
+    const ActionItem& item = m_items.at(index.row());
+    switch (role) {
+    case TitleRole: return QString::fromStdString(item.action.title);
+    case NameRole: return QString::fromStdString(item.action.name);
+    case EnabledRole: return item.enabled;
+    case CheckedRole: return item.checked;
+    }
+    return QVariant();
+}
+
+int NotationToolBarModel::rowCount(const QModelIndex&) const
+{
+    return m_items.count();
+}
+
+QHash<int,QByteArray> NotationToolBarModel::roleNames() const
+{
+    static const QHash<int, QByteArray> roles = {
+        { NameRole, "nameRole" },
+        { TitleRole, "titleRole" },
+        { EnabledRole, "enabledRole" },
+        { CheckedRole, "checkedRole" }
+    };
+    return roles;
+}
+
+void NotationToolBarModel::load()
+{
+    auto makeItem = [](const Action& action) {
+                        ActionItem item;
+                        item.action = action;
+                        return item;
+                    };
+
+    beginResetModel();
+
+    m_items << makeItem(NotationActions::action("domain/notation/file-open"))
+            << makeItem(NotationActions::action("domain/notation/note-input"))
+            << makeItem(NotationActions::action("domain/notation/pad-note-16"))
+            << makeItem(NotationActions::action("domain/notation/pad-note-8"))
+            << makeItem(NotationActions::action("domain/notation/pad-note-4"));
+
+    endResetModel();
+
+    onNotationChanged();
+    m_notationChanged = globalContext()->currentNotationChanged();
+    m_notationChanged.onNotify(this, [this]() {
+        onNotationChanged();
+    });
+}
+
+NotationToolBarModel::ActionItem& NotationToolBarModel::item(const actions::ActionName& name)
+{
+    for (ActionItem& item : m_items) {
+        if (item.action.name == name) {
+            return item;
+        }
+    }
+
+    LOGE() << "item not found with name: " << name;
+    static ActionItem null;
+    return null;
+}
+
+void NotationToolBarModel::onNotationChanged()
+{
+    updateState();
+    std::shared_ptr<INotation> notation = globalContext()->currentNotation();
+    if (notation) {
+        m_inputStateChanged = notation->inputStateChanged();
+        m_inputStateChanged.onNotify(this, [this]() {
+            updateState();
+        });
+    } else {
+        m_notationChanged.resetOnNotify(this);
+        m_inputStateChanged.resetOnNotify(this);
+    }
+}
+
+void NotationToolBarModel::updateState()
+{
+    std::shared_ptr<INotation> notation = globalContext()->currentNotation();
+    if (!notation) {
+        for (ActionItem& item : m_items) {
+            item.enabled = false;
+            item.checked = false;
+        }
+    } else {
+        for (ActionItem& item : m_items) {
+            item.enabled = true;
+            item.checked = false;
+        }
+
+        auto is = notation->inputState();
+        if (is->isNoteEnterMode()) {
+            item("domain/notation/note-input").checked = true;
+
+            item("domain/notation/pad-note-4").checked = is->duration() == DurationType::V_QUARTER;
+            item("domain/notation/pad-note-8").checked = is->duration() == DurationType::V_EIGHTH;
+            item("domain/notation/pad-note-16").checked = is->duration() == DurationType::V_16TH;
+        } else {
+            for (ActionItem& item : m_items) {
+                item.checked = false;
+            }
+        }
+    }
+
+    item("domain/notation/file-open").enabled = true;
+
+    emit dataChanged(index(0), index(rowCount() - 1));
+}
+
+void NotationToolBarModel::click(const QString& action)
+{
+    dispatcher()->dispatch(actions::namefromQString(action));
+}

--- a/mu4/scenes/notation/toolbar/notationtoolbarmodel.h
+++ b/mu4/scenes/notation/toolbar/notationtoolbarmodel.h
@@ -1,0 +1,76 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_NOTATIONSCENE_NOTATIONTOOLBARMODEL_H
+#define MU_NOTATIONSCENE_NOTATIONTOOLBARMODEL_H
+
+#include <QObject>
+#include <QAbstractListModel>
+#include "modularity/ioc.h"
+#include "actions/iactionsdispatcher.h"
+#include "context/iglobalcontext.h"
+#include "async/asyncable.h"
+
+namespace mu {
+namespace scene {
+namespace notation {
+class NotationToolBarModel : public QAbstractListModel, public async::Asyncable
+{
+    Q_OBJECT
+    INJECT(notation_scene, actions::IActionsDispatcher, dispatcher)
+    INJECT(notation_scene, context::IGlobalContext, globalContext)
+
+public:
+    explicit NotationToolBarModel(QObject* parent = nullptr);
+
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role) const override;
+    QHash<int,QByteArray> roleNames() const override;
+
+    Q_INVOKABLE void load();
+    Q_INVOKABLE void click(const QString& action);
+
+private:
+    enum Roles {
+        NameRole = Qt::UserRole + 1,
+        TitleRole,
+        EnabledRole,
+        CheckedRole
+    };
+
+    void onNotationChanged();
+    void updateState();
+    void disabledAll();
+
+    struct ActionItem {
+        actions::Action action;
+        bool enabled = false;
+        bool checked = false;
+    };
+
+    ActionItem& item(const actions::ActionName& name);
+    QList<ActionItem> m_items;
+
+    async::Notify m_notationChanged;
+    async::Notify m_inputStateChanged;
+};
+}
+}
+}
+
+#endif // MU_NOTATIONSCENE_NOTATIONTOOLBARMODEL_H

--- a/mu4/scenes/notation/toolbar/notationtoolbarmodel.h
+++ b/mu4/scenes/notation/toolbar/notationtoolbarmodel.h
@@ -66,8 +66,8 @@ private:
     ActionItem& item(const actions::ActionName& name);
     QList<ActionItem> m_items;
 
-    async::Notify m_notationChanged;
-    async::Notify m_inputStateChanged;
+    async::Notification m_notationChanged;
+    async::Notification m_inputStateChanged;
 };
 }
 }

--- a/mu4/scenes/notation/view/notationpaintview.cpp
+++ b/mu4/scenes/notation/view/notationpaintview.cpp
@@ -23,13 +23,15 @@
 
 #include "log.h"
 #include "notationviewinputcontroller.h"
+#include "actions/action.h"
 
 using namespace mu::scene::notation;
+using namespace mu::domain::notation;
 
 static constexpr int PREF_UI_CANVAS_MISC_SELECTIONPROXIMITY = 6;
 
-NotationPaintView::NotationPaintView() :
-    QQuickPaintedItem()
+NotationPaintView::NotationPaintView()
+    : QQuickPaintedItem()
 {
     setFlag(ItemHasContents, true);
     setAcceptedMouseButtons(Qt::AllButtons);
@@ -39,14 +41,12 @@ NotationPaintView::NotationPaintView() :
     m_matrix = QTransform::fromScale(mag, mag);
 
     m_inputController = new NotationViewInputController(this);
-}
 
-void NotationPaintView::cmd(const QString& name)
-{
-    //! NOTE Temporary
-    if ("open" == name) {
-        open();
-    }
+    connect(this, &QQuickPaintedItem::widthChanged, this, &NotationPaintView::onViewSizeChanged);
+    connect(this, &QQuickPaintedItem::heightChanged, this, &NotationPaintView::onViewSizeChanged);
+
+    // actions
+    dispatcher()->reg("domain/notation/file-open", [this](const actions::ActionName&) { open(); });
 }
 
 //! NOTE Temporary method for tests
@@ -62,14 +62,78 @@ void NotationPaintView::open()
         return;
     }
 
-    domain::notation::INotation::Params params;
-    params.pageSize.width = width();
-    params.pageSize.height = height();
-    bool ok = m_notation->load(filePath.toStdString(), params);
+    onViewSizeChanged();
+
+    bool ok = m_notation->load(filePath.toStdString());
     if (!ok) {
         LOGE() << "failed load: " << filePath;
     }
 
+    //! NOTE At the moment, only one notation, in the future it will change.
+    globalContext()->setCurrentNotation(m_notation);
+
+    m_notation->notationChanged().onNotify(this, [this]() {
+        update();
+    });
+
+    onInputStateChanged();
+    m_notation->inputStateChanged().onNotify(this, [this]() {
+        onInputStateChanged();
+    });
+
+    m_notation->selectionChanged().onNotify(this, [this]() {
+        onSelectionChanged();
+    });
+
+    update();
+}
+
+void NotationPaintView::onViewSizeChanged()
+{
+    if (!m_notation) {
+        return;
+    }
+
+    QPoint p1 = toLogical(QPoint(0, 0));
+    QPoint p2 = toLogical(QPoint(width(), height()));
+    m_notation->setViewSize(QSizeF(p2.x() - p1.x(), p2.y() - p1.y()));
+}
+
+void NotationPaintView::onInputStateChanged()
+{
+    INotationInputState* is = m_notation->inputState();
+    if (is->isNoteEnterMode()) {
+        setAcceptHoverEvents(true);
+    } else {
+        setAcceptHoverEvents(false);
+    }
+
+    update();
+}
+
+void NotationPaintView::onSelectionChanged()
+{
+    QRectF selRect = m_notation->selection()->canvasBoundingRect();
+    if (!selRect.isValid()) {
+        return;
+    }
+
+    adjustPosition(selRect);
+    update();
+}
+
+bool NotationPaintView::isNoteEnterMode() const
+{
+    if (!m_notation) {
+        return false;
+    }
+
+    return m_notation->inputState()->isNoteEnterMode();
+}
+
+void NotationPaintView::showShadowNote(const QPointF& pos)
+{
+    m_notation->showShadowNote(pos);
     update();
 }
 
@@ -82,9 +146,47 @@ void NotationPaintView::paint(QPainter* p)
 
     if (m_notation) {
         m_notation->paint(p, rect);
+        m_notation->paintShadowNote(p);
     } else {
         p->drawText(10, 10, "no notation");
     }
+}
+
+qreal NotationPaintView::xoffset() const
+{
+    return m_matrix.dx();
+}
+
+qreal NotationPaintView::yoffset() const
+{
+    return m_matrix.dy();
+}
+
+QRect NotationPaintView::viewport() const
+{
+    return toLogical(QRect(0, 0, width(), height()));
+}
+
+void NotationPaintView::adjustPosition(const QRectF& logicRect)
+{
+    //! TODO This is very simple adjustment of position.
+    //! Need to port the logic from ScoreView::adjustCanvasPosition
+    QPoint posTL = logicRect.topLeft().toPoint();
+
+    QRect viewRect = viewport();
+    if (viewRect.contains(posTL)) {
+        return;
+    }
+
+    posTL.setX(posTL.x() - 300);
+    posTL.setY(posTL.y() - 300);
+    moveToPosition(posTL);
+}
+
+void NotationPaintView::moveToPosition(const QPoint& logicPos)
+{
+    QPoint viewTL = toLogical(QPoint(0, 0));
+    moveScene(viewTL.x() - logicPos.x(), viewTL.y() - logicPos.y());
 }
 
 void NotationPaintView::moveScene(int dx, int dy)
@@ -159,12 +261,27 @@ void NotationPaintView::mouseReleaseEvent(QMouseEvent* ev)
     m_inputController->mouseReleaseEvent(ev);
 }
 
+void NotationPaintView::hoverMoveEvent(QHoverEvent* ev)
+{
+    m_inputController->hoverMoveEvent(ev);
+}
+
 QPoint NotationPaintView::toLogical(const QPoint& p) const
 {
     return m_matrix.inverted().map(p);
 }
 
+QRect NotationPaintView::toLogical(const QRect& r) const
+{
+    return m_matrix.inverted().mapRect(r);
+}
+
 QPoint NotationPaintView::toPhysical(const QPoint& p) const
 {
     return m_matrix.map(p);
+}
+
+std::shared_ptr<INotation> NotationPaintView::notation() const
+{
+    return m_notation;
 }

--- a/mu4/scenes/notation/view/notationpaintview.cpp
+++ b/mu4/scenes/notation/view/notationpaintview.cpp
@@ -118,7 +118,7 @@ void NotationPaintView::onSelectionChanged()
         return;
     }
 
-    adjustPosition(selRect);
+    adjustCanvasPosition(selRect);
     update();
 }
 
@@ -167,7 +167,7 @@ QRect NotationPaintView::viewport() const
     return toLogical(QRect(0, 0, width(), height()));
 }
 
-void NotationPaintView::adjustPosition(const QRectF& logicRect)
+void NotationPaintView::adjustCanvasPosition(const QRectF& logicRect)
 {
     //! TODO This is very simple adjustment of position.
     //! Need to port the logic from ScoreView::adjustCanvasPosition
@@ -180,16 +180,16 @@ void NotationPaintView::adjustPosition(const QRectF& logicRect)
 
     posTL.setX(posTL.x() - 300);
     posTL.setY(posTL.y() - 300);
-    moveToPosition(posTL);
+    moveCanvasToPosition(posTL);
 }
 
-void NotationPaintView::moveToPosition(const QPoint& logicPos)
+void NotationPaintView::moveCanvasToPosition(const QPoint& logicPos)
 {
     QPoint viewTL = toLogical(QPoint(0, 0));
-    moveScene(viewTL.x() - logicPos.x(), viewTL.y() - logicPos.y());
+    moveCanvas(viewTL.x() - logicPos.x(), viewTL.y() - logicPos.y());
 }
 
-void NotationPaintView::moveScene(int dx, int dy)
+void NotationPaintView::moveCanvas(int dx, int dy)
 {
     m_matrix.translate(dx, dy);
     update();

--- a/mu4/scenes/notation/view/notationpaintview.h
+++ b/mu4/scenes/notation/view/notationpaintview.h
@@ -74,7 +74,7 @@ private:
     QRect toLogical(const QRect& r) const;
     QPoint toPhysical(const QPoint& p) const;
 
-    void moveScene(int dx, int dy);
+    void moveCanvas(int dx, int dy);
     void scrollVertical(int dy);
     void scrollHorizontal(int dx);
     void zoomStep(qreal step, const QPoint& pos);
@@ -85,8 +85,8 @@ private:
     qreal yoffset() const;
     QRect viewport() const;
 
-    void adjustPosition(const QRectF& logicRect);
-    void moveToPosition(const QPoint& logicPos);
+    void adjustCanvasPosition(const QRectF& logicRect);
+    void moveCanvasToPosition(const QPoint& logicPos);
 
     void onInputStateChanged();
     void onSelectionChanged();

--- a/mu4/scenes/notation/view/notationviewinputcontroller.cpp
+++ b/mu4/scenes/notation/view/notationviewinputcontroller.cpp
@@ -20,13 +20,17 @@
 
 #include "log.h"
 #include "notationpaintview.h"
+#include "domain/notation/notationactions.h"
 
 using namespace mu::scene::notation;
+using namespace mu::domain::notation;
+using namespace mu::actions;
 
 static constexpr int PIXELSSTEPSFACTOR = 5;
+static constexpr int PREF_UI_CANVAS_MISC_SELECTIONPROXIMITY = 6;
 
-NotationViewInputController::NotationViewInputController(NotationPaintView* view) :
-    m_view(view)
+NotationViewInputController::NotationViewInputController(NotationPaintView* view)
+    : m_view(view)
 {
 }
 
@@ -63,11 +67,46 @@ void NotationViewInputController::wheelEvent(QWheelEvent* ev)
 void NotationViewInputController::mousePressEvent(QMouseEvent* ev)
 {
     QPoint logicPos = m_view->toLogical(ev->pos());
+    Qt::KeyboardModifiers keyState = ev->modifiers();
+
+    // note enter mode
+    if (m_view->isNoteEnterMode()) {
+        bool replace = ev->modifiers() & Qt::ShiftModifier;
+        bool insert = ev->modifiers() & Qt::ControlModifier;
+        dispatcher()->dispatch("domain/notation/put-note",
+                               ActionData::make_arg3<QPoint, bool, bool>(logicPos, replace, insert));
+
+        return;
+    }
+
     m_interactData.beginPoint = logicPos;
+    m_interactData.element = notationInputController()->hitElement(logicPos, hitWidth());
+
+    if (m_interactData.element) {
+        SelectType st = SelectType::SINGLE;
+        if (keyState == Qt::NoModifier) {
+            st = SelectType::SINGLE;
+        } else if (keyState & Qt::ShiftModifier) {
+            st = SelectType::RANGE;
+        } else if (keyState & Qt::ControlModifier) {
+            st = SelectType::ADD;
+        }
+
+        //! NOTE Maybe a better action?
+        m_view->notation()->select(m_interactData.element, st);
+    }
 }
 
 void NotationViewInputController::mouseMoveEvent(QMouseEvent* ev)
 {
+    if (m_view->isNoteEnterMode()) {
+        return;
+    }
+
+    if (m_interactData.element) {
+        return;
+    }
+
     QPoint pos = m_view->toLogical(ev->pos());
     QPoint d = pos - m_interactData.beginPoint;
     int dx = d.x();
@@ -82,4 +121,26 @@ void NotationViewInputController::mouseMoveEvent(QMouseEvent* ev)
 
 void NotationViewInputController::mouseReleaseEvent(QMouseEvent* /*ev*/)
 {
+}
+
+void NotationViewInputController::hoverMoveEvent(QHoverEvent* ev)
+{
+    if (m_view->isNoteEnterMode()) {
+        QPoint pos = m_view->toLogical(ev->pos());
+        m_view->showShadowNote(pos);
+    }
+}
+
+INotationInputController* NotationViewInputController::notationInputController() const
+{
+    auto notation = m_view->notation();
+    if (!notation) {
+        return nullptr;
+    }
+    return notation->inputController();
+}
+
+float NotationViewInputController::hitWidth() const
+{
+    return PREF_UI_CANVAS_MISC_SELECTIONPROXIMITY * 0.5 / m_view->scale(); //(preferences.getInt(PREF_UI_CANVAS_MISC_SELECTIONPROXIMITY) * .5) / matrix().m11();
 }

--- a/mu4/scenes/notation/view/notationviewinputcontroller.cpp
+++ b/mu4/scenes/notation/view/notationviewinputcontroller.cpp
@@ -116,7 +116,7 @@ void NotationViewInputController::mouseMoveEvent(QMouseEvent* ev)
         return;
     }
 
-    m_view->moveScene(dx, dy);
+    m_view->moveCanvas(dx, dy);
 }
 
 void NotationViewInputController::mouseReleaseEvent(QMouseEvent* /*ev*/)

--- a/mu4/scenes/notation/view/notationviewinputcontroller.h
+++ b/mu4/scenes/notation/view/notationviewinputcontroller.h
@@ -20,6 +20,10 @@
 #define MU_NOTATIONSCENE_NOTATIONVIEWINPUTCONTROLLER_H
 
 #include <QWheelEvent>
+#include "modularity/ioc.h"
+#include "actions/iactionsdispatcher.h"
+
+#include "notationpaintview.h"
 
 namespace mu {
 namespace scene {
@@ -27,6 +31,7 @@ namespace notation {
 class NotationPaintView;
 class NotationViewInputController
 {
+    INJECT(notation_scene, actions::IActionsDispatcher, dispatcher)
 public:
     NotationViewInputController(NotationPaintView* view);
 
@@ -34,12 +39,17 @@ public:
     void mousePressEvent(QMouseEvent* ev);
     void mouseMoveEvent(QMouseEvent* ev);
     void mouseReleaseEvent(QMouseEvent* ev);
+    void hoverMoveEvent(QHoverEvent* ev);
 
 private:
 
     struct InteractData {
         QPoint beginPoint;
+        domain::notation::Element* element = nullptr;
     };
+
+    domain::notation::INotationInputController* notationInputController() const;
+    float hitWidth() const;
 
     NotationPaintView* m_view = nullptr;
     InteractData m_interactData;

--- a/mu4/scenes/notation/view/qml/MuseScore/NotationScene/NotationView.qml
+++ b/mu4/scenes/notation/view/qml/MuseScore/NotationScene/NotationView.qml
@@ -5,11 +5,6 @@ Rectangle {
 
     id: root
 
-    function cmd(name) {
-        console.info("cmd: " + name)
-        view.cmd(name);
-    }
-
     NotationPaintView {
         id: view
         anchors.fill: parent

--- a/thirdparty/deto_async/LICENSE
+++ b/thirdparty/deto_async/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Igor Korsukov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/thirdparty/deto_async/README.md
+++ b/thirdparty/deto_async/README.md
@@ -1,0 +1,6 @@
+# Async primitives
+
+This is a set of primitives for asynchronous interaction.
+
+* Channel - channel for data transfer, like channels in GoLang
+* Notify - for notification of something

--- a/thirdparty/deto_async/async/async.cmake
+++ b/thirdparty/deto_async/async/async.cmake
@@ -1,0 +1,8 @@
+
+set (ASYNC_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/asyncable.h
+    ${CMAKE_CURRENT_LIST_DIR}/channel.h
+    ${CMAKE_CURRENT_LIST_DIR}/notify.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/abstractinvoker.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/abstractinvoker.h
+)

--- a/thirdparty/deto_async/async/async.cmake
+++ b/thirdparty/deto_async/async/async.cmake
@@ -2,7 +2,7 @@
 set (ASYNC_SRC
     ${CMAKE_CURRENT_LIST_DIR}/asyncable.h
     ${CMAKE_CURRENT_LIST_DIR}/channel.h
-    ${CMAKE_CURRENT_LIST_DIR}/notify.h
+    ${CMAKE_CURRENT_LIST_DIR}/notification.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/abstractinvoker.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/abstractinvoker.h
 )

--- a/thirdparty/deto_async/async/asyncable.h
+++ b/thirdparty/deto_async/async/asyncable.h
@@ -1,0 +1,50 @@
+#ifndef DETO_ASYNC_ASYNCABLE_H
+#define DETO_ASYNC_ASYNCABLE_H
+
+#include <set>
+#include <cstdint>
+
+namespace deto {
+namespace async {
+class Asyncable
+{
+public:
+
+    enum AsyncMode {
+        AsyncSetOnce = 0,
+        AsyncSetRepeat
+    };
+
+    virtual ~Asyncable()
+    {
+        for (uintptr_t k : m_connects) {
+            ptr(k)->disconnectAsync(this);
+        }
+    }
+
+    struct IConnectable {
+        virtual ~IConnectable() {}
+        virtual void disconnectAsync(Asyncable* a) = 0;
+    };
+
+    void connectAsync(IConnectable* d)
+    {
+        if (d && m_connects.count(key(d)) == 0) {
+            m_connects.insert(key(d));
+        }
+    }
+
+    void disconnectAsync(IConnectable* d)
+    {
+        m_connects.erase(key(d));
+    }
+
+private:
+    uintptr_t key(IConnectable* p) { return reinterpret_cast<uintptr_t>(p); }
+    IConnectable* ptr(uintptr_t k) { return reinterpret_cast<IConnectable*>(k); }
+    std::set<uintptr_t> m_connects;
+};
+}
+}
+
+#endif // DETO_ASYNC_ASYNCABLE_H

--- a/thirdparty/deto_async/async/channel.cpp
+++ b/thirdparty/deto_async/async/channel.cpp
@@ -16,26 +16,9 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#ifndef MU_DOMAIN_INOTATIONSELECTION_H
-#define MU_DOMAIN_INOTATIONSELECTION_H
+#include "channel.h"
 
-#include <QRectF>
-#include "async/notification.h"
-
-namespace mu {
-namespace domain {
-namespace notation {
-class INotationSelection
+Channel::Channel()
 {
-public:
-    virtual ~INotationSelection() = default;
 
-    virtual bool isNone() const = 0;
-
-    virtual QRectF canvasBoundingRect() const = 0;
-};
 }
-}
-}
-
-#endif // MU_DOMAIN_INOTATIONSELECTION_H

--- a/thirdparty/deto_async/async/channel.h
+++ b/thirdparty/deto_async/async/channel.h
@@ -1,0 +1,151 @@
+#ifndef DETO_ASYNC_CHANNEL_H
+#define DETO_ASYNC_CHANNEL_H
+
+#include <memory>
+#include "internal/abstractinvoker.h"
+
+namespace deto {
+namespace async {
+template<typename T>
+class Channel
+{
+public:
+    Channel() = default;
+    Channel(const Channel& ch)
+        : m_ptr(ch.ptr()) {}
+    ~Channel() {}
+
+    Channel& operator=(const Channel& ch)
+    {
+        if (m_ptr == ch.ptr()) {
+            return *this;
+        }
+
+        m_ptr = ch.ptr();
+        return *this;
+    }
+
+    void send(const T& d)
+    {
+        NotifyData nd;
+        nd.setArg<T>(0, d);
+        ptr()->invoke(Receive, nd);
+    }
+
+    template<typename Func>
+    void onReceive(const Asyncable* receiver, Func f, Asyncable::AsyncMode mode = Asyncable::AsyncSetOnce)
+    {
+        ptr()->setCallBack(Receive, const_cast<Asyncable*>(receiver), new ReceiveCall<Func, T>(f), mode);
+    }
+
+    void resetOnReceive(const Asyncable* receiver)
+    {
+        ptr()->removeCallBack(Receive, const_cast<Asyncable*>(receiver));
+    }
+
+    void close()
+    {
+        ptr()->invoke(Close);
+    }
+
+    template<typename Func>
+    void onClose(const Asyncable* receiver, Func f, Asyncable::AsyncMode mode = Asyncable::AsyncSetOnce)
+    {
+        ptr()->setCallBack(Close, const_cast<Asyncable*>(receiver), new CloseCall<Func>(f), mode);
+    }
+
+    bool isConnected() const
+    {
+        return ptr()->isConnected();
+    }
+
+private:
+
+    enum CallType {
+        Undefined = 0,
+        Receive,
+        Close
+    };
+
+    struct IReceive {
+        virtual ~IReceive() {}
+        virtual void received(const NotifyData& d) = 0;
+    };
+
+    template<typename Call, typename Arg>
+    struct ReceiveCall : public IReceive {
+        Call f;
+        ReceiveCall(Call _f)
+            : f(_f) {}
+        void received(const NotifyData& d) { f(d.arg<Arg>()); }
+    };
+
+    struct IClose {
+        virtual ~IClose() {}
+        virtual void closed() = 0;
+    };
+
+    template<typename Call>
+    struct CloseCall : public IClose {
+        Call f;
+        CloseCall(Call _f)
+            : f(_f) {}
+        void closed() { f(); }
+    };
+
+    struct ChannelInvoker : public AbstractInvoker
+    {
+        friend class Channel;
+
+        ChannelInvoker() = default;
+        ~ChannelInvoker()
+        {
+            removeAllCallBacks();
+        }
+
+        void deleteCall(int _type, void* call) override
+        {
+            CallType type = static_cast<CallType>(_type);
+            switch (type) {
+            case Undefined: {} break;
+            case Receive: {
+                delete static_cast<IReceive*>(call);
+            } break;
+            case Close: {
+                delete static_cast<IClose*>(call);
+            } break;
+            }
+        }
+
+        void onInvoke(int callKey, const NotifyData& d) override
+        {
+            CallType type = static_cast<CallType>(callKey);
+            std::vector<void*> cls = calls(callKey);
+            for (void* c : cls) {
+                switch (type) {
+                case Undefined:  break;
+                case Receive:
+                    static_cast<IReceive*>(c)->received(d);
+                    break;
+                case Close:
+                    static_cast<IClose*>(c)->closed();
+                    break;
+                }
+            }
+        }
+    };
+
+    std::shared_ptr<ChannelInvoker> ptr() const
+    {
+        if (!m_ptr) {
+            m_ptr = std::make_shared<ChannelInvoker>();
+        }
+        return m_ptr;
+    }
+
+    mutable std::shared_ptr<ChannelInvoker> m_ptr = nullptr;
+};
+}
+}
+
+#endif // DETO_ASYNC_CHANNEL_H

--- a/thirdparty/deto_async/async/internal/abstractinvoker.cpp
+++ b/thirdparty/deto_async/async/internal/abstractinvoker.cpp
@@ -1,0 +1,170 @@
+#include "abstractinvoker.h"
+
+#include <cassert>
+
+using namespace deto::async;
+
+AbstractInvoker::AbstractInvoker()
+    : m_key(100), m_threadID(std::this_thread::get_id())
+{
+}
+
+AbstractInvoker::~AbstractInvoker()
+{
+}
+
+int AbstractInvoker::newKey()
+{
+    ++m_key;
+    return m_key;
+}
+
+void AbstractInvoker::invokeMethod(int callKey, const NotifyData& data)
+{
+    if (std::this_thread::get_id() == m_threadID) {
+        onInvoke(callKey, data);
+    } else {
+        // todo
+        assert(std::this_thread::get_id() == m_threadID);
+    }
+}
+
+void AbstractInvoker::invoke(int callKey)
+{
+    invokeMethod(callKey, NotifyData());
+}
+
+void AbstractInvoker::invoke(int callKey, const NotifyData& data)
+{
+    invokeMethod(callKey, data);
+}
+
+bool AbstractInvoker::isConnected() const
+{
+    for (auto it = m_callbacks.cbegin(); it != m_callbacks.cend(); ++it) {
+        const CallBacks& cs = it->second;
+        if (cs.size() > 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+int AbstractInvoker::CallBacks::receiverIndexOf(Asyncable* receiver) const
+{
+    for (int i = 0; i < size(); ++i) {
+        if (at(i).receiver == receiver) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+bool AbstractInvoker::CallBacks::containsreceiver(Asyncable* receiver) const
+{
+    return receiverIndexOf(receiver) > -1;
+}
+
+void AbstractInvoker::removeCallBack(int type, Asyncable* receiver)
+{
+    auto it = m_callbacks.find(type);
+    if (it == m_callbacks.end()) {
+        return;
+    }
+
+    CallBacks& callbacks = it->second;
+    int index = callbacks.receiverIndexOf(receiver);
+    if (index < 0) {
+        return;
+    }
+
+    CallBack c = callbacks.at(index);
+    if (c.receiver) {
+        c.receiver->disconnectAsync(this);
+    }
+    callbacks.erase(callbacks.begin() + index);
+
+    deleteCall(type, c.call);
+}
+
+void AbstractInvoker::removeAllCallBacks()
+{
+    for (auto it = m_callbacks.begin(); it != m_callbacks.end(); ++it) {
+        for (CallBack& c : it->second) {
+            if (c.receiver) {
+                c.receiver->disconnectAsync(this);
+            }
+
+            deleteCall(c.type, c.call);
+        }
+    }
+    m_callbacks.clear();
+}
+
+void AbstractInvoker::setCallBack(int type, Asyncable* receiver, void* call, Asyncable::AsyncMode mode)
+{
+    const CallBacks& callbacks = m_callbacks[type];
+    if (callbacks.containsreceiver(receiver)) {
+        switch (mode) {
+        case Asyncable::AsyncSetOnce:
+            deleteCall(type, call);
+            return;
+        case Asyncable::AsyncSetRepeat:
+            removeCallBack(type, receiver);
+            break;
+        }
+    }
+
+    CallBack c(type, receiver, call);
+    m_callbacks[type].push_back(c);
+
+    if (c.receiver) {
+        c.receiver->connectAsync(this);
+    }
+}
+
+void AbstractInvoker::disconnectAsync(Asyncable* receiver)
+{
+    std::vector<int> types;
+    for (auto it = m_callbacks.begin(); it != m_callbacks.end(); ++it) {
+        for (CallBack& c : it->second) {
+            if (c.receiver == receiver) {
+                types.push_back(c.type);
+            }
+        }
+    }
+
+    for (int type : types) {
+        removeCallBack(type, receiver);
+    }
+}
+
+std::vector<void*> AbstractInvoker::calls(int type) const
+{
+    std::vector<void*> cls;
+    auto it = m_callbacks.find(type);
+    if (it == m_callbacks.end()) {
+        return cls;
+    }
+
+    const CallBacks& callbacks = it->second;
+    for (const CallBack& c : callbacks) {
+        cls.push_back(c.call);
+    }
+
+    return cls;
+}
+
+void AbstractInvoker::pushData(int key, const NotifyData& d)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_data.insert({ key, d });
+}
+
+NotifyData AbstractInvoker::popData(int key)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    NotifyData d = m_data.at(key);
+    m_data.erase(key);
+    return d;
+}

--- a/thirdparty/deto_async/async/internal/abstractinvoker.h
+++ b/thirdparty/deto_async/async/internal/abstractinvoker.h
@@ -1,0 +1,109 @@
+#ifndef DETO_ASYNC_ABSTRACTINVOKER_H
+#define DETO_ASYNC_ABSTRACTINVOKER_H
+
+#include <memory>
+#include <vector>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <thread>
+
+#include "../asyncable.h"
+
+namespace deto {
+namespace async {
+class NotifyData
+{
+public:
+    NotifyData() {}
+
+    template<typename T>
+    void setArg(int i, const T& val)
+    {
+        IArg* p = new Arg<T>(val);
+        m_args.insert(m_args.begin() + i, std::shared_ptr<IArg>(p));
+    }
+
+    template<typename T>
+    T arg(int i = 0) const
+    {
+        IArg* p = m_args.at(i).get();
+        if (!p) {
+            return T();
+        }
+        Arg<T>* d = reinterpret_cast<Arg<T>*>(p);
+        return d->val;
+    }
+
+    struct IArg {
+        virtual ~IArg() = default;
+    };
+
+    template<typename T>
+    struct Arg : public IArg {
+        T val;
+        Arg(const T& v)
+            : IArg(), val(v) {}
+    };
+
+private:
+    std::vector<std::shared_ptr<IArg> > m_args;
+};
+
+class AbstractInvoker : public Asyncable::IConnectable
+{
+public:
+    void disconnectAsync(Asyncable* receiver);
+
+    void invoke(int callKey);
+    void invoke(int callKey, const NotifyData& data);
+
+    bool isConnected() const;
+
+protected:
+    explicit AbstractInvoker();
+    ~AbstractInvoker();
+
+    virtual void deleteCall(int type, void* call) = 0;
+    virtual void onInvoke(int callKey, const NotifyData& data) = 0;
+
+    void doInvoke(int callKey, int dataKey);
+
+    struct CallBack {
+        int type = 0;
+        Asyncable* receiver = nullptr;
+        void* call = nullptr;
+        CallBack() {}
+        CallBack(int t, Asyncable* cr, void* c)
+            : type(t), receiver(cr), call(c) {}
+    };
+
+    class CallBacks : public std::vector<CallBack>
+    {
+    public:
+        int receiverIndexOf(Asyncable* receiver) const;
+        bool containsreceiver(Asyncable* receiver) const;
+    };
+
+    void setCallBack(int type, Asyncable* receiver, void* call, Asyncable::AsyncMode mode = Asyncable::AsyncSetRepeat);
+    void removeCallBack(int type, Asyncable* receiver);
+    void removeAllCallBacks();
+    std::vector<void*> calls(int type) const;
+
+    int newKey();
+    void invokeMethod(int callKey, const NotifyData& data);
+    void pushData(int key, const NotifyData& e);
+    NotifyData popData(int key);
+
+    std::map<int /*type*/, CallBacks > m_callbacks;
+
+    int m_key = 0;
+
+    std::thread::id m_threadID;
+    std::mutex m_mutex;
+    std::map<int, NotifyData> m_data;
+};
+}
+}
+
+#endif // DETO_ASYNC_ABSTRACTINVOKER_H

--- a/thirdparty/deto_async/async/notification.h
+++ b/thirdparty/deto_async/async/notification.h
@@ -1,11 +1,11 @@
-#ifndef DETO_ASYNC_NOTIFY_H
-#define DETO_ASYNC_NOTIFY_H
+#ifndef DETO_ASYNC_NOTIFICATION_H
+#define DETO_ASYNC_NOTIFICATION_H
 
 #include "channel.h"
 
 namespace deto {
 namespace async {
-class Notify
+class Notification
 {
 public:
 
@@ -47,4 +47,4 @@ private:
 }
 }
 
-#endif // DETO_ASYNC_NOTIFY_H
+#endif // DETO_ASYNC_NOTIFICATION_H

--- a/thirdparty/deto_async/async/notify.h
+++ b/thirdparty/deto_async/async/notify.h
@@ -1,0 +1,50 @@
+#ifndef DETO_ASYNC_NOTIFY_H
+#define DETO_ASYNC_NOTIFY_H
+
+#include "channel.h"
+
+namespace deto {
+namespace async {
+class Notify
+{
+public:
+
+    void notify()
+    {
+        m_ch.send(0);
+    }
+
+    template<typename Func>
+    void onNotify(const Asyncable* receiver, Func f, Asyncable::AsyncMode mode = Asyncable::AsyncSetOnce)
+    {
+        m_ch.onReceive(receiver, [f](int) { f(); }, mode);
+    }
+
+    void resetOnNotify(const Asyncable* receiver)
+    {
+        m_ch.resetOnReceive(receiver);
+    }
+
+    void close()
+    {
+        m_ch.close();
+    }
+
+    template<typename Func>
+    void onClose(const Asyncable* receiver, Func f, Asyncable::AsyncMode mode = Asyncable::AsyncSetOnce)
+    {
+        m_ch.onClose(receiver, f, mode);
+    }
+
+    bool isConnected() const
+    {
+        return m_ch.isConnected();
+    }
+
+private:
+    Channel<int> m_ch;
+};
+}
+}
+
+#endif // DETO_ASYNC_NOTIFY_H

--- a/thirdparty/deto_async/tests/CMakeLists.txt
+++ b/thirdparty/deto_async/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(async LANGUAGES CXX)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(${CMAKE_CURRENT_LIST_DIR}/../async/async.cmake)
+
+add_executable(async
+    ${ASYNC_SRC}
+    main.cpp
+)

--- a/thirdparty/deto_async/tests/main.cpp
+++ b/thirdparty/deto_async/tests/main.cpp
@@ -1,7 +1,7 @@
 #include <functional>
 #include <iostream>
 #include "../async/channel.h"
-#include "../async/notify.h"
+#include "../async/notification.h"
 
 using namespace deto::async;
 
@@ -24,7 +24,7 @@ struct Counter {
 struct Receiver : public deto::async::Asyncable
 {
     Channel<int> m_ch;
-    Notify m_nt;
+    Notification m_nt;
 
     Receiver(const Channel<int>& ch)
         : m_ch(ch)
@@ -34,26 +34,26 @@ struct Receiver : public deto::async::Asyncable
         });
     }
 
-    Receiver(const Notify& nt)
+    Receiver(const Notification& nt)
         : m_nt(nt)
     {
-        m_nt.onReceive(this, []() {
-            std::cout << "Receiver notify\n";
+        m_nt.onNotify(this, []() {
+            std::cout << "Receiver notification\n";
         });
     }
 };
 
 struct Notifer
 {
-    Notify m_nt;
-    Notify notify() const
+    Notification m_nt;
+    Notification notify() const
     {
         return m_nt;
     }
 
     void send()
     {
-        m_nt.send();
+        m_nt.notify();
     }
 };
 
@@ -92,15 +92,15 @@ int main(int argc, char* argv[])
         counter.increment();
     }
 
-    Notify nt1;
-    nt1.onReceive(nullptr, []() {
-        std::cout << "Notify 1 \n";
+    Notification nt1;
+    nt1.onNotify(nullptr, []() {
+        std::cout << "Notification 1 \n";
     });
 
-    nt1.send();
+    nt1.notify();
 
     Notifer ntr;
-    Notify nt2 = ntr.notify();
+    Notification nt2 = ntr.notify();
     {
         Receiver r(nt2);
         for (int i = 0; i < 5; ++i) {

--- a/thirdparty/deto_async/tests/main.cpp
+++ b/thirdparty/deto_async/tests/main.cpp
@@ -1,0 +1,110 @@
+#include <functional>
+#include <iostream>
+#include "../async/channel.h"
+#include "../async/notify.h"
+
+using namespace deto::async;
+
+struct Counter {
+    Channel<int> m_ch;
+    int m_val = 0;
+
+    void increment()
+    {
+        ++m_val;
+        m_ch.send(m_val);
+    }
+
+    Channel<int> channel() const
+    {
+        return m_ch;
+    }
+};
+
+struct Receiver : public deto::async::Asyncable
+{
+    Channel<int> m_ch;
+    Notify m_nt;
+
+    Receiver(const Channel<int>& ch)
+        : m_ch(ch)
+    {
+        m_ch.onReceive(this, [](int a) {
+            std::cout << "Receiver channel: " << a << "\n";
+        });
+    }
+
+    Receiver(const Notify& nt)
+        : m_nt(nt)
+    {
+        m_nt.onReceive(this, []() {
+            std::cout << "Receiver notify\n";
+        });
+    }
+};
+
+struct Notifer
+{
+    Notify m_nt;
+    Notify notify() const
+    {
+        return m_nt;
+    }
+
+    void send()
+    {
+        m_nt.send();
+    }
+};
+
+int main(int argc, char* argv[])
+{
+    std::cout << "Hello World, I am async\n";
+
+    Channel<int> ch1;
+    ch1.onReceive(nullptr, [](int a) {
+        std::cout << "onReceive a: " << a << "\n";
+    });
+
+    for (int i = 0; i < 5; ++i) {
+        ch1.send(i);
+    }
+
+    Counter counter;
+
+    Channel<int> ch2 = counter.channel();
+    ch2.onReceive(nullptr, [](int a) {
+        std::cout << "counter: " << a << "\n";
+    });
+
+    for (int i = 0; i < 5; ++i) {
+        counter.increment();
+    }
+
+    {
+        Receiver r(ch2);
+        for (int i = 0; i < 5; ++i) {
+            counter.increment();
+        }
+    }
+
+    for (int i = 0; i < 5; ++i) {
+        counter.increment();
+    }
+
+    Notify nt1;
+    nt1.onReceive(nullptr, []() {
+        std::cout << "Notify 1 \n";
+    });
+
+    nt1.send();
+
+    Notifer ntr;
+    Notify nt2 = ntr.notify();
+    {
+        Receiver r(nt2);
+        for (int i = 0; i < 5; ++i) {
+            ntr.send();
+        }
+    }
+}


### PR DESCRIPTION
In this PR added:

## System stuff

### Actions

Actions and action dispatcher is an implementation of actions from the Flux architecture
Replaces shortcuts + cmd in the current editor

See https://github.com/musescore/Documentation/pull/11

### Primitives for Asynchronous Interaction

Currently added:
* Notification - for notification of something
* Channel - a two-way channel for data transfer

See https://github.com/musescore/Documentation/pull/11

### Global Context

This is an object for storing a global (public) state, for example, which notation is currently current (active)

### Features

__All functionality is implemented as prototypes (not ready for production) to determine common approaches__

Entering notes:
* Added toolbar notations (basic implementation with several buttons).
* Added appropriate actions and methods to the notation.
* Added appropriate view response to change in notation state
* Added `INotationActionsController` interface - handles actions and calls the appropriate methods in the current notation
* Added `INotationInputState` interface - wrapper over `Ms::InputState`
* Added `INotationSelection` interface  - wrapper over `Ms::Selection`

The architecture of the interaction between the toolbar, notation, and view is closest to the Flux architecture (See https://github.com/musescore/Documentation/pull/11) 



