### PR TITLE
fix #306950 - allow Ctrl+Delete from note input mode

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -3340,7 +3340,40 @@ void Score::localTimeDelete()
             break;
             };
 
-      deselectAll();
+      if (noteEntryMode()) {
+            Segment* currentSegment = endSegment;
+            ChordRest* cr = nullptr;
+            if (!currentSegment && lastMeasureMM()) {
+                  // deleted to end of score - get last cr on current track
+                  currentSegment = lastMeasureMM()->last();
+                  if (currentSegment) {
+                        cr = currentSegment->nextChordRest(_is.track(), true);
+                        if (cr)
+                              currentSegment = cr->segment();
+                        }
+                  }
+            if (!currentSegment) {
+                  // no cr found - append a new measure
+                  appendMeasures(1);
+                  currentSegment = lastMeasureMM()->first(SegmentType::ChordRest);
+                  }
+            _is.setSegment(currentSegment);
+            cr = _is.cr();
+            if (cr) {
+                  if (cr->isChord())
+                        select(toChord(cr)->upNote(), SelectType::SINGLE);
+                  else
+                        select(cr, SelectType::SINGLE);
+                  }
+            else {
+                  // could not find cr to select,
+                  // may be that there is a "hole" in the current track
+                  deselectAll();
+                  }
+            }
+      else {
+            deselectAll();
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1291,7 +1291,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::SCORE_TAB,
-         STATE_NORMAL,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
          "time-delete",
          QT_TRANSLATE_NOOP("action","Remove Selected Range"),
          QT_TRANSLATE_NOOP("action","Remove selected range"),


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/306950

Currently, Ctrl+Delete to remove a range works well on single notes,
but only in normal mode.
Nothing about the code prevents it from working in note input mode,
where it would be incredibly valuable for certain types of edits
(particularly in conjunction with the insert note commands).
This commit enables the command for note input mode
by adding that state to the shortcut definition.
The only other change needed was to make sure something is selected
after deletion, so I added code to select the next note normally,
or if deleting to the end of score, the last note,
or if the user has deleted the entire score,
I append a new measure.
An alternative would be to force user out of note input mode,
but this felt better, plus I couldn't find a clean way to do that
from libmscore.
