### PR TITLE
fix #309860, fix #294941: crash in tablature

### DIFF
--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -392,13 +392,12 @@ void Rest::layout()
       rxpos() = 0.0;
       const StaffType* stt = staffType();
       if (stt && stt->isTabStaff()) {
-            const StaffType* tab = stt;
             // if rests are shown and note values are shown as duration symbols
-            if (tab->showRests() && tab->genDurations()) {
+            if (stt->showRests() && stt->genDurations()) {
                   TDuration::DurationType type = durationType().type();
                   int                     dots = durationType().dots();
                   // if rest is whole measure, convert into actual type and dot values
-                  if (type == TDuration::DurationType::V_MEASURE) {
+                  if (type == TDuration::DurationType::V_MEASURE && measure()) {
                         Fraction ticks = measure()->ticks();
                         TDuration dur  = TDuration(ticks).type();
                         type           = dur.type();
@@ -406,9 +405,9 @@ void Rest::layout()
                         }
                   // symbol needed; if not exist, create, if exists, update duration
                   if (!_tabDur)
-                        _tabDur = new TabDurationSymbol(score(), tab, type, dots);
+                        _tabDur = new TabDurationSymbol(score(), stt, type, dots);
                   else
-                        _tabDur->setDuration(type, dots, tab);
+                        _tabDur->setDuration(type, dots, stt);
                   _tabDur->setParent(this);
 // needed?        _tabDur->setTrack(track());
                   _tabDur->layout();


### PR DESCRIPTION
Resolves https://musescore.org/de/node/294941 and the crash part reported in https://musescore.org/de/node/309860

Affects at least custom tablature with "Show Rests" and "Durations", imported from MuseScore 2. Not sure exactly what the real trigger is though

Not a 3.5 regression nor a very common crash scenario, so may well wait for 3.6.