### PR TITLE
fix #306816: Crash when select Realize Chord Symbols by right clicking chord symbol with Fretboard Diagram

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3182,7 +3182,7 @@ void Score::cmdRealizeChordSymbols(bool literal, Voicing voicing, HDuration dura
             if (!h->isRealizable())
                   continue;
             RealizedHarmony r = h->getRealizedHarmony();
-            Segment* seg = toSegment(h->parent());
+            Segment* seg = h->parent()->isSegment() ? toSegment(h->parent()) : toSegment(h->parent()->parent());
             Fraction duration = r.getActualDuration(durationType);
             Fraction tick = seg->tick();
             bool concertPitch = styleB(Sid::concertPitch);


### PR DESCRIPTION
resolves https://musescore.org/en/node/306816