### PR TITLE
Fix #308912: Add a simple preview icon to Staff Type Change (suggestion)

### DIFF
--- a/libmscore/stafftypechange.cpp
+++ b/libmscore/stafftypechange.cpp
@@ -104,13 +104,31 @@ void StaffTypeChange::draw(QPainter* painter) const
       qreal _spatium = score()->spatium();
       qreal h  = _spatium * 2.5;
       qreal w  = _spatium * 2.5;
+      qreal lineDist = 0.35;         // line distance for the icon 'staff lines'
+      // draw icon rectangle
       painter->setPen(QPen(selected() ? MScore::selectColor[0] : MScore::layoutBreakColor,
          lw, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin));
       painter->setBrush(Qt::NoBrush);
       painter->drawRect(0, 0, w, h);
-      QFont f("FreeSans", 12.0 * _spatium * MScore::pixelRatio / SPATIUM20);
-      painter->setFont(f);
-      painter->drawText(QRectF(0.0, 0.0, w, h), Qt::AlignCenter, QString("S"));
+
+      // draw icon contents
+      int lines = 5;
+      if (staffType()) {
+            if (staffType()->stemless())     // a single notehead represents a stemless staff
+                  drawSymbol(SymId::noteheadBlack, painter, QPoint(w * 0.5 - 0.33 * _spatium, h * 0.5), 0.5);
+            if (staffType()->invisible())    // no lines needed. It's done.
+                  return;
+            // show up to 6 lines
+            lines = qMin(staffType()->lines(),6);
+            }
+      // calculate starting point Y for the lines from half the icon height (2.5) so staff lines appear vertically centered
+      qreal startY = 1.25 - (lines - 1) * lineDist * 0.5;
+      painter->setPen(QPen(selected() ? MScore::selectColor[0] : MScore::layoutBreakColor,
+         2.5, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin));
+      for (int i=0; i < lines; i++) {
+            int y = (startY + i * lineDist) * _spatium;
+            painter->drawLine(0, y, w, y);
+            }
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: *https://musescore.org/en/node/308912*

Adds a simple preview icon to the Staff Type Change (in the text palette) instead of the simple 'S' on a square.
Draws a square with up to 6 staff lines, or empty if the staff is set to invisible. Adds a single notehead to represent a stemless staff.

The purpose of this is to allow the user to drag these icons to her/his palette and keep a collection of "presets" that give a visual hint that allows to tell them apart. This, combined with the already implemented labels (tooltips) make the custom "tools" more efficient.

![image](https://user-images.githubusercontent.com/2843953/100039789-b9ec5a00-2de4-11eb-869e-11bfa2529daf.png)



<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
