### PR TITLE
Fix #306917 crash on tie in score with parts

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4829,13 +4829,13 @@ void Score::undoAddElement(Element* element)
                               sm = cr2->staffIdx() - cr1->staffIdx();
                         Chord* c1 = findLinkedChord(cr1, score->staff(staffIdx));
                         Chord* c2 = findLinkedChord(cr2, score->staff(staffIdx + sm));
-                        Note* nn1 = c1->findNote(n1->pitch(), n1->unisonIndex());
+                        Note* nn1 = c1 ? c1->findNote(n1->pitch(), n1->unisonIndex()) : 0;
                         Note* nn2 = c2 ? c2->findNote(n2->pitch(), n2->unisonIndex()) : 0;
 
                         // create tie
                         Tie* ntie = toTie(ne);
                         ntie->eraseSpannerSegments();
-                        ntie->setTrack(c1->track());
+                        ntie->setTrack(c1 ? c1->track() : 0);
                         ntie->setStartNote(nn1);
                         ntie->setEndNote(nn2);
                         undo(new AddElement(ntie));


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/306917

Added null pointer check

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
