### PR TITLE
Fix #306524: Control playback speed with the keyboard

### DIFF
--- a/audio/drivers/jackaudio.cpp
+++ b/audio/drivers/jackaudio.cpp
@@ -693,7 +693,7 @@ void JackAudio::checkTransportSeek(int cur_frame, int nframes, bool inCountIn)
       jack_transport_query(client, &pos);
 
       if (preferences.getBool(PREF_IO_JACK_USEJACKTRANSPORT)) {
-            if (mscore->playPanelInterface() && mscore->playPanelInterface()->isTempoSliderPressed())
+            if (mscore->playPanelInterface() && mscore->playPanelInterface()->isSpeedSliderPressed())
                   return;
             int cur_utick = seq->score()->utime2utick((qreal)cur_frame / MScore::sampleRate);
             int utick     = seq->score()->utime2utick((qreal)pos.frame / MScore::sampleRate);
@@ -720,7 +720,7 @@ void JackAudio::checkTransportSeek(int cur_frame, int nframes, bool inCountIn)
                   seq->setRelTempo(newRelTempo);
                   // Update UI
                   if (mscore->getPlayPanel()) {
-                        mscore->playPanelInterface()->setRelTempo(newRelTempo);
+                        mscore->playPanelInterface()->setSpeed(newRelTempo);
                         mscore->playPanelInterface()->setTempo(seq->curTempo() * newRelTempo);
                         }
                   }

--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -43,6 +43,7 @@
 #define PREF_APP_PLAYBACK_FOLLOWSONG                        "application/playback/followSong"
 #define PREF_APP_PLAYBACK_PANPLAYBACK                       "application/playback/panPlayback"
 #define PREF_APP_PLAYBACK_PLAYREPEATS                       "application/playback/playRepeats"
+#define PREF_APP_PLAYBACK_SPEEDINCREMENT                    "application/playback/speedIncrement"
 #define PREF_APP_PLAYBACK_LOOPTOSELECTIONONPLAY             "application/playback/setLoopToSelectionOnPlay"
 #define PREF_APP_USESINGLEPALETTE                           "application/useSinglePalette"
 #define PREF_APP_PALETTESCALE                               "application/paletteScale"

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -98,6 +98,7 @@ int     MScore::pedalEventsMinTicks;
 
 bool    MScore::playRepeats;
 bool    MScore::panPlayback;
+int     MScore::playbackSpeedIncrement;
 qreal   MScore::nudgeStep;
 qreal   MScore::nudgeStep10;
 qreal   MScore::nudgeStep50;
@@ -303,13 +304,14 @@ void MScore::init()
       selectColor[2].setNamedColor("#C53F00");   //orange
       selectColor[3].setNamedColor("#C31989");   //purple
 
-      defaultColor        = Qt::black;
-      dropColor           = QColor("#1778db");
-      defaultPlayDuration = 300;      // ms
-      warnPitchRange      = true;
-      pedalEventsMinTicks = 1;
-      playRepeats         = true;
-      panPlayback         = true;
+      defaultColor           = Qt::black;
+      dropColor              = QColor("#1778db");
+      defaultPlayDuration    = 300;      // ms
+      warnPitchRange         = true;
+      pedalEventsMinTicks    = 1;
+      playRepeats            = true;
+      panPlayback            = true;
+      playbackSpeedIncrement = 5;
 
       lastError           = "";
 

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -325,6 +325,7 @@ class MScore {
 
       static bool playRepeats;
       static bool panPlayback;
+      static int playbackSpeedIncrement;
       static qreal nudgeStep;
       static qreal nudgeStep10;
       static qreal nudgeStep50;

--- a/mscore/iplaypanel.h
+++ b/mscore/iplaypanel.h
@@ -8,9 +8,13 @@ class IPlayPanel {
    public:
       virtual ~IPlayPanel() {}
 
+      virtual double speed() const = 0;
       virtual void setTempo(double) = 0;
-      virtual void setRelTempo(qreal) = 0;
-      virtual bool isTempoSliderPressed() const = 0;
+      virtual void setSpeed(double) = 0;
+      virtual void increaseSpeed() = 0;
+      virtual void decreaseSpeed() = 0;
+      virtual void resetSpeed() = 0;
+      virtual bool isSpeedSliderPressed() const = 0;
 };
 
 }

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -465,6 +465,8 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void setPlayRepeats(bool repeat);
       void setPanPlayback(bool pan);
 
+      void createPlayPanel();
+
       ScoreTab* createScoreTab();
       void askResetOldScorePositions(Score* score);
 

--- a/mscore/osc.cpp
+++ b/mscore/osc.cpp
@@ -191,7 +191,7 @@ void MuseScore::oscTempo(int val)
             val = 300;
       qreal t = val * .01;
       if (playPanel)
-            playPanel->setRelTempo(t);
+            playPanel->setSpeed(t);
       if (seq)
             seq->setRelTempo(double(t));
       }

--- a/mscore/playpanel.h
+++ b/mscore/playpanel.h
@@ -36,7 +36,7 @@ class PlayPanel : public QDockWidget, private Ui::PlayPanelBase, public IPlayPan
       Q_OBJECT
       int cachedTickPosition;
       int cachedTimePosition;
-      bool tempoSliderIsPressed;
+      bool _isSpeedSliderPressed;
       EnablePlayForWidget* enablePlay;
 
       Score* cs;
@@ -51,10 +51,10 @@ class PlayPanel : public QDockWidget, private Ui::PlayPanelBase, public IPlayPan
    private slots:
       void volumeChanged(double,int);
       void metronomeGainChanged(double val, int);
-      void relTempoChanged(double,int);
-      void relTempoChanged();
-      void tempoSliderReleased(int);
-      void tempoSliderPressed(int);
+      void speedChanged(double,int);
+      void speedChanged();
+      void speedSliderReleased(int);
+      void speedSliderPressed(int);
       void volLabel();
       void volSpinBoxEdited();
 
@@ -63,7 +63,7 @@ class PlayPanel : public QDockWidget, private Ui::PlayPanelBase, public IPlayPan
       void retranslate()  { retranslateUi(this); }
 
    signals:
-      void relTempoChanged(double);
+      void speedChanged(double);
       void metronomeGainChanged(float);
       void posChange(int);
       void closed(bool);
@@ -77,12 +77,20 @@ class PlayPanel : public QDockWidget, private Ui::PlayPanelBase, public IPlayPan
       PlayPanel(QWidget* parent = 0);
       ~PlayPanel();
 
+      double speed() const override;
+
       void setTempo(double) override;
-      void setRelTempo(qreal) override;
+      void setSpeed(double) override;
+
+      void increaseSpeed() override;
+      void decreaseSpeed() override;
+      void resetSpeed() override;
 
       void setEndpos(int);
       void setScore(Score* s);
-      bool isTempoSliderPressed() const override { return tempoSliderIsPressed; }
+      bool isSpeedSliderPressed() const override { return _isSpeedSliderPressed; }
+
+      void setSpeedIncrement(int);
       };
 
 

--- a/mscore/playpanel.ui
+++ b/mscore/playpanel.ui
@@ -634,7 +634,7 @@ volume</string>
       <item row="1" column="1">
        <layout class="QHBoxLayout" name="tempoPercentLayout">
         <item>
-         <widget class="QDoubleSpinBox" name="relTempoBox">
+         <widget class="QSpinBox" name="speedSpinBox">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -648,10 +648,10 @@ volume</string>
            </size>
           </property>
           <property name="toolTip">
-           <string>Relative tempo (as percentage)</string>
+           <string>Playback speed (as percentage)</string>
           </property>
           <property name="accessibleName">
-           <string>Relative tempo (as percentage)</string>
+           <string>Playback speed (as percentage)</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignCenter</set>
@@ -659,26 +659,20 @@ volume</string>
           <property name="buttonSymbols">
            <enum>QAbstractSpinBox::NoButtons</enum>
           </property>
-          <property name="prefix">
-           <string/>
-          </property>
           <property name="suffix">
-           <string notr="true">%</string>
-          </property>
-          <property name="decimals">
-           <number>0</number>
+           <string>%</string>
           </property>
           <property name="minimum">
-           <double>10.000000000000000</double>
+           <number>10</number>
           </property>
           <property name="maximum">
-           <double>300.000000000000000</double>
+           <number>300</number>
           </property>
           <property name="singleStep">
-           <double>5.000000000000000</double>
+           <number>5</number>
           </property>
           <property name="value">
-           <double>100.000000000000000</double>
+           <number>100</number>
           </property>
          </widget>
         </item>
@@ -814,12 +808,12 @@ volume</string>
        </layout>
       </item>
       <item row="0" column="1">
-       <layout class="QHBoxLayout" name="tempoSliderLayout">
+       <layout class="QHBoxLayout" name="speedSliderLayout">
         <property name="topMargin">
          <number>0</number>
         </property>
         <item>
-         <widget class="Awl::Slider" name="tempoSlider" native="true">
+         <widget class="Awl::Slider" name="speedSlider" native="true">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
             <horstretch>0</horstretch>
@@ -842,10 +836,10 @@ volume</string>
            <enum>Qt::TabFocus</enum>
           </property>
           <property name="toolTip">
-           <string>Relative tempo</string>
+           <string>Playback speed</string>
           </property>
           <property name="accessibleName">
-           <string>Relative tempo</string>
+           <string>Playback speed</string>
           </property>
           <property name="accessibleDescription">
            <string>Use up and down arrows to change value</string>

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -113,6 +113,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_APP_PLAYBACK_FOLLOWSONG,                         new BoolPreference(true)},
             {PREF_APP_PLAYBACK_PANPLAYBACK,                        new BoolPreference(true, false)},
             {PREF_APP_PLAYBACK_PLAYREPEATS,                        new BoolPreference(true, false)},
+            {PREF_APP_PLAYBACK_SPEEDINCREMENT,                     new IntPreference(5)},
             {PREF_APP_PLAYBACK_LOOPTOSELECTIONONPLAY,              new BoolPreference(true)},
             {PREF_APP_USESINGLEPALETTE,                            new BoolPreference(false)},
             {PREF_APP_PALETTESCALE,                                new DoublePreference(1.0)},

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -3091,6 +3091,30 @@ Shortcut Shortcut::_sc[] = {
          ShortcutFlags::A_CHECKABLE
          },
       {
+         MsWidget::MAIN_WINDOW,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY | STATE_EDIT,
+         "playback-speed-increase",
+         QT_TRANSLATE_NOOP("action","Increase Playback Speed"),
+         QT_TRANSLATE_NOOP("action","Increase playback speed"),
+         QT_TRANSLATE_NOOP("action","Increase the playback speed")
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY | STATE_EDIT,
+         "playback-speed-decrease",
+         QT_TRANSLATE_NOOP("action","Decrease Playback Speed"),
+         QT_TRANSLATE_NOOP("action","Decrease playback speed"),
+         QT_TRANSLATE_NOOP("action","Decrease the playback speed")
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY | STATE_EDIT,
+         "playback-speed-reset",
+         QT_TRANSLATE_NOOP("action","Reset Playback Speed"),
+         QT_TRANSLATE_NOOP("action","Reset playback speed"),
+         QT_TRANSLATE_NOOP("action","Reset the playback speed to 100%")
+         },
+      {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
          "figured-bass",


### PR DESCRIPTION
Resolves: [#306524](https://musescore.org/en/node/306524)

Implemented three new commands that increase, decrease, and reset the playback speed to 100%. The speed increment defaults to 5% but is configurable via an advanced preference. The new commands are not assigned default keyboard shortcuts but are configurable by the user.

Also renamed “relative tempo” to “playback speed” in the relevant code, since that more accurately describes what it actually is. This distinction will become more important later if (or when) MuseScore gains true relative-tempo control at the score level (as opposed to the playback/transport level).

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made