### PR TITLE
Fix #307741 images attached to measures don't propagate between score and existing parts

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4513,6 +4513,7 @@ void Score::undoAddElement(Element* element)
          && et != ElementType::TREMOLO
          && et != ElementType::ARPEGGIO
          && et != ElementType::SYMBOL
+         && et != ElementType::IMAGE
          && et != ElementType::TREMOLOBAR
          && et != ElementType::FRET_DIAGRAM
          && et != ElementType::FERMATA

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -4271,6 +4271,18 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                         e->layout();
                   }
             }
+
+      //-------------------------------------------------------------
+      // Image
+      //-------------------------------------------------------------
+
+      for (const Segment* s : sl) {
+            for (Element* e : s->annotations()) {
+                  if (e->isImage())
+                        e->layout();
+                  }
+            }
+
       }
 
 //---------------------------------------------------------

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1952,16 +1952,6 @@ void Measure::read(XmlReader& e, int staffIdx)
                   e.setTick(tick());
                   readVoice(e, staffIdx, irregular);
                   }
-            else if (tag == "Image") {
-                  if (MScore::noImages)
-                        e.skipCurrentElement();
-                  else {
-                        Element* el = Element::name2Element(tag, score());
-                        el->setTrack(staffIdx * VOICES);
-                        el->read(e);
-                        add(el);
-                        }
-                  }
             else if (tag == "Marker" || tag == "Jump") {
                   Element* el = Element::name2Element(tag, score());
                   el->setTrack(e.track());
@@ -2314,9 +2304,6 @@ void Measure::readVoice(XmlReader& e, int staffIdx, bool irregular)
                   fermata->setPlacement(fermata->track() & 1 ? Placement::BELOW : Placement::ABOVE);
                   fermata->read(e);
                   }
-            // There could be an Image here if the score was saved with an earlier version of MuseScore 3.
-            // This image would not have been visible upon reload. Let's read it in and add it directly
-            // to the measure so that it can be displayed.
             else if (tag == "Image") {
                   if (MScore::noImages)
                         e.skipCurrentElement();
@@ -2324,7 +2311,8 @@ void Measure::readVoice(XmlReader& e, int staffIdx, bool irregular)
                         Element* el = Element::name2Element(tag, score());
                         el->setTrack(e.track());
                         el->read(e);
-                        add(el);
+                        segment = getSegment(SegmentType::ChordRest, e.tick());
+                        segment->add(el);
                         }
                   }
             //----------------------------------------------------

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -2048,7 +2048,8 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                         Element* el = Element::name2Element(tag, m->score());
                         el->setTrack(e.track());
                         el->read(e);
-                        m->add(el);
+                        segment = m->getSegment(SegmentType::ChordRest, e.tick());
+                        segment->add(el);
                         }
                   }
             else if (tag == "stretch") {

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -3343,7 +3343,8 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                         Element* el = Element::name2Element(tag, score);
                         el->setTrack(e.track());
                         el->read(e);
-                        m->add(el);
+                        segment = m->getSegment(SegmentType::ChordRest, e.tick());
+                        segment->add(el);
                         }
                   }
             //----------------------------------------------------

--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -464,13 +464,7 @@ void ScoreView::dropEvent(QDropEvent* event)
                               el = _score->pos2measure(pos, &staffIdx, 0, &seg, &offset);
                               if (el && el->isMeasure()) {
                                     editData.dropElement->setTrack(staffIdx * VOICES);
-                                    if (editData.dropElement->isImage()) {
-                                          editData.dropElement->setParent(el);
-                                          offset = pos - el->canvasPos();
-                                          }
-                                    else {
-                                          editData.dropElement->setParent(seg);
-                                          }
+                                    editData.dropElement->setParent(seg);
                                     if (applyUserOffset)
                                           editData.dropElement->setOffset(offset);
                                     score()->undoAddElement(editData.dropElement);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/307741.

#5445 made images added to measures children of the measure rather than children of the measure's first segment. This turned out to be not such a great idea after all, since it really only solved a problem that is better solved by simply turning off automatic placement for the image. So this reverts that change.

http://musescore.org/en/node/292606 is better solved by making sure to layout images within Score::layoutSystemElements(). Since there is no way to know the purpose of any particular image, I do not know that we can come up with a better ordering of the layout of images in relation to other system elements.

Finally, regarding https://musescore.org/en/node/307741, there is code to correctly deal with images, but it is not reached unless ElementType::IMAGE is excluded from what is handled earlier.