### PR TITLE
fix #308951: Crash on playback of score with MM rest at the end

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3808,7 +3808,10 @@ void MasterScore::setPos(POS pos, Fraction tick)
       {
       if (tick < Fraction(0,1))
             tick = Fraction(0,1);
-      Q_ASSERT(tick <= lastMeasure()->endTick());
+      if (tick > lastMeasure()->endTick()) {
+            // End Reverb may last longer than written notation, but cursor position should not
+            tick = lastMeasure()->endTick();
+            }
 
       _pos[int(pos)] = tick;
       // even though tick position might not have changed, layout might have


### PR DESCRIPTION
resolves https://musescore.org/en/node/308951

Code shamlelessly stolen from #6248's commit a537674

This PR here is not needed if #6248 gets merged first, shouldn't harm otherwise