### PR TITLE
Fix #306560: Toolbar zoom box does nothing

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -951,7 +951,7 @@ void MuseScore::populateFileOperations()
             zoomBox->setCurrentText(zoomBoxState.second);
             }
 
-      connect(zoomBox, SIGNAL(magChanged(MagIdx)), SLOT(magChanged(MagIdx)));
+      connect(zoomBox, SIGNAL(zoomIndexChanged(ZoomIndex)), SLOT(zoomBoxIndexChanged(ZoomIndex)));
       fileTools->addWidget(zoomBox);
 
       viewModeCombo = new QComboBox(this);
@@ -4876,7 +4876,7 @@ void MuseScore::dirtyChanged(Score* s)
       }
 
 //---------------------------------------------------------
-//   zoomBoxChanged
+//   zoomBoxIndexChanged
 //---------------------------------------------------------
 
 void MuseScore::zoomBoxIndexChanged(ZoomIndex index)


### PR DESCRIPTION
Resolves: [#306560](https://musescore.org/en/node/306560)

Fixed a problem introduced in [#306509](https://musescore.org/en/node/306509) that caused the new zoom level to fail to be applied if the user tried to change it using the toolbar zoom box.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made