### PR TITLE
[MU4] Fixed crash on score destructor

### DIFF
--- a/framework/actions/internal/actionsdispatcher.cpp
+++ b/framework/actions/internal/actionsdispatcher.cpp
@@ -22,8 +22,15 @@
 
 using namespace mu::actions;
 
-ActionsDispatcher::ActionsDispatcher()
+ActionsDispatcher::~ActionsDispatcher()
 {
+    for (auto it = m_clients.begin(); it != m_clients.end(); ++it) {
+        Clients& clients = it->second;
+        for (auto cit = clients.begin(); cit != clients.end(); ++cit) {
+            Actionable* client = cit->first;
+            client->setDispatcher(nullptr);
+        }
+    }
 }
 
 void ActionsDispatcher::dispatch(const ActionName& action)
@@ -71,6 +78,7 @@ void ActionsDispatcher::unReg(Actionable* client)
         Clients& clients = it->second;
         clients.erase(client);
     }
+    client->setDispatcher(nullptr);
 }
 
 void ActionsDispatcher::reg(Actionable* client, const ActionName& action, const ActionCallBackWithNameAndData& call)

--- a/framework/actions/internal/actionsdispatcher.h
+++ b/framework/actions/internal/actionsdispatcher.h
@@ -28,7 +28,8 @@ namespace actions {
 class ActionsDispatcher : public IActionsDispatcher
 {
 public:
-    ActionsDispatcher();
+    ActionsDispatcher() = default;
+    ~ActionsDispatcher() override;
 
     void dispatch(const ActionName& a) override;
     void dispatch(const ActionName& action, const ActionData& data) override;

--- a/mu4/context/contextmodule.cpp
+++ b/mu4/context/contextmodule.cpp
@@ -23,6 +23,8 @@
 
 using namespace mu::context;
 
+static std::shared_ptr<GlobalContext> s_globalContext = std::make_shared<GlobalContext>();
+
 std::string ContextModule::moduleName() const
 {
     return "context";
@@ -30,7 +32,11 @@ std::string ContextModule::moduleName() const
 
 void ContextModule::registerExports()
 {
-    auto ctx = std::make_shared<GlobalContext>();
-    framework::ioc()->registerExport<IGlobalContext>(moduleName(), ctx);
-    framework::ioc()->registerExport<shortcuts::IShortcutContextResolver>(moduleName(), ctx);
+    framework::ioc()->registerExport<IGlobalContext>(moduleName(), s_globalContext);
+    framework::ioc()->registerExport<shortcuts::IShortcutContextResolver>(moduleName(), s_globalContext);
+}
+
+void ContextModule::onDeinit()
+{
+    s_globalContext->setCurrentMasterNotation(nullptr);
 }

--- a/mu4/context/contextmodule.h
+++ b/mu4/context/contextmodule.h
@@ -29,6 +29,7 @@ public:
 
     std::string moduleName() const override;
     void registerExports() override;
+    void onDeinit() override;
 };
 }
 }


### PR DESCRIPTION
The static variable `Score::validScores` was removed before the destructor Score was called