### PR TITLE
(Outdated) Fix 281639: Cutaway staves - better handling of clefs

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2752,7 +2752,7 @@ bool Measure::isEmpty(int staffIdx) const
             strack = staffIdx * VOICES;
             etrack = strack + VOICES;
             }
-      for (Segment* s = first(SegmentType::ChordRest); s; s = s->next(SegmentType::ChordRest)) {
+      for (Segment* s = first(SegmentType::ChordRest | SegmentType::Clef); s; s = s->next(SegmentType::ChordRest | SegmentType::Clef)) {
             for (int track = strack; track < etrack; ++track) {
                   Element* e = s->element(track);
                   if (e && !e->isRest())


### PR DESCRIPTION

NOTE: PR dropped, replaced with PR #6409 




Resolves: *https://musescore.org/en/node/281639*

Makes measure::isEmpty() return false is there is any Clef on the measure. Currently, only chords make the measure read as non-empty.

This allows clefs and their measures to be visible on cutaway scores.

I checked on all references to measure::isEmpty and didn't find any conflicts with this so far.

_This is a page of Pendecki's Stabat Matter made in MuseScore with this build. 
(Including the workaround of covering part of the measure with a blank image for prettier results like of Penderecki's edition)_ 
![image](https://user-images.githubusercontent.com/2843953/89128062-45a24980-d4c9-11ea-9530-5c53c8542ab1.png)

As a side bonus, added invisible clefs make any measure visible (for example, sometimes a single rest measure between 2 non-empty measures must stay visible in a cutaway staff) - and also forces  a staff not to hide when empty.



<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
