### PR TITLE
fix #307720: assertion failure adding image to vertical frame

### DIFF
--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -296,7 +296,7 @@ void ScoreView::elementPropertyAction(const QString& cmd, Element* e)
                   }
             }
       else if (cmd == "picture") {
-            mscore->addImage(score(), toHBox(e));
+            mscore->addImage(score(), e);
             }
       else if (cmd == "frame-text") {
             Text* t = new Text(score(), Tid::FRAME);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/307720

we are tryng to cast an element to an HBox that isn't necessarily one.
No reason to do this; it works just fine without the cast.