### PR TITLE
Fix #294384: Curly braces do not scale with staff when Bravura or Mus…

### DIFF
--- a/libmscore/bracket.cpp
+++ b/libmscore/bracket.cpp
@@ -242,12 +242,11 @@ void Bracket::draw(QPainter* painter) const
                         }
                   else {
                         qreal h        = 2 * h2;
-                        qreal _spatium = spatium();
-                        qreal mag      = h / (4 *_spatium);
+                        qreal mag      = h / 100;
                         painter->setPen(curColor());
                         painter->save();
                         painter->scale(_magx, mag);
-                        drawSymbol(_braceSymbol, painter, QPointF(0, h/mag));
+                        drawSymbol(_braceSymbol, painter, QPointF(0, 100));
                         painter->restore();
                         }
                   }


### PR DESCRIPTION
…eJazz font is used

Resolves: *https://musescore.org/en/node/294384*

Fixed Bravura and MuseJazz BRACE bracket (curly brace) scaling properly to staff magnitude.
(Removed an unnecessary calculation that was actually making the bracket bigger as the staff was scaled down).

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n/A] I created the test (mtest, vtest, script test) to verify the changes I made
