### PR TITLE
Nashville bugs

### DIFF
--- a/libmscore/chordlist.cpp
+++ b/libmscore/chordlist.cpp
@@ -1779,7 +1779,7 @@ void ChordList::write(XmlWriter& xml) const
       if (!renderListRoot.empty())
             writeRenderList(xml, &renderListRoot, "renderRoot");
       if (!renderListFunction.empty())
-            writeRenderList(xml, &renderListRoot, "renderFunction");
+            writeRenderList(xml, &renderListFunction, "renderFunction");
       if (!renderListBase.empty())
             writeRenderList(xml, &renderListBase, "renderBase");
       for (const ChordDescription& cd : *this)

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1251,6 +1251,7 @@ const RealizedHarmony& Harmony::getRealizedHarmony()
             offset = interval.chromatic;
 
       //Adjust for Nashville Notation, might be temporary
+      // TODO: set dirty on add/remove of keysig
       if (_harmonyType == HarmonyType::NASHVILLE && !_realizedHarmony.valid()) {
             Key key = staff()->key(tick());
             //parse root

--- a/libmscore/realizedharmony.cpp
+++ b/libmscore/realizedharmony.cpp
@@ -215,7 +215,8 @@ void RealizedHarmony::update(int rootTpc, int bassTpc, int transposeOffset /*= 0
             return;
             }
 
-      _notes = generateNotes(rootTpc, bassTpc, _literal, _voicing, transposeOffset);
+      if (tpcIsValid(rootTpc))
+            _notes = generateNotes(rootTpc, bassTpc, _literal, _voicing, transposeOffset);
       _dirty = false;
       }
 

--- a/share/styles/chords_jazz.xml
+++ b/share/styles/chords_jazz.xml
@@ -455,6 +455,7 @@
     </token>
 
   <renderRoot>:n :a </renderRoot>
+  <renderFunction>:a :n</renderFunction>
   <renderBase>/ m:0:1 :n :a m:0:-1</renderBase>
 
 <!--


### PR DESCRIPTION
This fixes two bugs with Nashville numbers:

1) in debug builds, an assertion failure / crash entering an empty number (regression due to chord symbol playback code)
2) when using jazz chord symbol style, Nashville numbers lose their numbers (not a regression, has been this way since the feature was implemented)

The first problem appears critical at first because it is a crash and a regression, but since it only affects debug builds, maybe it's not as bad as it seemed at first.  I can't guarantee the failed assertion won't cause problems elsewhere though.

The second problem is probably more serious, but definitely not a regression.

Probably the bottom line is, this should be targeted for 3.,5.1