### PR TITLE
fix #185056: hard to enter notes above/below staff + collect_artifacts

### DIFF
--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -967,8 +967,8 @@ class Score : public QObject, public ScoreElement {
       void lassoSelectEnd();
 
       Page* searchPage(const QPointF&) const;
-      QList<System*> searchSystem(const QPointF& p, const System* preferredSystem = nullptr, qreal spacingFactor = 0.5) const;
-      Measure* searchMeasure(const QPointF& p, const System* preferredSystem = nullptr, qreal spacingFactor = 0.5) const;
+      QList<System*> searchSystem(const QPointF& p, const System* preferredSystem = nullptr, qreal spacingFactor = 0.5, qreal preferredSpacingFactor = 1.0) const;
+      Measure* searchMeasure(const QPointF& p, const System* preferredSystem = nullptr, qreal spacingFactor = 0.5, qreal preferredSpacingFactor = 1.0) const;
 
       bool getPosition(Position* pos, const QPointF&, int voice) const;
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/185056

Currently, when you click to enter a note in note input mode,
and you click a location between two staves or systems,
we try to guess which you mean using a simple split point
located half way between the staves or systems.
This makes it hard to enter notes far above or below the staff,
because at some point we think you mean a different staff.
This comes up all the time for piano music and also guitar,
especially guitar+tab.

My fix here is simple, I prefer the current system and staff.
Current meaning, the one where the note input cursor is.
I let this staff take 75% of the stave above and below,
instead of only 50%.
Thus, clicking far above/below the current staff
will still enter notes onto that staff until you get much closer
to the adjacent staff.

The code is based on existing code that already does the same thing
when choosing which *system* (and hence measure) to use.
One slight issue that I'll call a "feature" for now:
the existing code for preferring a system cannot be configured
as to how much to prefer it.
So instead of the current system taking 75% of the space above/below,
it takes 100%.
I think this is fine, it's much more common to be flipping
from staff to staff within a system than flipping from system to system
when entering notes,
so it makes sense we try even harder to prefer the current system.
You can of course still enter notes onto the system above or below,
if you click directly on the staff,
or move the note input cursor.