### PR TITLE
Several fixes with tremolos

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1463,11 +1463,13 @@ qreal Chord::minAbsStemLength() const
                   height = _tremolo->pos().y() + _tremolo->minHeight() * spatium() - (beam() ? downPos() : upPos());
             const bool hasHook = beamLvl && !beam();
             if (hasHook)
-                  beamLvl += (up() ? 4 : 2); // reserve more space for stem with both hook and tremolo
-           
-            const qreal additionalHeight = beamLvl ? 0 : sw * spatium();
+                  beamLvl += (up() ? 3 : 2); // reserve more space for stem with both hook and tremolo
+            
+            const qreal addHeight1 = beamLvl ? 0 : sw * spatium();
+            // buzz roll needs to have additional space so as not to collide with the beam/hook
+            const qreal addHeight2 = (_tremolo->isBuzzRoll() && beamLvl) ? sw * spatium() : 0;
 
-            return height + beamLvl * beamDist + additionalHeight;
+            return height + beamLvl * beamDist + addHeight1 + addHeight2;
             }
 
       // two-note tremolo

--- a/libmscore/tremolo.cpp
+++ b/libmscore/tremolo.cpp
@@ -90,7 +90,7 @@ qreal Tremolo::minHeight() const
 
 void Tremolo::draw(QPainter* painter) const
       {
-      if (tremoloType() == TremoloType::BUZZ_ROLL) {
+      if (isBuzzRoll()) {
             painter->setPen(curColor());
             drawSymbol(SymId::buzzRoll, painter);
             }
@@ -105,7 +105,7 @@ void Tremolo::draw(QPainter* painter) const
             QPen pen(curColor(), point(score()->styleS(Sid::stemWidth)));
             painter->setPen(pen);
             const qreal sp = spatium();
-            if (_tremoloType == TremoloType::BUZZ_ROLL)
+            if (isBuzzRoll())
                   painter->drawLine(QLineF(x, -sp, x, bbox().bottom() + sp));
             else
                   painter->drawLine(QLineF(x, -sp * .5, x, path.boundingRect().height() + sp));
@@ -188,7 +188,7 @@ void Tremolo::styleChanged()
 
 QPainterPath Tremolo::basePath() const
       {
-      if (_tremoloType == TremoloType::BUZZ_ROLL)
+      if (isBuzzRoll())
             return QPainterPath();
 
       const qreal sp = spatium() * mag();
@@ -229,7 +229,7 @@ void Tremolo::computeShape()
       if (parent() && twoNotes())
             return; // cannot compute shape here, should be done at layout stage
 
-      if (_tremoloType == TremoloType::BUZZ_ROLL)
+      if (isBuzzRoll())
             setbbox(symBbox(SymId::buzzRoll));
       else {
             path = basePath();
@@ -269,11 +269,14 @@ void Tremolo::layoutOneNoteTremolo(qreal x, qreal y, qreal spatium)
 
             qreal yLine = line + t;
             // prevent stroke from going out of staff at the top while stem direction is down
-            if (!chord()->up())
+            if (!chord()->up()) {
                   yLine = qMax(yLine, 0.0);
+                  }
             // prevent stroke from going out of staff at the bottom while stem direction is up
-            else
-                  yLine = qMin(yLine, (staff()->lines(tick()) - 1) * 2 - 2.0 * minHeight());
+            else {
+                  qreal height = isBuzzRoll() ? 0 : minHeight();
+                  yLine = qMin(yLine, (staff()->lines(tick()) - 1) * 2 - 2.0 * height);
+                  }
 
             y = yLine * .5 * spatium;
             }
@@ -493,7 +496,7 @@ void Tremolo::layout()
       _chord1 = toChord(parent());
       if (!_chord1) {
             // palette
-            if (_tremoloType != TremoloType::BUZZ_ROLL) {
+            if (!isBuzzRoll()) {
                   const QRectF box = path.boundingRect();
                   addbbox(QRectF(box.x(), box.bottom(), box.width(), spatium()));
                   }

--- a/libmscore/tremolo.cpp
+++ b/libmscore/tremolo.cpp
@@ -336,8 +336,7 @@ void Tremolo::layoutTwoNotesTremolo(qreal x, qreal y, qreal h, qreal spatium)
       bool defaultStyle = (strokeStyle() == TremoloStrokeStyle::DEFAULT);
 
       // non-default beam styles are only appliable to minim two-note tremolo in non-TAB staves
-      if (durationType().type() != TDuration::DurationType::V_HALF
-         || staff()->staffType(tick())->group() == StaffGroup::TAB)
+      if (!customStrokeStyleApplicable())
             defaultStyle = true;
 
       y += (h - bbox().height()) * .5;
@@ -679,6 +678,17 @@ QString Tremolo::accessibleInfo() const
       }
 
 //---------------------------------------------------------
+//   customStrokeStyleApplicable
+//---------------------------------------------------------
+
+bool Tremolo::customStrokeStyleApplicable() const
+      {
+      return twoNotes()
+         && (durationType().type() == TDuration::DurationType::V_HALF)
+         && (staffType()->group() != StaffGroup::TAB);
+      }
+
+//---------------------------------------------------------
 //   getProperty
 //---------------------------------------------------------
 
@@ -711,7 +721,8 @@ bool Tremolo::setProperty(Pid propertyId, const QVariant& val)
                   setTremoloPlacement(TremoloPlacement(val.toInt()));
                   break;
             case Pid::TREMOLO_STROKE_STYLE:
-                  setStrokeStyle(TremoloStrokeStyle(val.toInt()));
+                  if (customStrokeStyleApplicable())
+                        setStrokeStyle(TremoloStrokeStyle(val.toInt()));
                   break;
             default:
                   return Element::setProperty(propertyId, val);

--- a/libmscore/tremolo.cpp
+++ b/libmscore/tremolo.cpp
@@ -252,19 +252,19 @@ void Tremolo::layoutOneNoteTremolo(qreal x, qreal y, qreal spatium)
             qreal t = 0.0;
             // nearest distance between note and tremolo stroke should be no less than 3.0
             if (chord()->hook() || chord()->beam()) {
-                  t = up ? -3.0 - 2.0 * minHeight() : 3.0;
+                  t = up ? -3.0 * mag() - 2.0 * minHeight() : 3.0 * mag();
                   }
             else {
                   const qreal offset = 2.0 * score()->styleS(Sid::tremoloStrokeWidth).val();
 
                   if      (!up && !(line & 1)) // stem is down; even line
-                        t = qMax(4.0 + offset - 2.0 * minHeight(), 3.0);
+                        t = qMax((4.0 + offset) * mag() - 2.0 * minHeight(), 3.0 * mag());
                   else if (!up &&  (line & 1)) // stem is down; odd line
-                        t = qMax(5.0          - 2.0 * minHeight(), 3.0);
+                        t = qMax( 5.0 * mag()           - 2.0 * minHeight(), 3.0 * mag());
                   else if ( up && !(line & 1)) // stem is up; even line
-                        t = qMin(-3.0         - 2.0 * minHeight(), -4.0 - offset);
+                        t = qMin(-3.0 * mag()           - 2.0 * minHeight(), (-4.0 - offset) * mag());
                   else /*if ( up &&  (line & 1))*/ // stem is up; odd line
-                        t = qMin(-3.0         - 2.0 * minHeight(), -5.0);
+                        t = qMin(-3.0 * mag()           - 2.0 * minHeight(), -5.0 * mag());
                   }
 
             qreal yLine = line + t;

--- a/libmscore/tremolo.h
+++ b/libmscore/tremolo.h
@@ -115,6 +115,8 @@ class Tremolo final : public Element {
       TremoloStrokeStyle strokeStyle() const    { return _strokeStyle; }
       void setStrokeStyle(TremoloStrokeStyle v) { _strokeStyle = v;    }
 
+      bool customStrokeStyleApplicable() const;
+
       QVariant getProperty(Pid propertyId) const override;
       bool setProperty(Pid propertyId, const QVariant&) override;
       QVariant propertyDefault(Pid propertyId) const override;

--- a/libmscore/tremolo.h
+++ b/libmscore/tremolo.h
@@ -95,7 +95,8 @@ class Tremolo final : public Element {
             _chord2 = c2;
             }
       Fraction tremoloLen() const;
-      bool twoNotes() const { return tremoloType() >= TremoloType::C8; } // is it a two note tremolo?
+      bool isBuzzRoll() const { return _tremoloType == TremoloType::BUZZ_ROLL; }
+      bool twoNotes() const { return _tremoloType >= TremoloType::C8; } // is it a two note tremolo?
       int lines() const { return _lines; }
 
       bool placeMidStem() const;

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -1064,20 +1064,15 @@ InspectorTremolo::InspectorTremolo(QWidget* parent)
 void InspectorTremolo::setElement()
       {
       InspectorElementBase::setElement();
-      bool hasNonMinimTwoNoteTremolo = false;
-      bool hasTabStaffTremolo = false;
+      bool hasCustomStrokeStyleNonApplicable = false;
       for (Element* ee : *(inspector->el())) {
-            if (toTremolo(ee)->durationType().type() != TDuration::DurationType::V_HALF) {
-                  hasNonMinimTwoNoteTremolo = true;
-                  break;
-                  }
-            if (toTremolo(ee)->staffType()->group() == StaffGroup::TAB) {
-                  hasTabStaffTremolo = true;
+            if (!(toTremolo(ee)->customStrokeStyleApplicable())) {
+                  hasCustomStrokeStyleNonApplicable = true;
                   break;
                   }
             }
       // beam style setting is only appliable to minim two-note tremolo in non-TAB staves
-      if (hasNonMinimTwoNoteTremolo || hasTabStaffTremolo) {
+      if (hasCustomStrokeStyleNonApplicable) {
             g.labelStrokeStyle->setVisible(false);
             g.strokeStyle->setVisible(false);
             g.resetStrokeStyle->setVisible(false);


### PR DESCRIPTION
**Commit #1:**
- Lengthen stems with buzz rolls and connected to beams/hooks a bit more than those with normal one-stroke tremolos.
- Lengthen stems with tremolos and hooks less than what we're doing now to avoid them being absurdly long

This winds up leaving the stems which have buzz rolls and connected to hooks having the same lengths then they do now. But in other cases mentioned, the situation is improved.

Before:
![image](https://user-images.githubusercontent.com/46259489/90231050-1edefe00-de4d-11ea-9cc4-4805a73b1e2c.png)
After:
![image](https://user-images.githubusercontent.com/46259489/90231071-26060c00-de4d-11ea-9a49-ea3dca9313be.png)

**Commit #2:**
- Alter the position of tremolos and stem lengths so that small chords with tremolos look just like a miniature version of normal chords with tremolos without unnaturally long stems.

Before: ![image](https://user-images.githubusercontent.com/46259489/90245088-8fdde000-de64-11ea-9c4f-99dcd342d574.png); After: ![image](https://user-images.githubusercontent.com/46259489/90245047-7f2d6a00-de64-11ea-8ed4-e04510b562c7.png)
