### PR TITLE
[MU4] revert ffdd049 - 'play selected staves only' returns!

### DIFF
--- a/audio/midi/event.cpp
+++ b/audio/midi/event.cpp
@@ -172,6 +172,10 @@ bool NPlayEvent::isMuted() const
 {
     const Note* n = note();
     if (n) {
+        if (n->mutePlayback()) {
+            return true;
+        }
+
         MasterScore* cs = n->masterScore();
         Staff* staff = n->staff();
         Instrument* instr = staff->part()->instrument(n->tick());

--- a/audio/midi/event.cpp
+++ b/audio/midi/event.cpp
@@ -172,10 +172,6 @@ bool NPlayEvent::isMuted() const
 {
     const Note* n = note();
     if (n) {
-        if (n->mutePlayback()) {
-            return true;
-        }
-
         MasterScore* cs = n->masterScore();
         Staff* staff = n->staff();
         Instrument* instr = staff->part()->instrument(n->tick());

--- a/framework/preferencekeys.h
+++ b/framework/preferencekeys.h
@@ -43,6 +43,7 @@
 #define PREF_APP_PLAYBACK_PANPLAYBACK                       "application/playback/panPlayback"
 #define PREF_APP_PLAYBACK_PLAYREPEATS                       "application/playback/playRepeats"
 #define PREF_APP_PLAYBACK_LOOPTOSELECTIONONPLAY             "application/playback/setLoopToSelectionOnPlay"
+#define PREF_APP_PLAYBACK_PLAY_SELECTED_STAVES_ONLY         "application/playback/playSelectedStavesOnly"
 #define PREF_APP_USESINGLEPALETTE                           "application/useSinglePalette"
 #define PREF_APP_PALETTESCALE                               "application/paletteScale"
 #define PREF_APP_STARTUP_FIRSTSTART                         "application/startup/firstStart"

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2544,14 +2544,14 @@ int Note::ppitch() const
 //   mutePlayback
 //---------------------------------------------------------
 
-bool Note::mutePlayback() const
+bool Note::mutePlayback(bool allowMuteBySelection) const
 {
     const MasterScore* ms = masterScore();
     const Score* playbackScore = ms->playbackScore();
     if (score() != playbackScore && links()) {
         for (const ScoreElement* se : *links()) {
             if (se->score() == playbackScore) {
-                return toNote(se)->mutePlayback();
+                return toNote(se)->mutePlayback(allowMuteBySelection);
             }
         }
     }
@@ -2564,7 +2564,7 @@ bool Note::mutePlayback() const
     }
 
     const Selection& sel = score()->selection();
-    if (sel.isRange()) {
+    if (allowMuteBySelection && sel.isRange()) {
         const int stIdx = staffIdx();
         if (stIdx < sel.staffStart() || sel.staffEnd() <= stIdx) {
             // it may happen that at least some linked staff is selected

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -372,6 +372,7 @@ public:
     int ottaveCapoFret() const;
     int ppitch() const;             ///< playback pitch
     int epitch() const;             ///< effective pitch
+    bool mutePlayback() const;    ///< whether the note should be muted during the playback
     qreal tuning() const { return _tuning; }
     void setTuning(qreal v) { _tuning = v; }
     void undoSetTpc(int v);

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -372,7 +372,7 @@ public:
     int ottaveCapoFret() const;
     int ppitch() const;             ///< playback pitch
     int epitch() const;             ///< effective pitch
-    bool mutePlayback() const;    ///< whether the note should be muted during the playback
+    bool mutePlayback(bool allowMuteBySelection) const;    ///< whether the note should be muted during the playback
     qreal tuning() const { return _tuning; }
     void setTuning(qreal v) { _tuning = v; }
     void undoSetTpc(int v);

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -140,6 +140,7 @@ void Preferences::init(bool storeInMemoryOnly)
             { PREF_APP_PLAYBACK_PANPLAYBACK,                        new BoolPreference(true, false) },
             { PREF_APP_PLAYBACK_PLAYREPEATS,                        new BoolPreference(true, false) },
             { PREF_APP_PLAYBACK_LOOPTOSELECTIONONPLAY,              new BoolPreference(true) },
+            { PREF_APP_PLAYBACK_PLAY_SELECTED_STAVES_ONLY,          new BoolPreference(false) },
             { PREF_APP_USESINGLEPALETTE,                            new BoolPreference(false) },
             { PREF_APP_PALETTESCALE,                                new DoublePreference(1.0) },
             { PREF_APP_STARTUP_FIRSTSTART,                          new BoolPreference(true) },
@@ -523,7 +524,7 @@ void Preferences::setPreference(const QString key, QVariant value)
 
 Preferences::ListenerID Preferences::addOnSetListener(const OnSetListener& l)
 {
-    static ListenerID lastId{ 0 };
+    static ListenerID lastId { 0 };
     ++lastId;
     _onSetListeners[lastId] = l;
     return lastId;

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -567,7 +567,11 @@ void Seq::playEvent(const NPlayEvent& event, unsigned framePos)
 {
     int type = event.type();
     if (type == ME_NOTEON) {
-        if (!event.isMuted()) {
+        const Note* note = event.note();
+        bool allowMuteBySelection = preferences.getBool(PREF_APP_PLAYBACK_PLAY_SELECTED_STAVES_ONLY);
+        bool noteMutedBySelection = note->mutePlayback(allowMuteBySelection);
+
+        if (!event.isMuted() && !noteMutedBySelection) {
             if (event.discard()) {       // ignore noteoff but restrike noteon
                 if (event.velo() > 0) {
                     putEvent(NPlayEvent(ME_NOTEON, event.channel(), event.pitch(), 0),framePos);


### PR DESCRIPTION
I had a friend come to me recently to complain that you couldn't 'make it work like Sibelius' in that, you can't automatically solo instruments by making a range selection and hitting play. So, I resurrected @dmitrio95 's old PR and rebased it.

What's new: this feature is now managed by a preference, which defaults to have this turned off. To test it, see Edit > Preferences > Advanced > application/playback/playSelectedStavesOnly.

It'd be nice to see this in 3.5 or 3.5.1, if it gets enough approval. I'm also interested in hearing whether people think this is a good/bad decision.