### PR TITLE
Fix #309665: Alpha (transparency) not showing on several symbols and …

### DIFF
--- a/libmscore/sym.cpp
+++ b/libmscore/sym.cpp
@@ -5774,7 +5774,7 @@ void ScoreFont::draw(SymId id, QPainter* painter, const QSizeF& mag, const QPoin
                   unsigned char* src = (unsigned char*)(bm->buffer) + bm->pitch * y;
                   for (unsigned x = 0; x < bm->width; ++x) {
                         unsigned val = *src++;
-                        color.setAlpha(val);
+                        color.setAlpha(std::min(int(val), painter->pen().color().alpha()));
                         *dst++ = color.rgba();
                         }
                   }


### PR DESCRIPTION
…elements

Resolves: *https://musescore.org/en/node/309665*

Fixes Alpha channel (transparency) not honored in the drawing of Symbols.
Just added a <code>std::min()</code> function in the symbol-to-bitmap converter in the symbol Draw function, so the bitmap pixels' alpha value is never higher than the alpha value set by the user.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
