### PR TITLE
Fix #307121: Revert default zoom type to “100%”

### DIFF
--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -76,7 +76,7 @@ enum class MusicxmlExportBreaks : char {
 
 // Default-zoom-type options
 enum class ZoomType : int {
-      PAGE_WIDTH = 0, WHOLE_PAGE, TWO_PAGES, PERCENTAGE
+      PERCENTAGE = 0, PAGE_WIDTH, WHOLE_PAGE, TWO_PAGES,
       };
 
 class PreferenceVisitor;

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -150,10 +150,10 @@ PreferenceDialog::PreferenceDialog(QWidget* parent)
       connect(bgColorButton, &QRadioButton::toggled, this, &PreferenceDialog::updateBgView);
 
       zoomDefaultType->clear();
-      zoomDefaultType->addItem(tr("Page Width"), 0);
-      zoomDefaultType->addItem(tr("Whole Page"), 1);
-      zoomDefaultType->addItem(tr("Two Pages"), 2);
-      zoomDefaultType->addItem(tr("Percentage"), 3);
+      zoomDefaultType->addItem(tr("Percentage"), 0);
+      zoomDefaultType->addItem(tr("Page Width"), 1);
+      zoomDefaultType->addItem(tr("Whole Page"), 2);
+      zoomDefaultType->addItem(tr("Two Pages"), 3);
 
       zoomPrecisionKeyboard->setRange(ZOOM_PRECISION_MIN, ZOOM_PRECISION_MAX);
       zoomPrecisionMouse->setRange(ZOOM_PRECISION_MIN, ZOOM_PRECISION_MAX);

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -1158,6 +1158,11 @@
             </property>
             <item>
              <property name="text">
+              <string notr="true" extracomment="Dummy values. Used for clarity in the Designer. Translated elsewhere.">Percentage</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
               <string notr="true" extracomment="Dummy values. Used for clarity in the Designer. Translated elsewhere.">Page Width</string>
              </property>
             </item>
@@ -1169,11 +1174,6 @@
             <item>
              <property name="text">
               <string notr="true" extracomment="Dummy values. Used for clarity in the Designer. Translated elsewhere.">Two Pages</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string notr="true" extracomment="Dummy values. Used for clarity in the Designer. Translated elsewhere.">Percentage</string>
              </property>
             </item>
            </widget>


### PR DESCRIPTION
Resolves: [#307121](https://musescore.org/en/node/307121)

Reverted the default zoom type to “100%” (as it was prior to #5623).

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made