### PR TITLE
Fix #300340: Additive Time Signatures Do Not Appear Properly in the G…

### DIFF
--- a/libmscore/sym.cpp
+++ b/libmscore/sym.cpp
@@ -6236,7 +6236,7 @@ void ScoreFont::draw(const std::vector<SymId>& ids, QPainter* p, const QSizeF& m
       QPointF pos(_pos);
       for (SymId id : ids) {
             draw(id, p, mag, pos, scale);
-            pos.rx() += (sym(id).advance() * mag.width());
+            pos.rx() += advance(id, mag.width());
             }
       }
 
@@ -6745,7 +6745,7 @@ const QRectF ScoreFont::bbox(SymId id, qreal mag) const
 const QRectF ScoreFont::bbox(SymId id, const QSizeF& mag) const
       {
       if (useFallbackFont(id))
-            return fallbackFont()->bbox(id, mag.width());
+            return fallbackFont()->bbox(id, mag);
       QRectF r = sym(id).bbox();
       return QRectF(r.x() * mag.width(), r.y() * mag.height(), r.width() * mag.width(), r.height() * mag.height());
       }


### PR DESCRIPTION
…onville Font

Resolves: *https://musescore.org/en/node/300340*

**Fixes a series of problems with spacing** in which a sequence of glyphs is drawn as a string, and in particular, the 'advance' space value that was set to zero in case of a fallback glyph.
This includes sequence of time signature glyphs in certain fonts including Goinville, some sequences of glyphs that build mordents and ornaments, and some problems with dynamics with more than one glyph (ppp, fff).

For horizontal spacing:
_Found a call to ScoreFont::advance() that pointed to an override version that didn't compute the _advance value from the fallbackFont. Because of this, the missing + glyph was drawn from the fallbackFont but its advance was set to zero._

For vertical spacing (when stretching the time signature):
_Found a call to ScoreFont::BBox() that pointed to an override version that didn't allow scaling in different horizontal and vertical dimensions.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
