### PR TITLE
Fix #307904: Ledger Lines misaligned when using arbitrary staff line …

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -798,8 +798,6 @@ void Chord::addLedgerLines()
                   if (l < minLine) {
                         for (int i1 = l; i1 < minLine; i1 += 2) {
                               lld.line = i1;
-                              if (lineDistance != 1.0)
-                                    lld.line *= lineDistance;
                               lld.minX = minX;
                               lld.maxX = maxX;
                               lld.visible = visible;
@@ -811,8 +809,6 @@ void Chord::addLedgerLines()
                   if (l > maxLine) {
                         for (int i1 = maxLine+2; i1 <= l; i1 += 2) {
                               lld.line = i1;
-                              if (lineDistance != 1.0)
-                                    lld.line *= lineDistance;
                               lld.minX = minX;
                               lld.maxX = maxX;
                               lld.visible = visible;
@@ -824,7 +820,7 @@ void Chord::addLedgerLines()
                   }
             if (minLine < 0 || maxLine > lineBelow) {
                   qreal _spatium = spatium();
-                  qreal stepDistance = 0.5;     // staff() ? staff()->lineDistance() * 0.5 : 0.5;
+                  qreal stepDistance = lineDistance * 0.5;
                   for (auto lld : vecLines) {
                         LedgerLine* h = new LedgerLine(score());
                         h->setParent(this);


### PR DESCRIPTION
Resolves: *https://musescore.org/en/node/307904*

Fixes problem: Ledger lines only show correctly when staff line spacing set to 0.5 increments (i.e. 1.5 or 2.0). With any other arbitrary number, they show wrong and uneven spacing and don't match the notehead positions. 

Before:
![image](https://user-images.githubusercontent.com/2843953/100034267-98867080-2dda-11eb-8669-7b3d8af24aae.png)

After:
![image](https://user-images.githubusercontent.com/2843953/100034567-39752b80-2ddb-11eb-98de-15613af6f72a.png)

With fix, ledger lines position (and thus, the spacing between them) corresponds to any arbitrary staff line distance value (i.e. 1.25 or 1.93). Applies to either Staff/Part properties and to Staff Type Changes.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- N/A I created the test (mtest, vtest, script test) to verify the changes I made
