### PR TITLE
CMake: Print Qt version or useful error if it's not installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.3.0)
 
 include(build/functions.cmake) # library of CMake functions ("fn__" namespace)
 
+# Print Qt version or fail the build if Qt (qmake) is not in PATH.
+fn__require_program(QMAKE Qt --version "https://musescore.org/en/handbook/developers-handbook/compilation" qmake)
+
 set (CI $ENV{CI})
 if (CI)
     SET_PROPERTY(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)


### PR DESCRIPTION
Resolves: *No issue in tracker*

Adds a CMake function `fn__required_program()` that can be used to check that a program is installed and present in PATH. If the program is found then it is run with a test argument to check that it works. If it doesn't work, or if it wasn't found, then the build is stopped and a useful error message is displayed on the console. The message can include a URL that points to a webpage where help is available.

Demonstrates use of this function by running `qmake --version` at build time to print the Qt version, or failing with an appropriate error message.

## Success message

### Qt found and works as expected

QMake and Qt version displayed right after compiler version. (See [line 1005 in Travis build log](https://travis-ci.org/github/musescore/MuseScore/jobs/704938850#L1005-L1006).)
![image](https://user-images.githubusercontent.com/11011881/86532450-f533ce00-bec1-11ea-8759-51519eb1d41f.png)
Of course the build continues after this.


## Failure messages

### Qt not found
![image](https://user-images.githubusercontent.com/11011881/86534183-3f22b100-bece-11ea-9cb2-f0a002571410.png)

### Other error
![image](https://user-images.githubusercontent.com/11011881/86534119-bd328800-becd-11ea-9666-6503a0208184.png)

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [N/A] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
