### PR TITLE
[MU4] Interactive crash fix

### DIFF
--- a/mu4/appshell/qml/Window.qml
+++ b/mu4/appshell/qml/Window.qml
@@ -16,7 +16,9 @@ DockWindow {
 
     color: ui.theme.backgroundColor
 
-    currentPageUri: "musescore://home"
+    Component.onCompleted: {
+        api.launcher.open("musescore://home")
+    }
 
     property var provider: InteractiveProvider {
         topParent: dockWindow


### PR DESCRIPTION
The home page(default page) just showed up, didn't open through the launcher, so it didn't register with the launcher stack. After opening and closing the dialog, the stack was empty and the application crashed.

Register first primary page in launcher stack