### PR TITLE
Fix #307077: Dragging element(s) with keyboard modifiers were retaini…

### DIFF
--- a/mscore/dragelement.cpp
+++ b/mscore/dragelement.cpp
@@ -72,11 +72,11 @@ void ScoreView::doDragElement(QMouseEvent* ev)
 
       QPointF pt(delta);
       if (qApp->keyboardModifiers() == Qt::ShiftModifier) {
-            pt.setX(editData.delta.x());
+            pt.setX(editData.element->offset().x());
             evtDelta.setX(0.0);
             }
       else if (qApp->keyboardModifiers() == Qt::ControlModifier) {
-            pt.setY(editData.delta.y());
+            pt.setY(editData.element->offset().y());
             evtDelta.setY(0.0);
             }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/307077

In 3.5 there was introduced some group dragging code changes, and it seems that in the process this little bug crept in. Demonstration given at link above affecting CTRL+Drag and SHIFT+Drag of an element when another element had previously been dragged beforehand. Whatever the offset was given related to the "lock-in" position of the modifier ended up becoming the "lock-in" position of the next element even though it should've been only the newly selected element's position prior to dragging. Reverting back to 3.4.2's element-based statements while keeping everything else untouched fixes the problem and so far no side effects have been found related to group dragging or anything else. Any further testing, or if anyone knows of any alternative ways to do this that they think would be better: all that would be welcomed of course.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made

Update: I've tested some more and have no problems