### PR TITLE
Partially fix #294768: tremolos don't have cue size

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1443,8 +1443,8 @@ qreal Chord::minAbsStemLength() const
       if (!_tremolo)
             return 0.0;
 
-      const qreal sw = score()->styleS(Sid::tremoloStrokeWidth).val();
-      const qreal td = score()->styleS(Sid::tremoloDistance).val();
+      const qreal sw = score()->styleS(Sid::tremoloStrokeWidth).val() * mag();
+      const qreal td = score()->styleS(Sid::tremoloDistance).val() * mag();
       int beamLvl = beams();
       const qreal beamDist = beam() ? beam()->beamDist() : (sw * spatium());
 
@@ -1460,7 +1460,7 @@ qreal Chord::minAbsStemLength() const
             if (up())
                   height = (beam() ? upPos() : downPos()) - _tremolo->pos().y();
             else
-                  height = _tremolo->pos().y() + _tremolo->height() - (beam() ? downPos() : upPos());
+                  height = _tremolo->pos().y() + _tremolo->minHeight() * spatium() - (beam() ? downPos() : upPos());
             const bool hasHook = beamLvl && !beam();
             if (hasHook)
                   beamLvl += (up() ? 4 : 2); // reserve more space for stem with both hook and tremolo
@@ -1473,7 +1473,7 @@ qreal Chord::minAbsStemLength() const
       // two-note tremolo
       else {
             if (_tremolo->chord1()->up() == _tremolo->chord2()->up()) {
-                  const qreal tremoloMinHeight = ((_tremolo->lines() - 1) * td + sw) * spatium();
+                  const qreal tremoloMinHeight = _tremolo->minHeight() * spatium();
                   return tremoloMinHeight + beamLvl * beamDist + 2 * td * spatium();
                   }
             return 0.0;

--- a/libmscore/tremolo.cpp
+++ b/libmscore/tremolo.cpp
@@ -254,15 +254,17 @@ void Tremolo::layoutOneNoteTremolo(qreal x, qreal y, qreal spatium)
             if (chord()->hook() || chord()->beam()) {
                   t = up ? -3.0 - 2.0 * minHeight() : 3.0;
                   }
-            else { 
+            else {
+                  const qreal offset = 2.0 * score()->styleS(Sid::tremoloStrokeWidth).val();
+
                   if      (!up && !(line & 1)) // stem is down; even line
-                        t = qMax(6.0  - 2.0 * minHeight(), 3.0);
+                        t = qMax(4.0 + offset - 2.0 * minHeight(), 3.0);
                   else if (!up &&  (line & 1)) // stem is down; odd line
-                        t = qMax(5.0  - 2.0 * minHeight(), 3.0);
+                        t = qMax(5.0          - 2.0 * minHeight(), 3.0);
                   else if ( up && !(line & 1)) // stem is up; even line
-                        t = qMin(-3.0 - 2.0 * minHeight(), -6.0);
+                        t = qMin(-3.0         - 2.0 * minHeight(), -4.0 - offset);
                   else /*if ( up &&  (line & 1))*/ // stem is up; odd line
-                        t = qMin(-3.0 - 2.0 * minHeight(), -5.0);
+                        t = qMin(-3.0         - 2.0 * minHeight(), -5.0);
                   }
 
             qreal yLine = line + t;

--- a/libmscore/tremolo.cpp
+++ b/libmscore/tremolo.cpp
@@ -74,6 +74,17 @@ qreal Tremolo::mag() const
       }
 
 //---------------------------------------------------------
+//   minHeight
+//---------------------------------------------------------
+
+qreal Tremolo::minHeight() const
+      {
+      const qreal sw = score()->styleS(Sid::tremoloStrokeWidth).val() * mag();
+      const qreal td = score()->styleS(Sid::tremoloDistance).val() * mag();
+      return (lines() - 1) * td + sw;
+      }
+
+//---------------------------------------------------------
 //   draw
 //---------------------------------------------------------
 
@@ -88,15 +99,16 @@ void Tremolo::draw(QPainter* painter) const
             painter->setPen(Qt::NoPen);
             painter->drawPath(path);
             }
-      if ((parent() == 0) && !twoNotes()) {
+      // for palette
+      if (!parent() && !twoNotes()) {
             qreal x = 0.0; // bbox().width() * .25;
             QPen pen(curColor(), point(score()->styleS(Sid::stemWidth)));
             painter->setPen(pen);
-            const qreal _spatium = spatium();
+            const qreal sp = spatium();
             if (_tremoloType == TremoloType::BUZZ_ROLL)
-                  painter->drawLine(QLineF(x, -_spatium, x, bbox().bottom() + _spatium));
+                  painter->drawLine(QLineF(x, -sp, x, bbox().bottom() + sp));
             else
-                  painter->drawLine(QLineF(x, -_spatium*.5, x, path.boundingRect().height() + _spatium));
+                  painter->drawLine(QLineF(x, -sp * .5, x, path.boundingRect().height() + sp));
             }
       }
 
@@ -179,11 +191,11 @@ QPainterPath Tremolo::basePath() const
       if (_tremoloType == TremoloType::BUZZ_ROLL)
             return QPainterPath();
 
-      const qreal _spatium  = spatium();
+      const qreal sp = spatium() * mag();
 
-      qreal w2  = _spatium * score()->styleS(Sid::tremoloWidth).val() * .5;
-      qreal lw  = _spatium * score()->styleS(Sid::tremoloStrokeWidth).val();
-      qreal td  = _spatium * score()->styleS(Sid::tremoloDistance).val();
+      qreal w2  = sp * score()->styleS(Sid::tremoloWidth).val() * .5;
+      qreal lw  = sp * score()->styleS(Sid::tremoloStrokeWidth).val();
+      qreal td  = sp * score()->styleS(Sid::tremoloDistance).val();
 
       QPainterPath ppath;
       qreal ty  = 0.0;
@@ -229,7 +241,7 @@ void Tremolo::computeShape()
 //   layoutOneNoteTremolo
 //---------------------------------------------------------
 
-void Tremolo::layoutOneNoteTremolo(qreal x, qreal y, qreal _spatium)
+void Tremolo::layoutOneNoteTremolo(qreal x, qreal y, qreal spatium)
       {
       Q_ASSERT(!twoNotes());
 
@@ -237,23 +249,20 @@ void Tremolo::layoutOneNoteTremolo(qreal x, qreal y, qreal _spatium)
       int line = up ? chord()->upLine() : chord()->downLine();
 
       if (!placeMidStem()) {
-            const qreal td = score()->styleS(Sid::tremoloDistance).val();
-            const qreal sw = score()->styleS(Sid::tremoloStrokeWidth).val();
-
             qreal t = 0.0;
             // nearest distance between note and tremolo stroke should be no less than 3.0
             if (chord()->hook() || chord()->beam()) {
-                  t = up ? -3.0 - (2.0 * (lines() - 1)) * td - 2.0 * sw : 3.0;
+                  t = up ? -3.0 - 2.0 * minHeight() : 3.0;
                   }
             else { 
                   if      (!up && !(line & 1)) // stem is down; even line
-                        t = qMax(6.0  - (2.0 * (lines() - 1)) * td - 2.0 * sw, 3.0);
+                        t = qMax(6.0  - 2.0 * minHeight(), 3.0);
                   else if (!up &&  (line & 1)) // stem is down; odd line
-                        t = qMax(5.0  - (2.0 * (lines() - 1)) * td - 2.0 * sw, 3.0);
+                        t = qMax(5.0  - 2.0 * minHeight(), 3.0);
                   else if ( up && !(line & 1)) // stem is up; even line
-                        t = qMin(-3.0 - (2.0 * (lines() - 1)) * td - 2.0 * sw, -6.0);
+                        t = qMin(-3.0 - 2.0 * minHeight(), -6.0);
                   else /*if ( up &&  (line & 1))*/ // stem is up; odd line
-                        t = qMin(-3.0 - (2.0 * (lines() - 1)) * td - 2.0 * sw, -5.0);
+                        t = qMin(-3.0 - 2.0 * minHeight(), -5.0);
                   }
 
             qreal yLine = line + t;
@@ -262,16 +271,16 @@ void Tremolo::layoutOneNoteTremolo(qreal x, qreal y, qreal _spatium)
                   yLine = qMax(yLine, 0.0);
             // prevent stroke from going out of staff at the bottom while stem direction is up
             else
-                  yLine = qMin(yLine, (staff()->lines(tick()) - 1) * 2 - (2.0 * (lines() - 1)) * td - 2.0 * sw);
+                  yLine = qMin(yLine, (staff()->lines(tick()) - 1) * 2 - 2.0 * minHeight());
 
-            y = yLine * .5 * _spatium;
+            y = yLine * .5 * spatium;
             }
       else {
             const Note* n = up ? chord()->downNote() : chord()->upNote();
             const qreal noteBorder = n->y() + (up ? n->bbox().top() : n->bbox().bottom());
 
             const Stem* stem = chord()->stem();
-            const qreal stemLen = stem ? stem->height() : (3 * _spatium);
+            const qreal stemLen = stem ? stem->height() : (3 * spatium);
             const qreal stemY = stem ? (stem->y() + (up ? stem->bbox().bottom() : stem->bbox().top())) : noteBorder;
             const qreal stemNoteOverlap = std::max(0.0, (up ? 1.0 : -1.0) * (stemY - noteBorder));
 
@@ -303,55 +312,12 @@ void Tremolo::layoutOneNoteTremolo(qreal x, qreal y, qreal _spatium)
                   y += (up ? 1 : -1) * stemBeamOverlap / 2;
                   }
             else if (chord()->hook()) {
-                  const qreal hookLvlHeight = 0.5 * _spatium; // TODO: avoid hardcoding this (how?)
+                  const qreal hookLvlHeight = 0.5 * spatium; // TODO: avoid hardcoding this (how?)
                   y += (up ? 1 : -1) * (chord()->beams() + 0.5) * hookLvlHeight;
                   }
             }
 
       setPos(x, y);
-      }
-
-//---------------------------------------------------------
-//   layout
-//---------------------------------------------------------
-
-void Tremolo::layout()
-      {
-      const qreal _spatium  = spatium();
-
-      path = basePath();
-
-      _chord1 = toChord(parent());
-      if (!_chord1) {
-            // palette
-            if (_tremoloType != TremoloType::BUZZ_ROLL) {
-                  const QRectF box = path.boundingRect();
-                  addbbox(QRectF(box.x(), box.bottom(), box.width(), _spatium));
-                  }
-            return;
-            }
-
-      Note* anchor1 = _chord1->upNote();
-      Stem* stem    = _chord1->stem();
-      qreal x, y, h;
-      if (stem) {
-            x  = stem->pos().x();
-            y  = stem->pos().y();
-            h  = stem->stemLen();
-            }
-      else {
-            // center tremolo above note
-            x = anchor1->x() + anchor1->headWidth() * .5;
-            y = anchor1->y();
-            h = 2.0 * _spatium + bbox().height();
-            if (anchor1->line() > 4)
-                  h *= -1;
-            }
-
-      if (twoNotes())
-            layoutTwoNotesTremolo(x, y, h, _spatium);
-      else
-            layoutOneNoteTremolo(x, y, _spatium);
       }
 
 extern std::pair<qreal, qreal> extendedStemLenWithTwoNoteTremolo(Tremolo*, qreal, qreal);
@@ -360,7 +326,7 @@ extern std::pair<qreal, qreal> extendedStemLenWithTwoNoteTremolo(Tremolo*, qreal
 //   layoutTwoNotesTremolo
 //---------------------------------------------------------
 
-void Tremolo::layoutTwoNotesTremolo(qreal x, qreal y, qreal h, qreal _spatium)
+void Tremolo::layoutTwoNotesTremolo(qreal x, qreal y, qreal h, qreal spatium)
       {
       bool defaultStyle = (strokeStyle() == TremoloStrokeStyle::DEFAULT);
 
@@ -412,7 +378,7 @@ void Tremolo::layoutTwoNotesTremolo(qreal x, qreal y, qreal h, qreal _spatium)
             y2 = _chord2->stemPos().y() - firstChordStaffY + extendedLen.second;
             }
 
-      qreal lw = _spatium * score()->styleS(Sid::tremoloStrokeWidth).val();
+      qreal lw = spatium * score()->styleS(Sid::tremoloStrokeWidth).val();
       if (_chord1->beams() == 0 && _chord2->beams() == 0) {
             // improve the case when one stem is up and another is down
             if (defaultStyle && _chord1->up() != _chord2->up() && !crossStaffBeamBetween()) {
@@ -458,12 +424,12 @@ void Tremolo::layoutTwoNotesTremolo(qreal x, qreal y, qreal h, qreal _spatium)
       QTransform xScaleTransform;
       // TODO const qreal H_MULTIPLIER = score()->styleS(Sid::tremoloBeamLengthMultiplier).val();
       const qreal H_MULTIPLIER = defaultStyle ? 0.62 : 1;
-      // TODO const qreal MAX_H_LENGTH = _spatium * score()->styleS(Sid::tremoloBeamLengthMultiplier).val();
-      const qreal MAX_H_LENGTH = _spatium * 12.0;
+      // TODO const qreal MAX_H_LENGTH = spatium * score()->styleS(Sid::tremoloBeamLengthMultiplier).val();
+      const qreal MAX_H_LENGTH = spatium * 12.0;
 
       qreal defaultLength = qMin(H_MULTIPLIER * (x2 - x1), MAX_H_LENGTH);
       qreal xScaleFactor = defaultStyle ? defaultLength : H_MULTIPLIER * (x2 - x1);
-      const qreal w2 = _spatium * score()->styleS(Sid::tremoloWidth).val() * .5;
+      const qreal w2 = spatium * score()->styleS(Sid::tremoloWidth).val() * .5;
       xScaleFactor /= (2.0 * w2);
 
       xScaleTransform.scale(xScaleFactor, 1.0);
@@ -504,13 +470,55 @@ void Tremolo::layoutTwoNotesTremolo(qreal x, qreal y, qreal h, qreal _spatium)
       // 2. The chords are on different staves and the tremolo is between them.
       // The layout should be improved by extending both stems, so changes are not needed here.
       if (_chord1->up() != _chord2->up() && defaultStyle && !crossStaffBeamBetween())
-            dy = qMin(qMax(dy, -1.0 * _spatium / defaultLength * dx), 1.0 * _spatium / defaultLength * dx);
+            dy = qMin(qMax(dy, -1.0 * spatium / defaultLength * dx), 1.0 * spatium / defaultLength * dx);
       qreal ds = dy / dx;
       shearTransform.shear(0.0, ds);
       path = shearTransform.map(path);
 
       setbbox(path.boundingRect());
       setPos(x, y + beamYOffset);
+      }
+
+      
+//---------------------------------------------------------
+//   layout
+//---------------------------------------------------------
+
+void Tremolo::layout()
+      {
+      path = basePath();
+
+      _chord1 = toChord(parent());
+      if (!_chord1) {
+            // palette
+            if (_tremoloType != TremoloType::BUZZ_ROLL) {
+                  const QRectF box = path.boundingRect();
+                  addbbox(QRectF(box.x(), box.bottom(), box.width(), spatium()));
+                  }
+            return;
+            }
+
+      Note* anchor1 = _chord1->upNote();
+      Stem* stem    = _chord1->stem();
+      qreal x, y, h;
+      if (stem) {
+            x  = stem->pos().x();
+            y  = stem->pos().y();
+            h  = stem->stemLen();
+            }
+      else {
+            // center tremolo above note
+            x = anchor1->x() + anchor1->headWidth() * .5;
+            y = anchor1->y();
+            h = 2.0 * spatium() + bbox().height();
+            if (anchor1->line() > 4)
+                  h *= -1;
+            }
+
+      if (twoNotes())
+            layoutTwoNotesTremolo(x, y, h, spatium());
+      else
+            layoutOneNoteTremolo(x, y, spatium());
       }
 
 //---------------------------------------------------------

--- a/libmscore/tremolo.h
+++ b/libmscore/tremolo.h
@@ -75,6 +75,8 @@ class Tremolo final : public Element {
       void setTremoloType(TremoloType t);
       TremoloType tremoloType() const      { return _tremoloType; }
 
+      qreal minHeight() const;
+
       qreal mag() const override;
       void draw(QPainter*) const override;
       void layout() override;


### PR DESCRIPTION
Partially resolves: https://musescore.org/node/294768.

This is because the `mag()` factor isn't taken into consideration.

Along with multiplying `mag()` in some places, I also created a new member function `minHeight()` for `Tremolo` class to calculate the effective height of tremolo strokes, that is, the height the strokes spread across a given vertical line, without multiplying `spatium()`, to resolve an issue of stem length (a bit longer than intended when direction is down and has single-note tremolo on it) which is not obvious in normal size but obvious in cue size. Several places are already using this effective height, so a separate function for calculating it is really convenient to use.

Commit \#2: (resolves https://musescore.org/en/node/286504#comment-1011220)
Before:
![image](https://user-images.githubusercontent.com/46259489/86789751-3aaaf380-c09a-11ea-88f7-a844dd153d57.png)
After:
![image](https://user-images.githubusercontent.com/46259489/86789522-fae40c00-c099-11ea-86db-d2b0b1e09513.png)