### PR TITLE
fix #307075 : Bold and underlined text is not displayed properly unde…

### DIFF
--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -752,13 +752,15 @@ void TextFragment::draw(QPainter* p, const TextBase* t) const
       f.setPointSizeF(f.pointSizeF() * MScore::pixelRatio);
 #ifndef Q_OS_MACOS
       qreal mm = p->worldTransform().m11();
-      if (!(MScore::pdfPrinting) && (mm < 1.0) && f.bold()) {
+      if (!(MScore::pdfPrinting) && (mm < 1.0) && f.bold() && !(f.underline())) {
             // workaround for https://musescore.org/en/node/284218
             // and https://musescore.org/en/node/281601
             // only needed for certain artificially emboldened fonts
             // see https://musescore.org/en/node/281601#comment-900261
             // in Qt 5.12.x this workaround should be no more necessary if
-            // env variable QT_MAX_CACHED_GLYPH_SIZE is set to 1
+            // env variable QT_MAX_CACHED_GLYPH_SIZE is set to 1.
+            // The workaround works badly if the text is at the same time
+            // bold and underlined.
             p->save();
             qreal dx = p->worldTransform().dx();
             qreal dy = p->worldTransform().dy();


### PR DESCRIPTION
…r Windows and Linux

Resolves: https://musescore.org/en/node/307075

The workaround of https://github.com/musescore/MuseScore/commit/eb33bfa83 introduced a side effect for texts when they are bold and underlined at the same time.
This PR reverts to the previous behavior for this particular case. This means that for some particular fonts, when the texts are at the same time bold and underlined, bug https://musescore.org/en/node/284218 will appear again (as in MuseScore 3.4.2). For Windows and Linux.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
