### PR TITLE
[Regression] fix #307047: a problem with stem layout with tremolo

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1456,11 +1456,15 @@ qreal Chord::minAbsStemLength() const
       if (!_tremolo->twoNotes()) {
             _tremolo->layout(); // guarantee right "height value"
 
-            qreal height;
+            // distance between tremolo stroke(s) and chord
+            // choose the furthest/nearest note to calculate for unbeamed/beamed chords
+            // this is due to special layout mechanisms regarding beamed chords
+            // may be changed if beam layout code is improved/rewritten
+            qreal height = 0.0;
             if (up())
-                  height = upPos() - _tremolo->pos().y();
+                  height = (beam() ? upPos() : downPos()) - _tremolo->pos().y();
             else
-                  height = _tremolo->pos().y() + _tremolo->height() - downPos();
+                  height = _tremolo->pos().y() + _tremolo->height() - (beam() ? downPos() : upPos());
             const bool hasHook = beamLvl && !beam();
             if (hasHook)
                   beamLvl += (up() ? 4 : 2); // reserve more space for stem with both hook and tremolo


### PR DESCRIPTION
I honestly don't know why it has to be changed like that, but without this, the stems of either case will be too short or too long. Maybe @MarcSabatella or @mattmcclinch can help?
![image](https://user-images.githubusercontent.com/46259489/85229288-6a5fc780-b41b-11ea-895e-2eeeab451666.png)