### PR TITLE
followup to PR #6315

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -670,7 +670,9 @@ void LineSegment::editDrag(EditData& ed)
 void LineSegment::spatiumChanged(qreal ov, qreal nv)
       {
       Element::spatiumChanged(ov, nv);
-      _offset2 *= nv / ov;
+      qreal scale = nv / ov;
+      line()->setLineWidth(line()->lineWidth() * scale);
+      _offset2 *= scale;
       }
 
 //---------------------------------------------------------

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2261,10 +2261,11 @@ void Note::scanElements(void* data, void (*func)(void*, Element*), bool all)
             func(data, _accidental);
       for (NoteDot* dot : _dots)
             func(data, dot);
-      if (_tieFor && !_tieFor->spannerSegments().empty())
-            _tieFor->spannerSegments().front()->scanElements(data, func, all);
-      if (_tieBack && _tieBack->spannerSegments().size() > 1)
-            _tieBack->spannerSegments().back()->scanElements(data, func, all);
+      // see above - tie segments are still collected from System!
+      //if (_tieFor && !_tieFor->spannerSegments().empty())
+      //      _tieFor->spannerSegments().front()->scanElements(data, func, all);
+      //if (_tieBack && _tieBack->spannerSegments().size() > 1)
+      //      _tieBack->spannerSegments().back()->scanElements(data, func, all);
       }
 
 //---------------------------------------------------------

--- a/libmscore/pedal.cpp
+++ b/libmscore/pedal.cpp
@@ -40,6 +40,7 @@ static const ElementStyle pedalStyle {
       { Sid::pedalBeginTextOffset,               Pid::BEGIN_TEXT_OFFSET       },
       { Sid::pedalBeginTextOffset,               Pid::CONTINUE_TEXT_OFFSET    },
       { Sid::pedalBeginTextOffset,               Pid::END_TEXT_OFFSET         },
+      { Sid::pedalLineWidth,                     Pid::LINE_WIDTH              },
       { Sid::pedalPlacement,                     Pid::PLACEMENT               },
       { Sid::pedalPosBelow,                      Pid::OFFSET                  },
       };

--- a/libmscore/slurtie.cpp
+++ b/libmscore/slurtie.cpp
@@ -105,6 +105,7 @@ void SlurTieSegment::move(const QPointF& s)
 
 void SlurTieSegment::spatiumChanged(qreal oldValue, qreal newValue)
       {
+      Element::spatiumChanged(oldValue, newValue);
       qreal diff = newValue / oldValue;
       for (UP& u : _ups)
             u.off *= diff;

--- a/mtest/libmscore/compat114/pedal-ref.mscx
+++ b/mtest/libmscore/compat114/pedal-ref.mscx
@@ -102,6 +102,7 @@
               <beginText>&lt;sym&gt;keyboardPedalPed&lt;/sym&gt;</beginText>
               <endHookHeight>-1.5</endHookHeight>
               <lineWidth>0.006</lineWidth>
+              <lineWidth>0.006</lineWidth>
               </Pedal>
             <next>
               <location>


### PR DESCRIPTION
See https://github.com/musescore/MuseScore/pull/6315

This helps complete the resolution of https://musescore.org/node/307623.

Fixes a few cases where scaling still is not performed properly
because an individual element is not scaling itself properly
or its parent is scaling it multiple times (ties).
In the case of pedal, the scaling problem happens on add,
because the line width was never listed as a styled property.

This PR can either be merged after #6313 or the commit can be borrowed and added to that PR.