### PR TITLE
fix #307991: crash when deleting all measures

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -5455,6 +5455,8 @@ void ScoreView::moveViewportToLastEdit()
             }
       if (!mb)
             mb = sc->tick2measureMM(st.startTick());
+      if (!mb)
+            return;
 
       const Element* viewportElement = (editElement && editElement->bbox().isValid() && !mb->isMeasure()) ? editElement : mb;
 


### PR DESCRIPTION
resolves https://musescore.org/en/node/307991

Not a 3.5 regression, so probably not for 3.5.0, but rather a fix that might go into 3.5.1