### PR TITLE
WIP: Large Time Signatures

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -808,6 +808,7 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
                         if (!nsig)
                               continue;
                         nsig->undoChangeProperty(Pid::SHOW_COURTESY, ts->showCourtesySig());
+                        nsig->undoChangeProperty(Pid::TIMESIG_LARGE, ts->largeTimeSig());
                         nsig->undoChangeProperty(Pid::TIMESIG, QVariant::fromValue(ts->sig()));
                         nsig->undoChangeProperty(Pid::TIMESIG_TYPE, int(ts->timeSigType()));
                         nsig->undoChangeProperty(Pid::NUMERATOR_STRING, ts->numeratorString());
@@ -881,6 +882,7 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
                               }
                         else {
                               nsig->undoChangeProperty(Pid::SHOW_COURTESY, ts->showCourtesySig());
+                              nsig->undoChangeProperty(Pid::TIMESIG_LARGE, ts->largeTimeSig());
                               nsig->undoChangeProperty(Pid::TIMESIG_TYPE, int(ts->timeSigType()));
                               nsig->undoChangeProperty(Pid::TIMESIG, QVariant::fromValue(ts->sig()));
                               nsig->undoChangeProperty(Pid::NUMERATOR_STRING, ts->numeratorString());

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -98,6 +98,7 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::TIMESIG_NOMINAL,         false, 0,                       P_TYPE::FRACTION,            DUMMY_QT_TRANSLATE_NOOP("propertyName", "nominal time signature") },
 
       { Pid::TIMESIG_ACTUAL,          true,  0,                       P_TYPE::FRACTION,            DUMMY_QT_TRANSLATE_NOOP("propertyName", "actual time signature") },
+      { Pid::TIMESIG_LARGE,           false, "largeTimeSig",          P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "large time signature") },
       { Pid::NUMBER_TYPE,             false, "numberType",            P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "number type")      },
       { Pid::BRACKET_TYPE,            false, "bracketType",           P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "bracket type")     },
       { Pid::NORMAL_NOTES,            false, "normalNotes",           P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "normal notes")     },

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -105,6 +105,7 @@ enum class Pid {
       TIMESIG_NOMINAL,
 
       TIMESIG_ACTUAL,
+      TIMESIG_LARGE,
       NUMBER_TYPE,
       BRACKET_TYPE,
       NORMAL_NOTES,

--- a/libmscore/sym.cpp
+++ b/libmscore/sym.cpp
@@ -2659,6 +2659,33 @@ const std::array<const char*, int(SymId::lastSym)+1> Sym::symNames = { {
       "braceLarge",
       "braceLarger",
 
+//    SMuFL stylistic alternates for Large Time Signatures
+
+      "timeSig0Large",
+      "timeSig1Large",
+      "timeSig2Large",
+      "timeSig3Large",
+      "timeSig4Large",
+      "timeSig5Large",
+      "timeSig6Large",
+      "timeSig7Large",
+      "timeSig8Large",
+      "timeSig9Large",
+      "timeSigCommonLarge",
+      "timeSigCutCommonLarge",
+      "timeSigFractionHalfLarge",
+      "timeSigFractionOneThirdLarge",
+      "timeSigFractionQuarterLarge",
+      "timeSigFractionThreeQuartersLarge",
+      "timeSigFractionTwoThirdsLarge",
+      "timeSigOpenPendereckiLarge",
+      "timeSigParensLeftLarge",
+      "timeSigParensLeftSmallLarge",
+      "timeSigParensRightLarge",
+      "timeSigParensRightSmallLarge",
+      "timeSigPlusSmallLarge",
+      "timeSigXLarge",
+
 //    MuseScore local symbols, precomposed symbols to mimic some emmentaler glyphs
 
       "ornamentPrallMordent",       // ornamentPrecompTrillWithMordent ?
@@ -5817,7 +5844,7 @@ void ScoreFont::draw(const std::vector<SymId>& ids, QPainter* p, const QSizeF& m
       QPointF pos(_pos);
       for (SymId id : ids) {
             draw(id, p, mag, pos, scale);
-            pos.rx() += (sym(id).advance() * mag.width());
+            pos.rx() += advance(id, mag.width());
             }
       }
 
@@ -6189,6 +6216,102 @@ void ScoreFont::load()
                   {     QString("brace"),
                         QString("braceLarger"),
                         SymId::braceLarger
+                  },
+                  {     QString("timeSig0"),
+                        QString("timeSig0Large"),
+                        SymId::timeSig0Large
+                  },
+                  {     QString("timeSig1"),
+                        QString("timeSig1Large"),
+                        SymId::timeSig1Large
+                  },
+                  {     QString("timeSig2"),
+                        QString("timeSig2Large"),
+                        SymId::timeSig2Large
+                  },
+                  {     QString("timeSig3"),
+                        QString("timeSig3Large"),
+                        SymId::timeSig3Large
+                  },
+                  {     QString("timeSig4"),
+                        QString("timeSig4Large"),
+                        SymId::timeSig4Large
+                  },
+                  {     QString("timeSig5"),
+                        QString("timeSig5Large"),
+                        SymId::timeSig5Large
+                  },
+                  {     QString("timeSig6"),
+                        QString("timeSig6Large"),
+                        SymId::timeSig6Large
+                  },
+                  {     QString("timeSig7"),
+                        QString("timeSig7Large"),
+                        SymId::timeSig7Large
+                  },
+                  {     QString("timeSig8"),
+                        QString("timeSig8Large"),
+                        SymId::timeSig8Large
+                  },
+                  {     QString("timeSig9"),
+                        QString("timeSig9Large"),
+                        SymId::timeSig9Large
+                  },
+                  {     QString("timeSigCommon"),
+                        QString("timeSigCommonLarge"),
+                        SymId::timeSigCommonLarge
+                  },
+                  {     QString("timeSigCutCommon"),
+                        QString("timeSigCutCommonLarge"),
+                        SymId::timeSigCutCommonLarge
+                  },
+                  {     QString("timeSigFractionHalf"),
+                        QString("timeSigFractionHalfLarge"),
+                        SymId::timeSigFractionHalfLarge
+                  },
+                  {     QString("timeSigFractionOneThird"),
+                        QString("timeSigFractionOneThirdLarge"),
+                        SymId::timeSigFractionOneThirdLarge
+                  },
+                  {     QString("timeSigFractionQuarter"),
+                        QString("timeSigFractionQuarterLarge"),
+                        SymId::timeSigFractionQuarterLarge
+                  },
+                  {     QString("timeSigFractionThreeQuarters"),
+                        QString("timeSigFractionThreeQuartersLarge"),
+                        SymId::timeSigFractionThreeQuartersLarge
+                  },
+                  {     QString("timeSigFractionTwoThirds"),
+                        QString("timeSigFractionTwoThirdsLarge"),
+                        SymId::timeSigFractionTwoThirdsLarge
+                  },
+                  {     QString("timeSigOpenPenderecki"),
+                        QString("timeSigOpenPendereckiLarge"),
+                        SymId::timeSigOpenPendereckiLarge
+                  },
+                  {     QString("timeSigParensLeft"),
+                        QString("timeSigParensLeftLarge"),
+                        SymId::timeSigParensLeftLarge
+                  },
+                  {     QString("timeSigParensLeftSmall"),
+                        QString("timeSigParensLeftSmallLarge"),
+                        SymId::timeSigParensLeftSmallLarge
+                  },
+                  {     QString("timeSigParensRight"),
+                        QString("timeSigParensRightLarge"),
+                        SymId::timeSigParensRightLarge
+                  },
+                  {     QString("timeSigParensRightSmall"),
+                        QString("timeSigParensRightSmallLarge"),
+                        SymId::timeSigParensRightSmallLarge
+                  },
+                  {     QString("timeSigPlusSmall"),
+                        QString("timeSigPlusSmallLarge"),
+                        SymId::timeSigPlusSmallLarge
+                  },
+                  {     QString("timeSigX"),
+                        QString("timeSigXLarge"),
+                        SymId::timeSigXLarge
                   }
             };
 
@@ -6323,7 +6446,7 @@ const QRectF ScoreFont::bbox(SymId id, qreal mag) const
 const QRectF ScoreFont::bbox(SymId id, const QSizeF& mag) const
       {
       if (useFallbackFont(id))
-            return fallbackFont()->bbox(id, mag.width());
+            return fallbackFont()->bbox(id, mag);
       QRectF r = sym(id).bbox();
       return QRectF(r.x() * mag.width(), r.y() * mag.height(), r.width() * mag.width(), r.height() * mag.height());
       }

--- a/libmscore/sym.h
+++ b/libmscore/sym.h
@@ -2656,6 +2656,33 @@ enum class SymId {
       braceLarge,
       braceLarger,
 
+//    SMuFL stylistic alternates for Large Time Signatures
+
+      timeSig0Large,
+      timeSig1Large,
+      timeSig2Large,
+      timeSig3Large,
+      timeSig4Large,
+      timeSig5Large,
+      timeSig6Large,
+      timeSig7Large,
+      timeSig8Large,
+      timeSig9Large,
+      timeSigCommonLarge,
+      timeSigCutCommonLarge,
+      timeSigFractionHalfLarge,
+      timeSigFractionOneThirdLarge,
+      timeSigFractionQuarterLarge,
+      timeSigFractionThreeQuartersLarge,
+      timeSigFractionTwoThirdsLarge,
+      timeSigOpenPendereckiLarge,
+      timeSigParensLeftLarge,
+      timeSigParensLeftSmallLarge,
+      timeSigParensRightLarge,
+      timeSigParensRightSmallLarge,
+      timeSigPlusSmallLarge,
+      timeSigXLarge,
+
 //    MuseScore local symbols, precomposed symbols to mimic some emmentaler glyphs
 
       ornamentPrallMordent,

--- a/libmscore/timesig.h
+++ b/libmscore/timesig.h
@@ -56,6 +56,7 @@ class TimeSig final : public Element {
       QSizeF _scale;
       TimeSigType _timeSigType;
       bool _showCourtesySig;
+      bool  _largeTimeSig;
       bool _largeParentheses;
 
    public:
@@ -97,6 +98,9 @@ class TimeSig final : public Element {
 
       bool showCourtesySig() const       { return _showCourtesySig; }
       void setShowCourtesySig(bool v)    { _showCourtesySig = v;    }
+
+      int  largeTimeSig() const          { return _largeTimeSig;    } 
+      void setLargeTimeSig(bool v)       { _largeTimeSig = v;       }
 
       QString numeratorString() const    { return _numeratorString;   }
       void setNumeratorString(const QString&);

--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -997,46 +997,60 @@ Segment* skipTuplet(Tuplet* tuplet)
 
 std::vector<SymId> toTimeSigString(const QString& s)
       {
+      return toTimeSigString(s,0);       
+      }
+
+std::vector<SymId> toTimeSigString(const QString& s, int isLarge)
+      {
       struct Dict {
             QChar code;
-            SymId id;
+            SymId id[2];
             };
       static const std::vector<Dict> dict = {
-            { 43,    SymId::timeSigPlusSmall        },  // '+'
-            { 48,    SymId::timeSig0                },  // '0'
-            { 49,    SymId::timeSig1                },  // '1'
-            { 50,    SymId::timeSig2                },  // '2'
-            { 51,    SymId::timeSig3                },  // '3'
-            { 52,    SymId::timeSig4                },  // '4'
-            { 53,    SymId::timeSig5                },  // '5'
-            { 54,    SymId::timeSig6                },  // '6'
-            { 55,    SymId::timeSig7                },  // '7'
-            { 56,    SymId::timeSig8                },  // '8'
-            { 57,    SymId::timeSig9                },  // '9'
-            { 67,    SymId::timeSigCommon           },  // 'C'
-            { 40,    SymId::timeSigParensLeftSmall  },  // '('
-            { 41,    SymId::timeSigParensRightSmall },  // ')'
-            { 162,   SymId::timeSigCutCommon        },  // '¢'
-            { 189,   SymId::timeSigFractionHalf     },
-            { 188,   SymId::timeSigFractionQuarter  },
-            { 59664, SymId::mensuralProlation1      },
-            { 79,    SymId::mensuralProlation2      },  // 'O'
-            { 59665, SymId::mensuralProlation2      },
-            { 216,   SymId::mensuralProlation3      },  // 'Ø'
-            { 59666, SymId::mensuralProlation3      },
-            { 59667, SymId::mensuralProlation4      },
-            { 59668, SymId::mensuralProlation5      },
-            { 59670, SymId::mensuralProlation7      },
-            { 59671, SymId::mensuralProlation8      },
-            { 59673, SymId::mensuralProlation10     },
-            { 59674, SymId::mensuralProlation11     },
+            //ascii       SymId                                SymId (Large alternates)            
+            { 43,    { SymId::timeSigPlusSmall,             SymId::timeSigPlusSmallLarge        }  },  // '+'
+            { 48,    { SymId::timeSig0,                     SymId::timeSig0Large                }  },  // '0'
+            { 49,    { SymId::timeSig1,                     SymId::timeSig1Large                }  },  // '1'
+            { 50,    { SymId::timeSig2,                     SymId::timeSig2Large                }  },  // '2'
+            { 51,    { SymId::timeSig3,                     SymId::timeSig3Large                }  },  // '3'
+            { 52,    { SymId::timeSig4,                     SymId::timeSig4Large                }  },  // '4'
+            { 53,    { SymId::timeSig5,                     SymId::timeSig5Large                }  },  // '5'
+            { 54,    { SymId::timeSig6,                     SymId::timeSig6Large                }  },  // '6'
+            { 55,    { SymId::timeSig7,                     SymId::timeSig7Large                }  },  // '7'
+            { 56,    { SymId::timeSig8,                     SymId::timeSig8Large                }  },  // '8'
+            { 57,    { SymId::timeSig9,                     SymId::timeSig9Large                }  },  // '9'
+            { 67,    { SymId::timeSigCommon,                SymId::timeSigCommonLarge           }  },  // 'C'
+            { 40,    { SymId::timeSigParensLeftSmall,       SymId::timeSigParensLeftSmallLarge  }  },  // '('
+            { 41,    { SymId::timeSigParensRightSmall,      SymId::timeSigParensRightSmallLarge }  },  // ')'
+            { 162,   { SymId::timeSigCutCommon,             SymId::timeSigCutCommonLarge        }  },  // '¢'
+            { 59664, { SymId::mensuralProlation1,           SymId::mensuralProlation1           }  },
+            { 79,    { SymId::mensuralProlation2,           SymId::mensuralProlation2           }  },  // 'O'
+            { 59665, { SymId::mensuralProlation2,           SymId::mensuralProlation2           }  },
+            { 216,   { SymId::mensuralProlation3,           SymId::mensuralProlation3           }  },  // 'Ø'
+            { 59666, { SymId::mensuralProlation3,           SymId::mensuralProlation3           }  },
+            { 59667, { SymId::mensuralProlation4,           SymId::mensuralProlation4           }  },
+            { 59668, { SymId::mensuralProlation5,           SymId::mensuralProlation5           }  },
+            { 59670, { SymId::mensuralProlation7,           SymId::mensuralProlation7           }  },
+            { 59671, { SymId::mensuralProlation8,           SymId::mensuralProlation8           }  },
+            { 59673, { SymId::mensuralProlation10,          SymId::mensuralProlation10          }  },
+            { 59674, { SymId::mensuralProlation11,          SymId::mensuralProlation11          }  },
+            { 188,   { SymId::timeSigFractionQuarter,       SymId::timeSigFractionQuarterLarge  }  },  // '¼'
+            { 57495, { SymId::timeSigFractionQuarter,       SymId::timeSigFractionQuarterLarge  }  }, 
+            { 189,   { SymId::timeSigFractionHalf,          SymId::timeSigFractionHalfLarge     }  },  // '½'
+            { 57496, { SymId::timeSigFractionHalf,          SymId::timeSigFractionHalfLarge     }  },
+            { 57497, { SymId::timeSigFractionThreeQuarters, SymId::timeSigFractionThreeQuartersLarge }  },
+            { 190,   { SymId::timeSigFractionThreeQuarters, SymId::timeSigFractionThreeQuartersLarge }  }, // '¾'
+            { 57498, { SymId::timeSigFractionOneThird,      SymId::timeSigFractionOneThirdLarge      }  },
+            { 57499, { SymId::timeSigFractionTwoThirds,     SymId::timeSigFractionTwoThirdsLarge     }  },
+            { 88,    { SymId::timeSigX,                     SymId::timeSigXLarge                     }  }, // 'X'
+            { 126,   { SymId::timeSigOpenPenderecki,        SymId::timeSigOpenPendereckiLarge,       }  }, // '~'
             };
 
       std::vector<SymId> d;
       for (auto c : s) {
             for (const Dict& e : dict) {
                   if (c == e.code) {
-                        d.push_back(e.id);
+                        d.push_back(e.id[isLarge]);
                         break;
                         }
                   }

--- a/libmscore/utils.h
+++ b/libmscore/utils.h
@@ -88,6 +88,7 @@ extern int step2pitch(int step);
 
 extern Segment* skipTuplet(Tuplet* tuplet);
 extern std::vector<SymId> toTimeSigString(const QString&);
+extern std::vector<SymId> toTimeSigString(const QString& s, int isLarge);
 extern Fraction actualTicks(Fraction duration, Tuplet* tuplet, Fraction timeStretch);
 
 }     // namespace Ms

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -905,6 +905,7 @@ InspectorTimeSig::InspectorTimeSig(QWidget* parent)
       const std::vector<InspectorItem> iiList = {
             { Pid::LEADING_SPACE,  1, s.leadingSpace,   s.resetLeadingSpace  },
             { Pid::SHOW_COURTESY,  0, t.showCourtesy,   t.resetShowCourtesy  },
+            { Pid::TIMESIG_LARGE,   0, t.largeStyle,     t.resetLargeStyle    },
             { Pid::SCALE,          0, t.scale,          t.resetScale         },
 //          { Pid::TIMESIG,        0, t.timesigZ,       t.resetTimesig       },
 //          { Pid::TIMESIG,        0, t.timesigN,       t.resetTimesig       },

--- a/mscore/inspector/inspector_timesig.ui
+++ b/mscore/inspector/inspector_timesig.ui
@@ -79,13 +79,33 @@
       <property name="spacing">
        <number>3</number>
       </property>
-      <item row="0" column="0" colspan="2">
-       <widget class="QCheckBox" name="showCourtesy">
-        <property name="focusPolicy">
-         <enum>Qt::TabFocus</enum>
-        </property>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label">
         <property name="text">
-         <string>Show courtesy</string>
+         <string>Scale:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Ms::ScaleSelect" name="scale" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Scale</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="3">
+       <widget class="QPushButton" name="properties">
+        <property name="text">
+         <string>Properties</string>
         </property>
        </widget>
       </item>
@@ -102,30 +122,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Scale:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="Ms::ScaleSelect" name="scale" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Scale</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
+      <item row="3" column="2">
        <widget class="Ms::ResetButton" name="resetScale" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -138,10 +135,36 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="3">
-       <widget class="QPushButton" name="properties">
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="showCourtesy">
+        <property name="focusPolicy">
+         <enum>Qt::TabFocus</enum>
+        </property>
         <property name="text">
-         <string>Properties</string>
+         <string>Show courtesy</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="Ms::ResetButton" name="resetLargeStyle" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Show courtesy' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="largeStyle">
+        <property name="focusPolicy">
+         <enum>Qt::TabFocus</enum>
+        </property>
+        <property name="text">
+         <string>Large Time Signature</string>
         </property>
        </widget>
       </item>

--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -495,6 +495,7 @@ void ScoreView::editTimeSigProperties(TimeSig* ts)
 
       if (tsp.exec()) {
             ts->undoChangeProperty(Pid::SHOW_COURTESY, r->showCourtesySig());
+            ts->undoChangeProperty(Pid::TIMESIG_LARGE, r->largeTimeSig());
             ts->undoChangeProperty(Pid::NUMERATOR_STRING, r->numeratorString());
             ts->undoChangeProperty(Pid::DENOMINATOR_STRING, r->denominatorString());
             ts->undoChangeProperty(Pid::TIMESIG_TYPE, int(r->timeSigType()));

--- a/mscore/timesigproperties.cpp
+++ b/mscore/timesigproperties.cpp
@@ -51,7 +51,7 @@ TimeSigProperties::TimeSigProperties(TimeSig* t, QWidget* parent)
       nText->setText(timesig->denominatorString());
       // set validators for numerator and denominator strings
       // which only accept '+', '(', ')', digits and some time symb conventional representations
-      QRegExp rx("[0-9+CO()\\x00A2\\x00D8\\x00BD\\x00BC]*");
+      QRegExp rx("[0-9+CO()~X\\x00A2\\x00D8\\x00BC\\x00BD\\x00BE\\xE097\\xE098\\xE099\\xE09A\\xE09B\\xE09C\\xE09D]*");
       QValidator *validator = new QRegExpValidator(rx, this);
       zText->setValidator(validator);
       nText->setValidator(validator);


### PR DESCRIPTION
Resolves: *https://musescore.org/en/node/121336*

Related links:
https://musescore.org/en/node/298789
https://musescore.org/en/node/290091
https://musescore.org/en/node/25031
https://musescore.org/en/node/298308

This PR implements the "Large" SMuFL alternate glyphs (a narrow sans font) and adds a checkbox to the Time Signature inspector, to toggle between regular and alternate Large style. 
(see https://w3c.github.io/smufl/gitbook/tables/time-signatures.html under Recommended Styling Alternates)

This simplifies the workflow for Large time signatures: 
1. Select all time/signatures on a staff (via Select Similar...) 
2. Click on the inspector "Large Time Signature" checkbox
3. Scale and position the signatures using the inspector
4. Select and hide all key signatures in other staves if desired.

This PR doesn't automatically enlarge the symbols. (Might be a good idea to automate that - for instance, if user clicks on "Large Time Signatures", the t/s would scale to a certain value (3,3) - and unchecking the checkbox would reset scale to (1,1) 

![image](https://user-images.githubusercontent.com/2843953/91682844-414d6880-eb29-11ea-8046-8bb26868535f.png)

Additionally, the following glyphs have been added for use on Time Signatures (both as regular and "Large" alternative) 
- All timeSigFraction(s)  (Quarter, Half, TwoThirds, ThreeQuarters, OneThird)
- timeSigX
- timeSigOpenPenderecki (`~`)

~TODO:~ 
- ~Fix spacing: Time signatures with more than one digit on num/denom (i.e. 10/16) work fine when using Bravura, but not Emmentaler or the other fonts in Style.~ Fixed
- ~Add the Large parenthesis for the whole t/s (forgot that glyph)~

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [NA] I created the test (mtest, vtest, script test) to verify the changes I made
