### PR TITLE
fix #307593: prevent duplicated icon on Ubuntu

### DIFF
--- a/build/Linux+BSD/mscore.desktop.in
+++ b/build/Linux+BSD/mscore.desktop.in
@@ -10,6 +10,7 @@ Comment[fr]=Gravure de partitions musicales
 Exec=mscore@MSCORE_INSTALL_SUFFIX@ %F
 Icon=mscore@MSCORE_INSTALL_SUFFIX@
 StartupNotify=true
+StartupWMClass=mscore@MSCORE_INSTALL_SUFFIX@
 Terminal=false
 Type=Application
 Categories=Qt;Audio;Sequencer;Midi;AudioVideoEditing;Music;AudioVideo;


### PR DESCRIPTION
resolves https://musescore.org/en/node/307593