### PR TITLE
Fix 308242: Elements that need fixing with Staff Type Changes

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -478,6 +478,11 @@ void BarLine::drawDots(QPainter* painter, qreal x) const
             qreal offset = (score()->scoreFont()->name() == "Leland" || score()->scoreFont()->name() == "Bravura" || score()->scoreFont()->name() == "Petaluma") ? 0 : 0.5 * score()->spatium() * mag();
             y1l          = st->doty1() * _spatium + offset;
             y2l          = st->doty2() * _spatium + offset;
+            
+            //adjust for staffType offset
+            qreal stYOffset = st->yoffset().val() * _spatium;
+            y1l             += stYOffset;
+            y2l             += stYOffset;
             }
       drawSymbol(SymId::repeatDot, painter, QPointF(x, y1l));
       drawSymbol(SymId::repeatDot, painter, QPointF(x, y2l));

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -700,6 +700,7 @@ void Chord::addLedgerLines()
       qreal lineDistance = 1;
       qreal mag         = 1;
       bool staffVisible  = true;
+      int stepOffset = 0;                       // for staff type changes with a step offset
 
       if (segment()) { //not palette
             Fraction tick = segment()->tick();
@@ -710,10 +711,11 @@ void Chord::addLedgerLines()
             lineDistance  = st->lineDistance(tick);
             mag           = staff()->mag(tick);
             staffVisible  = !staff()->invisible(tick);
+            stepOffset = st->staffType(tick)->stepOffset();
             }
 
       // need ledger lines?
-      if (downLine() <= lineBelow + 1 && upLine() >= -1)
+      if (downLine() + stepOffset <= lineBelow + 1 && upLine() + stepOffset >= -1)
             return;
 
       // the extra length of a ledger line with respect to notehead (half of it on each side)
@@ -746,7 +748,7 @@ void Chord::addLedgerLines()
                   }
             for (int i = from; i < int(n) && i >= 0 ; i += delta) {
                   Note* note = _notes.at(i);
-                  int l = note->line();
+                  int l = note->line() + stepOffset;
 
                   // if 1st pass and note not below staff or 2nd pass and note not above staff
                   if ((!j && l <= lineBelow + 1) || (j && l >= -1))
@@ -1805,7 +1807,8 @@ QPointF Chord::pagePos() const
             System* system = pc->segment()->system();
             if (!system)
                   return p;
-            p.ry() += system->staffYpage(vStaffIdx());
+            qreal staffYOffset = staff() ? staff()->staffType(tick())->yoffset().val() * spatium() : 0.0;
+            p.ry() += system->staffYpage(vStaffIdx()) + staffYOffset;
             return p;
             }
       return Element::pagePos();

--- a/libmscore/clef.cpp
+++ b/libmscore/clef.cpp
@@ -160,7 +160,7 @@ void Clef::layout()
       qreal yoff     = 0.0;
       if (clefType() !=  ClefType::INVALID && clefType() !=  ClefType::MAX) {
             symId = ClefInfo::symId(clefType());
-            yoff = lineDist * (lines - ClefInfo::line(clefType()));
+            yoff = lineDist * (5 - ClefInfo::line(clefType())); 
             }
       else
             symId = SymId::noSym;
@@ -172,24 +172,30 @@ void Clef::layout()
             case ClefType::TAB:                            // TAB clef
                   // on tablature, position clef at half the number of spaces * line distance
                   yoff = lineDist * (lines - 1) * .5;
+                  stepOffset = 0; //  ignore stepOffset for TAB and pecussion clefs
                   break;
             case ClefType::TAB4:                            // TAB clef 4 strings
                   // on tablature, position clef at half the number of spaces * line distance
                   yoff = lineDist * (lines - 1) * .5;
+                  stepOffset = 0;
                   break;
             case ClefType::TAB_SERIF:                           // TAB clef alternate style
                   // on tablature, position clef at half the number of spaces * line distance
                   yoff = lineDist * (lines - 1) * .5;
+                  stepOffset = 0;
                   break;
             case ClefType::TAB4_SERIF:                           // TAB clef alternate style
                   // on tablature, position clef at half the number of spaces * line distance
                   yoff = lineDist * (lines - 1) * .5;
+                  stepOffset = 0;
                   break;
             case ClefType::PERC:                           // percussion clefs
                   yoff = lineDist * (lines - 1) * 0.5;
+                  stepOffset = 0;
                   break;
             case ClefType::PERC2:
                   yoff = lineDist * (lines - 1) * 0.5;
+                  stepOffset = 0;
                   break;
             case ClefType::INVALID:
             case ClefType::MAX:
@@ -202,7 +208,7 @@ void Clef::layout()
       // other clefs are right aligned
       QRectF r(symBbox(symId));
       qreal x = segment() && segment()->rtick().isNotZero() ? -r.right() : 0.0;
-      setPos(x, yoff * _spatium + (stepOffset * -_spatium));
+      setPos(x, yoff * _spatium + (stepOffset * 0.5 * _spatium));
 
       setbbox(r);
       }

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -690,6 +690,8 @@ void Score::createCRSequence(const Fraction& f, ChordRest* cr, const Fraction& t
                         Tie* tie = new Tie(this);
                         tie->setStartNote(on);
                         tie->setEndNote(nn);
+                        tie->setTick(tie->startNote()->tick());
+                        tie->setTick2(tie->endNote()->tick());
                         tie->setTrack(cr->track());
                         on->setTieFor(tie);
                         nn->setTieBack(tie);
@@ -756,6 +758,7 @@ Segment* Score::setNoteRest(Segment* segment, int track, NoteVal nval, Fraction 
 
                         if (tie) {
                               tie->setEndNote(note);
+                              tie->setTick2(tie->endNote()->tick());
                               note->setTieBack(tie);
                               addTie = tie;
                               }
@@ -779,6 +782,7 @@ Segment* Score::setNoteRest(Segment* segment, int track, NoteVal nval, Fraction 
                         if (i+1 < n) {
                               tie = new Tie(this);
                               tie->setStartNote(note);
+                              tie->setTick(tie->startNote()->tick());
                               tie->setTrack(track);
                               note->setTieFor(tie);
                               }
@@ -819,6 +823,7 @@ Segment* Score::setNoteRest(Segment* segment, int track, NoteVal nval, Fraction 
             if (!isRest) {
                   tie = new Tie(this);
                   tie->setStartNote((Note*)nr);
+                  tie->setTick(tie->startNote()->tick());
                   tie->setTrack(nr->track());
                   ((Note*)nr)->setTieFor(tie);
                   }
@@ -2946,6 +2951,8 @@ void Score::cmdImplode()
                                                             Tie* tie = new Tie(this);
                                                             tie->setStartNote(tn);
                                                             tie->setEndNote(nn);
+                                                            tie->setTick(tie->startNote()->tick());
+                                                            tie->setTick2(tie->endNote()->tick());
                                                             tie->setTrack(tn->track());
                                                             undoAddElement(tie);
                                                             }
@@ -3327,6 +3334,7 @@ Segment* Score::setChord(Segment* segment, int track, Chord* chordTemplate, Frac
                         for (size_t j = 0; j < notes.size(); ++j) {
                               tie[j] = new Tie(this);
                               tie[j]->setStartNote(notes[j]);
+                              tie[j]->setTick(tie[j]->startNote()->tick());
                               tie[j]->setTrack(track);
                               notes[j]->setTieFor(tie[j]);
                               addTie = true;
@@ -3371,6 +3379,7 @@ Segment* Score::setChord(Segment* segment, int track, Chord* chordTemplate, Frac
             for (size_t i = 0; i < notes.size(); ++i) {
                   tie[i] = new Tie(this);
                   tie[i]->setStartNote(notes[i]);
+                  tie[i]->setTick(tie[i]->startNote()->tick());
                   tie[i]->setTrack(notes[i]->track());
                   notes[i]->setTieFor(tie[i]);
                   }

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -238,6 +238,8 @@ Chord* Score::addChord(const Fraction& tick, TDuration d, Chord* oc, bool genTie
                   Tie* tie = new Tie(this);
                   tie->setStartNote(n1);
                   tie->setEndNote(n2);
+                  tie->setTick(tie->startNote()->tick());
+                  tie->setTick2(tie->endNote()->tick());
                   tie->setTrack(n1->track());
                   undoAddElement(tie);
                   }
@@ -988,6 +990,8 @@ Note* Score::addTiedMidiPitch(int pitch, bool addFlag, Chord* prevChord)
                   Tie* tie = new Tie(this);
                   tie->setStartNote(nn);
                   tie->setEndNote(n);
+                  tie->setTick(tie->startNote()->tick());
+                  tie->setTick2(tie->endNote()->tick());
                   tie->setTrack(n->track());
                   n->setTieBack(tie);
                   nn->setTieFor(tie);
@@ -1148,6 +1152,8 @@ void Score::regroupNotesAndRests(const Fraction& startTick, const Fraction& endT
                                                       tie = new Tie(this);
                                                       tie->setStartNote(nl1[j]);
                                                       tie->setEndNote(nl2[j]);
+                                                      tie->setTick(tie->startNote()->tick());
+                                                      tie->setTick2(tie->endNote()->tick());
                                                       tie->setTrack(tr);
                                                       nl1[j]->setTieFor(tie);
                                                       nl2[j]->setTieBack(tie);
@@ -1195,6 +1201,8 @@ void Score::regroupNotesAndRests(const Fraction& startTick, const Fraction& endT
                                           tie = new Tie(this);
                                           tie->setStartNote(tieBack[i]);
                                           tie->setEndNote(n);
+                                          tie->setTick(tie->startNote()->tick());
+                                          tie->setTick2(tie->endNote()->tick());
                                           tie->setTrack(track);
                                           n->setTieBack(tie);
                                           tieBack[i]->setTieFor(tie);
@@ -1204,6 +1212,8 @@ void Score::regroupNotesAndRests(const Fraction& startTick, const Fraction& endT
                                           tie = new Tie(this);
                                           tie->setStartNote(nn);
                                           tie->setEndNote(tieFor[i]);
+                                          tie->setTick(tie->startNote()->tick());
+                                          tie->setTick2(tie->endNote()->tick());
                                           tie->setTrack(track);
                                           n->setTieFor(tie);
                                           tieFor[i]->setTieBack(tie);
@@ -1319,8 +1329,8 @@ void Score::cmdAddTie(bool addToChord)
                               tie->setStartNote(note);
                               tie->setEndNote(nnote);
                               tie->setTrack(note->track());
-tie->setTick(note->chord()->segment()->tick());
-tie->setTicks(nnote->chord()->segment()->tick() - note->chord()->segment()->tick());
+                              tie->setTick(note->chord()->segment()->tick());
+                              tie->setTicks(nnote->chord()->segment()->tick() - note->chord()->segment()->tick());
                               undoAddElement(tie);
                               if (!addFlag || nnote->chord()->tick() >= lastAddedChord->tick() || nnote->chord()->isGrace()) {
                                     break;
@@ -1340,8 +1350,8 @@ tie->setTicks(nnote->chord()->segment()->tick() - note->chord()->segment()->tick
                         tie->setStartNote(note);
                         tie->setEndNote(note2);
                         tie->setTrack(note->track());
-tie->setTick(note->chord()->segment()->tick());
-tie->setTicks(note2->chord()->segment()->tick() - note->chord()->segment()->tick());
+                        tie->setTick(note->chord()->segment()->tick());
+                        tie->setTicks(note2->chord()->segment()->tick() - note->chord()->segment()->tick());
                         undoAddElement(tie);
                         }
                   }

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -2082,6 +2082,9 @@ QVector<QLineF> Element::genericDragAnchorLines() const
             yp = system->staffCanvasYpage(stIdx);
             if (placement() == Placement::BELOW)
                   yp += system->staff(stIdx)->bbox().height();
+            //adjust anchor Y positions to staffType offset
+            if (staff())
+                yp += staff()->staffTypeForElement(this)->yoffset().val()* spatium();
             }
       else
             yp = parent()->canvasPos().y();
@@ -2471,6 +2474,12 @@ void Element::autoplaceSegmentElement(bool above, bool add)
             SysStaff* ss = m->system()->staff(si);
             QRectF r = bbox().translated(m->pos() + s->pos() + pos());
 
+            // Adjust bbox Y pos for staffType offset 
+            if (staffType()) {
+                  qreal stYOffset = staffType()->yoffset().val() * sp;
+                  r.translate(0.0, stYOffset);
+                  }
+            
             SkylineLine sk(!above);
             qreal d;
             if (above) {

--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -269,6 +269,10 @@ void KeySig::layout()
                   }
             }
 
+      // Follow stepOffset
+      if (staffType())
+            rypos() = staffType()->stepOffset() * 0.5 * _spatium;
+
       // compute bbox
       for (KeySym& ks : _sig.keySymbols()) {
             ks.pos = ks.spos * _spatium;

--- a/libmscore/ledgerline.cpp
+++ b/libmscore/ledgerline.cpp
@@ -66,6 +66,11 @@ void LedgerLine::layout()
       if (staff())
             setColor(staff()->staffType(tick())->color());
       qreal w2 = _width * .5;
+
+      //Adjust Y position to staffType offset
+      if (staffType())
+            rypos() += staffType()->yoffset().val() * spatium();
+
       if (vertical)
             bbox().setRect(-w2, 0, w2, _len);
       else

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -153,6 +153,9 @@ QVector<QLineF> LineSegment::gripAnchorLines(Grip grip) const
             y = system()->staffYpage(stIdx);
             if (line()->placement() == Placement::BELOW)
                   y += system()->staff(stIdx)->bbox().height();
+            // adjust Y to staffType offset
+            if (staffType())
+                  y += staffType()->yoffset().val() * spatium();
             }
 
       const Page* p = system()->page();

--- a/libmscore/lyricsline.cpp
+++ b/libmscore/lyricsline.cpp
@@ -442,6 +442,10 @@ void LyricsLineSegment::layout()
                   nextLyr->rxpos() -= (toX - fromX);
             }
 
+      // apply yoffset for staff type change (keeps lyrics lines aligned with lyrics)
+      if (staffType())
+            rypos() += staffType()->yoffset().val() * spatium();
+
       // set bounding box
       QRectF r = QRectF(0.0, 0.0, pos2().x(), pos2().y()).normalized();
       qreal lw = lyricsLine()->lineWidth() * .5;

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -660,6 +660,7 @@ Note::Note(const Note& n, bool link)
       if (n._tieFor) {
             _tieFor = new Tie(*n._tieFor);
             _tieFor->setStartNote(this);
+            _tieFor->setTick(_tieFor->startNote()->tick());
             _tieFor->setEndNote(0);
             }
       else
@@ -1121,6 +1122,7 @@ void Note::add(Element* e)
             case ElementType::TIE: {
                   Tie* tie = toTie(e);
                   tie->setStartNote(this);
+                  tie->setTick(tie->startNote()->tick());
                   tie->setTrack(track());
                   setTieFor(tie);
                   if (tie->endNote())

--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -234,6 +234,8 @@ Note* Score::addPitch(NoteVal& nval, bool addFlag, InputState* externalInputStat
                   Tie* tie = new Tie(this);
                   tie->setStartNote(note);
                   tie->setEndNote(firstTiedNote);
+                  tie->setTick(tie->startNote()->tick());
+                  tie->setTick2(tie->endNote()->tick());
                   tie->setTrack(note->track());
                   undoAddElement(tie);
                   }
@@ -301,6 +303,14 @@ void Score::putNote(const QPointF& pos, bool replace, bool insert)
       Score* score = p.segment->score();
       // it is not safe to call Score::repitchNote() if p is on a TAB staff
       bool isTablature = staff(p.staffIdx)->isTabStaff(p.segment->tick());
+
+      //  calculate actual clicked line from staffType offset and stepOffset
+      Staff* ss = score->staff(p.staffIdx);
+      int stepOffset = ss->staffType(p.segment->tick())->stepOffset();
+      qreal stYOffset = ss->staffType(p.segment->tick())->yoffset().val();
+      qreal lineDist = ss->staffType(p.segment->tick())->lineDistance().val();
+      p.line -= stepOffset + 2 * stYOffset / lineDist;
+
       if (score->inputState().usingNoteEntryMethod(NoteEntryMethod::REPITCH) && !isTablature)
             score->repitchNote(p, replace);
       else {
@@ -546,6 +556,8 @@ void Score::repitchNote(const Position& p, bool replace)
             Tie* tie = new Tie(this);
             tie->setStartNote(note);
             tie->setEndNote(firstTiedNote);
+            tie->setTick(tie->startNote()->tick());
+            tie->setTick2(tie->endNote()->tick());
             tie->setTrack(note->track());
             undoAddElement(tie);
             }

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -638,6 +638,8 @@ void Score::pasteChordRest(ChordRest* cr, const Fraction& t, const Interval& src
                                     Tie* tie = new Tie(this);
                                     tie->setStartNote(nl1[i]);
                                     tie->setEndNote(nl2[i]);
+                                    tie->setTick(tie->startNote()->tick());
+                                    tie->setTick2(tie->endNote()->tick());
                                     tie->setTrack(c->track());
                                     Tie* tie2 = nl1[i]->tieFor();
                                     if (tie2) {

--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -373,6 +373,11 @@ void SlurSegment::layoutSegment(const QPointF& p1, const QPointF& p2)
       ups(Grip::START).p = p1;
       ups(Grip::END).p   = p2;
       _extraHeight = 0.0;
+
+      //Adjust Y pos to staff type yOffset before other calculations
+      if (staffType())
+            rypos() += staffType()->yoffset().val() * spatium();
+
       computeBezier();
 
       if (autoplace() && system()) {

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -944,7 +944,7 @@ int Staff::channel(const Fraction& tick,  int voice) const
 
 int Staff::middleLine(const Fraction& tick) const
       {
-      return lines(tick) - 1;
+      return lines(tick) - 1 - staffType(tick)->stepOffset();
       }
 
 //---------------------------------------------------------

--- a/libmscore/textlinebase.cpp
+++ b/libmscore/textlinebase.cpp
@@ -207,6 +207,10 @@ void TextLineBaseSegment::layout()
       if (spanner()->placeBelow())
             rypos() = staff() ? staff()->height() : 0.0;
 
+      // adjust Y pos to staffType offset
+      if (staffType())
+            rypos() += staffType()->yoffset().val() * spatium();
+
       if (!tl->diagonal())
             _offset2.setY(0);
 

--- a/libmscore/tie.cpp
+++ b/libmscore/tie.cpp
@@ -328,6 +328,11 @@ void TieSegment::layoutSegment(const QPointF& p1, const QPointF& p2)
       setPos(QPointF());
       ups(Grip::START).p = p1;
       ups(Grip::END).p   = p2;
+      
+      //Adjust Y pos to staff type offset before other calculations
+      if (staffType())
+            rypos() += staffType()->yoffset().val() * spatium();
+
       computeBezier();
 
       QRectF bbox = path.boundingRect();
@@ -341,6 +346,7 @@ void TieSegment::layoutSegment(const QPointF& p1, const QPointF& p2)
             // otherwise, adjusted tie might crowd an unadjusted tie unnecessarily
             Tie* t    = toTie(slurTie());
             Note* sn  = t->startNote();
+            t->setTick(t->startNote()->tick());
             Chord* sc = sn ? sn->chord() : 0;
 
             // normally, the adjustment moves ties according to their direction (eg, up if tie is up)

--- a/mtest/guitarpro/testIrrTuplet.gp-ref.mscx
+++ b/mtest/guitarpro/testIrrTuplet.gp-ref.mscx
@@ -416,6 +416,7 @@
                 <Spanner type="Tie">
                   <Tie>
                     <linked>
+                      <indexDiff>1</indexDiff>
                       </linked>
                     </Tie>
                   <next>

--- a/mtest/guitarpro/testIrrTuplet.gp4-ref.mscx
+++ b/mtest/guitarpro/testIrrTuplet.gp4-ref.mscx
@@ -461,6 +461,7 @@
                 <Spanner type="Tie">
                   <Tie>
                     <linked>
+                      <indexDiff>1</indexDiff>
                       </linked>
                     </Tie>
                   <next>
@@ -477,6 +478,7 @@
                   <Glissando>
                     <text>gliss.</text>
                     <linked>
+                      <indexDiff>1</indexDiff>
                       </linked>
                     <diagonal>1</diagonal>
                     <anchor>3</anchor>

--- a/mtest/guitarpro/testIrrTuplet.gpx-ref.mscx
+++ b/mtest/guitarpro/testIrrTuplet.gpx-ref.mscx
@@ -516,6 +516,7 @@
                 <Spanner type="Tie">
                   <Tie>
                     <linked>
+                      <indexDiff>1</indexDiff>
                       </linked>
                     </Tie>
                   <next>


### PR DESCRIPTION
Resolves: *https://musescore.org/en/node/308242*
*https://musescore.org/en/node/290157*
and *https://musescore.org/en/node/307905*

This PR fixes a number of issues with some elements and Staff Type Changes. (Most of the fixes required just adjusting the vertical position to the right staffType yOffset and stepOffset.)

Before:
![image](https://user-images.githubusercontent.com/2843953/100028649-2c057480-2dce-11eb-880f-33d240d7e9e6.png)
After:
![image](https://user-images.githubusercontent.com/2843953/100028683-3aec2700-2dce-11eb-8261-4019f7c21c8a.png)


**Ledger Lines**
- Now generate correctly after top/bottom staff line and stepOffset (chord.cpp)
- Now follow staffType yOffset (ledgerline.cpp)

**Slurs**
- Now follow staffType yOffset

**Ties**
- Now follow staffType yOffset
- Most generated ties (by pasting, changing note duration, etc) didn't have a *tick* set at creation time, so I went thru all them to set Tick to _startNote->tick()_ (and when possible _Tick2 to endNote->tick()_ ) on tie creation  (in cmd.cpp, note.cpp, noteentry.cpp, paste.cpp, edit.cpp). 

Before the fix:
![image](https://user-images.githubusercontent.com/2843953/88854580-e3470180-d1c7-11ea-88c0-b6f0218d0215.png)

**Clefs**
- Now stay at the right line when using more or less than 5 staff lines.
- Now are adjusted to mark the right pitch after stepOffset
- Percussion and tab clefs now ignore stepOffset (since they don't indicate a pitch) so they stay vertically centered to the staff.

**Key Signatures**
- Adjusted to follow stepOffset so they stay at right pitches

**Repeat barlines**
- Now the dots stay properly centered to the staff with an yOffset

**Line**
- Adjusted y pos to follow staffType yOffset (line.cpp)
- Adjusted anchor lines to reflect staffType yOffset (genericDragAnchorLines in element.cpp)

**text line**
- Adjusted  to follow yOffset  (textlinebase.cpp)
- Adjusted anchor lines (same as above)

**Text**
- Adjusted to follow yOffset 
- Adjusted anchor lines (same as above).

Before the fix:
![image](https://user-images.githubusercontent.com/2843953/88855932-02469300-d1ca-11ea-8998-9508adb8bbb4.png)

**Click note entry**
- Clicking to add notes on a changed staff Type now adds the note in the intended line/space, recalculated after the staffType yOffset, stepOffset and lineDistance. (noteentry.cpp)

**Grace Notes**
- Now follow staff Type yOffset

**Lyrics**
- Added staff yOffset to Lyrics lines so they stay aligned to lyrics. (lyricsline.cpp)

**Compute Up/down:**
- Now the staff middleLine is calculated including stepOffset, so beams and other elements have the right direction.


Additional notes (for a future PR):
- Symbols and images added to barlines do not to adjust to yOffset (they do when added to chord/rests). Should they? 
- Skylines: check on how rects are added to it on a staff type change with an offset (Maybe don't need a fix - in any case seems  too complex to include here)
- Some articulations like the accent follow stepOffset correctly, but staccato and dash (tenuto) don't. Need further checking on this.
- Some elements like dynamics seem to 'overdo' automatic placement along with the staffType Offset. Needs deeper checking (not in this PR for the time being).


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [NA] I created the test (mtest, vtest, script test) to verify the changes I made
