### PR TITLE
Fix #281639: Better handling of Clefs, Barlines on ossias and cutaway

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -388,9 +388,13 @@ int nextVisibleSpannedStaff(const BarLine* bl)
       int nstaves = score->nstaves();
       int staffIdx = bl->staffIdx();
       Segment* segment = bl->segment();
-      for (int i = staffIdx + 1; i < nstaves; ++i)  {
+      Measure* nm = bl->measure()->nextMeasure();
+      for (int i = staffIdx + 1; i < nstaves; ++i) {
             Staff* s = score->staff(i);
-            if (s->part()->show() && bl->measure()->visible(i))
+            if (s->part()->show() && (bl->measure()->visible(i) ||        // span bar line if measure is visible
+                 (segment && segment->isEndBarLineType() &&               // or if this is a measure's End Bar Line and...
+                   ((nm ? nm->visible(i) : false) && (nm ? nm->system() == bl->measure()->system() : false)    // ...next measure is visible in system
+                   || bl->measure()->isCutawayClef(i)))))                                                     // ...or measure has Courtesy Clef
                   return i;
             BarLine* nbl = toBarLine(segment->element(i * VOICES));
             if (!nbl || !nbl->spanStaff())
@@ -1192,7 +1196,7 @@ void BarLine::endEditDrag(EditData& ed)
             newSpanTo   = 0;
             }
 
-      bool localDrag = ed.control() || segment()->isBarLine();
+      bool localDrag = ed.control() || segment()->isBarLineType();
       if (localDrag) {
             Segment* s = segment();
             for (int staffIdx = staffIdx1; staffIdx < staffIdx2; ++staffIdx) {

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -224,6 +224,7 @@ class Measure final : public MeasureBase {
       void checkMultiVoices(int staffIdx);
       bool hasVoice(int track) const;
       bool isEmpty(int staffIdx) const;
+      bool isCutawayClef(int staffIdx) const;
       bool isFullMeasureRest() const;
       bool isRepeatMeasure(const Staff* staff) const;
       bool visible(int staffIdx) const;

--- a/libmscore/stafflines.cpp
+++ b/libmscore/stafflines.cpp
@@ -128,6 +128,53 @@ void StaffLines::layoutForWidth(qreal w)
       }
 
 //---------------------------------------------------------
+//   layoutPartialWidth
+///   Layout staff lines for the specified width only, aligned
+///   to the left or right of the measure
+//---------------------------------------------------------
+
+void StaffLines::layoutPartialWidth(qreal w, qreal wPartial, bool alignRight)
+      {
+      const Staff* s = staff();
+      qreal _spatium = spatium();
+      wPartial *= spatium();
+      qreal dist     = _spatium;
+      setPos(QPointF(0.0, 0.0));
+      int _lines;
+      if (s) {
+            setMag(s->mag(measure()->tick()));
+            setColor(s->color(measure()->tick()));
+            const StaffType* st = s->staffType(measure()->tick());
+            dist         *= st->lineDistance().val();
+            _lines        = st->lines();
+            rypos()       = st->yoffset().val() * _spatium;
+            }
+      else {
+            _lines = 5;
+            setColor(MScore::defaultColor);
+            }
+      lw       = score()->styleS(Sid::staffLineWidth).val() * _spatium;
+      qreal x1 = pos().x();
+      qreal x2 = x1 + w;
+      qreal y  = pos().y();
+      bbox().setRect(x1, -lw * .5 + y, w, (_lines-1) * dist + lw);
+
+      if (_lines == 1) {
+            qreal extraSize = _spatium;
+            bbox().adjust(0, -extraSize, 0, extraSize);
+      }
+
+      lines.clear();
+      for (int i = 0; i < _lines; ++i) {
+            if (alignRight)
+                  lines.push_back(QLineF(x2-wPartial, y, x2, y));
+            else
+                  lines.push_back(QLineF(x1, y, x1 + wPartial, y));
+            y += dist;
+            }
+      }
+
+//---------------------------------------------------------
 //   draw
 //---------------------------------------------------------
 

--- a/libmscore/stafflines.h
+++ b/libmscore/stafflines.h
@@ -38,6 +38,7 @@ class StaffLines final : public Element {
       Measure* measure() const { return (Measure*)parent(); }
       qreal y1() const;
       void layoutForWidth(qreal width);
+      void layoutPartialWidth(qreal w, qreal wPartial, bool alignLeft);
       };
 
 }     // namespace Ms


### PR DESCRIPTION
Partially Resolves: *https://musescore.org/en/node/281639*
(Brackets out of scope of this PR)

**Fixes visibility of Bar Lines for Ossias or Cutaway scores.**
The EndBarLine of an invisible measure will automatically show if next measure is visible and in the same system.
Span works as expected, no manual insert of bar line needed.
(Barlines can always be manually set to invisible, if desired)

**Fixes showing courtesy clefs on invisible measures**
On a cutaway staff, If a courtesy clef is added to the end of an empty measure, a short staff "trailer" will be created to display the clef. This allows clefs to be displayed on the first visible measure or after an invisible section of a cutaway staff.
  (Clefs must be created manually by adding the clef to a  whole measure, as always).

Before
![image](https://user-images.githubusercontent.com/2843953/90351925-1d156600-e018-11ea-90c3-63278ee7c660.png)

After
![image](https://user-images.githubusercontent.com/2843953/90352385-9d889680-e019-11ea-95f4-bcd1509beafb.png)


As always, feedback and review will be appreciated.

*Some additional small fixes:
- Dragging manually-added bar lines won't set the Global span anymore (which was probably the intention of the existing code)
- Measure numbers will show even if measure is invisible or cut away from the system.
- Spacers will always show, even on invisible measures, to avoid losing track of them on a cutaway score.*


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [] I created the test (mtest, vtest, script test) to verify the changes I made
