### PR TITLE
fix #309592: pasting a measure with "above" breaths/pauses flips them to "below"

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -397,8 +397,9 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff, Fraction scale)
                               }
                         else if (tag == "Breath") {
                               Breath* breath = new Breath(this);
-                              breath->read(e);
                               breath->setTrack(e.track());
+                              breath->setPlacement(breath->track() & 1 ? Placement::BELOW : Placement::ABOVE);
+                              breath->read(e);
                               Fraction tick = doScale ? (e.tick() - dstTick) * scale + dstTick : e.tick();
                               Measure* m = tick2measure(tick);
                               if (m->tick() == tick)


### PR DESCRIPTION
Resolves: https://musescore.org/node/309592.

See https://github.com/musescore/MuseScore/pull/4220, the copy-and-paste case was missed, causing this regression.