### PR TITLE
fix #307430: jazz override does not work in Realize Chord Symbols

### DIFF
--- a/libmscore/realizedharmony.cpp
+++ b/libmscore/realizedharmony.cpp
@@ -463,7 +463,7 @@ RealizedHarmony::PitchMap RealizedHarmony::getIntervals(int rootTpc, bool litera
             }
 
       Harmony* next = _harmony->findNext();
-      if (!_literal && next && tpcIsValid(next->rootTpc())) {
+      if (!literal && next && tpcIsValid(next->rootTpc())) {
             //jazz interpretation
             QString qNext = next->parsedForm()->quality();
             //pitch from current to next harmony normalized to a range between 0 and 12


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/307430

The "jazz" interpretation works as expected during normal playback
and also in Realize Chord Symbols if the chord is actual set to jazz
in its properties (via the Inspector).
But, if a chord is set to literal and you do Realize Chord Symbols
and you use the override options in the dialog to force jazz,
it does not work.
Cause is that the underlying getIntervals function was ignoring
the parameter it was passed, and was always using the object member.
I tested to be sure this parameter is being set correctly
in all code paths.