### PR TITLE
fix #18897: implement the third stroke style of minim-based two-note tremolos

### DIFF
--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -530,6 +530,7 @@ static const StyleType styleTypes[] {
       { Sid::tremoloStrokeWidth,      "tremoloLineWidth",        Spatium(0.5) },  // was 0.35
       { Sid::tremoloDistance,         "tremoloDistance",         Spatium(0.8) },
       { Sid::tremoloStrokeStyle,      "tremoloStrokeStyle",      int(TremoloStrokeStyle::DEFAULT) },
+      { Sid::tremoloStrokeLengthMultiplier, "tremoloStrokeLengthMultiplier", 0.62 },
 
       { Sid::linearStretch,           "linearStretch",           QVariant(qreal(1.5)) },
       { Sid::crossMeasureValues,      "crossMeasureValues",      QVariant(false) },

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -518,7 +518,7 @@ enum class Sid {
       tremoloStrokeWidth,
       tremoloDistance,
       tremoloStrokeStyle,
-      // TODO tremoloBeamLengthMultiplier,
+      tremoloStrokeLengthMultiplier,
       // TODO tremoloMaxBeamLength,
 
       linearStretch,

--- a/libmscore/tremolo.h
+++ b/libmscore/tremolo.h
@@ -29,7 +29,7 @@ enum class TremoloType : signed char {
 
 // only applicable to minim two-note tremolo in non-TAB staves
 enum class TremoloStrokeStyle : signed char {
-      DEFAULT = 0, ALL_STROKES_ATTACHED
+      DEFAULT = 0, ALL_STROKES_ATTACHED, SINGLE_STROKE_ATTACHED
       };
 
 //---------------------------------------------------------


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/46259489/90760381-5ef22500-e314-11ea-9af8-ca3ee71429b6.png)