### PR TITLE
fix #308281 : Blank upload dialog on MacOS Catalina + collect_artifacts

### DIFF
--- a/.github/workflows/collect_artifacts.yml
+++ b/.github/workflows/collect_artifacts.yml
@@ -5,6 +5,8 @@ on:
     branches:
     - master
     - 3.x
+env:
+  DEVELOPER_DIR: /Applications/Xcode_10.3.app/Contents/Developer
 
 jobs:
   collect_artifacts_Linux:

--- a/build/package_mac
+++ b/build/package_mac
@@ -205,6 +205,8 @@ echo "Codesign"
 find "${VOLUME}/${LONGER_NAME}.app/Contents/Resources" -name '*.dylib' -exec codesign --options runtime --deep -s "Developer ID Application: MuseScore" '{}' ';'
 # Sign code in other (more conventional) locations
 codesign --options runtime --entitlements "${WORKING_DIRECTORY}/../build/macosx_entitlements.plist" --deep -s "Developer ID Application: MuseScore" "${CODE_PATHS[@]}"
+# Sign QtWebEngine application for MacOS Catalina
+codesign --force --verify --verbose --options runtime --entitlements "${WORKING_DIRECTORY}/../build/qtwebengineprocess.entitlements" --deep --sign "Developer ID Application: MuseScore" "${VOLUME}/${LONGER_NAME}.app/Contents/Frameworks/QtWebEngineCore.framework/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess"
 echo "spctl"
 spctl --assess --type execute "${VOLUME}/${LONGER_NAME}.app"
 echo "Codesign verify"

--- a/build/qtwebengineprocess.entitlements
+++ b/build/qtwebengineprocess.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/308281

Apparently, QtWebEngine requires additional permissions to run under MacOS 10.15, see https://forum.qt.io/post/526704

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ N/A ] I created the test (mtest, vtest, script test) to verify the changes I made
