### PR TITLE
Set app category on Mac to "Music"

### DIFF
--- a/build/MacOSXBundleInfo.plist.in
+++ b/build/MacOSXBundleInfo.plist.in
@@ -362,6 +362,8 @@
 	<string>10.7.0</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.music</string>
 	<key>ATSApplicationFontsPath</key>
 	<string>fonts/</string>
 	<key>SUFeedURL</key>


### PR DESCRIPTION
In the Applications folder on Mac, you can group your apps by category. Previously, MuseScore appears in the "Other" category. Now, it will appear in the Music category.

(I closed my previous version of this pull request, because I ignorantly did it on my master branch, which indeed turned out to be inconvenient. Now I'm using a separate branch.)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
