### PR TITLE
[MU3] Partial fix for #306911

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2117,11 +2117,13 @@ static void resetElementPosition(void*, Element* e)
 //   cmdResetAllPositions
 //---------------------------------------------------------
 
-void Score::cmdResetAllPositions()
+void Score::cmdResetAllPositions(bool undoable)
       {
-      startCmd();
+      if (undoable)
+            startCmd();
       scanElements(nullptr, resetElementPosition);
-      endCmd();
+      if (undoable)
+            endCmd();
       }
 
 //---------------------------------------------------------

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2156,7 +2156,7 @@ void Note::updateAccidental(AccidentalState* as)
             int eRelLine = absStep(tpc(), epitch()+ottaveCapoFret());
             AccidentalVal relLineAccVal = as->accidentalVal(eRelLine, error);
             if (error) {
-                  qDebug("error accidetalVal");
+                  qDebug("error accidentalVal()");
                   return;
                   }
             if ((accVal != relLineAccVal) || hidden() || as->tieContext(eRelLine)) {

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -622,7 +622,7 @@ class Score : public QObject, public ScoreElement {
       void cmdAddOttava(OttavaType);
       void cmdAddStretch(qreal);
       void cmdResetNoteAndRestGroupings();
-      void cmdResetAllPositions();
+      void cmdResetAllPositions(bool undoable = true);
       void cmdDoubleDuration()      { cmdIncDecDuration(-1, false); }
       void cmdHalfDuration()        { cmdIncDecDuration( 1, false); }
       void cmdIncDurationDotted()   { cmdIncDecDuration(-1, true); }

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2602,17 +2602,17 @@ void MuseScore::askResetOldScorePositions(Score* score)
             if (resPref == "No")
                   return;
             else if (resPref == "Yes")
-                  score->cmdResetAllPositions();
+                  score->cmdResetAllPositions(false);
             else { // either set to "Ask" or not at all
                   QMessageBox msgBox;
                   QCheckBox ask;
-                  ask.setText(tr("Don't ask me again."));
+                  ask.setText(tr("Remember my choice and don't ask again"));
                   ask.setToolTip(tr("You can change this behaviour any time in 'Preferences… > Import > Reset Element Positions'"));
                   msgBox.setCheckBox(&ask);
                   QString question = tr("Reset the positions of all elements?");
                   msgBox.setWindowTitle(question);
-                  msgBox.setText(tr("To best take advantage of automatic placement in MuseScore 3 when importing '%1' from MuseScore %2, it is recommended to reset the positions of all elements.")
-                                 .arg(score->masterScore()->fileInfo()->completeBaseName(), score->mscoreVersion()) + "\n\n" + question);
+                  msgBox.setText(tr("To best take advantage of automatic placement in MuseScore %1 when importing '%2' from MuseScore %3, it is recommended to reset the positions of all elements.")
+                                 .arg(VERSION).arg(score->masterScore()->fileInfo()->completeBaseName(), score->mscoreVersion()) + "\n\n" + question);
                   msgBox.setIcon(QMessageBox::Question);
                   msgBox.setStandardButtons(
                                     QMessageBox::Yes | QMessageBox::No
@@ -2620,7 +2620,7 @@ void MuseScore::askResetOldScorePositions(Score* score)
 
                   int res = msgBox.exec();
                   if (res == QMessageBox::Yes)
-                        score->cmdResetAllPositions();
+                        score->cmdResetAllPositions(false);
                   if (ask.checkState() == Qt::Checked)
                         preferences.setPreference(PREF_IMPORT_COMPATIBILITY_RESET_ELEMENT_POSITIONS, res == QMessageBox::No? "Yes" : "No");
                   }


### PR DESCRIPTION
See https://musescore.org/en/node/306911

This PRs fixes:

* clarify the "don't ask again"
* mention the current MuseScore version (that way the same dialog still
works in MuseScore 4)
* don't mark the score dirty if the reset is taken (it it is not taken, it is not marked dirty anyway)

It does not resolve the core issue of showing a Save dialog on close of any imported score if no changes have been done to the score (other than the reset).

Its counterpart for master had been merged meanwhile