### PR TITLE
fix #302710: change default for harmony channel to piano

### DIFF
--- a/libmscore/part.cpp
+++ b/libmscore/part.cpp
@@ -599,6 +599,8 @@ void Part::updateHarmonyChannels(bool isDoOnInstrumentChanged, bool checkRemoval
       if (!harmonyChannel() && harmonyCount() > 0) {
             Instrument* instr = instrument();
             Channel* c = new Channel(*instr->channel(0));
+            // default to program 0, which is piano in General MIDI
+            c->setProgram(0);
             c->setName(Channel::HARMONY_NAME);
             instr->appendChannel(c);
             onInstrumentChanged();

--- a/mtest/libmscore/chordsymbol/add-link-ref.mscx
+++ b/mtest/libmscore/chordsymbol/add-link-ref.mscx
@@ -71,7 +71,7 @@
           <program value="24"/>
           </Channel>
         <Channel name="harmony">
-          <program value="24"/>
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>

--- a/mtest/libmscore/chordsymbol/add-part-ref.mscx
+++ b/mtest/libmscore/chordsymbol/add-part-ref.mscx
@@ -64,7 +64,7 @@
           <program value="24"/>
           </Channel>
         <Channel name="harmony">
-          <program value="24"/>
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>
@@ -162,7 +162,7 @@
             <program value="24"/>
             </Channel>
           <Channel name="harmony">
-            <program value="24"/>
+            <program value="0"/>
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/libmscore/chordsymbol/extend-ref.mscx
+++ b/mtest/libmscore/chordsymbol/extend-ref.mscx
@@ -64,7 +64,7 @@
           <program value="27"/>
           </Channel>
         <Channel name="harmony">
-          <program value="27"/>
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>

--- a/mtest/libmscore/chordsymbol/no-system-ref.mscx
+++ b/mtest/libmscore/chordsymbol/no-system-ref.mscx
@@ -95,7 +95,7 @@
           <program value="65"/>
           </Channel>
         <Channel name="harmony">
-          <program value="65"/>
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>
@@ -358,7 +358,7 @@
             <program value="65"/>
             </Channel>
           <Channel name="harmony">
-            <program value="65"/>
+            <program value="0"/>
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/libmscore/chordsymbol/realize-transpose-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-transpose-ref.mscx
@@ -69,7 +69,7 @@
           <program value="73"/>
           </Channel>
         <Channel name="harmony">
-          <program value="73"/>
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>

--- a/mtest/libmscore/chordsymbol/transpose-part-ref.mscx
+++ b/mtest/libmscore/chordsymbol/transpose-part-ref.mscx
@@ -69,7 +69,7 @@
           <program value="73"/>
           </Channel>
         <Channel name="harmony">
-          <program value="73"/>
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>
@@ -182,7 +182,7 @@
             <program value="73"/>
             </Channel>
           <Channel name="harmony">
-            <program value="73"/>
+            <program value="0"/>
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/libmscore/chordsymbol/transpose-ref.mscx
+++ b/mtest/libmscore/chordsymbol/transpose-ref.mscx
@@ -69,7 +69,7 @@
           <program value="73"/>
           </Channel>
         <Channel name="harmony">
-          <program value="73"/>
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>

--- a/mtest/libmscore/compat114/chord_symbol-ref.mscx
+++ b/mtest/libmscore/compat114/chord_symbol-ref.mscx
@@ -80,7 +80,7 @@
           <controller ctrl="91" value="30"/>
           </Channel>
         <Channel name="harmony">
-          <program value="73"/>
+          <program value="0"/>
           <controller ctrl="93" value="30"/>
           <controller ctrl="91" value="30"/>
           </Channel>

--- a/mtest/libmscore/compat114/text_scaling-ref.mscx
+++ b/mtest/libmscore/compat114/text_scaling-ref.mscx
@@ -80,7 +80,7 @@
           <controller ctrl="91" value="30"/>
           </Channel>
         <Channel name="harmony">
-          <program value="73"/>
+          <program value="0"/>
           <controller ctrl="93" value="30"/>
           <controller ctrl="91" value="30"/>
           </Channel>

--- a/mtest/libmscore/compat206/lidemptytext-ref.mscx
+++ b/mtest/libmscore/compat206/lidemptytext-ref.mscx
@@ -179,7 +179,7 @@
           <program value="44"/>
           </Channel>
         <Channel name="harmony">
-          <program value="43"/>
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>
@@ -351,7 +351,7 @@
             <program value="44"/>
             </Channel>
           <Channel name="harmony">
-            <program value="43"/>
+            <program value="0"/>
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/libmscore/copypaste/copypaste19-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste19-ref.mscx
@@ -54,6 +54,7 @@
         <Channel>
           </Channel>
         <Channel name="harmony">
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>

--- a/mtest/libmscore/copypaste/copypaste26-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste26-ref.mscx
@@ -81,6 +81,7 @@
         <Channel>
           </Channel>
         <Channel name="harmony">
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>

--- a/mtest/libmscore/copypastesymbollist/copypastesymbollist-chordnames-01-ref.mscx
+++ b/mtest/libmscore/copypastesymbollist/copypastesymbollist-chordnames-01-ref.mscx
@@ -55,7 +55,7 @@
           <program value="73"/>
           </Channel>
         <Channel name="harmony">
-          <program value="73"/>
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>

--- a/mtest/libmscore/copypastesymbollist/copypastesymbollist-chordnames-ref.mscx
+++ b/mtest/libmscore/copypastesymbollist/copypastesymbollist-chordnames-ref.mscx
@@ -55,7 +55,7 @@
           <program value="52"/>
           </Channel>
         <Channel name="harmony">
-          <program value="52"/>
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>

--- a/mtest/libmscore/selectionrangedelete/selectionrangedelete05-ref.mscx
+++ b/mtest/libmscore/selectionrangedelete/selectionrangedelete05-ref.mscx
@@ -70,7 +70,7 @@
           <program value="44"/>
           </Channel>
         <Channel name="harmony">
-          <program value="40"/>
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>

--- a/mtest/libmscore/timesig/timesig-03-ref.mscx
+++ b/mtest/libmscore/timesig/timesig-03-ref.mscx
@@ -55,7 +55,7 @@
           <program value="73"/>
           </Channel>
         <Channel name="harmony">
-          <program value="73"/>
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>

--- a/mtest/libmscore/timesig/timesig-05-ref.mscx
+++ b/mtest/libmscore/timesig/timesig-05-ref.mscx
@@ -58,7 +58,7 @@
           <program value="73"/>
           </Channel>
         <Channel name="harmony">
-          <program value="73"/>
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/302710

Chord symbols current play back using the sound of the staff
to which they are attached.
This makes perfect sense for instruments that normally play chords,
but is not expected when chords are attached to vocal or other staves.
Unfortunately it's not really possible for MuseScore
to know what sounds are actually being used,
and it would be difficult to decide on which instruments
should use their own sound versus a default.
So this change just arbitrarily sets the default harmony channel
to MIDI program 0, which is piano in general midi soundfonts.

It's still possible for individual socres or templates to override this,
and overrides can also be programmers into instruments.xml.
A potential downside of doing so is that the harony channel
would then be created even before chord symbols are present.
That's not *necessarily* a problem, but to me it's something
to worry about later.