### PR TITLE
fix #98101: [Audio + Buildsystem] Add support for the Haiku operating system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,16 @@ if (APPLE)
       option(BUILD_ALSA ${MAC_NOT_AVAIL} OFF)
 endif (APPLE)
 
+# Disable components not supported on Haiku
+if (HAIKU)
+      set(HAIKU_NOT_AVAIL "Not available on Haiku")
+      option(BUILD_JACK ${HAIKU_NOT_AVAIL} OFF)
+      option(BUILD_PULSEAUDIO ${HAIKU_NOT_AVAIL} OFF)
+      option(BUILD_ALSA ${HAIKU_NOT_AVAIL} OFF)
+      option(BUILD_PORTAUDIO ${HAIKU_NOT_AVAIL} OFF)
+      option(BUILD_PORTMIDI ${HAIKU_NOT_AVAIL} OFF)
+endif (HAIKU)
+
 # Disable components not supported on Linux/BSD
 if (NOT APPLE AND NOT MINGW AND NOT MSVC)
       set(NIX_NOT_AVAIL "Not available on Linux/BSD")
@@ -152,6 +162,7 @@ option(BUILD_PULSEAUDIO "Build with support for PulseAudio audio backend." ON)
 option(BUILD_ALSA "Build with support for ALSA audio backend." ON)
 option(BUILD_PORTAUDIO "Build with support for PortAudio audio backend." ON)
 option(BUILD_PORTMIDI "Build with support for PortAudio's MIDI features." ${BUILD_PORTAUDIO}) # PortAudio required
+option(BUILD_MEDIAKIT "Build with support for the Haiku Media Kit audio backend." OFF)
 option(BUILD_PCH "Build using precompiled headers." ON)
 option(BUILD_FOR_WINSTORE "Build for the Windows Store." OFF)
 option(COVERAGE "Build with instrumentation to record code coverage." OFF)
@@ -293,7 +304,9 @@ else (APPLE)
              set(CMAKE_EXE_LINKER_FLAGS "-Wl,--large-address-aware")
          endif (NOT BUILD_64)
       else (MINGW)
-         set(CMAKE_CXX_FLAGS         "${CMAKE_CXX_FLAGS} -fPIC")
+         if (NOT HAIKU)
+            set(CMAKE_CXX_FLAGS         "${CMAKE_CXX_FLAGS} -fPIC")
+         endif (NOT HAIKU)
          set(CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -Woverloaded-virtual")
          set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DQT_NO_DEBUG_OUTPUT")
       endif (MINGW)
@@ -304,20 +317,24 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH ON) # Call CMake with option -DCMAKE_SKIP_RPATH to not set RPATH (Debian packaging requirement)
 set(CMAKE_SKIP_RULE_DEPENDENCY TRUE)
 
-if (MINGW OR MSVC OR APPLE)
+if (MINGW OR MSVC OR APPLE OR HAIKU)
   if(MINGW OR MSVC)
       # Option for MINGW and MSVC
       SET(Mscore_INSTALL_NAME  "")
       SET(Mscore_SHARE_NAME    "./")
+  elseif(HAIKU)
+      # Option for Haiku
+      SET(Mscore_INSTALL_NAME "mscore${MSCORE_INSTALL_SUFFIX}-${MUSESCORE_VERSION}/")
+      SET(Mscore_SHARE_NAME   "data/")
   else(MINGW OR MSVC)
        # Option for Apple
        SET(Mscore_INSTALL_NAME  "Contents/Resources/")
        SET(Mscore_SHARE_NAME    "mscore.app/")
   endif(MINGW OR MSVC)
-else (MINGW OR MSVC OR APPLE)
+else (MINGW OR MSVC OR APPLE OR HAIKU)
       SET(Mscore_INSTALL_NAME  "mscore${MSCORE_INSTALL_SUFFIX}-${MUSESCORE_VERSION}/")
       SET(Mscore_SHARE_NAME    "share/")
-endif (MINGW OR MSVC OR APPLE)
+endif (MINGW OR MSVC OR APPLE OR HAIKU)
 
 # Download MuseScore SoundFont
 if (DOWNLOAD_SOUNDFONT)
@@ -403,6 +420,20 @@ if (BUILD_ALSA)
 else (BUILD_ALSA)
      message(STATUS "ALSA support disabled")
 endif (BUILD_ALSA)
+
+##
+## Haiku Media Kit
+##
+
+if (BUILD_MEDIAKIT)
+    if (HAIKU)
+        set(USE_MEDIAKIT 1)
+    else (HAIKU)
+        message(SEND_ERROR "Error: Haiku Media Kit supported requested, but target platform is not Haiku.")
+    endif (HAIKU)
+else (BUILD_MEDIAKIT)
+    message(STATUS "Haiku Media Kit support disabled")
+endif (BUILD_MEDIAKIT)
 
 ##
 ## MIDI
@@ -523,7 +554,7 @@ if (BUILD_PORTAUDIO)
         endif (PORTAUDIO_INCDIR)
     endif (MINGW OR MSVC)
 else (BUILD_PORTAUDIO)
-     message(STATUS "PortAudio support disabled")
+    message(STATUS "PortAudio support disabled")
 endif (BUILD_PORTAUDIO)
 
 ##
@@ -621,7 +652,7 @@ else(USE_SYSTEM_QTSINGLEAPPLICATION)
       set(QTSINGLEAPPLICATION_LIBRARIES qtsingleapp)
 endif(USE_SYSTEM_QTSINGLEAPPLICATION)
 
-if (NOT MINGW AND NOT MSVC AND NOT APPLE)
+if (NOT MINGW AND NOT MSVC AND NOT APPLE AND NOT HAIKU)
     #### PACKAGING for Linux and BSD based systems (more in mscore/CMakeLists.txt) ####
     #
     #     set library search path for runtime linker to load the same
@@ -720,7 +751,7 @@ if (NOT MINGW AND NOT MSVC AND NOT APPLE)
     configure_file(build/Linux+BSD/musescore.xml.in musescore${MSCORE_INSTALL_SUFFIX}.xml)
     install( FILES ${PROJECT_BINARY_DIR}/musescore${MSCORE_INSTALL_SUFFIX}.xml DESTINATION share/mime/packages COMPONENT doc)
     # Note: Must now run "update-mime-database" to apply changes. This is done in the Makefile.
-endif (NOT MINGW AND NOT MSVC AND NOT APPLE)
+endif (NOT MINGW AND NOT MSVC AND NOT APPLE AND NOT HAIKU)
 
 #
 #  Create precompiled header file

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,9 @@ BUILD_JACK="ON"       # Override with "OFF" to disable.
 BUILD_ALSA="ON"       # Override with "OFF" to disable.
 BUILD_PORTAUDIO="ON"  # Override with "OFF" to disable.
 BUILD_PORTMIDI="ON"   # Override with "OFF" to disable.
+BUILD_MEDIAKIT="OFF"  # Override with "ON" to enable.
 BUILD_WEBENGINE="ON"  # Override with "OFF" to disable.
+BUILD_TELEMETRY_MODULE="ON" # Override with "OFF" to disable.
 USE_SYSTEM_FREETYPE="OFF" # Override with "ON" to enable. Requires freetype >= 2.5.2.
 COVERAGE="OFF"        # Override with "ON" to enable.
 DOWNLOAD_SOUNDFONT="ON"   # Override with "OFF" to disable latest soundfont download.
@@ -65,7 +67,9 @@ release:
   	  -DBUILD_JACK="${BUILD_JACK}"             \
   	  -DBUILD_ALSA="${BUILD_ALSA}"              \
    	  -DBUILD_PORTAUDIO="${BUILD_PORTAUDIO}"   \
+   	  -DBUILD_MEDIAKIT="${BUILD_MEDIAKIT}"   \
    	  -DBUILD_WEBENGINE="${BUILD_WEBENGINE}"   \
+   	  -DBUILD_TELEMETRY_MODULE="${BUILD_TELEMETRY_MODULE}" \
    	  -DUSE_SYSTEM_FREETYPE="${USE_SYSTEM_FREETYPE}" \
    	  -DDOWNLOAD_SOUNDFONT="${DOWNLOAD_SOUNDFONT}"   \
   	  -DCMAKE_SKIP_RPATH="${NO_RPATH}"     ..; \
@@ -95,9 +99,11 @@ debug:
   	  -DBUILD_JACK="${BUILD_JACK}"                        \
   	  -DBUILD_ALSA="${BUILD_ALSA}"                         \
    	  -DBUILD_PORTAUDIO="${BUILD_PORTAUDIO}"              \
+   	  -DBUILD_MEDIAKIT="${BUILD_MEDIAKIT}"              \
    	  -DBUILD_WEBENGINE="${BUILD_WEBENGINE}"              \
+   	  -DBUILD_TELEMETRY_MODULE="${BUILD_TELEMETRY_MODULE}" \
    	  -DUSE_SYSTEM_FREETYPE="${USE_SYSTEM_FREETYPE}"      \
-      -DCOVERAGE="${COVERAGE}"                 \
+   	  -DCOVERAGE="${COVERAGE}"                 \
    	  -DDOWNLOAD_SOUNDFONT="${DOWNLOAD_SOUNDFONT}"        \
   	  -DCMAKE_SKIP_RPATH="${NO_RPATH}"     ..;            \
       make lrelease;                                        \

--- a/audio/drivers/drivers.cmake
+++ b/audio/drivers/drivers.cmake
@@ -32,4 +32,6 @@ if (USE_ALSA OR USE_PORTMIDI)
       set (DRIVERS_SRC ${DRIVERS_SRC} ${DRIVERS_DIR}/mididriver.cpp ${DRIVERS_DIR}/mididriver.h)
 endif (USE_ALSA OR USE_PORTMIDI)
 
-
+if (USE_MEDIAKIT)
+      set (DRIVERS_SRC ${DRIVERS_SRC} ${DRIVERS_DIR}/haiku.cpp ${DRIVERS_DIR}/haiku.h)
+endif (USE_MEDIAKIT)

--- a/audio/drivers/haiku.cpp
+++ b/audio/drivers/haiku.cpp
@@ -1,0 +1,155 @@
+//=============================================================================
+//  MusE Score
+//  Linux Music Score Editor
+//
+//  Copyright (C) 2020 Jacob Secunda
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#include "haiku.h"
+
+#include <MediaDefs.h>
+#include <MediaRoster.h>
+
+#include "mscore/seq.h"
+
+namespace Ms {
+//---------------------------------------------------------
+//   haikuBufferPlayer
+//---------------------------------------------------------
+
+void HaikuMediaKit::haikuBufferPlayer(void* cookie, void* buffer, size_t size,
+    const media_raw_audio_format& format)
+{
+    HaikuMediaKit* hmk = (HaikuMediaKit*)cookie;
+
+    hmk->seq->process(size / (2 * sizeof(float)), (float*)buffer);
+}
+
+//---------------------------------------------------------
+//   HaikuMediaKit
+//---------------------------------------------------------
+
+HaikuMediaKit::HaikuMediaKit(Seq* s)
+    : Driver(s)
+{
+    _sampleRate = 48000; // will be replaced by device default sample rate
+    state = Transport::STOP;
+}
+
+//---------------------------------------------------------
+//   ~HaikuMediaKit
+//---------------------------------------------------------
+
+HaikuMediaKit::~HaikuMediaKit()
+{
+    stop();
+    delete player;
+}
+
+
+//---------------------------------------------------------
+//   init
+//   	return false on error
+//---------------------------------------------------------
+
+bool HaikuMediaKit::init(bool /*hot*/)
+{
+    status_t error = B_ERROR;
+    BMediaRoster* roster = BMediaRoster::Roster(&error);
+    if (error != B_OK) {
+        return false;
+    }
+
+    media_raw_audio_format format;
+    format.frame_rate = _sampleRate;
+    format.channel_count = 2;
+    format.format = media_raw_audio_format::B_AUDIO_FLOAT;
+    format.byte_order = B_MEDIA_LITTLE_ENDIAN;
+    format.buffer_size = roster->AudioBufferSizeFor(2,
+        media_raw_audio_format::B_AUDIO_FLOAT, _sampleRate);
+
+    player = new BSoundPlayer(&format, "MuseScore", haikuBufferPlayer,
+        nullptr, this);
+
+    if (player == NULL || player->InitCheck() != B_OK) {
+        qDebug("HaikuMediaKit: BSoundPlayer failed to start up!");
+        return false;
+    }
+
+    _sampleRate = player->Format().frame_rate;
+
+    return true;
+}
+
+//---------------------------------------------------------
+//   start
+//---------------------------------------------------------
+
+bool HaikuMediaKit::start(bool /* hotPlug */)
+{
+    if (player == nullptr) {
+        return false;
+    }
+
+    if (player->Start() != B_OK) {
+        return false;
+    }
+
+    player->SetHasData(true);
+
+    return true;
+}
+
+//---------------------------------------------------------
+//   stop
+//---------------------------------------------------------
+
+bool HaikuMediaKit::stop()
+{
+    if (player != nullptr) {
+        player->SetHasData(false);
+        player->Stop();
+    }
+
+    return true;
+}
+
+//---------------------------------------------------------
+//   getState
+//---------------------------------------------------------
+
+Transport HaikuMediaKit::getState()
+{
+    return state;
+}
+
+//---------------------------------------------------------
+//   startTransport
+//---------------------------------------------------------
+
+void HaikuMediaKit::startTransport()
+{
+    state = Transport::PLAY;
+}
+
+//---------------------------------------------------------
+//   stopTransport
+//---------------------------------------------------------
+
+void HaikuMediaKit::stopTransport()
+{
+    state = Transport::STOP;
+}
+} // namespace Ms

--- a/audio/drivers/haiku.h
+++ b/audio/drivers/haiku.h
@@ -1,8 +1,8 @@
 //=============================================================================
-//  MuseScore
+//  MusE Score
 //  Linux Music Score Editor
 //
-//  Copyright (C) 2002-2009 Werner Schweer and others
+//  Copyright (C) 2020 Jacob Secunda
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2.
@@ -17,42 +17,44 @@
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
 
-#ifndef __DRIVER_H__
-#define __DRIVER_H__
+#ifndef __HAIKU_H__
+#define __HAIKU_H__
+
+#include "config.h"
+#include "driver.h"
+
+#include <SoundPlayer.h>
 
 namespace Ms {
+class Synth;
 class Seq;
-class NPlayEvent;
 enum class Transport : char;
 
 //---------------------------------------------------------
-//   Driver
+//   Haiku Media Kit Driver
 //---------------------------------------------------------
 
-class Driver
+class HaikuMediaKit : public Driver
 {
-protected:
-    Seq* seq;
+    int _sampleRate;
+    Transport state;
+
+    BSoundPlayer* player;
+
+    static void haikuBufferPlayer(void* cookie, void* buffer, size_t size,
+        const media_raw_audio_format& format);
 
 public:
-    Driver(Seq* s) { seq = s; }
-    virtual ~Driver() {}
-    virtual bool init(bool hot = false) = 0;
-    virtual bool start(bool hotPlug = false) = 0;
-    virtual bool stop() = 0;
-    virtual void stopTransport() = 0;
-    virtual void startTransport() = 0;
-    virtual Transport getState() = 0;
-    virtual void seekTransport(int) {}
-    virtual int sampleRate() const = 0;
-    virtual void putEvent(const NPlayEvent&, unsigned /*framePos*/) {}
-    virtual void midiRead() {}
-    virtual void handleTimeSigTempoChanged() {}
-    virtual void checkTransportSeek(int, int, bool) {}
-    virtual int bufferSize() { return 0; }
-    virtual void updateOutPortCount(int) {}
+    HaikuMediaKit(Seq*);
+    virtual ~HaikuMediaKit();
+    virtual bool init(bool hot = false);
+    virtual bool start(bool hotPlug = false);
+    virtual bool stop();
+    virtual Transport getState() override;
+    virtual void stopTransport();
+    virtual void startTransport();
+    virtual int sampleRate() const { return _sampleRate; }
+    virtual int bufferSize() { return player != nullptr ? player->Format().buffer_size : 0; }
 };
-
-extern bool alsaIsUsed, jackIsUsed, portAudioIsUsed, pulseAudioIsUsed, mediaKitIsUsed;
 } // namespace Ms
 #endif

--- a/build/config.h.in
+++ b/build/config.h.in
@@ -25,6 +25,7 @@
 #cmakedefine USE_PORTAUDIO
 #cmakedefine USE_PORTMIDI
 #cmakedefine USE_PULSEAUDIO
+#cmakedefine USE_MEDIAKIT
 #cmakedefine USE_LAME
 #cmakedefine USE_WEBENGINE
 

--- a/framework/preferencekeys.h
+++ b/framework/preferencekeys.h
@@ -80,6 +80,7 @@
 #define PREF_IO_JACK_USEJACKAUDIO                           "io/jack/useJackAudio"
 #define PREF_IO_JACK_USEJACKMIDI                            "io/jack/useJackMIDI"
 #define PREF_IO_JACK_USEJACKTRANSPORT                       "io/jack/useJackTransport"
+#define PREF_IO_MEDIAKIT_USEMEDIAKITAUDIO                   "io/mediakit/useMediaKitAudio"
 #define PREF_IO_MIDI_ADVANCEONRELEASE                       "io/midi/advanceOnRelease"
 #define PREF_IO_MIDI_ENABLEINPUT                            "io/midi/enableInput"
 #define PREF_IO_MIDI_EXPANDREPEATS                          "io/midi/expandRepeats"

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -260,7 +260,7 @@ else (MINGW)
 
       if (APPLE)
         target_link_libraries(mscore ${OsxFrameworks})
-      else (APPLE)
+      elseif (NOT HAIKU)
           target_link_libraries(mscore rt)
       endif (APPLE)
 

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -434,6 +434,11 @@ else (MINGW)
          target_link_libraries(mscoreapp ${PULSEAUDIO_LIBRARY})
        endif (USE_PULSEAUDIO)
 
+      if (USE_MEDIAKIT)
+         target_link_libraries(mscoreapp be media)
+      endif (USE_MEDIAKIT)
+
+
       set_target_properties (
          mscoreapp
          PROPERTIES
@@ -447,10 +452,14 @@ else (MINGW)
          endif (OCR)
       endif (OMR)
 
+      if (HAIKU)
+         target_link_libraries(mscoreapp root)
+      endif (HAIKU)
+
       if (APPLE)
-        target_link_libraries(mscoreapp ${OsxFrameworks})
-      else (APPLE)
-          target_link_libraries(mscoreapp rt)
+         target_link_libraries(mscoreapp ${OsxFrameworks})
+      elseif (NOT HAIKU)
+         target_link_libraries(mscoreapp rt)
       endif (APPLE)
 
       # 'gold' does not use indirect shared libraries for symbol resolution, Linux only
@@ -458,7 +467,9 @@ else (MINGW)
          if(USE_JACK)
             target_link_libraries(mscoreapp ${CMAKE_DL_LIBS})
          endif(USE_JACK)
-         target_link_libraries(mscoreapp rt)
+         if(NOT HAIKU)
+            target_link_libraries(mscoreapp rt)
+         endif(NOT HAIKU)
       endif (NOT APPLE)
 
       if (APPLE)

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -74,6 +74,7 @@ void Preferences::init(bool storeInMemoryOnly)
     bool defaultUsePulseAudio = false;
     bool defaultUseJackAudio = false;
     bool defaultUseAlsaAudio = false;
+    bool defaultUseMediaKitAudio = false;
 
 #if defined(Q_OS_MAC) || defined(Q_OS_WIN)
     defaultUsePortAudio  = true;
@@ -84,6 +85,8 @@ void Preferences::init(bool storeInMemoryOnly)
     defaultUseAlsaAudio = true;
 #elif defined(USE_PORTAUDIO)
     defaultUsePortAudio = true;
+#elif defined(USE_MEDIAKIT)
+    defaultUseMediaKitAudio = true;
 #endif
 
 #if defined(Q_OS_MAC) && !defined(TESTROOT)
@@ -178,6 +181,7 @@ void Preferences::init(bool storeInMemoryOnly)
             { PREF_IO_JACK_USEJACKAUDIO,                            new BoolPreference(defaultUseJackAudio, false) },
             { PREF_IO_JACK_USEJACKMIDI,                             new BoolPreference(false, false) },
             { PREF_IO_JACK_USEJACKTRANSPORT,                        new BoolPreference(false, false) },
+            { PREF_IO_MEDIAKIT_USEMEDIAKITAUDIO,                    new BoolPreference(defaultUseMediaKitAudio, false) },
             { PREF_IO_MIDI_ADVANCEONRELEASE,                        new BoolPreference(true, false) },
             { PREF_IO_MIDI_ENABLEINPUT,                             new BoolPreference(true, false) },
             { PREF_IO_MIDI_EXPANDREPEATS,                           new BoolPreference(true, false) },

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>834</width>
-    <height>701</height>
+    <width>919</width>
+    <height>735</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -2703,6 +2703,25 @@
        <string>I/O</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_8">
+       <item>
+        <widget class="Ms::RadioButtonGroupBox" name="mediakitDriver">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>30</height>
+          </size>
+         </property>
+         <property name="focusPolicy">
+          <enum>Qt::StrongFocus</enum>
+         </property>
+         <property name="title">
+          <string>Haiku Media Kit Audio</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
        <item>
         <widget class="Ms::RadioButtonGroupBox" name="pulseaudioDriver">
          <property name="sizePolicy">

--- a/thirdparty/google_analytics/ganalytics.cpp
+++ b/thirdparty/google_analytics/ganalytics.cpp
@@ -381,7 +381,7 @@ QString GAnalytics::Private::getSystemInfo()
             .arg(QAndroidJniObject::getStaticObjectField<jstring>("android/os/Build", "ID").toString())
             .arg(QAndroidJniObject::getStaticObjectField<jstring>("android/os/Build", "BRAND").toString());
 }
-#elif defined(Q_OS_LINUX)
+#elif defined(Q_OS_LINUX) || defined(Q_OS_HAIKU)
 #include <sys/utsname.h>
 
 /**
@@ -463,7 +463,7 @@ void GAnalytics::Private::setUserID(const QString &userID)
  * @return userID         A string with the user id.
  */
 QString GAnalytics::Private::getUserID()
-{    
+{
     QSettings settings;
     QString userID = settings.value("GAnalytics-uid", QString("")).toString();
 


### PR DESCRIPTION
This commit adds support for the Haiku operating system through some buildsystem changes and the addition
of a simple audio driver for Haiku's Media Kit.

Resolves: https://musescore.org/en/node/98101 for master

MuseScore was already ported recently to the Haiku operating system and is available through HaikuPorts (Haiku's online package management repository). However, there was no audio playback functionality due to how none of MuseScore's available audio backends (PulseAudio, Alsa, Jack, and PortAudio) are available for Haiku. In addition, MuseScore does not build on Haiku by default and requires extra patches to be built (found here: https://github.com/haikuports/haikuports/tree/master/media-sound/musescore). I have made sure to test the functionality of this patch in a Haiku environment.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
