### PR TITLE
fix #98816 - wrong tie direction in tabs

### DIFF
--- a/libmscore/tie.cpp
+++ b/libmscore/tie.cpp
@@ -541,6 +541,17 @@ void Tie::write(XmlWriter& xml) const
 //   calculateDirection
 //---------------------------------------------------------
 
+static int compareNotesPos(const Note* n1, const Note* n2)
+{
+    if (n1->line() != n2->line()) {
+        return n2->line() - n1->line();
+    } else if (n1->string() != n2->string()) {
+        return n2->string() - n1->string();
+    } else {
+        return n1->pitch() - n2->pitch();
+    }
+}
+
 void Tie::calculateDirection()
 {
     Chord* c1   = startNote()->chord();
@@ -569,31 +580,47 @@ void Tie::calculateDirection()
             //
             // chords
             //
-            QList<int> ties;
-            int idx = 0;
-            int noteIdx = -1;
+            int tiesCount = 0;
+            Note* tieNote = startNote();
+            Note* tieAbove = nullptr;
+            Note* tieBelow = nullptr;
+
             for (size_t i = 0; i < n; ++i) {
                 if (notes[i]->tieFor()) {
-                    ties.append(notes[i]->line());
-                    if (notes[i] == startNote()) {
-                        idx = ties.size() - 1;
-                        noteIdx = int(i);
+                    tiesCount++;
+                    int noteDiff = compareNotesPos(notes[i], tieNote);
+
+                    if (noteDiff > 0) {
+                        if (!tieAbove) {
+                            tieAbove = notes[i];
+                        } else if (compareNotesPos(notes[i], tieAbove) < 0) {
+                            tieAbove = notes[i];
+                        }
+                    } else if (noteDiff < 0) {
+                        if (!tieBelow) {
+                            tieBelow = notes[i];
+                        } else if (compareNotesPos(notes[i], tieBelow) > 0) {
+                            tieBelow = notes[i];
+                        }
                     }
                 }
             }
-            if (idx == 0) {
-                if (ties.size() == 1) {               // if just one tie
-                    _up = noteIdx != 0;               // it is up if not the bottom note of the chord
-                } else {                              // if several ties and this is the bottom one (idx == 0)
-                    _up = false;                      // it is down
-                }
-            } else if (idx == ties.size() - 1) {
+            if (!tieBelow) {
+                // bottom tie is up if it is the only tie and not the bottom note of the chord
+                _up = tiesCount == 1 && tieNote != c1->downNote();
+            } else if (!tieAbove) {
+                // top tie always up
                 _up = true;
             } else {
-                if (ties[idx] <= 4) {
-                    _up = ((ties[idx - 1] - ties[idx]) <= 1) || ((ties[idx] - ties[idx + 1]) > 1);
+                bool tabStaff = onTabStaff();
+                int tieLine = tabStaff ? tieNote->string() : tieNote->line();
+                int belowLine = tabStaff ? tieBelow->string() : tieBelow->line();
+                int aboveLine = tabStaff ? tieAbove->string() : tieAbove->line();
+
+                if (tieLine <= (tabStaff ? 2 : 4)) {
+                    _up = ((belowLine - tieLine) <= 1) || ((tieLine - aboveLine) > 1);
                 } else {
-                    _up = ((ties[idx - 1] - ties[idx]) <= 1) && ((ties[idx] - ties[idx + 1]) > 1);
+                    _up = ((belowLine - tieLine) <= 1) && ((tieLine - aboveLine) > 1);
                 }
             }
         }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/98816
also related to: https://musescore.org/en/node/117351

the issues were caused by two problems:
1. the order of `ties` was based on the order of `notes` in the chord, which are ordered by `pitch` first and not `line`.
2. note in tabs need to be compared by `string` and not `line` (the value of which is `INVALID_LINE`).

the logic of deciding the tie direction stayed the same, but the variables changed like so:
* `tieNote` - the start note of the current tie
* `tieAbove` - the tie above the current tie (if null - the current tie is the top one)
* `tieBelow` - the tie below the current tie (if null - the current tie is the bottom one)

the procedure `compareNotesPos` (maybe needs to be renamed) decides the order of the notes,
such that `line` and `string` take priority over `pitch`, solving the case of ukulele in #98816.

before (ukulele tabs):

![before-uke](https://user-images.githubusercontent.com/22118580/90011036-92480a80-dca9-11ea-8817-2911619bf229.png)

the problem in the first bar was caused by the ukulele tuning as explained in #98816,
and the problem in the second bar was caused by note input as explained in the first comment of #117351.

after (ukulele tabs):

![after-uke](https://user-images.githubusercontent.com/22118580/90011048-97a55500-dca9-11ea-9ccc-5685301e9382.png)

I used the score in https://musescore.org/en/node/22459 to confirm that the normal cases of tie direction were
not affected by this change. result after the change:

![after-tie-direction](https://user-images.githubusercontent.com/22118580/90011590-890b6d80-dcaa-11ea-9c40-d3bad1947c7a.png)

for the CLA, my username in musescore.org is liorkl

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
