### PR TITLE
Fix Xcode error with gettimeofday in fluid_sys.c

### DIFF
--- a/thirdparty/fluidsynth/fluidsynth-2.1.4/src/utils/fluid_sys.c
+++ b/thirdparty/fluidsynth/fluidsynth-2.1.4/src/utils/fluid_sys.c
@@ -352,6 +352,8 @@ int gettimeofday(struct timeval * tp, struct timezone * tzp)
     tp->tv_usec = (long) (system_time.wMilliseconds * 1000);
     return 0;
 }
+#else
+#include <sys/time.h>
 #endif
 
 /**


### PR DESCRIPTION
When trying to build MuseScore in Xcode, I got an error in the file `thirdparty/fluidsynth/fluidsynth-2.1.4/src/utils/fluid_sys.c` at this line: `gettimeofday(&t, NULL);`: "Implicit declaration of function 'gettimeofday' is invalid in C99". The error was preventing me from building MuseScore in Xcode. 

This PR gets rid of this problem. I'm not completely sure tough if this is the best solution, so please let me know if I'm missing something. 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- N/A I created the test (mtest, vtest, script test) to verify the changes I made
