### PR TITLE
Fix #307883 - Key Signature appears too many times in Parts in 3.5 Beta

### DIFF
--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -547,8 +547,8 @@ void Excerpt::cloneStaves(Score* oscore, Score* score, const QList<int>& map, QM
                               for (int track : t) {
                                     //Clone KeySig TimeSig and Clefs if voice 1 of source staff is not mapped to a track
                                     Element* oef = oseg->element(srcTrack & ~3);
-                                    if (oef && (oef->isTimeSig() || oef->isKeySig()) && oseg->rtick().isZero()
-                                        && !(trackList.size() == (score->excerpt()->parts().size() * VOICES))) {
+                                    if (oef && !oef->generated() && (oef->isTimeSig() || oef->isKeySig())
+                                        && !(trackList.size() == (score->excerpt()->nstaves() * VOICES))) {
                                           Element* ne = oef->linkedClone();
                                           ne->setTrack(track & ~3);
                                           ne->setScore(score);


### PR DESCRIPTION
Suppress generation of generated time and key signature.

Resolves: https://musescore.org/en/node/307883

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
