### PR TITLE
fix #298820: fix inability to minimize MuseScore on Linux with Gnome-based desktop environments

### DIFF
--- a/mscore/mixer/mixer.cpp
+++ b/mscore/mixer/mixer.cpp
@@ -240,7 +240,7 @@ void Mixer::retranslate(bool firstTime)
 void Mixer::closeEvent(QCloseEvent* ev)
       {
       emit closed(false);
-      QWidget::closeEvent(ev);
+      QDockWidget::closeEvent(ev);
       }
 
 //---------------------------------------------------------
@@ -249,11 +249,18 @@ void Mixer::closeEvent(QCloseEvent* ev)
 
 void Mixer::showEvent(QShowEvent* e)
       {
-      enablePlay->showEvent(e);
-      QWidget::showEvent(e);
-      activateWindow();
-      setFocus();
-      getAction("toggle-mixer")->setChecked(true);
+      if (e->spontaneous() && !isFloating()) {
+            QDockWidget::showEvent(e);
+            }
+      else {
+            enablePlay->showEvent(e);
+            QDockWidget::showEvent(e);
+            activateWindow();
+            setFocus();
+            }
+
+      if (!e->spontaneous())
+            getAction("toggle-mixer")->setChecked(true);
       }
 
 
@@ -263,8 +270,9 @@ void Mixer::showEvent(QShowEvent* e)
 
 void Mixer::hideEvent(QHideEvent* e)
       {
-      QWidget::hideEvent(e);
-      getAction("toggle-mixer")->setChecked(false);
+      QDockWidget::hideEvent(e);
+      if (!e->spontaneous())
+            getAction("toggle-mixer")->setChecked(false);
       }
 
 
@@ -276,7 +284,7 @@ bool Mixer::eventFilter(QObject* obj, QEvent* e)
       {
       if (enablePlay->eventFilter(obj, e))
             return true;
-      return QWidget::eventFilter(obj, e);
+      return QDockWidget::eventFilter(obj, e);
       }
 
 //---------------------------------------------------------
@@ -288,7 +296,7 @@ void Mixer::keyPressEvent(QKeyEvent* ev) {
             close();
             return;
             }
-      QWidget::keyPressEvent(ev);
+      QDockWidget::keyPressEvent(ev);
       }
 
 //---------------------------------------------------------
@@ -297,7 +305,7 @@ void Mixer::keyPressEvent(QKeyEvent* ev) {
 
 void Mixer::changeEvent(QEvent *event)
       {
-      QWidget::changeEvent(event);
+      QDockWidget::changeEvent(event);
       if (event->type() == QEvent::LanguageChange)
             retranslate();
       }

--- a/mscore/playpanel.cpp
+++ b/mscore/playpanel.cpp
@@ -136,7 +136,7 @@ void PlayPanel::speedChanged()
 void PlayPanel::closeEvent(QCloseEvent* ev)
       {
       emit closed(false);
-      QWidget::closeEvent(ev);
+      QDockWidget::closeEvent(ev);
       }
 
 //---------------------------------------------------------
@@ -151,7 +151,7 @@ void PlayPanel::closeEvent(QCloseEvent* ev)
 void PlayPanel::hideEvent(QHideEvent* ev)
       {
       MuseScore::saveGeometry(this);
-      QWidget::hideEvent(ev);
+      QDockWidget::hideEvent(ev);
       }
 
 //---------------------------------------------------------
@@ -160,10 +160,15 @@ void PlayPanel::hideEvent(QHideEvent* ev)
 
 void PlayPanel::showEvent(QShowEvent* e)
       {
-      enablePlay->showEvent(e);
-      QWidget::showEvent(e);
-      activateWindow();
-      setFocus();
+      if (e->spontaneous() && !isFloating()) {
+            QDockWidget::showEvent(e);
+            }
+      else {
+            enablePlay->showEvent(e);
+            QDockWidget::showEvent(e);
+            activateWindow();
+            setFocus();
+            }
       }
 
 //---------------------------------------------------------
@@ -174,7 +179,7 @@ bool PlayPanel::eventFilter(QObject* obj, QEvent* e)
       {
       if (enablePlay->eventFilter(obj, e))
             return true;
-      return QWidget::eventFilter(obj, e);
+      return QDockWidget::eventFilter(obj, e);
       }
 
 void PlayPanel::keyPressEvent(QKeyEvent* ev) {
@@ -182,7 +187,7 @@ void PlayPanel::keyPressEvent(QKeyEvent* ev) {
             close();
             return;
             }
-      QWidget::keyPressEvent(ev);
+      QDockWidget::keyPressEvent(ev);
       }
 
 //---------------------------------------------------------
@@ -453,7 +458,7 @@ void PlayPanel::speedSliderReleased(int)
 
 void PlayPanel::changeEvent(QEvent *event)
       {
-      QWidget::changeEvent(event);
+      QDockWidget::changeEvent(event);
       if (event->type() == QEvent::LanguageChange)
             retranslate();
       }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/298820

The issue happens if some QML view is opened, e.g. a plugin dock or,
more importantly, Palettes panel. Fixes the issue by leaving the code
in Mixer and Play Panel forcing a window to take focus only in cases
when it might make sense: when opening the corresponding widget and
when unminimizing MuseScore if the widget is in floating state (otherwise
it won't take focus). This is enough to avoid triggering the issue
which happens only if Play Panel or Mixer is docked.

To add some more details, I managed to reproduce the issue only if all of the following is true:
1) System has a Gnome-based desktop environment active (the important part is probably a window manager being used);
2) There is Play Panel or Mixer open in the docked state;
3) There is some QML-based view in an open state (usually QML-based Palettes, but the issue is reproducible even before 3.3 version with dock plugins).

The issue should persist since 2015 with #1475 and/or #1752 but the fact that dock plugins were probably rarely used made this issue remain unnoticed until 3.3 version, where QML-based palettes were introduced.