### PR TITLE
Rhythm note input mode fixes and improvements

### DIFF
--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -427,18 +427,23 @@ void Score::repitchNote(const Position& p, bool replace)
       NoteVal nval;
       bool error = false;
       AccidentalType at = _is.accidentalType();
-      AccidentalVal acci = (at == AccidentalType::NONE ? s->measure()->findAccidental(s, p.staffIdx, p.line, error) : Accidental::subtype2value(at));
-      if (error)
-            return;
-      int step   = absStep(p.line, clef);
-      int octave = step / 7;
-      nval.pitch = step2pitch(step) + octave * 12 + int(acci);
-
-      if (styleB(Sid::concertPitch))
-            nval.tpc1 = step2tpc(step % 7, acci);
+      if (_is.drumset() && _is.drumNote() != -1) {
+            nval.pitch = _is.drumNote();
+            }
       else {
-            nval.pitch += st->part()->instrument(s->tick())->transpose().chromatic;
-            nval.tpc2 = step2tpc(step % 7, acci);
+            AccidentalVal acci = (at == AccidentalType::NONE ? s->measure()->findAccidental(s, p.staffIdx, p.line, error) : Accidental::subtype2value(at));
+            if (error)
+                  return;
+            int step   = absStep(p.line, clef);
+            int octave = step / 7;
+            nval.pitch = step2pitch(step) + octave * 12 + int(acci);
+
+            if (styleB(Sid::concertPitch))
+                  nval.tpc1 = step2tpc(step % 7, acci);
+            else {
+                  nval.pitch += st->part()->instrument(s->tick())->transpose().chromatic;
+                  nval.tpc2 = step2tpc(step % 7, acci);
+                  }
             }
 
       if (!_is.segment())

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2811,6 +2811,12 @@ void Score::padToggle(Pad n, const EditData& ed)
                               case 2:
                                     padToggle(Pad::DOTDOT, ed);
                                     break;
+                              case 3:
+                                    padToggle(Pad::DOT3, ed);
+                                    break;
+                              case 4:
+                                    padToggle(Pad::DOT4, ed);
+                                    break;
                               }
                         NoteVal nval;
                         Direction stemDirection = Direction::AUTO;

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2813,19 +2813,51 @@ void Score::padToggle(Pad n, const EditData& ed)
                                     break;
                               }
                         NoteVal nval;
+                        Direction stemDirection = Direction::AUTO;
                         if (_is.rest()) {
                               // Enter a rest
                               nval = NoteVal();
                               }
                         else {
-                              // Enter a note on the middle staff line
-                              Staff* s = staff(_is.track() / VOICES);
-                              Fraction tick = _is.tick();
-                              ClefType clef = s->clef(tick);
-                              Key key = s->key(tick);
-                              nval = NoteVal(line2pitch(4, clef, key));
+                              Element* e = selection().element();
+                              if (e && e->isNote()) {
+                                    // use same pitch etc. as previous note
+                                    Note* n = toNote(e);
+                                    nval = n->noteVal();
+                                    stemDirection = n->chord()->stemDirection();
+                                    }
+                              else {
+                                    // enter a reasonable default note
+                                    Staff* s = staff(_is.track() / VOICES);
+                                    Fraction tick = _is.tick();
+                                    if (s->isTabStaff(tick)) {
+                                          // tab - use fret 0 on current string
+                                          nval.fret = 0;
+                                          nval.string = _is.string();
+                                          const Instrument* instr = s->part()->instrument(tick);
+                                          const StringData* stringData = instr->stringData();
+                                          nval.pitch = stringData->getPitch(nval.string, nval.fret, s, tick);
+                                          }
+                                    else if (s->isDrumStaff(tick)) {
+                                          // drum - use selected drum palette note
+                                          int n = _is.drumNote();
+                                          if (n == -1) {
+                                                // no selection on palette - find next valid pitch
+                                                const Drumset* ds = _is.drumset();
+                                                n = ds->nextPitch(n);
+                                                }
+                                          nval = NoteVal(n);
+                                          }
+                                    else {
+                                          // standard staff - use middle line
+                                          ClefType clef = s->clef(tick);
+                                          Key key = s->key(tick);
+                                          int line = ((s->lines(tick) - 1) / 2) * 2;
+                                          nval = NoteVal(line2pitch(line, clef, key));
+                                          }
+                                    }
                               }
-                        setNoteRest(_is.segment(), _is.track(), nval, _is.duration().fraction());
+                        setNoteRest(_is.segment(), _is.track(), nval, _is.duration().fraction(), stemDirection);
                         _is.moveToNextInputPos();
                         }
                   else

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4431,6 +4431,16 @@ void MuseScore::changeState(ScoreState val)
                   {
                   if (getAction("note-input-repitch")->isChecked())
                         cs->setNoteEntryMethod(NoteEntryMethod::REPITCH);
+                  else if (getAction("note-input-rhythm")->isChecked())
+                        cs->setNoteEntryMethod(NoteEntryMethod::RHYTHM);
+                  else if (getAction("note-input-realtime-auto")->isChecked())
+                        cs->setNoteEntryMethod(NoteEntryMethod::REALTIME_AUTO);
+                  else if (getAction("note-input-realtime-manual")->isChecked())
+                        cs->setNoteEntryMethod(NoteEntryMethod::REALTIME_MANUAL);
+                  else if (getAction("note-input-timewise")->isChecked())
+                        cs->setNoteEntryMethod(NoteEntryMethod::TIMEWISE);
+                  else
+                        cs->setNoteEntryMethod(NoteEntryMethod::STEPTIME);
                   showModeText(tr("Drumset input mode"));
                   InputState& is = cs->inputState();
                   showDrumTools(is.drumset(), cs->staff(is.track() / VOICES));
@@ -4439,6 +4449,18 @@ void MuseScore::changeState(ScoreState val)
                   }
                   break;
             case STATE_NOTE_ENTRY_STAFF_TAB:
+                  if (getAction("note-input-repitch")->isChecked())
+                        cs->setNoteEntryMethod(NoteEntryMethod::REPITCH);
+                  else if (getAction("note-input-rhythm")->isChecked())
+                        cs->setNoteEntryMethod(NoteEntryMethod::RHYTHM);
+                  else if (getAction("note-input-realtime-auto")->isChecked())
+                        cs->setNoteEntryMethod(NoteEntryMethod::REALTIME_AUTO);
+                  else if (getAction("note-input-realtime-manual")->isChecked())
+                        cs->setNoteEntryMethod(NoteEntryMethod::REALTIME_MANUAL);
+                  else if (getAction("note-input-timewise")->isChecked())
+                        cs->setNoteEntryMethod(NoteEntryMethod::TIMEWISE);
+                  else
+                        cs->setNoteEntryMethod(NoteEntryMethod::STEPTIME);
                   showModeText(tr("TAB input mode"));
                   break;
             case STATE_EDIT:


### PR DESCRIPTION
This PR fixes a number of small but collectively serious issues with the "rhythm" note input mode workflow.  Where possible, these are separated into individual commits, but they all relate to each other and are thus collected in this one PR.

To me these should probably be merged together, and I would advocate it happen for 3.5.  No string changes, no document changes required although we could mention the new behavior in 1a) rather than let people discover it for themselves.  Mostly it just improves the rhythm mode workflow with no penalty.

1a) As discussed on the forum (see for instance https://musescore.org/en/node/306781 and many previous discussions in the past), always defaulting to the middle line when entering notes is not optimal.  If you want that, fine, but many people want to be able to choose a pitch.  This PR simply copies the previous pitch, so while the first pitch you enter default to the middle line, if you immediately repitch using Up/Down, the next note inherits that pitch.  This is valuable for people trying to use this mode to input notes using cursor and duration only, and is especially valuable for drums

1b) There was a bug where the initial note for both drum and tab staves was poorly chosen, since the original calculation only worked for pitched staves.  This makes a better choice for drum staves (use current drum not from palette, or first valid drum note in set) and tab (use fret 0 of current string).  It also corrects the "middle line" calculation for standard staves of other than 5 lines.

2) The originally intended purpose of rhythm mode was a prelude to repitch, but repitch produces incorrect results on drum staves - again, the pitch calculation assumed a standard staff.  Corrected honor the drumset shortcuts correctly.

Note: there is also a crash when attempting to repitch a drum staff with the mouse, possible to reproduce without this PR but more likely now.  Fix coming...

3) Triple and quadruple dots were not working in rhythm mode due to a simple oversight, fixed here.

4) Rhythm mode was difficult to enable on drum staves, because it was actually ignored when setting the internal mode.  The only way to get a drum staff into rhythm mode was to change modes while on a standard staff, then change to the drum staff.  Again, just some missing code, added here.