### PR TITLE
Fix #307946 Fix #307945 - Strange behavior with chord alignment.

### DIFF
--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1314,6 +1314,7 @@ void Harmony::layout()
       //      setOffset(propertyDefault(Pid::OFFSET).toPointF());
 
       layout1();
+      setPos(calculateBoundingRect());
       }
 
 //---------------------------------------------------------
@@ -1336,11 +1337,13 @@ void Harmony::layout1()
 //   calculateBoundingRect
 //---------------------------------------------------------
 
-void Harmony::calculateBoundingRect()
+QPoint Harmony::calculateBoundingRect()
       {
       const qreal        ypos = (placeBelow() && staff()) ? staff()->height() : 0.0;
       const FretDiagram* fd   = (parent() && parent()->isFretDiagram()) ? toFretDiagram(parent()) : nullptr;
       const qreal        cw   = symWidth(SymId::noteheadBlack);
+      qreal              newx = 0.0;
+      qreal              newy = 0.0;
 
       if (textList.empty()) {
             TextBase::layout1();
@@ -1363,7 +1366,8 @@ void Harmony::calculateBoundingRect()
                   yy = ypos - ((align() & Align::BOTTOM) ? _harmonyHeight - bbox().height() : 0.0);
                   }
 
-            setPos(xx, yy);
+            newx = xx;
+            newy = yy;
             }
       else {
             QRectF bb;
@@ -1385,7 +1389,8 @@ void Harmony::calculateBoundingRect()
                   else if (align() & Align::HCENTER)
                         xx = fd->centerX() - bb.width() / 2.0;
 
-                  setPos(0.0, ypos - yy - score()->styleP(Sid::harmonyFretDist));
+                  newx = 0.0;
+                  newy = ypos - yy - score()->styleP(Sid::harmonyFretDist);
                   }
             else {
                   if (align() & Align::RIGHT)
@@ -1393,7 +1398,8 @@ void Harmony::calculateBoundingRect()
                   else if (align() & Align::HCENTER)
                         xx = -bb.x() -bb.width() / 2.0 + cw / 2.0;
 
-                  setPos(0.0, ypos);
+                  newx = 0.0;
+                  newy = ypos;
                   }
 
             for (TextSegment* ts : textList)
@@ -1415,6 +1421,7 @@ void Harmony::calculateBoundingRect()
 
                   }
             }
+      return QPoint(newx, newy);
       }
 
 //---------------------------------------------------------

--- a/libmscore/harmony.h
+++ b/libmscore/harmony.h
@@ -206,7 +206,7 @@ class Harmony final : public TextBase {
       void spatiumChanged(qreal oldValue, qreal newValue) override;
       void localSpatiumChanged(qreal oldValue, qreal newValue) override;
       void setHarmony(const QString& s);
-      void calculateBoundingRect();
+      QPoint calculateBoundingRect();
       qreal xShapeOffset() const;
 
       QString userName() const override;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/307945
Resolves: https://musescore.org/en/node/307946

<code>Harmony::calculateBoundingRect()</code> no longer sets the new position of the <code>Harmony</code> but returns it. <code>Harmony::layout1()</code> ignores the the position while <code>Harmony::layout()</code> will use to set the position of the <code>Harmony</code>.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
