### PR TITLE
Fix #295722: allow changing staff visibility mid-score

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -431,7 +431,7 @@ void BarLine::getY() const
 
       int from    = _spanFrom;
       int to      = _spanTo;
-      int oneLine = st1->lines() == 1;
+      int oneLine = st1->lines() <= 1;
       if (oneLine && _spanFrom == 0) {
             from = BARLINE_SPAN_1LINESTAFF_FROM;
             if (!_spanStaff || (staffIdx1 == nstaves - 1))

--- a/libmscore/stafflines.cpp
+++ b/libmscore/stafflines.cpp
@@ -114,7 +114,10 @@ void StaffLines::layoutForWidth(qreal w)
       if (_lines == 1) {
             qreal extraSize = _spatium;
             bbox().adjust(0, -extraSize, 0, extraSize);
-      }
+            }
+      else if (_lines == 0) {
+            bbox().adjust(0, -2 * dist, 0, 2*dist);
+            }
 
       lines.clear();
       for (int i = 0; i < _lines; ++i) {

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -283,7 +283,7 @@ void System::layoutSystem(qreal xo1)
             ++nVisible;
             qreal staffMag = staff->mag(Fraction(0,1));     // ??? TODO
             int staffLines = staff->lines(Fraction(0,1));
-            if (staffLines == 1) {
+            if (staffLines <= 1) {
                   qreal h = staff->lineDistance(Fraction(0,1)) * staffMag * spatium();
                   s->bbox().setRect(_leftMargin + xo1, -h, 0.0, 2 * h);
                   }

--- a/mscore/editstaff.ui
+++ b/mscore/editstaff.ui
@@ -160,7 +160,7 @@
           <item row="1" column="1">
            <widget class="QSpinBox" name="lines">
             <property name="minimum">
-             <number>1</number>
+             <number>0</number>
             </property>
             <property name="maximum">
              <number>14</number>

--- a/mscore/editstafftype.ui
+++ b/mscore/editstafftype.ui
@@ -118,7 +118,7 @@
           </sizepolicy>
          </property>
          <property name="minimum">
-          <number>1</number>
+          <number>0</number>
          </property>
          <property name="maximum">
           <number>14</number>

--- a/mscore/inspector/inspector_stafftypechange.ui
+++ b/mscore/inspector/inspector_stafftypechange.ui
@@ -259,7 +259,7 @@
          <string>Lines</string>
         </property>
         <property name="minimum">
-         <number>1</number>
+         <number>0</number>
         </property>
         <property name="maximum">
          <number>14</number>


### PR DESCRIPTION
Resolves: *https://musescore.org/en/node/295722#comment-1016563*

## Allows zero-line staves

This fix reduces the minimum staff lines from 1 to 0 in Staff properties and Staff Type Changes.
It is a quick solution to manually change staves to non-visible mid-score.

![image](https://user-images.githubusercontent.com/2843953/89595775-ccd62100-d82b-11ea-9179-3a0827677b83.png)

Also double checked for all places in the code when a 0-staff line should also behave as a 1-staff line.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
