### PR TITLE
fixbuild - disable midi out port for macos

### DIFF
--- a/framework/midi/CMakeLists.txt
+++ b/framework/midi/CMakeLists.txt
@@ -36,8 +36,8 @@ elseif(PLATFORM_LINUX)
     )
 elseif(PLATFORM_OSX)
     set(DRIVER_SRC
-        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/osx/coremidioutport.cpp
-        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/osx/coremidioutport.h
+#        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/osx/coremidioutport.cpp
+#        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/osx/coremidioutport.h
     )
 endif()
 

--- a/framework/midi/midimodule.cpp
+++ b/framework/midi/midimodule.cpp
@@ -51,8 +51,11 @@ static std::shared_ptr<IMidiOutPort> midiOutPort = std::make_shared<WinMidiOutPo
 #endif
 
 #ifdef Q_OS_MACOS
-#include "internal/platform/osx/coremidioutport.h"
-static std::shared_ptr<IMidiOutPort> midiOutPort = std::make_shared<CoreMidiOutPort>();
+//#include "internal/platform/osx/coremidioutport.h"
+//static std::shared_ptr<IMidiOutPort> midiOutPort = std::make_shared<CoreMidiOutPort>();
+
+#include "internal/dummymidioutport.h"
+static std::shared_ptr<IMidiOutPort> midiOutPort = std::make_shared<DummyMidiOutPort>();
 #endif
 
 static SynthesizerController s_synthesizerController;


### PR DESCRIPTION
MacOS midi out port not completed yet