### PR TITLE
GSoC 2020: scanElements refactoring based on tree model [vtests]

### DIFF
--- a/libmscore/ambitus.cpp
+++ b/libmscore/ambitus.cpp
@@ -506,15 +506,11 @@ void Ambitus::draw(QPainter* p) const
 //   scanElements
 //---------------------------------------------------------
 
-void Ambitus::scanElements(void* data, void (* func)(void*, Element*), bool /*all*/)
+void Ambitus::scanElements(void* data, void (* func)(void*, Element*), bool all)
 {
+    Q_UNUSED(all);
+    ScoreElement::scanElements(data, func, all);
     func(data, this);
-    if (_topAccid.accidentalType() != AccidentalType::NONE) {
-        func(data, &_topAccid);
-    }
-    if (_bottomAccid.accidentalType() != AccidentalType::NONE) {
-        func(data, &_bottomAccid);
-    }
 }
 
 //---------------------------------------------------------

--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -1519,10 +1519,8 @@ void BarLine::scanElements(void* data, void (* func)(void*, Element*), bool all)
     if (width() == 0.0 && !all) {
         return;
     }
+    ScoreElement::scanElements(data, func, all);
     func(data, this);
-    for (Element* e : _el) {
-        e->scanElements(data, func, all);
-    }
 }
 
 //---------------------------------------------------------

--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -2708,4 +2708,17 @@ void Beam::startDrag(EditData& editData)
 {
     initBeamEditData(editData);
 }
+
+//---------------------------------------------------------
+//   scanElements
+//---------------------------------------------------------
+
+void Beam::scanElements(void* data, void (* func)(void*, Element*), bool all)
+{
+    ChordRest* cr = toChordRest(treeParent());
+    if (!all && cr->measure()->stemless(cr->staffIdx())) {
+        return;
+    }
+    Element::scanElements(data, func, all);
+}
 }

--- a/libmscore/beam.h
+++ b/libmscore/beam.h
@@ -86,6 +86,8 @@ public:
     ScoreElement* treeChild(int idx) const override;
     int treeChildCount() const override;
 
+    void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
+
     Beam* clone() const override { return new Beam(*this); }
     ElementType type() const override { return ElementType::BEAM; }
     QPointF pagePos() const override;      ///< position in page coordinates

--- a/libmscore/box.cpp
+++ b/libmscore/box.cpp
@@ -61,6 +61,18 @@ void Box::layout()
 }
 
 //---------------------------------------------------------
+//   scanElements
+//---------------------------------------------------------
+
+void Box::scanElements(void* data, void (* func)(void*, Element*), bool all)
+{
+    ScoreElement::scanElements(data, func, all);
+    if (all || visible() || score()->showInvisible()) {
+        func(data, this);
+    }
+}
+
+//---------------------------------------------------------
 //   computeMinWidth
 //---------------------------------------------------------
 

--- a/libmscore/box.h
+++ b/libmscore/box.h
@@ -45,6 +45,9 @@ class Box : public MeasureBase
 
 public:
     Box(Score*);
+
+    void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
+
     virtual void draw(QPainter*) const override;
     virtual bool isEditable() const override { return true; }
 

--- a/libmscore/bsymbol.cpp
+++ b/libmscore/bsymbol.cpp
@@ -115,18 +115,6 @@ void BSymbol::remove(Element* e)
 }
 
 //---------------------------------------------------------
-//   scanElements
-//---------------------------------------------------------
-
-void BSymbol::scanElements(void* data, void (* func)(void*, Element*), bool all)
-{
-    func(data, this);
-    foreach (Element* e, _leafs) {
-        e->scanElements(data, func, all);
-    }
-}
-
-//---------------------------------------------------------
 //   acceptDrop
 //---------------------------------------------------------
 

--- a/libmscore/bsymbol.h
+++ b/libmscore/bsymbol.h
@@ -39,7 +39,6 @@ public:
 
     virtual void add(Element*) override;
     virtual void remove(Element*) override;
-    virtual void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
     virtual bool acceptDrop(EditData&) const override;
     virtual Element* drop(EditData&) override;
     virtual void layout() override;

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1230,49 +1230,6 @@ qreal Chord::centerX() const
 }
 
 //---------------------------------------------------------
-//   scanElements
-//---------------------------------------------------------
-
-void Chord::scanElements(void* data, void (* func)(void*, Element*), bool all)
-{
-    for (Articulation* a : _articulations) {
-        func(data, a);
-    }
-    if (_hook) {
-        func(data, _hook);
-    }
-    if (_stem) {
-        func(data, _stem);
-    }
-    if (_stemSlash) {
-        func(data, _stemSlash);
-    }
-    if (_arpeggio) {
-        func(data, _arpeggio);
-    }
-    if (_tremolo && (tremoloChordType() != TremoloChordType::TremoloSecondNote)) {
-        func(data, _tremolo);
-    }
-    const Staff* st = staff();
-    if ((st && st->showLedgerLines(tick())) || !st) {       // also for palette
-        for (LedgerLine* ll = _ledgerLines; ll; ll = ll->next()) {
-            func(data, ll);
-        }
-    }
-    size_t n = _notes.size();
-    for (size_t i = 0; i < n; ++i) {
-        _notes.at(i)->scanElements(data, func, all);
-    }
-    for (Chord* chord : _graceNotes) {
-        chord->scanElements(data, func, all);
-    }
-    for (Element* e : el()) {
-        e->scanElements(data, func, all);
-    }
-    ChordRest::scanElements(data, func, all);
-}
-
-//---------------------------------------------------------
 //   processSiblings
 //---------------------------------------------------------
 

--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -189,7 +189,6 @@ public:
     void setNoteType(NoteType t) { _noteType = t; }
     bool isGrace() const { return _noteType != NoteType::NORMAL; }
     void toGraceAfter();
-    void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
 
     void setTrack(int val) override;
 

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -120,29 +120,6 @@ ChordRest::~ChordRest()
 }
 
 //---------------------------------------------------------
-//   scanElements
-//---------------------------------------------------------
-
-void ChordRest::scanElements(void* data, void (* func)(void*, Element*), bool all)
-{
-    if (_beam && (_beam->elements().front() == this)
-        && !measure()->stemless(staffIdx())) {
-        _beam->scanElements(data, func, all);
-    }
-    for (Lyrics* l : _lyrics) {
-        l->scanElements(data, func, all);
-    }
-    DurationElement* de = this;
-    while (de->tuplet() && de->tuplet()->elements().front() == de) {
-        de->tuplet()->scanElements(data, func, all);
-        de = de->tuplet();
-    }
-    if (_tabDur) {
-        func(data, _tabDur);
-    }
-}
-
-//---------------------------------------------------------
 //   writeProperties
 //---------------------------------------------------------
 

--- a/libmscore/chordrest.h
+++ b/libmscore/chordrest.h
@@ -89,7 +89,6 @@ public:
     virtual void writeProperties(XmlWriter& xml) const;
     virtual bool readProperties(XmlReader&);
     virtual void readAddConnector(ConnectorInfoReader* info, bool pasteMode) override;
-    virtual void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
 
     void setBeamMode(Beam::Mode m) { _beamMode = m; }
     void undoSetBeamMode(Beam::Mode m);

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -228,12 +228,20 @@ void Element::deleteLater()
 
 //---------------------------------------------------------
 //   scanElements
+/// If leaf node, apply `func` on this element (after checking if it is visible).
+/// Otherwise, recurse over all children (see ScoreElement::scanElements).
+/// Note: This function is overridden in some classes to skip certain children,
+/// or to apply `func` even to non-leaf nodes.
 //---------------------------------------------------------
 
 void Element::scanElements(void* data, void (* func)(void*, Element*), bool all)
 {
-    if (all || visible() || score()->showInvisible()) {
-        func(data, this);
+    if (treeChildCount() == 0) {
+        if (all || visible() || score()->showInvisible()) {
+            func(data, this);
+        }
+    } else {
+        ScoreElement::scanElements(data, func, all);
     }
 }
 

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -443,7 +443,7 @@ public:
 
     mutable bool itemDiscovered      { false };       ///< helper flag for bsp
 
-    virtual void scanElements(void* data, void (* func)(void*, Element*), bool all=true);
+    void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
 
     virtual void reset() override;           // reset all properties & position to default
 

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -1283,11 +1283,8 @@ Element* FretDiagram::drop(EditData& data)
 void FretDiagram::scanElements(void* data, void (* func)(void*, Element*), bool all)
 {
     Q_UNUSED(all);
+    ScoreElement::scanElements(data, func, all);
     func(data, this);
-    // don't display harmony in palette
-    if (_harmony && !!parent()) {
-        func(data, _harmony);
-    }
 }
 
 //---------------------------------------------------------

--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -201,21 +201,6 @@ LineSegment* Glissando::createLineSegment()
 }
 
 //---------------------------------------------------------
-//   scanElements
-//---------------------------------------------------------
-
-void Glissando::scanElements(void* data, void (* func)(void*, Element*), bool all)
-{
-    func(data, this);
-    // don't scan segments belonging to systems; the systems themselves will scan them
-    for (SpannerSegment* seg : spannerSegments()) {
-        if (!seg->parent() || !seg->parent()->isSystem()) {
-            seg->scanElements(data, func, all);
-        }
-    }
-}
-
-//---------------------------------------------------------
 //   layout
 //---------------------------------------------------------
 

--- a/libmscore/glissando.h
+++ b/libmscore/glissando.h
@@ -74,7 +74,7 @@ public:
     Glissando* clone() const override { return new Glissando(*this); }
     ElementType type() const override { return ElementType::GLISSANDO; }
     LineSegment* createLineSegment() override;
-    void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
+
     void layout() override;
     void write(XmlWriter&) const override;
     void read(XmlReader&) override;

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -2299,4 +2299,17 @@ Sid Harmony::getPropertyStyle(Pid pid) const
     }
     return TextBase::getPropertyStyle(pid);
 }
+
+//---------------------------------------------------------
+//   scanElements
+//---------------------------------------------------------
+
+void Harmony::scanElements(void* data, void (* func)(void*, Element*), bool all)
+{
+    // don't display harmony in palette
+    if (!parent()) {
+        return;
+    }
+    func(data, this);
+}
 }

--- a/libmscore/harmony.h
+++ b/libmscore/harmony.h
@@ -136,6 +136,8 @@ public:
     void setLeftParen(bool leftParen) { _leftParen = leftParen; }
     void setRightParen(bool rightParen) { _rightParen = rightParen; }
 
+    void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
+
     Harmony* findNext() const;
     Harmony* findPrev() const;
     Fraction ticksTilNext(bool stopAtMeasureEnd = false) const;

--- a/libmscore/iname.cpp
+++ b/libmscore/iname.cpp
@@ -151,4 +151,15 @@ QVariant InstrumentName::propertyDefault(Pid id) const
         return TextBase::propertyDefault(id);
     }
 }
+
+//---------------------------------------------------------
+//   scanElements
+//---------------------------------------------------------
+
+void InstrumentName::scanElements(void* data, void (* func)(void*, Element*), bool all)
+{
+    if (all || sysStaff()->show()) {
+        func(data, this);
+    }
+}
 }

--- a/libmscore/iname.h
+++ b/libmscore/iname.h
@@ -21,6 +21,7 @@ enum class InstrumentNameType : char {
 };
 
 class System;
+class SysStaff;
 
 //---------------------------------------------------------
 //   InstrumentName
@@ -30,6 +31,7 @@ class InstrumentName final : public TextBase
 {
     InstrumentNameType _instrumentNameType;
     int _layoutPos { 0 };
+    SysStaff* _sysStaff { nullptr };
 
 public:
     InstrumentName(Score*);
@@ -46,6 +48,11 @@ public:
     void setInstrumentNameType(const QString& s);
 
     System* system() const { return toSystem(parent()); }
+
+    SysStaff* sysStaff() const { return _sysStaff; }
+    void setSysStaff(SysStaff* s) { _sysStaff = s; }
+
+    void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
 
     Fraction playTick() const override;
     bool isEditable() const override { return false; }

--- a/libmscore/ledgerline.cpp
+++ b/libmscore/ledgerline.cpp
@@ -133,4 +133,17 @@ bool LedgerLine::readProperties(XmlReader& e)
     }
     return true;
 }
+
+//---------------------------------------------------------
+//   scanElements
+//---------------------------------------------------------
+
+void LedgerLine::scanElements(void* data, void (* func)(void*, Element*), bool all)
+{
+    Staff* st = chord()->staff();
+    if (st && !st->showLedgerLines(tick())) {
+        return;
+    }
+    Element::scanElements(data, func, all);
+}
 }

--- a/libmscore/ledgerline.h
+++ b/libmscore/ledgerline.h
@@ -43,6 +43,8 @@ public:
     QPointF pagePos() const override;        ///< position in page coordinates
     Chord* chord() const { return toChord(parent()); }
 
+    void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
+
     qreal len() const { return _len; }
     qreal lineWidth() const { return _width; }
     void setLen(qreal v) { _len = v; }

--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -65,19 +65,6 @@ Lyrics::~Lyrics()
 }
 
 //---------------------------------------------------------
-//   scanElements
-//---------------------------------------------------------
-
-void Lyrics::scanElements(void* data, void (* func)(void*, Element*), bool /*all*/)
-{
-    func(data, this);
-/* DO NOT ADD EITHER THE LYRICSLINE OR THE SEGMENTS: segments are added through the system each belongs to;
-      LyricsLine is not needed, as it is internally manged.
-      if (_separator)
-            _separator->scanElements(data, func, all); */
-}
-
-//---------------------------------------------------------
 //   write
 //---------------------------------------------------------
 

--- a/libmscore/lyrics.h
+++ b/libmscore/lyrics.h
@@ -65,7 +65,6 @@ public:
 
     Lyrics* clone() const override { return new Lyrics(*this); }
     ElementType type() const override { return ElementType::LYRICS; }
-    void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
     bool acceptDrop(EditData&) const override;
     Element* drop(EditData&) override;
 

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2528,31 +2528,11 @@ bool Measure::isFirstInSystem() const
 
 void Measure::scanElements(void* data, void (* func)(void*, Element*), bool all)
 {
-    MeasureBase::scanElements(data, func, all);
-
-    int nstaves = score()->nstaves();
-    for (int staffIdx = 0; staffIdx < nstaves; ++staffIdx) {
-        if (!all && !(visible(staffIdx) && score()->staff(staffIdx)->show())) {
-            continue;
+    for (ScoreElement* el : (*this)) {
+        if (el->isMeasure()) {
+            continue;  // do not scan Measures 'inside' mmrest measure
         }
-        MStaff* ms = _mstaves[staffIdx];
-        func(data, ms->lines());
-        if (ms->vspacerUp()) {
-            func(data, ms->vspacerUp());
-        }
-        if (ms->vspacerDown()) {
-            func(data, ms->vspacerDown());
-        }
-        if (ms->noText()) {
-            func(data, ms->noText());
-        }
-    }
-
-    for (Segment* s = first(); s; s = s->next()) {
-        if (!s->enabled()) {
-            continue;
-        }
-        s->scanElements(data, func, all);
+        el->scanElements(data, func, all);
     }
 }
 

--- a/libmscore/measurebase.cpp
+++ b/libmscore/measurebase.cpp
@@ -92,35 +92,6 @@ MeasureBase::~MeasureBase()
 }
 
 //---------------------------------------------------------
-//   scanElements
-//---------------------------------------------------------
-
-void MeasureBase::scanElements(void* data, void (* func)(void*, Element*), bool all)
-{
-    if (isMeasure()) {
-        for (Element* e : _el) {
-            if (score()->tagIsValid(e->tag())) {
-                if (e->staffIdx() >= score()->staves().size()) {
-                    qDebug("MeasureBase::scanElements: bad staffIdx %d in element %s", e->staffIdx(), e->name());
-                }
-                if ((e->track() == -1) || e->systemFlag() || ((Measure*)this)->visible(e->staffIdx())) {
-                    e->scanElements(data, func, all);
-                }
-            }
-        }
-    } else {
-        for (Element* e : _el) {
-            if (score()->tagIsValid(e->tag())) {
-                e->scanElements(data, func, all);
-            }
-        }
-    }
-    if (isBox()) {
-        func(data, this);
-    }
-}
-
-//---------------------------------------------------------
 //   add
 ///   Add new Element \a el to MeasureBase
 //---------------------------------------------------------

--- a/libmscore/measurebase.h
+++ b/libmscore/measurebase.h
@@ -107,7 +107,6 @@ public:
 
     virtual void layout();
 
-    virtual void scanElements(void* data, void (* func)(void*, Element*), bool all=true);
     ElementList& el() { return _el; }
     const ElementList& el() const { return _el; }
     System* system() const { return (System*)parent(); }

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2385,31 +2385,10 @@ QString Note::noteTypeUserName() const
 
 void Note::scanElements(void* data, void (* func)(void*, Element*), bool all)
 {
-    func(data, this);
-    // tie segments are collected from System
-    //      if (_tieFor && !staff()->isTabStaff(chord->tick()))  // no ties in tablature
-    //            _tieFor->scanElements(data, func, all);
-    for (Element* e : _el) {
-        if (score()->tagIsValid(e->tag())) {
-            e->scanElements(data, func, all);
-        }
+    ScoreElement::scanElements(data, func, all);
+    if (all || visible() || score()->showInvisible()) {
+        func(data, this);
     }
-    for (Spanner* sp : _spannerFor) {
-        sp->scanElements(data, func, all);
-    }
-
-    if (!dragMode && _accidental) {
-        func(data, _accidental);
-    }
-    for (NoteDot* dot : _dots) {
-        func(data, dot);
-    }
-
-    // see above - tie segments are still collected from System!
-    // if (_tieFor && !_tieFor->spannerSegments().empty())
-    //      _tieFor->spannerSegments().front()->scanElements(data, func, all);
-    // if (_tieBack && _tieBack->spannerSegments().size() > 1)
-    //      _tieBack->spannerSegments().back()->scanElements(data, func, all);
 }
 
 //---------------------------------------------------------

--- a/libmscore/page.cpp
+++ b/libmscore/page.cpp
@@ -221,13 +221,10 @@ void Page::styleChanged()
 
 void Page::scanElements(void* data, void (* func)(void*, Element*), bool all)
 {
-    for (System* s :_systems) {
-        for (MeasureBase* m : s->measures()) {
-            m->scanElements(data, func, all);
-        }
-        s->scanElements(data, func, all);
+    ScoreElement::scanElements(data, func, all);
+    if (all || visible() || score()->showInvisible()) {
+        func(data, this);
     }
-    func(data, this);
 }
 
 #ifdef USE_BSP

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -603,13 +603,7 @@ qreal Rest::downPos() const
 
 void Rest::scanElements(void* data, void (* func)(void*, Element*), bool all)
 {
-    ChordRest::scanElements(data, func, all);
-    for (Element* e : el()) {
-        e->scanElements(data, func, all);
-    }
-    for (NoteDot* dot : m_dots) {
-        dot->scanElements(data, func, all);
-    }
+    ScoreElement::scanElements(data, func, all);
     if (!isGap()) {
         func(data, this);
     }

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1915,31 +1915,6 @@ Fraction Score::inputPos() const
 }
 
 //---------------------------------------------------------
-//   scanElements
-//    scan all elements
-//---------------------------------------------------------
-
-void Score::scanElements(void* data, void (* func)(void*, Element*), bool all)
-{
-    for (MeasureBase* mb = first(); mb; mb = mb->next()) {
-        mb->scanElements(data, func, all);
-        if (mb->type() == ElementType::MEASURE) {
-            Measure* m = toMeasure(mb);
-            Measure* mmr = m->mmRest();
-            if (mmr) {
-                mmr->scanElements(data, func, all);
-            }
-        }
-    }
-    for (Page* page : pages()) {
-        for (System* s :page->systems()) {
-            s->scanElements(data, func, all);
-        }
-        func(data, page);
-    }
-}
-
-//---------------------------------------------------------
 //   scanElementsInRange
 //---------------------------------------------------------
 

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -111,6 +111,7 @@ void MeasureBaseList::push_back(MeasureBase* e)
         e->setNext(0);
     }
     _last = e;
+    fixupSystems();
 }
 
 //---------------------------------------------------------
@@ -130,6 +131,7 @@ void MeasureBaseList::push_front(MeasureBase* e)
         e->setNext(0);
     }
     _first = e;
+    fixupSystems();
 }
 
 //---------------------------------------------------------
@@ -152,6 +154,7 @@ void MeasureBaseList::add(MeasureBase* e)
     e->setPrev(el->prev());
     el->prev()->setNext(e);
     el->setPrev(e);
+    fixupSystems();
 }
 
 //---------------------------------------------------------
@@ -195,6 +198,7 @@ void MeasureBaseList::insert(MeasureBase* fm, MeasureBase* lm)
     } else {
         _last = lm;
     }
+    fixupSystems();
 }
 
 //---------------------------------------------------------
@@ -247,6 +251,28 @@ void MeasureBaseList::change(MeasureBase* ob, MeasureBase* nb)
     }
     foreach (Element* e, nb->el()) {
         e->setParent(nb);
+    }
+    fixupSystems();
+}
+
+//---------------------------------------------------------
+//   fixupSystems
+///   After modifying measures, make sure each measure
+///   belongs to some system. This is to make sure the
+///   score tree contains all the measures in some system.
+//---------------------------------------------------------
+
+void MeasureBaseList::fixupSystems()
+{
+    MeasureBase* m = _first;
+    while (m != _last) {
+        m = m->next();
+        if (m->prev()->system() && !m->system()) {
+            m->setSystem(m->prev()->system());
+            if (m->isMeasure() && !toMeasure(m)->hasMMRest()) {
+                m->system()->appendMeasure(m);
+            }
+        }
     }
 }
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -172,6 +172,7 @@ public:
     void remove(MeasureBase*, MeasureBase*);
     void change(MeasureBase* o, MeasureBase* n);
     int size() const { return _size; }
+    void fixupSystems();
 };
 
 //---------------------------------------------------------

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -1081,7 +1081,6 @@ public:
 
     qreal point(const Spatium sp) const { return sp.val() * spatium(); }
 
-    void scanElements(void* data, void (* func)(void*, Element*), bool all=true);
     void scanElementsInRange(void* data, void (* func)(void*, Element*), bool all = true);
     int fileDivision() const { return _fileDivision; }   ///< division of current loading *.msc file
     void splitStaff(int staffIdx, int splitPoint);

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -620,6 +620,7 @@ public:
     ScoreElement* treeParent() const override;
     ScoreElement* treeChild(int idx) const override;
     int treeChildCount() const override;
+    void dumpScoreTree();  // for debugging purposes
 
     virtual inline QList<Excerpt*>& excerpts();
     virtual inline const QList<Excerpt*>& excerpts() const;

--- a/libmscore/scoreElement.cpp
+++ b/libmscore/scoreElement.cpp
@@ -198,6 +198,19 @@ int ScoreElement::treeChildIdx(ScoreElement* child) const
 }
 
 //---------------------------------------------------------
+//   scanElements
+/// Recursively apply scanElements to all children.
+/// See also Element::scanElements.
+//---------------------------------------------------------
+
+void ScoreElement::scanElements(void* data, void (* func)(void*, Element*), bool all)
+{
+    for (ScoreElement* child : (*this)) {
+        child->scanElements(data, func, all);
+    }
+}
+
+//---------------------------------------------------------
 //   propertyDefault
 //---------------------------------------------------------
 

--- a/libmscore/scoreElement.h
+++ b/libmscore/scoreElement.h
@@ -236,6 +236,8 @@ public:
     static ElementType name2type(const QString& s) { return name2type(QStringRef(&s)); }
     static const char* name(ElementType);
 
+    virtual void scanElements(void* data, void (* func)(void*, Element*), bool all=true);
+
     virtual QVariant getProperty(Pid) const = 0;
     virtual bool setProperty(Pid, const QVariant&) = 0;
     virtual QVariant propertyDefault(Pid) const;

--- a/libmscore/scoretree.cpp
+++ b/libmscore/scoretree.cpp
@@ -66,8 +66,7 @@ ScoreElement* Score::treeParent() const
 
 ScoreElement* Score::treeChild(int idx) const
 {
-    Q_ASSERT(0 <= idx && idx <= treeChildCount());
-    // Should measure be the child instead of page?
+    Q_ASSERT(0 <= idx && idx < treeChildCount());
     return pages()[idx];
 }
 
@@ -87,7 +86,7 @@ ScoreElement* Page::treeParent() const
 
 ScoreElement* Page::treeChild(int idx) const
 {
-    Q_ASSERT(0 <= idx && idx <= treeChildCount());
+    Q_ASSERT(0 <= idx && idx < treeChildCount());
     return systems()[idx];
 }
 
@@ -107,7 +106,7 @@ ScoreElement* System::treeParent() const
 
 ScoreElement* System::treeChild(int idx) const
 {
-    Q_ASSERT(0 <= idx && idx <= treeChildCount());
+    Q_ASSERT(0 <= idx && idx < treeChildCount());
     if (idx < int(brackets().size())) {
         return brackets()[idx];
     }
@@ -165,7 +164,7 @@ ScoreElement* MeasureBase::treeParent() const
 
 ScoreElement* MeasureBase::treeChild(int idx) const
 {
-    Q_ASSERT(0 <= idx && idx <= treeChildCount());
+    Q_ASSERT(0 <= idx && idx < treeChildCount());
     return el()[idx];
 }
 
@@ -185,7 +184,7 @@ ScoreElement* Measure::treeParent() const
 
 ScoreElement* Measure::treeChild(int idx) const
 {
-    Q_ASSERT(0 <= idx && idx <= treeChildCount());
+    Q_ASSERT(0 <= idx && idx < treeChildCount());
     // TODO: check for MMRest
     Segment* seg = _segments.first();
     while (seg) {
@@ -281,7 +280,7 @@ ScoreElement* Segment::treeParent() const
 
 ScoreElement* Segment::treeChild(int idx) const
 {
-    Q_ASSERT(0 <= idx && idx <= treeChildCount());
+    Q_ASSERT(0 <= idx && idx < treeChildCount());
     if (idx < int(_elist.size())) {
         return _elist[idx];
     }
@@ -342,7 +341,7 @@ ScoreElement* ChordRest::treeParent() const
 
 ScoreElement* ChordRest::treeChild(int idx) const
 {
-    Q_ASSERT(0 <= idx && idx <= treeChildCount());
+    Q_ASSERT(0 <= idx && idx < treeChildCount());
     if (beam() && beam()->treeParent() == this) {
         if (idx == 0) {
             return beam();
@@ -410,7 +409,7 @@ ScoreElement* Chord::treeParent() const
 
 ScoreElement* Chord::treeChild(int idx) const
 {
-    Q_ASSERT(0 <= idx && idx <= treeChildCount());
+    Q_ASSERT(0 <= idx && idx < treeChildCount());
 
     if (idx < int(notes().size())) {
         return notes()[idx];
@@ -508,7 +507,7 @@ ScoreElement* Rest::treeParent() const
 
 ScoreElement* Rest::treeChild(int idx) const
 {
-    Q_ASSERT(0 <= idx && idx <= treeChildCount());
+    Q_ASSERT(0 <= idx && idx < treeChildCount());
     if (idx < int(m_dots.size())) {
         return m_dots[idx];
     }
@@ -532,7 +531,7 @@ ScoreElement* Note::treeParent() const
 
 ScoreElement* Note::treeChild(int idx) const
 {
-    Q_ASSERT(0 <= idx && idx <= treeChildCount());
+    Q_ASSERT(0 <= idx && idx < treeChildCount());
     if (accidental()) {
         if (idx == 0) {
             return accidental();
@@ -629,7 +628,7 @@ ScoreElement* Ambitus::treeParent() const
 
 ScoreElement* Ambitus::treeChild(int idx) const
 {
-    Q_ASSERT(0 <= idx && idx <= treeChildCount());
+    Q_ASSERT(0 <= idx && idx < treeChildCount());
     Accidental* topAccid = const_cast<Accidental*>(&_topAccid);
     Accidental* bottomAccid = const_cast<Accidental*>(&_bottomAccid);
     // TODO: check if accidentalType() == AccidentalType::NONE?
@@ -673,7 +672,7 @@ ScoreElement* FretDiagram::treeParent() const
 
 ScoreElement* FretDiagram::treeChild(int idx) const
 {
-    Q_ASSERT(0 <= idx && idx <= treeChildCount());
+    Q_ASSERT(0 <= idx && idx < treeChildCount());
     if (idx == 0) {
         return harmony();
     }
@@ -710,7 +709,7 @@ ScoreElement* Spanner::treeParent() const
 
 ScoreElement* Spanner::treeChild(int idx) const
 {
-    Q_ASSERT(0 <= idx && idx <= treeChildCount());
+    Q_ASSERT(0 <= idx && idx < treeChildCount());
     return spannerSegments()[idx];
 }
 
@@ -733,7 +732,7 @@ ScoreElement* SpannerSegment::treeChild(int idx) const
 #ifdef NDEBUG
     Q_UNUSED(idx)
 #endif
-    Q_ASSERT(0 <= idx && idx <= treeChildCount());
+    Q_ASSERT(0 <= idx && idx < treeChildCount());
     return nullptr;
 }
 
@@ -753,7 +752,7 @@ ScoreElement* BSymbol::treeParent() const
 
 ScoreElement* BSymbol::treeChild(int idx) const
 {
-    Q_ASSERT(0 <= idx && idx <= treeChildCount());
+    Q_ASSERT(0 <= idx && idx < treeChildCount());
     return _leafs[idx];
 }
 
@@ -773,7 +772,7 @@ ScoreElement* Tuplet::treeParent() const
 
 ScoreElement* Tuplet::treeChild(int idx) const
 {
-    Q_ASSERT(0 <= idx && idx <= treeChildCount());
+    Q_ASSERT(0 <= idx && idx < treeChildCount());
     if (idx == 0) {
         return _number;
     }
@@ -799,7 +798,7 @@ ScoreElement* BarLine::treeParent() const
 
 ScoreElement* BarLine::treeChild(int idx) const
 {
-    Q_ASSERT(0 <= idx && idx <= treeChildCount());
+    Q_ASSERT(0 <= idx && idx < treeChildCount());
     return _el[idx];
 }
 
@@ -819,7 +818,7 @@ ScoreElement* Trill::treeParent() const
 
 ScoreElement* Trill::treeChild(int idx) const
 {
-    Q_ASSERT(0 <= idx && idx <= treeChildCount());
+    Q_ASSERT(0 <= idx && idx < treeChildCount());
     if (accidental()) {
         if (idx == 0) {
             return accidental();
@@ -848,7 +847,7 @@ ScoreElement* TBox::treeParent() const
 
 ScoreElement* TBox::treeChild(int idx) const
 {
-    Q_ASSERT(0 <= idx && idx <= treeChildCount());
+    Q_ASSERT(0 <= idx && idx < treeChildCount());
     if (idx == 0) {
         return _text;
     }

--- a/libmscore/scoretree.cpp
+++ b/libmscore/scoretree.cpp
@@ -960,4 +960,22 @@ int TBox::treeChildCount() const
     }
     return 0;
 }
+
+//---------------------------------------------------------
+//   dumpScoreTree
+///   for debugging purposes
+//---------------------------------------------------------
+
+void _dumpScoreTree(ScoreElement* s, int depth)
+{
+    qDebug() << qPrintable(QString(" ").repeated(4 * depth)) << s->name() << "at" << s;
+    for (ScoreElement* c : *s) {
+        _dumpScoreTree(c, depth + 1);
+    }
+}
+
+void Score::dumpScoreTree()
+{
+    _dumpScoreTree(this, 0);
+}
 }  // namespace Ms

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -1196,21 +1196,13 @@ Ms::Element* Segment::elementAt(int track) const
 
 void Segment::scanElements(void* data, void (* func)(void*, Element*), bool all)
 {
-    for (int track = 0; track < score()->nstaves() * VOICES; ++track) {
-        int staffIdx = track / VOICES;
-        if (!all && !(measure()->visible(staffIdx) && score()->staff(staffIdx)->show())) {
-            track += VOICES - 1;
-            continue;
-        }
-        Element* e = element(track);
-        if (e == 0) {
-            continue;
-        }
-        e->scanElements(data, func, all);
+    if (!enabled()) {
+        return;
     }
-    for (Element* e : annotations()) {
-        if (all || e->systemFlag() || measure()->visible(e->staffIdx())) {
-            e->scanElements(data,  func, all);
+    for (ScoreElement* el : (*this)) {
+        Element* e = toElement(el);
+        if (all || e->systemFlag() || (score()->staff(e->staffIdx())->show() && measure()->visible(e->staffIdx()))) {
+            e->scanElements(data, func, all);
         }
     }
 }

--- a/libmscore/spacer.cpp
+++ b/libmscore/spacer.cpp
@@ -12,8 +12,10 @@
 
 #include "spacer.h"
 #include "score.h"
+#include "staff.h"
 #include "mscore.h"
 #include "xml.h"
+#include "measure.h"
 
 namespace Ms {
 //---------------------------------------------------------
@@ -250,6 +252,17 @@ QVariant Spacer::propertyDefault(Pid id) const
         return QVariant(0.0);
     default:
         return Element::propertyDefault(id);
+    }
+}
+
+//---------------------------------------------------------
+//   scanElements
+//---------------------------------------------------------
+
+void Spacer::scanElements(void* data, void (* func)(void*, Element*), bool all)
+{
+    if (all || (measure()->visible(staffIdx()) && score()->staff(staffIdx())->show())) {
+        func(data, this);
     }
 }
 }

--- a/libmscore/spacer.h
+++ b/libmscore/spacer.h
@@ -44,6 +44,7 @@ public:
 
     Spacer* clone() const override { return new Spacer(*this); }
     ElementType type() const override { return ElementType::SPACER; }
+    Measure* measure() const { return toMeasure(parent()); }
 
     SpacerType spacerType() const { return _spacerType; }
     void setSpacerType(SpacerType t) { _spacerType = t; }
@@ -52,6 +53,8 @@ public:
     void read(XmlReader&) override;
 
     void draw(QPainter*) const override;
+
+    void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
 
     bool isEditable() const override { return true; }
     void startEditDrag(EditData&) override;

--- a/libmscore/spanner.h
+++ b/libmscore/spanner.h
@@ -107,6 +107,8 @@ public:
     virtual void setVisible(bool f) override;
     virtual void setColor(const QColor& col) override;
 
+    virtual void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
+
     virtual Element* nextSegmentElement() override;
     virtual Element* prevSegmentElement() override;
     virtual QString accessibleInfo() const override;
@@ -211,6 +213,7 @@ public:
     size_t nsegments() const { return segments.size(); }
     bool segmentsEmpty() const { return segments.empty(); }
     void eraseSpannerSegments();
+    bool eitherEndVisible() const;
 
     virtual SpannerSegment* layoutSystem(System*);
     virtual void layoutSystemsDone();

--- a/libmscore/stafflines.cpp
+++ b/libmscore/stafflines.cpp
@@ -143,4 +143,15 @@ qreal StaffLines::y1() const
       */
     return system->staff(staffIdx())->y() + ipos().y();
 }
+
+//---------------------------------------------------------
+//   scanElements
+//---------------------------------------------------------
+
+void StaffLines::scanElements(void* data, void (* func)(void*, Element*), bool all)
+{
+    if (all || (measure()->visible(staffIdx()) && score()->staff(staffIdx())->show())) {
+        func(data, this);
+    }
+}
 }

--- a/libmscore/stafflines.h
+++ b/libmscore/stafflines.h
@@ -34,6 +34,8 @@ public:
     QPointF pagePos() const override;      ///< position in page coordinates
     QPointF canvasPos() const override;    ///< position in page coordinates
 
+    void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
+
     QVector<QLineF>& getLines() { return lines; }
     Measure* measure() const { return (Measure*)parent(); }
     qreal y1() const;

--- a/libmscore/textframe.cpp
+++ b/libmscore/textframe.cpp
@@ -115,16 +115,6 @@ void TBox::read(XmlReader& e)
 }
 
 //---------------------------------------------------------
-//   scanElements
-//---------------------------------------------------------
-
-void TBox::scanElements(void* data, void (* func)(void*, Element*), bool all)
-{
-    _text->scanElements(data, func, all);
-    Box::scanElements(data, func, all);
-}
-
-//---------------------------------------------------------
 //   drop
 //---------------------------------------------------------
 

--- a/libmscore/textframe.h
+++ b/libmscore/textframe.h
@@ -47,7 +47,6 @@ public:
     virtual void remove(Element* el) override;
 
     virtual void layout();
-    virtual void scanElements(void* data, void (* func)(void*, Element*), bool all=true);
     virtual QString accessibleExtraInfo() const override;
     Text* text() { return _text; }
 

--- a/libmscore/tremolo.cpp
+++ b/libmscore/tremolo.cpp
@@ -778,4 +778,16 @@ QString Tremolo::propertyUserValue(Pid pid) const
     }
     return Element::propertyUserValue(pid);
 }
+
+//---------------------------------------------------------
+//   scanElements
+//---------------------------------------------------------
+
+void Tremolo::scanElements(void* data, void (* func)(void*, Element*), bool all)
+{
+    if (chord() && chord()->tremoloChordType() == TremoloChordType::TremoloSecondNote) {
+        return;
+    }
+    Element::scanElements(data, func, all);
+}
 }

--- a/libmscore/tremolo.h
+++ b/libmscore/tremolo.h
@@ -65,6 +65,8 @@ public:
     int subtype() const override { return static_cast<int>(_tremoloType); }
     QString subtypeName() const override;
 
+    void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
+
     QString tremoloTypeName() const;
     void setTremoloType(const QString& s);
     static TremoloType name2Type(const QString& s);

--- a/libmscore/trill.cpp
+++ b/libmscore/trill.cpp
@@ -233,21 +233,6 @@ Element* TrillSegment::propertyDelegate(Pid pid)
 }
 
 //---------------------------------------------------------
-//   scanElements
-//---------------------------------------------------------
-
-void TrillSegment::scanElements(void* data, void (* func)(void*, Element*), bool /*all*/)
-{
-    func(data, this);
-    if (isSingleType() || isBeginType()) {
-        Accidental* a = trill()->accidental();
-        if (a) {
-            func(data, a);
-        }
-    }
-}
-
-//---------------------------------------------------------
 //   getPropertyStyle
 //---------------------------------------------------------
 
@@ -452,19 +437,6 @@ QString Trill::trillTypeName() const
 QString Trill::trillTypeUserName() const
 {
     return qApp->translate("trillType", trillTable[static_cast<int>(trillType())].userName.toUtf8().constData());
-}
-
-//---------------------------------------------------------
-//   scanElements
-//---------------------------------------------------------
-
-void Trill::scanElements(void* data, void (* func)(void*, Element*), bool all)
-{
-    if (_accidental) {
-        _accidental->scanElements(data, func, all);
-    }
-    func(data, this);         // ?
-    SLine::scanElements(data, func, all);
 }
 
 //---------------------------------------------------------

--- a/libmscore/trill.h
+++ b/libmscore/trill.h
@@ -50,7 +50,6 @@ public:
 
     void add(Element*) override;
     void remove(Element*) override;
-    void scanElements(void* data, void (* func)(void*, Element*), bool all) override;
     Shape shape() const override;
 
     std::vector<SymId> symbols() const { return _symbols; }
@@ -110,7 +109,6 @@ public:
     void setAccidental(Accidental* a) { _accidental = a; }
 
     Segment* segment() const { return (Segment*)parent(); }
-    void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
 
     QVariant getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const QVariant&) override;

--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -757,10 +757,15 @@ Shape Tuplet::shape() const
 
 void Tuplet::scanElements(void* data, void (* func)(void*, Element*), bool all)
 {
-    if (_number && all) {
-        func(data, _number);
+    for (ScoreElement* child : *this) {
+        if (child == _number && !all) {
+            continue; // don't scan number unless all is true
+        }
+        child->scanElements(data, func, all);
     }
-    func(data, this);
+    if (all || visible() || score()->showInvisible()) {
+        func(data, this);
+    }
 }
 
 //---------------------------------------------------------

--- a/mtest/libmscore/all_elements/tst_tree_model.cpp
+++ b/mtest/libmscore/all_elements/tst_tree_model.cpp
@@ -73,10 +73,17 @@ void TestTreeModel::tstTree(QString file)
 void TestTreeModel::traverseTree(ScoreElement* element)
 {
     for (ScoreElement* child : (*element)) {
+        // child should never be nullptr
         if (!child) {
-            continue;
+            qDebug() << "Element returned nullptr in treeChild()!";
+            qDebug() << "Element: " << elementToText(element);
+            qDebug() << "Number of children: " << element->treeChildCount();
+            qDebug() << "Children: ";
+            for (int i = 0; i < element->treeChildCount(); i++) {
+                qDebug() << element->treeChild(i);
+            }
         }
-
+        QVERIFY(child);
         // if parent is not correct print some logging info and exit
         if (child->treeParent() != element) {
             qDebug() << "Element does not have correct parent!";

--- a/mtest/libmscore/all_elements/tst_tree_model.cpp
+++ b/mtest/libmscore/all_elements/tst_tree_model.cpp
@@ -30,12 +30,8 @@ class TestTreeModel : public QObject, public MTest
 {
     Q_OBJECT
 
-    MasterScore * score;
-    void beam(const char* path);
     void tstTree(QString file);
     void traverseTree(ScoreElement* element);
-
-    QString elementToText(ScoreElement* element);
 
 private slots:
     void initTestCase();
@@ -44,6 +40,8 @@ private slots:
     void tstTreeMoonlight() { tstTree("moonlight.mscx"); }
     void tstTreeGoldberg() { tstTree("goldberg.mscx"); }
 };
+
+QString elementToText(ScoreElement* element);
 
 //---------------------------------------------------------
 //   initTestCase
@@ -103,7 +101,7 @@ void TestTreeModel::traverseTree(ScoreElement* element)
 ///   for printing debug info about any element
 //---------------------------------------------------------
 
-QString TestTreeModel::elementToText(ScoreElement* element)
+QString elementToText(ScoreElement* element)
 {
     if (element == nullptr) {
         return "nullptr";


### PR DESCRIPTION
This PR refactors the scanElements function to scan the elements using the score tree to traverse the elements instead of handling each element case by case.

This builds up on the tree model that I created in my previous PR, #6174 .

Latest GSoC blog link: https://musescore.org/en/user/1743616/blog/2020/07/20/gsoc-2020-tree-model-week-7-finished-scanelements-refactoring