### PR TITLE
[MU4] Add bracket to notehead toggle in inspector

### DIFF
--- a/inspectors/models/notation/notes/noteheads/noteheadsettingsmodel.cpp
+++ b/inspectors/models/notation/notes/noteheads/noteheadsettingsmodel.cpp
@@ -19,6 +19,7 @@ void NoteheadSettingsModel::createProperties()
         onPropertyValueChanged(static_cast<Ms::Pid>(pid), !isHeadHidden.toBool());
     });
 
+    m_parenthesesNotehead = buildPropertyItem(Ms::Pid::PARENTHESES_NOTEHEAD);
     m_headDirection = buildPropertyItem(Ms::Pid::MIRROR_HEAD);
     m_headGroup = buildPropertyItem(Ms::Pid::HEAD_GROUP);
     m_headType = buildPropertyItem(Ms::Pid::HEAD_TYPE);
@@ -44,6 +45,7 @@ void NoteheadSettingsModel::loadProperties()
        return !isVisible.toBool();
     });
 
+    loadPropertyItem(m_parenthesesNotehead);
     loadPropertyItem(m_headDirection);
     loadPropertyItem(m_headGroup);
     loadPropertyItem(m_headType);
@@ -61,6 +63,7 @@ void NoteheadSettingsModel::loadProperties()
 void NoteheadSettingsModel::resetProperties()
 {
     m_isHeadHidden->resetToDefault();
+    m_parenthesesNotehead->resetToDefault();
     m_headDirection->resetToDefault();
     m_headGroup->resetToDefault();
     m_headType->resetToDefault();
@@ -78,6 +81,11 @@ QObject* NoteheadSettingsModel::noteheadTypesModel() const
 PropertyItem* NoteheadSettingsModel::isHeadHidden() const
 {
     return m_isHeadHidden;
+}
+
+PropertyItem* NoteheadSettingsModel::parenthesesNotehead() const
+{
+    return m_parenthesesNotehead;
 }
 
 PropertyItem* NoteheadSettingsModel::headDirection() const

--- a/inspectors/models/notation/notes/noteheads/noteheadsettingsmodel.h
+++ b/inspectors/models/notation/notes/noteheads/noteheadsettingsmodel.h
@@ -10,6 +10,7 @@ class NoteheadSettingsModel : public AbstractInspectorModel
 
     Q_PROPERTY(QObject* noteheadTypesModel READ noteheadTypesModel NOTIFY noteheadTypesModelChanged)
     Q_PROPERTY(PropertyItem* isHeadHidden READ isHeadHidden CONSTANT)
+    Q_PROPERTY(PropertyItem* parenthesesNotehead READ parenthesesNotehead CONSTANT)
     Q_PROPERTY(PropertyItem* headDirection READ headDirection CONSTANT)
     Q_PROPERTY(PropertyItem* headGroup READ headGroup CONSTANT)
     Q_PROPERTY(PropertyItem* headType READ headType CONSTANT)
@@ -25,6 +26,7 @@ public:
     QObject* noteheadTypesModel() const;
 
     PropertyItem* isHeadHidden() const;
+    PropertyItem* parenthesesNotehead() const;
     PropertyItem* headDirection() const;
     PropertyItem* headGroup() const;
     PropertyItem* headType() const;
@@ -48,6 +50,7 @@ private:
     NoteheadTypesModel* m_noteheadTypesModel = nullptr;
 
     PropertyItem* m_isHeadHidden = nullptr;
+    PropertyItem* m_parenthesesNotehead = nullptr;
     PropertyItem* m_headDirection = nullptr;
     PropertyItem* m_headGroup = nullptr;
     PropertyItem* m_headType = nullptr;

--- a/inspectors/types/noteheadtypes.h
+++ b/inspectors/types/noteheadtypes.h
@@ -69,11 +69,20 @@ public:
         SCHEME_SHAPE_NOTE_7_WALKER
     };
 
+    enum class ParenthesesFlags : signed char {
+        PARENTHESIS_NONE  = 0x0,
+        PARENTHESIS_LEFT  = 0x1,
+        PARENTHESIS_RIGHT = 0x2,
+        PARENTHESIS_ALL   = PARENTHESIS_RIGHT | PARENTHESIS_LEFT
+    };
+
     Q_ENUM(Group)
     Q_ENUM(HorizontalDirection)
     Q_ENUM(Type)
     Q_ENUM(NoteDotPosition)
     Q_ENUM(SchemeType)
+    Q_ENUM(ParenthesesFlags)
+
 };
 
 #endif // NOTEHEADTYPES_H

--- a/inspectors/view/qml/notation/notes/HeadSettings.qml
+++ b/inspectors/view/qml/notation/notes/HeadSettings.qml
@@ -41,6 +41,27 @@ FocusableItem {
             noteHeadTypesModel: root.model ? root.model.noteheadTypesModel : null
         }
 
+        CheckBox {
+            isIndeterminate: {
+                if (!model)
+                    return false;
+                if (model.isUndefined)
+                    return false;
+
+                return model.parenthesesNotehead.value === NoteHead.PARENTHESIS_RIGHT || model.parenthesesNotehead.value === NoteHead.PARENTHESIS_LEFT;
+            }
+            checked: (model && !isIndeterminate) ? (model.parenthesesNotehead.value === NoteHead.PARENTHESIS_ALL) : false
+            text: qsTr("Bracket Notehead")
+
+            onClicked: {
+                if (isIndeterminate) {
+                    model.parenthesesNotehead.value = NoteHead.PARENTHESIS_ALL;
+                    return;
+                }
+                model.parenthesesNotehead.value = (checked ? NoteHead.PARENTHESIS_NONE : NoteHead.PARENTHESIS_ALL);
+            }
+        }
+
         StyledTextLabel {
             id: notePositionLabel
 

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2712,7 +2712,8 @@ void Score::cmdAddParentheses()
     for (Element* el : selection().elements()) {
         if (el->type() == ElementType::NOTE) {
             Note* n = toNote(el);
-            n->addParentheses();
+            n->addSymbol(SymId::noteheadParenthesisLeft);
+            n->addSymbol(SymId::noteheadParenthesisRight);
         } else if (el->type() == ElementType::ACCIDENTAL) {
             Accidental* acc = toAccidental(el);
             acc->undoChangeProperty(Pid::ACCIDENTAL_BRACKET, int(AccidentalBracket::PARENTHESIS));

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -155,9 +155,20 @@ public:
         ///\}
     };
 
+    enum class ParenthesesFlags : signed char {
+        ///.\{
+        PARENTHESIS_NONE  = 0x0,
+        PARENTHESIS_LEFT  = 0x1,
+        PARENTHESIS_RIGHT = 0x2,
+        PARENTHESIS_ALL   = PARENTHESIS_RIGHT | PARENTHESIS_LEFT
+        ///\}
+    };
+
     Q_ENUM(Scheme);
     Q_ENUM(Group);
     Q_ENUM(Type);
+    Q_ENUM(ParenthesesFlags);
+    typedef QFlags<ParenthesesFlags> Parentheses;
 
     NoteHead(Score* s = 0)
         : Symbol(s) {}
@@ -177,6 +188,8 @@ public:
     static Group name2group(const QString& s);
     static Type name2type(const QString& s);
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(NoteHead::Parentheses)
 
 //---------------------------------------------------------
 //   NoteVal
@@ -460,6 +473,9 @@ public:
     MScore::DirectionH userMirror() const { return _userMirror; }
     void setUserMirror(MScore::DirectionH d) { _userMirror = d; }
 
+    NoteHead::Parentheses parentheses() const;
+    void setParentheses(NoteHead::Parentheses val);
+
     Direction userDotPosition() const { return _userDotPosition; }
     void setUserDotPosition(Direction d) { _userDotPosition = d; }
     bool dotIsUp() const;                 // actual dot position
@@ -521,7 +537,10 @@ public:
     void setScore(Score* s) override;
     void setDotY(Direction);
 
-    void addParentheses();
+    void addSymbol(SymId sym);
+    Symbol* findSymbol(SymId sym) const;
+
+    void removeParentheses();
 
     static SymId noteHead(int direction, NoteHead::Group, NoteHead::Type, int tpc, Key key, NoteHead::Scheme scheme);
     static SymId noteHead(int direction, NoteHead::Group, NoteHead::Type);

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -109,6 +109,8 @@ static constexpr PropertyMetaData propertyList[] = {
       DUMMY_QT_TRANSLATE_NOOP("propertyName", "distributed") },
     { Pid::MIRROR_HEAD,             false, "mirror",                P_TYPE::DIRECTION_H,
       DUMMY_QT_TRANSLATE_NOOP("propertyName", "mirror") },
+    { Pid::PARENTHESES_NOTEHEAD,            false, "bracket",               P_TYPE::BOOL,
+      DUMMY_QT_TRANSLATE_NOOP("propertyName", "bracket") },
     { Pid::DOT_POSITION,            false, "dotPosition",           P_TYPE::DIRECTION,
       DUMMY_QT_TRANSLATE_NOOP("propertyName", "dot position") },
     { Pid::TUNING,                  false, "tuning",                P_TYPE::REAL,

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -88,6 +88,7 @@ enum class Pid {
     LEADING_SPACE,
     DISTRIBUTE,
     MIRROR_HEAD,
+    PARENTHESES_NOTEHEAD,
     DOT_POSITION,
     TUNING,
     PAUSE,


### PR DESCRIPTION
Resolves: Inspector redesign component

We can add brackets to a note, but can't remove them.
A checkbox was added to the inspector to remove toggle the brackets. 
In the case of there being only one bracket, the checkbox shows as "undefined".
When clicked and undefined, a second bracket is added to the note.


- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n/a] I created the test (mtest, vtest, script test) to verify the changes I made
