### PR TITLE
MinGW mtests on Windows with QtCreator

### DIFF
--- a/mtest/CMakeLists.txt
+++ b/mtest/CMakeLists.txt
@@ -236,21 +236,6 @@ subdirs (
         testscript
         )
 
-if (NOT MSVC)
-install(FILES
-      ../share/styles/chords_std.xml
-      ../share/styles/chords_jazz.xml
-      ../share/styles/chords.xml
-      ../share/styles/stdchords.xml
-      ../share/styles/jazzchords.xml
-      ../share/styles/cchords_muse.xml
-      ../share/styles/cchords_nrb.xml
-      ../share/styles/cchords_rb.xml
-      ../share/styles/cchords_sym.xml
-      DESTINATION ${PROJECT_BINARY_DIR}/mtest/styles
-      )
-endif (NOT MSVC)
-
 if (OMR)
 subdirs(omr)
 endif (OMR)

--- a/mtest/CMakeLists.txt
+++ b/mtest/CMakeLists.txt
@@ -166,6 +166,12 @@ add_custom_target(reporthtml
       COMMAND ant -f ${PROJECT_SOURCE_DIR}/mtest/build.xml -Droot.dir=${PROJECT_BINARY_DIR}/mtest reporthtml
       WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/mtest"
       )
+
+add_custom_target(mtest_build_and_install
+      COMMAND ${CMAKE_COMMAND} --build . --target install
+      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/mtest"
+      COMMENT "Build and install all mtests"
+      )
 endif (NOT MSVC)
 
 subdirs (

--- a/mtest/biab/CMakeLists.txt
+++ b/mtest/biab/CMakeLists.txt
@@ -13,3 +13,14 @@
 set(TARGET tst_biab)
 
 include(${PROJECT_SOURCE_DIR}/mtest/cmake.inc)
+
+get_target_property(
+      MTEST_INSTALL_DESTINATION_DIR
+      ${TARGET}
+      MTEST_INSTALL_DESTINATION_DIR
+      )
+install(DIRECTORY
+      ${PROJECT_SOURCE_DIR}/share/styles
+      DESTINATION "${MTEST_INSTALL_DESTINATION_DIR}"
+      FILES_MATCHING PATTERN "*.xml"
+      )

--- a/mtest/cmake.inc
+++ b/mtest/cmake.inc
@@ -30,26 +30,17 @@ if (MSVC)
             ${PCH}
             )
       include(FindStaticLibrary)
-      target_link_libraries(
-            ${TARGET}
-            ${QT_QTTEST_LIBRARY}
-            testResources
-            libmscore
-            audio
-            qzip
-            zlibstat
-            )
-else (MSVC)
-      target_link_libraries(
-            ${TARGET}
-            ${QT_QTTEST_LIBRARY}
-            testResources
-            libmscore
-            audio
-            qzip
-            z
-            )
 endif (MSVC)
+
+target_link_libraries(
+      ${TARGET}
+      ${QT_LIBRARIES}
+      ${QT_QTTEST_LIBRARY}
+      testResources
+      libmscore
+      audio
+      qzip
+      )
 
 if (OMR)
       target_link_libraries(${TARGET} omr poppler-qt5)
@@ -58,16 +49,15 @@ if (OMR)
       endif (OCR)
 endif (OMR)
 
+# ZIP library
 if (MSVC)
       target_link_libraries(
             ${TARGET}
-            ${QT_LIBRARIES}
             zlibstat
             )
 else (MSVC)
       target_link_libraries(
             ${TARGET}
-            ${QT_LIBRARIES}
             z
             )
 endif (MSVC)
@@ -126,17 +116,19 @@ endif (APPLE AND (CMAKE_VERSION VERSION_LESS "3.5.0"))
 
 add_test(${TARGET} ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}  -xunitxml -o result.xml)
 
+# On Windows some tests need access to supporting files
+# MSVC has a different definition for CMAKE_CURRENT_BINARY_DIR
+# so we use this install destination variable instead
 if (MSVC)
-install(FILES
-      ${PROJECT_SOURCE_DIR}/share/styles/chords_std.xml
-      ${PROJECT_SOURCE_DIR}/share/styles/chords_jazz.xml
-      ${PROJECT_SOURCE_DIR}/share/styles/chords.xml
-      ${PROJECT_SOURCE_DIR}/share/styles/stdchords.xml
-      ${PROJECT_SOURCE_DIR}/share/styles/jazzchords.xml
-      ${PROJECT_SOURCE_DIR}/share/styles/cchords_muse.xml
-      ${PROJECT_SOURCE_DIR}/share/styles/cchords_nrb.xml
-      ${PROJECT_SOURCE_DIR}/share/styles/cchords_rb.xml
-      ${PROJECT_SOURCE_DIR}/share/styles/cchords_sym.xml
-      DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/styles
-      )
+      set_target_properties(
+            ${TARGET}
+            PROPERTIES
+            MTEST_INSTALL_DESTINATION_DIR "${CMAKE_CURRENT_BINARY_DIR}"
+            )
+else (MSVC)
+      set_target_properties(
+            ${TARGET}
+            PROPERTIES
+            MTEST_INSTALL_DESTINATION_DIR "${CMAKE_CURRENT_BINARY_DIR}/.."
+            )
 endif (MSVC)

--- a/mtest/libmscore/compat114/CMakeLists.txt
+++ b/mtest/libmscore/compat114/CMakeLists.txt
@@ -14,3 +14,13 @@ set(TARGET tst_compat114)
 
 include(${PROJECT_SOURCE_DIR}/mtest/cmake.inc)
 
+get_target_property(
+      MTEST_INSTALL_DESTINATION_DIR
+      ${TARGET}
+      MTEST_INSTALL_DESTINATION_DIR
+      )
+install(DIRECTORY
+      ${PROJECT_SOURCE_DIR}/share/styles
+      DESTINATION "${MTEST_INSTALL_DESTINATION_DIR}"
+      FILES_MATCHING PATTERN "*.xml"
+      )

--- a/mtest/mscore/palette/CMakeLists.txt
+++ b/mtest/mscore/palette/CMakeLists.txt
@@ -23,10 +23,16 @@ set(MTEST_LINK_MSCOREAPP TRUE)
 
 include(${PROJECT_SOURCE_DIR}/mtest/cmake.inc)
 
-if (MSVC)
-      install(DIRECTORY
-            ${CMAKE_INSTALL_PREFIX}/workspaces
-            USE_SOURCE_PERMISSIONS
-            DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+if (MSVC OR MINGW)
+      get_target_property(
+            MTEST_INSTALL_DESTINATION_DIR
+            ${TARGET}
+            MTEST_INSTALL_DESTINATION_DIR
             )
-endif (MSVC)
+      install(FILES
+            "${PROJECT_BINARY_DIR}/share/workspaces/Basic.workspace"
+            "${PROJECT_BINARY_DIR}/share/workspaces/Advanced.workspace"
+            DESTINATION "${MTEST_INSTALL_DESTINATION_DIR}/workspaces"
+            PERMISSIONS OWNER_READ GROUP_READ WORLD_READ
+            )
+endif (MSVC OR MINGW)

--- a/mtest/mscore/workspaces/CMakeLists.txt
+++ b/mtest/mscore/workspaces/CMakeLists.txt
@@ -23,10 +23,16 @@ set(MTEST_LINK_MSCOREAPP TRUE)
 
 include(${PROJECT_SOURCE_DIR}/mtest/cmake.inc)
 
-if (MSVC)
-      install(DIRECTORY
-            ${CMAKE_INSTALL_PREFIX}/workspaces
-            USE_SOURCE_PERMISSIONS
-            DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+if (MSVC OR MINGW)
+      get_target_property(
+            MTEST_INSTALL_DESTINATION_DIR
+            ${TARGET}
+            MTEST_INSTALL_DESTINATION_DIR
             )
-endif (MSVC)
+      install(FILES
+            "${PROJECT_BINARY_DIR}/share/workspaces/Basic.workspace"
+            "${PROJECT_BINARY_DIR}/share/workspaces/Advanced.workspace"
+            DESTINATION "${MTEST_INSTALL_DESTINATION_DIR}/workspaces"
+            PERMISSIONS OWNER_READ GROUP_READ WORLD_READ
+            )
+endif (MSVC OR MINGW)

--- a/mtest/mscore/workspaces/tst_workspaces.cpp
+++ b/mtest/mscore/workspaces/tst_workspaces.cpp
@@ -128,17 +128,13 @@ void TestWorkspaces::cleanup()
 
 static QString forceSaveWorkspace(Workspace* w)
       {
-      if (!w->readOnly()) {
-            w->write();
-            return w->path();
+      if (w->readOnly()) {
+            // Clearing our path will allow write to construct a new one
+            w->setPath("");
+            w->setReadOnly(false);
             }
-
-      const QString name = w->translatableName().isEmpty() ? w->name() : w->translatableName();
-      const QString workspacePath = name + ".workspace";
-      w->setPath(workspacePath);
-      w->setReadOnly(false);
       w->write();
-      return workspacePath;
+      return w->path();
       }
 
 void TestWorkspaces::prepareStandardWorkspaceXml(const QString& name, const QString& refXml)

--- a/mtest/scripting/CMakeLists.txt
+++ b/mtest/scripting/CMakeLists.txt
@@ -16,14 +16,19 @@ set(MTEST_LINK_MSCOREAPP TRUE)
 
 include(${PROJECT_SOURCE_DIR}/mtest/cmake.inc)
 
-if (MSVC)
+if (MSVC OR MINGW)
+      get_target_property(
+            MTEST_INSTALL_DESTINATION_DIR
+            ${TARGET}
+            MTEST_INSTALL_DESTINATION_DIR
+            )
       install(DIRECTORY
             ${QT_INSTALL_QML}
-            DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+            DESTINATION "${MTEST_INSTALL_DESTINATION_DIR}"
             REGEX ".*d\\.dll" EXCLUDE
             REGEX ".*QtMultimedia.*" EXCLUDE
             REGEX ".*QtSensors.*" EXCLUDE
             REGEX ".*QtTest.*" EXCLUDE
             REGEX ".*QtWebkit.*" EXCLUDE
             )
-endif (MSVC)
+endif (MSVC OR MINGW)


### PR DESCRIPTION
Resolves: Enable mtest for MinGW on Windows

* Ensures dependent files to run a test are installed by that test
* Removes dependency on having installed mscore first (mtest_build_and_install target can be run on a clean clone)
* Removes duplicate commands only due to a different mtest project dir for MSVC
* Introduces new build target _mtest_build_and_install_ for easier configuration from within an IDE (such as QtCreator)

See https://musescore.org/en/node/307131 for a writeup of the QtCreator configuration (starting from "Enabling mtests")

Hopefully will turn out to apply quite cleanly to master as well (untested)

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
- [x] I ran the related test(s) on my local machine successfully