### PR TITLE
fix #309066 + fix #283996: the same headers/footers are used for the score and all its parts (4.x)

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -281,7 +281,7 @@ void MeasureBaseList::fixupSystems()
 //---------------------------------------------------------
 
 Score::Score()
-    : ScoreElement(this), _selection(this), _selectionFilter(this)
+    : ScoreElement(this), _headersText(MAX_HEADERS, nullptr), _footersText(MAX_FOOTERS, nullptr), _selection(this), _selectionFilter(this)
 {
     Score::validScores.insert(this);
     _masterScore = 0;
@@ -5173,7 +5173,7 @@ bool Score::isTopScore() const
 //---------------------------------------------------------
 
 Movements::Movements()
-    : std::vector<MasterScore*>(), _headersText(MAX_HEADERS, nullptr), _footersText(MAX_FOOTERS, nullptr)
+    : std::vector<MasterScore*>()
 {
     _undo = new UndoStack();
 }

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -371,8 +371,6 @@ class Movements : public std::vector<MasterScore*>
     UndoStack* _undo;
     QList<Page*> _pages;            // pages are build from systems
     MStyle _style;
-    std::vector<Text*> _headersText;
-    std::vector<Text*> _footersText;
 
 public:
     Movements();
@@ -384,10 +382,6 @@ public:
     UndoStack* undo() const { return _undo; }
     MStyle& style() { return _style; }
     const MStyle& style() const { return _style; }
-    std::vector<Text*> headersText() const { return _headersText; }
-    std::vector<Text*> footersText() const { return _footersText; }
-    void setHeaderText(Text* t, int index) { _headersText[index] = t; }
-    void setFooterText(Text* t, int index) { _footersText[index] = t; }
 };
 
 //---------------------------------------------------------------------------------------
@@ -444,6 +438,9 @@ private:
     MasterScore* _masterScore { 0 };
     QList<MuseScoreView*> viewer;
     Excerpt* _excerpt  { 0 };
+
+    std::vector<Text*> _headersText;
+    std::vector<Text*> _footersText;
 
     QString _mscoreVersion;
     int _mscoreRevision;
@@ -1277,10 +1274,10 @@ public:
 
     bool isTopScore() const;
 
-    Text* headerText(int index) const { return movements()->headersText()[index]; }
-    Text* footerText(int index) const { return movements()->footersText()[index]; }
-    void setHeaderText(Text* t, int index) { movements()->setHeaderText(t, index); }
-    void setFooterText(Text* t, int index) { movements()->setFooterText(t, index); }
+    Text* headerText(int index) const { return _headersText[index]; }
+    Text* footerText(int index) const { return _footersText[index]; }
+    void setHeaderText(Text* t, int index) { _headersText.at(index) = t; }
+    void setFooterText(Text* t, int index) { _footersText.at(index) = t; }
 
     void cmdAddPitch(int note, bool addFlag, bool insert);
     void forAllLyrics(std::function<void(Lyrics*)> f);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/309066, https://musescore.org/en/node/283996

Moved headers/footers from the `Movements` class to `Score`.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made
