### PR TITLE
fix #308469: changing portaudio preferences does not work (3.x) 

### DIFF
--- a/mscore/preferenceslistwidget.cpp
+++ b/mscore/preferenceslistwidget.cpp
@@ -230,7 +230,6 @@ IntPreferenceItem::IntPreferenceItem(QString name, QSpinBox* editor, std::functi
 
 IntPreferenceItem::IntPreferenceItem(QString name, QComboBox* editor, std::function<void()> applyFunc, std::function<void()> updateFunc)
       : PreferenceItem(name),
-        _initialValue(preferences.getInt(name)),
         _editorComboBox(editor)
       {
       int index = _editorComboBox->findData(preferences.getInt(name));
@@ -255,7 +254,6 @@ void IntPreferenceItem::apply()
                   }
             else if (_editorComboBox) {
                   int newValue = _editorComboBox->currentData().toInt();
-                  _initialValue = newValue;
                   PreferenceItem::apply(newValue);
                   _initialEditorIndex = _editorComboBox->currentIndex();
                   }
@@ -363,7 +361,6 @@ DoublePreferenceItem::DoublePreferenceItem(QString name, QDoubleSpinBox* editor,
 
 DoublePreferenceItem::DoublePreferenceItem(QString name, QComboBox* editor, std::function<void()> applyFunc, std::function<void()> updateFunc)
       : PreferenceItem(name),
-        _initialValue(preferences.getDouble(name)),
         _editorComboBox(editor)
       {
       int index = _editorComboBox->findData(preferences.getDouble(name));
@@ -401,14 +398,13 @@ void DoublePreferenceItem::apply()
                   }
             else if (_editorComboBox) {
                   double newValue = _editorComboBox->currentData().toDouble();
-                  _initialValue = newValue;
                   PreferenceItem::apply(newValue);
+                   _initialEditorIndex = _editorComboBox->currentIndex();
                   }
             else if (_editorSpinBox) {
                   double newValue = _editorSpinBox->value();
                   _initialValue = newValue;
                   PreferenceItem::apply(newValue);
-                  _initialEditorIndex = _editorComboBox->currentIndex();
                   }
             }
       }
@@ -679,7 +675,6 @@ StringPreferenceItem::StringPreferenceItem(QString name, QFontComboBox* editor, 
 
 StringPreferenceItem::StringPreferenceItem(QString name, QComboBox* editor, std::function<void()> applyFunc, std::function<void()> updateFunc)
       : PreferenceItem(name),
-        _initialValue(preferences.getString(name)),
         _editorComboBox(editor)
       {
       int index = _editorComboBox->findData(preferences.getString(name));
@@ -723,7 +718,6 @@ void StringPreferenceItem::apply()
                   }
             else if (_editorComboBox) {
                   QString newValue = _editorComboBox->currentText();
-                  _initialValue = newValue;
                   PreferenceItem::apply(newValue);
                   _initialEditorIndex = _editorComboBox->currentIndex();;
                   }

--- a/mscore/preferenceslistwidget.h
+++ b/mscore/preferenceslistwidget.h
@@ -59,7 +59,7 @@ class PreferenceItem : public QObject, public QTreeWidgetItem {
 //   BoolPreferenceItem
 //---------------------------------------------------------
 class BoolPreferenceItem : public PreferenceItem {
-      bool _initialValue;
+      bool _initialValue                        { false };
       QCheckBox* _editorCheckBox                { nullptr };
       QGroupBox* _editorGroupBox                { nullptr };
       QRadioButton* _editorRadioButton          { nullptr };
@@ -85,7 +85,7 @@ class BoolPreferenceItem : public PreferenceItem {
 //   IntPreferenceItem
 //---------------------------------------------------------
 class IntPreferenceItem : public PreferenceItem {
-      int _initialValue;
+      int _initialValue                         { 0 };
       int _initialEditorIndex                   { -1 };
       QSpinBox* _editorSpinBox                  { nullptr };
       QComboBox* _editorComboBox                { nullptr };


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/308469
3.x version of: #6423 

PortAudio does not work perfectly on my machine (options are missing), but I don't think that has to do with the preferences. The problem was that the preferences related to it were not added to the new system. I added them and fixed some bugs with combo boxes.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made