### PR TITLE
fix fluid's malloc include

### DIFF
--- a/thirdparty/fluidsynth/fluidsynth-2.1.4/src/utils/fluidsynth_priv.h
+++ b/thirdparty/fluidsynth/fluidsynth-2.1.4/src/utils/fluidsynth_priv.h
@@ -73,7 +73,7 @@ typedef double fluid_real_t;
 #else
 
 #if defined(NO_GLIB)
-#include <malloc.h>
+#include <stdlib.h>
 #ifdef _MSC_VER
 #  define FLUID_DECLARE_VLA(_type, _name, _len) \
      _type* _name = _alloca(_len*sizeof(_type))


### PR DESCRIPTION
Resolves: https://musescore.org/ru/node/309100

malloc.h is not the [standard](https://en.cppreference.com/w/c/memory) include, should be used stdlib.h