### PR TITLE
Fix #306598: Canvas: impossible to choose a custom zoom default, difficult to override in toolbar

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -128,7 +128,7 @@ bool ScoreView::gestureEvent(QGestureEvent *event)
                   if (value == 1) {
                         value = pinch->scaleFactor();
                         }
-                  setLogicalZoomLevel(ZoomIndex::ZOOM_FREE, startLogicalZoomLevel * value, pinch->centerPoint());
+                  setLogicalZoom(ZoomIndex::ZOOM_FREE, startLogicalZoomLevel * value, pinch->centerPoint());
                   }
             }
       return true;
@@ -175,7 +175,7 @@ void ScoreView::wheelEvent(QWheelEvent* event)
 
       if (event->modifiers() & Qt::ControlModifier) { // Windows touch pad pinches also execute this
             QApplication::sendPostedEvents(this, 0);
-            zoomSteps(nReal, true, event->posF());
+            zoomBySteps(nReal, true, event->posF());
             return;
             }
 
@@ -205,8 +205,12 @@ void ScoreView::wheelEvent(QWheelEvent* event)
 
 void ScoreView::resizeEvent(QResizeEvent* /*ev*/)
       {
-      if (_zoomIndex != ZoomIndex::ZOOM_FREE)
-            setPhysicalZoomLevel(mscore->getPhysicalZoomLevel(this));
+      // No need to do anything if we're not the currently visible score view.
+      if (this != mscore->currentScoreView())
+            return;
+
+      setLogicalZoom(_zoomIndex, calculateLogicalZoomLevel(_zoomIndex, logicalZoomLevel()));
+
       emit sizeChanged();
 
       // The score may need to be repositioned now.

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -460,7 +460,13 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void showModeText(const QString& s, bool informScreenReader = true);
       void addRecentScore(const QString& scorePath);
 
+      void setZoom(const ZoomIndex, const qreal logicalFreeZoomLevel = 0.0);
+      void setZoomWithToggle(const ZoomIndex index);
+      void zoomBySteps(const qreal numSteps);
+      void zoomAndSavePrevious(const std::function<void(void)>& zoomFunction);
+
       void updateViewModeCombo();
+
       void switchLayoutMode(LayoutMode);
       void setPlayRepeats(bool repeat);
       void setPanPlayback(bool pan);
@@ -501,7 +507,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void seqStopped();
       void cmdAppendMeasures();
       void cmdInsertMeasures();
-      void zoomBoxIndexChanged(ZoomIndex);
+      void zoomBoxChanged(const ZoomIndex, const qreal);
       void showPageSettings();
       void removeTab(int);
       void removeTab();
@@ -596,9 +602,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       bool loadPlugin(const QString& filename);
       QString createDefaultName() const;
       void startAutoSave();
-      qreal getPhysicalZoomLevel(ScoreView*) const;
-      void setZoomBoxIndex(ZoomIndex);
-      void setLogicalZoomBoxLevel(qreal);
+      void updateZoomBox(const ZoomIndex, const qreal logicalLevel);
       bool noScore() const { return scoreList.isEmpty(); }
 
       TextTools* textTools();

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -185,7 +185,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_UI_CANVAS_BG_WALLPAPER,                          new StringPreference(QFileInfo(QString("%1%2").arg(mscoreGlobalShare).arg("wallpaper/background1.png")).absoluteFilePath(), false)},
             {PREF_UI_CANVAS_FG_WALLPAPER,                          new StringPreference(QFileInfo(QString("%1%2").arg(mscoreGlobalShare).arg("wallpaper/paper5.png")).absoluteFilePath(), false)},
             {PREF_UI_CANVAS_ZOOM_DEFAULT_TYPE,                     new IntPreference(0, false)},
-            {PREF_UI_CANVAS_ZOOM_DEFAULT_LEVEL,                    new DoublePreference(1.0, false)},
+            {PREF_UI_CANVAS_ZOOM_DEFAULT_LEVEL,                    new IntPreference(100, false)},
             {PREF_UI_CANVAS_ZOOM_PRECISION_KEYBOARD,               new IntPreference(2, false)},
             {PREF_UI_CANVAS_ZOOM_PRECISION_MOUSE,                  new IntPreference(6, false)},
             {PREF_UI_CANVAS_MISC_ANTIALIASEDDRAWING,               new BoolPreference(true, false)},

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -468,10 +468,14 @@ void PreferenceDialog::start()
                   new ColorPreferenceItem(PREF_UI_CANVAS_FG_COLOR, fgColorLabel, nullptr, doNothing),
                   new StringPreferenceItem(PREF_UI_CANVAS_BG_WALLPAPER, bgWallpaper, nullptr, doNothing),
                   new StringPreferenceItem(PREF_UI_CANVAS_FG_WALLPAPER, fgWallpaper, nullptr, doNothing),
-                  new IntPreferenceItem(PREF_UI_CANVAS_ZOOM_DEFAULT_TYPE, zoomDefaultType),
-                  new DoublePreferenceItem(PREF_UI_CANVAS_ZOOM_DEFAULT_LEVEL, zoomDefaultLevel,
-                                          [this]() { preferences.setPreference(PREF_UI_CANVAS_ZOOM_DEFAULT_LEVEL, zoomDefaultLevel->value() / 100.0); },    // apply function
-                                          [this]() { zoomDefaultLevel->setValue(preferences.getDouble(PREF_UI_CANVAS_ZOOM_DEFAULT_LEVEL) * 100.0); }        // update function
+                  new IntPreferenceItem(PREF_UI_CANVAS_ZOOM_DEFAULT_TYPE, zoomDefaultType, nullptr,
+                                          [this]() { // update function
+                                                zoomDefaultType->setCurrentIndex(preferences.getInt(PREF_UI_CANVAS_ZOOM_DEFAULT_TYPE));
+                                                zoomDefaultTypeChanged(preferences.getInt(PREF_UI_CANVAS_ZOOM_DEFAULT_TYPE));
+                                                }),
+                  new IntPreferenceItem(PREF_UI_CANVAS_ZOOM_DEFAULT_LEVEL, zoomDefaultLevel,
+                                          [this]() { preferences.setPreference(PREF_UI_CANVAS_ZOOM_DEFAULT_LEVEL, zoomDefaultLevel->value()); }, // apply function
+                                          [this]() { zoomDefaultLevel->setValue(preferences.getInt(PREF_UI_CANVAS_ZOOM_DEFAULT_LEVEL)); }        // update function
                                                 ),
                   new IntPreferenceItem(PREF_UI_CANVAS_ZOOM_PRECISION_KEYBOARD, zoomPrecisionKeyboard),
                   new IntPreferenceItem(PREF_UI_CANVAS_ZOOM_PRECISION_MOUSE, zoomPrecisionMouse),

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -1063,7 +1063,7 @@
          </property>
          <layout class="QGridLayout" name="gridLayout3">
           <item row="0" column="2">
-           <widget class="QDoubleSpinBox" name="zoomDefaultLevel">
+           <widget class="QSpinBox" name="zoomDefaultLevel">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -1079,20 +1079,17 @@
             <property name="suffix">
              <string notr="true">%</string>
             </property>
-            <property name="decimals">
-             <number>0</number>
-            </property>
             <property name="minimum">
-             <double>10.000000000000000</double>
+             <number>10</number>
             </property>
             <property name="maximum">
-             <double>1600.000000000000000</double>
+             <number>1600</number>
             </property>
             <property name="singleStep">
-             <double>10.000000000000000</double>
+             <number>10</number>
             </property>
             <property name="value">
-             <double>100.000000000000000</double>
+             <number>100</number>
             </property>
            </widget>
           </item>

--- a/mscore/scoretab.cpp
+++ b/mscore/scoretab.cpp
@@ -575,7 +575,7 @@ void ScoreTab::initScoreView(const int idx, const qreal logicalZoomLevel, const 
             vs->addWidget(v);
             stack->addWidget(vs);
             }
-      v->setLogicalZoomLevel(zoomIndex, logicalZoomLevel);
+      v->setLogicalZoom(zoomIndex, logicalZoomLevel);
       v->setOffset(xoffset, yoffset);
       }
 }

--- a/mscore/zoombox.h
+++ b/mscore/zoombox.h
@@ -26,7 +26,7 @@ class ScoreView;
 
 //---------------------------------------------------------
 //   ZoomIndex
-//    indices of items shown in QComboBox "ZoomBox"
+//    Indices of the items in the zoom box.
 //---------------------------------------------------------
 
 enum class ZoomIndex : char {
@@ -34,6 +34,41 @@ enum class ZoomIndex : char {
        ZOOM_PAGE_WIDTH, ZOOM_WHOLE_PAGE, ZOOM_TWO_PAGES,
        ZOOM_FREE
       };
+
+//---------------------------------------------------------
+//   zoomEntry
+//    The string, index, and zoom level for each item in the zoom box.
+//---------------------------------------------------------
+
+struct ZoomEntry {
+      ZoomIndex index;
+      int level; // Must be set to 0 for all entries that aren't numeric presets (including ZOOM_FREE).
+      const char* txt;
+
+      bool isNumericPreset() const { return level != 0; }
+
+      friend bool operator==(const ZoomEntry& e, const int l) { return e.level == l; }
+      friend bool operator==(const ZoomEntry& e, const ZoomIndex i) { return e.index == i; }
+      };
+
+//---------------------------------------------------------
+//   ZoomState
+//    The zoom index and level of a single zoom state.
+//---------------------------------------------------------
+
+struct ZoomState {
+      ZoomIndex index;
+      qreal level;
+
+      friend bool operator!=(const ZoomState& l, const ZoomState& r) { return (l.index != r.index) || (l.level != r.level); }
+      };
+
+//---------------------------------------------------------
+//   zoomEntries
+//    All of the entries in the zoom box.
+//---------------------------------------------------------
+
+extern const std::array<ZoomEntry, 13> zoomEntries;
 
 //---------------------------------------------------------
 //   ZoomValidator
@@ -46,6 +81,8 @@ class ZoomValidator : public QValidator {
 
    public:
       ZoomValidator(QObject* parent = 0);
+
+      static std::tuple<QValidator::State, ZoomIndex, int> validationHelper(const QString& input);
       };
 
 //---------------------------------------------------------
@@ -55,21 +92,23 @@ class ZoomValidator : public QValidator {
 class ZoomBox : public QComboBox {
       Q_OBJECT
 
-      qreal _logicalLevel;
+      qreal _previousLogicalLevel;
+      ScoreView* _previousScoreView;
 
    private slots:
       void indexChanged(int);
       void textChanged();
 
    signals:
-      void zoomIndexChanged(ZoomIndex);
+      void zoomChanged(const ZoomIndex zoomIndex, const qreal logicalFreeZoomLevel = 0.0);
 
    public:
       ZoomBox(QWidget* parent = 0);
-      void setLogicalZoomLevel(qreal);
-      void setZoomIndex(ZoomIndex);
-      qreal getPhysicalZoomLevel(ScoreView*) const;
-      qreal getLogicalZoomLevel(ScoreView*) const;
+
+      static ZoomState getDefaultLogicalZoom();
+
+      void setLogicalZoom(const ZoomIndex index, const qreal logicalLevel);
+      void resetToDefaultLogicalZoom();
       void setEnabled(bool val) { QComboBox::setEnabled(val); }
       QString currentText() const { return QComboBox::currentText(); }
       int count() const { return QComboBox::count(); }
@@ -82,6 +121,3 @@ class ZoomBox : public QComboBox {
 Q_DECLARE_METATYPE(Ms::ZoomIndex);
 
 #endif
-
-
-


### PR DESCRIPTION
Resolves: [#306598](https://musescore.org/en/node/306598)

Fixed the following zoom-related problems:

1. On the *Canvas* tab of the *MuseScore Preferences* dialog:

   * The combobox for specifying the default zoom level as a percentage was not initially disabled as it should have been when the zoom type was set to something other than *Percentage*.

   * On the *Canvas* tab of the *MuseScore Preferences* dialog, the up and down buttons on the spin box for specifying the default zoom level did not correctly increase or decrease the value.

2. If the default zoom type was set to *Percentage*:

   * The default zoom level was not applied to any new or newly opened scores.

   * The corresponding numeric preset in the zoom box on the *File Operations* toolbar did not become selected in some cases.

3. The free-zoom percentage in the zoom box on the *File Operations* toolbar was sometimes incorrectly restored and appeared blank after the user applied preferences.

4. The zoom box on the *File Operations* toolbar failed to apply any free-zoom-level percentages entered by the user after the first one.

5. The zoom box on the *File Operations* toolbar did not reflect the default zoom type and/or level when there were no scores open.

6. Not all items in the zoom box on the *File Operations* toolbar were visible without scrolling.

7. The keyboard shortcut to toggle the zoom type between “Page Width” and the previous zoom type did not correctly toggle back to the previous zoom type.

8. The zoom type and level for each score were not correctly restored when continuing the last session on startup.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made