### PR TITLE
[MU4] Externally Load Fonts + Reload Without Rebuild

### DIFF
--- a/libmscore/sym.cpp
+++ b/libmscore/sym.cpp
@@ -34,10 +34,13 @@ namespace Ms {
 static const int FALLBACK_FONT = 0;       // Bravura
 
 QVector<ScoreFont> ScoreFont::_scoreFonts {
-      ScoreFont("Bravura",    "Bravura",     ":/fonts/bravura/",   "Bravura.otf"  ),
-      ScoreFont("Emmentaler", "MScore",      ":/fonts/mscore/",    "mscore.ttf"   ),
-      ScoreFont("Gonville",   "Gootville",   ":/fonts/gootville/", "Gootville.otf" ),
-      ScoreFont("MuseJazz",   "MuseJazz",     ":/fonts/musejazz/", "MuseJazz.otf" ),
+      // making these externally loadable by removing :
+      // Make sure to have /fonts/font-name/" in the build directory with all original
+      // files copied there before making alterations
+      ScoreFont("Bravura",    "Bravura",     "/fonts/bravura/",   "Bravura.otf"  ),
+      ScoreFont("Emmentaler", "MScore",      "/fonts/mscore/",    "mscore.ttf"   ),
+      ScoreFont("Gonville",   "Gootville",   "/fonts/gootville/", "Gootville.otf" ),
+      ScoreFont("MuseJazz",   "MuseJazz",     "/fonts/musejazz/", "MuseJazz.otf" ),
       };
 
 std::array<uint, size_t(SymId::lastSym)+1> ScoreFont::_mainSymCodeTable { {0} };
@@ -6254,8 +6257,15 @@ ScoreFont* ScoreFont::fontFactory(QString s)
             return fallbackFont();
             }
 
-      if (!f->face)
-            f->load();
+      // To be on the safe side: print out the directory of the executable when doing so
+      // to facilitate knowing where to put the /font directory in case it is unknown
+      qDebug() << "App path: " << QCoreApplication::applicationDirPath();
+
+      // Unconditionally call f->load() to demand reloading to allow for updating
+      // externally edited fonts while running MuseScore. Switching back and forth
+      // between fonts will show the updates of the edited fonts
+
+      f->load();
       return f;
       }
 


### PR DESCRIPTION
Provides a quick-fix for being able to edit the included fonts in MuseScore externally. Additionally, this guarantees that the font gets reloaded upon changing the symbol font in preferences, as originally the code checks to see if it was "previously" loaded and will not re-load it if it already was. These two simple changes allow for updating a font's ttf/otf file and checking the results after reloading it. 

1) Copy complete font directory (/MuseScore/fonts) into build directory (debug building for example:   /MuseScore/build.debug/install/bin/ is where fonts folder goes on my linux box), making sure to copy the font directory with all sub-directories + files.

2) Edit the fonts as they are and don't re-name anything since this simply relies on how the files are named originally

**To do** (maybe): 
This can be upgraded to include a dialogue box to open up any font from anywhere and get that and its folder (for metadata) to be added to the font list, but for now this should help Tantacrul et co. to be able to facilitate some font editing without having to rebuild over and over again

+ Also, maybe allow for editing and reloading the text fonts externally. 

This will most definitely not pass the online tests.

**Update**: added a qDebug line to print out the current directory of the executable to facilitate knowing where to put the font directory just in case