### PR TITLE
fix #309032: allow "add clef" shortcuts to also work in normal mode

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2687,8 +2687,6 @@ void Score::cmdMoveLyrics(Lyrics* lyrics, Direction dir)
 
 void Score::cmdInsertClef(ClefType type)
       {
-      if (!noteEntryMode())
-            return;
       undoChangeClef(staff(inputTrack()/VOICES), inputState().cr(), type);
       }
 


### PR DESCRIPTION
resolves https://musescore.org/en/node/309032

As per https://github.com/musescore/MuseScore/blob/bd675e7ce8a2385407ec5997ab0938a2bcdcb839/mscore/shortcut.cpp#L2377-L2396 this shortcut is supposed to work in `STATE_NORMAL`and  `STATE_NOTE_ENTRY`, but https://github.com/musescore/MuseScore/blob/bd675e7ce8a2385407ec5997ab0938a2bcdcb839/libmscore/cmd.cpp#L2690-L2691 prevents this from working in normal mode. Removing those 2 lines does seem to make it work, so far I can't find any negative impact of that change