### PR TITLE
Inspector issues

### DIFF
--- a/inspectors/view/qml/InspectorForm.qml
+++ b/inspectors/view/qml/InspectorForm.qml
@@ -24,8 +24,9 @@ FocusableItem {
     Flickable {
         id: flickableArea
 
-        anchors.top: tabTitleColumn.bottom
-        anchors.topMargin: 12
+        anchors.top: parent.top
+        //anchors.top: tabTitleColumn.bottom
+        //anchors.topMargin: 12
         anchors.left: parent.left
         anchors.leftMargin: 24
         anchors.bottom: parent.bottom
@@ -144,6 +145,11 @@ FocusableItem {
         }
     }
 
+    /// For now the styled text for inspector does not fit with the palettes text.
+    /// When a general tab style will be implemented, uncomment the following to get a styled inspector text.
+    /// You will also need to change the anchors of the flickableArea to take into account this text.
+    /// This stack overflow question might be of some help: https://stackoverflow.com/questions/47518075/how-to-set-different-text-for-a-qdockwidgets-tab-and-window-title
+/*
     Rectangle {
         id: tabTitleBackgroundRect
 
@@ -176,11 +182,12 @@ FocusableItem {
             height: 3
             width: inspectorTitle.width
 
-            color: globalStyle.voice1Color
+            color: globalStyle.highlight
 
             radius: 2
         }
-    }
+
+    } */
 
     FocusableItem {
         id: focusChainBreak

--- a/inspectors/view/qml/common/CheckBox.qml
+++ b/inspectors/view/qml/common/CheckBox.qml
@@ -16,6 +16,10 @@ FocusableItem {
 
     opacity: root.enabled ? 1.0 : 0.3
 
+    Behavior on opacity {
+        NumberAnimation { duration: 100; }
+    }
+
     Item {
         id: contentRow
 
@@ -39,6 +43,13 @@ FocusableItem {
                 iconCode: root.isIndeterminate ? IconNameTypes.MINUS : IconNameTypes.TICK_RIGHT_ANGLE
 
                 visible: root.checked || root.isIndeterminate
+            }
+
+            Behavior on border.color {
+                ColorAnimation { duration: 100; }
+            }
+            Behavior on color {
+                ColorAnimation { duration: 100; }
             }
         }
 
@@ -74,7 +85,7 @@ FocusableItem {
                 target: box
                 radius: 1
                 color: Qt.rgba(globalStyle.button.r, globalStyle.button.g, globalStyle.button.b, 1.0)
-                border.color: Qt.rgba(0, 0, 0, 0.15)
+                border.color: globalStyle.highlight
             }
         },
 
@@ -86,7 +97,7 @@ FocusableItem {
                 target: box
                 radius: 1
                 color: "#C0C0C0"
-                border.color: Qt.rgba(0, 0, 0, 0.15)
+                border.color: globalStyle.highlight
             }
         }
     ]

--- a/inspectors/view/qml/common/CheckBox.qml
+++ b/inspectors/view/qml/common/CheckBox.qml
@@ -16,10 +16,6 @@ FocusableItem {
 
     opacity: root.enabled ? 1.0 : 0.3
 
-    Behavior on opacity {
-        NumberAnimation { duration: 100; }
-    }
-
     Item {
         id: contentRow
 

--- a/inspectors/view/qml/common/FlatButton.qml
+++ b/inspectors/view/qml/common/FlatButton.qml
@@ -59,14 +59,15 @@ FocusableItem {
         hoverEnabled: true
 
         onReleased: {
-            root.clicked()
+            if (containsMouse)
+                root.clicked()
         }
     }
 
     states: [
         State {
             name: "PRESSED"
-            when: clickableArea.pressed
+            when: clickableArea.pressed && clickableArea.containsMouse
 
             PropertyChanges {
                 target: backgroundRect

--- a/inspectors/view/qml/common/IncrementalPropertyControl.qml
+++ b/inspectors/view/qml/common/IncrementalPropertyControl.qml
@@ -74,25 +74,8 @@ Item {
 
             icon: IconNameTypes.SMALL_ARROW_DOWN
 
-            onIncreaseButtonClicked: {
-                var value = root.isIndeterminate ? 0.0 : currentValue
-                var newValue = value + step
-
-                if (newValue > root.maxValue)
-                    return
-
-                root.valueEdited(+newValue.toFixed(decimals))
-            }
-
-            onDecreaseButtonClicked: {
-                var value = root.isIndeterminate ? 0.0 : currentValue
-                var newValue = value - step
-
-                if (newValue < root.minValue)
-                    return
-
-                root.valueEdited(+newValue.toFixed(decimals))
-            }
+            onIncreaseButtonClicked: increment()
+            onDecreaseButtonClicked: decrement()
         }
 
         onCurrentTextEdited: {
@@ -112,11 +95,8 @@ Item {
             when: root.iconMode === iconModeEnum.left
 
             AnchorChanges { target: iconBackground; anchors.left: root.left }
-
             PropertyChanges { target: iconBackground; visible: true }
-
             AnchorChanges { target: textInputField; anchors.left: iconBackground.right }
-
             PropertyChanges { target: textInputField; anchors.leftMargin: spacing
                                                           width: root.width - iconBackground.width - root.spacing }
         },
@@ -126,11 +106,8 @@ Item {
             when: root.iconMode === iconModeEnum.right
 
             AnchorChanges { target: textInputField; anchors.left: root.left }
-
             PropertyChanges { target: textInputField; width: root.width - iconBackground.width - root.spacing }
-
             AnchorChanges { target: iconBackground; anchors.left: textInputField.right }
-
             PropertyChanges { target: iconBackground; anchors.leftMargin: spacing
                                                       visible: true }
         },
@@ -140,10 +117,31 @@ Item {
             when: root.iconMode === iconModeEnum.hidden
 
             AnchorChanges { target: textInputField; anchors.left: root.left }
-
             PropertyChanges { target: textInputField; width: root.width }
-
             PropertyChanges { target: iconBackground; visible: false }
         }
     ]
+
+    function increment() {
+        var value = root.isIndeterminate ? 0.0 : currentValue
+        var newValue = value + root.step
+
+        if (newValue > root.maxValue)
+            return
+
+        root.valueEdited(+newValue.toFixed(decimals))
+    }
+
+    function decrement() {
+        var value = root.isIndeterminate ? 0.0 : currentValue
+        var newValue = value - root.step
+
+        if (newValue > root.maxValue)
+            return
+
+        root.valueEdited(+newValue.toFixed(decimals))
+    }
+
+    Keys.onUpPressed: increment()
+    Keys.onDownPressed: decrement()
 }

--- a/inspectors/view/qml/common/StyledComboBox.qml
+++ b/inspectors/view/qml/common/StyledComboBox.qml
@@ -53,6 +53,7 @@ ComboBox {
     padding: 0
 
     delegate: ItemDelegate {
+        id: appearingBoxDelegate
         height: root.implicitHeight
         width: root.width
 
@@ -68,7 +69,18 @@ ComboBox {
             anchors.fill: parent
 
             radius: 4
-            color: highlighted ? globalStyle.highlight : globalStyle.button
+            color: {
+                if (highlighted)
+                    return globalStyle.highlight
+
+                return appearingBoxDelegate.hovered ? Qt.darker(globalStyle.button, 1.1) : globalStyle.button
+            }
+
+            Behavior on color {
+                ColorAnimation {
+                    duration: 100
+                }
+            }
 
             Rectangle {
                 id: roundedCornersOverlay
@@ -139,7 +151,18 @@ ComboBox {
 
         radius: 4
 
-        color: root.pressed || root.isExpanded ? globalStyle.highlight : globalStyle.button
+        color: {
+            if (root.pressed || root.isExpanded)
+                return globalStyle.highlight
+
+            return root.hovered ? Qt.darker(globalStyle.highlight, 1.1) : globalStyle.button
+        }
+
+        Behavior on color {
+            ColorAnimation {
+                duration: 100
+            }
+        }
 
         StyledIconLabel {
             anchors.fill: parent

--- a/inspectors/view/qml/common/StyledComboBox.qml
+++ b/inspectors/view/qml/common/StyledComboBox.qml
@@ -58,7 +58,7 @@ ComboBox {
 
         contentItem: Text {
             text: valueFromModel(index, textRoleName)
-            color: "#000000"
+            color: globalStyle.buttonText
             font: root.font
             elide: Text.ElideRight
             verticalAlignment: Text.AlignVCenter
@@ -117,7 +117,7 @@ ComboBox {
 
         text: root.displayText
         font: root.font
-        color: "#000000"
+        color: globalStyle.buttonText
         verticalAlignment: Text.AlignVCenter
         elide: Text.ElideRight
     }

--- a/inspectors/view/qml/common/TabPanel.qml
+++ b/inspectors/view/qml/common/TabPanel.qml
@@ -7,15 +7,13 @@ TabView {
 
     readonly property int tabBarHeight: 24
 
-    width: parent.width
-
     Rectangle {
-        id: selectionHighlighting
+        id: activeHighlight
 
         height: 3
         width: parent.width / count
 
-        color: globalStyle.voice1Color
+        color: globalStyle.highlight
 
         radius: 2
 
@@ -26,7 +24,7 @@ TabView {
                 if (currentIndex < 0)
                     return
 
-                selectionHighlighting.x = currentIndex * (root.width / count)
+                activeHighlight.x = currentIndex * (root.width / count)
             }
         }
 
@@ -41,7 +39,6 @@ TabView {
         frameOverlap: 1
 
         tab: Column {
-
             height: tabBarHeight
             width: styleData.availableWidth / count
 
@@ -52,8 +49,25 @@ TabView {
 
                 text: styleData.title
                 horizontalAlignment: Text.AlignHCenter
-                color: styleData.selected ? globalStyle.buttonText : "#AEAEAE"
+                color: globalStyle.buttonText
                 font.bold: true
+            }
+
+            Rectangle {
+                anchors.horizontalCenter: inspectorTitle.horizontalCenter
+
+                height: 2
+                radius: 2
+                width: styleData.hovered && !styleData.selected ? inspectorTitle.paintedWidth : 0.0
+
+                color: globalStyle.highlight
+
+                Behavior on width {
+                    NumberAnimation {
+                        duration: 100
+                        easing.type: "InOutQuad"
+                    }
+                }
             }
         }
 

--- a/inspectors/view/qml/common/TextInputField.qml
+++ b/inspectors/view/qml/common/TextInputField.qml
@@ -15,12 +15,16 @@ Rectangle {
     implicitHeight: 32
     implicitWidth: parent.width
 
-    color: "#FFFFFF"
+    color: globalStyle.button
     border.width: 0
+    border.color: globalStyle.highlight
 
     opacity: root.enabled ? 1.0 : 0.3
 
     radius: 4
+
+    Behavior on color { ColorAnimation { duration: 100 } }
+    Behavior on radius { NumberAnimation { duration: 100 } }
 
     TextInput {
         id: valueInput
@@ -29,7 +33,7 @@ Rectangle {
         anchors.left: root.left
         anchors.leftMargin: 12
 
-        color: "#000000"
+        color: globalStyle.buttonText
         font {
             family: globalStyle.font.family
             pointSize: globalStyle.font.pointSize
@@ -39,7 +43,7 @@ Rectangle {
         activeFocusOnPress: false
         selectByMouse: true
         selectionColor: Qt.rgba(globalStyle.highlight.r, globalStyle.highlight.g, globalStyle.highlight.b, 0.75)
-        selectedTextColor: "#000000"
+        selectedTextColor: globalStyle.buttonText
         visible: !root.isIndeterminate || activeFocus
 
         text: root.currentText === undefined ? "" : root.currentText
@@ -70,32 +74,36 @@ Rectangle {
                 name: "NORMAL"
                 when: !clickableArea.containsMouse && !valueInput.focus
 
-                PropertyChanges { target: root; border.color: "#FFFFFF"
-                                                border.width: 1 }
+                PropertyChanges {
+                    target: root
+                    border.color: globalStyle.button
+                    border.width: 0
+                    radius: 4
+                }
             },
 
             State {
                 name: "HOVERED"
                 when: clickableArea.containsMouse && !valueInput.focus
 
-                PropertyChanges { target: root; border.color: "#CECECE"
-                                                border.width: 1 }
+                PropertyChanges {
+                    target: root
+                    border.color: globalStyle.highlight
+                    border.width: 1
+                    radius: 0
+                }
             },
 
             State {
                 name: "FOCUSED"
-                when: valueInput.focus && valueInput.selectedText === ""
+                when: valueInput.focus
 
-                PropertyChanges { target: root; border.color: "#ADADAD"
-                                                border.width: 1 }
-            },
-
-            State {
-                name: "TEXT_SELECTED"
-                when: valueInput.focus && valueInput.selectedText !== ""
-
-                PropertyChanges { target: root; border.color: globalStyle.highlight
-                                                border.width: 1}
+                PropertyChanges {
+                    target: root
+                    border.color: Qt.lighter(globalStyle.button)
+                    border.width: 1
+                    radius: 0
+                }
             }
         ]
     }
@@ -107,7 +115,7 @@ Rectangle {
         anchors.leftMargin: 4
         anchors.verticalCenter: valueInput.verticalCenter
 
-        color: "#000000"
+        color: globalStyle.buttonText
         visible: !root.isIndeterminate
     }
 
@@ -119,7 +127,7 @@ Rectangle {
         anchors.leftMargin: 12
 
         text: root.indeterminateText
-        color: "#000000"
+        color: globalStyle.buttonText
         visible: root.isIndeterminate && valueInput.activeFocus === false
     }
 

--- a/inspectors/view/qml/common/ValueAdjustControl.qml
+++ b/inspectors/view/qml/common/ValueAdjustControl.qml
@@ -33,29 +33,37 @@ Item {
 
                 anchors.fill: parent
 
-                preventStealing: true
-
                 onClicked: {
                     root.increaseButtonClicked()
                 }
 
-                onPressAndHold: {
-                    continiousIncreaseTimer.running = true
+                hoverEnabled: true
+
+                onHoveredChanged: {
+                    if (containsMouse)
+                        incrementButtonLoader.item.color = globalStyle.highlight
+                    else
+                        incrementButtonLoader.item.color = "transparent"
                 }
 
                 onReleased: {
-                    continiousIncreaseTimer.running = false
+                    continuousIncreaseTimer.running = false
+                    continuousIncreaseTimer.interval = 300
+                }
+
+                onPressAndHold: {
+                    continuousIncreaseTimer.running = true
                 }
 
                 Timer {
-                    id: continiousIncreaseTimer
+                    id: continuousIncreaseTimer
 
                     interval: 300
-
                     repeat: true
 
                     onTriggered: {
                         root.increaseButtonClicked()
+                        interval = Math.max(interval - 10, 50) // accelerate
                     }
                 }
             }
@@ -78,24 +86,32 @@ Item {
                     root.decreaseButtonClicked()
                 }
 
-                onPressAndHold: {
-                    continiousDecreaseTimer.running = true
+                hoverEnabled: true
+                onHoveredChanged: {
+                    if (containsMouse)
+                        decrementButtonLoader.item.color = globalStyle.highlight
+                    else
+                        decrementButtonLoader.item.color = "transparent"
                 }
 
                 onReleased: {
-                    continiousDecreaseTimer.running = false
+                    continuousDecreaseTimer.running = false;
+                    continuousDecreaseTimer.interval = 300
+                }
+
+                onPressAndHold: {
+                    continuousDecreaseTimer.running = true
                 }
 
                 Timer {
-                    id: continiousDecreaseTimer
+                    id: continuousDecreaseTimer
 
                     interval: 300
                     repeat: true
 
-                    running: decreaseMouseArea.pressed
-
                     onTriggered: {
                         root.decreaseButtonClicked()
+                        interval = Math.max(interval - 10, 50) // accelerate
                     }
                 }
             }
@@ -112,6 +128,9 @@ Item {
             width: iconPixelSize
 
             color: "transparent"
+            radius: 1
+
+            Behavior on color { ColorAnimation { duration: 100 } }
 
             StyledIconLabel {
                 id: buttonIcon

--- a/inspectors/view/qml/general/GeneralInspectorView.qml
+++ b/inspectors/view/qml/general/GeneralInspectorView.qml
@@ -20,12 +20,12 @@ InspectorSectionView {
         spacing: 16
 
         Item {
-
             height: childrenRect.height
             width: root.width
 
             CheckBox {
                 anchors.left: parent.left
+                anchors.right: parent.horizontalCenter
 
                 text: qsTr("Visible")
 
@@ -56,6 +56,7 @@ InspectorSectionView {
 
             CheckBox {
                 anchors.left: parent.left
+                anchors.right: parent.horizontalCenter
 
                 text: qsTr("Auto-place")
 

--- a/inspectors/view/ui/inspector.cpp
+++ b/inspectors/view/ui/inspector.cpp
@@ -83,6 +83,7 @@ Inspector::Inspector(QQmlEngine *engine, QWidget* parent)
       : QDockWidget(parent)
       {
       setObjectName("inspector");
+      setWindowTitle("Inspector");
       setAllowedAreas(Qt::DockWidgetAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea));
 
       m_qmlEngine = engine;

--- a/share/themes/palette_dark_fusion.json
+++ b/share/themes/palette_dark_fusion.json
@@ -4,7 +4,7 @@
 "Base":          "#424242",
 "AlternateBase": "#626262",
 "Text":          "#EFF0F1",
-"Button":        "#2C2C2C",
+"Button":        "#343434",
 "ButtonText":    "#EFF0F1",
 "BrightText":    "#000000",
 "ToolTipBase":   "#fefac2",


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/pull/6149#issuecomment-636603333

I'm digging into qml to fix as many of these issues as I can. 
This PR can be merged anytime, or you can wait for all the fixes to be there.

- [x]  2) When something is tabbed with the inspector, the latter doesn't have a name: 

<details><summary>Details...</summary>

![image](https://user-images.githubusercontent.com/35939574/83373189-7bc23080-a395-11ea-86a3-3b2ba6958585.png)

## Commit 3:
![image](https://user-images.githubusercontent.com/35939574/84601269-e753d580-ae4c-11ea-877d-ac4e3655b9a8.png)

</details>

- [x] 4) Checkboxes react weirdly to hover events: it looks like they get greyed out on hover, which is counterintuitive:

<details><summary>Details...</summary>

![1](https://user-images.githubusercontent.com/35939574/83373409-3ce0aa80-a396-11ea-8b46-afcb35c9b5d1.gif)
(it is even weirder in light mode)

## Commit 1:
![3](https://user-images.githubusercontent.com/35939574/84598817-6809d600-ae3b-11ea-9294-bb3e177e3f9e.gif)

</details>

- [x] 5) in dark mode, some buttons look like they aren't buttons until they are hovered. 
<details><summary>Details...</summary>
Look at the difference between these two:

![image](https://user-images.githubusercontent.com/35939574/83373457-63064a80-a396-11ea-8f60-e6268ed7b21d.png) ![image](https://user-images.githubusercontent.com/35939574/83373473-6e597600-a396-11ea-812c-4265224f80a9.png)

## Commit 4
![image](https://user-images.githubusercontent.com/35939574/84602222-ca6ed080-ae53-11ea-933d-70a6a1c91f5e.png)

</details>

- [x] 6) In the following image, I think the greyed out text serves no purpose. Actually, the wide blue line below the active tab should be enough to tell him what he presently is looking at. Take it that way. What would you do if you wanted to actually disable the tab? You wouldn't be able to do anything more except completely hide it, which is a bad idea.

<details><summary>Details...</summary>

![image](https://user-images.githubusercontent.com/35939574/83373844-d066ab00-a397-11ea-8896-d94c06449c1c.png)

2 solutions (I actually think both should be applied):
 - keep the inactive tab's text dark (do not grey it)
 - accept hover events to show that this text is actually clickable.

## Commit 5:
![4](https://user-images.githubusercontent.com/35939574/84604807-b1234f80-ae66-11ea-8452-959d307972ae.gif)

</details>

- [x] 7) hover events for the buttons inside spin boxes, please.

- [ ] 8) Reset to default box goes out of the screen. ( that might be my screen's problem, needing some adjustments, but a little margin would still be appreciated if possible. Anyway, why is this much width needed? )

<details><summary>Details...</summary>

![image](https://user-images.githubusercontent.com/35939574/83375243-3e14d600-a39c-11ea-97db-312e2d88417b.png)

</details>

- [ ] 9) (same image as above) The 3 points inside the icon are almost invisible in the selected blue.

- [x] 10) Some text in combo boxes stay black even in dark them. Low contrast:

<details><summary>Details...</summary>

![image](https://user-images.githubusercontent.com/35939574/83374134-ad88c680-a398-11ea-8e66-f77a8c3c677f.png)

## Commit 6:
![image](https://user-images.githubusercontent.com/35939574/84605236-debdc800-ae69-11ea-8056-9f513b16a408.png)

</details>

- [ ] 12) (maybe out of the scope of this PR) some (many) old inspectors had tooltips indicating the precise behaviour of every complex action. These tooltips completely disappeared. Now a lot of information is missing...

- [x] 13) Some spinboxes stay in light mode even when dark mode is enabled. 

<details><summary>Details...</summary>

Have a look at the ambitus' inspector. 

![image](https://user-images.githubusercontent.com/35939574/83374441-a6ae8380-a399-11ea-8e7f-a42de37203f9.png)

The spinboxes don't look like spinboxes.

</details>

- [x] 14) Spinboxes don't react to up and down arrows for navigation. (they actually don't react to much)

- [ ] 16) why is this the smallest possible inspector? 

<details><summary>Details...</summary>

I'll soon need 3 screens:

![image](https://user-images.githubusercontent.com/35939574/83375132-e0808980-a39b-11ea-9397-711028e87dd3.png)

</details>

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
