### PR TITLE
fix #307900: Crash when switching voices if notes are tied

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -2276,7 +2276,7 @@ void ChangeSpannerElements::flip(EditData*)
       Element*    oldEndElement     = spanner->endElement();
       if (spanner->anchor() == Spanner::Anchor::NOTE) {
             // be sure new spanner elements are of the right type
-            if (!startElement->isNote() || !endElement->isNote())
+            if (!startElement || !startElement->isNote() || !endElement || !endElement->isNote())
                   return;
             Note* oldStartNote = toNote(oldStartElement);
             Note* oldEndNote = toNote(oldEndElement);


### PR DESCRIPTION
Resolves https://musescore.org/en/node/307900
Probably to late for 3.5RC or 3.5.0 final (not being a regression) but might be something for 3.5.1