### PR TITLE
fix #307242: [MusicXML import] Musescore crashes when loading .mxl fi…

### DIFF
--- a/mu4/domain/importexport/internal/musicxml/importmxmlpass2.cpp
+++ b/mu4/domain/importexport/internal/musicxml/importmxmlpass2.cpp
@@ -1294,9 +1294,10 @@ static Rest* addRest(Score* score, Measure* m,
     Segment* s = m->getSegment(SegmentType::ChordRest, tick);
     // Sibelius might export two rests at the same place, ignore the 2nd one
     // <?DoletSibelius Two NoteRests in same voice at same position may be an error?>
+    // Same issue may result from trying to import incomplete tuplets
     if (s->element(track)) {
-        qDebug("cannot add rest at tick %d track %d: element already present", tick.ticks(), track);                 // TODO
-        return 0;
+        qDebug("cannot add rest at tick %s (%d) track %d: element already present", qPrintable(tick.print()), tick.ticks(), track); // TODO
+        return nullptr;
     }
 
     Rest* cr = new Rest(score);
@@ -1328,8 +1329,10 @@ static void resetTuplets(Tuplets& tuplets)
                 const auto extraRest = addRest(firstElement->score(), firstElement->measure(),
                                                firstElement->tick() + missingDuration, firstElement->track(), 0,
                                                TDuration { missingDuration* tuplet->ratio() }, missingDuration);
-                extraRest->setTuplet(tuplet);
-                tuplet->add(extraRest);
+                if (extraRest) {
+                    extraRest->setTuplet(tuplet);
+                    tuplet->add(extraRest);
+                }
             }
             const auto normalNotes = tuplet->ratio().denominator();
             handleTupletStop(tuplet, normalNotes);
@@ -4479,9 +4482,11 @@ Note* MusicXMLParserPass2::note(const QString& partId,
                 const auto track = msTrack + msVoice;
                 const auto extraRest = addRest(_score, measure, noteStartTime, track, msMove,
                                                TDuration { missingPrev* tuplet->ratio() }, missingPrev);
-                extraRest->setTuplet(tuplet);
-                tuplet->add(extraRest);
-                noteStartTime += missingPrev;
+                if (extraRest) {
+                    extraRest->setTuplet(tuplet);
+                    tuplet->add(extraRest);
+                    noteStartTime += missingPrev;
+                }
             }
             // recover by simply stopping the current tuplet first
             const auto normalNotes = timeMod.numerator();
@@ -4658,8 +4663,10 @@ Note* MusicXMLParserPass2::note(const QString& partId,
                         const auto track = msTrack + msVoice;
                         const auto extraRest = addRest(_score, measure, noteStartTime + dura, track, msMove,
                                                        TDuration { missingCurr* tuplet->ratio() }, missingCurr);
-                        extraRest->setTuplet(tuplet);
-                        tuplet->add(extraRest);
+                        if (extraRest) {
+                            extraRest->setTuplet(tuplet);
+                            tuplet->add(extraRest);
+                        }
                     }
                     handleTupletStop(tuplet, normalNotes);
                 }


### PR DESCRIPTION
…le containing incomplete tuplet

Resolves: https://musescore.org/en/node/307242 for master

Prevent crash on importing MusicXML file containing incomplete tuplet. Crash caused by missing nullptr check.
See also: https://github.com/musescore/MuseScore/pull/6269 (3.x PR)

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made