### PR TITLE
Fix #306832 - AppImage doesn't store the correct wallpaper filename f…

### DIFF
--- a/mscore/exampleview.cpp
+++ b/mscore/exampleview.cpp
@@ -34,6 +34,7 @@ ExampleView::ExampleView(QWidget* parent)
       setFocusPolicy(Qt::StrongFocus);
       resetMatrix();
       _fgPixmap = nullptr;
+      _fgColor  = Qt::white;
       if (preferences.getBool(PREF_UI_CANVAS_FG_USECOLOR))
             _fgColor = preferences.getColor(PREF_UI_CANVAS_FG_COLOR);
       else {


### PR DESCRIPTION
…or Background and Paper

Resolves: https://musescore.org/en/node/306832 (partially)

When for the foreground a wallpaper is selected but the file is not found, <code>ScoreView</code> falls back on the foreground color <code>White</code>. However, in <code>ExampleView</code> the foreground color <code>_fgColor</code> wasn't set so it falls back on the default color <code>Black</code>.
Now the default foreground color of <code>ExampleView</code> is also set to <code>white</code>.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
