### PR TITLE
Set app category on Mac to "Music"

### DIFF
--- a/build/MacOSXBundleInfo.plist.in
+++ b/build/MacOSXBundleInfo.plist.in
@@ -362,6 +362,8 @@
 	<string>10.7.0</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.music</string>
 	<key>ATSApplicationFontsPath</key>
 	<string>fonts/</string>
 	<key>SUFeedURL</key>


### PR DESCRIPTION
In the Applications folder on Mac, you can group your apps by category. Previously, MuseScore appears in the "Other" category. Now, it will appear in the Music category. It's something really small, but I think a professional application should have this. 