### PR TITLE
preferences to disable chord symbol playback when opening old scores, or creating new ones

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -104,6 +104,8 @@
 #define PREF_IO_PULSEAUDIO_USEPULSEAUDIO                    "io/pulseAudio/usePulseAudio"
 #define PREF_SCORE_CHORD_PLAYONADDNOTE                      "score/chord/playOnAddNote"
 #define PREF_SCORE_HARMONY_PLAY_ONEDIT                      "score/harmony/play/onedit"
+#define PREF_SCORE_HARMONY_PLAY_DISABLE_COMPATIBILITY       "score/harmony/play/disableCompatibility"
+#define PREF_SCORE_HARMONY_PLAY_DISABLE_NEW                 "score/harmony/play/disableNew"
 #define PREF_SCORE_NOTE_PLAYONCLICK                         "score/note/playOnClick"
 #define PREF_SCORE_NOTE_DEFAULTPLAYDURATION                 "score/note/defaultPlayDuration"
 #define PREF_SCORE_NOTE_WARNPITCHRANGE                      "score/note/warnPitchRange"

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -2771,7 +2771,7 @@ static void readStyle(MStyle* style, XmlReader& e)
             }
 
       QSettings settings;
-      bool disableHarmonyPlay = settings.value("score/harmony/play/disableCompatibility").toBool();
+      bool disableHarmonyPlay = settings.value("score/harmony/play/disableCompatibility").toBool() && !MScore::testMode;
       if (disableHarmonyPlay) {
             style->set(Sid::harmonyPlay, false);
             }

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -146,6 +146,7 @@ static const StyleVal2 style114[] = {
       { Sid::chordStyle,                   QVariant(QString("custom")) },
       { Sid::chordsXmlFile,                QVariant(true) },
 //      { Sid::harmonyY,                     QVariant(0.0) },
+//      { Sid::harmonyPlay,                  QVariant(false) },
       { Sid::concertPitch,                 QVariant(false) },
       { Sid::createMultiMeasureRests,      QVariant(false) },
       { Sid::minEmptyMeasures,             QVariant(2) },
@@ -2768,6 +2769,13 @@ static void readStyle(MStyle* style, XmlReader& e)
                   }
 //TODO                  style->convertToUnit(tag, val);
             }
+
+      QSettings settings;
+      bool disableHarmonyPlay = settings.value("score/harmony/play/disableCompatibility").toBool();
+      if (disableHarmonyPlay) {
+            style->set(Sid::harmonyPlay, false);
+            }
+
 
       // if we just specified a new chord description file
       // and didn't encounter a ChordList tag

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -3701,7 +3701,7 @@ static void readStyle(MStyle* style, XmlReader& e)
             }
 
       QSettings settings;
-      bool disableHarmonyPlay = settings.value("score/harmony/play/disableCompatibility").toBool();
+      bool disableHarmonyPlay = settings.value("score/harmony/play/disableCompatibility").toBool() && !MScore::testMode;
       if (disableHarmonyPlay) {
             style->set(Sid::harmonyPlay, false);
             }

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -200,6 +200,7 @@ struct StyleVal2 {
       { Sid::chordStyle,                  QVariant(QString("std")) },
       { Sid::chordsXmlFile,               QVariant(false) },
       { Sid::chordDescriptionFile,        QVariant(QString("chords_std.xml")) },
+//      { Sid::harmonyPlay,                 QVariant(false) },
       { Sid::concertPitch,                QVariant(false) },
       { Sid::createMultiMeasureRests,     QVariant(false) },
       { Sid::minEmptyMeasures,            QVariant(2) },
@@ -3697,6 +3698,12 @@ static void readStyle(MStyle* style, XmlReader& e)
                         e.skipCurrentElement();
                         }
                   }
+            }
+
+      QSettings settings;
+      bool disableHarmonyPlay = settings.value("score/harmony/play/disableCompatibility").toBool();
+      if (disableHarmonyPlay) {
+            style->set(Sid::harmonyPlay, false);
             }
 
       // if we just specified a new chord description file

--- a/libmscore/read301.cpp
+++ b/libmscore/read301.cpp
@@ -38,6 +38,19 @@ namespace Ms {
 
 bool Score::read(XmlReader& e)
       {
+      // HACK
+      // style setting compatibility settings for minor versions
+      // this allows new style settings to be added
+      // with different default values for older vs newer scores
+      // note: older templates get the default values for older scores
+      // these can be forced back in MuseScore::getNewFile() if necessary
+      QString programVersion = masterScore()->mscoreVersion();
+      QSettings settings;
+      bool disableHarmonyPlay = settings.value("score/harmony/play/disableCompatibility").toBool();
+      if (!programVersion.isEmpty() && programVersion < "3.5" && disableHarmonyPlay) {
+            style().set(Sid::harmonyPlay, false);
+            }
+
       while (e.readNextStartElement()) {
             e.setTrack(-1);
             const QStringRef& tag(e.name());

--- a/libmscore/read301.cpp
+++ b/libmscore/read301.cpp
@@ -46,7 +46,7 @@ bool Score::read(XmlReader& e)
       // these can be forced back in MuseScore::getNewFile() if necessary
       QString programVersion = masterScore()->mscoreVersion();
       QSettings settings;
-      bool disableHarmonyPlay = settings.value("score/harmony/play/disableCompatibility").toBool();
+      bool disableHarmonyPlay = settings.value("score/harmony/play/disableCompatibility").toBool() && !MScore::testMode;
       if (!programVersion.isEmpty() && programVersion < "3.5" && disableHarmonyPlay) {
             style().set(Sid::harmonyPlay, false);
             }

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -584,6 +584,9 @@ MasterScore* MuseScore::getNewFile()
                   delete score;
                   return 0;
                   }
+            if (preferences.getBool(PREF_SCORE_HARMONY_PLAY_DISABLE_NEW)) {
+                  tscore->style().set(Sid::harmonyPlay, false);
+                  }
             score->setStyle(tscore->style());
 
             // create instruments from template
@@ -634,6 +637,9 @@ MasterScore* MuseScore::getNewFile()
             }
       else {
             score = new MasterScore(MScore::defaultStyle());
+            if (preferences.getBool(PREF_SCORE_HARMONY_PLAY_DISABLE_NEW)) {
+                  score->style().set(Sid::harmonyPlay, false);
+                  }
             newWizard->createInstruments(score);
             }
       score->setCreated(true);

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -587,6 +587,11 @@ MasterScore* MuseScore::getNewFile()
             if (preferences.getBool(PREF_SCORE_HARMONY_PLAY_DISABLE_NEW)) {
                   tscore->style().set(Sid::harmonyPlay, false);
                   }
+            else if (preferences.getBool(PREF_SCORE_HARMONY_PLAY_DISABLE_COMPATIBILITY)) {
+                  // if template was older, then harmonyPlay may have been forced off by the compatibility preference
+                  // that's not appropriatew when creating new scores, even from old templates, so return it to default
+                  tscore->style().set(Sid::harmonyPlay, MScore::defaultStyle().value(Sid::harmonyPlay));
+                  }
             score->setStyle(tscore->style());
 
             // create instruments from template

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -3521,6 +3521,9 @@ static void loadScores(const QStringList& argv)
                               MasterScore* score = mscore->readScore(startScore);
                               if (startScore.startsWith(":/") && score) {
                                     score->setStyle(MScore::defaultStyle());
+                                    if (preferences.getBool(PREF_SCORE_HARMONY_PLAY_DISABLE_NEW)) {
+                                          score->style().set(Sid::harmonyPlay, false);
+                                          }
                                     score->style().checkChordList();
                                     score->styleChanged();
                                     score->setName(mscore->createDefaultName());
@@ -3532,6 +3535,9 @@ static void loadScores(const QStringList& argv)
                                     score = mscore->readScore(":/data/My_First_Score.mscx");
                                     if (score) {
                                           score->setStyle(MScore::defaultStyle());
+                                          if (preferences.getBool(PREF_SCORE_HARMONY_PLAY_DISABLE_NEW)) {
+                                                score->style().set(Sid::harmonyPlay, false);
+                                                }
                                           score->style().checkChordList();
                                           score->styleChanged();
                                           score->setName(mscore->createDefaultName());

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -178,7 +178,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_IO_PULSEAUDIO_USEPULSEAUDIO,                     new BoolPreference(defaultUsePulseAudio, false)},
             {PREF_SCORE_CHORD_PLAYONADDNOTE,                       new BoolPreference(true, false)},
             {PREF_SCORE_HARMONY_PLAY_ONEDIT,                       new BoolPreference(true, false)},
-            {PREF_SCORE_HARMONY_PLAY_DISABLE_COMPATIBILITY,        new BoolPreference(false, true)},
+            {PREF_SCORE_HARMONY_PLAY_DISABLE_COMPATIBILITY,        new BoolPreference(true, true)},
             {PREF_SCORE_HARMONY_PLAY_DISABLE_NEW,                  new BoolPreference(false, true)},
             {PREF_SCORE_NOTE_PLAYONCLICK,                          new BoolPreference(true, false)},
             {PREF_SCORE_NOTE_DEFAULTPLAYDURATION,                  new IntPreference(300 /* ms */, false)},

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -178,6 +178,8 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_IO_PULSEAUDIO_USEPULSEAUDIO,                     new BoolPreference(defaultUsePulseAudio, false)},
             {PREF_SCORE_CHORD_PLAYONADDNOTE,                       new BoolPreference(true, false)},
             {PREF_SCORE_HARMONY_PLAY_ONEDIT,                       new BoolPreference(true, false)},
+            {PREF_SCORE_HARMONY_PLAY_DISABLE_COMPATIBILITY,        new BoolPreference(false, true)},
+            {PREF_SCORE_HARMONY_PLAY_DISABLE_NEW,                  new BoolPreference(false, true)},
             {PREF_SCORE_NOTE_PLAYONCLICK,                          new BoolPreference(true, false)},
             {PREF_SCORE_NOTE_DEFAULTPLAYDURATION,                  new IntPreference(300 /* ms */, false)},
             {PREF_SCORE_NOTE_WARNPITCHRANGE,                       new BoolPreference(true, false)},

--- a/mtest/testscript/scripts/init/Guitar-tab-parts.mscx
+++ b/mtest/testscript/scripts/init/Guitar-tab-parts.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>29165bb</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/init/Treble.mscx
+++ b/mtest/testscript/scripts/init/Treble.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>d4d1d69</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/init/TrebleWithPart-Lyrics.mscx
+++ b/mtest/testscript/scripts/init/TrebleWithPart-Lyrics.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.3.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>6c0bef1</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/init/TrebleWithPart.mscx
+++ b/mtest/testscript/scripts/init/TrebleWithPart.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/init/Voice-Piano-3-4.mscx
+++ b/mtest/testscript/scripts/init/Voice-Piano-3-4.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>7c71ea7</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/init/oneStaffWithNotesAndMM.mscx
+++ b/mtest/testscript/scripts/init/oneStaffWithNotesAndMM.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>


### PR DESCRIPTION
This adds checks for the version that used when a file was saved,
so we can force older scores (both pre-3.0 and 3.0 - 3.4.2)
to have the playHarmony style setting off by default,
for better playback compatibility with older versions.
This code is a hack but is set up in a way
to easily allow other new style settings to be handled in a similar way.
New scores continue to have chord symbol playback enabled by default.
In order to get scores created from (possibly older) templates
to also have chord symbol playback enabled by default,
a second hack resets this value after the template is loaded.

Note: I can't say I'm especially proud of the code, but I didn't see a betterway to accomplish the goal and have it handle templates, command-line conversion, custom default style files, musescore.com, etc.  Well, we could at least avoid the second hack to correct templates by somehow having a "template load mode" flag passed to the various read functions, or add a member to the Score itself that we could check.  But I really didn't think it worth making that level of change for this.