### PR TITLE
fix #309290: fix crash on some corrupt score

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3372,7 +3372,7 @@ void Measure::stretchMeasure(qreal targetWidth)
             Segment* s = first();
             while (s && !s->enabled())
                   s = s->next();
-            qreal x = s->pos().x();
+            qreal x = s ? s->pos().x() : 0.0;
             while (s) {
                   s->rxpos() = x;
                   x += s->width();


### PR DESCRIPTION
resolves the crash from https://musescore.org/en/node/309290, not the corruption though, but with the crash out of the way, the corruption can get manually fixed