### PR TITLE
Fix #97416 - toggle between pitched and unpitched instruments

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1736,11 +1736,15 @@ void Chord::cmdUpdateNotes(AccidentalState* as)
       const Staff* st = staff();
       StaffGroup staffGroup = st->staffTypeForElement(this)->group();
       if (staffGroup == StaffGroup::TAB) {
-            const Instrument* instrument = part()->instrument();
+            const Instrument* instrument = part()->instrument(this->tick());
             for (Chord* ch : graceNotes())
                   instrument->stringData()->fretChords(ch);
             instrument->stringData()->fretChords(this);
             return;
+            }
+      else  {
+            // if not tablature, use instrument->useDrumset to set staffGroup (to allow pitched to unpitched in same staff)
+            staffGroup = st->part()->instrument(this->tick())->useDrumset() ? StaffGroup::PERCUSSION : StaffGroup::STANDARD;
             }
 
       // PITCHED_ and PERCUSSION_STAFF can go note by note
@@ -1775,7 +1779,7 @@ void Chord::cmdUpdateNotes(AccidentalState* as)
                   }
             }
       else if (staffGroup == StaffGroup::PERCUSSION) {
-            const Instrument* instrument = part()->instrument();
+            const Instrument* instrument = part()->instrument(this->tick());
             const Drumset* drumset = instrument->drumset();
             if (!drumset)
                   qWarning("no drumset");
@@ -2845,7 +2849,7 @@ void Chord::setSlash(bool flag, bool stemless)
                   n->undoChangeProperty(Pid::PLAY, true);
                   n->undoChangeProperty(Pid::VISIBLE, true);
                   if (staff()->isDrumStaff(tick())) {
-                        const Drumset* ds = part()->instrument()->drumset();
+                        const Drumset* ds = part()->instrument(tick())->drumset();
                         int pitch = n->pitch();
                         if (ds && ds->isValid(pitch)) {
                               undoChangeProperty(Pid::STEM_DIRECTION, QVariant::fromValue<Direction>(ds->stemDirection(pitch)));

--- a/libmscore/clef.cpp
+++ b/libmscore/clef.cpp
@@ -26,6 +26,7 @@
 #include "staff.h"
 #include "segment.h"
 #include "stafftype.h"
+#include "part.h"
 
 namespace Ms {
 
@@ -121,9 +122,14 @@ void Clef::layout()
             Fraction tick = clefSeg->tick();
             const StaffType* st = staff()->staffType(tick);
             bool show     = st->genClef();        // check staff type allows clef display
+            StaffGroup staffGroup = st->group();
+
+            // if not tab, use instrument->useDrumset to set staffGroup (to allow pitched to unpitched in same staff)
+            if ( staffGroup != StaffGroup::TAB)
+                  staffGroup = staff()->part()->instrument(this->tick())->useDrumset() ? StaffGroup::PERCUSSION : StaffGroup::STANDARD;
 
             // check clef is compatible with staff type group:
-            if (ClefInfo::staffGroup(clefType()) != st->group()) {
+            if (ClefInfo::staffGroup(clefType()) != staffGroup) {
                   if (tick > Fraction(0,1) && !generated()) // if clef is not generated, hide it
                         show = false;
                   else                          // if generated, replace with initial clef type

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1491,10 +1491,15 @@ void Score::upDown(bool up, UpDownMode mode)
             int string   = oNote->string();
             int fret     = oNote->fret();
 
-            switch (staff->staffType(oNote->chord()->tick())->group()) {
+            StaffGroup staffGroup = staff->staffType(oNote->chord()->tick())->group();
+            // if not tab, check for instrument instead of staffType (for pitched to unpitched instrument changes) 
+            if ( staffGroup != StaffGroup::TAB)
+                  staffGroup = staff->part()->instrument(oNote->tick())->useDrumset() ? StaffGroup::PERCUSSION : StaffGroup::STANDARD;
+
+            switch (staffGroup) {
                   case StaffGroup::PERCUSSION:
                         {
-                        const Drumset* ds = part->instrument()->drumset();
+                        const Drumset* ds = part->instrument(tick)->drumset();
                         if (ds) {
                               newPitch = up ? ds->nextPitch(pitch) : ds->prevPitch(pitch);
                               newTpc1 = pitch2tpc(newPitch, Key::C, Prefer::NEAREST);
@@ -1504,7 +1509,7 @@ void Score::upDown(bool up, UpDownMode mode)
                         break;
                   case StaffGroup::TAB:
                         {
-                        const StringData* stringData = part->instrument()->stringData();
+                        const StringData* stringData = part->instrument(tick)->stringData();
                         switch (mode) {
                               case UpDownMode::OCTAVE:          // move same note to next string, if possible
                                     {
@@ -1638,7 +1643,7 @@ void Score::upDown(bool up, UpDownMode mode)
                         refret = true;
                         }
                   if (refret) {
-                        const StringData* stringData = part->instrument()->stringData();
+                        const StringData* stringData = part->instrument(tick)->stringData();
                         stringData->fretChords(oNote->chord());
                         }
                   }
@@ -1765,7 +1770,7 @@ static void changeAccidental2(Note* n, int pitch, int tpc)
                   // as pitch has changed, calculate new
                   // string & fret
                   //
-                  const StringData* stringData = n->part()->instrument()->stringData();
+                  const StringData* stringData = n->part()->instrument(n->tick())->stringData();
                   if (stringData)
                         stringData->convertPitch(pitch, st, chord->tick(), &string, &fret);
                   }
@@ -2162,7 +2167,7 @@ bool Score::processMidiInput()
                               ev.pitch += p->instrument(selection().tickStart())->transpose().chromatic;
                               }
                         MScore::seq->startNote(
-                                          p->instrument()->channel(0)->channel(),
+                                          p->instrument(selection().tickStart())->channel(0)->channel(),   // tick that way?
                                           ev.pitch,
                                           ev.velocity,
                                           0.0);

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -3980,8 +3980,8 @@ void Score::undoChangeClef(Staff* ostaff, Element* e, ClefType ct, bool forInstr
       Fraction rtick = e->rtick();
       bool small = (st == SegmentType::Clef);
       for (Staff* staff : ostaff->staffList()) {
-            if (staff->staffType(tick)->group() != ClefInfo::staffGroup(ct))
-                  continue;
+      //      if (staff->staffType(tick)->group() != ClefInfo::staffGroup(ct))
+      //            continue;
 
             Score* score     = staff->score();
             Measure* measure = score->tick2measure(tick);

--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -238,7 +238,7 @@ void Excerpt::createExcerpt(Excerpt* excerpt)
                         continue;
 
                   // if this staff has no transposition, and no instrument changes, we can skip it
-                  Interval interval = staff->part()->instrument()->transpose();
+                  Interval interval = staff->part()->instrument()->transpose(); //tick?
                   if (interval.isZero() && staff->part()->instruments()->size() == 1)
                         continue;
                   bool flip = false;

--- a/libmscore/input.cpp
+++ b/libmscore/input.cpp
@@ -47,7 +47,14 @@ StaffGroup InputState::staffGroup() const
       {
       if (_segment == 0 || _track == -1)
             return StaffGroup::STANDARD;
-      return _segment->score()->staff(_track/VOICES)->staffType(_segment->tick())->group();
+
+      StaffGroup staffGroup = _segment->score()->staff(_track/VOICES)->staffType(_segment->tick())->group();
+      Instrument* instrument = _segment->score()->staff(_track/VOICES)->part()->instrument(_segment->tick());
+
+      // if not tab, pitched/unpitched input depends on instrument, not staff (override StaffGroup)
+      if ( staffGroup != StaffGroup::TAB)
+            staffGroup = instrument->useDrumset() ? StaffGroup::PERCUSSION : StaffGroup::STANDARD;
+      return staffGroup;
       }
 
 //---------------------------------------------------------
@@ -175,7 +182,7 @@ void InputState::update(Selection& selection)
 
       setDrumNote(-1);
       if (n) {
-            const Instrument* instr = n->part()->instrument();
+            const Instrument* instr = n->part()->instrument(n->tick());
             if (instr->useDrumset())
                   setDrumNote(n->pitch());
             }

--- a/libmscore/instrchange.cpp
+++ b/libmscore/instrchange.cpp
@@ -209,7 +209,7 @@ void InstrumentChange::read(XmlReader& e)
             // There is also code in read206 to try to deal with this, but it is out of date and therefore disabled
             // What this means is, scores created in 2.1 or later should be fine, scores created in 2.0 maybe not so much
 
-            Interval v = staff() ? staff()->part()->instrument()->transpose() : 0;
+            Interval v = staff() ? staff()->part()->instrument(tick())->transpose() : 0;
             _instrument->setTranspose(v);
             }
       }

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2693,7 +2693,7 @@ void Score::getNextMeasure(LayoutContext& lc)
       //
       for (int staffIdx = 0; staffIdx < score()->nstaves(); ++staffIdx) {
             const Staff* staff     = Score::staff(staffIdx);
-            const Drumset* drumset = staff->part()->instrument()->useDrumset() ? staff->part()->instrument()->drumset() : 0;
+            const Drumset* drumset = staff->part()->instrument(measure->tick())->useDrumset() ? staff->part()->instrument(measure->tick())->drumset() : 0;
             AccidentalState as;      // list of already set accidentals for this measure
             as.init(staff->keySigEvent(measure->tick()), staff->clef(measure->tick()));
 

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2541,8 +2541,9 @@ void Note::verticalDrag(EditData &ed)
       Fraction _tick      = chord()->tick();
       const Staff* stf    = staff();
       const StaffType* st = stf->staffType(_tick);
+      const Instrument* instr = part()->instrument(_tick);
 
-      if (st->isDrumStaff())
+      if (instr->useDrumset())
             return;
 
       NoteEditData* ned   = static_cast<NoteEditData*>(ed.getData(this));
@@ -2553,7 +2554,7 @@ void Note::verticalDrag(EditData &ed)
       int lineOffset      = lrint(ed.moveDelta.y() / step);
 
       if (tab) {
-            const StringData* strData = staff()->part()->instrument()->stringData();
+            const StringData* strData = staff()->part()->instrument(_tick)->stringData();
             int nString = ned->string + (st->upsideDown() ? -lineOffset : lineOffset);
             int nFret   = strData->fret(_pitch, nString, staff(), _tick);
 
@@ -3026,7 +3027,7 @@ QString Note::accessibleInfo() const
             if (on != 0 || off != NoteEvent::NOTE_LENGTH)
                   onofftime = QObject::tr(" (on %1‰ off %2‰)").arg(on).arg(off);
             }
-      const Drumset* drumset = part()->instrument()->drumset();
+      const Drumset* drumset = part()->instrument(chord()->tick())->drumset();
       if (fixed() && headGroup() == NoteHead::Group::HEAD_SLASH)
             pitchName = chord()->noStem() ? QObject::tr("Beat slash") : QObject::tr("Rhythm slash");
       else if (staff()->isDrumStaff(tick()) && drumset)
@@ -3058,7 +3059,7 @@ QString Note::screenReaderInfo() const
       bool voices = m ? m->hasVoices(staffIdx()) : false;
       QString voice = voices ? QObject::tr("Voice: %1").arg(QString::number(track() % VOICES + 1)) : "";
       QString pitchName;
-      const Drumset* drumset = part()->instrument()->drumset();
+      const Drumset* drumset = part()->instrument(chord()->tick())->drumset();
       if (fixed() && headGroup() == NoteHead::Group::HEAD_SLASH)
             pitchName = chord()->noStem() ? QObject::tr("Beat Slash") : QObject::tr("Rhythm Slash");
       else if (staff()->isDrumStaff(tick()) && drumset)

--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -46,7 +46,12 @@ NoteVal Score::noteValForPosition(Position pos, AccidentalType at, bool &error)
       NoteVal nval;
       const StringData* stringData = 0;
 
-      switch (st->staffType(tick)->group()) {
+      // pitched/unpitched note entry depends on instrument (override StaffGroup)
+      StaffGroup staffGroup = st->staffType(tick)->group();
+      if (staffGroup != StaffGroup::TAB) 
+            staffGroup = instr->useDrumset() ? StaffGroup::PERCUSSION : StaffGroup::STANDARD;
+
+      switch (staffGroup) {
             case StaffGroup::PERCUSSION: {
                   if (_is.rest())
                         break;
@@ -325,7 +330,13 @@ void Score::putNote(const Position& p, bool replace)
             return;
 
       const StringData* stringData = 0;
-      switch (st->staffType(s->tick())->group()) {
+
+      // pitched/unpitched note entry depends on instrument (override StaffGroup)
+      StaffGroup staffGroup = st->staffType(s->tick())->group();
+      if (staffGroup != StaffGroup::TAB)
+            staffGroup = st->part()->instrument(s->tick())->useDrumset() ? StaffGroup::PERCUSSION : StaffGroup::STANDARD;
+
+      switch (staffGroup) {
             case StaffGroup::PERCUSSION: {
                   const Drumset* ds = st->part()->instrument(s->tick())->drumset();
                   stemDirection     = ds->stemDirection(nval.pitch);

--- a/libmscore/pitchspelling.cpp
+++ b/libmscore/pitchspelling.cpp
@@ -653,7 +653,7 @@ void changeAllTpcs(Note* n, int tpc1)
       {
       Interval v;
       Fraction tick = n && n->chord() ? n->chord()->tick() : Fraction(-1,1);
-      if (n && n->part() && n->part()->instrument()) {
+      if (n && n->part() && n->part()->instrument(tick)) {
             v = n->part()->instrument(tick)->transpose();
             v.flip();
             }

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2696,7 +2696,7 @@ void Score::cmdConcertPitchChanged(bool flag, bool /*useDoubleSharpsFlats*/)
             if (staff->staffType(Fraction(0,1))->group() == StaffGroup::PERCUSSION)       // TODO
                   continue;
             // if this staff has no transposition, and no instrument changes, we can skip it
-            Interval interval = staff->part()->instrument()->transpose();
+            Interval interval = staff->part()->instrument()->transpose(); //tick?
             if (interval.isZero() && staff->part()->instruments()->size() == 1)
                   continue;
             if (!flag)
@@ -4273,7 +4273,7 @@ int Score::keysig()
             if (st->staffType(t)->group() == StaffGroup::PERCUSSION || st->keySigEvent(t).custom() || st->keySigEvent(t).isAtonal())       // ignore percussion and custom / atonal key
                   continue;
             result = key;
-            int diff = st->part()->instrument()->transpose().chromatic;
+            int diff = st->part()->instrument()->transpose().chromatic; //TODO keySigs and pitched to unpitched instr changes
             if (!styleB(Sid::concertPitch) && diff)
                   result = transposeKey(key, diff, st->part()->preferSharpFlat());
             break;

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -301,7 +301,12 @@ ClefTypeList Staff::clefType(const Fraction& tick) const
       {
       ClefTypeList ct = clefs.clef(tick.ticks());
       if (ct._concertClef == ClefType::INVALID) {
-            switch (staffType(tick)->group()) {
+            // Clef compatibility based on instrument (override StaffGroup) 
+            StaffGroup staffGroup = staffType(tick)->group();
+            if (staffGroup != StaffGroup::TAB)
+                  staffGroup = part()->instrument(tick)->useDrumset() ? StaffGroup::PERCUSSION : StaffGroup::STANDARD;
+
+            switch (staffGroup) {
                   case StaffGroup::TAB:
                         {
                         ClefType sct = ClefType(score()->styleI(Sid::tabClef));
@@ -1480,7 +1485,8 @@ void Staff::localSpatiumChanged(double oldVal, double newVal, Fraction tick)
 
 bool Staff::isPitchedStaff(const Fraction& tick) const
       {
-      return staffType(tick)->group() == StaffGroup::STANDARD;
+      //return staffType(tick)->group() == StaffGroup::STANDARD;
+      return (staffType(tick)->group() != StaffGroup::TAB && !part()->instrument(tick)->useDrumset());
       }
 
 //---------------------------------------------------------
@@ -1498,7 +1504,8 @@ bool Staff::isTabStaff(const Fraction& tick) const
 
 bool Staff::isDrumStaff(const Fraction& tick) const
       {
-      return staffType(tick)->group() == StaffGroup::PERCUSSION;
+      //check for instrument instead of staffType (for pitched to unpitched instr. changes)
+      return part()->instrument(tick)->useDrumset();
       }
 
 //---------------------------------------------------------

--- a/libmscore/stringdata.cpp
+++ b/libmscore/stringdata.cpp
@@ -164,7 +164,7 @@ void StringData::fretChords(Chord * chord) const
       int   count = 0;
       // store staff pitch offset at this tick, to speed up actual note pitch calculations
       // (ottavas not implemented yet)
-      int transp = chord->staff() ? chord->part()->instrument()->transpose().chromatic : 0;     // TODO: tick?
+      int transp = chord->staff() ? chord->part()->instrument(chord->tick())->transpose().chromatic : 0;     // TODO: tick?
       int pitchOffset = /*chord->staff()->pitchOffset(chord->segment()->tick())*/ - transp;
       // if chord parent is not a segment, the chord is special (usually a grace chord):
       // fret it by itself, ignoring the segment

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1612,7 +1612,7 @@ ChangePart::ChangePart(Part* _part, Instrument* i, const QString& s)
 
 void ChangePart::flip(EditData*)
       {
-      Instrument* oi = part->instrument();
+      Instrument* oi = part->instrument();  //tick?
       QString s      = part->partName();
       part->setInstrument(instrument);
       part->setPartName(partName);

--- a/mscore/drumroll.cpp
+++ b/mscore/drumroll.cpp
@@ -367,7 +367,7 @@ void DrumrollEditor::velocityChanged(int val)
 
 void DrumrollEditor::keyPressed(int p)
       {
-      seq->startNote(staff->part()->instrument()->channel(0)->channel(), p, 80, 0, 0.0);
+      seq->startNote(staff->part()->instrument()->channel(0)->channel(), p, 80, 0, 0.0);  //tick?
       }
 
 //---------------------------------------------------------

--- a/mscore/drumtools.cpp
+++ b/mscore/drumtools.cpp
@@ -183,8 +183,10 @@ void DrumTools::editDrumset()
       {
       EditDrumset eds(drumset, this);
       if (eds.exec()) {
+            ChordRest* cr = _score->getSelectedChordRest();
+            Fraction tick = cr ? cr->tick() : Fraction(0,1);
             _score->startCmd();
-            _score->undo(new ChangeDrumset(staff->part()->instrument(), eds.drumset()));
+            _score->undo(new ChangeDrumset(staff->part()->instrument(tick), eds.drumset()));
             mscore->updateDrumTools(eds.drumset());
             if (_score->undoStack()->active()) {
                   _score->setLayoutAll();
@@ -205,7 +207,7 @@ void DrumTools::drumNoteSelected(int val)
             Note* note       = ch->downNote();
             int ticks        = MScore::defaultPlayDuration;
             int pitch        = note->pitch();
-            seq->startNote(staff->part()->instrument()->channel(0)->channel(), pitch, 80, ticks, 0.0);
+            seq->startNote(staff->part()->instrument()->channel(0)->channel(), pitch, 80, ticks, 0.0);  //tick?
 
             int track = (_score->inputState().track() / VOICES) * VOICES + element->track();
             _score->inputState().setTrack(track);

--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -384,7 +384,7 @@ void EditStaff::apply()
             else {
                   // change part name globally, instrument locally if possible
                   if (part->partName() != newPartName)
-                        score->undo(new ChangePart(part, new Instrument(*part->instrument()), newPartName));
+                        score->undo(new ChangePart(part, new Instrument(*part->instrument()), newPartName));  //tick?
                   if (instrumentFieldChanged) {
                         Segment* s = score->tick2segment(_tickStart, true, SegmentType::ChordRest);
                         const std::vector<Element*> elist = s ? s->findAnnotations(ElementType::INSTRUMENT_CHANGE, part->startTrack(), part->endTrack()) : std::vector<Element*>();

--- a/mscore/editstafftype.cpp
+++ b/mscore/editstafftype.cpp
@@ -59,7 +59,7 @@ EditStaffType::EditStaffType(QWidget* parent, Staff* st)
 
       staff     = st;
       staffType = *staff->staffType(Fraction(0,1));
-      Instrument* instr = staff->part()->instrument();
+      Instrument* instr = staff->part()->instrument(); //tick?
 
       // template combo
 

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -689,7 +689,7 @@ MasterScore* MuseScore::getNewFile()
                               Segment* s = m->getSegment(SegmentType::TimeSig, Fraction(0,1));
                               s->add(ts);
                               Part* part = staff->part();
-                              if (!part->instrument()->useDrumset()) {
+                              if (!part->instrument()->useDrumset()) {  //tick?
                                     //
                                     // transpose key
                                     //

--- a/mscore/keyb.cpp
+++ b/mscore/keyb.cpp
@@ -75,7 +75,13 @@ void MuseScore::updateInputState(Score* score)
                   is.setDuration(d);
                   }
             Staff* staff = score->staff(is.track() / VOICES);
-            switch (staff->staffType(is.tick())->group()) {
+
+            //if not tab, note entry depends on instrument (override StaffGroup) 
+            StaffGroup staffGroup = staff->staffType(is.tick())->group();
+            if (staffGroup != StaffGroup::TAB)
+                  staffGroup = staff->part()->instrument(is.tick())->useDrumset() ? StaffGroup::PERCUSSION : StaffGroup::STANDARD;
+
+            switch (staffGroup) {
                   case StaffGroup::STANDARD:
                         changeState(STATE_NOTE_ENTRY_STAFF_PITCHED);
                         break;


### PR DESCRIPTION
Resolves: *https://musescore.org/en/node/97416*
Resolves *https://musescore.org/en/node/307659*

Changes:
The main changes in the code are:
- Most "unticked" queries for part()->instrument() were properly "ticked" (part()->instrument(tick)), for staff changes
- If the staff is not a tablature, queries for the staff "StaffGroup" (i.e. "Percussion Standard" vs "pitched standard" etc)  are overridden by queries to the part()->instrument(tick)->isDrumSet, so now it is the instrument who determines if the staff behavior -  valid clefs, transposition, entry mode, clicking, etc. - is suited for pitched or unpitched.

As consequence, the following has been fixed: 
- Allows pitched and unpitched (drumset) instrument changes on the same staff. 
- Fixes Drumset Edits not having effect after instrument changes


- Different note entry modes are now activated under different instrument changes without exiting Note Entry
(User can just navigate left or right and MuseScore will activate or deactivate the proper note entry mode/tools seamlessly)
- The DrumTools panel will open, show and edit the correct drumset in note entry mode depending on the current instrument change, if it has a drumset. 
- Dragging up/down will only transpose pitched notes (if both pitched and unpitched are selected)
- Using  up/down keys will give the expected results for either  pitched notes (transposing) or unpitched notes (cycle thru percussion hits) even if both pitched and unpitched parts of the staff are selected. Of course this is not recommended.
- Clef compatibility now checks for instrument instead of staff, so the right clefs are allowed for the instrument changes - and automatically generated if needed.

- Fixes string data changes along with instrument changes in tablatures.
- Also fixes editing (custom) instrument string data on an instrument change.

~~Known issue: when editing string data on linked staves, the wrong string data is saved to the file. Will try to fix this too, if possible in this PR.~~ this issue is fixed in this PR: https://github.com/musescore/MuseScore/pull/6491

- TO DO:  Key signatures are still showing after changing to unpitched instrument.

![image](https://user-images.githubusercontent.com/2843953/89124586-8ccf1100-d4ae-11ea-9154-659b08bee580.png)

![image](https://user-images.githubusercontent.com/2843953/90801214-fee78880-e2eb-11ea-9a74-08658f02486a.png)


(History...)

The first approach was to set StaffType StaffGroup every time an instrument changed, but that should be not required (Except for tabs of different strings, a visually different staff type is not mandatory for every instrument).  Then I implemented this second approach in which most checks for staffType->group are overriden by instrument->useDrumset (except on tablatures). This way, all normal edit/entry operations are allowed for standard or percussion depending on the instrument change of current tick, and the staff type change is optional.

The plan was to make smaller commits, but as I added the 'Ticks' to part()->instrument(tick) queries, all related issues ended up being fixed with just a bit more of code.

Note about clefs and instrument/staff changes (for a later fix): 
_- Generated clefs before measures with a  staffType change will need a special fix since they are computed from stafftype in previous measure. A solution is needed allow staff type changes to visually start mid measure, or the user will have to decide if she/he adds a stc one measure before the instrument change (so the clef displays correctly) or adding the clef after the barline, which is not as elegant on an instrument change.(See G clefs on 3rd staff on first image)._


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
