### PR TITLE
fix #306612: insert horizontal frame in front of frame using palette

### DIFF
--- a/libmscore/box.cpp
+++ b/libmscore/box.cpp
@@ -500,6 +500,7 @@ bool Box::acceptDrop(EditData& data) const
                         case IconType::VFRAME:
                         case IconType::TFRAME:
                         case IconType::FFRAME:
+                        case IconType::HFRAME:
                         case IconType::MEASURE:
                               return true;
                         default:
@@ -575,6 +576,9 @@ Element* Box::drop(EditData& data)
                               break;
                         case IconType::FFRAME:
                               score()->insertMeasure(ElementType::FBOX, this);
+                              break;
+                        case IconType::HFRAME:
+                              score()->insertMeasure(ElementType::HBOX, this);
                               break;
                         case IconType::MEASURE:
                               score()->insertMeasure(ElementType::MEASURE, this);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/306612

You can select a frame and insert any other type of frame in front
using the palette, but you cannot insert a horizontal frame this way.
Cause is simple: missing handler for this in acceptDrop() and drop().
Fix is trivial.

Not a regression (been this way since 2.0, probably earlier!) but I only finally got around to being annoyed by this enough to do something about it.  Comes up really often for me putting together educational worksheets.