### PR TITLE
fix #309064 : mtests not building for Qt >= 5.11

### DIFF
--- a/mtest/CMakeLists.txt
+++ b/mtest/CMakeLists.txt
@@ -41,26 +41,14 @@ if (MSVC)
       set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
 endif (MSVC)
 
-if (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.11.0")
-      find_package(Qt5QuickCompiler)
-      qtquick_compiler_add_resources(qrc_files ${PROJECT_SOURCE_DIR}/mtest/mtest.qrc
-            ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-MScore.qrc
-            ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-Gootville.qrc
-            ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-Bravura.qrc
-            ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-MuseJazz.qrc
-            ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-Free.qrc
-            ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-FreeSerif.qrc
+QT5_ADD_RESOURCES(qrc_files ${PROJECT_SOURCE_DIR}/mtest/mtest.qrc
+      ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-MScore.qrc
+      ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-Gootville.qrc
+      ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-Bravura.qrc
+      ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-MuseJazz.qrc
+      ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-Free.qrc
+      ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-FreeSerif.qrc
       )
-else (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.11.0")
-      QT5_ADD_RESOURCES(qrc_files ${PROJECT_SOURCE_DIR}/mtest/mtest.qrc
-            ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-MScore.qrc
-            ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-Gootville.qrc
-            ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-Bravura.qrc
-            ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-MuseJazz.qrc
-            ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-Free.qrc
-            ${PROJECT_SOURCE_DIR}/mscore/musescorefonts-FreeSerif.qrc
-      )
-endif (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.11.0")
 
 add_library (testResources STATIC
       ${qrc_files}


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/309064

Apparently, qtquick_compiler_add_resources really adds the resources only if there is at least one of them needing to be compiled by Qt5QuickCompiler (e.g. a qml file), so in the case of mtests a simple QT5_ADD_RESOURCES is needed.
Moreover, QT5_ADD_RESOURCES seems not to give problems if the resources are added more than once (for example, in the case of the -three at the moment- mtests linking to mscoreapp, in which some of the resources were already added to mscoreapp).

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
