### PR TITLE
Setting a decent default for the chord symbol alignment algorithm

### DIFF
--- a/share/templates/05-Jazz/01-Jazz_Lead_Sheet.mscx
+++ b/share/templates/05-Jazz/01-Jazz_Lead_Sheet.mscx
@@ -29,6 +29,8 @@
       <hairpinFontFace>MuseJazz Text</hairpinFontFace>
       <pedalLineWidth>0.2</pedalLineWidth>
       <pedalFontFace>MuseJazz Text</pedalFontFace>
+      <maxChordShiftAbove>3</maxChordShiftAbove>
+      <maxChordShiftBelow>3</maxChordShiftBelow>
       <chordSymbolPosAbove x="0" y="-2.5"/>
       <chordSymbolBPosAbove x="0" y="-5.5"/>
       <chordSymbolAFontFace>MuseJazz Text</chordSymbolAFontFace>
@@ -36,6 +38,8 @@
       <chordSymbolAAlign>left,baseline</chordSymbolAAlign>
       <chordSymbolBPosAbove x="0" y="-5.5"/>
       <chordSymbolBFontFace>MuseJazz Text</chordSymbolBFontFace>
+      <maxFretShiftAbove>3</maxFretShiftAbove>
+      <maxFretShiftBelow>3</maxFretShiftBelow>
       <chordSymbolBFontSize>12</chordSymbolBFontSize>
       <chordSymbolBAlign>left,baseline</chordSymbolBAlign>
       <showMeasureNumber>0</showMeasureNumber>

--- a/share/templates/05-Jazz/02-Big_Band.mscx
+++ b/share/templates/05-Jazz/02-Big_Band.mscx
@@ -28,6 +28,8 @@
       <hairpinFontFace>MuseJazz Text</hairpinFontFace>
       <pedalLineWidth>0.2</pedalLineWidth>
       <pedalFontFace>MuseJazz Text</pedalFontFace>
+      <maxChordShiftAbove>3</maxChordShiftAbove>
+      <maxChordShiftBelow>3</maxChordShiftBelow>
       <chordSymbolPosAbove x="0" y="-2.5"/>
       <chordSymbolBPosAbove x="0" y="-5.5"/>
       <chordSymbolAFontFace>MuseJazz Text</chordSymbolAFontFace>
@@ -36,6 +38,8 @@
       <chordSymbolBFontFace>MuseJazz Text</chordSymbolBFontFace>
       <chordSymbolBFontSize>12</chordSymbolBFontSize>
       <chordSymbolBAlign>left,baseline</chordSymbolBAlign>
+      <maxFretShiftAbove>3</maxFretShiftAbove>
+      <maxFretShiftBelow>3</maxFretShiftBelow>
       <showMeasureNumber>0</showMeasureNumber>
       <chordStyle>jazz</chordStyle>
       <chordDescriptionFile>chords_jazz.xml</chordDescriptionFile>

--- a/share/templates/05-Jazz/03-Jazz_Combo.mscx
+++ b/share/templates/05-Jazz/03-Jazz_Combo.mscx
@@ -28,12 +28,16 @@
       <hairpinFontFace>MuseJazz Text</hairpinFontFace>
       <pedalLineWidth>0.2</pedalLineWidth>
       <pedalFontFace>MuseJazz Text</pedalFontFace>
+      <maxChordShiftAbove>3</maxChordShiftAbove>
+      <maxChordShiftBelow>3</maxChordShiftBelow>
       <chordSymbolPosAbove x="0" y="-2.5"/>
       <chordSymbolBPosAbove x="0" y="-5.5"/>
       <chordSymbolAFontFace>MuseJazz Text</chordSymbolAFontFace>
       <chordSymbolAFontSize>15</chordSymbolAFontSize>
       <chordSymbolAAlign>left,baseline</chordSymbolAAlign>
       <chordSymbolBFontFace>MuseJazz Text</chordSymbolBFontFace>
+      <maxFretShiftAbove>3</maxFretShiftAbove>
+      <maxFretShiftBelow>3</maxFretShiftBelow>
       <chordSymbolBFontSize>12</chordSymbolBFontSize>
       <chordSymbolBAlign>left,baseline</chordSymbolBAlign>
       <showMeasureNumber>0</showMeasureNumber>


### PR DESCRIPTION
Setting a decent default (3.0sp) for the chord symbol alignment algorithm.

PR #6060 introduced an algorithm for aligning chord symbols but for compatibility reasons the default for this algorithm was set to 0.0sp so existing scores are not effected.
However in the discussion in [issue 281759](https://musescore.org/en/node/281759) the [suggestion was made](https://musescore.org/en/node/281759#comment-1006048) to change at least the templates in the <code>Jazz</code> category, which will most likely benefit most of the new algorithm, so new scores will start using the aligning be default.
This PR is the implementation of this suggestion.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [n.a.] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [n.a.] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [n.a.] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n.a.] I created the test (mtest, vtest, script test) to verify the changes I made
