### PR TITLE
Fix #307323: Vertical-frame dragging with vertical-scrolling performs…

### DIFF
--- a/libmscore/box.cpp
+++ b/libmscore/box.cpp
@@ -136,7 +136,7 @@ void Box::startEditDrag(EditData& ed)
 void Box::editDrag(EditData& ed)
       {
       if (isVBox()) {
-            _boxHeight = Spatium((ed.pos.y() - abbox().y()) / spatium());
+            _boxHeight += Spatium(ed.delta.y() / spatium());
             if (ed.vRaster) {
                   qreal vRaster = 1.0 / MScore::vRaster();
                   int n = lrint(_boxHeight.val() / vRaster);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/307323 with a little conversation @ https://musescore.org/en/node/307226

This bug has been outstanding since 2.x days (for all I know even before that), but seems like few use vertical scrolling extensively to find it. See the "resolves" link for more information. This one liner fix takes care of the issue and I've yet to find any negative after-effects. For people like me who use vertical scrolling + page width + occasional mouse dragging, this is important to get rid of the nasty jumping behavior as demonstrated in the issue + forum conversation. The y-offset was cumulatively summing (# of pages * heights) + offset, strangely enough, and this only seemed to happen when vertical scrolling + Page View (not Single Page) were enabled. 

<!-- Use "x" to fill the checkboxes below like [x] -->
- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
