### PR TITLE
fix #307005: chord playback default not consistent

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -103,7 +103,6 @@
 #define PREF_IO_PORTMIDI_OUTPUTLATENCYMILLISECONDS          "io/portMidi/outputLatencyMilliseconds"
 #define PREF_IO_PULSEAUDIO_USEPULSEAUDIO                    "io/pulseAudio/usePulseAudio"
 #define PREF_SCORE_CHORD_PLAYONADDNOTE                      "score/chord/playOnAddNote"
-#define PREF_SCORE_HARMONY_PLAY                             "score/harmony/play"
 #define PREF_SCORE_HARMONY_PLAY_ONEDIT                      "score/harmony/play/onedit"
 #define PREF_SCORE_NOTE_PLAYONCLICK                         "score/note/playOnClick"
 #define PREF_SCORE_NOTE_DEFAULTPLAYDURATION                 "score/note/defaultPlayDuration"

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -2162,7 +2162,7 @@ void Score::renderMidi(EventMap* events, bool metronome, bool expandRepeats, con
       masterScore()->setExpandRepeats(expandRepeats);
       MidiRenderer::Context ctx(synthState);
       ctx.metronome = metronome;
-      ctx.renderHarmony = preferences.getBool(PREF_SCORE_HARMONY_PLAY);
+      ctx.renderHarmony = true;
       MidiRenderer(this).renderScore(events, ctx);
       }
 

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4737,7 +4737,6 @@ void MuseScore::play(Element* e) const
             seq->startNoteTimer(MScore::defaultPlayDuration);
             }
       else if (e->isHarmony()
-               && preferences.getBool(PREF_SCORE_HARMONY_PLAY)
                && preferences.getBool(PREF_SCORE_HARMONY_PLAY_ONEDIT)) {
             seq->stopNotes();
             Harmony* h = toHarmony(e);

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -170,7 +170,6 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_IO_PORTMIDI_OUTPUTLATENCYMILLISECONDS,           new IntPreference(0)},
             {PREF_IO_PULSEAUDIO_USEPULSEAUDIO,                     new BoolPreference(defaultUsePulseAudio, false)},
             {PREF_SCORE_CHORD_PLAYONADDNOTE,                       new BoolPreference(true, false)},
-            {PREF_SCORE_HARMONY_PLAY,                              new BoolPreference(false, false)},
             {PREF_SCORE_HARMONY_PLAY_ONEDIT,                       new BoolPreference(true, false)},
             {PREF_SCORE_NOTE_PLAYONCLICK,                          new BoolPreference(true, false)},
             {PREF_SCORE_NOTE_DEFAULTPLAYDURATION,                  new IntPreference(300 /* ms */, false)},

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -306,7 +306,6 @@ void PreferenceDialog::start()
                   new IntPreferenceItem(PREF_IO_OSC_PORTNUMBER, oscPort),
                   new BoolPreferenceItem(PREF_IO_OSC_USEREMOTECONTROL, oscServer),
                   new BoolPreferenceItem(PREF_SCORE_CHORD_PLAYONADDNOTE, playChordOnAddNote),
-                  new BoolPreferenceItem(PREF_SCORE_HARMONY_PLAY, playHarmony),
                   new BoolPreferenceItem(PREF_SCORE_HARMONY_PLAY_ONEDIT, playHarmonyOnEdit),
                   new IntPreferenceItem(PREF_SCORE_NOTE_DEFAULTPLAYDURATION, defaultPlayDuration),
                   new BoolPreferenceItem(PREF_SCORE_NOTE_PLAYONCLICK, playNotes),

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -1477,28 +1477,7 @@
             </property>
            </widget>
           </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="playHarmony">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="mouseTracking">
-          <bool>true</bool>
-         </property>
-         <property name="title">
-          <string>Play Chord Symbols</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_41">
-          <item row="0" column="0">
+          <item row="2" column="0">
            <widget class="QCheckBox" name="playHarmonyOnEdit">
             <property name="text">
              <string>Play chord symbol when editing</string>

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -1043,7 +1043,7 @@ void Seq::renderChunk(const MidiRenderer::Chunk& ch, EventMap* eventMap)
       SynthesizerState synState = mscore->synthesizerState();
       MidiRenderer::Context ctx(synState);
       ctx.metronome = true;
-      ctx.renderHarmony = preferences.getBool(PREF_SCORE_HARMONY_PLAY);
+      ctx.renderHarmony = true;
       midi.renderChunk(ch, eventMap, ctx);
       renderEventsStatus.setOccupied(ch.utick1(), ch.utick2());
       }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/307005

Currently chord symbols playback is off by default
controlled by a global program preference.
This means a given user has to learn the feature exists before using it,
which is not how we handle playback of dynamics, ornaments, etc.
And worse, it means a user might turn it on, hear the chord playback,
save and share a score that relies on it,
but the people he sahres it with (including musescore.com)
will not hear the chords unless they happen to have enabled the option.
And musescore.com won't play it no matter what
(or else, it will always play chords symbols for everyone,
which isn't good either).

This commit removes the preference and enables chord sytmbol playback
according to the style setting and property on the chord symbol itself,
which is exactly how it is done for ornaments etc.
The style setting and property already existed,
they were just being overridden by the program preference.