### PR TITLE
fix #308139: time signatures created pre-3.5 need special handling to avoid unintended loss of denominator

### DIFF
--- a/libmscore/timesig.cpp
+++ b/libmscore/timesig.cpp
@@ -215,6 +215,18 @@ void TimeSig::read(XmlReader& e)
             _sig.set(z1+z2+z3+z4, n);
             }
       _stretch.reduce();
+
+      // HACK: handle time signatures from scores before 3.5 differently on some special occasions.
+      // See https://musescore.org/node/308139.
+      QString version = masterScore()->mscoreVersion();
+      if (!version.isEmpty() && (version >= "3.0") && (version < "3.5")) {
+            if ((_timeSigType == TimeSigType::NORMAL) && !_numeratorString.isEmpty() && _denominatorString.isEmpty()) {
+                  if (_numeratorString == QString::number(_sig.numerator()))
+                        _numeratorString.clear();
+                  else
+                        setDenominatorString(QString::number(_sig.denominator()));
+                  }
+            }
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/node/308139.

If the numerator text is not empty but the denominator text is, we need special handling because this kind of time signatures look different in 3.4.x and 3.5.x. The denominator is missing in 3.5.x, and this change is not good and expected.

In this situation, if the numerator text is the same as the internal numerator value, the numerator text is removed, changing the appearance of the time signature back to the default look, showing both the numerator and the denominator. If the numerator text is not the same as the internal numerator value, a denominator text is complemented so that both figures are shown without them being different than in 3.4.x.

See https://musescore.org/en/node/308139#comment-1022363.