### PR TITLE
Fix #298849: The 2nd note in a passage of grace notes will not tie to the main chord

### DIFF
--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -783,7 +783,7 @@ Note* searchTieNote(Note* note)
 
             // try to tie to next grace note
 
-            int index = chord->graceIndex();
+            int index = note->chord()->graceIndex();
             for (Chord* c : chord->graceNotes()) {
                   if (c->graceIndex() == index + 1) {
                         note2 = c->findNote(note->pitch());


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/298849.

At this point in `searchTieNote()`, `chord`is not pointing to `note->chord()`, but rather to `note->chord()->parent()`. What we are really interested in is the grace index of `note->chord()`, and not that of the parent chord.