### PR TITLE
[master] Changed appimage release path from continuous to 12 +collect_artifacts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,8 @@ clone_folder: C:\MuseScore
 # set clone depth
 clone_depth: 50                      # clone entire repository history if not defined
 
-image: Visual Studio 2019
+# see https://github.com/musescore/MuseScore/pull/6294
+image: Previous Visual Studio 2019
 
 branches:
   only:

--- a/.github/workflows/collect_artifacts.yml
+++ b/.github/workflows/collect_artifacts.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Build the AppImage
       if: contains( env.commitmsg, 'collect_artifacts')
       run: |
-        sudo docker run -i -v "${PWD}:/MuseScore" "musescore/musescore-x86_64:latest" ./Recipe
+        sudo docker run -i -v "${PWD}:/MuseScore" "musescore/musescore-x86_64:latest" /MuseScore/build/Linux+BSD/portable/Recipe
     - name: Upload Linux AppImage artifact
       if: contains( env.commitmsg, 'collect_artifacts')
       uses: actions/upload-artifact@v1

--- a/build/Linux+BSD/portable/Recipe
+++ b/build/Linux+BSD/portable/Recipe
@@ -154,15 +154,15 @@ function download_github_release()
 
 function download_appimage_release()
 {
-  local -r github_repo_slug="$1" binary_name="$2"
+  local -r github_repo_slug="$1" binary_name="$2" tag="$3"
   local -r appimage="${binary_name}-x86_64.AppImage"
-  download_github_release "${github_repo_slug}" continuous "${appimage}"
+  download_github_release "${github_repo_slug}" "${tag}" "${appimage}"
   extract_appimage "${appimage}" "${binary_name}"
 }
 
 function download_linuxdeploy_component()
 {
-  download_appimage_release "linuxdeploy/$1" "$1"
+  download_appimage_release "linuxdeploy/$1" "$1" continuous
 }
 
 # GET LATEST APPIMAGETOOL AND LINUXDEPLOY
@@ -174,7 +174,8 @@ function download_linuxdeploy_component()
 if [[ ! -d "appimagetool" ]]; then
   mkdir appimagetool
   cd appimagetool
-  download_appimage_release AppImage/AppImageKit appimagetool
+  # `12` and not `continuous` because see https://github.com/AppImage/AppImageKit/issues/1060
+  download_appimage_release AppImage/AppImageKit appimagetool 12
   cd ..
 fi
 export PATH="${PWD%/}/appimagetool:$PATH"


### PR DESCRIPTION
Now no image https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
See AppImage/AppImageKit#1060
Changed to the latest release (12) with this image