### PR TITLE
fix #309760: chord symbols realized before executing dialog

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5934,10 +5934,9 @@ void MuseScore::transpose()
       }
 
 //---------------------------------------------------------
-//   cmdRealizeChordSymbols
+//   realizeChordSymbols
 ///   Realize selected chord symbols into notes on the staff.
-///   Currently just pops up a dialog to list TPCs,
-///   Intervals, and pitches.
+///   Display dialog to offer overrides to default behavior
 //---------------------------------------------------------
 
 void MuseScore::realizeChordSymbols()

--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -200,7 +200,7 @@ void ScoreView::createElementPropertyMenu(Element* e, QMenu* popup)
             genPropertyMenu1(e, popup);
             QAction* a = getAction("realize-chord-symbols");
             if (a)
-                  popup->addAction(a->text() + "…")->setData("realize-chord-symbols-dialog");
+                  popup->addAction(a->text())->setData("realize-chord-symbols-dialog");
             }
       else if (e->isTempoText())
             genPropertyMenu1(e, popup);

--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -198,7 +198,9 @@ void ScoreView::createElementPropertyMenu(Element* e, QMenu* popup)
             }
       else if (e->isHarmony()) {
             genPropertyMenu1(e, popup);
-            popup->addAction(getAction("realize-chord-symbols"));
+            QAction* a = getAction("realize-chord-symbols");
+            if (a)
+                  popup->addAction(a->text() + "…")->setData("realize-chord-symbols-dialog");
             }
       else if (e->isTempoText())
             genPropertyMenu1(e, popup);

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -372,10 +372,15 @@ void ScoreView::objectPopup(const QPoint& pos, Element* obj)
             mscore->selectSimilarInRange(obj);
       else if (cmd == "select-dialog")
             mscore->selectElementDialog(obj);
-      else if (cmd == "realize-chord-symbols") {
+      else if (cmd == "realize-chord-symbols-dialog") {
             if (obj->isEditable()) {
-                  if (obj->score())
-                        obj->score()->select(obj, SelectType::ADD);
+                  // try to construct a reasonable selection
+                  if (obj->score()) {
+                        Score* score = obj->score();
+                        if (score->selection().isRange())
+                              mscore->selectSimilarInRange(obj);
+                        score->select(obj, SelectType::ADD);
+                        }
                   mscore->realizeChordSymbols();
                   }
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/309760

There is a command realize-chord-symbols that you can access
from the tools menu or shortcut if you have defined it,
and also a similarly item on the context menu for chord symbols.
They are slightly differently, however -
the command just runs, whereas the context menu brings up a dialog.
Because they shared the same action,
the context menu was actually executing both versions.
This is fixed by creating a new action for the context menu.
I reuse the name of the command but add an ellipsis,
since it brings up a dialog.

I suppose it's an open question why the behaviors should be different
between invoking this from the Tools menu versus the context menu,
but I'll wait until someone actually complains before changing it.