### PR TITLE
fix #309098: fix parts playback for chord symbols

### DIFF
--- a/audio/midi/event.cpp
+++ b/audio/midi/event.cpp
@@ -186,8 +186,10 @@ bool NPlayEvent::isMuted() const
       const Harmony* h = harmony();
       if (h) {
             const Channel* hCh = h->part()->harmonyChannel();
-            if (hCh) //if there is a harmony channel
-                  return hCh->mute() || hCh->soloMute();
+            if (hCh) { //if there is a harmony channel
+                  const Channel* pCh = h->masterScore()->playbackChannel(hCh);
+                  return pCh->mute() || pCh->soloMute();
+                  }
             }
 
       return false;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/309098

Makes chord symbols playback honor playback channel settings which is needed to play or mute them correctly when playing a part instead of the entire score.