### PR TITLE
Fix MSVC builds / update to Qt 5.9.9 (patched)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,8 +4,7 @@ clone_folder: C:\MuseScore
 # set clone depth
 clone_depth: 50                      # clone entire repository history if not defined
 
-# see https://github.com/musescore/MuseScore/pull/6294
-image: Previous Visual Studio 2019
+image: Visual Studio 2019
 
 branches:
   only:
@@ -14,8 +13,8 @@ branches:
 # build cache to preserve files/folders between builds
 cache:
   - dependencies.7z
-  - qt598_msvc2017_64.7z # if not using AppVeyor's built-in Qt in before_build.bat
-  - qt598_msvc2015.7z # if not using AppVeyor's built-in Qt in before_build.bat
+  - qt599_msvc2017_64.7z # if not using AppVeyor's built-in Qt in before_build.bat
+  - qt599_msvc2015.7z # if not using AppVeyor's built-in Qt in before_build.bat
   - C:\Program Files (x86)\Jack
   - C:\MuseScore\build.release\thirdparty
   - C:\ccache

--- a/build/appveyor/before_build.bat
+++ b/build/appveyor/before_build.bat
@@ -2,15 +2,15 @@
 IF "%PLATFORM%" == "x64" (
   SET "QTURL=https://utils.musescore.org.s3.amazonaws.com/qt598_msvc2017_64.7z"
   SET "QTDIR=%cd%\qt\msvc2017_64" & :: uncomment to use our Qt
-  SET "QTCACHE=qt598_msvc2017_64.7z" & :: bump version here and .appveyor.yml to trigger cache rebuild when upgrading Qt
-  :: SET "QTDIR=C:\Qt\5.12.4\msvc2017_64" & :: uncomment to use AppVeyor's Qt
+  SET "QTCACHE=qt599_msvc2017_64.7z" & :: bump version here and .appveyor.yml to trigger cache rebuild when upgrading Qt
+  :: SET "QTDIR=C:\Qt\5.12.9\msvc2017_64" & :: uncomment to use AppVeyor's Qt
   SET "TARGET_PROCESSOR_BITS=64"
   SET "TARGET_PROCESSOR_ARCH=x86_64"
 ) ELSE (
   SET "QTURL=https://utils.musescore.org.s3.amazonaws.com/qt598_msvc2015.7z"
   SET "QTDIR=%cd%\qt\msvc2015" & :: uncomment to use our Qt
-  SET "QTCACHE=qt598_msvc2015.7z" & :: bump version here and .appveyor.yml to trigger cache rebuild when upgrading Qt
-  :: SET "QTDIR=C:\Qt\5.12.4\msvc2017" & :: uncomment to use AppVeyor's Qt
+  SET "QTCACHE=qt599_msvc2015.7z" & :: bump version here and .appveyor.yml to trigger cache rebuild when upgrading Qt
+  :: SET "QTDIR=C:\Qt\5.12.9\msvc2017" & :: uncomment to use AppVeyor's Qt
   SET "TARGET_PROCESSOR_BITS=32"
   SET "TARGET_PROCESSOR_ARCH=x86"
 )


### PR DESCRIPTION
MSCV compilers 16.6.3 and later (current is 16.6.5) trigger a bug in Qt code, so need patched versions of Qt 5.9 (like available at [qt599_msvc2015.7z](https://1drv.ms/u/s!Aui46Jz59Vj1hwIVfMuYF8TZZF8A) and [qt599_msvc2017_64.7z](https://1drv.ms/u/s!Aui46Jz59Vj1hwMt5KUzSEsWYDMv)) or the official Qt 5.12.9 or even Qt 5.15.0.
The former should get used for the 3.x branch, the latter might get used for the master branch (let me know if you want packages for those).

See also the previous #6294

As is (i.e. without the updated Qt packages) this PR will fail the appveyor build...

BTW: I think we should update all the other builds to (at least) Qt 5.9.9, the latest **and last** 5.9 patch. We should do this at least for the 3.x branch, for master branch we may want to go to the later LTS releases Qt 5.12(.9 currently) or even 5.15(.0 currently), as Qt 5.9 is out of LTS support since end of May 2020. That may mean though, that we'd either need to drop support for macOS 10.10 and 10.11, or have separate builds for those still using Qt 5.9.