### PR TITLE
Fix #308034: Add user line spacing to text inspector

### DIFF
--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -272,12 +272,13 @@ static constexpr PropertyMetaData propertyList[] = {
 
       { Pid::BRACKET_COLUMN,          false, "level",                 P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "level")            },
       { Pid::INAME_LAYOUT_POSITION,   false, "layoutPosition",        P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "layout position")  },
+//200
       { Pid::SUB_STYLE,               false, "style",                 P_TYPE::SUB_STYLE,           DUMMY_QT_TRANSLATE_NOOP("propertyName", "style")            },
 
       { Pid::FONT_FACE,               false, "family",                P_TYPE::FONT,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "family")           },
       { Pid::FONT_SIZE,               false, "size",                  P_TYPE::REAL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "size")             },
-//200
       { Pid::FONT_STYLE,              false, "fontStyle",             P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "font style")       },
+      { Pid::TEXT_LINE_SPACING,       false, "textLineSpacing",       P_TYPE::REAL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "user line distancing") },
 
       { Pid::FRAME_TYPE,              false, "frameType",             P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "frame type")       },
       { Pid::FRAME_WIDTH,             false, "frameWidth",            P_TYPE::SPATIUM,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "frame width")      },

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -279,18 +279,20 @@ enum class Pid {
 
       BRACKET_COLUMN,
       INAME_LAYOUT_POSITION,
+//200
       SUB_STYLE,
 
       FONT_FACE,
       FONT_SIZE,
       FONT_STYLE,
+      TEXT_LINE_SPACING,
 
       FRAME_TYPE,
       FRAME_WIDTH,
       FRAME_PADDING,
       FRAME_ROUND,
       FRAME_FG_COLOR,
-//200
+
       FRAME_BG_COLOR,
       SIZE_SPATIUM_DEPENDENT,
       ALIGN,

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -99,6 +99,7 @@ static const StyleType styleTypes[] {
 
       { Sid::lyricsOddFontFace,       "lyricsOddFontFace",       "FreeSerif" },
       { Sid::lyricsOddFontSize,       "lyricsOddFontSize",       11.0 },
+      { Sid::lyricsOddLineSpacing,    "lyricsOddLineSpacing",    1.0 },
       { Sid::lyricsOddFontSpatiumDependent, "lyricsOddFontSpatiumDependent", true },
       { Sid::lyricsOddFontStyle,      "lyricsOddFontStyle",      int(FontStyle::Normal) },
       { Sid::lyricsOddColor,          "lyricsOddColor",          QColor(0, 0, 0, 255) },
@@ -112,6 +113,7 @@ static const StyleType styleTypes[] {
 
       { Sid::lyricsEvenFontFace,      "lyricsEvenFontFace",      "FreeSerif" },
       { Sid::lyricsEvenFontSize,      "lyricsEvenFontSize",      11.0 },
+      { Sid::lyricsEvenLineSpacing,   "lyricsEvenLineSpacing",   1.0 },
       { Sid::lyricsEvenFontSpatiumDependent, "lyricsEvenFontSpatiumDependent", true },
       { Sid::lyricsEvenFontStyle,     "lyricsEvenFontStyle",     int(FontStyle::Normal) },
       { Sid::lyricsEvenColor,         "lyricsEvenColor",         QColor(0, 0, 0, 255) },
@@ -223,6 +225,7 @@ static const StyleType styleTypes[] {
       { Sid::hairpinLineWidth,        "hairpinWidth",            Spatium(0.13) },
       { Sid::hairpinFontFace,         "hairpinFontFace",         "FreeSerif" },
       { Sid::hairpinFontSize,         "hairpinFontSize",         12.0 },
+      { Sid::hairpinLineSpacing,      "hairpinLineSpacing",      1.0 },
       { Sid::hairpinFontSpatiumDependent, "hairpinFontSpatiumDependent", true },
       { Sid::hairpinFontStyle,        "hairpinFontStyle",        int(FontStyle::Italic) },
       { Sid::hairpinColor,            "hairpinColor",            QColor(0, 0, 0, 255) },
@@ -250,6 +253,7 @@ static const StyleType styleTypes[] {
       { Sid::pedalHookHeight,         "pedalHookHeight",         Spatium(-1.2) },
       { Sid::pedalFontFace,           "pedalFontFace",           "FreeSerif" },
       { Sid::pedalFontSize,           "pedalFontSize",           12.0 },
+      { Sid::pedalLineSpacing,        "pedalLineSpacing",        1.0 },
       { Sid::pedalFontSpatiumDependent, "pedalFontSpatiumDependent", true },
       { Sid::pedalFontStyle,          "pedalFontStyle",          int(FontStyle::Normal) },
       { Sid::pedalColor,              "pedalColor",              QColor(0, 0, 0, 255) },
@@ -297,6 +301,7 @@ static const StyleType styleTypes[] {
 
       { Sid::chordSymbolAFontFace,      "chordSymbolAFontFace",      "FreeSerif" },
       { Sid::chordSymbolAFontSize,      "chordSymbolAFontSize",      12.0 },
+      { Sid::chordSymbolALineSpacing,   "chordSymbolALineSpacing",   1.0 },
       { Sid::chordSymbolAFontSpatiumDependent, "chordSymbolAFontSpatiumDependent", true },
       { Sid::chordSymbolAFontStyle,     "chordSymbolAFontStyle",     int(FontStyle::Normal) },
       { Sid::chordSymbolAColor,         "chordSymbolAColor",         QColor(0, 0, 0, 255) },
@@ -310,6 +315,7 @@ static const StyleType styleTypes[] {
 
       { Sid::chordSymbolBFontFace,      "chordSymbolBFontFace",      "FreeSerif" },
       { Sid::chordSymbolBFontSize,      "chordSymbolBFontSize",      12.0 },
+      { Sid::chordSymbolBLineSpacing,   "chordSymbolBLineSpacing",   1.0 },
       { Sid::chordSymbolBFontSpatiumDependent, "chordSymbolBFontSpatiumDependent", true },
       { Sid::chordSymbolBFontStyle,     "chordSymbolBFontStyle",     int(FontStyle::Italic) },
       { Sid::chordSymbolBColor,         "chordSymbolBColor",         QColor(0, 0, 0, 255) },
@@ -323,6 +329,7 @@ static const StyleType styleTypes[] {
 
       { Sid::romanNumeralFontFace,      "romanNumeralFontFace",      "Campania" },
       { Sid::romanNumeralFontSize,      "romanNumeralFontSize",      12.0 },
+      { Sid::romanNumeralLineSpacing,   "romanNumeralLineSpacing",   1.0 },
       { Sid::romanNumeralFontSpatiumDependent, "romanNumeralFontSpatiumDependent", true },
       { Sid::romanNumeralFontStyle,     "romanNumeralFontStyle",     int(FontStyle::Normal) },
       { Sid::romanNumeralColor,         "romanNumeralColor",         QColor(0, 0, 0, 255) },
@@ -336,6 +343,7 @@ static const StyleType styleTypes[] {
 
       { Sid::nashvilleNumberFontFace,      "nashvilleNumberFontFace",      "FreeSerif" },
       { Sid::nashvilleNumberFontSize,      "nashvilleNumberFontSize",      12.0 },
+      { Sid::nashvilleNumberLineSpacing,   "nashvilleNumberLineSpacing",   1.0 },
       { Sid::nashvilleNumberFontSpatiumDependent, "nashvilleNumberFontSpatiumDependent", true },
       { Sid::nashvilleNumberFontStyle,     "nashvilleNumberFontStyle",     int(FontStyle::Normal) },
       { Sid::nashvilleNumberColor,         "nashvilleNumberColor",         QColor(0, 0, 0, 255) },
@@ -458,6 +466,7 @@ static const StyleType styleTypes[] {
       { Sid::voltaLineStyle,          "voltaLineStyle",          QVariant(int(Qt::SolidLine)) },
       { Sid::voltaFontFace,           "voltaFontFace",           "FreeSerif" },
       { Sid::voltaFontSize,           "voltaFontSize",           11.0 },
+      { Sid::voltaLineSpacing,        "voltaLineSpacing",        1.0 },
       { Sid::voltaFontSpatiumDependent, "voltaFontSpatiumDependent", true },
       { Sid::voltaFontStyle,          "voltaFontStyle",          int(FontStyle::Bold) },
       { Sid::voltaColor,              "voltaColor",              QColor(0, 0, 0, 255) },
@@ -512,6 +521,7 @@ static const StyleType styleTypes[] {
       { Sid::ottavaNumbersOnly,       "ottavaNumbersOnly",       true },
       { Sid::ottavaFontFace,          "ottavaFontFace",          "FreeSerif" },
       { Sid::ottavaFontSize,          "ottavaFontSize",          10.0 },
+      { Sid::ottavaLineSpacing,       "ottavaLineSpacing",       1.0 },
       { Sid::ottavaFontSpatiumDependent, "ottavaFontSpatiumDependent", true },
       { Sid::ottavaFontStyle,         "ottavaFontStyle",         int(FontStyle::Normal) },
       { Sid::ottavaColor,             "ottavaColor",             QColor(0, 0, 0, 255) },
@@ -550,6 +560,7 @@ static const StyleType styleTypes[] {
       { Sid::tupletBracketType,       "tupletBracketType",       int(TupletBracketType::AUTO_BRACKET) },
       { Sid::tupletFontFace,          "tupletFontFace",          "FreeSerif" },
       { Sid::tupletFontSize,          "tupletFontSize",          10.0 },
+      { Sid::tupletLineSpacing,       "tupletLineSpacing",       1.0 },
       { Sid::tupletFontSpatiumDependent, "tupletFontSpatiumDependent", true },
       { Sid::tupletFontStyle,         "tupletFontStyle",         int(FontStyle::Italic) },
       { Sid::tupletColor,             "tupletColor",             QColor(0, 0, 0, 255) },
@@ -595,6 +606,7 @@ static const StyleType styleTypes[] {
 
       { Sid::defaultFontFace,               "defaultFontFace",               "FreeSerif" },
       { Sid::defaultFontSize,               "defaultFontSize",               10.0  },
+      { Sid::defaultLineSpacing,            "defaultLineSpacing",            1.0 },
       { Sid::defaultFontSpatiumDependent,   "defaultFontSpatiumDependent",   true  },
       { Sid::defaultFontStyle,              "defaultFontStyle",              int(FontStyle::Normal) },
       { Sid::defaultColor,                  "defaultColor",                  QColor(0, 0, 0, 255) },
@@ -612,6 +624,7 @@ static const StyleType styleTypes[] {
 
       { Sid::titleFontFace,                 "titleFontFace",                 "FreeSerif" },
       { Sid::titleFontSize,                 "titleFontSize",                 24.0 },
+      { Sid::titleLineSpacing,              "titleLineSpacing",              1.0 },
       { Sid::titleFontSpatiumDependent,     "titleFontSpatiumDependent",     false  },
       { Sid::titleFontStyle,                "titleFontStyle",                int(FontStyle::Normal) },
       { Sid::titleColor,                    "titleColor",                    QColor(0, 0, 0, 255) },
@@ -627,6 +640,7 @@ static const StyleType styleTypes[] {
 
       { Sid::subTitleFontFace,              "subTitleFontFace",              "FreeSerif" },
       { Sid::subTitleFontSize,              "subTitleFontSize",              14.0 },
+      { Sid::subTitleLineSpacing,           "subTitleLineSpacing",           1.0 },
       { Sid::subTitleFontSpatiumDependent,  "subTitleFontSpatiumDependent",  false  },
       { Sid::subTitleFontStyle,             "subTitleFontStyle",             int(FontStyle::Normal) },
       { Sid::subTitleColor,                 "subTitleColor",                 QColor(0, 0, 0, 255) },
@@ -642,6 +656,7 @@ static const StyleType styleTypes[] {
 
       { Sid::composerFontFace,              "composerFontFace",              "FreeSerif" },
       { Sid::composerFontSize,              "composerFontSize",              12.0 },
+      { Sid::composerLineSpacing,           "composerLineSpacing",           1.0 },
       { Sid::composerFontSpatiumDependent,  "composerFontSpatiumDependent",  false  },
       { Sid::composerFontStyle,             "composerFontStyle",             int(FontStyle::Normal) },
       { Sid::composerColor,                 "composerColor",                 QColor(0, 0, 0, 255) },
@@ -657,6 +672,7 @@ static const StyleType styleTypes[] {
 
       { Sid::lyricistFontFace,              "lyricistFontFace",              "FreeSerif" },
       { Sid::lyricistFontSize,              "lyricistFontSize",              12.0 },
+      { Sid::lyricistLineSpacing,           "lyricistLineSpacing",           1.0 },
       { Sid::lyricistFontSpatiumDependent,  "lyricistFontSpatiumDependent",  false  },
       { Sid::lyricistFontStyle,             "lyricistFontStyle",             int(FontStyle::Normal) },
       { Sid::lyricistColor,                 "lyricistColor",                 QColor(0, 0, 0, 255) },
@@ -672,6 +688,7 @@ static const StyleType styleTypes[] {
 
       { Sid::fingeringFontFace,             "fingeringFontFace",             "FreeSerif" },
       { Sid::fingeringFontSize,             "fingeringFontSize",             8.0 },
+      { Sid::fingeringLineSpacing,          "fingeringLineSpacing",          1.0 },
       { Sid::fingeringFontSpatiumDependent, "fingeringFontSpatiumDependent", true },
       { Sid::fingeringFontStyle,            "fingeringFontStyle",             int(FontStyle::Normal) },
       { Sid::fingeringColor,                "fingeringColor",                QColor(0, 0, 0, 255) },
@@ -686,6 +703,7 @@ static const StyleType styleTypes[] {
 
       { Sid::lhGuitarFingeringFontFace,     "lhGuitarFingeringFontFace",     "FreeSerif" },
       { Sid::lhGuitarFingeringFontSize,     "lhGuitarFingeringFontSize",     8.0 },
+      { Sid::lhGuitarFingeringLineSpacing,  "lhGuitarFingeringLineSpacing",  1.0 },
       { Sid::lhGuitarFingeringFontSpatiumDependent, "lhGuitarFingeringFontSpatiumDependent", true },
       { Sid::lhGuitarFingeringFontStyle,    "lhGuitarFingeringFontStyle",    int(FontStyle::Normal) },
       { Sid::lhGuitarFingeringColor,        "lhGuitarFingeringColor",        QColor(0, 0, 0, 255) },
@@ -700,6 +718,7 @@ static const StyleType styleTypes[] {
 
       { Sid::rhGuitarFingeringFontFace,     "rhGuitarFingeringFontFace",     "FreeSerif" },
       { Sid::rhGuitarFingeringFontSize,     "rhGuitarFingeringFontSize",     8.0 },
+      { Sid::rhGuitarFingeringLineSpacing,  "rhGuitarFingeringLineSpacing",  1.0 },
       { Sid::rhGuitarFingeringFontSpatiumDependent, "rhGuitarFingeringFontSpatiumDependent", true },
       { Sid::rhGuitarFingeringFontStyle,    "rhGuitarFingeringFontStyle",    int(FontStyle::Normal) },
       { Sid::rhGuitarFingeringColor,        "rhGuitarFingeringColor",        QColor(0, 0, 0, 255) },
@@ -714,6 +733,7 @@ static const StyleType styleTypes[] {
 
       { Sid::stringNumberFontFace,          "stringNumberFontFace",          "FreeSerif" },
       { Sid::stringNumberFontSize,          "stringNumberFontSize",          8.0 },
+      { Sid::stringNumberLineSpacing,       "stringNumberLineSpacing",       1.0 },
       { Sid::stringNumberFontSpatiumDependent, "stringNumberFontSpatiumDependent", true },
       { Sid::stringNumberFontStyle,         "stringNumberFontStyle",         int(FontStyle::Normal) },
       { Sid::stringNumberColor,             "stringNumberColor",             QColor(0, 0, 0, 255) },
@@ -728,6 +748,7 @@ static const StyleType styleTypes[] {
 
       { Sid::longInstrumentFontFace,        "longInstrumentFontFace",       "FreeSerif" },
       { Sid::longInstrumentFontSize,        "longInstrumentFontSize",       12.0 },
+      { Sid::longInstrumentLineSpacing,     "longInstrumentLineSpacing",    1.0 },
       { Sid::longInstrumentFontSpatiumDependent, "longInstrumentFontSpatiumDependent", true },
       { Sid::longInstrumentFontStyle,       "longInstrumentFontStyle",      int(FontStyle::Normal) },
       { Sid::longInstrumentColor,           "longInstrumentColor",          QColor(0, 0, 0, 255) },
@@ -742,6 +763,7 @@ static const StyleType styleTypes[] {
 
       { Sid::shortInstrumentFontFace,       "shortInstrumentFontFace",      "FreeSerif" },
       { Sid::shortInstrumentFontSize,       "shortInstrumentFontSize",      12.0 },
+      { Sid::shortInstrumentLineSpacing,    "shortInstrumentLineSpacing",   1.0 },
       { Sid::shortInstrumentFontSpatiumDependent, "shortInstrumentFontSpatiumDependent", true },
       { Sid::shortInstrumentFontStyle,      "shortInstrumentFontStyle",     int(FontStyle::Normal) },
       { Sid::shortInstrumentColor,          "shortInstrumentColor",         QColor(0, 0, 0, 255) },
@@ -756,6 +778,7 @@ static const StyleType styleTypes[] {
 
       { Sid::partInstrumentFontFace,        "partInstrumentFontFace",       "FreeSerif" },
       { Sid::partInstrumentFontSize,        "partInstrumentFontSize",       18.0 },
+      { Sid::partInstrumentLineSpacing,     "partInstrumentLineSpacing",    1.0 },
       { Sid::partInstrumentFontSpatiumDependent, "partInstrumentFontSpatiumDependent", false },
       { Sid::partInstrumentFontStyle,       "partInstrumentFontStyle",      int(FontStyle::Normal) },
       { Sid::partInstrumentColor,           "partInstrumentColor",          QColor(0, 0, 0, 255) },
@@ -770,6 +793,7 @@ static const StyleType styleTypes[] {
 
       { Sid::dynamicsFontFace,              "dynamicsFontFace",             "FreeSerif" },
       { Sid::dynamicsFontSize,              "dynamicsFontSize",             12.0 },
+      { Sid::dynamicsLineSpacing,           "dynamicsLineSpacing",          1.0 },
       { Sid::dynamicsFontSpatiumDependent,  "dynamicsFontSpatiumDependent", true },
       { Sid::dynamicsFontStyle,             "dynamicsFontStyle",            int(FontStyle::Italic) },
       { Sid::dynamicsColor,                 "dynamicsColor",                QColor(0, 0, 0, 255) },
@@ -783,6 +807,7 @@ static const StyleType styleTypes[] {
 
       { Sid::expressionFontFace,            "expressionFontFace",           "FreeSerif" },
       { Sid::expressionFontSize,            "expressionFontSize",           11.0 },
+      { Sid::expressionLineSpacing,         "expressionLineSpacing",        1.0 },
       { Sid::expressionFontSpatiumDependent, "expressionFontSpatiumDependent", true },
       { Sid::expressionFontStyle,           "expressionFontStyle",          int(FontStyle::Italic) },
       { Sid::expressionColor,               "expressionColor",              QColor(0, 0, 0, 255) },
@@ -798,6 +823,7 @@ static const StyleType styleTypes[] {
 
       { Sid::tempoFontFace,                 "tempoFontFace",                "FreeSerif" },
       { Sid::tempoFontSize,                 "tempoFontSize",                12.0 },
+      { Sid::tempoLineSpacing,              "tempoLineSpacing",             1.0 },
       { Sid::tempoFontSpatiumDependent,     "tempoFontSpatiumDependent",    true },
       { Sid::tempoFontStyle,                "tempoFontStyle",               int(FontStyle::Bold) },
       { Sid::tempoColor,                    "tempoColor",                   QColor(0, 0, 0, 255) },
@@ -816,6 +842,7 @@ static const StyleType styleTypes[] {
 
       { Sid::metronomeFontFace,             "metronomeFontFace",            "FreeSerif" },
       { Sid::metronomeFontSize,             "metronomeFontSize",            12.0 },
+      { Sid::metronomeLineSpacing,          "metronomeLineSpacing",         1.0 },
       { Sid::metronomeFontSpatiumDependent, "metronomeFontSpatiumDependent", false },
       { Sid::metronomeFontStyle,            "metronomeFontStyle",           int(FontStyle::Bold) },
       { Sid::metronomeColor,                "metronomeColor",               QColor(0, 0, 0, 255) },
@@ -831,6 +858,7 @@ static const StyleType styleTypes[] {
 
       { Sid::measureNumberFontFace,         "measureNumberFontFace",        "FreeSerif" },
       { Sid::measureNumberFontSize,         "measureNumberFontSize",        8.0 },
+      { Sid::measureNumberLineSpacing,      "measureNumberLineSpacing",     1.0 },
       { Sid::measureNumberFontSpatiumDependent, "measureNumberFontSpatiumDependent", true },
       { Sid::measureNumberFontStyle,        "measureNumberFontStyle",       int(FontStyle::Normal) },
       { Sid::measureNumberColor,            "measureNumberColor",           QColor(0, 0, 0, 255) },
@@ -849,6 +877,7 @@ static const StyleType styleTypes[] {
 
       { Sid::translatorFontFace,            "translatorFontFace",           "FreeSerif" },
       { Sid::translatorFontSize,            "translatorFontSize",           11.0 },
+      { Sid::translatorLineSpacing,         "translatorLineSpacing",        1.0 },
       { Sid::translatorFontSpatiumDependent, "translatorFontSpatiumDependent", false },
       { Sid::translatorFontStyle,           "translatorFontStyle",          int(FontStyle::Normal) },
       { Sid::translatorColor,               "translatorColor",              QColor(0, 0, 0, 255) },
@@ -863,6 +892,7 @@ static const StyleType styleTypes[] {
 
       { Sid::systemTextFontFace,            "systemFontFace",               "FreeSerif" },
       { Sid::systemTextFontSize,            "systemFontSize",               10.0 },
+      { Sid::systemTextLineSpacing,         "systemTextLineSpacing",        1.0 },
       { Sid::systemTextFontSpatiumDependent, "systemFontSpatiumDependent",  true },
       { Sid::systemTextFontStyle,           "systemFontStyle",              int(FontStyle::Normal) },
       { Sid::systemTextColor,               "systemTextColor",              QColor(0, 0, 0, 255) },
@@ -881,6 +911,7 @@ static const StyleType styleTypes[] {
 
       { Sid::staffTextFontFace,             "staffFontFace",                "FreeSerif" },
       { Sid::staffTextFontSize,             "staffFontSize",                10.0 },
+      { Sid::staffTextLineSpacing,          "staffTextLineSpacing",         1.0 },
       { Sid::staffTextFontSpatiumDependent, "staffFontSpatiumDependent",    true },
       { Sid::staffTextFontStyle,            "staffFontStyle",               int(FontStyle::Normal) },
       { Sid::staffTextColor,                "staffTextColor",               QColor(0, 0, 0, 255) },
@@ -899,6 +930,7 @@ static const StyleType styleTypes[] {
 
       { Sid::rehearsalMarkFontFace,         "rehearsalMarkFontFace",        "FreeSerif" },
       { Sid::rehearsalMarkFontSize,         "rehearsalMarkFontSize",        14.0 },
+      { Sid::rehearsalMarkLineSpacing,      "rehearsalMarkLineSpacing",     1.0 },
       { Sid::rehearsalMarkFontSpatiumDependent, "rehearsalMarkFontSpatiumDependent", true },
       { Sid::rehearsalMarkFontStyle,        "rehearsalMarkFontStyle",       int(FontStyle::Bold) },
       { Sid::rehearsalMarkColor,            "rehearsalMarkColor",           QColor(0, 0, 0, 255) },
@@ -916,6 +948,7 @@ static const StyleType styleTypes[] {
 
       { Sid::repeatLeftFontFace,            "repeatLeftFontFace",           "FreeSerif" },
       { Sid::repeatLeftFontSize,            "repeatLeftFontSize",           20.0 },
+      { Sid::repeatLeftLineSpacing,         "repeatLeftLineSpacing",        1.0 },
       { Sid::repeatLeftFontSpatiumDependent, "repeatLeftFontSpatiumDependent", true },
       { Sid::repeatLeftFontStyle,           "repeatLeftFontStyle",          int(FontStyle::Normal) },
       { Sid::repeatLeftColor,               "repeatLeftColor",              QColor(0, 0, 0, 255) },
@@ -930,6 +963,7 @@ static const StyleType styleTypes[] {
 
       { Sid::repeatRightFontFace,           "repeatRightFontFace",          "FreeSerif" },
       { Sid::repeatRightFontSize,           "repeatRightFontSize",          12.0 },
+      { Sid::repeatRightLineSpacing,        "repeatRightLineSpacing",       1.0 },
       { Sid::repeatRightFontSpatiumDependent, "repeatRightFontSpatiumDependent", true },
       { Sid::repeatRightFontStyle,          "repeatRightFontStyle",         int(FontStyle::Normal) },
       { Sid::repeatRightColor,              "repeatRightColor",             QColor(0, 0, 0, 255) },
@@ -944,6 +978,7 @@ static const StyleType styleTypes[] {
 
       { Sid::frameFontFace,                 "frameFontFace",                "FreeSerif" },
       { Sid::frameFontSize,                 "frameFontSize",                12.0 },
+      { Sid::frameLineSpacing,              "frameLineSpacing",             1.0 },
       { Sid::frameFontSpatiumDependent,     "frameFontSpatiumDependent",    false },
       { Sid::frameFontStyle,                "frameFontStyle",               int(FontStyle::Normal) },
       { Sid::frameColor,                    "frameColor",                   QColor(0, 0, 0, 255) },
@@ -958,6 +993,7 @@ static const StyleType styleTypes[] {
 
       { Sid::textLineFontFace,              "textLineFontFace",             "FreeSerif" },
       { Sid::textLineFontSize,              "textLineFontSize",             12.0 },
+      { Sid::textLineLineSpacing,           "textLineLineSpacing",          1.0 },
       { Sid::textLineFontSpatiumDependent,  "textLineFontSpatiumDependent", true },
       { Sid::textLineFontStyle,             "textLineFontStyle",            int(FontStyle::Normal) },
       { Sid::textLineColor,                 "textLineColor",                QColor(0, 0, 0, 255) },
@@ -965,6 +1001,7 @@ static const StyleType styleTypes[] {
 
       { Sid::glissandoFontFace,             "glissandoFontFace",            "FreeSerif" },
       { Sid::glissandoFontSize,             "glissandoFontSize",            QVariant(8.0) },
+      { Sid::glissandoLineSpacing,         "glissandoLineSpacing",          1.0 },
       { Sid::glissandoFontSpatiumDependent, "glissandoFontSpatiumDependent", true },
       { Sid::glissandoFontStyle,            "glissandoFontStyle",           int(FontStyle::Italic) },
       { Sid::glissandoColor,                "glissandoColor",               QColor(0, 0, 0, 255) },
@@ -981,6 +1018,7 @@ static const StyleType styleTypes[] {
 
       { Sid::bendFontFace,                  "bendFontFace",                 "FreeSerif" },
       { Sid::bendFontSize,                  "bendFontSize",                 8.0 },
+      { Sid::bendLineSpacing,               "bendLineSpacing",              1.0 },
       { Sid::bendFontSpatiumDependent,      "bendFontSpatiumDependent",     true },
       { Sid::bendFontStyle,                 "bendFontStyle",                int(FontStyle::Normal) },
       { Sid::bendColor,                     "bendColor",                    QColor(0, 0, 0, 255) },
@@ -997,6 +1035,7 @@ static const StyleType styleTypes[] {
 
       { Sid::headerFontFace,                "headerFontFace",               "FreeSerif" },
       { Sid::headerFontSize,                "headerFontSize",               8.0 },
+      { Sid::headerLineSpacing,             "headerLineSpacing",            1.0 },
       { Sid::headerFontSpatiumDependent,    "headerFontSpatiumDependent",   false },
       { Sid::headerFontStyle,               "headerFontStyle",              int(FontStyle::Normal) },
       { Sid::headerColor,                   "headerColor",                  QColor(0, 0, 0, 255) },
@@ -1011,6 +1050,7 @@ static const StyleType styleTypes[] {
 
       { Sid::footerFontFace,                "footerFontFace",               "FreeSerif" },
       { Sid::footerFontSize,                "footerFontSize",               8.0 },
+      { Sid::footerLineSpacing,             "footerLineSpacing",            1.0 },
       { Sid::footerFontSpatiumDependent,    "footerFontSpatiumDependent",   false },
       { Sid::footerFontStyle,               "footerFontStyle",              int(FontStyle::Normal) },
       { Sid::footerColor,                   "footerColor",                  QColor(0, 0, 0, 255) },
@@ -1025,6 +1065,7 @@ static const StyleType styleTypes[] {
 
       { Sid::instrumentChangeFontFace,      "instrumentChangeFontFace",     "FreeSerif" },
       { Sid::instrumentChangeFontSize,      "instrumentChangeFontSize",     12.0 },
+      { Sid::instrumentChangeLineSpacing,   "instrumentChangeLineSpacing",  1.0 },
       { Sid::instrumentChangeFontSpatiumDependent, "instrumentChangeFontSpatiumDependent", true },
       { Sid::instrumentChangeFontStyle,     "instrumentChangeFontStyle",    int(FontStyle::Bold) },
       { Sid::instrumentChangeColor,         "instrumentChangeColor",        QColor(0, 0, 0, 255) },
@@ -1043,6 +1084,7 @@ static const StyleType styleTypes[] {
 
       { Sid::stickingFontFace,              "stickingFontFace",     "FreeSerif" },
       { Sid::stickingFontSize,              "stickingFontSize",     12.0 },
+      { Sid::stickingLineSpacing,           "stickingLineSpacing",  1.0 },
       { Sid::stickingFontSpatiumDependent,  "stickingFontSpatiumDependent", true },
       { Sid::stickingFontStyle,             "stickingFontStyle",    int(FontStyle::Normal) },
       { Sid::stickingColor,                 "stickingColor",        QColor(0, 0, 0, 255) },
@@ -1061,6 +1103,7 @@ static const StyleType styleTypes[] {
 
       { Sid::figuredBassFontFace,           "figuredBassFontFace",          "MScoreBC" },
       { Sid::figuredBassFontSize,           "figuredBassFontSize",          8.0 },
+      { Sid::figuredBassLineSpacing,        "figuredBassLineSpacing",       1.0 },
       { Sid::figuredBassFontSpatiumDependent, "figuredBassFontSpatiumDependent", true },
       { Sid::figuredBassFontStyle,          "figuredBassFontStyle",         int(FontStyle::Normal) },
       { Sid::figuredBassColor,              "figuredBassColor",             QColor(0, 0, 0, 255) },
@@ -1068,6 +1111,7 @@ static const StyleType styleTypes[] {
       { Sid::user1Name,                     "user1Name",                    "" },
       { Sid::user1FontFace,                 "user1FontFace",                "FreeSerif" },
       { Sid::user1FontSize,                 "user1FontSize",                10.0 },
+      { Sid::user1LineSpacing,              "user1LineSpacing",             1.0 },
       { Sid::user1FontSpatiumDependent,     "user1FontSpatiumDependent",    true },
       { Sid::user1FontStyle,                "user1FontStyle",               int(FontStyle::Normal) },
       { Sid::user1Color,                    "user1Color",                   QColor(0, 0, 0, 255) },
@@ -1084,6 +1128,7 @@ static const StyleType styleTypes[] {
       { Sid::user2Name,                     "user2Name",                    "" },
       { Sid::user2FontFace,                 "user2FontFace",                "FreeSerif" },
       { Sid::user2FontSize,                 "user2FontSize",                10.0 },
+      { Sid::user2LineSpacing,              "user2LineSpacing",             1.0 },
       { Sid::user2FontSpatiumDependent,     "user2FontSpatiumDependent",    true },
       { Sid::user2FontStyle,                "user2FontStyle",               int(FontStyle::Normal) },
       { Sid::user2Color,                    "user2Color",                   QColor(0, 0, 0, 255) },
@@ -1100,6 +1145,7 @@ static const StyleType styleTypes[] {
       { Sid::user3Name,                     "user3Name",                    "" },
       { Sid::user3FontFace,                 "user3FontFace",                "FreeSerif" },
       { Sid::user3FontSize,                 "user3FontSize",                10.0 },
+      { Sid::user3LineSpacing,              "user3LineSpacing",             1.0 },
       { Sid::user3FontSpatiumDependent,     "user3FontSpatiumDependent",    true },
       { Sid::user3FontStyle,                "user3FontStyle",               int(FontStyle::Normal) },
       { Sid::user3Color,                    "user3Color",                   QColor(0, 0, 0, 255) },
@@ -1116,6 +1162,7 @@ static const StyleType styleTypes[] {
       { Sid::user4Name,                     "user4Name",                    "" },
       { Sid::user4FontFace,                 "user4FontFace",                "FreeSerif" },
       { Sid::user4FontSize,                 "user4FontSize",                10.0 },
+      { Sid::user4LineSpacing,              "user4LineSpacing",             1.0 },
       { Sid::user4FontSpatiumDependent,     "user4FontSpatiumDependent",    true },
       { Sid::user4FontStyle,                "user4FontStyle",               int(FontStyle::Normal) },
       { Sid::user4Color,                    "user4Color",                   QColor(0, 0, 0, 255) },
@@ -1132,6 +1179,7 @@ static const StyleType styleTypes[] {
       { Sid::user5Name,                     "user5Name",                    "" },
       { Sid::user5FontFace,                 "user5FontFace",                "FreeSerif" },
       { Sid::user5FontSize,                 "user5FontSize",                10.0 },
+      { Sid::user5LineSpacing,              "user5LineSpacing",             1.0 },
       { Sid::user5FontSpatiumDependent,     "user5FontSpatiumDependent",    true },
       { Sid::user5FontStyle,                "user5FontStyle",               int(FontStyle::Normal) },
       { Sid::user5Color,                    "user5Color",                   QColor(0, 0, 0, 255) },
@@ -1148,6 +1196,7 @@ static const StyleType styleTypes[] {
       { Sid::user6Name,                     "user6Name",                    "" },
       { Sid::user6FontFace,                 "user6FontFace",                "FreeSerif" },
       { Sid::user6FontSize,                 "user6FontSize",                10.0 },
+      { Sid::user6LineSpacing,              "user6LineSpacing",             1.0 },
       { Sid::user6FontSpatiumDependent,     "user6FontSpatiumDependent",    true },
       { Sid::user6FontStyle,                "user6FontStyle",               int(FontStyle::Normal) },
       { Sid::user6Color,                    "user6Color",                   QColor(0, 0, 0, 255) },
@@ -1164,6 +1213,7 @@ static const StyleType styleTypes[] {
       { Sid::user7Name,                     "user7Name",                    "" },
       { Sid::user7FontFace,                 "user7FontFace",                "FreeSerif" },
       { Sid::user7FontSize,                 "user7FontSize",                10.0 },
+      { Sid::user7LineSpacing,              "user7LineSpacing",             1.0 },
       { Sid::user7FontSpatiumDependent,     "user7FontSpatiumDependent",    true },
       { Sid::user7FontStyle,                "user7FontStyle",               int(FontStyle::Normal) },
       { Sid::user7Color,                    "user7Color",                   QColor(0, 0, 0, 255) },
@@ -1180,6 +1230,7 @@ static const StyleType styleTypes[] {
       { Sid::user8Name,                     "user8Name",                    "" },
       { Sid::user8FontFace,                 "user8FontFace",                "FreeSerif" },
       { Sid::user8FontSize,                 "user8FontSize",                10.0 },
+      { Sid::user8LineSpacing,              "user8LineSpacing",             1.0 },
       { Sid::user8FontSpatiumDependent,     "user8FontSpatiumDependent",    true },
       { Sid::user8FontStyle,                "user8FontStyle",               int(FontStyle::Normal) },
       { Sid::user8Color,                    "user8Color",                   QColor(0, 0, 0, 255) },
@@ -1196,6 +1247,7 @@ static const StyleType styleTypes[] {
       { Sid::user9Name,                     "user9Name",                    "" },
       { Sid::user9FontFace,                 "user9FontFace",                "FreeSerif" },
       { Sid::user9FontSize,                 "user9FontSize",                10.0 },
+      { Sid::user9LineSpacing,              "user9LineSpacing",             1.0 },
       { Sid::user9FontSpatiumDependent,     "user9FontSpatiumDependent",    true },
       { Sid::user9FontStyle,                "user9FontStyle",               int(FontStyle::Normal) },
       { Sid::user9Color,                    "user9Color",                   QColor(0, 0, 0, 255) },
@@ -1212,6 +1264,7 @@ static const StyleType styleTypes[] {
       { Sid::user10Name,                    "user10Name",                   "" },
       { Sid::user10FontFace,                "user10FontFace",               "FreeSerif" },
       { Sid::user10FontSize,                "user10FontSize",               10.0 },
+      { Sid::user10LineSpacing,             "user10LineSpacing",            1.0 },
       { Sid::user10FontSpatiumDependent,    "user10FontSpatiumDependent",   true },
       { Sid::user10FontStyle,               "user10FontStyle",              int(FontStyle::Normal) },
       { Sid::user10Color,                   "user10Color",                  QColor(0, 0, 0, 255) },
@@ -1228,6 +1281,7 @@ static const StyleType styleTypes[] {
       { Sid::user11Name,                    "user11Name",                   "" },
       { Sid::user11FontFace,                "user11FontFace",               "FreeSerif" },
       { Sid::user11FontSize,                "user11FontSize",               10.0 },
+      { Sid::user11LineSpacing,             "user11LineSpacing",            1.0 },
       { Sid::user11FontSpatiumDependent,    "user11FontSpatiumDependent",   true },
       { Sid::user11FontStyle,               "user11FontStyle",              int(FontStyle::Normal) },
       { Sid::user11Color,                   "user11Color",                  QColor(0, 0, 0, 255) },
@@ -1244,6 +1298,7 @@ static const StyleType styleTypes[] {
       { Sid::user12Name,                    "user12Name",                   "" },
       { Sid::user12FontFace,                "user12FontFace",               "FreeSerif" },
       { Sid::user12FontSize,                "user12FontSize",               10.0 },
+      { Sid::user12LineSpacing,             "user12LineSpacing",            1.0 },
       { Sid::user12FontSpatiumDependent,    "user12FontSpatiumDependent",   true },
       { Sid::user12FontStyle,               "user12FontStyle",              int(FontStyle::Normal) },
       { Sid::user12Color,                   "user12Color",                  QColor(0, 0, 0, 255) },
@@ -1259,6 +1314,7 @@ static const StyleType styleTypes[] {
 
       { Sid::letRingFontFace,               "letRingFontFace",              "FreeSerif" },
       { Sid::letRingFontSize,               "letRingFontSize",              10.0 },
+      { Sid::letRingLineSpacing,            "letRingLineSpacing",           1.0 },
       { Sid::letRingFontSpatiumDependent,   "letRingFontSpatiumDependent",  true },
       { Sid::letRingFontStyle,              "letRingFontStyle",             int(FontStyle::Normal) },
       { Sid::letRingColor,                  "letRingColor",                 QColor(0, 0, 0, 255) },
@@ -1281,6 +1337,7 @@ static const StyleType styleTypes[] {
 
       { Sid::palmMuteFontFace,              "palmMuteFontFace",              "FreeSerif" },
       { Sid::palmMuteFontSize,              "palmMuteFontSize",              10.0 },
+      { Sid::palmMuteLineSpacing,           "palmMuteLineSpacing",           1.0 },
       { Sid::palmMuteFontSpatiumDependent,  "palmMuteFontSpatiumDependent",  true },
       { Sid::palmMuteFontStyle,             "palmMuteFontStyle",             int(FontStyle::Normal) },
       { Sid::palmMuteColor,                 "palmMuteColor",                 QColor(0, 0, 0, 255) },
@@ -1336,6 +1393,7 @@ MStyle  MScore::_defaultStyle;
 const TextStyle defaultTextStyle {{
       { Sid::defaultFontFace,                    Pid::FONT_FACE              },
       { Sid::defaultFontSize,                    Pid::FONT_SIZE              },
+      { Sid::defaultLineSpacing,                 Pid::TEXT_LINE_SPACING      },
       { Sid::defaultFontSpatiumDependent,        Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::defaultFontStyle,                   Pid::FONT_STYLE             },
       { Sid::defaultColor,                       Pid::COLOR                  },
@@ -1352,6 +1410,7 @@ const TextStyle defaultTextStyle {{
 const TextStyle titleTextStyle {{
       { Sid::titleFontFace,                      Pid::FONT_FACE              },
       { Sid::titleFontSize,                      Pid::FONT_SIZE              },
+      { Sid::titleLineSpacing,                   Pid::TEXT_LINE_SPACING      },
       { Sid::titleFontSpatiumDependent,          Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::titleFontStyle,                     Pid::FONT_STYLE             },
       { Sid::titleColor,                         Pid::COLOR                  },
@@ -1363,11 +1422,13 @@ const TextStyle titleTextStyle {{
       { Sid::titleFrameRound,                    Pid::FRAME_ROUND            },
       { Sid::titleFrameFgColor,                  Pid::FRAME_FG_COLOR         },
       { Sid::titleFrameBgColor,                  Pid::FRAME_BG_COLOR         },
+      
       }};
 
 const TextStyle subTitleTextStyle {{
       { Sid::subTitleFontFace,                   Pid::FONT_FACE              },
       { Sid::subTitleFontSize,                   Pid::FONT_SIZE              },
+      { Sid::subTitleLineSpacing,                Pid::TEXT_LINE_SPACING      },
       { Sid::subTitleFontSpatiumDependent,       Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::subTitleFontStyle,                  Pid::FONT_STYLE             },
       { Sid::subTitleColor,                      Pid::COLOR                  },
@@ -1384,6 +1445,7 @@ const TextStyle subTitleTextStyle {{
 const TextStyle composerTextStyle {{
       { Sid::composerFontFace,                   Pid::FONT_FACE              },
       { Sid::composerFontSize,                   Pid::FONT_SIZE              },
+      { Sid::composerLineSpacing,                Pid::TEXT_LINE_SPACING      },
       { Sid::composerFontSpatiumDependent,       Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::composerFontStyle,                  Pid::FONT_STYLE             },
       { Sid::composerColor,                      Pid::COLOR                  },
@@ -1400,6 +1462,7 @@ const TextStyle composerTextStyle {{
 const TextStyle lyricistTextStyle {{
       { Sid::lyricistFontFace,                   Pid::FONT_FACE              },
       { Sid::lyricistFontSize,                   Pid::FONT_SIZE              },
+      { Sid::lyricistLineSpacing,                Pid::TEXT_LINE_SPACING      },
       { Sid::lyricistFontSpatiumDependent,       Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::lyricistFontStyle,                  Pid::FONT_STYLE             },
       { Sid::lyricistColor,                      Pid::COLOR                  },
@@ -1416,6 +1479,7 @@ const TextStyle lyricistTextStyle {{
 const TextStyle lyricsEvenTextStyle {{
       { Sid::lyricsEvenFontFace,                 Pid::FONT_FACE              },
       { Sid::lyricsEvenFontSize,                 Pid::FONT_SIZE              },
+      { Sid::lyricsEvenLineSpacing,              Pid::TEXT_LINE_SPACING      },
       { Sid::lyricsEvenFontSpatiumDependent,     Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::lyricsEvenFontStyle,                Pid::FONT_STYLE             },
       { Sid::lyricsEvenColor,                    Pid::COLOR                  },
@@ -1432,6 +1496,7 @@ const TextStyle lyricsEvenTextStyle {{
 const TextStyle lyricsOddTextStyle {{
       { Sid::lyricsOddFontFace,                  Pid::FONT_FACE              },
       { Sid::lyricsOddFontSize,                  Pid::FONT_SIZE              },
+      { Sid::lyricsOddLineSpacing,               Pid::TEXT_LINE_SPACING      },
       { Sid::lyricsOddFontSpatiumDependent,      Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::lyricsOddFontStyle,                 Pid::FONT_STYLE             },
       { Sid::lyricsOddColor,                     Pid::COLOR                  },
@@ -1448,6 +1513,7 @@ const TextStyle lyricsOddTextStyle {{
 const TextStyle fingeringTextStyle {{
       { Sid::fingeringFontFace,                  Pid::FONT_FACE              },
       { Sid::fingeringFontSize,                  Pid::FONT_SIZE              },
+      { Sid::fingeringLineSpacing,               Pid::TEXT_LINE_SPACING      },
       { Sid::fingeringFontSpatiumDependent,      Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::fingeringFontStyle,                 Pid::FONT_STYLE             },
       { Sid::fingeringColor,                     Pid::COLOR                  },
@@ -1464,6 +1530,7 @@ const TextStyle fingeringTextStyle {{
 const TextStyle lhGuitarFingeringTextStyle {{
       { Sid::lhGuitarFingeringFontFace,             Pid::FONT_FACE              },
       { Sid::lhGuitarFingeringFontSize,             Pid::FONT_SIZE              },
+      { Sid::lhGuitarFingeringLineSpacing,          Pid::TEXT_LINE_SPACING      },
       { Sid::lhGuitarFingeringFontSpatiumDependent, Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::lhGuitarFingeringFontStyle,            Pid::FONT_STYLE             },
       { Sid::lhGuitarFingeringColor,                Pid::COLOR                  },
@@ -1480,6 +1547,7 @@ const TextStyle lhGuitarFingeringTextStyle {{
 const TextStyle rhGuitarFingeringTextStyle {{
       { Sid::rhGuitarFingeringFontFace,             Pid::FONT_FACE              },
       { Sid::rhGuitarFingeringFontSize,             Pid::FONT_SIZE              },
+      { Sid::rhGuitarFingeringLineSpacing,          Pid::TEXT_LINE_SPACING      },
       { Sid::rhGuitarFingeringFontSpatiumDependent, Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::rhGuitarFingeringFontStyle,            Pid::FONT_STYLE             },
       { Sid::rhGuitarFingeringColor,                Pid::COLOR                  },
@@ -1496,6 +1564,7 @@ const TextStyle rhGuitarFingeringTextStyle {{
 const TextStyle stringNumberTextStyle {{
       { Sid::stringNumberFontFace,               Pid::FONT_FACE              },
       { Sid::stringNumberFontSize,               Pid::FONT_SIZE              },
+      { Sid::stringNumberLineSpacing,            Pid::TEXT_LINE_SPACING      },
       { Sid::stringNumberFontSpatiumDependent,   Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::stringNumberFontStyle,              Pid::FONT_STYLE             },
       { Sid::stringNumberColor,                  Pid::COLOR                  },
@@ -1512,6 +1581,7 @@ const TextStyle stringNumberTextStyle {{
 const TextStyle longInstrumentTextStyle {{
       { Sid::longInstrumentFontFace,             Pid::FONT_FACE              },
       { Sid::longInstrumentFontSize,             Pid::FONT_SIZE              },
+      { Sid::longInstrumentLineSpacing,          Pid::TEXT_LINE_SPACING      },
       { Sid::longInstrumentFontSpatiumDependent, Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::longInstrumentFontStyle,            Pid::FONT_STYLE             },
       { Sid::longInstrumentColor,                Pid::COLOR                  },
@@ -1528,6 +1598,7 @@ const TextStyle longInstrumentTextStyle {{
 const TextStyle shortInstrumentTextStyle {{
       { Sid::shortInstrumentFontFace,             Pid::FONT_FACE              },
       { Sid::shortInstrumentFontSize,             Pid::FONT_SIZE              },
+      { Sid::shortInstrumentLineSpacing,          Pid::TEXT_LINE_SPACING      },
       { Sid::shortInstrumentFontSpatiumDependent, Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::shortInstrumentFontStyle,            Pid::FONT_STYLE             },
       { Sid::shortInstrumentColor,                Pid::COLOR                  },
@@ -1544,6 +1615,7 @@ const TextStyle shortInstrumentTextStyle {{
 const TextStyle partInstrumentTextStyle {{
       { Sid::partInstrumentFontFace,             Pid::FONT_FACE              },
       { Sid::partInstrumentFontSize,             Pid::FONT_SIZE              },
+      { Sid::partInstrumentLineSpacing,          Pid::TEXT_LINE_SPACING      },
       { Sid::partInstrumentFontSpatiumDependent, Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::partInstrumentFontStyle,            Pid::FONT_STYLE             },
       { Sid::partInstrumentColor,                Pid::COLOR                  },
@@ -1560,6 +1632,7 @@ const TextStyle partInstrumentTextStyle {{
 const TextStyle dynamicsTextStyle {{
       { Sid::dynamicsFontFace,                   Pid::FONT_FACE              },
       { Sid::dynamicsFontSize,                   Pid::FONT_SIZE              },
+      { Sid::dynamicsLineSpacing,                Pid::TEXT_LINE_SPACING      },
       { Sid::dynamicsFontSpatiumDependent,       Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::dynamicsFontStyle,                  Pid::FONT_STYLE             },
       { Sid::dynamicsColor,                      Pid::COLOR                  },
@@ -1576,6 +1649,7 @@ const TextStyle dynamicsTextStyle {{
 const TextStyle expressionTextStyle {{
       { Sid::expressionFontFace,                 Pid::FONT_FACE              },
       { Sid::expressionFontSize,                 Pid::FONT_SIZE              },
+      { Sid::expressionLineSpacing,              Pid::TEXT_LINE_SPACING      },
       { Sid::expressionFontSpatiumDependent,     Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::expressionFontStyle,                Pid::FONT_STYLE             },
       { Sid::expressionColor,                    Pid::COLOR                  },
@@ -1592,6 +1666,7 @@ const TextStyle expressionTextStyle {{
 const TextStyle tempoTextStyle {{
       { Sid::tempoFontFace,                      Pid::FONT_FACE              },
       { Sid::tempoFontSize,                      Pid::FONT_SIZE              },
+      { Sid::tempoLineSpacing,                   Pid::TEXT_LINE_SPACING      },
       { Sid::tempoFontSpatiumDependent,          Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::tempoFontStyle,                     Pid::FONT_STYLE             },
       { Sid::tempoColor,                         Pid::COLOR                  },
@@ -1608,6 +1683,7 @@ const TextStyle tempoTextStyle {{
 const TextStyle metronomeTextStyle {{
       { Sid::metronomeFontFace,                  Pid::FONT_FACE              },
       { Sid::metronomeFontSize,                  Pid::FONT_SIZE              },
+      { Sid::metronomeLineSpacing,               Pid::TEXT_LINE_SPACING      },
       { Sid::metronomeFontSpatiumDependent,      Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::metronomeFontStyle,                 Pid::FONT_STYLE             },
       { Sid::metronomeColor,                     Pid::COLOR                  },
@@ -1624,6 +1700,7 @@ const TextStyle metronomeTextStyle {{
 const TextStyle measureNumberTextStyle {{
       { Sid::measureNumberFontFace,              Pid::FONT_FACE              },
       { Sid::measureNumberFontSize,              Pid::FONT_SIZE              },
+      { Sid::measureNumberLineSpacing,           Pid::TEXT_LINE_SPACING      },
       { Sid::measureNumberFontSpatiumDependent,  Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::measureNumberFontStyle,             Pid::FONT_STYLE             },
       { Sid::measureNumberColor,                 Pid::COLOR                  },
@@ -1640,6 +1717,7 @@ const TextStyle measureNumberTextStyle {{
 const TextStyle translatorTextStyle {{
       { Sid::translatorFontFace,                 Pid::FONT_FACE              },
       { Sid::translatorFontSize,                 Pid::FONT_SIZE              },
+      { Sid::translatorLineSpacing,              Pid::TEXT_LINE_SPACING      },
       { Sid::translatorFontSpatiumDependent,     Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::translatorFontStyle,                Pid::FONT_STYLE             },
       { Sid::translatorColor,                    Pid::COLOR                  },
@@ -1656,6 +1734,7 @@ const TextStyle translatorTextStyle {{
 const TextStyle tupletTextStyle {{
       { Sid::tupletFontFace,                     Pid::FONT_FACE              },
       { Sid::tupletFontSize,                     Pid::FONT_SIZE              },
+      { Sid::tupletLineSpacing,                  Pid::TEXT_LINE_SPACING      },
       { Sid::tupletFontSpatiumDependent,         Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::tupletFontStyle,                    Pid::FONT_STYLE             },
       { Sid::tupletColor,                        Pid::COLOR                  },
@@ -1672,6 +1751,7 @@ const TextStyle tupletTextStyle {{
 const TextStyle systemTextStyle {{
       { Sid::systemTextFontFace,                 Pid::FONT_FACE              },
       { Sid::systemTextFontSize,                 Pid::FONT_SIZE              },
+      { Sid::systemTextLineSpacing,              Pid::TEXT_LINE_SPACING      },
       { Sid::systemTextFontSpatiumDependent,     Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::systemTextFontStyle,                Pid::FONT_STYLE             },
       { Sid::systemTextColor,                    Pid::COLOR                  },
@@ -1688,6 +1768,7 @@ const TextStyle systemTextStyle {{
 const TextStyle staffTextStyle {{
       { Sid::staffTextFontFace,                  Pid::FONT_FACE              },
       { Sid::staffTextFontSize,                  Pid::FONT_SIZE              },
+      { Sid::staffTextLineSpacing,               Pid::TEXT_LINE_SPACING      },
       { Sid::staffTextFontSpatiumDependent,      Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::staffTextFontStyle,                 Pid::FONT_STYLE             },
       { Sid::staffTextColor,                     Pid::COLOR                  },
@@ -1704,6 +1785,7 @@ const TextStyle staffTextStyle {{
 const TextStyle chordSymbolTextStyleA {{
       { Sid::chordSymbolAFontFace,               Pid::FONT_FACE              },
       { Sid::chordSymbolAFontSize,               Pid::FONT_SIZE              },
+      { Sid::chordSymbolALineSpacing,            Pid::TEXT_LINE_SPACING      },
       { Sid::chordSymbolAFontSpatiumDependent,   Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::chordSymbolAFontStyle,              Pid::FONT_STYLE             },
       { Sid::chordSymbolAColor,                  Pid::COLOR                  },
@@ -1720,6 +1802,7 @@ const TextStyle chordSymbolTextStyleA {{
 const TextStyle chordSymbolTextStyleB {{
       { Sid::chordSymbolBFontFace,               Pid::FONT_FACE              },
       { Sid::chordSymbolBFontSize,               Pid::FONT_SIZE              },
+      { Sid::chordSymbolBLineSpacing,            Pid::TEXT_LINE_SPACING      },
       { Sid::chordSymbolBFontSpatiumDependent,   Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::chordSymbolBFontStyle,              Pid::FONT_STYLE             },
       { Sid::chordSymbolBColor,                  Pid::COLOR                  },
@@ -1736,6 +1819,7 @@ const TextStyle chordSymbolTextStyleB {{
 const TextStyle romanNumeralTextStyle {{
       { Sid::romanNumeralFontFace,               Pid::FONT_FACE              },
       { Sid::romanNumeralFontSize,               Pid::FONT_SIZE              },
+      { Sid::romanNumeralLineSpacing,            Pid::TEXT_LINE_SPACING      },
       { Sid::romanNumeralFontSpatiumDependent,   Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::romanNumeralFontStyle,              Pid::FONT_STYLE             },
       { Sid::romanNumeralColor,                  Pid::COLOR                  },
@@ -1752,6 +1836,7 @@ const TextStyle romanNumeralTextStyle {{
 const TextStyle nashvilleNumberTextStyle {{
       { Sid::nashvilleNumberFontFace,               Pid::FONT_FACE              },
       { Sid::nashvilleNumberFontSize,               Pid::FONT_SIZE              },
+      { Sid::nashvilleNumberLineSpacing,            Pid::TEXT_LINE_SPACING      },
       { Sid::nashvilleNumberFontSpatiumDependent,   Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::nashvilleNumberFontStyle,              Pid::FONT_STYLE             },
       { Sid::nashvilleNumberColor,                  Pid::COLOR                  },
@@ -1768,6 +1853,7 @@ const TextStyle nashvilleNumberTextStyle {{
 const TextStyle rehearsalMarkTextStyle {{
       { Sid::rehearsalMarkFontFace,              Pid::FONT_FACE              },
       { Sid::rehearsalMarkFontSize,              Pid::FONT_SIZE              },
+      { Sid::rehearsalMarkLineSpacing,           Pid::TEXT_LINE_SPACING      },
       { Sid::rehearsalMarkFontSpatiumDependent,  Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::rehearsalMarkFontStyle,             Pid::FONT_STYLE             },
       { Sid::rehearsalMarkColor,                 Pid::COLOR                  },
@@ -1784,6 +1870,7 @@ const TextStyle rehearsalMarkTextStyle {{
 const TextStyle repeatLeftTextStyle {{
       { Sid::repeatLeftFontFace,                 Pid::FONT_FACE              },
       { Sid::repeatLeftFontSize,                 Pid::FONT_SIZE              },
+      { Sid::repeatLeftLineSpacing,              Pid::TEXT_LINE_SPACING      },
       { Sid::repeatLeftFontSpatiumDependent,     Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::repeatLeftFontStyle,                Pid::FONT_STYLE             },
       { Sid::repeatLeftColor,                    Pid::COLOR                  },
@@ -1800,6 +1887,7 @@ const TextStyle repeatLeftTextStyle {{
 const TextStyle repeatRightTextStyle {{
       { Sid::repeatRightFontFace,                Pid::FONT_FACE              },
       { Sid::repeatRightFontSize,                Pid::FONT_SIZE              },
+      { Sid::repeatRightLineSpacing,             Pid::TEXT_LINE_SPACING      },
       { Sid::repeatRightFontSpatiumDependent,    Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::repeatRightFontStyle,               Pid::FONT_STYLE             },
       { Sid::repeatRightColor,                   Pid::COLOR                  },
@@ -1816,6 +1904,7 @@ const TextStyle repeatRightTextStyle {{
 const TextStyle frameTextStyle {{
       { Sid::frameFontFace,                      Pid::FONT_FACE              },
       { Sid::frameFontSize,                      Pid::FONT_SIZE              },
+      { Sid::frameLineSpacing,                   Pid::TEXT_LINE_SPACING      },
       { Sid::frameFontSpatiumDependent,          Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::frameFontStyle,                     Pid::FONT_STYLE             },
       { Sid::frameColor,                         Pid::COLOR                  },
@@ -1832,6 +1921,7 @@ const TextStyle frameTextStyle {{
 const TextStyle textLineTextStyle {{
       { Sid::textLineFontFace,                   Pid::BEGIN_FONT_FACE        },
       { Sid::textLineFontSize,                   Pid::BEGIN_FONT_SIZE        },
+      { Sid::textLineLineSpacing,                Pid::TEXT_LINE_SPACING      },
       { Sid::textLineFontSpatiumDependent,       Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::textLineFontStyle,                  Pid::BEGIN_FONT_STYLE       },
       { Sid::textLineColor,                      Pid::COLOR                  },
@@ -1848,6 +1938,7 @@ const TextStyle textLineTextStyle {{
 const TextStyle glissandoTextStyle {{
       { Sid::glissandoFontFace,                  Pid::FONT_FACE              },
       { Sid::glissandoFontSize,                  Pid::FONT_SIZE              },
+      { Sid::glissandoLineSpacing,               Pid::TEXT_LINE_SPACING      },
       { Sid::glissandoFontSpatiumDependent,      Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::glissandoFontStyle,                 Pid::FONT_STYLE             },
       { Sid::glissandoColor,                     Pid::COLOR                  },
@@ -1864,6 +1955,7 @@ const TextStyle glissandoTextStyle {{
 const TextStyle ottavaTextStyle {{
       { Sid::ottavaFontFace,                     Pid::BEGIN_FONT_FACE        },
       { Sid::ottavaFontSize,                     Pid::BEGIN_FONT_SIZE        },
+      { Sid::ottavaLineSpacing,                  Pid::TEXT_LINE_SPACING      },
       { Sid::ottavaFontSpatiumDependent,         Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::ottavaFontStyle,                    Pid::BEGIN_FONT_STYLE       },
       { Sid::ottavaColor,                        Pid::COLOR                  },
@@ -1880,6 +1972,7 @@ const TextStyle ottavaTextStyle {{
 const TextStyle voltaTextStyle {{
       { Sid::voltaFontFace,                      Pid::BEGIN_FONT_FACE        },
       { Sid::voltaFontSize,                      Pid::BEGIN_FONT_SIZE        },
+      { Sid::voltaLineSpacing,                   Pid::TEXT_LINE_SPACING      },
       { Sid::voltaFontSpatiumDependent,          Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::voltaFontStyle,                     Pid::BEGIN_FONT_STYLE       },
       { Sid::voltaColor,                         Pid::COLOR                  },
@@ -1896,6 +1989,7 @@ const TextStyle voltaTextStyle {{
 const TextStyle pedalTextStyle {{
       { Sid::pedalFontFace,                      Pid::BEGIN_FONT_FACE        },
       { Sid::pedalFontSize,                      Pid::BEGIN_FONT_SIZE        },
+      { Sid::pedalLineSpacing,                   Pid::TEXT_LINE_SPACING      },
       { Sid::pedalFontSpatiumDependent,          Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::pedalFontStyle,                     Pid::BEGIN_FONT_STYLE       },
       { Sid::pedalColor,                         Pid::COLOR                  },
@@ -1912,6 +2006,7 @@ const TextStyle pedalTextStyle {{
 const TextStyle letRingTextStyle {{
       { Sid::letRingFontFace,                    Pid::BEGIN_FONT_FACE        },
       { Sid::letRingFontSize,                    Pid::BEGIN_FONT_SIZE        },
+      { Sid::letRingLineSpacing,                 Pid::TEXT_LINE_SPACING      },
       { Sid::letRingFontSpatiumDependent,        Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::letRingFontStyle,                   Pid::BEGIN_FONT_STYLE       },
       { Sid::letRingColor,                       Pid::COLOR                  },
@@ -1928,6 +2023,7 @@ const TextStyle letRingTextStyle {{
 const TextStyle palmMuteTextStyle {{
       { Sid::palmMuteFontFace,                   Pid::BEGIN_FONT_FACE        },
       { Sid::palmMuteFontSize,                   Pid::BEGIN_FONT_SIZE        },
+      { Sid::palmMuteLineSpacing,                Pid::TEXT_LINE_SPACING      },
       { Sid::palmMuteFontSpatiumDependent,       Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::palmMuteFontStyle,                  Pid::BEGIN_FONT_STYLE       },
       { Sid::palmMuteColor,                      Pid::COLOR                  },
@@ -1944,6 +2040,7 @@ const TextStyle palmMuteTextStyle {{
 const TextStyle hairpinTextStyle {{
       { Sid::hairpinFontFace,                    Pid::BEGIN_FONT_FACE        },
       { Sid::hairpinFontSize,                    Pid::BEGIN_FONT_SIZE        },
+      { Sid::hairpinLineSpacing,                 Pid::TEXT_LINE_SPACING      },
       { Sid::hairpinFontSpatiumDependent,        Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::hairpinFontStyle,                   Pid::BEGIN_FONT_STYLE       },
       { Sid::hairpinColor,                       Pid::COLOR                  },
@@ -1960,6 +2057,7 @@ const TextStyle hairpinTextStyle {{
 const TextStyle bendTextStyle {{
       { Sid::bendFontFace,                       Pid::FONT_FACE              },
       { Sid::bendFontSize,                       Pid::FONT_SIZE              },
+      { Sid::bendLineSpacing,                    Pid::TEXT_LINE_SPACING      },
       { Sid::bendFontSpatiumDependent,           Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::bendFontStyle,                      Pid::FONT_STYLE             },
       { Sid::bendColor,                          Pid::COLOR                  },
@@ -1976,6 +2074,7 @@ const TextStyle bendTextStyle {{
 const TextStyle headerTextStyle {{
       { Sid::headerFontFace,                     Pid::FONT_FACE              },
       { Sid::headerFontSize,                     Pid::FONT_SIZE              },
+      { Sid::headerLineSpacing,                  Pid::TEXT_LINE_SPACING      },
       { Sid::headerFontSpatiumDependent,         Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::headerFontStyle,                    Pid::FONT_STYLE             },
       { Sid::headerColor,                        Pid::COLOR                  },
@@ -1992,6 +2091,7 @@ const TextStyle headerTextStyle {{
 const TextStyle footerTextStyle {{
       { Sid::footerFontFace,                     Pid::FONT_FACE              },
       { Sid::footerFontSize,                     Pid::FONT_SIZE              },
+      { Sid::footerLineSpacing,                  Pid::TEXT_LINE_SPACING      },
       { Sid::footerFontSpatiumDependent,         Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::footerFontStyle,                    Pid::FONT_STYLE             },
       { Sid::footerColor,                        Pid::COLOR                  },
@@ -2008,6 +2108,7 @@ const TextStyle footerTextStyle {{
 const TextStyle instrumentChangeTextStyle {{
       { Sid::instrumentChangeFontFace,             Pid::FONT_FACE              },
       { Sid::instrumentChangeFontSize,             Pid::FONT_SIZE              },
+      { Sid::instrumentChangeLineSpacing,          Pid::TEXT_LINE_SPACING      },
       { Sid::instrumentChangeFontSpatiumDependent, Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::instrumentChangeFontStyle,            Pid::FONT_STYLE             },
       { Sid::instrumentChangeColor,                Pid::COLOR                  },
@@ -2024,6 +2125,7 @@ const TextStyle instrumentChangeTextStyle {{
 const TextStyle stickingTextStyle {{
       { Sid::stickingFontFace,                   Pid::FONT_FACE              },
       { Sid::stickingFontSize,                   Pid::FONT_SIZE              },
+      { Sid::stickingLineSpacing,                Pid::TEXT_LINE_SPACING      },
       { Sid::stickingFontSpatiumDependent,       Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::stickingFontStyle,                  Pid::FONT_STYLE             },
       { Sid::stickingColor,                      Pid::COLOR                  },
@@ -2040,6 +2142,7 @@ const TextStyle stickingTextStyle {{
 const TextStyle user1TextStyle {{
       { Sid::user1FontFace,                      Pid::FONT_FACE              },
       { Sid::user1FontSize,                      Pid::FONT_SIZE              },
+      { Sid::user1LineSpacing,                   Pid::TEXT_LINE_SPACING      },
       { Sid::user1FontSpatiumDependent,          Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::user1FontStyle,                     Pid::FONT_STYLE             },
       { Sid::user1Color,                         Pid::COLOR                  },
@@ -2056,6 +2159,7 @@ const TextStyle user1TextStyle {{
 const TextStyle user2TextStyle {{
       { Sid::user2FontFace,                      Pid::FONT_FACE              },
       { Sid::user2FontSize,                      Pid::FONT_SIZE              },
+      { Sid::user2LineSpacing,                   Pid::TEXT_LINE_SPACING      },
       { Sid::user2FontSpatiumDependent,          Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::user2FontStyle,                     Pid::FONT_STYLE             },
       { Sid::user2Color,                         Pid::COLOR                  },
@@ -2072,6 +2176,7 @@ const TextStyle user2TextStyle {{
 const TextStyle user3TextStyle {{
       { Sid::user3FontFace,                      Pid::FONT_FACE              },
       { Sid::user3FontSize,                      Pid::FONT_SIZE              },
+      { Sid::user3LineSpacing,                   Pid::TEXT_LINE_SPACING      },
       { Sid::user3FontSpatiumDependent,          Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::user3FontStyle,                     Pid::FONT_STYLE             },
       { Sid::user3Color,                         Pid::COLOR                  },
@@ -2088,6 +2193,7 @@ const TextStyle user3TextStyle {{
 const TextStyle user4TextStyle {{
       { Sid::user4FontFace,                      Pid::FONT_FACE              },
       { Sid::user4FontSize,                      Pid::FONT_SIZE              },
+      { Sid::user4LineSpacing,                   Pid::TEXT_LINE_SPACING      },
       { Sid::user4FontSpatiumDependent,          Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::user4FontStyle,                     Pid::FONT_STYLE             },
       { Sid::user4Color,                         Pid::COLOR                  },
@@ -2104,6 +2210,7 @@ const TextStyle user4TextStyle {{
 const TextStyle user5TextStyle {{
       { Sid::user5FontFace,                      Pid::FONT_FACE              },
       { Sid::user5FontSize,                      Pid::FONT_SIZE              },
+      { Sid::user5LineSpacing,                   Pid::TEXT_LINE_SPACING      },
       { Sid::user5FontSpatiumDependent,          Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::user5FontStyle,                     Pid::FONT_STYLE             },
       { Sid::user5Color,                         Pid::COLOR                  },
@@ -2120,6 +2227,7 @@ const TextStyle user5TextStyle {{
 const TextStyle user6TextStyle {{
       { Sid::user6FontFace,                      Pid::FONT_FACE              },
       { Sid::user6FontSize,                      Pid::FONT_SIZE              },
+      { Sid::user6LineSpacing,                   Pid::TEXT_LINE_SPACING      },
       { Sid::user6FontSpatiumDependent,          Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::user6FontStyle,                     Pid::FONT_STYLE             },
       { Sid::user6Color,                         Pid::COLOR                  },
@@ -2136,6 +2244,7 @@ const TextStyle user6TextStyle {{
 const TextStyle user7TextStyle {{
       { Sid::user7FontFace,                      Pid::FONT_FACE              },
       { Sid::user7FontSize,                      Pid::FONT_SIZE              },
+      { Sid::user7LineSpacing,                   Pid::TEXT_LINE_SPACING      },
       { Sid::user7FontSpatiumDependent,          Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::user7FontStyle,                     Pid::FONT_STYLE             },
       { Sid::user7Color,                         Pid::COLOR                  },
@@ -2152,6 +2261,7 @@ const TextStyle user7TextStyle {{
 const TextStyle user8TextStyle {{
       { Sid::user8FontFace,                      Pid::FONT_FACE              },
       { Sid::user8FontSize,                      Pid::FONT_SIZE              },
+      { Sid::user8LineSpacing,                   Pid::TEXT_LINE_SPACING      },
       { Sid::user8FontSpatiumDependent,          Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::user8FontStyle,                     Pid::FONT_STYLE             },
       { Sid::user8Color,                         Pid::COLOR                  },
@@ -2168,6 +2278,7 @@ const TextStyle user8TextStyle {{
 const TextStyle user9TextStyle {{
       { Sid::user9FontFace,                      Pid::FONT_FACE              },
       { Sid::user9FontSize,                      Pid::FONT_SIZE              },
+      { Sid::user9LineSpacing,                   Pid::TEXT_LINE_SPACING      },
       { Sid::user9FontSpatiumDependent,          Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::user9FontStyle,                     Pid::FONT_STYLE             },
       { Sid::user9Color,                         Pid::COLOR                  },
@@ -2184,6 +2295,7 @@ const TextStyle user9TextStyle {{
 const TextStyle user10TextStyle {{
       { Sid::user10FontFace,                     Pid::FONT_FACE              },
       { Sid::user10FontSize,                     Pid::FONT_SIZE              },
+      { Sid::user10LineSpacing,                  Pid::TEXT_LINE_SPACING      },
       { Sid::user10FontSpatiumDependent,         Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::user10FontStyle,                    Pid::FONT_STYLE             },
       { Sid::user10Color,                        Pid::COLOR                  },
@@ -2200,6 +2312,7 @@ const TextStyle user10TextStyle {{
 const TextStyle user11TextStyle {{
       { Sid::user11FontFace,                     Pid::FONT_FACE              },
       { Sid::user11FontSize,                     Pid::FONT_SIZE              },
+      { Sid::user11LineSpacing,                  Pid::TEXT_LINE_SPACING      },
       { Sid::user11FontSpatiumDependent,         Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::user11FontStyle,                    Pid::FONT_STYLE             },
       { Sid::user11Color,                        Pid::COLOR                  },
@@ -2216,6 +2329,7 @@ const TextStyle user11TextStyle {{
 const TextStyle user12TextStyle {{
       { Sid::user12FontFace,                     Pid::FONT_FACE              },
       { Sid::user12FontSize,                     Pid::FONT_SIZE              },
+      { Sid::user12LineSpacing,                  Pid::TEXT_LINE_SPACING      },
       { Sid::user12FontSpatiumDependent,         Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::user12FontStyle,                    Pid::FONT_STYLE             },
       { Sid::user12Color,                        Pid::COLOR                  },

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -91,6 +91,7 @@ enum class Sid {
 
       lyricsOddFontFace,
       lyricsOddFontSize,
+      lyricsOddLineSpacing,
       lyricsOddFontSpatiumDependent,
       lyricsOddFontStyle,
       lyricsOddColor,
@@ -104,6 +105,7 @@ enum class Sid {
 
       lyricsEvenFontFace,
       lyricsEvenFontSize,
+      lyricsEvenLineSpacing,
       lyricsEvenFontSpatiumDependent,
       lyricsEvenFontStyle,
       lyricsEvenColor,
@@ -212,6 +214,7 @@ enum class Sid {
       hairpinLineWidth,
       hairpinFontFace,
       hairpinFontSize,
+      hairpinLineSpacing,
       hairpinFontSpatiumDependent,
       hairpinFontStyle,
       hairpinColor,
@@ -239,6 +242,7 @@ enum class Sid {
       pedalHookHeight,
       pedalFontFace,
       pedalFontSize,
+      pedalLineSpacing,
       pedalFontSpatiumDependent,
       pedalFontStyle,
       pedalColor,
@@ -286,6 +290,7 @@ enum class Sid {
 
       chordSymbolAFontFace,
       chordSymbolAFontSize,
+      chordSymbolALineSpacing,
       chordSymbolAFontSpatiumDependent,
       chordSymbolAFontStyle,
       chordSymbolAColor,
@@ -299,6 +304,7 @@ enum class Sid {
 
       chordSymbolBFontFace,
       chordSymbolBFontSize,
+      chordSymbolBLineSpacing,
       chordSymbolBFontSpatiumDependent,
       chordSymbolBFontStyle,
       chordSymbolBColor,
@@ -312,6 +318,7 @@ enum class Sid {
 
       romanNumeralFontFace,
       romanNumeralFontSize,
+      romanNumeralLineSpacing,
       romanNumeralFontSpatiumDependent,
       romanNumeralFontStyle,
       romanNumeralColor,
@@ -325,6 +332,7 @@ enum class Sid {
 
       nashvilleNumberFontFace,
       nashvilleNumberFontSize,
+      nashvilleNumberLineSpacing,
       nashvilleNumberFontSpatiumDependent,
       nashvilleNumberFontStyle,
       nashvilleNumberColor,
@@ -446,6 +454,7 @@ enum class Sid {
       voltaLineStyle,
       voltaFontFace,
       voltaFontSize,
+      voltaLineSpacing,
       voltaFontSpatiumDependent,
       voltaFontStyle,
       voltaColor,
@@ -500,6 +509,7 @@ enum class Sid {
       ottavaNumbersOnly,
       ottavaFontFace,
       ottavaFontSize,
+      ottavaLineSpacing,
       ottavaFontSpatiumDependent,
       ottavaFontStyle,
       ottavaColor,
@@ -540,6 +550,7 @@ enum class Sid {
       tupletBracketType,
       tupletFontFace,
       tupletFontSize,
+      tupletLineSpacing,
       tupletFontSpatiumDependent,
       tupletFontStyle,
       tupletColor,
@@ -586,6 +597,7 @@ enum class Sid {
 
       defaultFontFace,
       defaultFontSize,
+      defaultLineSpacing,
       defaultFontSpatiumDependent,
       defaultFontStyle,
       defaultColor,
@@ -603,6 +615,7 @@ enum class Sid {
 
       titleFontFace,
       titleFontSize,
+      titleLineSpacing,
       titleFontSpatiumDependent,
       titleFontStyle,
       titleColor,
@@ -618,6 +631,7 @@ enum class Sid {
 
       subTitleFontFace,
       subTitleFontSize,
+      subTitleLineSpacing,
       subTitleFontSpatiumDependent,
       subTitleFontStyle,
       subTitleColor,
@@ -633,6 +647,7 @@ enum class Sid {
 
       composerFontFace,
       composerFontSize,
+      composerLineSpacing,
       composerFontSpatiumDependent,
       composerFontStyle,
       composerColor,
@@ -648,6 +663,7 @@ enum class Sid {
 
       lyricistFontFace,
       lyricistFontSize,
+      lyricistLineSpacing,
       lyricistFontSpatiumDependent,
       lyricistFontStyle,
       lyricistColor,
@@ -663,6 +679,7 @@ enum class Sid {
 
       fingeringFontFace,
       fingeringFontSize,
+      fingeringLineSpacing,
       fingeringFontSpatiumDependent,
       fingeringFontStyle,
       fingeringColor,
@@ -677,6 +694,7 @@ enum class Sid {
 
       lhGuitarFingeringFontFace,
       lhGuitarFingeringFontSize,
+      lhGuitarFingeringLineSpacing,
       lhGuitarFingeringFontSpatiumDependent,
       lhGuitarFingeringFontStyle,
       lhGuitarFingeringColor,
@@ -691,6 +709,7 @@ enum class Sid {
 
       rhGuitarFingeringFontFace,
       rhGuitarFingeringFontSize,
+      rhGuitarFingeringLineSpacing,
       rhGuitarFingeringFontSpatiumDependent,
       rhGuitarFingeringFontStyle,
       rhGuitarFingeringColor,
@@ -705,6 +724,7 @@ enum class Sid {
 
       stringNumberFontFace,
       stringNumberFontSize,
+      stringNumberLineSpacing,
       stringNumberFontSpatiumDependent,
       stringNumberFontStyle,
       stringNumberColor,
@@ -719,6 +739,7 @@ enum class Sid {
 
       longInstrumentFontFace,
       longInstrumentFontSize,
+      longInstrumentLineSpacing,
       longInstrumentFontSpatiumDependent,
       longInstrumentFontStyle,
       longInstrumentColor,
@@ -733,6 +754,7 @@ enum class Sid {
 
       shortInstrumentFontFace,
       shortInstrumentFontSize,
+      shortInstrumentLineSpacing,
       shortInstrumentFontSpatiumDependent,
       shortInstrumentFontStyle,
       shortInstrumentColor,
@@ -747,6 +769,7 @@ enum class Sid {
 
       partInstrumentFontFace,
       partInstrumentFontSize,
+      partInstrumentLineSpacing,
       partInstrumentFontSpatiumDependent,
       partInstrumentFontStyle,
       partInstrumentColor,
@@ -761,6 +784,7 @@ enum class Sid {
 
       dynamicsFontFace,
       dynamicsFontSize,
+      dynamicsLineSpacing,
       dynamicsFontSpatiumDependent,
       dynamicsFontStyle,
       dynamicsColor,
@@ -774,6 +798,7 @@ enum class Sid {
 
       expressionFontFace,
       expressionFontSize,
+      expressionLineSpacing,
       expressionFontSpatiumDependent,
       expressionFontStyle,
       expressionColor,
@@ -789,6 +814,7 @@ enum class Sid {
 
       tempoFontFace,
       tempoFontSize,
+      tempoLineSpacing,
       tempoFontSpatiumDependent,
       tempoFontStyle,
       tempoColor,
@@ -807,6 +833,7 @@ enum class Sid {
 
       metronomeFontFace,
       metronomeFontSize,
+      metronomeLineSpacing,
       metronomeFontSpatiumDependent,
       metronomeFontStyle,
       metronomeColor,
@@ -822,6 +849,7 @@ enum class Sid {
 
       measureNumberFontFace,
       measureNumberFontSize,
+      measureNumberLineSpacing,
       measureNumberFontSpatiumDependent,
       measureNumberFontStyle,
       measureNumberColor,
@@ -840,6 +868,7 @@ enum class Sid {
 
       translatorFontFace,
       translatorFontSize,
+      translatorLineSpacing,
       translatorFontSpatiumDependent,
       translatorFontStyle,
       translatorColor,
@@ -854,6 +883,7 @@ enum class Sid {
 
       systemTextFontFace,
       systemTextFontSize,
+      systemTextLineSpacing,
       systemTextFontSpatiumDependent,
       systemTextFontStyle,
       systemTextColor,
@@ -872,6 +902,7 @@ enum class Sid {
 
       staffTextFontFace,
       staffTextFontSize,
+      staffTextLineSpacing,
       staffTextFontSpatiumDependent,
       staffTextFontStyle,
       staffTextColor,
@@ -890,6 +921,7 @@ enum class Sid {
 
       rehearsalMarkFontFace,
       rehearsalMarkFontSize,
+      rehearsalMarkLineSpacing,
       rehearsalMarkFontSpatiumDependent,
       rehearsalMarkFontStyle,
       rehearsalMarkColor,
@@ -907,6 +939,7 @@ enum class Sid {
 
       repeatLeftFontFace,
       repeatLeftFontSize,
+      repeatLeftLineSpacing,
       repeatLeftFontSpatiumDependent,
       repeatLeftFontStyle,
       repeatLeftColor,
@@ -921,6 +954,7 @@ enum class Sid {
 
       repeatRightFontFace,
       repeatRightFontSize,
+      repeatRightLineSpacing,
       repeatRightFontSpatiumDependent,
       repeatRightFontStyle,
       repeatRightColor,
@@ -935,6 +969,7 @@ enum class Sid {
 
       frameFontFace,
       frameFontSize,
+      frameLineSpacing,
       frameFontSpatiumDependent,
       frameFontStyle,
       frameColor,
@@ -949,6 +984,7 @@ enum class Sid {
 
       textLineFontFace,
       textLineFontSize,
+      textLineLineSpacing,
       textLineFontSpatiumDependent,
       textLineFontStyle,
       textLineColor,
@@ -956,6 +992,7 @@ enum class Sid {
 
       glissandoFontFace,
       glissandoFontSize,
+      glissandoLineSpacing,
       glissandoFontSpatiumDependent,
       glissandoFontStyle,
       glissandoColor,
@@ -972,6 +1009,7 @@ enum class Sid {
 
       bendFontFace,
       bendFontSize,
+      bendLineSpacing,
       bendFontSpatiumDependent,
       bendFontStyle,
       bendColor,
@@ -988,6 +1026,7 @@ enum class Sid {
 
       headerFontFace,
       headerFontSize,
+      headerLineSpacing,
       headerFontSpatiumDependent,
       headerFontStyle,
       headerColor,
@@ -1002,6 +1041,7 @@ enum class Sid {
 
       footerFontFace,
       footerFontSize,
+      footerLineSpacing,
       footerFontSpatiumDependent,
       footerFontStyle,
       footerColor,
@@ -1016,6 +1056,7 @@ enum class Sid {
 
       instrumentChangeFontFace,
       instrumentChangeFontSize,
+      instrumentChangeLineSpacing,
       instrumentChangeFontSpatiumDependent,
       instrumentChangeFontStyle,
       instrumentChangeColor,
@@ -1034,6 +1075,7 @@ enum class Sid {
 
       stickingFontFace,
       stickingFontSize,
+      stickingLineSpacing,
       stickingFontSpatiumDependent,
       stickingFontStyle,
       stickingColor,
@@ -1052,6 +1094,7 @@ enum class Sid {
 
       figuredBassFontFace,
       figuredBassFontSize,
+      figuredBassLineSpacing,
       figuredBassFontSpatiumDependent,
       figuredBassFontStyle,
       figuredBassColor,
@@ -1059,6 +1102,7 @@ enum class Sid {
       user1Name,
       user1FontFace,
       user1FontSize,
+      user1LineSpacing,
       user1FontSpatiumDependent,
       user1FontStyle,
       user1Color,
@@ -1075,6 +1119,7 @@ enum class Sid {
       user2Name,
       user2FontFace,
       user2FontSize,
+      user2LineSpacing,
       user2FontSpatiumDependent,
       user2FontStyle,
       user2Color,
@@ -1091,6 +1136,7 @@ enum class Sid {
       user3Name,
       user3FontFace,
       user3FontSize,
+      user3LineSpacing,
       user3FontSpatiumDependent,
       user3FontStyle,
       user3Color,
@@ -1107,6 +1153,7 @@ enum class Sid {
       user4Name,
       user4FontFace,
       user4FontSize,
+      user4LineSpacing,
       user4FontSpatiumDependent,
       user4FontStyle,
       user4Color,
@@ -1123,6 +1170,7 @@ enum class Sid {
       user5Name,
       user5FontFace,
       user5FontSize,
+      user5LineSpacing,
       user5FontSpatiumDependent,
       user5FontStyle,
       user5Color,
@@ -1139,6 +1187,7 @@ enum class Sid {
       user6Name,
       user6FontFace,
       user6FontSize,
+      user6LineSpacing,
       user6FontSpatiumDependent,
       user6FontStyle,
       user6Color,
@@ -1155,6 +1204,7 @@ enum class Sid {
       user7Name,
       user7FontFace,
       user7FontSize,
+      user7LineSpacing,
       user7FontSpatiumDependent,
       user7FontStyle,
       user7Color,
@@ -1171,6 +1221,7 @@ enum class Sid {
       user8Name,
       user8FontFace,
       user8FontSize,
+      user8LineSpacing,
       user8FontSpatiumDependent,
       user8FontStyle,
       user8Color,
@@ -1187,6 +1238,7 @@ enum class Sid {
       user9Name,
       user9FontFace,
       user9FontSize,
+      user9LineSpacing,
       user9FontSpatiumDependent,
       user9FontStyle,
       user9Color,
@@ -1203,6 +1255,7 @@ enum class Sid {
       user10Name,
       user10FontFace,
       user10FontSize,
+      user10LineSpacing,
       user10FontSpatiumDependent,
       user10FontStyle,
       user10Color,
@@ -1219,6 +1272,7 @@ enum class Sid {
       user11Name,
       user11FontFace,
       user11FontSize,
+      user11LineSpacing,
       user11FontSpatiumDependent,
       user11FontStyle,
       user11Color,
@@ -1235,6 +1289,7 @@ enum class Sid {
       user12Name,
       user12FontFace,
       user12FontSize,
+      user12LineSpacing,
       user12FontSpatiumDependent,
       user12FontStyle,
       user12Color,
@@ -1250,6 +1305,7 @@ enum class Sid {
 
       letRingFontFace,
       letRingFontSize,
+      letRingLineSpacing,
       letRingFontSpatiumDependent,
       letRingFontStyle,
       letRingColor,
@@ -1272,6 +1328,7 @@ enum class Sid {
 
       palmMuteFontFace,
       palmMuteFontSize,
+      palmMuteLineSpacing,
       palmMuteFontSpatiumDependent,
       palmMuteFontStyle,
       palmMuteColor,
@@ -1376,7 +1433,7 @@ struct StyledProperty {
 
 typedef std::vector<StyledProperty> ElementStyle;
 
-#define TEXT_STYLE_SIZE 13
+#define TEXT_STYLE_SIZE 14
 
 typedef std::array<StyledProperty, TEXT_STYLE_SIZE> TextStyle;
 

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -992,6 +992,10 @@ void TextBlock::layout(TextBase* t)
                   _lineSpacing = qMax(_lineSpacing, fm.lineSpacing());
                   }
             }
+
+      // Apply style/custom line spacing
+      _lineSpacing *= t->textLineSpacing();
+
       qreal rx;
       if (t->align() & Align::RIGHT)
             rx = layoutWidth-_bbox.right();
@@ -1488,6 +1492,7 @@ TextBase::TextBase(Score* s, Tid tid, ElementFlags f)
       _tid                    = tid;
       _family                 = "FreeSerif";
       _size                   = 10.0;
+      _textLineSpacing        = 1.0;
       _fontStyle              = FontStyle::Normal;
       _bgColor                = QColor(255, 255, 255, 0);
       _frameColor             = QColor(0, 0, 0, 255);
@@ -1517,6 +1522,7 @@ TextBase::TextBase(const TextBase& st)
       _tid                         = st._tid;
       _family                      = st._family;
       _size                        = st._size;
+      _textLineSpacing             = st._textLineSpacing;
       _fontStyle                   = st._fontStyle;
       _bgColor                     = st._bgColor;
       _frameColor                  = st._frameColor;
@@ -2134,6 +2140,7 @@ static constexpr std::array<Pid, 18> pids { {
       Pid::SUB_STYLE,
       Pid::FONT_FACE,
       Pid::FONT_SIZE,
+      Pid::TEXT_LINE_SPACING,
       Pid::FONT_STYLE,
       Pid::COLOR,
       Pid::FRAME_TYPE,
@@ -2720,6 +2727,8 @@ QVariant TextBase::getProperty(Pid propertyId) const
                   return size();
             case Pid::FONT_STYLE:
                   return int(fontStyle());
+            case Pid::TEXT_LINE_SPACING:
+                return textLineSpacing();
             case Pid::FRAME_TYPE:
                   return int(frameType());
             case Pid::FRAME_WIDTH:
@@ -2762,6 +2771,9 @@ bool TextBase::setProperty(Pid pid, const QVariant& v)
                   break;
             case Pid::FONT_STYLE:
                   setFontStyle(FontStyle(v.toInt()));
+                  break;
+            case Pid::TEXT_LINE_SPACING:
+                  setTextLineSpacing(v.toReal());
                   break;
             case Pid::FRAME_TYPE:
                   setFrameType(FrameType(v.toInt()));

--- a/libmscore/textbase.h
+++ b/libmscore/textbase.h
@@ -66,6 +66,7 @@ class CharFormat {
       bool _preedit             { false };
       VerticalAlignment _valign { VerticalAlignment::AlignNormal };
       qreal _fontSize           { 12.0  };
+      qreal _textLineSpacing    { 1.0 };
       QString _fontFamily;
 
    public:
@@ -88,6 +89,7 @@ class CharFormat {
       void setPreedit(bool val)              { _preedit     = val;  }
       void setValign(VerticalAlignment val)  { _valign      = val;  }
       void setFontSize(qreal val)            { Q_ASSERT(val > 0.0); _fontSize = val; }
+      void setTextLineSpacing(qreal val)     { _textLineSpacing = val; }
       void setFontFamily(const QString& val) { _fontFamily  = val;  }
 
       void setFormat(FormatId, QVariant);
@@ -231,6 +233,7 @@ class TextBase : public Element {
       M_PROPERTY(FrameType,  frameType,              setFrameType)
       M_PROPERTY(QString,    family,                 setFamily)
       M_PROPERTY(qreal,      size,                   setSize)
+      M_PROPERTY(qreal,      textLineSpacing,        setTextLineSpacing)
       M_PROPERTY(QColor,     bgColor,                setBgColor)
       M_PROPERTY(QColor,     frameColor,             setFrameColor)
       M_PROPERTY(Spatium,    frameWidth,             setFrameWidth)

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -617,6 +617,15 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
          [=](){ textStyleValueChanged(Pid::FONT_SIZE, QVariant(textStyleFontSize->value())); }
          );
 
+      // line spacing
+      resetTextStyleLineSpacing->setIcon(*icons[int(Icons::reset_ICON)]);
+      connect(resetTextStyleLineSpacing, &QToolButton::clicked,
+          [=]() { resetTextStyle(Pid::TEXT_LINE_SPACING); }
+      );
+      connect(textStyleLineSpacing, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+          [=]() { textStyleValueChanged(Pid::TEXT_LINE_SPACING, QVariant(textStyleLineSpacing->value())); }
+      );
+
       // font style
       resetTextStyleFontStyle->setIcon(*icons[int(Icons::reset_ICON)]);
       connect(resetTextStyleFontStyle, &QToolButton::clicked,
@@ -1442,6 +1451,11 @@ void EditStyle::textStyleChanged(int row)
                         textStyleFontSize->setValue(cs->styleD(a.sid));
                         resetTextStyleFontSize->setEnabled(cs->styleV(a.sid) != MScore::defaultStyle().value(a.sid));
                         break;
+
+                  case Pid::TEXT_LINE_SPACING:
+                      textStyleLineSpacing->setValue(cs->styleD(a.sid));
+                      resetTextStyleLineSpacing->setEnabled(cs->styleV(a.sid) != MScore::defaultStyle().value(a.sid));
+                      break;
 
                   case Pid::FONT_STYLE:
                         textStyleFontStyle->setFontStyle(FontStyle(cs->styleV(a.sid).toInt()));

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -2285,7 +2285,7 @@
               <string>Reset 'Position below' value</string>
              </property>
              <property name="text">
-             <string notr="true"/>
+              <string notr="true"/>
              </property>
              <property name="icon">
               <iconset resource="musescore.qrc">
@@ -10276,150 +10276,7 @@
            <string>Edit Text Style</string>
           </property>
           <layout class="QGridLayout" name="_12">
-           <item row="4" column="0">
-            <widget class="QLabel" name="label_209">
-             <property name="text">
-              <string>Style:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="2">
-            <widget class="QToolButton" name="resetTextStyleSpatiumDependent">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Follow staff size' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="2">
-            <widget class="QToolButton" name="resetTextStyleFontStyle">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Font style' values</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="2">
-            <widget class="QToolButton" name="resetTextStyleFontSize">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Font size' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="2">
-            <widget class="QToolButton" name="resetTextStyleName">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Name' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="0">
-            <widget class="QLabel" name="labelStyleName">
-             <property name="text">
-              <string>Name:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="1">
-            <widget class="Ms::AlignSelect" name="textStyleAlign" native="true"/>
-           </item>
-           <item row="1" column="2">
-            <widget class="QToolButton" name="resetTextStyleFontFace">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Font face' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="2">
-            <widget class="QToolButton" name="resetTextStyleOffset">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Offset' values</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="0">
-            <widget class="QLabel" name="label_210">
-             <property name="text">
-              <string>Align:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="2">
-            <widget class="QToolButton" name="resetTextStyleColor">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Color' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="9" column="0" colspan="3">
+           <item row="12" column="0" colspan="3">
             <widget class="QGroupBox" name="groupBox_40">
              <property name="title">
               <string/>
@@ -10628,13 +10485,47 @@
              </layout>
             </widget>
            </item>
-           <item row="6" column="1">
-            <widget class="Awl::ColorLabel" name="textStyleColor"/>
-           </item>
-           <item row="7" column="1">
+           <item row="10" column="1">
             <widget class="Ms::OffsetSelect" name="textStyleOffset" native="true"/>
            </item>
-           <item row="5" column="2">
+           <item row="9" column="1">
+            <widget class="Awl::ColorLabel" name="textStyleColor"/>
+           </item>
+           <item row="7" column="2">
+            <widget class="QToolButton" name="resetTextStyleFontStyle">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Font style' values</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QDoubleSpinBox" name="textStyleFontSize">
+             <property name="suffix">
+              <string>pt</string>
+             </property>
+             <property name="minimum">
+              <double>1.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_208">
+             <property name="text">
+              <string>Font:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="2">
             <widget class="QToolButton" name="resetTextStyleAlign">
              <property name="toolTip">
               <string>Reset to default</string>
@@ -10651,10 +10542,156 @@
              </property>
             </widget>
            </item>
+           <item row="9" column="2">
+            <widget class="QToolButton" name="resetTextStyleColor">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Color' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="9" column="0">
+            <widget class="QLabel" name="textStyleColorLabel">
+             <property name="text">
+              <string>Color:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="1">
+            <widget class="Ms::FontStyleSelect" name="textStyleFontStyle" native="true"/>
+           </item>
+           <item row="2" column="2">
+            <widget class="QToolButton" name="resetTextStyleFontSize">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Font size' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLineEdit" name="styleName"/>
+           </item>
            <item row="7" column="0">
+            <widget class="QLabel" name="label_209">
+             <property name="text">
+              <string>Style:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="1">
+            <widget class="Ms::AlignSelect" name="textStyleAlign" native="true"/>
+           </item>
+           <item row="6" column="2">
+            <widget class="QToolButton" name="resetTextStyleSpatiumDependent">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Follow staff size' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="0">
             <widget class="QLabel" name="label_186">
              <property name="text">
               <string>Offset:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="0" colspan="2">
+            <widget class="QCheckBox" name="textStyleSpatiumDependent">
+             <property name="text">
+              <string>Follow staff size</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="QToolButton" name="resetTextStyleName">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Name' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="2">
+            <widget class="QToolButton" name="resetTextStyleFontFace">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Font face' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="2">
+            <widget class="QToolButton" name="resetTextStyleOffset">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Offset' values</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="0">
+            <widget class="QLabel" name="label_210">
+             <property name="text">
+              <string>Align:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="labelStyleName">
+             <property name="text">
+              <string>Name:</string>
              </property>
             </widget>
            </item>
@@ -10668,13 +10705,6 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="label_208">
-             <property name="text">
-              <string>Font:</string>
-             </property>
-            </widget>
-           </item>
            <item row="2" column="0">
             <widget class="QLabel" name="label_207">
              <property name="text">
@@ -10682,33 +10712,40 @@
              </property>
             </widget>
            </item>
-           <item row="6" column="0">
-            <widget class="QLabel" name="textStyleColorLabel">
-             <property name="text">
-              <string>Color:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="0" colspan="2">
-            <widget class="QCheckBox" name="textStyleSpatiumDependent">
-             <property name="text">
-              <string>Follow staff size</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <widget class="Ms::FontStyleSelect" name="textStyleFontStyle" native="true"/>
-           </item>
-           <item row="0" column="1">
-            <widget class="QLineEdit" name="styleName"/>
-           </item>
-           <item row="2" column="1">
-            <widget class="QDoubleSpinBox" name="textStyleFontSize">
+           <item row="3" column="1">
+            <widget class="QDoubleSpinBox" name="textStyleLineSpacing">
              <property name="suffix">
-              <string>pt</string>
+              <string> lines</string>
              </property>
-             <property name="minimum">
+             <property name="singleStep">
+              <double>0.100000000000000</double>
+             </property>
+             <property name="value">
               <double>1.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_147">
+             <property name="text">
+              <string>Line Spacing: </string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="2">
+            <widget class="QToolButton" name="resetTextStyleLineSpacing">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Font size' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
              </property>
             </widget>
            </item>
@@ -11206,6 +11243,8 @@
   <tabstop>resetTextStyleFontFace</tabstop>
   <tabstop>textStyleFontSize</tabstop>
   <tabstop>resetTextStyleFontSize</tabstop>
+  <tabstop>textStyleLineSpacing</tabstop>
+  <tabstop>resetTextStyleLineSpacing</tabstop>
   <tabstop>textStyleSpatiumDependent</tabstop>
   <tabstop>resetTextStyleSpatiumDependent</tabstop>
   <tabstop>resetTextStyleFontStyle</tabstop>

--- a/mscore/inspector/inspectorTextBase.cpp
+++ b/mscore/inspector/inspectorTextBase.cpp
@@ -34,6 +34,7 @@ InspectorTextBase::InspectorTextBase(QWidget* parent)
             { Pid::SIZE_SPATIUM_DEPENDENT,        0,  t.spatiumDependent,    t.resetSpatiumDependent    },
             { Pid::FONT_STYLE,        0, t.fontStyle,    t.resetFontStyle    },
             { Pid::FRAME_TYPE,        0, t.frameType,    t.resetFrameType    },
+            { Pid::TEXT_LINE_SPACING, 0, t.textLineSpacing, t.resetTextLineSpacing                      },
             { Pid::FRAME_FG_COLOR,    0, t.frameColor,   t.resetFrameColor   },
             { Pid::FRAME_BG_COLOR,    0, t.bgColor,      t.resetBgColor      },
             { Pid::FRAME_WIDTH,       0, t.frameWidth,   t.resetFrameWidth   },

--- a/mscore/inspector/inspector_text.ui
+++ b/mscore/inspector/inspector_text.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>329</width>
-    <height>320</height>
+    <width>231</width>
+    <height>495</height>
    </rect>
   </property>
   <property name="accessibleName">
@@ -82,15 +82,24 @@
       <property name="spacing">
        <number>3</number>
       </property>
-      <item row="9" column="0" colspan="4">
-       <widget class="QPushButton" name="resetToStyle">
+      <item row="7" column="0">
+       <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
-         <string>Remove Custom Formatting</string>
+         <string>Frame:</string>
+        </property>
+        <property name="buddy">
+         <cstring>frameType</cstring>
         </property>
        </widget>
       </item>
-      <item row="6" column="3">
-       <widget class="Ms::ResetButton" name="resetFrameType" native="true">
+      <item row="2" column="3">
+       <widget class="Ms::ResetButton" name="resetFontStyle" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
           <horstretch>0</horstretch>
@@ -98,105 +107,11 @@
          </sizepolicy>
         </property>
         <property name="accessibleName">
-         <string>Reset 'Frame' value</string>
+         <string>Reset 'Style' values</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="1" colspan="2">
-       <widget class="QComboBox" name="frameType">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Frame</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0" colspan="3">
-       <widget class="Ms::AlignSelect" name="align" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>Text alignment</string>
-        </property>
-        <property name="accessibleName">
-         <string>Alignment</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="3">
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QDoubleSpinBox" name="fontSize">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>Font size</string>
-          </property>
-          <property name="accessibleName">
-           <string>Font size</string>
-          </property>
-          <property name="suffix">
-           <string>pt</string>
-          </property>
-          <property name="minimum">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Ms::ResetButton" name="resetFontSize" native="true">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="accessibleName">
-           <string>Reset 'Style' values</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Ms::FontStyleSelect" name="fontStyle" native="true">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="accessibleName">
-           <string>Style</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="7" column="0" colspan="4">
+      <item row="8" column="0" colspan="4">
        <widget class="QFrame" name="frameWidget">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -424,8 +339,24 @@
         </layout>
        </widget>
       </item>
-      <item row="0" column="3">
-       <widget class="Ms::ResetButton" name="resetFontFace" native="true">
+      <item row="6" column="0" colspan="3">
+       <widget class="Ms::AlignSelect" name="align" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Text alignment</string>
+        </property>
+        <property name="accessibleName">
+         <string>Alignment</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="Ms::ResetButton" name="resetSpatiumDependent" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
           <horstretch>0</horstretch>
@@ -433,23 +364,7 @@
          </sizepolicy>
         </property>
         <property name="accessibleName">
-         <string>Reset 'Font face' value</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="label">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Frame:</string>
-        </property>
-        <property name="buddy">
-         <cstring>frameType</cstring>
+         <string>Reset 'Frame' value</string>
         </property>
        </widget>
       </item>
@@ -475,7 +390,40 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="3">
+      <item row="10" column="0" colspan="4">
+       <widget class="QPushButton" name="resetToStyle">
+        <property name="text">
+         <string>Remove Custom Formatting</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="3">
+       <widget class="Ms::ResetButton" name="resetFrameType" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Frame' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1" colspan="2">
+       <widget class="QComboBox" name="frameType">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Frame</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="3">
        <widget class="Ms::ResetButton" name="resetAlign" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -488,50 +436,175 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="0" colspan="3">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QDoubleSpinBox" name="fontSize">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Font size</string>
+          </property>
+          <property name="accessibleName">
+           <string>Font size</string>
+          </property>
+          <property name="suffix">
+           <string>pt</string>
+          </property>
+          <property name="minimum">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Ms::ResetButton" name="resetFontSize" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="accessibleName">
+           <string>Reset 'Style' values</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::MinimumExpanding</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>80</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Ms::FontStyleSelect" name="fontStyle" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="accessibleName">
+           <string>Style</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="0" column="3">
+       <widget class="Ms::ResetButton" name="resetFontFace" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Font face' value</string>
+        </property>
+       </widget>
+      </item>
       <item row="3" column="0" colspan="3">
-       <widget class="QCheckBox" name="spatiumDependent">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="focusPolicy">
-         <enum>Qt::TabFocus</enum>
-        </property>
-        <property name="text">
-         <string>Follow staff size</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="3">
-       <widget class="Ms::ResetButton" name="resetSpatiumDependent" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Follow staff size' value</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="3">
-       <widget class="Ms::ResetButton" name="resetFontStyle" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Style' values</string>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QDoubleSpinBox" name="textLineSpacing">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Line spacing</string>
+          </property>
+          <property name="accessibleName">
+           <string>Line spacing</string>
+          </property>
+          <property name="suffix">
+           <string> li</string>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="value">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Ms::ResetButton" name="resetTextLineSpacing" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="accessibleName">
+           <string>Reset 'Line Spacing' value</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Expanding</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item alignment="Qt::AlignRight">
+         <widget class="QCheckBox" name="spatiumDependent">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::TabFocus</enum>
+          </property>
+          <property name="text">
+           <string>Follow staff size</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -546,15 +619,15 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>Ms::FontStyleSelect</class>
-   <extends>QWidget</extends>
-   <header>inspector/fontStyleSelect.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>Awl::ColorLabel</class>
    <extends>QPushButton</extends>
    <header>awl/colorlabel.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>Ms::FontStyleSelect</class>
+   <extends>QWidget</extends>
+   <header>inspector/fontStyleSelect.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -568,6 +641,7 @@
   <tabstop>title</tabstop>
   <tabstop>fontFace</tabstop>
   <tabstop>fontSize</tabstop>
+  <tabstop>textLineSpacing</tabstop>
   <tabstop>spatiumDependent</tabstop>
   <tabstop>frameType</tabstop>
   <tabstop>frameWidth</tabstop>


### PR DESCRIPTION
Resolves  *https://musescore.org/en/node/308034*

**Adds custom text line spacing control to Text Inspector and Text Styles**

Spacing is in *lines* (li.)
The new property is a multiplier to the font's natural line spacing, in which `1.0 lines` would be the full natural spacing of the font (and MuseScore's current default), 0.5 lines would be half of this space and so on, in a similar way than most word processors  deal with line spacing.

This property was added for every Text Style and to the Text inspector.

Image shows the modified inspector and some text elements adjusted to different spacing.

![image](https://user-images.githubusercontent.com/2843953/87990347-35966d00-caba-11ea-8148-764f26d90720.png)

Code review, feedback and testing will be greatly appreciated!

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code

