### PR TITLE
[MU4] Fix #69291 Fix #306387 - Stems are too long on small chords with beam…

### DIFF
--- a/src/libmscore/beam.cpp
+++ b/src/libmscore/beam.cpp
@@ -1572,8 +1572,13 @@ void Beam::computeStemLen(const std::vector<ChordRest*>& cl, qreal& py1, int bea
     qreal firstStemLenPoints = bm.l * _spStaff4;
     const qreal sgn = (firstStemLenPoints < 0 ? -1.0 : 1.0);
     const QPointF p1 = cl[0]->stemPosBeam();
+    bool small = true;
     for (const ChordRest* cr : cl) {
         if (cr->isChord()) {
+            if (!cr->small()) {
+                small = false;
+            }
+
             const qreal minAbsLen = toChord(cr)->minAbsStemLength();
 
             const QPointF p2 = cr->stemPosBeam();
@@ -1589,6 +1594,15 @@ void Beam::computeStemLen(const std::vector<ChordRest*>& cl, qreal& py1, int bea
     }
 
     py1 += (dy + bm.l) * _spStaff4;
+    if (small && !staff()->isTabStaff(Fraction(0,1))) {
+        const qreal f = (beamLevels == 4) ? _beamDist / 2.0 : 0.0;
+
+        if (bm.l > 0) {
+            py1 -= _spatium - score()->styleP(Sid::beamWidth) / 4.0 - f;
+        } else {
+            py1 += _spatium - score()->styleP(Sid::beamWidth) / 4.0 - f;
+        }
+    }
 }
 
 //---------------------------------------------------------

--- a/src/libmscore/chord.cpp
+++ b/src/libmscore/chord.cpp
@@ -1390,13 +1390,9 @@ qreal Chord::defaultStemLength() const
     qreal shortest      = score()->styleS(Sid::shortestStem).val();
     if (hookIdx) {
         if (up()) {
-            if (shortest < 3.0) {
-                shortest = 3.0;
-            }
+            shortest = qMax(shortest, small() ? 2.0 : 3.0);
         } else {
-            if (shortest < 3.5) {
-                shortest = 3.5;
-            }
+            shortest = qMax(shortest, small() ? 2.25 : 3.5);
         }
     }
 

--- a/src/libmscore/tests/tools_data/undoSlashRhythm01-ref.mscx
+++ b/src/libmscore/tests/tools_data/undoSlashRhythm01-ref.mscx
@@ -530,8 +530,8 @@
             <durationType>quarter</durationType>
             </Rest>
           <Beam>
-            <l1>-15</l1>
-            <l2>-15</l2>
+            <l1>-12</l1>
+            <l2>-12</l2>
             </Beam>
           <Chord>
             <small>1</small>
@@ -567,8 +567,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-15</l1>
-            <l2>-15</l2>
+            <l1>-12</l1>
+            <l2>-12</l2>
             </Beam>
           <Chord>
             <small>1</small>
@@ -645,8 +645,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>31</l1>
-            <l2>31</l2>
+            <l1>28</l1>
+            <l2>28</l2>
             </Beam>
           <Chord>
             <small>1</small>
@@ -682,8 +682,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>31</l1>
-            <l2>31</l2>
+            <l1>28</l1>
+            <l2>28</l2>
             </Beam>
           <Chord>
             <small>1</small>
@@ -944,8 +944,8 @@
             <durationType>quarter</durationType>
             </Rest>
           <Beam>
-            <l1>-13</l1>
-            <l2>-13</l2>
+            <l1>-10</l1>
+            <l2>-10</l2>
             </Beam>
           <Chord>
             <small>1</small>
@@ -979,8 +979,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-13</l1>
-            <l2>-13</l2>
+            <l1>-10</l1>
+            <l2>-10</l2>
             </Beam>
           <Chord>
             <small>1</small>
@@ -1050,8 +1050,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>29</l1>
-            <l2>29</l2>
+            <l1>26</l1>
+            <l2>26</l2>
             </Beam>
           <Chord>
             <small>1</small>
@@ -1085,8 +1085,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>29</l1>
-            <l2>29</l2>
+            <l1>26</l1>
+            <l2>26</l2>
             </Beam>
           <Chord>
             <small>1</small>

--- a/src/libmscore/tests/tools_data/undoSlashRhythm02-ref.mscx
+++ b/src/libmscore/tests/tools_data/undoSlashRhythm02-ref.mscx
@@ -481,8 +481,8 @@
             <durationType>quarter</durationType>
             </Rest>
           <Beam>
-            <l1>-15</l1>
-            <l2>-15</l2>
+            <l1>-12</l1>
+            <l2>-12</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -508,8 +508,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-15</l1>
-            <l2>-15</l2>
+            <l1>-12</l1>
+            <l2>-12</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -566,8 +566,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>31</l1>
-            <l2>31</l2>
+            <l1>28</l1>
+            <l2>28</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -593,8 +593,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>31</l1>
-            <l2>31</l2>
+            <l1>28</l1>
+            <l2>28</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -803,8 +803,8 @@
             <durationType>quarter</durationType>
             </Rest>
           <Beam>
-            <l1>-13</l1>
-            <l2>-13</l2>
+            <l1>-10</l1>
+            <l2>-10</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -832,8 +832,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-13</l1>
-            <l2>-13</l2>
+            <l1>-10</l1>
+            <l2>-10</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -891,8 +891,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>29</l1>
-            <l2>29</l2>
+            <l1>26</l1>
+            <l2>26</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -920,8 +920,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>29</l1>
-            <l2>29</l2>
+            <l1>26</l1>
+            <l2>26</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>


### PR DESCRIPTION
…s or flags

Resolves https://musescore.org/en/node/69291
Resolves https://musescore.org/en/node/306387

Shortens the stems of cue (small) notes by 1.0sp.

The 4 updates are intentional, there contains now the shortened stems.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
