### PR TITLE
[MusicXML] Add missing Gould arrow quartertone accidentals

### DIFF
--- a/importexport/musicxml/musicxmlsupport.cpp
+++ b/importexport/musicxml/musicxmlsupport.cpp
@@ -481,6 +481,10 @@ QString accidentalType2MxmlString(const AccidentalType type)
             case AccidentalType::SHARP_SLASH3:       s = "slash-quarter-sharp";  break;
             case AccidentalType::FLAT_SLASH2:        s = "double-slash-flat";    break;
             case AccidentalType::SHARP_SLASH2:       s = "slash-sharp";          break;
+            case AccidentalType::SHARP2_ARROW_DOWN:  s = "double-sharp-down";    break;
+            case AccidentalType::SHARP2_ARROW_UP:    s = "double-sharp-up";      break;
+            case AccidentalType::FLAT2_ARROW_DOWN:   s = "flat-flat-down";       break;
+            case AccidentalType::FLAT2_ARROW_UP:     s = "flat-flat-up";         break;
             case AccidentalType::SORI:               s = "sori";                 break;
             case AccidentalType::KORON:              s = "koron";                break;
             default:
@@ -520,6 +524,10 @@ AccidentalType mxmlString2accidentalType(const QString mxmlName)
       map["natural-up"] = AccidentalType::NATURAL_ARROW_UP;
       map["flat-down"] = AccidentalType::FLAT_ARROW_DOWN;
       map["flat-up"] = AccidentalType::FLAT_ARROW_UP;
+      map["double-sharp-down"] = AccidentalType::SHARP2_ARROW_DOWN;
+      map["double-sharp-up"] = AccidentalType::SHARP2_ARROW_UP;
+      map["flat-flat-down"] = AccidentalType::FLAT2_ARROW_DOWN;
+      map["flat-flat-up"] = AccidentalType::FLAT2_ARROW_UP;
 
       map["slash-quarter-sharp"] = AccidentalType::SHARP_SLASH3; // MIRRORED_FLAT_SLASH; ?
       map["slash-sharp"] = AccidentalType::SHARP_SLASH2; // SHARP_SLASH; ?


### PR DESCRIPTION
This PR is a simple addition to allow import/export of the added Gould arrow quartertone accidentals in MusicXML 3.1.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
