### PR TITLE
fix #308698: repeats won't play after entering continuous view (3.x)

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -739,6 +739,7 @@ void MasterScore::setPlaylistDirty()
       {
       _playlistDirty = true;
       _repeatList->setScoreChanged();
+      _repeatList2->setScoreChanged();
       }
 
 //---------------------------------------------------------
@@ -1771,6 +1772,7 @@ void MasterScore::setExpandRepeats(bool expand)
 void MasterScore::updateRepeatListTempo()
       {
       _repeatList->updateTempo();
+      _repeatList2->updateTempo();
       }
 
 //---------------------------------------------------------
@@ -1781,6 +1783,16 @@ const RepeatList& MasterScore::repeatList() const
       {
       _repeatList->update(_expandRepeats);
       return *_repeatList;
+      }
+
+//---------------------------------------------------------
+//   repeatList2
+//---------------------------------------------------------
+
+const RepeatList& MasterScore::repeatList2() const
+      {
+      _repeatList2->update(false);
+      return *_repeatList2;
       }
 
 //---------------------------------------------------------
@@ -4223,8 +4235,7 @@ int Score::duration()
 
 int Score::durationWithoutRepeats()
       {
-      masterScore()->setExpandRepeats(false);
-      const RepeatList& rl = repeatList();
+      const RepeatList& rl = repeatList2();
       if (rl.empty())
             return 0;
       const RepeatSegment* rs = rl.last();
@@ -4583,6 +4594,7 @@ MasterScore::MasterScore()
       _tempomap    = new TempoMap;
       _sigmap      = new TimeSigMap();
       _repeatList  = new RepeatList(this);
+      _repeatList2 = new RepeatList(this);
       _revisions   = new Revisions;
       setMasterScore(this);
 
@@ -4625,6 +4637,7 @@ MasterScore::~MasterScore()
       {
       delete _revisions;
       delete _repeatList;
+      delete _repeatList2;
       delete _sigmap;
       delete _tempomap;
       qDeleteAll(_excerpts);

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -984,6 +984,7 @@ class Score : public QObject, public ScoreElement {
       Measure* searchLabel(const QString& s, Measure* startMeasure = nullptr, Measure* endMeasure = nullptr);
       Measure* searchLabelWithinSectionFirst(const QString& s, Measure* sectionStartMeasure, Measure* sectionEndMeasure);
       virtual inline const RepeatList& repeatList() const;
+      virtual inline const RepeatList& repeatList2() const;
       qreal utick2utime(int tick) const;
       int utime2utick(qreal utime) const;
 
@@ -1257,6 +1258,7 @@ class MasterScore : public Score {
       TimeSigMap* _sigmap;
       TempoMap* _tempomap;
       RepeatList* _repeatList;
+      RepeatList* _repeatList2;
       bool _expandRepeats     { MScore::playRepeats };
       bool _playlistDirty     { true };
       QList<Excerpt*> _excerpts;
@@ -1320,6 +1322,7 @@ class MasterScore : public Score {
       void setExpandRepeats(bool expandRepeats);
       void updateRepeatListTempo();
       virtual const RepeatList& repeatList() const override;
+      virtual const RepeatList& repeatList2() const override;
 
       virtual QList<Excerpt*>& excerpts() override                    { return _excerpts;   }
       virtual const QList<Excerpt*>& excerpts() const override        { return _excerpts;   }
@@ -1440,6 +1443,7 @@ class ScoreLoad {
 
 inline UndoStack* Score::undoStack() const             { return _masterScore->undoStack();      }
 inline const RepeatList& Score::repeatList()  const    { return _masterScore->repeatList();     }
+inline const RepeatList& Score::repeatList2()  const   { return _masterScore->repeatList2();    }
 inline TempoMap* Score::tempomap() const               { return _masterScore->tempomap();       }
 inline TimeSigMap* Score::sigmap() const               { return _masterScore->sigmap();         }
 inline QList<Excerpt*>& Score::excerpts()              { return _masterScore->excerpts();       }

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -609,6 +609,17 @@ void MuseScore::onLongOperationFinished()
       }
 
 //---------------------------------------------------------
+//   moveControlCursor
+//---------------------------------------------------------
+
+void MuseScore::moveControlCursor()
+      {
+      if (!cv)
+            return;
+      cv->moveControlCursorNearCursor();
+      }
+
+//---------------------------------------------------------
 //   importExtension
 //---------------------------------------------------------
 

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -599,6 +599,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void writeSettings();
       void play(Element* e) const;
       void play(Element* e, int pitch) const;
+      void moveControlCursor();
       bool loadPlugin(const QString& filename);
       QString createDefaultName() const;
       void startAutoSave();

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -637,7 +637,7 @@ void ScoreView::moveCursor(const Fraction& tick)
       _cursor->setRect(QRectF(x, y, w, h));
       update(_matrix.mapRect(_cursor->rect()).toRect().adjusted(-1,-1,1,1));
 
-      if (_score->layoutMode() == LayoutMode::LINE)
+      if (_score->layoutMode() == LayoutMode::LINE && seq->isPlaying() && panSettings().enabled)
             moveControlCursor(tick);
 
       if (mscore->state() == ScoreState::STATE_PLAY && mscore->panDuringPlayback()) {
@@ -708,7 +708,7 @@ void ScoreView::moveControlCursor(const Fraction& tick)
                   }
             _timeElapsed += addition;
             }
-      else { // reposition the cursor when the score is not playing
+      else { // reposition the cursor when distance is too great
             double curOffset = _cursor->rect().x() - score()->firstMeasure()->pos().x();
             double length = score()->lastMeasure()->pos().x() - score()->firstMeasure()->pos().x();
             _timeElapsed = (curOffset / length) * score()->durationWithoutRepeats() * 1000;
@@ -762,6 +762,22 @@ bool ScoreView::isCursorDistanceReasonable()
             return cursorDistance < maxLeftDistance;
 
       return true;
+      }
+
+//---------------------------------------------------------
+//   moveControlCursorNearCursor
+///     used to position the control cursor correctly
+///     when starting playback
+//---------------------------------------------------------
+
+void ScoreView::moveControlCursorNearCursor()
+      {
+      double curOffset = _cursor->rect().x() - score()->firstMeasure()->pos().x();
+      double length = score()->lastMeasure()->pos().x() - score()->firstMeasure()->pos().x();
+      _timeElapsed = (curOffset / length) * score()->durationWithoutRepeats() * 1000;
+      qreal x = score()->firstMeasure()->pos().x() + (score()->lastMeasure()->pos().x() - score()->firstMeasure()->pos().x()) * (_timeElapsed / (score()->durationWithoutRepeats() * 1000));
+      x -= score()->spatium();
+      _controlCursor->setRect(QRectF(x, _cursor->rect().y(), _cursor->rect().width(), _cursor->rect().height()));
       }
 
 //---------------------------------------------------------
@@ -3561,7 +3577,7 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack, int staff
 
             qreal xo = 0.0;  // new x offset
             QRectF curPos = playBack ? _cursor->rect() : el->canvasBoundingRect();
-            if (_score->layoutMode() == LayoutMode::LINE && seq->isPlaying())
+            if (playBack && _cursor && seq->isPlaying() && panSettings().enabled)
                   curPos = _controlCursor->rect();
             // keep current note in view as well if applicable (note input mode)
             Element* current = nullptr;
@@ -5468,6 +5484,7 @@ void ScoreView::moveViewportToLastEdit()
 
 void SmoothPanSettings::loadFromPreferences()
       {
+      enabled = preferences.getBool(PREF_PAN_SMOOTHLY_ENABLED);
       controlModifierBase = preferences.getDouble(PREF_PAN_MODIFIER_BASE);
       if(mscore->currentScoreView() != nullptr)
             mscore->currentScoreView()->_controlModifier = controlModifierBase;

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -70,6 +70,8 @@ enum class ZoomIndex : char;
 struct SmoothPanSettings {
       // these are all actually loaded from the loadFromPreferences fuction so don't change these to change the default values,
       // change the corresponding preferences
+      bool enabled                        { false };
+
       double controlModifierBase          { 1 };      // initial speed modifier
       double controlModifierSteps         { 0.01 };   // modification steps for the modifier
       double minContinuousModifier        { 0.2 };    // minimum speed, 0.2 was chosen instead of 0 to remove stuttering
@@ -365,6 +367,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void moveCursor(const Fraction& tick);
       void moveControlCursor(const Fraction& tick);
       bool isCursorDistanceReasonable();
+      void moveControlCursorNearCursor();
       Fraction cursorTick() const;
       void setCursorOn(bool);
       void setBackground(QPixmap*);

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -345,6 +345,8 @@ void Seq::start()
             return;
             }
 
+      mscore->moveControlCursor();
+
       allowBackgroundRendering = true;
       collectEvents(getPlayStartUtick());
       if (cs->playMode() == PlayMode::AUDIO) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/308698

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made
