### PR TITLE
Fix #308821: Fractional Time Signatures Support

### DIFF
--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -1017,6 +1017,8 @@ std::vector<SymId> toTimeSigString(const QString& s)
             { 40,    SymId::timeSigParensLeftSmall  },  // '('
             { 41,    SymId::timeSigParensRightSmall },  // ')'
             { 162,   SymId::timeSigCutCommon        },  // '¢'
+            { 189,   SymId::timeSigFractionHalf     },
+            { 188,   SymId::timeSigFractionQuarter  },
             { 59664, SymId::mensuralProlation1      },
             { 79,    SymId::mensuralProlation2      },  // 'O'
             { 59665, SymId::mensuralProlation2      },

--- a/mscore/timesigproperties.cpp
+++ b/mscore/timesigproperties.cpp
@@ -51,7 +51,7 @@ TimeSigProperties::TimeSigProperties(TimeSig* t, QWidget* parent)
       nText->setText(timesig->denominatorString());
       // set validators for numerator and denominator strings
       // which only accept '+', '(', ')', digits and some time symb conventional representations
-      QRegExp rx("[0-9+CO()\\x00A2\\x00D8]*");
+      QRegExp rx("[0-9+CO()\\x00A2\\x00D8\\x00BD\\x00BC]*");
       QValidator *validator = new QRegExpValidator(rx, this);
       zText->setValidator(validator);
       nText->setValidator(validator);


### PR DESCRIPTION
Resolves: *https://musescore.org/en/node/308821*

Allows Time Signature fractional symbols 1/2 and 1/4 to custom nominator/denominator text (in Time Signature creation dialog and Time Signature properties from inspector).

If the user keyboard doesn't have the ½ or ¼ characters, they can be added via code (in Windows, ALT+0189 and ALT+0188) or  copied from elsewhere and pasted into the text field.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
