### PR TITLE
keyBarlineDistance gets overwritten by keyTimesigDistance

### DIFF
--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -169,7 +169,7 @@ static const StyleType styleTypes[] {
       { Sid::clefKeyDistance,         "clefKeyDistance",         Spatium(1.0) },   // gould: 1 - 1.25
       { Sid::clefTimesigDistance,     "clefTimesigDistance",     Spatium(1.0) },
       { Sid::keyTimesigDistance,      "keyTimesigDistance",      Spatium(1.0) },    // gould: 1 - 1.5
-      { Sid::keyBarlineDistance,      "keyTimesigDistance",      Spatium(1.0) },
+      { Sid::keyBarlineDistance,      "keyBarlineDistance",      Spatium(1.0) },
       { Sid::systemHeaderDistance,    "systemHeaderDistance",    Spatium(2.5) },     // gould: 2.5
       { Sid::systemHeaderTimeSigDistance, "systemHeaderTimeSigDistance", Spatium(2.0) },  // gould: 2.0
 


### PR DESCRIPTION
came up in the Telegram MuseScore developers' chat, https://t.me/musescoreeditorchat/81303 ff.
Not really a regression, so might wait for 3.5.1, even if being small enough and obviously correct (famous last words?)?
Needed in master too and should merge there cleanly, except for the formatting changes.