### PR TITLE
fix #308371: wrong stem directions on tab staves with multiple voices

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2671,6 +2671,17 @@ void Measure::checkMultiVoices(int staffIdx)
 
 bool Measure::hasVoices(int staffIdx, Fraction stick, Fraction len) const
       {
+      Staff* s = score()->staff(staffIdx);
+      if (s->isTabStaff(stick)) {
+            // TODO: tab staves use different rules for stem directin etc
+            // see for example https://musescore.org/en/node/308371
+            // we should consider coming up with a more comprehensive solution
+            // but for now, we are forcing measures on tab staves to be consider as a whole -
+            // either they have voices or not
+            // (rather than checking tick ranges)
+            stick = tick();
+            len = stretchedLen(s);
+            }
       int strack = staffIdx * VOICES + 1;
       int etrack = staffIdx * VOICES + VOICES;
       Fraction etick = stick + len;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/308371

For 3.5 we changes the hasVoices() algorithm,
used to determine default stem direction and other things,
to look at partial measures rather than full measures.
Overall, that's a good thing, but there are cases where it isn't.
While there will probably always be debate on some corner cases
and there probably is no good algorithmic way of differentiating them,
one thing that seems clear is the rules for using voices on tab staves
is totally different, and this partial method does not work well.
You end up with notes having down stem
even though they are in voice 1 and there is also content in voice 2,
which just does not make sense in that context.
So this change simply checks for tab and makes sure
to look at the full measure in that case.