### PR TITLE
fix #309273: crash on flipping beam across system break

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -2194,6 +2194,8 @@ std::vector<QPointF> Beam::gripsPositions(const EditData& ed) const
                   break;
                   }
             }
+      if (!c1) // no chord/rest found, no need to check again below
+            return {}; // just ignore the requested operation
       for (int i = n-1; i >= 0; --i) {
             if (_elements[i]->isChordRest()) {
                   c2 = toChordRest(_elements[i]);


### PR DESCRIPTION
resolves https://musescore.org/en/node/309273, brings us back to a state before 3.4.x, where this flip didn't crash but just got ignored. Better than that actually in older version the flip got ignored but dragging the handles in edit mode crashed, with this fix no longer.