### PR TITLE
[MU3] Rename note Hooks to Flags, to match SMuFL terms and some more text fixes

### DIFF
--- a/libmscore/hook.cpp
+++ b/libmscore/hook.cpp
@@ -55,7 +55,7 @@ void Hook::setHookType(int i)
             case -7:   setSym(SymId::flag512thDown); break;
             case -8:   setSym(SymId::flag1024thDown);break;
             default:
-                  qDebug("no hook for subtype %d", i);
+                  qDebug("no hook/flag for subtype %d", i);
                   break;
             }
       }

--- a/libmscore/scoreElement.cpp
+++ b/libmscore/scoreElement.cpp
@@ -61,7 +61,7 @@ static const ElementName elementNames[] = {
       { ElementType::CHORDLINE,            "ChordLine",            QT_TRANSLATE_NOOP("elementName", "Chord Line") },
       { ElementType::DYNAMIC,              "Dynamic",              QT_TRANSLATE_NOOP("elementName", "Dynamic") },
       { ElementType::BEAM,                 "Beam",                 QT_TRANSLATE_NOOP("elementName", "Beam") },
-      { ElementType::HOOK,                 "Hook",                 QT_TRANSLATE_NOOP("elementName", "Hook") },
+      { ElementType::HOOK,                 "Hook",                 QT_TRANSLATE_NOOP("elementName", "Flag") }, // internally called "Hook", but "Flag" in SMuFL, so here externally too
       { ElementType::LYRICS,               "Lyrics",               QT_TRANSLATE_NOOP("elementName", "Lyrics") },
       { ElementType::FIGURED_BASS,         "FiguredBass",          QT_TRANSLATE_NOOP("elementName", "Figured Bass") },
       { ElementType::MARKER,               "Marker",               QT_TRANSLATE_NOOP("elementName", "Marker") },

--- a/mscore/debugger/chord.ui
+++ b/mscore/debugger/chord.ui
@@ -56,7 +56,7 @@
          <string notr="true"/>
         </property>
         <property name="text">
-         <string notr="true">Hook</string>
+         <string notr="true">Flag</string>
         </property>
        </widget>
       </item>

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -247,7 +247,7 @@
        </size>
       </property>
       <property name="currentIndex">
-       <number>31</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="PageScore">
        <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -2331,7 +2331,7 @@
            <item row="0" column="0">
             <widget class="QLabel" name="label_91">
              <property name="text">
-              <string>Bracket thickness:</string>
+              <string comment="System bracket">Bracket thickness:</string>
              </property>
              <property name="buddy">
               <cstring>bracketWidth</cstring>
@@ -2385,7 +2385,7 @@
            <item row="1" column="0">
             <widget class="QLabel" name="label_52">
              <property name="text">
-              <string>Bracket distance:</string>
+              <string comment="System bracket">Bracket distance:</string>
              </property>
              <property name="buddy">
               <cstring>bracketDistance</cstring>
@@ -4962,7 +4962,7 @@
               <item row="0" column="0">
                <widget class="QLabel" name="label_6">
                 <property name="text">
-                 <string>Bracket thickness:</string>
+                 <string comment="Tuplet bracket">Bracket thickness:</string>
                 </property>
                 <property name="buddy">
                  <cstring>tupletBracketWidth</cstring>
@@ -5008,7 +5008,7 @@
               <item row="1" column="0">
                <widget class="QLabel" name="label_187">
                 <property name="text">
-                 <string>Bracket hook height:</string>
+                 <string comment="Tuplet bracket">Bracket hook height:</string>
                 </property>
                </widget>
               </item>

--- a/mscore/inspector/inspector_note.ui
+++ b/mscore/inspector/inspector_note.ui
@@ -275,7 +275,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>Hook</string>
+           <string>Flag</string>
           </property>
          </widget>
         </item>

--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -124,7 +124,7 @@ void StaffListItem::initStaffTypeCombo(bool forceRecreate)
 void StaffListItem::setPartIdx(int val)
       {
       _partIdx = val;
-      setText(0, InstrumentsWidget::tr("Staff %1").arg(_partIdx + 1));
+      setText(0, InstrumentsWidget::tr("Staff: %1").arg(_partIdx + 1));
       }
 
 //---------------------------------------------------------

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -2635,7 +2635,7 @@
              <string>Instrument list 1</string>
             </property>
             <property name="accessibleDescription">
-             <string>Insert path to a instrument list file</string>
+             <string>Insert path to an instrument list file</string>
             </property>
            </widget>
           </item>
@@ -2725,7 +2725,7 @@
              <string>Instrument list 2</string>
             </property>
             <property name="accessibleDescription">
-             <string>Insert path to a instrument list file</string>
+             <string>Insert path to an instrument list file</string>
             </property>
            </widget>
           </item>

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4715,7 +4715,7 @@ void ScoreView::appendMeasures(int n, ElementType type)
       if (_score->noStaves()) {
             QMessageBox::warning(0, "MuseScore",
                tr("No staves found:\n"
-                  "please use the instruments dialog to\n"
+                  "Please use the instruments dialog to\n"
                   "first create some staves"));
             return;
             }

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -32,8 +32,8 @@ Shortcut Shortcut::_sc[] = {
          MsWidget::MAIN_WINDOW,
          STATE_ALL,
          "help",
-         QT_TRANSLATE_NOOP("action","Online Handbook…"),   // Appears in menu
-         QT_TRANSLATE_NOOP("action","Online handbook"),      // Appears in Edit > Preferences > Shortcuts
+         QT_TRANSLATE_NOOP("action","Online Handbook…"),     // Appears in menu, so Title Case
+         QT_TRANSLATE_NOOP("action","Online handbook"),      // Appears in Edit > Preferences > Shortcuts, so Sentence case
          QT_TRANSLATE_NOOP("action","Show online handbook"), // Appears if you use Help > What's This?
          Icons::Invalid_ICON,
          Qt::ApplicationShortcut,
@@ -837,7 +837,7 @@ Shortcut Shortcut::_sc[] = {
          STATE_NORMAL | STATE_NOTE_ENTRY,
          "move-up",
          QT_TRANSLATE_NOOP("action","Move Up"),
-         QT_TRANSLATE_NOOP("action","Move up"),
+         QT_TRANSLATE_NOOP("action","Move chord/rest to staff above"),
          0,
          Icons::Invalid_ICON,
          Qt::WindowShortcut,
@@ -1012,7 +1012,7 @@ Shortcut Shortcut::_sc[] = {
          STATE_NORMAL | STATE_NOTE_ENTRY,
          "move-down",
          QT_TRANSLATE_NOOP("action","Move Down"),
-         QT_TRANSLATE_NOOP("action","Move down"),
+         QT_TRANSLATE_NOOP("action","Move chord/rest to staff below"),
          0,
          Icons::Invalid_ICON,
          Qt::WindowShortcut,

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -301,7 +301,7 @@ void WorkspacesManager::remove(Workspace* workspace)
 
 static void writeFailed(const QString& _path)
       {
-      QString s = qApp->translate("Workspace", "Writing Workspace File\n%1\nfailed: ");
+      QString s = qApp->translate("Workspace", "Writing Workspace File\n%1\nfailed");
       QMessageBox::critical(mscore, qApp->translate("Workspace", "Writing Workspace File"), s.arg(_path));
       }
 


### PR DESCRIPTION
and to differentiate from line hooks.

Change some more strings too. Including some that came up as an issue on Transifex

Something to consider for 3.5.1 or 3.6.
A similar one for master is available too, see #6293