### PR TITLE
fix #309369: status bar does not show concert pitch of octave transposing instruments

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -825,7 +825,7 @@ QString Note::tpcUserName(const bool explicitAccidental) const
       const auto playbackPitch = ppitch();
       const auto tpc1Str = tpcUserName(tpc1(), playbackPitch, explicitAccidental);
 
-      if ((tpc1() == tpc2()) || concertPitch()) {
+      if ((epitch() == ppitch()) || concertPitch()) {
             return tpc1Str;
             }
       else {


### PR DESCRIPTION
resolves https://musescore.org/en/node/309369