### PR TITLE
[MU4] [inspector] weird behaviour of hover events in general view

### DIFF
--- a/inspectors/view/qml/general/GeneralInspectorView.qml
+++ b/inspectors/view/qml/general/GeneralInspectorView.qml
@@ -22,12 +22,12 @@ InspectorSectionView {
         spacing: 16
 
         Item {
-
             height: childrenRect.height
             width: root.width
 
             CheckBox {
                 anchors.left: parent.left
+                anchors.right: parent.horizontalCenter
 
                 text: qsTr("Visible")
 
@@ -58,6 +58,7 @@ InspectorSectionView {
 
             CheckBox {
                 anchors.left: parent.left
+                anchors.right: parent.horizontalCenter
 
                 text: qsTr("Auto-place")
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/pull/6149#issuecomment-636605369

Since dark mode is still unsupported in the new inspector, I will rebase my previously open PR into multiple smaller one, like this one.

The left checkboxes in the main view of the inspector had no right anchors, and were thus hidden under the right checkboxes. Because of that, they got hover events when they should not, like when the left checkboxes were disabled.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n.a.] I created the test (mtest, vtest, script test) to verify the changes I made
