### PR TITLE
fix #306551: make symbols accessible to plugins

### DIFF
--- a/Doxyfile.plugins
+++ b/Doxyfile.plugins
@@ -799,6 +799,7 @@ INPUT                  = doc/plugins.md \
                          mscore/plugin/api \
                          libmscore/types.h \
                          libmscore/style.h \
+                         libmscore/sym.h \
                          libmscore/note.h \
                          libmscore/mscore.h \
                          libmscore/lyrics.h \

--- a/libmscore/accidental.h
+++ b/libmscore/accidental.h
@@ -24,11 +24,11 @@
 
 #include "config.h"
 #include "element.h"
+#include "sym.h"
 
 namespace Ms {
 
 class Note;
-enum class SymId;
 enum class AccidentalVal : signed char;
 
 //---------------------------------------------------------

--- a/libmscore/articulation.h
+++ b/libmscore/articulation.h
@@ -15,6 +15,7 @@
 
 #include "element.h"
 #include "mscore.h"
+#include "sym.h"
 
 namespace Ms {
 
@@ -23,8 +24,6 @@ class Segment;
 class Measure;
 class System;
 class Page;
-
-enum class SymId;
 
 //---------------------------------------------------------
 //   ArticulationInfo

--- a/libmscore/breath.h
+++ b/libmscore/breath.h
@@ -14,10 +14,9 @@
 #define __BREATH_H__
 
 #include "element.h"
+#include "sym.h"
 
 namespace Ms {
-
-enum class SymId;
 
 //---------------------------------------------------------
 //   BreathType

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -19,6 +19,7 @@
 #include "scoreElement.h"
 #include "shape.h"
 #include "sig.h"
+#include "sym.h"
 
 namespace Ms {
 
@@ -34,7 +35,6 @@ namespace Ms {
 
 class XmlReader;
 class XmlWriter;
-enum class SymId;
 enum class Pid;
 class StaffType;
 

--- a/libmscore/fermata.h
+++ b/libmscore/fermata.h
@@ -15,6 +15,7 @@
 
 #include "element.h"
 #include "mscore.h"
+#include "sym.h"
 
 namespace Ms {
 
@@ -23,8 +24,6 @@ class Segment;
 class Measure;
 class System;
 class Page;
-
-enum class SymId;
 
 //---------------------------------------------------------
 //    Fermata

--- a/libmscore/key.h
+++ b/libmscore/key.h
@@ -13,6 +13,8 @@
 #ifndef __KEY__H__
 #define __KEY__H__
 
+#include "sym.h"
+
 namespace Ms {
 
 class XmlWriter;
@@ -74,8 +76,6 @@ static inline bool operator== (const Key a, const Key b) { return int(a) == int(
 static inline bool operator!= (const Key a, const Key b) { return static_cast<int>(a) != static_cast<int>(b); }
 static inline Key operator+= (Key& a, const Key& b) { return a = Key(static_cast<int>(a) + static_cast<int>(b)); }
 static inline Key operator-= (Key& a, const Key& b) { return a = Key(static_cast<int>(a) - static_cast<int>(b)); }
-
-enum class SymId;
 
 //---------------------------------------------------------
 //   KeySym

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -24,6 +24,7 @@
 #include "pitchspelling.h"
 #include "shape.h"
 #include "key.h"
+#include "sym.h"
 
 namespace Ms {
 
@@ -41,7 +42,6 @@ class NoteDot;
 class Spanner;
 class StaffType;
 class NoteEditData;
-enum class SymId;
 enum class AccidentalType : char;
 
 static const int MAX_DOTS = 4;

--- a/libmscore/rest.h
+++ b/libmscore/rest.h
@@ -15,11 +15,11 @@
 
 #include "chordrest.h"
 #include "notedot.h"
+#include "sym.h"
 
 namespace Ms {
 
 class TDuration;
-enum class SymId;
 
 //---------------------------------------------------------
 //    @@ Rest

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -27,6 +27,7 @@
 #include "spannermap.h"
 #include "layoutbreak.h"
 #include "property.h"
+#include "sym.h"
 
 namespace Ms {
 
@@ -95,7 +96,6 @@ struct LayoutContext;
 enum class Tid;
 enum class ClefType : signed char;
 enum class BeatType : char;
-enum class SymId;
 enum class Key;
 enum class HairpinType : signed char;
 enum class SegmentType;

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -24,6 +24,7 @@ struct ChordDescription;
 class Element;
 class Score;
 
+// Needs to be duplicated here and in sym.h since moc doesn't handle macros from #include'd files
 #ifdef SCRIPT_INTERFACE
 #define BEGIN_QT_REGISTERED_ENUM(Name) \
 class MSQE_##Name { \

--- a/libmscore/sym.h
+++ b/libmscore/sym.h
@@ -19,6 +19,21 @@
 #include "ft2build.h"
 #include FT_FREETYPE_H
 
+// Needs to be duplicated here and in style.h since moc doesn't handle macros from #include'd files
+#ifdef SCRIPT_INTERFACE
+#define BEGIN_QT_REGISTERED_ENUM(Name) \
+class MSQE_##Name { \
+      Q_GADGET \
+   public:
+#define END_QT_REGISTERED_ENUM(Name) \
+      Q_ENUM(Name); \
+      }; \
+using Name = MSQE_##Name::Name;
+#else
+#define BEGIN_QT_REGISTERED_ENUM(Name)
+#define END_QT_REGISTERED_ENUM(Name)
+#endif
+
 namespace Ms {
 
 //---------------------------------------------------------
@@ -26,10 +41,11 @@ namespace Ms {
 //    must be in sync with symNames
 //---------------------------------------------------------
 
+BEGIN_QT_REGISTERED_ENUM(SymId)
 enum class SymId {
 
       // SMuFL standard symbol ID's
-
+      ///.\{
       noSym,
       fourStringTabClef,
       sixStringTabClef,
@@ -2662,10 +2678,13 @@ enum class SymId {
 //    END OF TABLE
 
       lastSym
+      ///\}
       };
+END_QT_REGISTERED_ENUM(SymId)
 
 //---------------------------------------------------------
 //   Sym
+///   \cond PLUGIN_API \private \endcond
 //---------------------------------------------------------
 
 class Sym {
@@ -2734,6 +2753,7 @@ class Sym {
 
 //---------------------------------------------------------
 //   GlyphKey
+///   \cond PLUGIN_API \private \endcond
 //---------------------------------------------------------
 
 struct GlyphKey {
@@ -2750,6 +2770,11 @@ struct GlyphKey {
       bool operator==(const GlyphKey&) const;
       };
 
+//---------------------------------------------------------
+//   GlyphPixmap
+///   \cond PLUGIN_API \private \endcond
+//---------------------------------------------------------
+
 struct GlyphPixmap {
       QPixmap pm;
       QPointF offset;
@@ -2762,6 +2787,7 @@ inline uint qHash(const GlyphKey& k)
 
 //---------------------------------------------------------
 //   ScoreFont
+///   \cond PLUGIN_API \private \endcond
 //---------------------------------------------------------
 
 class ScoreFont {

--- a/libmscore/symbol.h
+++ b/libmscore/symbol.h
@@ -14,12 +14,12 @@
 #define __SYMBOL_H__
 
 #include "bsymbol.h"
+#include "sym.h"
 
 namespace Ms {
 
 class Segment;
 class ScoreFont;
-enum class SymId;
 
 //---------------------------------------------------------
 //   @@ Symbol

--- a/libmscore/utils.h
+++ b/libmscore/utils.h
@@ -15,11 +15,11 @@
 
 #include "mscore.h"
 #include "interval.h"
+#include "sym.h"
 
 namespace Ms {
 
 enum class Key;
-enum class SymId;
 
 //---------------------------------------------------------
 //   cycles

--- a/mscore/plugin/api/elements.h
+++ b/mscore/plugin/api/elements.h
@@ -309,6 +309,10 @@ class Element : public Ms::PluginAPI::ScoreElement {
       API_PROPERTY( dashLineLen,             DASH_LINE_LEN             )
       API_PROPERTY( dashGapLen,              DASH_GAP_LEN              )
 //       API_PROPERTY_READ_ONLY( tick,          TICK                      ) // wasn't available in 2.X, disabled due to fractions transition
+      /**
+       * Symbol ID of this element (if approproate),
+       * one of PluginAPI::PluginAPI::SymId values.
+       */
       API_PROPERTY( symbol,                  SYMBOL                    )
       API_PROPERTY( playRepeats,             PLAY_REPEATS              )
       API_PROPERTY( createSystemHeader,      CREATE_SYSTEM_HEADER      )
@@ -411,8 +415,10 @@ class Note : public Element {
       Q_OBJECT
       Q_PROPERTY(Ms::PluginAPI::Element*          accidental        READ accidental)
       Q_PROPERTY(Ms::AccidentalType               accidentalType    READ accidentalType  WRITE setAccidentalType)
+      /** List of dots attached to this note */
       Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::Element>  dots              READ dots)
 //       Q_PROPERTY(int                            dotsCount         READ qmlDotsCount)
+      /** List of other elements attached to this note: fingerings, symbols, bends etc. */
       Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::Element>  elements          READ elements)
       /// List of PlayEvents associated with this note.
       /// Important: You must call Score.createPlayEvents()

--- a/mscore/plugin/api/qmlpluginapi.cpp
+++ b/mscore/plugin/api/qmlpluginapi.cpp
@@ -52,6 +52,7 @@ Enum* PluginAPI::noteHeadGroupEnum;
 Enum* PluginAPI::noteValueTypeEnum;
 Enum* PluginAPI::segmentTypeEnum;
 Enum* PluginAPI::spannerAnchorEnum;
+Enum* PluginAPI::symIdEnum;
 
 //---------------------------------------------------------
 //   PluginAPI::initEnums
@@ -83,6 +84,7 @@ void PluginAPI::initEnums() {
       PluginAPI::noteValueTypeEnum = wrapEnum<Ms::Note::ValueType>();
       PluginAPI::segmentTypeEnum = wrapEnum<Ms::SegmentType>();
       PluginAPI::spannerAnchorEnum = wrapEnum<Ms::Spanner::Anchor>();
+      PluginAPI::symIdEnum = wrapEnum<Ms::SymId>();
 
       initialized = true;
       }

--- a/mscore/plugin/api/qmlpluginapi.cpp
+++ b/mscore/plugin/api/qmlpluginapi.cpp
@@ -24,70 +24,34 @@
 #include "shortcut.h"
 #include "musescore.h"
 #include "libmscore/musescoreCore.h"
-#include "libmscore/score.h"
 
 #include <QQmlEngine>
 
 namespace Ms {
 namespace PluginAPI {
 
-Enum* PluginAPI::elementTypeEnum;
-Enum* PluginAPI::accidentalTypeEnum;
-Enum* PluginAPI::beamModeEnum;
-Enum* PluginAPI::placementEnum;
-Enum* PluginAPI::glissandoTypeEnum;
-Enum* PluginAPI::layoutBreakTypeEnum;
-Enum* PluginAPI::lyricsSyllabicEnum;
-Enum* PluginAPI::directionEnum;
-Enum* PluginAPI::directionHEnum;
-Enum* PluginAPI::ornamentStyleEnum;
-Enum* PluginAPI::glissandoStyleEnum;
-Enum* PluginAPI::tidEnum;
-Enum* PluginAPI::alignEnum;
-Enum* PluginAPI::noteTypeEnum;
-Enum* PluginAPI::playEventTypeEnum;
-Enum* PluginAPI::noteHeadTypeEnum;
-Enum* PluginAPI::noteHeadSchemeEnum;
-Enum* PluginAPI::noteHeadGroupEnum;
-Enum* PluginAPI::noteValueTypeEnum;
-Enum* PluginAPI::segmentTypeEnum;
-Enum* PluginAPI::spannerAnchorEnum;
-Enum* PluginAPI::symIdEnum;
-
-//---------------------------------------------------------
-//   PluginAPI::initEnums
-//---------------------------------------------------------
-
-void PluginAPI::initEnums() {
-      static bool initialized = false;
-      if (initialized)
-            return;
-
-      PluginAPI::elementTypeEnum = wrapEnum<Ms::ElementType>();
-      PluginAPI::accidentalTypeEnum = wrapEnum<Ms::AccidentalType>();
-      PluginAPI::beamModeEnum = wrapEnum<Ms::Beam::Mode>();
-      PluginAPI::placementEnum = wrapEnum<Ms::Placement>();
-      PluginAPI::glissandoTypeEnum = wrapEnum<Ms::GlissandoType>();
-      PluginAPI::layoutBreakTypeEnum = wrapEnum<Ms::LayoutBreak::Type>();
-      PluginAPI::lyricsSyllabicEnum = wrapEnum<Ms::Lyrics::Syllabic>();
-      PluginAPI::directionEnum = wrapEnum<Ms::Direction>();
-      PluginAPI::directionHEnum = wrapEnum<Ms::MScore::DirectionH>();
-      PluginAPI::ornamentStyleEnum = wrapEnum<Ms::MScore::OrnamentStyle>();
-      PluginAPI::glissandoStyleEnum = wrapEnum<Ms::GlissandoStyle>();
-      PluginAPI::tidEnum = wrapEnum<Ms::Tid>();
-      PluginAPI::alignEnum = wrapEnum<Ms::Align>();
-      PluginAPI::noteTypeEnum = wrapEnum<Ms::NoteType>();
-      PluginAPI::playEventTypeEnum = wrapEnum<Ms::PlayEventType>();
-      PluginAPI::noteHeadTypeEnum = wrapEnum<Ms::NoteHead::Type>();
-      PluginAPI::noteHeadSchemeEnum = wrapEnum<Ms::NoteHead::Scheme>();
-      PluginAPI::noteHeadGroupEnum = wrapEnum<Ms::NoteHead::Group>();
-      PluginAPI::noteValueTypeEnum = wrapEnum<Ms::Note::ValueType>();
-      PluginAPI::segmentTypeEnum = wrapEnum<Ms::SegmentType>();
-      PluginAPI::spannerAnchorEnum = wrapEnum<Ms::Spanner::Anchor>();
-      PluginAPI::symIdEnum = wrapEnum<Ms::SymId>();
-
-      initialized = true;
-      }
+Enum* PluginAPI::elementTypeEnum = nullptr;
+Enum* PluginAPI::accidentalTypeEnum = nullptr;
+Enum* PluginAPI::beamModeEnum = nullptr;
+Enum* PluginAPI::placementEnum = nullptr;
+Enum* PluginAPI::glissandoTypeEnum = nullptr;
+Enum* PluginAPI::layoutBreakTypeEnum = nullptr;
+Enum* PluginAPI::lyricsSyllabicEnum = nullptr;
+Enum* PluginAPI::directionEnum = nullptr;
+Enum* PluginAPI::directionHEnum = nullptr;
+Enum* PluginAPI::ornamentStyleEnum = nullptr;
+Enum* PluginAPI::glissandoStyleEnum = nullptr;
+Enum* PluginAPI::tidEnum = nullptr;
+Enum* PluginAPI::alignEnum = nullptr;
+Enum* PluginAPI::noteTypeEnum = nullptr;
+Enum* PluginAPI::playEventTypeEnum = nullptr;
+Enum* PluginAPI::noteHeadTypeEnum = nullptr;
+Enum* PluginAPI::noteHeadSchemeEnum = nullptr;
+Enum* PluginAPI::noteHeadGroupEnum = nullptr;
+Enum* PluginAPI::noteValueTypeEnum = nullptr;
+Enum* PluginAPI::segmentTypeEnum = nullptr;
+Enum* PluginAPI::spannerAnchorEnum = nullptr;
+Enum* PluginAPI::symIdEnum = nullptr;
 
 //---------------------------------------------------------
 //   PluginAPI
@@ -96,7 +60,6 @@ void PluginAPI::initEnums() {
 PluginAPI::PluginAPI(QQuickItem* parent)
    : Ms::QmlPlugin(parent)
       {
-      initEnums();
       setRequiresScore(true);              // by default plugins require a score to work
       }
 

--- a/mscore/plugin/api/qmlpluginapi.h
+++ b/mscore/plugin/api/qmlpluginapi.h
@@ -152,6 +152,9 @@ class PluginAPI : public Ms::QmlPlugin {
       /// Contains Ms::SegmentType enumeration values
       DECLARE_API_ENUM( Segment,          segmentTypeEnum         )
       DECLARE_API_ENUM( Spanner,          spannerAnchorEnum       ) // probably unavailable in 2.X
+      /// Contains Ms::SymId enumeration values
+      /// \since MuseScore 3.5
+      DECLARE_API_ENUM( SymId,            symIdEnum               )
 
       QFile logFile;
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/306551

Exposes `SymId` enumeration to plugins thus making possible handling symbols in plugins depending on their type. As mentioned in the issue, `Symbol` elements can already be accessed (and even be added to a score) by plugins.

This PR employs the same technique as #6065 to expose enumeration to plugins while avoiding copying it between files. However `BEGIN_QT_REGISTERED_ENUM` and `END_QT_REGISTERED_ENUM` macro definitions needed to be duplicated in `style.h` and `sym.h` as `moc` tool doesn't handle macros from included files (not sure whether it handles `#include` statements at all). Also, since `SymId` enumerators begin from lower case letters, in order to expose their values to QML adding a wrapper for this enumeration was also necessary.

Since `SymId` contains a lot of elements (about 2600) creating a wrapper caused a significant delay on MuseScore startup. In order to avoid this in the second commit I implemented lazy initialization of enumerations exposed to QML plugins framework. Now enumeration wrappers are created when they are actually used for the first time. Therefore first access within a session to `SymId` enumeration still causes a significant delay, but it doesn't happen after that, and it doesn't cause any issues for anyone not using plugins accessing `SymId` enumeration. This trade-off seems to be the best solution we can afford at the moment if exposing `SymId` enumeration in the same way as other enumerations.