### PR TITLE
Fix #299214: Reimplement Shift+L/R for leading space while in edit mode upon notehead

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2504,8 +2504,13 @@ void Note::endDrag(EditData& ed)
 void Note::editDrag(EditData& editData)
       {
       Chord* ch = chord();
+      Segment* seg = ch->segment();
 
-      if (ch->notes().size() == 1) {
+      if (editData.modifiers & Qt::ShiftModifier) {
+            const Spatium deltaSp = Spatium(editData.delta.x() / spatium());
+            seg->undoChangeProperty(Pid::LEADING_SPACE, seg->extraLeadingSpace() + deltaSp);
+            }
+      else if (ch->notes().size() == 1) {
             // if the chord contains only this note, then move the whole chord
             // including stem, flag etc.
             ch->undoChangeProperty(Pid::OFFSET, ch->offset() + offset() + editData.evtDelta);
@@ -2616,15 +2621,8 @@ void Note::horizontalDrag(EditData &ed)
 
       NoteEditData* ned = static_cast<NoteEditData*>(ed.getData(this));
 
-      // adjust segment on plain drag or Shift+cursor,
-      // adjust note/chord for Ctrl+drag or plain cursor
-      if (seg &&
-          (((ed.buttons & Qt::LeftButton) && !(ed.modifiers & Qt::ControlModifier))
-           || (ed.modifiers & Qt::ShiftModifier))) {
-
-            if (ed.moveDelta.x() < 0)
-                  normalizeLeftDragDelta(seg, ed, ned);
-            }
+      if (ed.moveDelta.x() < 0)
+            normalizeLeftDragDelta(seg, ed, ned);
 
       const Spatium deltaSp = Spatium(ned->delta.x() / spatium());
 

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -1164,4 +1164,22 @@ Shape Rest::shape() const
       return shape;
       }
 
+//---------------------------------------------------------
+//   editDrag
+//---------------------------------------------------------
+
+void Rest::editDrag(EditData& editData)
+      {
+      Segment* seg = segment();
+
+      if (editData.modifiers & Qt::ShiftModifier) {
+            const Spatium deltaSp = Spatium(editData.delta.x() / spatium());
+            seg->undoChangeProperty(Pid::LEADING_SPACE, seg->extraLeadingSpace() + deltaSp);
+            }
+      else {
+            setOffset(offset() + editData.evtDelta);
+            }
+      triggerLayout();
+      }
+
 }

--- a/libmscore/rest.h
+++ b/libmscore/rest.h
@@ -108,6 +108,7 @@ class Rest : public ChordRest {
       QString accessibleInfo() const override;
       QString screenReaderInfo() const override;
       Shape shape() const override;
+      void editDrag(EditData& editData) override;
       };
 
 }     // namespace Ms


### PR DESCRIPTION
...and do the same for rests also.

Resolves: https://musescore.org/node/299214.