### PR TITLE
fix #307841: crashes and more with hbox within vbox

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2998,6 +2998,8 @@ void Score::insertMeasure(ElementType type, MeasureBase* measure, bool createEmp
             MeasureBase* mb = toMeasureBase(Element::create(type, score));
             mb->setTick(tick);
 
+            if (im)
+                  im = im->top(); // don't try to insert in front of nested frame
             mb->setNext(im);
             mb->setPrev(im ? im->prev() : score->last());
             if (mb->isMeasure()) {

--- a/libmscore/measurebase.cpp
+++ b/libmscore/measurebase.cpp
@@ -302,13 +302,42 @@ void MeasureBase::layout()
       }
 
 //---------------------------------------------------------
+//   top
+//---------------------------------------------------------
+
+MeasureBase* MeasureBase::top() const
+      {
+      const MeasureBase* mb = this;
+      while (mb->parent()) {
+            if (mb->parent()->isMeasureBase())
+                  mb = toMeasureBase(mb->parent());
+            else
+                  break;
+            }
+      return const_cast<MeasureBase*>(mb);
+      }
+
+//---------------------------------------------------------
+//   tick
+//---------------------------------------------------------
+
+Fraction MeasureBase::tick() const
+      {
+      const MeasureBase* mb = top();
+      return mb ? mb->_tick : Fraction(-1, 1);
+      }
+
+//---------------------------------------------------------
 //   triggerLayout
 //---------------------------------------------------------
 
 void MeasureBase::triggerLayout() const
       {
-      if (prev() || next()) // avoid triggering layout before getting added to a score
-            score()->setLayout(tick(), -1, this);
+      // for measurebases within other measurebases (e.g., hbox within vbox), use top level
+      const MeasureBase* mb = top();
+      // avoid triggering layout before getting added to a score
+      if (mb->prev() || mb->next())
+            score()->setLayout(mb->tick(), -1, this);
       }
 
 //---------------------------------------------------------

--- a/libmscore/measurebase.h
+++ b/libmscore/measurebase.h
@@ -88,6 +88,7 @@ class MeasureBase : public Element {
       MeasureBase* prev() const              { return _prev;   }
       MeasureBase* prevMM() const;
       void setPrev(MeasureBase* e)           { _prev = e;      }
+      MeasureBase *top() const;
 
       Ms::Measure* nextMeasure() const;
       Ms::Measure* prevMeasure() const;
@@ -120,7 +121,7 @@ class MeasureBase : public Element {
       virtual void writeProperties(XmlWriter&) const override;
       virtual bool readProperties(XmlReader&) override;
 
-      Fraction tick() const                { return _tick; }
+      Fraction tick() const override;
       void setTick(const Fraction& f)      { _tick = f;    }
 
       Fraction ticks() const               { return _len;         }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/307841

When adding an hbox within a vbox,
we never set its tick,
and as a result other operations that depend on the tick
(like triggering layout) do not work correctly.
This is fixed by overriding HBox::tick() to check the parent.
It was also necessary to alter MeasureBase::triggerLayout(),
as it actually did nothing for hbox-within-vbox,
because it checks for prev() and next() which are nullptr here.
That check is needed to avoid triggering layout for measurebases
that are not yet added to the score.
This problem is solved here by checking the parent,
just as is done for the tick itself.