### PR TITLE
Fix #307059 - Crash when entering a newline before composer name

### DIFF
--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -200,7 +200,8 @@ const CharFormat TextCursor::selectedFragmentsFormat() const
 
     int endSelectionRow = hasSelection() ? qMax(selectLine(), _row) : _text->rows() - 1;
 
-    CharFormat resultFormat = _text->textBlock(startRow).fragment(startColumn)->format;
+    const TextFragment* tf = _text->textBlock(startRow).fragment(startColumn);
+    CharFormat resultFormat = tf ? tf->format : CharFormat();
 
     for (int row = startRow; row <= endSelectionRow; ++row) {
 
@@ -213,7 +214,7 @@ const CharFormat TextCursor::selectedFragmentsFormat() const
         int endSelectionColumn = hasSelection() ? qMax(selectColumn(), _column) : block->columns();
 
         for (int column = startColumn; column < endSelectionColumn; column++) {
-            CharFormat format = block->fragment(column)->format;
+            CharFormat format = block->fragment(column) ? block->fragment(column)->format : CharFormat();
 
             if (resultFormat.style() != format.style()) {
                 resultFormat.setStyle(FontStyle::Undefined);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/307059

If a TextFragment is empty <code>TextCursor::selectedFragmentsFormat()</code> will create a default <code>CharFormat</code> object instead of retrieving a non-existent one.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n.a.] I created the test (mtest, vtest, script test) to verify the changes I made
