### PR TITLE
Followup to PR #6443: Fix assertion failure in ElementRepositoryService::findTremolos()

### DIFF
--- a/mu4/inspector/internal/services/elementrepositoryservice.cpp
+++ b/mu4/inspector/internal/services/elementrepositoryservice.cpp
@@ -335,12 +335,14 @@ QList<Ms::Element*> ElementRepositoryService::findTremolos() const
     QList<Ms::Element*> resultList;
 
     for (Ms::Element* element : m_elementList) {
-        Ms::Tremolo* tremolo = Ms::toTremolo(element);
-        // currently only minim-based two-note tremolos on non-TAB staves enable the tremolo section
-        // because there's only one setting and it's only applicable to those tremolos
-        if (tremolo->twoNotes() && (tremolo->durationType().type() == Ms::TDuration::DurationType::V_HALF)
-            && (tremolo->staffType()->group() != Ms::StaffGroup::TAB)) {
-            resultList << element;
+        if (element->isTremolo()) {
+            Ms::Tremolo* tremolo = Ms::toTremolo(element);
+            // currently only minim-based two-note tremolos on non-TAB staves enable the tremolo section
+            // because there's only one setting and it's only applicable to those tremolos
+            if (tremolo->twoNotes() && (tremolo->durationType().type() == Ms::TDuration::DurationType::V_HALF)
+                && (tremolo->staffType()->group() != Ms::StaffGroup::TAB)) {
+                resultList << element;
+            }
         }
     }
 


### PR DESCRIPTION
We need to make sure that `element` is actually a tremolo before casting it to a `Tremolo`.

See https://github.com/musescore/MuseScore/pull/6443#pullrequestreview-476853966.