### PR TITLE
Fix #290157: Ledger lines with staff type change

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -698,8 +698,11 @@ void Chord::addLedgerLines()
       // the line pos corresponding to the bottom line of the staff
       int lineBelow      = 8;                   // assuming 5-lined "staff"
       qreal lineDistance = 1;
-      qreal mag         = 1;
+      qreal mag          = 1;
       bool staffVisible  = true;
+      // for staff changes
+      qreal yOffset      = 0.0;
+      int stepOffset     = 0;
 
       if (segment()) { //not palette
             Fraction tick = segment()->tick();
@@ -710,10 +713,12 @@ void Chord::addLedgerLines()
             lineDistance  = st->lineDistance(tick);
             mag           = staff()->mag(tick);
             staffVisible  = !staff()->invisible();
+            yOffset       = st->staffType(tick)->yoffset().val();
+            stepOffset    = st->staffType(tick)->stepOffset();
             }
 
       // need ledger lines?
-      if (downLine() <= lineBelow + 1 && upLine() >= -1)
+      if (downLine() + stepOffset <= lineBelow + 1 && upLine() + stepOffset >= -1)
             return;
 
       // the extra length of a ledger line with respect to notehead (half of it on each side)
@@ -746,7 +751,7 @@ void Chord::addLedgerLines()
                   }
             for (int i = from; i < int(n) && i >= 0 ; i += delta) {
                   Note* note = _notes.at(i);
-                  int l = note->line();
+                  int l = note->line() + stepOffset;
 
                   // if 1st pass and note not below staff or 2nd pass and note not above staff
                   if ((!j && l <= lineBelow + 1) || (j && l >= -1))
@@ -831,7 +836,7 @@ void Chord::addLedgerLines()
                         h->setTrack(track);
                         h->setVisible(lld.visible && staffVisible);
                         h->setLen(lld.maxX - lld.minX);
-                        h->setPos(lld.minX, lld.line * _spatium * stepDistance);
+                        h->setPos(lld.minX, (lld.line * stepDistance + yOffset) * _spatium);
                         h->setNext(_ledgerLines);
                         _ledgerLines = h;
                         }


### PR DESCRIPTION
Resolves: *https://musescore.org/en/node/290157*

Displays ledger lines at correct y position after a ***Staff type change with offset***.
Additionally, calculates correct number of ledger lines accordingly to the Staff type change ***step Offset***.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- N/A I created the test (mtest, vtest, script test) to verify the changes I made
