### PR TITLE
fix #305069: Chord symbols attached to fret diagrams don't play back

### DIFF
--- a/libmscore/part.cpp
+++ b/libmscore/part.cpp
@@ -24,6 +24,7 @@
 #include "stafftype.h"
 #include "sym.h"
 #include "chordrest.h"
+#include "fret.h"
 
 namespace Ms {
 
@@ -549,7 +550,7 @@ int Part::harmonyCount() const
       int count = 0;
       for (const Segment* seg = firstM->first(st); seg; seg = seg->next1(st)) {
             for (const Element* e : seg->annotations()) {
-                  if (e->type() == ElementType::HARMONY && e->track() >= startTrack() && e->track() < endTrack())
+                  if ((e->isHarmony() || (e->isFretDiagram() && toFretDiagram(e)->harmony())) && e->track() >= startTrack() && e->track() < endTrack())
                         count++;
                   }
             }


### PR DESCRIPTION
resolves https://musescore.org/en/node/305069