### PR TITLE
[MU4] Fix #308052: Some scores not showing properly in Score View

### DIFF
--- a/mu4/scenes/inspector/models/abstractinspectormodel.cpp
+++ b/mu4/scenes/inspector/models/abstractinspectormodel.cpp
@@ -183,6 +183,7 @@ void AbstractInspectorModel::setIsEmpty(bool isEmpty)
 
 void AbstractInspectorModel::updateProperties()
 {
+    m_shouldUpdateStyleValues = false;
     requestElements();
 
     setIsEmpty(!hasAcceptableElements());
@@ -190,6 +191,7 @@ void AbstractInspectorModel::updateProperties()
     if (!isEmpty()) {
         loadProperties();
     }
+    m_shouldUpdateStyleValues = true;
 }
 
 Ms::Sid AbstractInspectorModel::styleIdByPropertyId(const Ms::Pid pid) const
@@ -207,11 +209,23 @@ Ms::Sid AbstractInspectorModel::styleIdByPropertyId(const Ms::Pid pid) const
     return result;
 }
 
+void AbstractInspectorModel::updateStyleValues(const QList<StyleSetting>& styleSettings)
+{
+    if (m_shouldUpdateStyleValues) {
+        adapter()->beginCommand();
+        for (StyleSetting s : styleSettings) {
+            adapter()->updateStyleValue(s.sid, s.value);
+        }
+        adapter()->endCommand();
+    }
+}
+
 void AbstractInspectorModel::updateStyleValue(const Ms::Sid& sid, const QVariant& newValue)
 {
-    adapter()->beginCommand();
-    adapter()->updateStyleValue(sid, newValue);
-    adapter()->endCommand();
+    const QList<StyleSetting>& styleSettings = {
+        { sid, newValue }
+    };
+    updateStyleValues(styleSettings);
 }
 
 QVariant AbstractInspectorModel::styleValue(const Ms::Sid& sid) const

--- a/mu4/scenes/inspector/models/abstractinspectormodel.h
+++ b/mu4/scenes/inspector/models/abstractinspectormodel.h
@@ -78,6 +78,11 @@ public:
         TYPE_TREMOLOBAR
     };
 
+    struct StyleSetting {
+        Ms::Sid sid;
+        QVariant value;
+    };
+
     explicit AbstractInspectorModel(QObject* parent, IElementRepositoryService* repository = nullptr);
 
     Q_INVOKABLE virtual void requestResetToDefaults();
@@ -123,6 +128,7 @@ protected:
     QVariant valueToElementUnits(const Ms::Pid& pid, const QVariant& value, const Ms::Element* element) const;
     QVariant valueFromElementUnits(const Ms::Pid& pid, const QVariant& value, const Ms::Element* element) const;
 
+    void updateStyleValues(const QList<StyleSetting>& styleSettings);
     void updateStyleValue(const Ms::Sid& sid, const QVariant& newValue);
     QVariant styleValue(const Ms::Sid& sid) const;
 
@@ -142,6 +148,7 @@ private:
     InspectorSectionType m_sectionType = SECTION_UNDEFINED;
     InspectorModelType m_modelType = TYPE_UNDEFINED;
     bool m_isEmpty = false;
+    bool m_shouldUpdateStyleValues = false;
 };
 
 #endif // ABSTRACTINSPECTORMODEL_H

--- a/mu4/scenes/inspector/models/score/scoreappearancesettingsmodel.cpp
+++ b/mu4/scenes/inspector/models/score/scoreappearancesettingsmodel.cpp
@@ -88,8 +88,11 @@ void ScoreAppearanceSettingsModel::setPageTypeListModel(PageTypeListModel* pageT
     connect(m_pageTypeListModel, &PageTypeListModel::currentPageSizeIdChanged, this, [this] (const int newCurrentPageSizeId) {
         QSizeF pageSize = QPageSize::size(QPageSize::PageSizeId(newCurrentPageSizeId), QPageSize::Inch);
 
-        updateStyleValue(Ms::Sid::pageWidth, pageSize.width());
-        updateStyleValue(Ms::Sid::pageHeight, pageSize.height());
+        const QList<StyleSetting>& styleSettings {
+            { Ms::Sid::pageWidth, pageSize.width() },
+            { Ms::Sid::pageHeight, pageSize.height() }
+        };
+        updateStyleValues(styleSettings);
     });
 }
 
@@ -103,8 +106,11 @@ void ScoreAppearanceSettingsModel::setOrientationType(int orientationType)
 
     QSizeF pageSize(styleValue(Ms::Sid::pageWidth).toDouble(), styleValue(Ms::Sid::pageHeight).toDouble());
 
-    updateStyleValue(Ms::Sid::pageWidth, pageSize.height());
-    updateStyleValue(Ms::Sid::pageHeight, pageSize.width());
+    const QList<StyleSetting>& styleSettings {
+        { Ms::Sid::pageWidth, pageSize.height() },
+        { Ms::Sid::pageHeight, pageSize.width() }
+    };
+    updateStyleValues(styleSettings);
     emit orientationTypeChanged(m_orientationType);
 }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/308052.

This solves two problems.

The first problem is that the score's style values are updated when the `ScoreAppearanceSettingsModel` loads its properties from the score. This should not happen, because loading properties from the score ought to be considered to be a read-only operation, and should not result in any commands being executed and pushed to the undo stack. Each call to `AbstractInspectorModel::updateStyleValue()` involves a call to `Score::startCmd()` and a matching call to `Score::endCmd()`, and `ScoreAppearanceSettingsModel::loadProperties()` involves the loading of four separate properties. And two of these properties (page size and orientation) involve two separate style values (page width and page height). Therefore, (and here is the second problem), the user would have to press undo twice in order to undo a change to one of these two properties.

The first problem is solved by making sure not to actually update any style values as a result of `AbstractInspectorModel::updateProperties()`. The second problem is solved by replacing multiple calls to `AbstractInspectorModel::updateStyleValue()` with a single call to `AbstractInspectorModel::updateStyleValues()`, which takes a list of Sids and values to update, and only calls `Score::startCmd()` and `Score::endCmd()` once. `AbstractInspectorModel::updateStyleValue()` now exists as a convenience function for when there is exactly one style value to update.