### PR TITLE
Make the check for the soundfont name case insensitive

### DIFF
--- a/libmscore/instrument.cpp
+++ b/libmscore/instrument.cpp
@@ -823,7 +823,7 @@ void Channel::switchExpressive(Synthesizer* synth, bool expressive, bool force /
       if (fontsInfo.empty())
             return;
       const auto& info = fontsInfo.front();
-      if (!info.fontName.contains("MuseScore_General")) {
+      if (!info.fontName.contains("MuseScore_General", Qt::CaseInsensitive)) {
             qDebug().nospace() << "Soundfont '" << info.fontName << "' is not MuseScore General, cannot update expressive";
             return;
             }


### PR DESCRIPTION
as it changed from `MuseScore_General v0.1.8` to `Musescore_General v0.2`, note the 2nd `s`.

This is not about the soundfont's file name (which would be case insensitive on Windows, but not on Mac and Linux), but about its internal meta data.