### PR TITLE
Code style: Allow Uncrustify scripts to run from repository root

### DIFF
--- a/tools/codestyle/uncrustify_run.sh
+++ b/tools/codestyle/uncrustify_run.sh
@@ -1,15 +1,37 @@
 #!/usr/bin/env bash
 
-DIR="$1"
+# Go to repository root directory regardless of where script was run from:
+cd "${BASH_SOURCE%/*}/../.."
 
-SRC_DIRS="aeolus audio audiofile avsomr awl bww2mxml crashreporter effects fonttools global importexport \
-libmscore main miditools mscore mtest omr telemetry"
+HERE="tools/codestyle" # path to dir that contains this script
+
+SRC_DIRS=(
+    # Alphabetical order please!
+    aeolus
+    audio
+    audiofile
+    avsomr
+    awl
+    bww2mxml
+    crashreporter
+    effects
+    fonttools
+    global
+    importexport
+    libmscore
+    main
+    miditools
+    mscore
+    mtest
+    omr
+    telemetry
+)
 
 START_TIME=$(date +%s)
 
-for var in $SRC_DIRS
+for dir in "${SRC_DIRS[@]}"
 do
-    uncrustify_run_dir.sh $DIR/$var
+    "${HERE}/uncrustify_run_dir.sh" "${dir}"
 done
 
 END_TIME=$(date +%s)

--- a/tools/codestyle/uncrustify_run_dir.sh
+++ b/tools/codestyle/uncrustify_run_dir.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
-DIR="$1"
+HERE="${BASH_SOURCE%/*}" # path to dir that contains this script
+
+DIR="${1-.}" # use $1 or "." (current dir) if $1 is not defined
 
 START_TIME=$(date +%s)
 
 find $DIR -type f -regex '.*\.\(cpp\|h\|hpp\|cc\)$' | xargs -n 1 -P 16 \
-uncrustify -c uncrustify_musescore.cfg --no-backup -l CPP
+    uncrustify -c "${HERE}/uncrustify_musescore.cfg" --no-backup -l CPP
 
 END_TIME=$(date +%s)
 DIFF_TIME=$(( $END_TIME - $START_TIME ))

--- a/tools/codestyle/uncrustify_run_file.sh
+++ b/tools/codestyle/uncrustify_run_file.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-FILE="$1"
+HERE="${BASH_SOURCE%/*}" # path to dir that contains this script
 
-uncrustify -c uncrustify_musescore.cfg --no-backup -l CPP $FILE
+exec uncrustify -c "${HERE}/uncrustify_musescore.cfg" --no-backup -l CPP "$@"


### PR DESCRIPTION
Enables scripts to be used like this:

```bash
tools/codestyle/uncrustify_run_file.sh libmscore/note.cpp libmscore/measure.cpp
```

Instead of having to do this:

```bash
cd tools/codestyle
./uncrustify_run_dir.sh ../../libmscore/note.cpp
./uncrustify_run_dir.sh ../../libmscore/measure.cpp
```

Though the latter syntax will still work if that's what you prefer.

Plus a few other improvements to Bash syntax.