### PR TITLE
fix #309380: Crashes when pasting fret diagram without chord symbol in score with parts

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4616,9 +4616,11 @@ void Score::undoAddElement(Element* element)
                         if (ne->isFretDiagram()) {
                               FretDiagram* fd = toFretDiagram(ne);
                               Harmony* fdHarmony = fd->harmony();
-                              fdHarmony->setScore(score);
-                              fdHarmony->setSelected(false);
-                              fdHarmony->setTrack(staffIdx * VOICES + element->voice());
+                              if (fdHarmony) {
+                                    fdHarmony->setScore(score);
+                                    fdHarmony->setSelected(false);
+                                    fdHarmony->setTrack(staffIdx * VOICES + element->voice());
+                                    }
                               }
                         }
 


### PR DESCRIPTION
resolves https://musescore.org/en/node/309380