### PR TITLE
Fix #271636: Translate notenames in piano role editor and status bar

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -810,7 +810,7 @@ int Note::tpc() const
 
 QString Note::tpcUserName(const int tpc, const int pitch, const bool explicitAccidental)
       {
-      const auto pitchStr = tpc2name(tpc, NoteSpellingType::STANDARD, NoteCaseType::AUTO, explicitAccidental);
+      const auto pitchStr = qApp->translate("InspectorAmbitus", tpc2name(tpc, NoteSpellingType::STANDARD, NoteCaseType::AUTO, explicitAccidental).replace("b", "♭").replace("#", "♯").toUtf8().constData());
       const auto octaveStr = QString::number(((pitch - static_cast<int>(tpc2alter(tpc))) / PITCH_DELTA_OCTAVE) - 1);
 
       return pitchStr + (explicitAccidental ? " " : "") + octaveStr;

--- a/mscore/pianoroll/pianokeyboard.cpp
+++ b/mscore/pianoroll/pianokeyboard.cpp
@@ -28,8 +28,8 @@ namespace Ms {
 
 const QColor colKeySelect = QColor(224, 170, 20);
 
-const QString PianoKeyboard::pitchNames[] =
-            {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
+const char* PianoKeyboard::pitchNames[] =
+            {"C", "C♯", "D", "D♯", "E", "F", "F♯", "G", "G♯", "A", "A♯", "B"}; // keep in sync with `valu` in limbscore/utils.cpp
 
 
 //---------------------------------------------------------
@@ -89,7 +89,6 @@ void PianoKeyboard::paintEvent(QPaintEvent* /*event*/)
       //White keys
       p.setPen(QPen(Qt::black));
       for (int midiPitch = 0; midiPitch < 128; ++midiPitch) {
-
             int instrPitch = midiPitch - transp.chromatic;
 
             int octave = instrPitch / 12;
@@ -105,9 +104,9 @@ void PianoKeyboard::paintEvent(QPaintEvent* /*event*/)
             if (key == -1)
                   continue;
 
-            QString noteName = pitchNames[degree] % QString::number(octave - 1);
+            QString noteName = qApp->translate("utils", pitchNames[degree]) + QString::number(octave - 1);
             if (ds)
-                  noteName = ds->name(instrPitch);
+                  noteName = qApp->translate("drumset", ds->name(instrPitch).toUtf8().constData());
 
             p.setBrush(curPitch == midiPitch ? colKeySelect : Qt::white);
 
@@ -164,9 +163,9 @@ void PianoKeyboard::paintEvent(QPaintEvent* /*event*/)
             if (key == -1)
                   continue;
 
-            QString noteName = pitchNames[blackKeyDegree[key]]  % QString::number(octave) + " ";
+            QString noteName = qApp->translate("utils", pitchNames[blackKeyDegree[key]]) + QString::number(octave);
             if (ds)
-                  noteName = ds->name(instrPitch);
+                  noteName = qApp->translate("drumset", ds->name(instrPitch).toUtf8().constData());
 
             qreal center = blackKeyOffset[key] * noteHeight;
             qreal offset = center - noteHeight / 2.0 + (octave * 12 + transp.chromatic) * noteHeight;
@@ -202,7 +201,6 @@ void PianoKeyboard::paintEvent(QPaintEvent* /*event*/)
                         }
                   }
             }
-
       }
 
 //---------------------------------------------------------
@@ -295,11 +293,11 @@ void PianoKeyboard::mouseMoveEvent(QMouseEvent* event)
             //Set tooltip
             int degree = curPitch % 12;
             int octave = curPitch / 12;
-            QString text = pitchNames[degree] + QString::number(octave - 1);
+            QString text = qApp->translate("utils", pitchNames[degree]) + QString::number(octave - 1);
             Part* part = _staff->part();
             Drumset* ds = part->instrument()->drumset();
             if (ds)
-                  text += " - " + ds->name(curPitch);
+                  text += " - " + qApp->translate("drumset", ds->name(curPitch).toUtf8().constData());
 
             setToolTip(text);
 

--- a/mscore/pianoroll/pianokeyboard.h
+++ b/mscore/pianoroll/pianokeyboard.h
@@ -40,7 +40,7 @@ const double X_ZOOM_INITIAL = 0.1;
 class PianoKeyboard : public QWidget {
       Q_OBJECT
 
-      static const QString pitchNames[];
+      static const char* pitchNames[];
 
       PianoOrientation _orientation;
       int _ypos;

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -240,7 +240,7 @@ void PianoItem::paintNoteBlock(QPainter* painter, NoteEvent* evt)
             painter->setFont(f);
 
             //Note name
-            QString name = tpc2name(_note->tpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, false);
+            QString name = qApp->translate("InspectorAmbitus", tpc2name(_note->tpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, false).replace("b", "♭").replace("#", "♯").toUtf8().constData());
             painter->setPen(QPen(noteColor.lighter(130)));
             painter->drawText(textHiliteRect,
                   Qt::AlignLeft | Qt::AlignTop, name);

--- a/mscore/pianotools.cpp
+++ b/mscore/pianotools.cpp
@@ -247,8 +247,8 @@ PianoKeyItem::PianoKeyItem(HPiano* _piano, int p)
       _highlighted = false;
       type = -1;
 
-      QString pitchNames[] = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
-      QString text = pitchNames[_pitch % 12] + QString::number((_pitch / 12) - 1);
+      const char* pitchNames[] = {"C", "C♯", "D", "D♯", "E", "F", "F♯", "G", "G♯", "A", "A♯", "B"}; // keep in sync with `valu` in limbscore/utils.cpp
+      QString text = qApp->translate("utils", pitchNames[_pitch % 12]) + QString::number((_pitch / 12) - 1);
       setToolTip(text);
       }
 


### PR DESCRIPTION
Resolves 
https://musescore.org/en/node/271636

including the piano tool keyboard tooltips, also for piano roll editor, there including the strings for drumsets too.