### PR TITLE
fix #308698: repeats won't play after entering continuous view (4.x)

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -774,6 +774,7 @@ void MasterScore::setPlaylistDirty()
 {
     _playlistDirty = true;
     _repeatList->setScoreChanged();
+    _repeatList2->setScoreChanged();
 }
 
 //---------------------------------------------------------
@@ -1867,6 +1868,7 @@ void MasterScore::setExpandRepeats(bool expand)
 void MasterScore::updateRepeatListTempo()
 {
     _repeatList->updateTempo();
+    _repeatList2->updateTempo();
 }
 
 //---------------------------------------------------------
@@ -1877,6 +1879,16 @@ const RepeatList& MasterScore::repeatList() const
 {
     _repeatList->update(_expandRepeats);
     return *_repeatList;
+}
+
+//---------------------------------------------------------
+//   repeatList2
+//---------------------------------------------------------
+
+const RepeatList& MasterScore::repeatList2() const
+{
+    _repeatList2->update(false);
+    return *_repeatList2;
 }
 
 //---------------------------------------------------------
@@ -4330,8 +4342,7 @@ int Score::duration()
 
 int Score::durationWithoutRepeats()
 {
-    masterScore()->setExpandRepeats(false);
-    const RepeatList& rl = repeatList();
+    const RepeatList& rl = repeatList2();
     if (rl.empty()) {
         return 0;
     }
@@ -4696,6 +4707,7 @@ MasterScore::MasterScore()
     _tempomap    = new TempoMap;
     _sigmap      = new TimeSigMap();
     _repeatList  = new RepeatList(this);
+    _repeatList2 = new RepeatList(this);
     _revisions   = new Revisions;
     setMasterScore(this);
 
@@ -4738,6 +4750,7 @@ MasterScore::~MasterScore()
 {
     delete _revisions;
     delete _repeatList;
+    delete _repeatList2;
     delete _sigmap;
     delete _tempomap;
     qDeleteAll(_excerpts);

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -1035,6 +1035,7 @@ public:
     Measure* searchLabel(const QString& s, Measure* startMeasure = nullptr, Measure* endMeasure = nullptr);
     Measure* searchLabelWithinSectionFirst(const QString& s, Measure* sectionStartMeasure, Measure* sectionEndMeasure);
     virtual inline const RepeatList& repeatList() const;
+    virtual inline const RepeatList& repeatList2() const;
     qreal utick2utime(int tick) const;
     int utime2utick(qreal utime) const;
 
@@ -1310,6 +1311,7 @@ class MasterScore : public Score
     TimeSigMap * _sigmap;
     TempoMap* _tempomap;
     RepeatList* _repeatList;
+    RepeatList* _repeatList2;
     bool _expandRepeats     { MScore::playRepeats };
     bool _playlistDirty     { true };
     QList<Excerpt*> _excerpts;
@@ -1373,6 +1375,7 @@ public:
     void setExpandRepeats(bool expandRepeats);
     void updateRepeatListTempo();
     virtual const RepeatList& repeatList() const override;
+    virtual const RepeatList& repeatList2() const override;
 
     virtual QList<Excerpt*>& excerpts() override { return _excerpts; }
     virtual const QList<Excerpt*>& excerpts() const override { return _excerpts; }
@@ -1494,6 +1497,7 @@ public:
 
 inline UndoStack* Score::undoStack() const { return _masterScore->undoStack(); }
 inline const RepeatList& Score::repeatList()  const { return _masterScore->repeatList(); }
+inline const RepeatList& Score::repeatList2()  const { return _masterScore->repeatList2(); }
 inline TempoMap* Score::tempomap() const { return _masterScore->tempomap(); }
 inline TimeSigMap* Score::sigmap() const { return _masterScore->sigmap(); }
 inline QList<Excerpt*>& Score::excerpts() { return _masterScore->excerpts(); }

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5126,6 +5126,18 @@ void MuseScore::play(Element* e, int pitch) const
 }
 
 //---------------------------------------------------------
+//   moveControlCursor
+//---------------------------------------------------------
+
+void MuseScore::moveControlCursor()
+{
+    if (!cv) {
+        return;
+    }
+    cv->moveControlCursorNearCursor();
+}
+
+//---------------------------------------------------------
 //   reportBug
 //---------------------------------------------------------
 

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -600,6 +600,7 @@ public:
     void writeSettings();
     void play(Element* e) const;
     void play(Element* e, int pitch) const;
+    void moveControlCursor();
     bool loadPlugin(const QString& filename);
     QString createDefaultName() const;
     void startAutoSave();

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -68,6 +68,8 @@ enum class MagIdx : char;
 struct SmoothPanSettings {
     // these are all actually loaded from the loadFromPreferences method so don't change these initializations to change the default values,
     // change the corresponding default preference value
+    bool enabled                        { false };
+
     double controlModifierBase          { 1 };      // initial speed modifier
     double controlModifierSteps         { 0.01 };   // modification steps for the modifier
     double minContinuousModifier        { 0.2 };    // minimum speed, 0.2 was chosen instead of 0 to remove stuttering
@@ -363,6 +365,7 @@ public:
     void moveCursor(const Fraction& tick);
     void moveControlCursor(const Fraction& tick);
     bool isCursorDistanceReasonable();
+    void moveControlCursorNearCursor();
     Fraction cursorTick() const;
     void setCursorOn(bool);
     void setBackground(QPixmap*);

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -348,6 +348,8 @@ void Seq::start()
         return;
     }
 
+    mscore->moveControlCursor();
+
     allowBackgroundRendering = true;
     collectEvents(getPlayStartUtick());
     if (cs->playMode() == PlayMode::AUDIO) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/308698

`Score::scoreDurationWithouRepeats` changed the state of `MasterScore::_expandRepeats`. At the same time `ScoreView::moveControlCursor` was called even when smooth playback was not enabled.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made
