### PR TITLE
make Apply and Applying in preferences translatable

### DIFF
--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -1295,7 +1295,7 @@ void PreferenceDialog::apply()
       bool audioModified = false;
 
       applySetActive(false);
-      buttonBox->button(QDialogButtonBox::Apply)->setText("Applying...");
+      buttonBox->button(QDialogButtonBox::Apply)->setText(tr("Applying..."));
       buttonBox->repaint();
 
       std::vector<QString> changedAdvancedProperties = advancedWidget->save();
@@ -1422,7 +1422,7 @@ void PreferenceDialog::apply()
       modifiedUiWidgets.clear();
       modifiedAudioWidgets.clear();
 
-      buttonBox->button(QDialogButtonBox::Apply)->setText("Apply");
+      buttonBox->button(QDialogButtonBox::Apply)->setText(tr("Apply"));
       qDebug() << "Final: " << timer.elapsed() << endl;
       }
 


### PR DESCRIPTION
Added 2 translatable strings (Apply/Applying).

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ n\a] I created the test (mtest, vtest, script test) to verify the changes I made
