### PR TITLE
fix #304880: wrong beam positions when changing spatium

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -2092,7 +2092,7 @@ void Beam::layout2(std::vector<ChordRest*> crl, SpannerSegmentType, int frag)
 
 void Beam::spatiumChanged(qreal oldValue, qreal newValue)
 {
-    int idx = (_direction == Direction::AUTO || _direction == Direction::DOWN) ? 0 : 1;
+    int idx = (!_up) ? 0 : 1;
     if (_userModified[idx]) {
         qreal diff = newValue / oldValue;
         for (BeamFragment* f : fragments) {


### PR DESCRIPTION
this is #6034, but for the master branch