### PR TITLE
fix #284357: Ambitus not correctly calculated for (octave) transposing instruments

### DIFF
--- a/libmscore/ambitus.cpp
+++ b/libmscore/ambitus.cpp
@@ -607,7 +607,7 @@ void Ambitus::updateRange()
                   for (Note* n : chord->notes()) {
                         if (!n->play())         // skip notes which are not to be played
                               continue;
-                        int pitch = n->ppitch();
+                        int pitch = n->epitch();
                         if (pitch > pitchTop) {
                               pitchTop = pitch;
                               tpcTop   = n->tpc();


### PR DESCRIPTION
resolves https://musescore.org/en/node/284357