### PR TITLE
Fix #281639: Cutaway staves - better handling of clefs, barlines...

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -437,14 +437,12 @@ Element* ChordRest::drop(EditData& data)
                         bl->setTrack(staffIdx() * VOICES);
                         bl->setGenerated(false);
 
-                        if (tick() == m->tick())
-                              return m->drop(data);
-
                         BarLine* obl = 0;
                         for (Staff* st  : staff()->staffList()) {
                               Score* score = st->score();
                               Measure* measure = score->tick2measure(m->tick());
-                              Segment* seg = measure->undoGetSegmentR(SegmentType::BarLine, rtick());
+                              SegmentType segmentType = tick() == m->tick() ? SegmentType::BeginBarLine : SegmentType::BarLine;
+                              Segment* seg = measure->undoGetSegmentR(segmentType, rtick());
                               BarLine* l;
                               if (obl == 0)
                                     obl = l = bl->clone();

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -219,6 +219,7 @@ class Measure final : public MeasureBase {
       void checkMultiVoices(int staffIdx);
       bool hasVoice(int track) const;
       bool isEmpty(int staffIdx) const;
+      bool isCourtesyClef(int staffIdx) const;
       bool isFullMeasureRest() const;
       bool isRepeatMeasure(const Staff* staff) const;
       bool visible(int staffIdx) const;

--- a/libmscore/stafflines.cpp
+++ b/libmscore/stafflines.cpp
@@ -124,6 +124,51 @@ void StaffLines::layoutForWidth(qreal w)
       }
 
 //---------------------------------------------------------
+//   layoutPartial
+//---------------------------------------------------------
+
+void StaffLines::layoutPartial(qreal w, qreal wPartial, bool alignLeft)
+      {
+      const Staff* s = staff();
+      qreal _spatium = spatium();
+      wPartial *= spatium();
+      qreal dist     = _spatium;
+      setPos(QPointF(0.0, 0.0));
+      int _lines;
+      if (s) {
+            setMag(s->mag(measure()->tick()));
+            setColor(s->color());
+            const StaffType* st = s->staffType(measure()->tick());
+            dist         *= st->lineDistance().val();
+            _lines        = st->lines();
+            rypos()       = st->yoffset().val() * _spatium;
+            }
+      else {
+            _lines = 5;
+            setColor(MScore::defaultColor);
+            }
+      lw       = score()->styleS(Sid::staffLineWidth).val() * _spatium;
+      qreal x1 = pos().x();
+      qreal x2 = x1 + w;
+      qreal y  = pos().y();
+      bbox().setRect(x1, -lw * .5 + y, w, (_lines-1) * dist + lw);
+
+      if (_lines == 1) {
+            qreal extraSize = _spatium;
+            bbox().adjust(0, -extraSize, 0, extraSize);
+      }
+
+      lines.clear();
+      for (int i = 0; i < _lines; ++i) {
+            if (alignLeft)
+                  lines.push_back(QLineF(x1, y, x1 + wPartial, y));
+            else
+                  lines.push_back(QLineF(x2-wPartial, y, x2, y));
+            y += dist;
+            }
+      }
+
+//---------------------------------------------------------
 //   draw
 //---------------------------------------------------------
 

--- a/libmscore/stafflines.h
+++ b/libmscore/stafflines.h
@@ -38,6 +38,7 @@ class StaffLines final : public Element {
       Measure* measure() const { return (Measure*)parent(); }
       qreal y1() const;
       void layoutForWidth(qreal width);
+      void layoutPartial (qreal width, qreal widthPartial, bool alignRight);
       };
 
 }     // namespace Ms


### PR DESCRIPTION
Resolves: *https://musescore.org/en/node/281639*

Better handling of clefs and barlines for cutaway engraving and ossias.

Barlines:
- Begin Bar Lines now can be added to a measure by adding to the first chordRest of the measure
- A measure Begin bar line will overlap previous measure's end bar line so there is no visual change if both barlines are visible
- The span handles of the Begin bar line are slightly at right of the barline
- the span of this or other custom (added) bar lines don't set the global span anymore.

![image](https://user-images.githubusercontent.com/2843953/89264257-ff540400-d608-11ea-94fa-f2b008a4f6ba.png)
*(ossias with added start barlines)*

~~Clefs:~~
- ~~A clef present on a measure makes the measure visible~~ 
- ~~As usual, clefs added to the whole measure show before the bar line, thus making the previous measure visible.~~
- ~~Hidden clefs can be used as a workaround to force unhide a measure in cutaway staff (or a whole staff when staves set to hide when empty).~~

Clefs (Update):
- In cutaway staves, clefs added before barlines on an empty measure (as in adding a clef to the the the next measure) turns the measure visible but showing only portion of its staff lines lines, as a clef "trailer" (or "leader").
- (if desired, rests need to be hidden manually).

*A workaround to force measures to be non-empty (and force visible) is to use a staff text, set to white or transparent, since the measure containing the text can be easily copied and pasted around. 

![image](https://user-images.githubusercontent.com/2843953/89464156-54e1fb00-d746-11ea-9832-7ee7f71d5300.png)
*(Clefs added to measures partially reveal previous measures as courtesy/trailer for clefs. )

Brackets: will be left out of the scope of this PR. 
Any feedback is appreciated.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
