### PR TITLE
fix #307428: don't disable "remove selected range"

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -313,9 +313,10 @@ void ScoreView::objectPopup(const QPoint& pos, Element* obj)
       popup->addAction(getAction("paste"));
       popup->addAction(getAction("swap"));
       popup->addAction(getAction("delete"));
-      a = getAction("time-delete");
-      a->setEnabled(obj->isChordRest());
-      popup->addAction(a);
+      if (obj->isNote() || obj->isRest()) {
+            a = getAction("time-delete");
+            popup->addAction(a);
+            }
 
       QMenu* selMenu = popup->addMenu(tr("Select"));
       selMenu->addAction(getAction("select-similar"));


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/307428

A recent change simplified the handling
of the remove selected range command in the right-click menu,
but also disabled it for elements other than rests.
Unfortunately, it was never re-enabled, leaving you unable
to delete measures after right-clicking something other than a rest.
There is no good place to re-enable it as far as I know,
so I have changed this to simply not disable it.
Instead, I don't display it at all except for rests or notes.
This doesn't change the *measure* popup, only the *object* popup.

See #6008 for when this particular issue was introduced.  But, I note that there have been reports of Ctrl+Delete mysteriously disabling itself, going back several years.  So there may well be something else going on too.  But this PR fixes a very recent regression.