### PR TITLE
fix #308023: realize chord symbol menu command inactive

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -4170,6 +4170,7 @@ void Score::cmd(const QAction* a, EditData& ed)
             { "grace32after",               [](Score* cs, EditData&){ cs->cmdAddGrace(NoteType::GRACE32_AFTER, MScore::division / 8); }},
             { "explode",                    [](Score* cs, EditData&){ cs->cmdExplode();                                               }},
             { "implode",                    [](Score* cs, EditData&){ cs->cmdImplode();                                               }},
+            { "realize-chord-symbols",      [](Score* cs, EditData&){ cs->cmdRealizeChordSymbols();                                   }},
             { "slash-fill",                 [](Score* cs, EditData&){ cs->cmdSlashFill();                                             }},
             { "slash-rhythm",               [](Score* cs, EditData&){ cs->cmdSlashRhythm();                                           }},
             { "resequence-rehearsal-marks", [](Score* cs, EditData&){ cs->cmdResequenceRehearsalMarks();                              }},


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/308023

The realize-chord-symbols command exists in the shortcut list
and is shown in the Tools menu,
but it was never actually hooked up to a command.
This simply adds it to the command list,
which enables the menu item to work.
Note the command in the context menu works already,
it is handled differently.