### PR TITLE
fix AppVeyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: C:\MuseScore
 # set clone depth
 clone_depth: 50                      # clone entire repository history if not defined
 
-image: Visual Studio 2019
+image: Previous Visual Studio 2019
 
 branches:
   only:


### PR DESCRIPTION
at least for now...
The [July 3rd update of AppVeyor](https://www.appveyor.com/updates/2020/07/03/) updated to MSVC 16.6.3, which triggers a [Qt 5.9 bug](https://bugreports.qt.io/browse/QTBUG-81727)
Another possible fix would be to patch Qt 5.9 as per https://codereview.qt-project.org/c/qt/qtbase/+/301315/1/src/corelib/tools/qlinkedlist.h, a rather simple 2-line change and we're using a 'private' Qt version anyhow. This though is nothing a PR could do.
I can provide archives with the patch.

As LTS for 5.9 had just ended in May, for master we'd better move to Qt 5.12.9 or 5.15.0 or later, which have the above bug fixed, but for 3.x we should IMHO better stay on Qt 5.9 (but maybe move to the latest 5.9.9, we're still using 5.9.8)

See also https://t.me/musescoreeditorchat/78898 ff.