### PR TITLE
Fix #309419: instrument change data not properly saved in linked staves

### DIFF
--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -387,9 +387,10 @@ void EditStaff::apply()
                         score->undo(new ChangePart(part, new Instrument(*part->instrument()), newPartName));
                   if (instrumentFieldChanged) {
                         Segment* s = score->tick2segment(_tickStart, true, SegmentType::ChordRest);
-                        Element* e = s ? s->findAnnotation(ElementType::INSTRUMENT_CHANGE, part->startTrack(), part->endTrack()) : nullptr;
-                        if (e)
-                              score->undo(new ChangeInstrument(toInstrumentChange(e), new Instrument(instrument)));
+                        const std::vector<Element*> elist = s ? s->findAnnotations(ElementType::INSTRUMENT_CHANGE, part->startTrack(), part->endTrack()) : elist;
+                        if (elist.size())
+                              for (Element* e : elist) // Change instrument in all Instrument Changes (for linked staves)
+                                    score->undo(new ChangeInstrument(toInstrumentChange(e), new Instrument(instrument)));
                         else
                               score->undo(new ChangePart(part, new Instrument(instrument), newPartName));
                         }


### PR DESCRIPTION
Resolves: *https://musescore.org/en/node/309419*

Problem: Editing a Staff instrument on linked staves, after an instrument change, only changed the instrument for the first InstrumentChange element (the first staff).  The changes apparently worked, but they were lost after saving and reloading the file (because the second staff's instrument change was written with the stock unchanged instrument).

Just added a loop in Edit Staff so it now finds all Instrument Changes on the part and its staves and sets all of them to the new instrument data.



<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [NA] I created the test (mtest, vtest, script test) to verify the changes I made
