### PR TITLE
fix #309108: add support for quality after extension

### DIFF
--- a/libmscore/chordlist.cpp
+++ b/libmscore/chordlist.cpp
@@ -862,6 +862,18 @@ bool ParsedChord::parse(const QString& s, const ChordList* cl, bool syntaxOnly, 
                         tok2L = "5";
                         }
                   }
+            else if (diminished.contains(tok1)) {
+                  _quality = "diminished";
+                  if (!syntaxOnly) {
+                        _xmlKind = "diminished";
+                        _xmlText = _extension + tok1;
+                        chord -= 4;
+                        chord += 3;
+                        chord -= 7;
+                        chord += 6;
+                        }
+                  tok1L = "";
+                  }
             else if ((lower.contains(tok1L) || raise.contains(tok1L)) && tok2L == "") {
                   // trailing alteration - treat as applying to extension (and convert to modifier)
                   // this handles C5b, C9#, etc
@@ -1071,6 +1083,9 @@ bool ParsedChord::parse(const QString& s, const ChordList* cl, bool syntaxOnly, 
                   else if (raise.contains(tok1L)) {
                         tok1L = "#";
                         alter = true;
+                        }
+                  else if (tok1L == "") {
+                        // token was already handled fully
                         }
                   else {
                         _understandable = false;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/309108

The chord symbol parser was implemented many years ago
and it supports msot common notations, but a few used in some regions
slipped through the track.  In particular, C7o and C7+.
These place the quality after the extension.
There was partial support for C7+, and it parsed OK,
but a bug never noticed until now is that it was also marked
as not "understandable", which now prevents playback.

This commit fixes the bug that prevented C7+ from fully working,
but adding a null handler for an empty token in the loop
during which the "+" is processed and replaced with an empty token.
It also adds the same processing for C7o.