### PR TITLE
[WIP] Fix #307659-Drumset edits have no effect after a change instrument ob…

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1734,7 +1734,7 @@ void Chord::cmdUpdateNotes(AccidentalState* as)
       const Staff* st = staff();
       StaffGroup staffGroup = st->staffTypeForElement(this)->group();
       if (staffGroup == StaffGroup::TAB) {
-            const Instrument* instrument = part()->instrument();
+            const Instrument* instrument = part()->instrument(this->tick());
             for (Chord* ch : graceNotes())
                   instrument->stringData()->fretChords(ch);
             instrument->stringData()->fretChords(this);
@@ -1773,7 +1773,7 @@ void Chord::cmdUpdateNotes(AccidentalState* as)
                   }
             }
       else if (staffGroup == StaffGroup::PERCUSSION) {
-            const Instrument* instrument = part()->instrument();
+            const Instrument* instrument = part()->instrument(this->tick());
             const Drumset* drumset = instrument->drumset();
             if (!drumset)
                   qWarning("no drumset");
@@ -2841,7 +2841,7 @@ void Chord::setSlash(bool flag, bool stemless)
                   n->undoChangeProperty(Pid::PLAY, true);
                   n->undoChangeProperty(Pid::VISIBLE, true);
                   if (staff()->isDrumStaff(tick())) {
-                        const Drumset* ds = part()->instrument()->drumset();
+                        const Drumset* ds = part()->instrument(tick())->drumset();
                         int pitch = n->pitch();
                         if (ds && ds->isValid(pitch)) {
                               undoChangeProperty(Pid::STEM_DIRECTION, QVariant::fromValue<Direction>(ds->stemDirection(pitch)));

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1487,7 +1487,7 @@ void Score::upDown(bool up, UpDownMode mode)
             switch (staff->staffType(oNote->chord()->tick())->group()) {
                   case StaffGroup::PERCUSSION:
                         {
-                        const Drumset* ds = part->instrument()->drumset();
+                        const Drumset* ds = part->instrument(tick)->drumset();
                         if (ds) {
                               newPitch = up ? ds->nextPitch(pitch) : ds->prevPitch(pitch);
                               newTpc1 = pitch2tpc(newPitch, Key::C, Prefer::NEAREST);
@@ -1497,7 +1497,7 @@ void Score::upDown(bool up, UpDownMode mode)
                         break;
                   case StaffGroup::TAB:
                         {
-                        const StringData* stringData = part->instrument()->stringData();
+                        const StringData* stringData = part->instrument(tick)->stringData();
                         switch (mode) {
                               case UpDownMode::OCTAVE:          // move same note to next string, if possible
                                     {
@@ -1631,7 +1631,7 @@ void Score::upDown(bool up, UpDownMode mode)
                         refret = true;
                         }
                   if (refret) {
-                        const StringData* stringData = part->instrument()->stringData();
+                        const StringData* stringData = part->instrument(tick)->stringData();
                         stringData->fretChords(oNote->chord());
                         }
                   }
@@ -1758,7 +1758,7 @@ static void changeAccidental2(Note* n, int pitch, int tpc)
                   // as pitch has changed, calculate new
                   // string & fret
                   //
-                  const StringData* stringData = n->part()->instrument()->stringData();
+                  const StringData* stringData = n->part()->instrument(n->tick())->stringData();
                   if (stringData)
                         stringData->convertPitch(pitch, st, chord->tick(), &string, &fret);
                   }

--- a/libmscore/input.cpp
+++ b/libmscore/input.cpp
@@ -175,7 +175,7 @@ void InputState::update(Selection& selection)
 
       setDrumNote(-1);
       if (n) {
-            const Instrument* instr = n->part()->instrument();
+            const Instrument* instr = n->part()->instrument(n->tick());
             if (instr->useDrumset())
                   setDrumNote(n->pitch());
             }

--- a/libmscore/instrchange.cpp
+++ b/libmscore/instrchange.cpp
@@ -209,7 +209,7 @@ void InstrumentChange::read(XmlReader& e)
             // There is also code in read206 to try to deal with this, but it is out of date and therefore disabled
             // What this means is, scores created in 2.1 or later should be fine, scores created in 2.0 maybe not so much
 
-            Interval v = staff() ? staff()->part()->instrument()->transpose() : 0;
+            Interval v = staff() ? staff()->part()->instrument(tick())->transpose() : 0;
             _instrument->setTranspose(v);
             }
       }

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2686,7 +2686,7 @@ void Score::getNextMeasure(LayoutContext& lc)
       //
       for (int staffIdx = 0; staffIdx < score()->nstaves(); ++staffIdx) {
             const Staff* staff     = Score::staff(staffIdx);
-            const Drumset* drumset = staff->part()->instrument()->useDrumset() ? staff->part()->instrument()->drumset() : 0;
+            const Drumset* drumset = staff->part()->instrument(measure->tick())->useDrumset() ? staff->part()->instrument(measure->tick())->drumset() : 0;
             AccidentalState as;      // list of already set accidentals for this measure
             as.init(staff->keySigEvent(measure->tick()), staff->clef(measure->tick()));
 

--- a/mscore/drumtools.cpp
+++ b/mscore/drumtools.cpp
@@ -183,8 +183,12 @@ void DrumTools::editDrumset()
       {
       EditDrumset eds(drumset, this);
       if (eds.exec()) {
+            Fraction tick(0, 1);
+            ChordRest* cr = _score->getSelectedChordRest();
+            if (cr)
+                tick = cr->tick();
             _score->startCmd();
-            _score->undo(new ChangeDrumset(staff->part()->instrument(), eds.drumset()));
+            _score->undo(new ChangeDrumset(staff->part()->instrument(tick), eds.drumset()));
             mscore->updateDrumTools(eds.drumset());
             if (_score->undoStack()->active()) {
                   _score->setLayoutAll();

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -415,7 +415,7 @@ void ScoreView::measurePopup(QContextMenuEvent* ev, Measure* obj)
       a->setText(tr("Staff"));
       a = popup->addAction(tr("Edit Drumset…"));
       a->setData("edit-drumset");
-      a->setEnabled(staff->part()->instrument()->drumset() != 0);
+      a->setEnabled(staff->part()->instrument(obj->tick())->drumset() != 0);
 
       a = popup->addAction(tr("Piano Roll Editor…"));
       a->setData("pianoroll");
@@ -475,10 +475,14 @@ void ScoreView::measurePopup(QContextMenuEvent* ev, Measure* obj)
                   }
             }
       else if (cmd == "edit-drumset") {
-            EditDrumset drumsetEdit(staff->part()->instrument()->drumset(), this);
+            EditDrumset drumsetEdit(staff->part()->instrument(obj->tick())->drumset(), this);
             if (drumsetEdit.exec()) {
-                  _score->undo(new ChangeDrumset(staff->part()->instrument(), drumsetEdit.drumset()));
+                  _score->undo(new ChangeDrumset(staff->part()->instrument(obj->tick()), drumsetEdit.drumset()));
                   mscore->updateDrumTools(drumsetEdit.drumset());
+                  if (_score->undoStack()->active()) {
+                        _score->setLayoutAll();
+                        _score->endCmd();
+                        }
                   }
             }
       else if (cmd == "drumroll") {


### PR DESCRIPTION
Resolves: *https://musescore.org/en/node/307659*

- Right-clicking on a measure to Edit Drumset now edits the proper drumset after an Instrument Change.
Previously (without a "tick") it applied the Drumset Edit to the first staff instrument.
- The Edit Drumset button on the drumtools input palette now edits the proper Drumset
 
- Also added a Tick to every part->instrument() call when appropriate (after @MarcSabatella's suggestion) to hopefully prevent or help fix other erratic behaviors regarding instrument changes.
- (Still can't switch between pitched and unpitched instruments)

Any code review will be welcome.


![image](https://user-images.githubusercontent.com/2843953/88986328-085f7100-d2a9-11ea-9d50-e3173edda135.png)
_Woodblocks intentionally moved to weird lines_



<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- NA I created the test (mtest, vtest, script test) to verify the changes I made
