### PR TITLE
[MU4] [inspector] Differentiate checkboxes disabled and hovered.

### DIFF
--- a/framework/uicomponents/qml/MuseScore/UiComponents/CheckBox.qml
+++ b/framework/uicomponents/qml/MuseScore/UiComponents/CheckBox.qml
@@ -16,6 +16,10 @@ FocusableItem {
 
     opacity: root.enabled ? 1.0 : 0.3
 
+    Behavior on opacity {
+        NumberAnimation { duration: 100; }
+    }
+
     Item {
         id: contentRow
 
@@ -39,6 +43,13 @@ FocusableItem {
                 iconCode: root.isIndeterminate ? IconCode.MINUS : IconCode.TICK_RIGHT_ANGLE
 
                 visible: root.checked || root.isIndeterminate
+            }
+
+            Behavior on border.color {
+                ColorAnimation { duration: 100; }
+            }
+            Behavior on color {
+                ColorAnimation { duration: 100; }
             }
         }
 
@@ -74,7 +85,7 @@ FocusableItem {
                 target: box
                 radius: 1
                 color: Qt.rgba(ui.theme.button.r, ui.theme.button.g, ui.theme.button.b, 1.0)
-                border.color: Qt.rgba(0, 0, 0, 0.15)
+                border.color: ui.theme.highlight
             }
         },
 
@@ -86,7 +97,7 @@ FocusableItem {
                 target: box
                 radius: 1
                 color: "#C0C0C0"
-                border.color: Qt.rgba(0, 0, 0, 0.15)
+                border.color: globalStyle.highlight
             }
         }
     ]


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/pull/6149#issuecomment-636603333 #4

Checkboxes were very similar (opacity 0.3 vs 0.15) when disabled and when hovered, which was confusing.

![3](https://user-images.githubusercontent.com/35939574/84598817-6809d600-ae3b-11ea-9294-bb3e177e3f9e.gif)

<details><summary>Before</summary>

![1](https://user-images.githubusercontent.com/35939574/83373409-3ce0aa80-a396-11ea-8b46-afcb35c9b5d1.gif)
(it is even weirder in light mode)

</details>

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n.a.] I created the test (mtest, vtest, script test) to verify the changes I made
