### PR TITLE
fix #308568: bad selection and corruption on delete

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -3299,7 +3299,7 @@ void Score::localTimeDelete()
       MeasureBase* ie;
 
       if (endSegment)
-            ie = endSegment->prev() ? endSegment->measure() : endSegment->measure()->prev();
+            ie = endSegment->prev(SegmentType::ChordRest) ? endSegment->measure() : endSegment->measure()->prev();
       else
             ie = lastMeasure();
 
@@ -3372,6 +3372,9 @@ void Score::localTimeDelete()
 
 void Score::timeDelete(Measure* m, Segment* startSegment, const Fraction& f)
       {
+      if (f.isZero())
+            return;
+
       const Fraction tick  = startSegment->rtick();
       const Fraction len   = f;
       const Fraction etick = tick + len;

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3154,7 +3154,7 @@ void Score::selectRange(Element* e, int staffIdx)
                               oe = oe->parent();
                         ChordRest* ocr = toChordRest(oe);
 
-                        Segment* endSeg = tick2segmentMM(ocr->segment()->tick() + ocr->actualTicks());
+                        Segment* endSeg = tick2segmentMM(ocr->segment()->tick() + ocr->actualTicks(), true);
                         if (!endSeg)
                               endSeg = ocr->segment()->next();
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/308568

If you make a range selection "in reverse",
by selecting a note then extending it to the left
(whether using Shift+Left or Shift+click),
you get a bad selection where the endSemgent is in the next measure.
And in the case of a measure at the end of a system,
it means the selection includes the header of the next system.
This glitch has been the case since MuseScore 2 at least,
but with the reimplementation of measure delete as time delete,
it actually causes corruption when deleting the select range.
That is because we are getting the wrong measure
for the end of the selection, and attempting to do a partial time delete
(with length of 0) in the next measure.

This change fixes the basic problem with selection, so reverse selection
no longer causes this bad result.
This is done by adjusting the initial range to end with
the *first* segment after the originally-selected CR
rather than the last.
I also fix the calculation of the range of measures
to not be fooled if the endSegment comes after a header -
this was causing an unnecessary invocation of time delete
to delete the beginning of that next measure.
Finally, I also check to be sure we aren't trying to delete zero time,
since that was where the corruption was coming from.