### PR TITLE
fix #309754: Create Time Signatures dialogue doesn't need to add special text whenever the internal value of nominator or denominator is changed

### DIFF
--- a/mscore/timedialog.cpp
+++ b/mscore/timedialog.cpp
@@ -127,7 +127,6 @@ void TimeDialog::save()
 
 void TimeDialog::zChanged(int val)
       {
-      zText->setText(QString("%1").arg(val));
       Fraction sig(zNominal->value(), denominator());
       groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text());
       }
@@ -138,7 +137,6 @@ void TimeDialog::zChanged(int val)
 
 void TimeDialog::nChanged(int /*val*/)
       {
-      nText->setText(QString("%1").arg(denominator()));
       Fraction sig(zNominal->value(), denominator());
       groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text());
       }


### PR DESCRIPTION
Resolves: https://musescore.org/node/309754.

Special texts are useful just because they can be different from the internal values. There's no need of updating them if the internal values are changed, because they are either blank (and are most likely wished to still be blank, because then they won't affect the layout of the internal values for the time signature) or different from the original values (and are most likely wished to still be different, because if not, there's no point of having them).

See more in https://musescore.org/node/308139#comment-1022250.