### PR TITLE
fix #309852: undefined playback of chord symbol attached to fret diagram

### DIFF
--- a/libmscore/harmony.h
+++ b/libmscore/harmony.h
@@ -109,7 +109,6 @@ class Harmony final : public TextBase {
       void render(const QList<RenderAction>& renderList, qreal&, qreal&, int tpc, NoteSpellingType noteSpelling = NoteSpellingType::STANDARD, NoteCaseType noteCase = NoteCaseType::AUTO);
       Sid getPropertyStyle(Pid) const override;
 
-      Segment* getParentSeg() const;
       Harmony* findInSeg(Segment* seg) const;
 
    public:
@@ -137,6 +136,7 @@ class Harmony final : public TextBase {
       Harmony* findNext() const;
       Harmony* findPrev() const;
       Fraction ticksTilNext(bool stopAtMeasureEnd = false) const;
+      Segment* getParentSeg() const;
 
       const ChordDescription* descr() const;
       const ChordDescription* descr(const QString&, const ParsedChord* pc = 0) const;

--- a/libmscore/realizedharmony.cpp
+++ b/libmscore/realizedharmony.cpp
@@ -24,6 +24,7 @@
 #include "harmony.h"
 #include "fraction.h"
 #include "segment.h"
+#include "chordrest.h"
 
 namespace Ms {
 
@@ -250,9 +251,23 @@ Fraction RealizedHarmony::getActualDuration(HDuration durationType) const
             case HDuration::STOP_AT_MEASURE_END:
                   return _harmony->ticksTilNext(true);
                   break;
-            case HDuration::SEGMENT_DURATION:
-                  return toSegment(_harmony->parent())->ticks();
+            case HDuration::SEGMENT_DURATION: {
+                  Segment* s = _harmony->getParentSeg();
+                  if (s) {
+                        // TODO - use duration of chordrest on this segment / track
+                        // currently, this will result in too short of a duration
+                        // if there are shorter notes on other staves
+                        // but, we can only do this up to the next harmony that is being realized,
+                        // or elese we would get overlap
+                        // (e.g., if the notes are dotted half / quarter, but chords are half / half,
+                        // then we can't actually make the first chord a dotted half)
+                        return s->ticks();
+                        }
+                  else {
+                        return Fraction(0, 1);
+                        }
                   break;
+                  }
             default:
                   return Fraction(0, 1);
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/309852

If a chord symbol has "Chord/Rest Duration" in its playback properties,
and the chord symbol has a fret diagram as a parent,
then the results are not defined, but can potentially crash,
as we are casting the parent to a segment when it isn't.
This yields an assertion failure in debug builds,
just randomly bad results in release builds.

Avoiding the crash is simple, I changed parent() to getParentSeg().
I realize, though, that segment duration isn't really the same
as chord/rest duration, since there might be content on other tracks
that results in the segment duration being shorter.
Or, for that matter, another chord symbol on this track.
Eventually we should look at really making this chord/rest duration.
My initial attempt created corruption if there was in fact
another chord symbol on the same track before the end
of the current chord/rest duration.
Fixing this is no doubt possible, and something to consider.
I left a TODO for this.