### PR TITLE
[MU3] Allow ledgerlines exactly as wide as the noteheads

### DIFF
--- a/libmscore/ledgerline.cpp
+++ b/libmscore/ledgerline.cpp
@@ -67,9 +67,9 @@ void LedgerLine::layout()
             setColor(staff()->color());
       qreal w2 = _width * .5;
       if (vertical)
-            bbox().setRect(-w2, -w2, _width, _len + _width);
+            bbox().setRect(-w2, 0, w2, _len);
       else
-            bbox().setRect(-w2, -w2, _len + _width, _width);
+            bbox().setRect(0, -w2, _len, w2);
       }
 
 //---------------------------------------------------------
@@ -80,7 +80,7 @@ void LedgerLine::draw(QPainter* painter) const
       {
       if (chord()->crossMeasure() == CrossMeasure::SECOND)
             return;
-      painter->setPen(QPen(curColor(), _width));
+      painter->setPen(QPen(curColor(), _width, Qt::SolidLine, Qt::FlatCap));
       if (vertical)
             painter->drawLine(QLineF(0.0, 0.0, 0.0, _len));
       else

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -138,7 +138,7 @@ struct StyleVal2 {
       { Sid::measureSpacing,              QVariant(1.2) },
       { Sid::staffLineWidth,              Spatium(0.08) },      // 0.09375
       { Sid::ledgerLineWidth,             Spatium(0.16) },     // 0.1875
-      { Sid::ledgerLineLength,            Spatium(.6) },     // notehead width + this value
+      { Sid::ledgerLineLength,            Spatium(0.76) },     // notehead width + this value
       { Sid::accidentalDistance,          Spatium(0.22) },
       { Sid::accidentalNoteDistance,      Spatium(0.22) },
       { Sid::beamWidth,                   Spatium(0.5) },           // was 0.48

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -189,7 +189,7 @@ static const StyleType styleTypes[] {
       { Sid::measureSpacing,          "measureSpacing",          QVariant(1.2) },
       { Sid::staffLineWidth,          "staffLineWidth",          Spatium(0.08) },     // 0.09375
       { Sid::ledgerLineWidth,         "ledgerLineWidth",         Spatium(0.16) },     // 0.1875
-      { Sid::ledgerLineLength,        "ledgerLineLength",        Spatium(.6)   },     // notehead width + this value
+      { Sid::ledgerLineLength,        "ledgerLineLength",        Spatium(0.76) },     // notehead width + this value
       { Sid::accidentalDistance,      "accidentalDistance",      Spatium(0.22) },
       { Sid::accidentalNoteDistance,  "accidentalNoteDistance",  Spatium(0.22) },
 

--- a/vtest/gen-ref.bat
+++ b/vtest/gen-ref.bat
@@ -1,9 +1,9 @@
 
 rem create reference
 
-set MSCORE=..\msvc.install_x64\bin\musescore.exe
+set MSCORE=..\msvc.install_x64\bin\musescore3.exe
 set DPI=130
 
-%MSCORE% %1.mscz -r %DPI% -o %1.png
+%MSCORE% %1.mscx -r %DPI% -o %1.png
 del %1-ref.png 2>nul
 rename %1-1.png %1-ref.png

--- a/vtest/gen.bat
+++ b/vtest/gen.bat
@@ -56,7 +56,7 @@ IF NOT "%1"=="" (
    SET INSTALL_PATH=msvc.install_x64
    )
 
-set MSCORE=..\%INSTALL_PATH%\bin\musescore.exe
+set MSCORE=..\%INSTALL_PATH%\bin\musescore3.exe
 
 IF NOT EXIST ..\%INSTALL_PATH%\nul (
    echo "Current folder: ..\%INSTALL_PATH%"


### PR DESCRIPTION
following a discussion in the MuseScore developers' chat on Telegram, see https://t.me/musescoreeditorchat/81326 ff.

Before this change the ledgerlines stick out the notedheads by 1/2 the line thickness either side, if their length is set to 0:
![image](https://user-images.githubusercontent.com/1786669/88069251-84530e00-cb71-11ea-87d8-b85918b466cf.png)
due to `QPen()` using `Qt::SquareCap` by default, which adds that half a line width either side.

Issue applies to 3.x (maybe 3.6, which is planned to improve layout?) and master