### PR TITLE
Fix #308562: 1-line staves show unexpected vertical offset

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1137,7 +1137,8 @@ bool Score::getPosition(Position* pos, const QPointF& p, int voice) const
       // in TABs, step from one string to another; in other staves, step on and between lines
       qreal lineDist = s->staffType(tick)->lineDistance().val() * (s->isTabStaff(measure->tick()) ? 1 : .5) * mag * spatium();
 
-      pos->line  = lrint((pppp.y() - sstaff->bbox().y()) / lineDist);
+      const qreal yOff = sstaff->yOffset();  // Get system staff vertical offset (usually for 1-line staves)
+      pos->line  = lrint((pppp.y() - sstaff->bbox().y() - yOff) / lineDist);
       if (s->isTabStaff(measure->tick())) {
             if (pos->line < -1 || pos->line > s->lines(tick)+1)
                   return false;

--- a/libmscore/system.h
+++ b/libmscore/system.h
@@ -60,6 +60,7 @@ class SysStaff {
       void setbbox(const QRectF& r) { _bbox = r; }
       qreal y() const               { return _bbox.y() + _yOff; }
       void setYOff(qreal offset)    { _yOff = offset; }
+      qreal yOffset() const         { return _yOff; }
 
       qreal continuousDist() const      { return _continuousDist;  }
       void setContinuousDist(qreal val) { _continuousDist = val;   }


### PR DESCRIPTION
...on note entry mode.

Resolves: *https://musescore.org/en/node/308562*

The note entry cursor is drawn about 2 lines below the actual mouse pointer in 3.5 RC, when hovering over staves that are "born" as 1-line (even if a Staff Type Change sets it to 5-lines later as in second image below).

This is a side effect of an yOff added to 1-line system staves in order to fix issues with brackets.
I just added a complementary code to getPosition() to fix this side effect.



![image](https://user-images.githubusercontent.com/2843953/89240105-81283b00-d5d1-11ea-8a25-6dcf56c43022.png)

![image](https://user-images.githubusercontent.com/2843953/89239410-77053d00-d5cf-11ea-96b8-b5f1548d0ab8.png)



<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
