### PR TITLE
fix #308469: changing portaudio preferences does not work (4.x)

### DIFF
--- a/mscore/preferenceslistwidget.cpp
+++ b/mscore/preferenceslistwidget.cpp
@@ -232,7 +232,6 @@ IntPreferenceItem::IntPreferenceItem(QString name, QSpinBox* editor, std::functi
 IntPreferenceItem::IntPreferenceItem(QString name, QComboBox* editor, std::function<void()> applyFunc,
                                      std::function<void()> updateFunc)
     : PreferenceItem(name),
-    _initialValue(preferences.getInt(name)),
     _editorComboBox(editor)
 {
     int index = _editorComboBox->findData(preferences.getInt(name));
@@ -256,7 +255,6 @@ void IntPreferenceItem::apply()
             PreferenceItem::apply(newValue);
         } else if (_editorComboBox) {
             int newValue = _editorComboBox->currentData().toInt();
-            _initialValue = newValue;
             PreferenceItem::apply(newValue);
             _initialEditorIndex = _editorComboBox->currentIndex();
         }
@@ -373,7 +371,6 @@ DoublePreferenceItem::DoublePreferenceItem(QString name, QDoubleSpinBox* editor,
 DoublePreferenceItem::DoublePreferenceItem(QString name, QComboBox* editor,
                                            std::function<void()> applyFunc, std::function<void()> updateFunc)
     : PreferenceItem(name),
-    _initialValue(preferences.getDouble(name)),
     _editorComboBox(editor)
 {
     int index = _editorComboBox->findData(preferences.getDouble(name));
@@ -412,13 +409,12 @@ void DoublePreferenceItem::apply()
             PreferenceItem::apply(newValue);
         } else if (_editorComboBox) {
             double newValue = _editorComboBox->currentData().toDouble();
-            _initialValue = newValue;
+            _initialEditorIndex = _editorComboBox->currentIndex();
             PreferenceItem::apply(newValue);
         } else if (_editorSpinBox) {
             double newValue = _editorSpinBox->value();
             _initialValue = newValue;
             PreferenceItem::apply(newValue);
-            _initialEditorIndex = _editorComboBox->currentIndex();
         }
     }
 }
@@ -697,7 +693,6 @@ StringPreferenceItem::StringPreferenceItem(QString name, QFontComboBox* editor,
 StringPreferenceItem::StringPreferenceItem(QString name, QComboBox* editor,
                                            std::function<void()> applyFunc, std::function<void()> updateFunc)
     : PreferenceItem(name),
-    _initialValue(preferences.getString(name)),
     _editorComboBox(editor)
 {
     int index = _editorComboBox->findData(preferences.getString(name));
@@ -739,7 +734,6 @@ void StringPreferenceItem::apply()
             PreferenceItem::apply(newValue);
         } else if (_editorComboBox) {
             QString newValue = _editorComboBox->currentText();
-            _initialValue = newValue;
             PreferenceItem::apply(newValue);
             _initialEditorIndex = _editorComboBox->currentIndex();
         } else if (_editorRadioButton) {

--- a/mscore/preferenceslistwidget.h
+++ b/mscore/preferenceslistwidget.h
@@ -62,7 +62,7 @@ signals:
 class BoolPreferenceItem : public PreferenceItem
 {
 private:
-    bool _initialValue;
+    bool _initialValue                        { false };
     QCheckBox* _editorCheckBox                { nullptr };
     QGroupBox* _editorGroupBox                { nullptr };
     QRadioButton* _editorRadioButton          { nullptr };
@@ -92,7 +92,7 @@ public:
 
 class IntPreferenceItem : public PreferenceItem
 {
-    int _initialValue;
+    int _initialValue                         { 0 };
     int _initialEditorIndex                   { -1 };
     QSpinBox* _editorSpinBox                  { nullptr };
     QComboBox* _editorComboBox                { nullptr };

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -322,11 +322,6 @@ void PreferenceDialog::start()
             },                                                                                                                          // apply function
                                  [this]() { scale->setValue(preferences.getDouble(PREF_SCORE_MAGNIFICATION) * 100.0); }                 // update function
                                  ),
-            #ifdef USE_PORTMIDI
-        new StringPreferenceItem(PREF_IO_PORTMIDI_INPUTDEVICE, portMidiInput),
-        new StringPreferenceItem(PREF_IO_PORTMIDI_OUTPUTDEVICE, portMidiOutput),
-        new IntPreferenceItem(PREF_IO_PORTMIDI_OUTPUTLATENCYMILLISECONDS, portMidiOutputLatencyMilliseconds),
-            #endif
         new IntPreferenceItem(PREF_EXPORT_AUDIO_SAMPLERATE, exportAudioSampleRate),
         new IntPreferenceItem(PREF_EXPORT_MP3_BITRATE, exportMp3BitRate),
         new StringPreferenceItem(PREF_SCORE_STYLE_DEFAULTSTYLEFILE, defaultStyle,
@@ -526,6 +521,13 @@ void PreferenceDialog::start()
         new IntPreferenceItem(PREF_IO_ALSA_SAMPLERATE, alsaSampleRate, doNothing),
         new IntPreferenceItem(PREF_IO_ALSA_PERIODSIZE, alsaPeriodSize, doNothing),
         new IntPreferenceItem(PREF_IO_ALSA_FRAGMENTS, alsaFragments, doNothing),
+        new IntPreferenceItem(PREF_IO_PORTAUDIO_DEVICE, portaudioApi, doNothing, doNothing),
+        new IntPreferenceItem(PREF_IO_PORTAUDIO_DEVICE, portaudioDevice, doNothing, doNothing),
+#ifdef USE_PORTMIDI
+        new StringPreferenceItem(PREF_IO_PORTMIDI_INPUTDEVICE, portMidiInput, doNothing, doNothing),
+        new StringPreferenceItem(PREF_IO_PORTMIDI_OUTPUTDEVICE, portMidiOutput, doNothing, doNothing),
+        new IntPreferenceItem(PREF_IO_PORTMIDI_OUTPUTLATENCYMILLISECONDS, portMidiOutputLatencyMilliseconds),
+#endif
     };
 
     // These connections are used to enable the Apply button and to save only the changed preferences.
@@ -727,9 +729,6 @@ void PreferenceDialog::updateValues(bool useDefaultValues, bool setup)
                     }
                 }
                 portMidiOutput->setCurrentIndex(curMidiOutIdx);
-
-                portMidiOutputLatencyMilliseconds->setValue(preferences.getInt(
-                                                                PREF_IO_PORTMIDI_OUTPUTLATENCYMILLISECONDS));
             }
 #endif
         }
@@ -1425,31 +1424,31 @@ void PreferenceDialog::apply()
 
             restartAudioEngine();
         }
-    }
 
-#ifdef USE_PORTAUDIO
-    if (portAudioIsUsed && !noSeq) {
-        Portaudio* audio = static_cast<Portaudio*>(seq->driver());
-        preferences.setPreference(PREF_IO_PORTAUDIO_DEVICE,
-                                  audio->deviceIndex(portaudioApi->currentIndex(), portaudioDevice->currentIndex()));
-    }
-#endif
+    #ifdef USE_PORTAUDIO
+        if (portAudioIsUsed && !noSeq) {
+            Portaudio* audio = static_cast<Portaudio*>(seq->driver());
+            preferences.setPreference(PREF_IO_PORTAUDIO_DEVICE,
+                                      audio->deviceIndex(portaudioApi->currentIndex(), portaudioDevice->currentIndex()));
+        }
+    #endif
 
-#ifdef USE_PORTMIDI
-    if (seq->driver()
-        && static_cast<PortMidiDriver*>(static_cast<Portaudio*>(seq->driver())->mididriver())->isSameCoreMidiIacBus(
-            preferences.getString(PREF_IO_PORTMIDI_INPUTDEVICE),
-            preferences.getString(PREF_IO_PORTMIDI_OUTPUTDEVICE))) {
+    #ifdef USE_PORTMIDI
         preferences.setPreference(PREF_IO_PORTMIDI_INPUTDEVICE, portMidiInput->currentText());
         preferences.setPreference(PREF_IO_PORTMIDI_OUTPUTDEVICE, portMidiOutput->currentText());
-        QMessageBox msgBox;
-        msgBox.setWindowTitle(tr("Possible MIDI Loopback"));
-        msgBox.setIcon(QMessageBox::Warning);
-        msgBox.setText(tr(
-                           "Warning: You used the same CoreMIDI IAC bus for input and output. This will cause problematic loopback, whereby MuseScore's output MIDI messages will be sent back to MuseScore as input, causing confusion. To avoid this problem, access Audio MIDI Setup via Spotlight to create a dedicated virtual port for MuseScore's MIDI output, restart MuseScore, return to Preferences, and select your new virtual port for MuseScore's MIDI output. Other programs may then use that dedicated virtual port to receive MuseScore's MIDI output."));
-        msgBox.exec();
+        if (seq->driver()
+            && static_cast<PortMidiDriver*>(static_cast<Portaudio*>(seq->driver())->mididriver())->isSameCoreMidiIacBus(
+                preferences.getString(PREF_IO_PORTMIDI_INPUTDEVICE),
+                preferences.getString(PREF_IO_PORTMIDI_OUTPUTDEVICE))) {
+            QMessageBox msgBox;
+            msgBox.setWindowTitle(tr("Possible MIDI Loopback"));
+            msgBox.setIcon(QMessageBox::Warning);
+            msgBox.setText(tr(
+                               "Warning: You used the same CoreMIDI IAC bus for input and output. This will cause problematic loopback, whereby MuseScore's output MIDI messages will be sent back to MuseScore as input, causing confusion. To avoid this problem, access Audio MIDI Setup via Spotlight to create a dedicated virtual port for MuseScore's MIDI output, restart MuseScore, return to Preferences, and select your new virtual port for MuseScore's MIDI output. Other programs may then use that dedicated virtual port to receive MuseScore's MIDI output."));
+            msgBox.exec();
+        }
+    #endif
     }
-#endif
 
     if (shortcutsChanged) {
         shortcutsChanged = false;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/308469

PortAudio does not work perfectly on my machine (options are missing), but I don't think that has to do with the preferences. The problem was that the preferences related to it were not added to the new system. I added them and fixed some bugs with combo boxes.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made
