### PR TITLE
fix #307279 failed init importexport and ui modules

### DIFF
--- a/framework/ui/internal/uiengine.cpp
+++ b/framework/ui/internal/uiengine.cpp
@@ -42,7 +42,6 @@ std::shared_ptr<UiEngine> UiEngine::instance()
 
 UiEngine::UiEngine()
 {
-    m_theme = new QmlTheme(QApplication::palette(), this);
     m_translation = new QmlTranslation(this);
     m_launchProvider = std::make_shared<QmlLaunchProvider>(this);
     m_api = new QmlApi(this);
@@ -76,6 +75,10 @@ void UiEngine::setup(QQmlEngine* e)
         return;
     }
     m_engine = e;
+
+    if (!m_theme) {
+        m_theme = new QmlTheme(QApplication::palette(), this);
+    }
 
     m_engine->rootContext()->setContextProperty("ui", this);
     m_engine->rootContext()->setContextProperty("api", m_api);

--- a/mu4/domain/importexport/importexportmodule.cpp
+++ b/mu4/domain/importexport/importexportmodule.cpp
@@ -19,6 +19,7 @@
 #include "importexportmodule.h"
 
 #include "log.h"
+#include "config.h"
 #include "modularity/ioc.h"
 #include "domain/notation/inotationreadersregister.h"
 #include "internal/musicxmlreader.h"
@@ -40,6 +41,11 @@ std::string ImportExportModule::moduleName() const
 
 void ImportExportModule::onInit()
 {
+    //! NOTE The "importexport" module is linked when the BUILD_UI_MU4 is off
+    //! So that the import/export implementation is linked and used in the old code.
+    //! But of course there is no "INotationReadersRegister"
+
+#ifdef BUILD_UI_MU4
     auto readers = framework::ioc()->resolve<INotationReadersRegister>(moduleName());
     IF_ASSERT_FAILED(readers) {
         return;
@@ -53,4 +59,5 @@ void ImportExportModule::onInit()
     readers->reg({ "ove", "scw" }, std::make_shared<OveReader>());
     readers->reg({ "bmw", "bww" }, std::make_shared<NotationBwwReader>());
     readers->reg({ "gtp", "gp3", "gp4", "gp5", "gpx", "gp", "ptb" }, std::make_shared<GuitarProReader>());
+#endif
 }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/307279

I work with the switched-on option `BUILD_UI_MU4`.
But the default is off at the moment.

When the option is turned off, two problems occurred:

* Calling QApplication when it is not already created
* Request for the implementation of an interface which is not

I did not think to check the build with the `BUILD_UI_MU4` option turned off :(


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue

