### PR TITLE
[MU4] GSoC 2020: Change ScoreView to QAbstractItemView (Also adds tooltips)

### DIFF
--- a/libmscore/mscoreview.cpp
+++ b/libmscore/mscoreview.cpp
@@ -34,7 +34,7 @@ static bool elementLower(const Element* e1, const Element* e2)
 //   elementAt
 //---------------------------------------------------------
 
-Element* MuseScoreView::elementAt(const QPointF& p)
+Element* MuseScoreView::elementAt(const QPointF& p) const
 {
     QList<Element*> el = elementsAt(p);
 #if 0
@@ -54,7 +54,7 @@ Element* MuseScoreView::elementAt(const QPointF& p)
 //   point2page
 //---------------------------------------------------------
 
-Page* MuseScoreView::point2page(const QPointF& p)
+Page* MuseScoreView::point2page(const QPointF& p) const
 {
     if (score()->layoutMode() == LayoutMode::LINE) {
         return score()->pages().isEmpty() ? 0 : score()->pages().front();
@@ -72,7 +72,7 @@ Page* MuseScoreView::point2page(const QPointF& p)
 //    p is in canvas coordinates
 //---------------------------------------------------------
 
-const QList<Element*> MuseScoreView::elementsAt(const QPointF& p)
+const QList<Element*> MuseScoreView::elementsAt(const QPointF& p) const
 {
     QList<Element*> el;
 

--- a/libmscore/mscoreview.h
+++ b/libmscore/mscoreview.h
@@ -35,9 +35,9 @@ protected:
 
 public:
     virtual ~MuseScoreView() = default;
-    Page* point2page(const QPointF&);
-    Element* elementAt(const QPointF& p);
-    const QList<Element*> elementsAt(const QPointF&);
+    Page* point2page(const QPointF&) const;
+    Element* elementAt(const QPointF& p) const;
+    const QList<Element*> elementsAt(const QPointF&) const;
     virtual Element* elementNear(QPointF) { return 0; }
 
     virtual void layoutChanged() {}

--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -189,6 +189,7 @@ bool ScoreView::dragMeasureAnchorElement(const QPointF& pos)
 
 void ScoreView::dragEnterEvent(QDragEnterEvent* event)
 {
+    QAbstractItemView::dragEnterEvent(event);
     double _spatium = score()->spatium();
     editData.dropElement = 0;
 
@@ -322,6 +323,7 @@ Element* ScoreView::getDropTarget(EditData& ed)
 
 void ScoreView::dragMoveEvent(QDragMoveEvent* event)
 {
+    QAbstractItemView::dragMoveEvent(event);
     // we always accept the drop action
     // to get a "drop" Event:
 
@@ -427,6 +429,7 @@ void ScoreView::dragMoveEvent(QDragMoveEvent* event)
 
 void ScoreView::dropEvent(QDropEvent* event)
 {
+    QAbstractItemView::dropEvent(event);
     if (state == ViewState::PLAY) {
         event->ignore();
         return;
@@ -653,8 +656,9 @@ void ScoreView::dropEvent(QDropEvent* event)
 //   dragLeaveEvent
 //---------------------------------------------------------
 
-void ScoreView::dragLeaveEvent(QDragLeaveEvent*)
+void ScoreView::dragLeaveEvent(QDragLeaveEvent* event)
 {
+    QAbstractItemView::dragLeaveEvent(event);
     if (editData.dropElement) {
         _score->setUpdateAll();
         delete editData.dropElement;

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -39,6 +39,7 @@ namespace Ms {
 
 bool ScoreView::event(QEvent* event)
 {
+    QAbstractItemView::event(event);
     switch (event->type()) {
     case QEvent::KeyPress: {
         QKeyEvent* ke = static_cast<QKeyEvent*>(event);
@@ -106,7 +107,7 @@ bool ScoreView::event(QEvent* event)
         break;
     }
 
-    return QWidget::event(event);
+    return QAbstractItemView::event(event);
 }
 
 //---------------------------------------------------------
@@ -143,6 +144,7 @@ bool ScoreView::gestureEvent(QGestureEvent* event)
 
 void ScoreView::wheelEvent(QWheelEvent* event)
 {
+    QAbstractItemView::wheelEvent(event);
 #define PIXELSSTEPSFACTOR 5
 
     QPoint pixelsScrolled = event->pixelDelta();
@@ -212,8 +214,9 @@ void ScoreView::wheelEvent(QWheelEvent* event)
 //   resizeEvent
 //---------------------------------------------------------
 
-void ScoreView::resizeEvent(QResizeEvent* /*ev*/)
+void ScoreView::resizeEvent(QResizeEvent* event)
 {
+    QAbstractItemView::resizeEvent(event);
     if (_magIdx != MagIdx::MAG_FREE) {
         setMag(mscore->getMag(this));
     }
@@ -244,6 +247,7 @@ void ScoreView::resizeEvent(QResizeEvent* /*ev*/)
 
 void ScoreView::focusInEvent(QFocusEvent* event)
 {
+    QAbstractItemView::focusInEvent(event);
     if (this != mscore->currentScoreView()) {
         mscore->setCurrentScoreView(this);
     }
@@ -269,6 +273,7 @@ void ScoreView::focusInEvent(QFocusEvent* event)
 
 void ScoreView::focusOutEvent(QFocusEvent* event)
 {
+    QAbstractItemView::focusOutEvent(event);
     if (state == ViewState::NORMAL) {
         setEditElement(nullptr);
     }
@@ -319,6 +324,7 @@ bool ScoreView::startTextEditingOnMouseRelease(QMouseEvent* mouseEvent)
 
 void ScoreView::mouseReleaseEvent(QMouseEvent* mouseEvent)
 {
+    QAbstractItemView::mouseReleaseEvent(mouseEvent);
     editData.buttons = Qt::NoButton;
     if (seq) {
         seq->stopNoteTimer();
@@ -489,13 +495,14 @@ void ScoreView::mousePressEventNormal(QMouseEvent* ev)
 
 void ScoreView::mousePressEvent(QMouseEvent* ev)
 {
+    QAbstractItemView::mousePressEvent(ev);
     if (tripleClickPending) {
         if (textEditMode()) {
             TextBase* textBase = toTextBase(editData.element);
             textBase->multiClickSelect(editData, MultiClick::Triple);
             mscore->textTools()->updateTools(editData);
             textBase->endHexState(editData);
-            update();
+            viewport()->update();
             return;
         }
     }
@@ -660,6 +667,7 @@ void ScoreView::adjustCursorForTextEditing(QMouseEvent* mouseEvent)
 
 void ScoreView::mouseMoveEvent(QMouseEvent* me)
 {
+    QAbstractItemView::mouseMoveEvent(me);
     adjustCursorForTextEditing(me);
 
     if (state != ViewState::NOTE_ENTRY && editData.buttons == Qt::NoButton) {
@@ -748,7 +756,7 @@ void ScoreView::mouseMoveEvent(QMouseEvent* me)
     default:
         break;
     }
-    update();
+    viewport()->update();
 }
 
 //---------------------------------------------------------
@@ -766,6 +774,7 @@ void ScoreView::tripleClickTimeOut()
 
 void ScoreView::mouseDoubleClickEvent(QMouseEvent* mouseEvent)
 {
+    QAbstractItemView::mouseDoubleClickEvent(mouseEvent);
     QTimer::singleShot(QApplication::doubleClickInterval(), this, SLOT(tripleClickTimeOut()));
     tripleClickPending = true;
 
@@ -775,7 +784,7 @@ void ScoreView::mouseDoubleClickEvent(QMouseEvent* mouseEvent)
         textBase->multiClickSelect(editData, MultiClick::Double);
         mscore->textTools()->updateTools(editData);
         textBase->endHexState(editData);
-        update();
+        viewport()->update();
         return;
     }
 
@@ -839,6 +848,7 @@ public:
 
 void ScoreView::keyPressEvent(QKeyEvent* ev)
 {
+    QAbstractItemView::keyPressEvent(ev);
     editData.key       = ev->key();
     editData.modifiers = ev->modifiers();
     editData.s         = ev->text();
@@ -1011,13 +1021,14 @@ bool ScoreView::handleArrowKeyPress(const QKeyEvent* ev)
 
 void ScoreView::keyReleaseEvent(QKeyEvent* ev)
 {
+    QAbstractItemView::keyReleaseEvent(ev);
     if (textEditMode()) {
         auto modifiers = Qt::ControlModifier | Qt::ShiftModifier;
         if ((ev->modifiers() & modifiers) == 0) {
             TextBase* text = toTextBase(editData.element);
             text->endHexState(editData);
             ev->accept();
-            update();
+            viewport()->update();
         }
     }
 }
@@ -1028,6 +1039,7 @@ void ScoreView::keyReleaseEvent(QKeyEvent* ev)
 
 void ScoreView::contextMenuEvent(QContextMenuEvent* ev)
 {
+    QAbstractItemView::contextMenuEvent(ev);
     if (state == ViewState::NOTE_ENTRY) {
         // Do not show context menu in note input mode.
         return;
@@ -1101,7 +1113,7 @@ void ScoreView::escapeCmd()
         break;
     case ViewState::NORMAL:
         _score->deselectAll();
-        update();
+        viewport()->update();
         break;
     default:
         break;
@@ -1279,6 +1291,7 @@ void ScoreView::changeState(ViewState s)
 
 void ScoreView::inputMethodEvent(QInputMethodEvent* event)
 {
+    QAbstractItemView::inputMethodEvent(event);
     if (textEditMode()) {
         toTextBase(editData.element)->inputTransition(editData, event);
     }

--- a/mscore/scoreitemmodel.cpp
+++ b/mscore/scoreitemmodel.cpp
@@ -26,7 +26,7 @@ ScoreItemModel::ScoreItemModel(Score* score, QObject* parent)
 }
 
 //---------------------------------------------------------
-//   ScoreItemModel::elementFromIndex
+//   ScoreItemModel::scoreElementFromIndex
 //---------------------------------------------------------
 
 ScoreElement* ScoreItemModel::scoreElementFromIndex(const QModelIndex& index) const
@@ -36,6 +36,25 @@ ScoreElement* ScoreItemModel::scoreElementFromIndex(const QModelIndex& index) co
     } else {
         return _scoreRoot;
     }
+}
+
+//---------------------------------------------------------
+//   ScoreItemModel::scoreElementToIndex
+//---------------------------------------------------------
+
+QModelIndex ScoreItemModel::scoreElementToIndex(const ScoreElement* el) const
+{
+    QModelIndex idx;
+    std::function<void(QModelIndex)> dfs = [&](QModelIndex currentIndex) {
+                                               if (scoreElementFromIndex(currentIndex) == el) {
+                                                   idx = currentIndex;
+                                               }
+                                               for (int i = 0; i < rowCount(currentIndex); i++) {
+                                                   dfs(index(i, 0, currentIndex));
+                                               }
+                                           };
+    dfs(QModelIndex());
+    return idx;
 }
 
 //---------------------------------------------------------

--- a/mscore/scoreitemmodel.h
+++ b/mscore/scoreitemmodel.h
@@ -42,8 +42,8 @@ public:
     // optional overrides
     virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 
-private:
     ScoreElement* scoreElementFromIndex(const QModelIndex& index) const;
+    QModelIndex scoreElementToIndex(const ScoreElement* el) const;
 };
 }  // namespace Ms
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -108,7 +108,7 @@ extern QErrorMessage* errorMessage;
 //---------------------------------------------------------
 
 ScoreView::ScoreView(QWidget* parent)
-    : QWidget(parent), editData(this)
+    : QAbstractItemView(parent), editData(this)
 {
     setObjectName("scoreview");
     setStatusTip("scoreview");
@@ -278,6 +278,102 @@ ScoreView::~ScoreView()
     delete _fgPixmap;
     delete shadowNote;
 }
+
+//=========================================================
+//-------- STUFF REQUIRED FOR Q ABSTRACT ITEM VIEW --------
+//=========================================================
+
+//---------------------------------------------------------
+//   visualRect
+//---------------------------------------------------------
+
+QRect ScoreView::visualRect(const QModelIndex& index) const
+{
+    Q_UNUSED(index);
+    return QRect();
+}
+
+//---------------------------------------------------------
+//   scrollTo
+//---------------------------------------------------------
+
+void ScoreView::scrollTo(const QModelIndex& index, ScrollHint hint)
+{
+    Q_UNUSED(index);
+    Q_UNUSED(hint);
+}
+
+//---------------------------------------------------------
+//   indexAt
+//---------------------------------------------------------
+
+QModelIndex ScoreView::indexAt(const QPoint& point) const
+{
+    Q_UNUSED(point);
+    return QModelIndex();
+}
+
+//---------------------------------------------------------
+//   moveCursor
+//---------------------------------------------------------
+
+QModelIndex ScoreView::moveCursor(CursorAction cursorAction, Qt::KeyboardModifiers modifiers)
+{
+    Q_UNUSED(cursorAction);
+    Q_UNUSED(modifiers);
+    return QModelIndex();
+}
+
+//---------------------------------------------------------
+//   horizontalOffset
+//---------------------------------------------------------
+
+int ScoreView::horizontalOffset() const
+{
+    return 0;
+}
+
+//---------------------------------------------------------
+//   verticalOffset
+//---------------------------------------------------------
+
+int ScoreView::verticalOffset() const
+{
+    return 0;
+}
+
+//---------------------------------------------------------
+//   isIndexHidden
+//---------------------------------------------------------
+
+bool ScoreView::isIndexHidden(const QModelIndex& index) const
+{
+    Q_UNUSED(index);
+    return false;
+}
+
+//---------------------------------------------------------
+//   setSelection
+//---------------------------------------------------------
+
+void ScoreView::setSelection(const QRect& rect, QItemSelectionModel::SelectionFlags command)
+{
+    Q_UNUSED(rect);
+    Q_UNUSED(command);
+}
+
+//---------------------------------------------------------
+//   visualRegionForSelection
+//---------------------------------------------------------
+
+QRegion ScoreView::visualRegionForSelection(const QItemSelection& selection) const
+{
+    Q_UNUSED(selection);
+    return QRegion();
+}
+
+//=========================================================
+//=========================================================
 
 //---------------------------------------------------------
 //   objectPopup

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -129,7 +129,7 @@ enum class ViewState {
 //   ScoreView
 //---------------------------------------------------------
 
-class ScoreView : public QWidget, public MuseScoreView
+class ScoreView : public QAbstractItemView, public MuseScoreView
 {
     Q_OBJECT
 
@@ -355,6 +355,20 @@ public:
     ScoreView(QWidget* parent = 0);
     ~ScoreView();
 
+    // For QAbstractItemModel
+    QRect        visualRect(const QModelIndex& index) const override;
+    void         scrollTo(const QModelIndex& index, ScrollHint hint = EnsureVisible) override;
+    QModelIndex  indexAt(const QPoint& point) const override;
+
+protected Q_SLOTS:
+    QModelIndex  moveCursor(CursorAction cursorAction, Qt::KeyboardModifiers modifiers) override;
+    int          horizontalOffset() const override;
+    int          verticalOffset() const override;
+    bool         isIndexHidden(const QModelIndex& index) const override;
+    void         setSelection(const QRect& rect, QItemSelectionModel::SelectionFlags command) override;
+    QRegion      visualRegionForSelection(const QItemSelection& selection) const override;
+
+public:
     QPixmap* fgPixmap() { return _fgPixmap; }
 
     void startEdit(Element*, Grip) override;

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -37,6 +37,7 @@ class Measure;
 class System;
 class Score;
 class ScoreView;
+class ScoreItemModel;
 class Text;
 class MeasureBase;
 class Staff;
@@ -132,6 +133,8 @@ enum class ViewState {
 class ScoreView : public QAbstractItemView, public MuseScoreView
 {
     Q_OBJECT
+
+    ScoreItemModel * _model { 0 };
 
     ViewState state;
     OmrView* _omrView;
@@ -321,6 +324,14 @@ private slots:
     void seqStopped();
     void tripleClickTimeOut();
 
+protected Q_SLOTS:
+    int horizontalOffset() const override;
+    int verticalOffset() const override;
+    bool isIndexHidden(const QModelIndex& index) const override;
+    void setSelection(const QRect& rect, QItemSelectionModel::SelectionFlags command) override;
+    QRegion visualRegionForSelection(const QItemSelection& selection) const override;
+    QModelIndex moveCursor(CursorAction cursorAction, Qt::KeyboardModifiers modifiers) override;
+
 public slots:
     void setViewRect(const QRectF&);
 
@@ -355,20 +366,10 @@ public:
     ScoreView(QWidget* parent = 0);
     ~ScoreView();
 
-    // For QAbstractItemModel
     QRect        visualRect(const QModelIndex& index) const override;
     void         scrollTo(const QModelIndex& index, ScrollHint hint = EnsureVisible) override;
     QModelIndex  indexAt(const QPoint& point) const override;
 
-protected Q_SLOTS:
-    QModelIndex  moveCursor(CursorAction cursorAction, Qt::KeyboardModifiers modifiers) override;
-    int          horizontalOffset() const override;
-    int          verticalOffset() const override;
-    bool         isIndexHidden(const QModelIndex& index) const override;
-    void         setSelection(const QRect& rect, QItemSelectionModel::SelectionFlags command) override;
-    QRegion      visualRegionForSelection(const QItemSelection& selection) const override;
-
-public:
     QPixmap* fgPixmap() { return _fgPixmap; }
 
     void startEdit(Element*, Grip) override;


### PR DESCRIPTION
Resolves: Currently none, but in the future may help with https://musescore.org/en/node/12074, https://musescore.org/en/node/270143, https://musescore.org/en/node/301495, etc.

This PR makes ScoreView a QAbstractItemView instead of a QWidget, and the corresponding QAbstractItemModel is the ScoreItemModel (based on the score tree, introduced in PR #6174).

Right now, the only observable effect of this PR is that tooltips are shown automatically for each element when you hover your mouse on them.

![tooltips-image](https://user-images.githubusercontent.com/5488078/90418706-1dbf0280-e0d3-11ea-8f87-3ad038fd6e03.png)

By implementing various virtual functions of QAbstractItemView, this could help with better accessibility, keyboard navigation, etc.