### PR TITLE
Partially fix #294768: tremolos don't have cue size

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1512,9 +1512,9 @@ qreal Chord::minAbsStemLength() const
     if (!_tremolo) {
         return 0.0;
     }
-
-    const qreal sw = score()->styleS(Sid::tremoloStrokeWidth).val();
-    const qreal td = score()->styleS(Sid::tremoloDistance).val();
+    
+    const qreal sw = score()->styleS(Sid::tremoloStrokeWidth).val() * mag();
+    const qreal td = score()->styleS(Sid::tremoloDistance).val() * mag();
     int beamLvl = beams();
     const qreal beamDist = beam() ? beam()->beamDist() : (sw * spatium());
 
@@ -1526,20 +1526,20 @@ qreal Chord::minAbsStemLength() const
         if (up()) {
             height = upPos() - _tremolo->pos().y();
         } else {
-            height = _tremolo->pos().y() + _tremolo->height() - downPos();
+            height = _tremolo->pos().y() + _tremolo->minHeight() * spatium() - downPos();
         }
         const bool hasHook = beamLvl && !beam();
         if (hasHook) {
             beamLvl += (up() ? 4 : 2);       // reserve more space for stem with both hook and tremolo
         }
-        const qreal additionalHeight = beamLvl ? 0 : sw* spatium();
+        const qreal additionalHeight = beamLvl ? 0 : sw * spatium();
 
         return height + beamLvl * beamDist + additionalHeight;
     }
     // two-note tremolo
     else {
         if (_tremolo->chord1()->up() == _tremolo->chord2()->up()) {
-            const qreal tremoloMinHeight = ((_tremolo->lines() - 1) * td + sw) * spatium();
+            const qreal tremoloMinHeight = _tremolo->minHeight() * spatium();
             return tremoloMinHeight + beamLvl * beamDist + 2 * td * spatium();
         }
         return 0.0;

--- a/libmscore/tremolo.h
+++ b/libmscore/tremolo.h
@@ -75,6 +75,8 @@ public:
     void setTremoloType(TremoloType t);
     TremoloType tremoloType() const { return _tremoloType; }
 
+    qreal minHeight() const;
+
     qreal mag() const override;
     void draw(QPainter*) const override;
     void layout() override;


### PR DESCRIPTION
Partially resolves: https://musescore.org/node/294768.

This is because the `mag()` factor isn't taken into consideration.

Along with multiplying `mag()` in some places, I also created a new member function `minHeight()` for `Tremolo` class to calculate the effective height of tremolo strokes, that is, the height the strokes spread across a given vertical line, without multiplying `spatium()`, to resolve an issue of stem length (a bit longer than intended when direction is down and has single-note tremolo on it) which is not obvious in normal size but obvious in cue size. Several places are already using this effective height, so a separate function for calculating it is really convenient to use.