### PR TITLE
Fix #307623: Y offsets change when stave space is changed

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1686,6 +1686,9 @@ void ChangeStyleVal::flip(EditData*)
                         score->style().chordList()->read(score->styleSt(Sid::chordDescriptionFile));
                         }
                         break;
+                  case Sid::spatium:
+                        score->spatiumChanged(v.toDouble(), value.toDouble());
+                        break;
                   default:
                         break;
                   }

--- a/mscore/pagesettings.cpp
+++ b/mscore/pagesettings.cpp
@@ -311,13 +311,7 @@ void PageSettings::applyToScore(Score* s)
       s->undoChangeStyleVal(Sid::pageOddBottomMargin, oddPageBottomMargin->value() * f);
       s->undoChangeStyleVal(Sid::pageOddLeftMargin, oddPageLeftMargin->value() * f);
       s->undoChangeStyleVal(Sid::pageTwosided, twosided->isChecked());
-
-      qreal oldSpatium = s->spatium();
-      qreal newSpatium = spatiumEntry->value() * f1;
-      s->undoChangeStyleVal(Sid::spatium, newSpatium);
-      if (oldSpatium != newSpatium)
-            s->spatiumChanged(oldSpatium, newSpatium);
-
+      s->undoChangeStyleVal(Sid::spatium, spatiumEntry->value() * f1);
       s->undoChangePageNumberOffset(pageOffsetEntry->value() - 1);
       }
 

--- a/mscore/plugin/api/style.cpp
+++ b/mscore/plugin/api/style.cpp
@@ -94,21 +94,7 @@ void MStyle::setValue(const QString& key, QVariant value) {
 
       if (_score) {
             // Style belongs to actual score: change style value in undoable way
-            switch (sid) {
-                  case Sid::spatium: {
-                        const qreal oldSpatium = _score->spatium();
-                        const qreal newSpatium = value.toReal();
-
-                        if (newSpatium > 0.0 && oldSpatium != newSpatium) {
-                              _score->undoChangeStyleVal(Sid::spatium, newSpatium);
-                              _score->spatiumChanged(oldSpatium, newSpatium);
-                              }
-                        }
-                        break;
-                  default:
-                        _score->undoChangeStyleVal(sid, value);
-                        break;
-                  }
+            _score->undoChangeStyleVal(sid, value);
             }
       else {
             // Style is not bound to a score: change the value directly


### PR DESCRIPTION
Resolves: https://musescore.org/node/307623.

This reverts #5699 and calls `Score::spatiumChanged()` from within `ChangeStyleVal::flip()`. Not only does it now do the right thing on undo, but it solves the rest of the problem that was introduced recently.