### PR TITLE
Fix #306807: Crash on [Go to first empty trailing measure] command with specific circumstance

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2439,14 +2439,29 @@ Element* Score::move(const QString& cmd)
                    _is.moveInputPos(el);
              }
        else if (cmd == "empty-trailing-measure") {
+             // Ensures a valid Element if no empty-trailing-measure exists
+             // by utilizing the score's last measure.
+
              // Entire score: don't yet have a valid active element
-             if (!cr)
-                   el = firstTrailingMeasure()->first()->nextChordRest(0, false);
+             if (!cr) {
+                   auto ftm = firstTrailingMeasure();
+                   if (!ftm)
+                         ftm = lastMeasure();
+                   el = ftm->first()->nextChordRest(0, false);
+                   }
+
              // Staff-Specific trailing measure:
              else {
-                   firstTrailingMeasure(&cr);
-                   el = cr;
+                   // Store current position
+                   auto tmp = cr;
+                   // Get first trailing measure and its accompanying chord-rest
+                   auto ftm = firstTrailingMeasure(&cr);
+                   if ((cr->measure() != ftm) && (cr->measure() == tmp->measure()))
+                         el = lastMeasure()->first()->nextChordRest(tmp->track(), false);
+                   else
+                         el = cr;
                    }
+
              // Note: Due to the nature of this command, ensure Note-Entry Mode afterwards
              // from within ScoreView::cmd()
              _is.moveInputPos(el);

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3971,9 +3971,10 @@ Measure* Score::firstTrailingMeasure(ChordRest** cr)
             for (; m && m->isFullMeasureRest(); firstMeasure = m, m = m->prevMeasure());
       // Active selection: select full measure rest of active staff's empty trailing measure
       else {
-            ChordRest* tempCR = nullptr;
+            ChordRest* tempCR = *cr;
             while (m && (tempCR = m->first()->nextChordRest(trackZeroVoice((*cr)->track()), false))->isFullMeasureRest()) {
                   *cr = tempCR;
+                  firstMeasure = m;
                   m = m->prevMeasure();
                   }
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/306807

New navigation commands were implemented into 3.x (https://github.com/musescore/MuseScore/pull/5620 for Master -> manually added into 3.5). After 3.5Beta release, I've run into one problem that I didn't catch earlier:  If issuing "Go To First Empty Trailing Measure" when there is no selection at all whatsoever + there _is no first empty trailing measure_, then a crash occurs! Obviously that needed to be fixed, so this PR makes sure that under that circumstance, instead of crashing, and instead of _doing nothing_, the result is to take the user to the last measure of the score. With this change, I had to also be consistent with the use case when using a specific staff with the same problem, i.e., no empty trailing measure. Before, nothing would happen and then the issuing of the command would be exactly equivalent to entering into Note Entry at current location. Now, this is congruous with no selection at all: take the user to the last measure, only retain the current staff in this instance. 

Now I can not get this to crash at all, and in a sense there's some added functionality in that this doubles-down in allowing the user to go to the end of the score if the score is already full or has no empty trailing measure rather than doing nothing. 

P.S. I will need to update accordingly the open PR mentioned at the top of this description for the master branch which has yet to be merged.

- [X] I signed [CLA](https://musescore.org/en/cla)
- [X] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [X] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
  (Passes online testing)