### PR TITLE
fix #306517 assert on fotodrag

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -1120,6 +1120,7 @@ void ScoreView::changeState(ViewState s)
                         e->triggerLayout();
                         }
                   setDropTarget(0); // this also resets dropAnchor
+                  _score->selection().unlock("drag");
                   _score->endCmd();
                   break;
             case ViewState::DRAG_OBJECT:


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/306517

When dragging the capture frame, the `ScoreView::startDrag` method is called, and the `ScoreView::endDrag` method is not called, so unlock is not done.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue

