### PR TITLE
fix #308931: Adding solo & mute flags to Part

### DIFF
--- a/audio/midi/event.cpp
+++ b/audio/midi/event.cpp
@@ -176,15 +176,15 @@ bool NPlayEvent::isMuted() const
         Staff* staff = n->staff();
         Instrument* instr = staff->part()->instrument(n->tick());
         const Channel* a = instr->playbackChannel(n->subchannel(), cs);
-        return a->mute() || a->soloMute() || !staff->playbackVoice(n->voice());
+        return a->mute() || a->playbackMute() || !staff->playbackVoice(n->voice());
     }
 
     const Harmony* h = harmony();
     if (h) {
         const Channel* hCh = h->part()->harmonyChannel();
-        if (hCh) { //if there is a harmony channel
+        if (hCh) {   //if there is a harmony channel
             const Channel* pCh = h->masterScore()->playbackChannel(hCh);
-            return pCh->mute() || pCh->soloMute();
+            return pCh->mute() || pCh->playbackMute();
         }
     }
 

--- a/libmscore/instrument.cpp
+++ b/libmscore/instrument.cpp
@@ -456,7 +456,7 @@ Channel::Channel()
 
     _mute     = false;
     _solo     = false;
-    _soloMute = false;
+    _playbackMute = false;
 
 //      qDebug("construct Channel ");
 }
@@ -616,10 +616,10 @@ void Channel::setChannel(int value)
 //   setSoloMute
 //---------------------------------------------------------
 
-void Channel::setSoloMute(bool value)
+void Channel::setPlaybackMute(bool value)
 {
-    if (_soloMute != value) {
-        _soloMute = value;
+    if (_playbackMute != value) {
+        _playbackMute = value;
         firePropertyChanged(Prop::SOLOMUTE);
     }
 }
@@ -1038,7 +1038,7 @@ void PartChannelSettingsLink::applyProperty(Channel::Prop p, const Channel* from
         to->setColor(from->color());
         break;
     case Channel::Prop::SOLOMUTE:
-        to->setSoloMute(from->soloMute());
+        to->setPlaybackMute(from->playbackMute());
         break;
     case Channel::Prop::SOLO:
         to->setSolo(from->solo());

--- a/libmscore/instrument.h
+++ b/libmscore/instrument.h
@@ -122,7 +122,7 @@ class Channel
     int _bank;          // initialized from "init"
     int _channel { 0 };        // mscore channel number, mapped to midi port/channel
 
-    bool _soloMute;
+    bool _playbackMute;
     bool _mute;
     bool _solo;
 
@@ -180,8 +180,8 @@ public:
     int channel() const { return _channel; }
     void setChannel(int value);
 
-    bool soloMute() const { return _soloMute; }
-    void setSoloMute(bool value);
+    bool playbackMute() const { return _playbackMute; }
+    void setPlaybackMute(bool value);
     bool mute() const { return _mute; }
     void setMute(bool value);
     bool solo() const { return _solo; }

--- a/libmscore/part.cpp
+++ b/libmscore/part.cpp
@@ -36,6 +36,8 @@ Part::Part(Score* s)
 {
     _color = DEFAULT_COLOR;
     _show  = true;
+    _solo = false;
+    _mute = false;
     _instruments.setInstrument(new Instrument, -1);     // default instrument
     _preferSharpFlat = PreferSharpFlat::DEFAULT;
 }
@@ -435,6 +437,48 @@ void Part::setPlainShortName(const QString& s)
 }
 
 //---------------------------------------------------------
+//   setMute
+//---------------------------------------------------------
+
+void Part::setMute(bool value)
+{
+    if (_mute != value) {
+        _mute = value;
+        firePropertyChanged(Prop::MUTE);
+    }
+}
+
+//---------------------------------------------------------
+//   setSolo
+//---------------------------------------------------------
+
+void Part::setSolo(bool value)
+{
+    if (_solo != value) {
+        _solo = value;
+        firePropertyChanged(Prop::SOLO);
+    }
+}
+
+//---------------------------------------------------------
+//   addListener
+//---------------------------------------------------------
+
+void Part::addListener(PartListener* l)
+{
+    _notifier.addListener(l);
+}
+
+//---------------------------------------------------------
+//   removeListener
+//---------------------------------------------------------
+
+void Part::removeListener(PartListener* l)
+{
+    _notifier.removeListener(l);
+}
+
+//---------------------------------------------------------
 //   getProperty
 //---------------------------------------------------------
 
@@ -693,6 +737,25 @@ bool Part::hasDrumStaff() const
             return true;
         }
     }
+    return false;
+}
+
+//---------------------------------------------------------
+//   hasSoloChannel
+//---------------------------------------------------------
+
+bool Part::hasSoloedChannel() const
+{
+    const InstrumentList* il = instruments();
+    for (auto i = il->begin(); i != il->end(); ++i) {
+        const Instrument* instr = i->second;
+        for (const Channel* c: instr->channel()) {
+            if (c->solo()) {
+                return true;
+            }
+        }
+    }
+
     return false;
 }
 }

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -4239,12 +4239,12 @@ void MasterScore::setSoloMute()
     for (unsigned i = 0; i < _midiMapping.size(); i++) {
         Channel* b = _midiMapping[i].articulation();
         if (b->solo()) {
-            b->setSoloMute(false);
+            b->setPlaybackMute(false);
             for (unsigned j = 0; j < _midiMapping.size(); j++) {
                 Channel* a = _midiMapping[j].articulation();
                 bool sameMidiMapping = _midiMapping[i].port() == _midiMapping[j].port()
                                        && _midiMapping[i].channel() == _midiMapping[j].channel();
-                a->setSoloMute((i != j && !a->solo() && !sameMidiMapping));
+                a->setPlaybackMute((i != j && !a->solo() && !sameMidiMapping));
                 a->setSolo(i == j || a->solo() || sameMidiMapping);
             }
         }
@@ -5121,7 +5121,7 @@ void MasterScore::setPlaybackScore(Score* score)
     }
 
     for (MidiMapping& mm : _midiMapping) {
-        mm.articulation()->setSoloMute(true);
+        mm.articulation()->setPlaybackMute(true);
     }
     for (Part* part : score->parts()) {
         for (auto& i : *part->instruments()) {

--- a/mscore/mixer/mixer.cpp
+++ b/mscore/mixer/mixer.cpp
@@ -216,7 +216,7 @@ void Mixer::on_partOnlyCheckBox_toggled(bool checked)
     // Prevent muted channels from sounding
     for (const MidiMapping& mm : _activeScore->masterScore()->midiMapping()) {
         const Channel* ch = mm.articulation();
-        if (ch && (ch->mute() || ch->soloMute())) {
+        if (ch && (ch->mute() || ch->playbackMute())) {
             seq->stopNotes(ch->channel());
         }
     }

--- a/mscore/mixer/mixertrackitem.h
+++ b/mscore/mixer/mixertrackitem.h
@@ -72,6 +72,7 @@ public:
 
     void setMute(bool value);
     void setSolo(bool value);
+    void updatePlaybackMute();
 };
 }
 

--- a/mscore/mixer/mixertrackpart.cpp
+++ b/mscore/mixer/mixertrackpart.cpp
@@ -103,9 +103,10 @@ MixerTrackPart::MixerTrackPart(QWidget* parent, MixerTrackItemPtr mti, bool expa
 
     Channel* chan = _mti->focusedChan();
 
-    soloBn->setChecked(chan->solo());
-    muteBn->setChecked(chan->mute());
+    soloBn->setChecked(part->solo());
+    muteBn->setChecked(part->mute());
 
+    part->addListener(this);
     chan->addListener(this);
     volumeSlider->setValue(chan->volume());
     volumeSlider->setToolTip(tr("Volume: %1").arg(QString::number(chan->volume())));
@@ -243,24 +244,36 @@ void MixerTrackPart::propertyChanged(Channel::Prop property)
         panSlider->blockSignals(false);
         break;
     }
-    case Channel::Prop::MUTE: {
-        muteBn->blockSignals(true);
-        muteBn->setChecked(chan->mute());
-        muteBn->blockSignals(false);
-        break;
-    }
-    case Channel::Prop::SOLO: {
-        soloBn->blockSignals(true);
-        soloBn->setChecked(chan->solo());
-        soloBn->blockSignals(false);
-        break;
-    }
     case Channel::Prop::COLOR: {
         updateNameLabel();
         break;
     }
     default:
         break;
+    }
+}
+
+//---------------------------------------------------------
+//   propertyChanged
+//---------------------------------------------------------
+
+void MixerTrackPart::propertyChanged(Part::Prop property)
+{
+    Part* part = _mti->part();
+
+    switch (property) {
+    case Part::Prop::MUTE: {
+        muteBn->blockSignals(true);
+        muteBn->setChecked(part->mute());
+        muteBn->blockSignals(false);
+        break;
+    }
+    case Part::Prop::SOLO: {
+        soloBn->blockSignals(true);
+        soloBn->setChecked(part->solo());
+        soloBn->blockSignals(false);
+        break;
+    }
     }
 }
 

--- a/mscore/mixer/mixertrackpart.h
+++ b/mscore/mixer/mixertrackpart.h
@@ -25,6 +25,7 @@
 #include "mixertrack.h"
 #include "mixertrackitem.h"
 #include "libmscore/instrument.h"
+#include "libmscore/part.h"
 
 namespace Ms {
 class MidiMapping;
@@ -34,7 +35,7 @@ class MixerTrackItem;
 //   MixerTrackPart
 //---------------------------------------------------------
 
-class MixerTrackPart : public QWidget, public Ui::MixerTrackPart, public ChannelListener, public MixerTrack
+class MixerTrackPart : public QWidget, public Ui::MixerTrackPart, public ChannelListener, public PartListener, public MixerTrack
 {
     Q_OBJECT
 
@@ -67,6 +68,7 @@ public slots:
 protected:
     void mouseReleaseEvent(QMouseEvent* event) override;
     void propertyChanged(Channel::Prop property) override;
+    void propertyChanged(Part::Prop property) override;
 
 public:
     explicit MixerTrackPart(QWidget* parent, MixerTrackItemPtr trackItem, bool expanded);

--- a/mscore/parteditbase.cpp
+++ b/mscore/parteditbase.cpp
@@ -276,7 +276,7 @@ void PartEdit::muteChanged(bool val, bool syncControls)
 void PartEdit::soloToggled(bool val, bool syncControls)
 {
     channel->setSolo(val);
-    channel->setSoloMute(!val);
+    channel->setPlaybackMute(!val);
     if (val) {
         mute->setChecked(false);
         for (Part* p : part->score()->parts()) {
@@ -285,9 +285,9 @@ void PartEdit::soloToggled(bool val, bool syncControls)
                 const Instrument* instr = i->second;
                 for (Channel* instrChan : instr->channel()) {
                     Channel* a = part->masterScore()->playbackChannel(instrChan);
-                    a->setSoloMute((channel != a && !a->solo()));
+                    a->setPlaybackMute((channel != a && !a->solo()));
                     a->setSolo(channel == a || a->solo());
-                    if (a->soloMute()) {
+                    if (a->playbackMute()) {
                         seq->stopNotes(a->channel());
                     }
                 }
@@ -316,7 +316,7 @@ void PartEdit::soloToggled(bool val, bool syncControls)
                     const Instrument* instr = i->second;
                     for (Channel* instrChan : instr->channel()) {
                         Channel* a = part->masterScore()->playbackChannel(instrChan);
-                        a->setSoloMute(false);
+                        a->setPlaybackMute(false);
                         a->setSolo(false);
                     }
                 }


### PR DESCRIPTION
Adding solo and mute boolean flags to Part.
Adding support for listeners to Part.
Rewriting logic so that playback mute state depends on the solo and mute flags of both the Part and the Channel.
These changes are necessary so that both the mixer and new sequencer can read, write and be notified of solo and mute state.

Currently this commit is causing problems due to tst_repeat.cpp.  This was checked in by someone else and has nothing to do with my commit.  It ought to compile after the problems with this file have been fixed.
Resolves: https://musescore.org/en/node/308931

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
