### PR TITLE
[master] AppImage: Bundle OpenSSL to fix Save Online on recent distros

### DIFF
--- a/build/Linux+BSD/portable/Recipe
+++ b/build/Linux+BSD/portable/Recipe
@@ -53,6 +53,7 @@ apt_packages_runtime=(
   libegl1-mesa-dev
   libodbc1
   libpq-dev
+  libssl1.0.0
   libxcomposite-dev
   libxcursor-dev
   libxi-dev
@@ -275,7 +276,8 @@ additional_qt_components=(
 # linuxdeploy may have missed some libraries that we need
 # Report new additions at https://github.com/linuxdeploy/linuxdeploy/issues
 additional_libraries=(
-  # none
+  libssl.so.1.0.0    # OpenSSL (for Save Online)
+  libcrypto.so.1.0.0 # OpenSSL (for Save Online)
 )
 
 # FALLBACK LIBRARIES


### PR DESCRIPTION
Port PR #6249 to the master branch.

The [first commit](https://github.com/musescore/MuseScore/pull/6249/commits/adde9b83dc2a2969c1ed16cb193ee99a072f3cf7) from that PR has been dropped since its changes were implemented in master by PR #6311 commit [8ea3376912](https://github.com/musescore/MuseScore/pull/6311/commits/8ea3376912f5aa2ecb60f260117f0490d67045b8).