### PR TITLE
fix #307721: blank lines ignored at top of text elements

### DIFF
--- a/libmscore/textbase.h
+++ b/libmscore/textbase.h
@@ -196,6 +196,7 @@ class TextBlock {
       void layout(TextBase*);
       const QList<TextFragment>& fragments() const { return _fragments; }
       QList<TextFragment>& fragments()             { return _fragments; }
+      QList<TextFragment>* fragmentsWithoutEmpty();
       const QRectF& boundingRect() const           { return _bbox; }
       QRectF boundingRect(int col1, int col2, const TextBase*) const;
       int columns() const;
@@ -205,7 +206,7 @@ class TextBlock {
       QString remove(int column, TextCursor*);
       QString remove(int start, int n, TextCursor*);
       int column(qreal x, TextBase*) const;
-      TextBlock split(int column);
+      TextBlock split(int column, TextCursor* cursor);
       qreal xpos(int col, const TextBase*) const;
       const CharFormat* formatAt(int) const;
       const TextFragment* fragment(int col) const;

--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -521,15 +521,21 @@ void SplitJoinText::join(EditData* ed)
       CharFormat* charFmt = c.format();         // take current format
       int col             = t->textBlock(line-1).columns();
       int eol             = t->textBlock(line).eol();
-      t->textBlock(line-1).fragments().append(t->textBlock(line).fragments());
+      auto fragmentsList = t->textBlock(line).fragmentsWithoutEmpty();
+      if (fragmentsList->size() > 0)
+            t->textBlock(line-1).removeEmptyFragment();
+      t->textBlock(line-1).fragments().append(*fragmentsList);
+      delete fragmentsList;
       int lines = t->rows();
       if (line < lines)
             t->textBlock(line).setEol(eol);
       t->textBlockList().removeAt(line);
+
       c.setRow(line-1);
       c.setColumn(col);
       c.setFormat(*charFmt);             // restore orig. format at new line
       c.clearSelection();
+
       if (ed)
             *t->cursor(*ed) = c;
       c.text()->setTextInvalid();
@@ -543,7 +549,7 @@ void SplitJoinText::split(EditData* ed)
       t->triggerLayout();
 
       CharFormat* charFmt = c.format();         // take current format
-      t->textBlockList().insert(line + 1, c.curLine().split(c.column()));
+      t->textBlockList().insert(line + 1, c.curLine().split(c.column(), t->cursor(*ed)));
       c.curLine().setEol(true);
 
       c.setRow(line+1);


### PR DESCRIPTION
Resolves: Blank lines added before the first line of text would disappear when not editing.

Edit: The source of the problem is that blank lines have no bounding boxes, since they are empty. Essentially they are ignored during layout. I added handling for that. I also improved the handling of empty text fragments and modified genText (which saves all information about the text as text) to include them.
 
- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made
