### PR TITLE
[MU4] Rename note Hooks to Flags, to match SMuFL terms and some more text fixes

### DIFF
--- a/libmscore/hook.cpp
+++ b/libmscore/hook.cpp
@@ -79,7 +79,7 @@ void Hook::setHookType(int i)
     case -8:   setSym(SymId::flag1024thDown);
         break;
     default:
-        qDebug("no hook for subtype %d", i);
+        qDebug("no hook/flag for subtype %d", i);
         break;
     }
 }

--- a/libmscore/scoreElement.cpp
+++ b/libmscore/scoreElement.cpp
@@ -62,7 +62,7 @@ static const ElementName elementNames[] = {
     { ElementType::CHORDLINE,            "ChordLine",            QT_TRANSLATE_NOOP("elementName", "Chord Line") },
     { ElementType::DYNAMIC,              "Dynamic",              QT_TRANSLATE_NOOP("elementName", "Dynamic") },
     { ElementType::BEAM,                 "Beam",                 QT_TRANSLATE_NOOP("elementName", "Beam") },
-    { ElementType::HOOK,                 "Hook",                 QT_TRANSLATE_NOOP("elementName", "Hook") },
+    { ElementType::HOOK,                 "Hook",                 QT_TRANSLATE_NOOP("elementName", "Flag") }, // internally called "Hook", but "Flag" in SMuFL, so here externally too
     { ElementType::LYRICS,               "Lyrics",               QT_TRANSLATE_NOOP("elementName", "Lyrics") },
     { ElementType::FIGURED_BASS,         "FiguredBass",          QT_TRANSLATE_NOOP("elementName", "Figured Bass") },
     { ElementType::MARKER,               "Marker",               QT_TRANSLATE_NOOP("elementName", "Marker") },

--- a/mscore/debugger/chord.ui
+++ b/mscore/debugger/chord.ui
@@ -56,7 +56,7 @@
          <string notr="true"/>
         </property>
         <property name="text">
-         <string notr="true">Hook</string>
+         <string notr="true">Flag</string>
         </property>
        </widget>
       </item>

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -2117,7 +2117,7 @@
            <item row="0" column="0">
             <widget class="QLabel" name="label_91">
              <property name="text">
-              <string>Bracket thickness:</string>
+              <string comment="System bracket">Bracket thickness:</string>
              </property>
              <property name="buddy">
               <cstring>bracketWidth</cstring>
@@ -2171,7 +2171,7 @@
            <item row="1" column="0">
             <widget class="QLabel" name="label_52">
              <property name="text">
-              <string>Bracket distance:</string>
+              <string comment="System bracket">Bracket distance:</string>
              </property>
              <property name="buddy">
               <cstring>bracketDistance</cstring>
@@ -5083,7 +5083,7 @@
               <item row="0" column="0">
                <widget class="QLabel" name="label_6">
                 <property name="text">
-                 <string>Bracket thickness:</string>
+                 <string comment="Tuplet bracket">Bracket thickness:</string>
                 </property>
                 <property name="buddy">
                  <cstring>tupletBracketWidth</cstring>
@@ -5129,7 +5129,7 @@
               <item row="1" column="0">
                <widget class="QLabel" name="label_187">
                 <property name="text">
-                 <string>Bracket hook height:</string>
+                 <string comment="Tuplet bracket">Bracket hook height:</string>
                 </property>
                </widget>
               </item>

--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -126,7 +126,7 @@ void StaffListItem::initStaffTypeCombo(bool forceRecreate)
 void StaffListItem::setPartIdx(int val)
 {
     _partIdx = val;
-    setText(0, InstrumentsWidget::tr("Staff %1").arg(_partIdx + 1));
+    setText(0, InstrumentsWidget::tr("Staff: %1").arg(_partIdx + 1));
 }
 
 //---------------------------------------------------------

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -2539,7 +2539,7 @@
              <string>Instrument list 1</string>
             </property>
             <property name="accessibleDescription">
-             <string>Insert path to a instrument list file</string>
+             <string>Insert path to an instrument list file</string>
             </property>
            </widget>
           </item>
@@ -2629,7 +2629,7 @@
              <string>Instrument list 2</string>
             </property>
             <property name="accessibleDescription">
-             <string>Insert path to a instrument list file</string>
+             <string>Insert path to an instrument list file</string>
             </property>
            </widget>
           </item>

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4855,7 +4855,7 @@ void ScoreView::appendMeasures(int n, ElementType type)
     if (_score->noStaves()) {
         QMessageBox::warning(0, "MuseScore",
                              tr("No staves found:\n"
-                                "please use the instruments dialog to\n"
+                                "Please use the instruments dialog to\n"
                                 "first create some staves"));
         return;
     }

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -30,8 +30,8 @@ Shortcut Shortcut::_sc[] = {
         MsWidget::MAIN_WINDOW,
         STATE_ALL,
         "help",
-        QT_TRANSLATE_NOOP("action","Online Handbook…"),    // Appears in menu
-        QT_TRANSLATE_NOOP("action","Online handbook"),       // Appears in Edit > Preferences > Shortcuts
+        QT_TRANSLATE_NOOP("action","Online Handbook…"),      // Appears in menu, so Title Case
+        QT_TRANSLATE_NOOP("action","Online handbook"),       // Appears in Edit > Preferences > Shortcuts, so Sentence case
         QT_TRANSLATE_NOOP("action","Show online handbook"),  // Appears if you use Help > What's This?
         Icons::Invalid_ICON,
         Qt::ApplicationShortcut,
@@ -824,7 +824,7 @@ Shortcut Shortcut::_sc[] = {
         STATE_NORMAL | STATE_NOTE_ENTRY,
         "move-up",
         QT_TRANSLATE_NOOP("action","Move Up"),
-        QT_TRANSLATE_NOOP("action","Move up"),
+        QT_TRANSLATE_NOOP("action","Move chord/rest to staff above"),
         0,
         Icons::Invalid_ICON,
         Qt::WindowShortcut,
@@ -988,7 +988,7 @@ Shortcut Shortcut::_sc[] = {
         STATE_NORMAL | STATE_NOTE_ENTRY,
         "move-down",
         QT_TRANSLATE_NOOP("action","Move Down"),
-        QT_TRANSLATE_NOOP("action","Move down"),
+        QT_TRANSLATE_NOOP("action","Move chord/rest to staff below"),
         0,
         Icons::Invalid_ICON,
         Qt::WindowShortcut,

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -315,7 +315,7 @@ void WorkspacesManager::remove(Workspace* workspace)
 
 static void writeFailed(const QString& _path)
 {
-    QString s = qApp->translate("Workspace", "Writing Workspace File\n%1\nfailed: ");
+    QString s = qApp->translate("Workspace", "Writing Workspace File\n%1\nfailed");
     QMessageBox::critical(mscore, qApp->translate("Workspace", "Writing Workspace File"), s.arg(_path));
 }
 

--- a/mu4/inspector/models/notation/notes/hooks/hooksettingsmodel.cpp
+++ b/mu4/inspector/models/notation/notes/hooks/hooksettingsmodel.cpp
@@ -6,7 +6,7 @@ HookSettingsModel::HookSettingsModel(QObject* parent, IElementRepositoryService*
     : AbstractInspectorModel(parent, repository)
 {
     setModelType(TYPE_HOOK);
-    setTitle(tr("Hook"));
+    setTitle(tr("Flag")); // internally called "Hook", but "Flag" in SMuFL, so here externally too
 
     createProperties();
 }


### PR DESCRIPTION
and to differentiate from line hooks. Also the new Inspector uses "Flag offset" already.

Change some more strings too. Including some that came up as an issue on Transifex.

Counterpart to #6292, but for master