### PR TITLE
[MU4] Added load qml from source files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,7 @@ set(TELEMETRY_TRACK_ID "" CACHE STRING "Telemetry track id")
 option(BUILD_UI_MU4 "Build Modern UI MuseScore 4" OFF)
 option(BUILD_UI_MU4_WITH_MU3 "Build Modern UI MuseScore 4 and MU3 source code" OFF)
 option(BUILD_UNIT_TESTS "Build gtest unit test" OFF)
+option(QML_LOAD_FROM_SOURCE "Load qml files from source (not resource)" OFF)
 
 SET(VST3_SDK_VERSION "3.7")
 option(BUILD_VST "Build VST MODULE" OFF)

--- a/build/config.h.in
+++ b/build/config.h.in
@@ -63,6 +63,7 @@
 #cmakedefine SOUNDFONT3
 
 #cmakedefine BUILD_UI_MU4
+#cmakedefine QML_LOAD_FROM_SOURCE
 #cmakedefine BUILD_VST
 
 #cmakedefine Q_WS_UIKIT

--- a/build/module.cmake
+++ b/build/module.cmake
@@ -68,6 +68,7 @@ target_include_directories(${MODULE} PUBLIC
 
 target_compile_definitions(${MODULE} PUBLIC
     ${MODULE_DEF}
+    ${MODULE}_QML_IMPORT="${MODULE_QML_IMPORT}"
 )
 
 if(NOT ${MODULE} MATCHES global)

--- a/framework/audio/audiomodule.cpp
+++ b/framework/audio/audiomodule.cpp
@@ -30,6 +30,7 @@
 #include "internal/worker/audiothreadstreamworker.h"
 #include "internal/rpcmidisource.h"
 
+#include "ui/iuiengine.h"
 #include "devtools/audioenginedevtools.h"
 
 #ifdef Q_OS_LINUX
@@ -80,6 +81,9 @@ void AudioModule::registerExports()
 void AudioModule::registerUiTypes()
 {
     qmlRegisterType<AudioEngineDevTools>("MuseScore.Audio", 1, 0, "AudioEngineDevTools");
+
+    //! NOTE No Qml, as it will be, need to uncomment
+    //framework::ioc()->resolve<framework::IUiEngine>(moduleName())->addSourceImportPath(mu4_audio_QML_IMPORT);
 }
 
 void AudioModule::onInit()

--- a/framework/midi/midimodule.cpp
+++ b/framework/midi/midimodule.cpp
@@ -37,6 +37,7 @@
 
 #include "internal/synthesizercontroller.h"
 
+#include "ui/iuiengine.h"
 #include "devtools/midiportdevmodel.h"
 
 using namespace mu::midi;
@@ -93,6 +94,9 @@ void MidiModule::registerUiTypes()
 {
     qmlRegisterType<SynthsSettingsModel>("MuseScore.Midi", 1, 0, "SynthsSettingsModel");
     qmlRegisterType<MidiPortDevModel>("MuseScore.Midi", 1, 0, "MidiPortDevModel");
+
+    //! NOTE No Qml, as it will be, need to uncomment
+    //framework::ioc()->resolve<framework::IUiEngine>(moduleName())->addSourceImportPath(mu4_midi_QML_IMPORT);
 }
 
 void MidiModule::onInit()

--- a/framework/shortcuts/shortcutsmodule.cpp
+++ b/framework/shortcuts/shortcutsmodule.cpp
@@ -20,11 +20,15 @@
 
 #include <QtQml>
 
+#include "log.h"
+
 #include "modularity/ioc.h"
 #include "internal/shortcutsinstancemodel.h"
 #include "internal/shortcutsregister.h"
 #include "internal/shortcutscontroller.h"
 #include "internal/midiremote.h"
+
+#include "ui/iuiengine.h"
 
 using namespace mu::shortcuts;
 
@@ -55,6 +59,8 @@ void ShortcutsModule::registerResources()
 void ShortcutsModule::registerUiTypes()
 {
     qmlRegisterType<ShortcutsInstanceModel>("MuseScore.Shortcuts", 1, 0, "ShortcutsInstanceModel");
+
+    framework::ioc()->resolve<framework::IUiEngine>(moduleName())->addSourceImportPath(shortcuts_QML_IMPORT);
 }
 
 void ShortcutsModule::onInit()

--- a/framework/ui/CMakeLists.txt
+++ b/framework/ui/CMakeLists.txt
@@ -19,6 +19,9 @@
 
 set(MODULE ui)
 
+set(MODULE_QRC ui.qrc)
+set(MODULE_QML_IMPORT ${CMAKE_CURRENT_LIST_DIR}/qml)
+
 set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/uimodule.cpp
     ${CMAKE_CURRENT_LIST_DIR}/uimodule.h
@@ -62,8 +65,5 @@ set(MODULE_SRC
 set(MODULE_UI
     ${CMAKE_CURRENT_LIST_DIR}/dev/testdialog.ui
     )
-
-set(MODULE_QRC ui.qrc)
-set(MODULE_QML_IMPORT ${CMAKE_CURRENT_LIST_DIR}/qml )
 
 include(${PROJECT_SOURCE_DIR}/build/module.cmake)

--- a/framework/ui/internal/uiengine.cpp
+++ b/framework/ui/internal/uiengine.cpp
@@ -25,6 +25,7 @@
 #include <QDir>
 #include <QQmlContext>
 
+#include "config.h"
 #include "log.h"
 
 namespace Ms {
@@ -95,6 +96,25 @@ void UiEngine::setup(QQmlEngine* e)
 #endif
 
     m_engine->addImportPath(":/qml");
+
+#ifdef QML_LOAD_FROM_SOURCE
+    for (const QString& path : m_sourceImportPaths) {
+        m_engine->addImportPath(path);
+    }
+#endif
+}
+
+void UiEngine::addSourceImportPath(const QString& path)
+{
+#ifdef QML_LOAD_FROM_SOURCE
+    LOGD() << path;
+    m_sourceImportPaths << path;
+    if (m_engine) {
+        m_engine->addImportPath(path);
+    }
+#else
+    Q_UNUSED(path);
+#endif
 }
 
 void UiEngine::updateTheme()

--- a/framework/ui/internal/uiengine.h
+++ b/framework/ui/internal/uiengine.h
@@ -61,6 +61,7 @@ public:
     void updateTheme() override;
     QQmlEngine* qmlEngine() const override;
     void clearComponentCache() override;
+    void addSourceImportPath(const QString& path) override;
     // ---
 
     void moveQQmlEngine(QQmlEngine* e);
@@ -75,6 +76,7 @@ private:
     void setup(QQmlEngine* e);
 
     QQmlEngine* m_engine = nullptr;
+    QStringList m_sourceImportPaths;
     QmlTheme* m_theme = nullptr;
     QmlTranslation* m_translation = nullptr;
     std::shared_ptr<InteractiveProvider> m_interactiveProvider = nullptr;

--- a/framework/ui/iuiengine.h
+++ b/framework/ui/iuiengine.h
@@ -20,6 +20,7 @@
 #ifndef MU_FRAMEWORK_IUIENGINE_H
 #define MU_FRAMEWORK_IUIENGINE_H
 
+#include <QString>
 #include "framework/global/modularity/imoduleexport.h"
 
 class QQmlEngine;
@@ -36,6 +37,8 @@ public:
     virtual void updateTheme() = 0;
     virtual QQmlEngine* qmlEngine() const = 0;
     virtual void clearComponentCache() = 0;
+
+    virtual void addSourceImportPath(const QString& path) = 0;
 };
 }
 }

--- a/framework/ui/uimodule.cpp
+++ b/framework/ui/uimodule.cpp
@@ -66,6 +66,8 @@ void UiModule::registerUiTypes()
     qmlRegisterType<InteractiveTestsModel>("MuseScore.Ui", 1, 0, "InteractiveTestsModel");
 
     qRegisterMetaType<TestDialog>("TestDialog");
+
+    framework::ioc()->resolve<framework::IUiEngine>(moduleName())->addSourceImportPath(ui_QML_IMPORT);
 }
 
 void UiModule::onInit()

--- a/framework/uicomponents/uicomponentsmodule.cpp
+++ b/framework/uicomponents/uicomponentsmodule.cpp
@@ -7,6 +7,9 @@
 #include "view/iconview.h"
 #include "view/filterproxymodel.h"
 
+#include "modularity/ioc.h"
+#include "ui/iuiengine.h"
+
 using namespace mu::framework;
 
 static void uicomponents_init_qrc()
@@ -39,4 +42,6 @@ void UiComponentsModule::registerUiTypes()
     qmlRegisterType<FilterProxyModel>("MuseScore.UiComponents", 1, 0, "FilterProxyModel");
     qmlRegisterType<FilterValue>("MuseScore.UiComponents", 1, 0, "FilterValue");
     qmlRegisterUncreatableType<CompareType>("MuseScore.UiComponents", 1, 0, "CompareType", "Cannot create a CompareType");
+
+    framework::ioc()->resolve<framework::IUiEngine>(moduleName())->addSourceImportPath(uicomponents_QML_IMPORT);
 }

--- a/mu4/appshell/CMakeLists.txt
+++ b/mu4/appshell/CMakeLists.txt
@@ -20,6 +20,7 @@
 set(MODULE appshell)
 
 set(MODULE_QRC appshell.qrc)
+set(MODULE_QML_IMPORT ${CMAKE_CURRENT_LIST_DIR}/qml)
 
 include(${CMAKE_CURRENT_LIST_DIR}/dockwindow/dockwindow.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/settings/settings.cmake)

--- a/mu4/appshell/appshell.cpp
+++ b/mu4/appshell/appshell.cpp
@@ -27,6 +27,7 @@
 #include "ui/internal/uiengine.h"
 #include "settings.h"
 #include "version.h"
+#include "config.h"
 
 using namespace mu::appshell;
 
@@ -62,7 +63,12 @@ int AppShell::run(int argc, char** argv, std::function<void()> moduleSetup)
     //! NOTE Move ownership to UiEngine
     framework::UiEngine::instance()->moveQQmlEngine(engine);
 
+#ifdef QML_LOAD_FROM_SOURCE
+    QUrl url(QString(appshell_QML_IMPORT) + "/Main.qml");
+#else
     const QUrl url(QStringLiteral("qrc:/qml/Main.qml"));
+#endif
+
     QObject::connect(engine, &QQmlApplicationEngine::objectCreated,
                      &app, [url](QObject* obj, const QUrl& objUrl) {
         if (!obj && url == objUrl) {

--- a/mu4/cloud/cloudmodule.cpp
+++ b/mu4/cloud/cloudmodule.cpp
@@ -18,7 +18,9 @@
 //=============================================================================
 #include "cloudmodule.h"
 
+#include <QQmlEngine>
 #include "modularity/ioc.h"
+#include "ui/iuiengine.h"
 
 #include "internal/accountcontroller.h"
 #include "view/accountmodel.h"
@@ -50,6 +52,8 @@ void CloudModule::registerResources()
 void CloudModule::registerUiTypes()
 {
     qmlRegisterType<AccountModel>("MuseScore.Cloud", 1, 0, "AccountModel");
+
+    framework::ioc()->resolve<framework::IUiEngine>(moduleName())->addSourceImportPath(cloud_QML_IMPORT);
 }
 
 void CloudModule::onInit()

--- a/mu4/extensions/extensionsmodule.cpp
+++ b/mu4/extensions/extensionsmodule.cpp
@@ -25,6 +25,9 @@
 #include "internal/extensionunpacker.h"
 #include "view/extensionlistmodel.h"
 
+#include "modularity/ioc.h"
+#include "ui/iuiengine.h"
+
 using namespace mu::extensions;
 
 static ExtensionsConfiguration* m_extensionsConfiguration = new ExtensionsConfiguration();
@@ -56,6 +59,8 @@ void ExtensionsModule::registerUiTypes()
 {
     qmlRegisterType<ExtensionListModel>("MuseScore.Extensions", 1, 0, "ExtensionListModel");
     qmlRegisterUncreatableType<ExtensionStatus>("MuseScore.Extensions", 1, 0, "ExtensionStatus", "Cannot create an ExtensionStatus");
+
+    framework::ioc()->resolve<framework::IUiEngine>(moduleName())->addSourceImportPath(extensions_QML_IMPORT);
 }
 
 void ExtensionsModule::onInit()

--- a/mu4/inspector/inspectormodule.cpp
+++ b/mu4/inspector/inspectormodule.cpp
@@ -19,6 +19,7 @@
 
 #include "inspectormodule.h"
 #include "modularity/ioc.h"
+#include "ui/iuiengine.h"
 
 using namespace mu::inspector;
 
@@ -38,8 +39,7 @@ std::string InspectorModule::moduleName() const
 void InspectorModule::registerExports()
 {
 #ifdef BUILD_UI_MU4
-    static std::shared_ptr<mu::inspector::MU4InspectorAdapter> adapter
-        = std::make_shared<mu::inspector::MU4InspectorAdapter>();
+    static std::shared_ptr<MU4InspectorAdapter> adapter = std::make_shared<MU4InspectorAdapter>();
 
     mu::framework::ioc()->registerExport<mu::inspector::IInspectorAdapter>(moduleName(), adapter);
 #endif
@@ -87,50 +87,32 @@ void InspectorModule::registerResources()
 void InspectorModule::registerUiTypes()
 {
     qmlRegisterType<InspectorListModel>("MuseScore.Inspector", 1, 0, "InspectorListModel");
-    qmlRegisterUncreatableType<AbstractInspectorModel>("MuseScore.Inspector", 1, 0, "Inspector",
-                                                       "Not creatable as it is an enum type");
-    qmlRegisterUncreatableType<DirectionTypes>("MuseScore.Inspector", 1, 0, "DirectionTypes",
-                                               "Not creatable as it is an enum type");
-    qmlRegisterUncreatableType<NoteHeadTypes>("MuseScore.Inspector", 1, 0, "NoteHead",
-                                              "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<AbstractInspectorModel>("MuseScore.Inspector", 1, 0, "Inspector", "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<DirectionTypes>("MuseScore.Inspector", 1, 0, "DirectionTypes", "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<NoteHeadTypes>("MuseScore.Inspector", 1, 0, "NoteHead", "Not creatable as it is an enum type");
     qmlRegisterUncreatableType<BeamTypes>("MuseScore.Inspector", 1, 0, "Beam", "Not creatable as it is an enum type");
-    qmlRegisterUncreatableType<HairpinTypes>("MuseScore.Inspector", 1, 0, "Hairpin",
-                                             "Not creatable as it is an enum type");
-    qmlRegisterUncreatableType<OrnamentTypes>("MuseScore.Inspector", 1, 0, "OrnamentTypes",
-                                              "Not creatable as it is an enum type");
-    qmlRegisterUncreatableType<DynamicTypes>("MuseScore.Inspector", 1, 0, "Dynamic",
-                                             "Not creatable as it is an enum type");
-    qmlRegisterUncreatableType<GlissandoTypes>("MuseScore.Inspector", 1, 0, "Glissando",
-                                               "Not creatable as it is an enum type");
-    qmlRegisterUncreatableType<FermataTypes>("MuseScore.Inspector", 1, 0, "FermataTypes",
-                                             "Not creatable as it is an enum type");
-    qmlRegisterUncreatableType<BarlineTypes>("MuseScore.Inspector", 1, 0, "BarlineTypes",
-                                             "Not creatable as it is an enum type");
-    qmlRegisterUncreatableType<MarkerTypes>("MuseScore.Inspector", 1, 0, "MarkerTypes",
-                                            "Not creatable as it is an enum type");
-    qmlRegisterUncreatableType<KeySignatureTypes>("MuseScore.Inspector", 1, 0, "KeySignatureTypes",
-                                                  "Not creatable as it is an enum type");
-    qmlRegisterUncreatableType<AccidentalTypes>("MuseScore.Inspector", 1, 0, "AccidentalTypes",
-                                                "Not creatable as it is an enum type");
-    qmlRegisterUncreatableType<FretDiagramTypes>("MuseScore.Inspector", 1, 0, "FretDiagramTypes",
-                                                 "Not creatable as it is an enum type");
-    qmlRegisterUncreatableType<PedalTypes>("MuseScore.Inspector", 1, 0, "PedalTypes",
-                                           "Not creatable as it is an enum type");
-    qmlRegisterUncreatableType<TextTypes>("MuseScore.Inspector", 1, 0, "TextTypes",
-                                          "Not creatable as it is an enum type");
-    qmlRegisterUncreatableType<CrescendoTypes>("MuseScore.Inspector", 1, 0, "CrescendoTypes",
-                                               "Not creatable as it is an enum type");
-    qmlRegisterUncreatableType<ArticulationTypes>("MuseScore.Inspector", 1, 0, "ArticulationTypes",
-                                                  "Not creatable as it is an enum type");
-    qmlRegisterUncreatableType<AmbitusTypes>("MuseScore.Inspector", 1, 0, "AmbitusTypes",
-                                             "Not creatable as it is an enum type");
-    qmlRegisterUncreatableType<ChordSymbolTypes>("MuseScore.Inspector", 1, 0, "ChordSymbolTypes",
-                                                 "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<HairpinTypes>("MuseScore.Inspector", 1, 0, "Hairpin", "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<OrnamentTypes>("MuseScore.Inspector", 1, 0, "OrnamentTypes", "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<DynamicTypes>("MuseScore.Inspector", 1, 0, "Dynamic", "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<GlissandoTypes>("MuseScore.Inspector", 1, 0, "Glissando", "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<FermataTypes>("MuseScore.Inspector", 1, 0, "FermataTypes", "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<BarlineTypes>("MuseScore.Inspector", 1, 0, "BarlineTypes", "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<MarkerTypes>("MuseScore.Inspector", 1, 0, "MarkerTypes", "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<KeySignatureTypes>("MuseScore.Inspector", 1, 0, "KeySignatureTypes", "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<AccidentalTypes>("MuseScore.Inspector", 1, 0, "AccidentalTypes", "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<FretDiagramTypes>("MuseScore.Inspector", 1, 0, "FretDiagramTypes", "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<PedalTypes>("MuseScore.Inspector", 1, 0, "PedalTypes", "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<TextTypes>("MuseScore.Inspector", 1, 0, "TextTypes", "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<CrescendoTypes>("MuseScore.Inspector", 1, 0, "CrescendoTypes", "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<ArticulationTypes>("MuseScore.Inspector", 1, 0, "ArticulationTypes", "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<AmbitusTypes>("MuseScore.Inspector", 1, 0, "AmbitusTypes", "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<ChordSymbolTypes>("MuseScore.Inspector", 1, 0, "ChordSymbolTypes", "Not creatable as it is an enum type");
     qmlRegisterType<FretCanvas>("MuseScore.Inspector", 1, 0, "FretCanvas");
-    qmlRegisterUncreatableType<ScoreAppearanceTypes>("MuseScore.Inspector", 1, 0, "ScoreAppearanceTypes",
-                                                     "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<ScoreAppearanceTypes>("MuseScore.Inspector", 1, 0, "ScoreAppearanceTypes", "Not creatable...");
     qmlRegisterType<GridCanvas>("MuseScore.Inspector", 1, 0, "GridCanvas");
     qmlRegisterUncreatableType<BendTypes>("MuseScore.Inspector", 1, 0, "BendTypes", "Not creatable as it is an enum type");
     qmlRegisterUncreatableType<TremoloBarTypes>("MuseScore.Inspector", 1, 0, "TremoloBarTypes", "Not creatable as it is an enum type");
     qmlRegisterUncreatableType<TremoloTypes>("MuseScore.Inspector", 1, 0, "TremoloTypes", "Not creatable as it is an enum type");
+
+    framework::ioc()->resolve<framework::IUiEngine>(moduleName())->addSourceImportPath(inspector_QML_IMPORT);
 }

--- a/mu4/instruments/instrumentsmodule.cpp
+++ b/mu4/instruments/instrumentsmodule.cpp
@@ -21,6 +21,7 @@
 #include <QQmlEngine>
 
 #include "modularity/ioc.h"
+#include "ui/iuiengine.h"
 
 #include "internal/instrumentsreader.h"
 #include "internal/instrumentsrepository.h"
@@ -63,6 +64,8 @@ void InstrumentsModule::registerResources()
 void InstrumentsModule::registerUiTypes()
 {
     qmlRegisterType<InstrumentListModel>("MuseScore.Instruments", 1, 0, "InstrumentListModel");
+
+    framework::ioc()->resolve<framework::IUiEngine>(moduleName())->addSourceImportPath(instruments_QML_IMPORT);
 }
 
 void InstrumentsModule::onInit()

--- a/mu4/languages/languagesmodule.cpp
+++ b/mu4/languages/languagesmodule.cpp
@@ -20,6 +20,9 @@
 
 #include <QQmlEngine>
 
+#include "modularity/ioc.h"
+#include "ui/iuiengine.h"
+
 #include "internal/languagesconfiguration.h"
 #include "internal/languagescontroller.h"
 #include "internal/languageunpacker.h"
@@ -56,6 +59,8 @@ void LanguagesModule::registerUiTypes()
 {
     qmlRegisterType<LanguageListModel>("MuseScore.Languages", 1, 0, "LanguageListModel");
     qmlRegisterUncreatableType<LanguageStatus>("MuseScore.Languages", 1, 0, "LanguageStatus", "Cannot create an LanguageStatus");
+
+    framework::ioc()->resolve<framework::IUiEngine>(moduleName())->addSourceImportPath(languages_QML_IMPORT);
 }
 
 void LanguagesModule::onInit()

--- a/mu4/notation/notationmodule.cpp
+++ b/mu4/notation/notationmodule.cpp
@@ -21,6 +21,8 @@
 #include <QQmlEngine>
 
 #include "modularity/ioc.h"
+#include "ui/iuiengine.h"
+
 #include "internal/notationcreator.h"
 #include "internal/notation.h"
 #include "internal/notationactioncontroller.h"
@@ -105,6 +107,8 @@ void NotationModule::registerUiTypes()
     qmlRegisterType<NotationSwitchListModel>("MuseScore.NotationScene", 1, 0, "NotationSwitchListModel");
 
     qRegisterMetaType<EditStyle>("EditStyle");
+
+    framework::ioc()->resolve<framework::IUiEngine>(moduleName())->addSourceImportPath(notation_QML_IMPORT);
 }
 
 void NotationModule::onInit()

--- a/mu4/palette/palettemodule.cpp
+++ b/mu4/palette/palettemodule.cpp
@@ -24,6 +24,7 @@
 
 #include "config.h"
 #include "modularity/ioc.h"
+#include "ui/iuiengine.h"
 
 #include "internal/mu4paletteadapter.h"
 #include "internal/paletteconfiguration.h"
@@ -98,6 +99,8 @@ void PaletteModule::registerUiTypes()
     qmlRegisterUncreatableType<FilterPaletteTreeModel>("MuseScore.Palette", 1, 0, "FilterPaletteTreeModel", "Cannot");
 
     qmlRegisterType<PaletteRootModel>("MuseScore.Palette", 1, 0, "PaletteRootModel");
+
+    framework::ioc()->resolve<framework::IUiEngine>(moduleName())->addSourceImportPath(palette_QML_IMPORT);
 }
 
 void PaletteModule::onInit()

--- a/mu4/playback/playbackmodule.cpp
+++ b/mu4/playback/playbackmodule.cpp
@@ -21,6 +21,8 @@
 #include <QQmlEngine>
 
 #include "modularity/ioc.h"
+#include "ui/iuiengine.h"
+
 #include "actions/iactionsregister.h"
 
 #include "internal/playbackcontroller.h"
@@ -65,6 +67,8 @@ void PlaybackModule::registerResources()
 void PlaybackModule::registerUiTypes()
 {
     qmlRegisterType<PlaybackToolBarModel>("MuseScore.Playback", 1, 0, "PlaybackToolBarModel");
+
+    framework::ioc()->resolve<framework::IUiEngine>(moduleName())->addSourceImportPath(playback_QML_IMPORT);
 }
 
 void PlaybackModule::onInit()

--- a/mu4/userscores/userscoresmodule.cpp
+++ b/mu4/userscores/userscoresmodule.cpp
@@ -21,6 +21,8 @@
 #include <QQmlEngine>
 
 #include "modularity/ioc.h"
+#include "ui/iuiengine.h"
+
 #include "view/recentscoresmodel.h"
 #include "view/newscoremodel.h"
 #include "view/scorethumbnail.h"
@@ -32,8 +34,8 @@
 using namespace mu::userscores;
 using namespace mu::framework;
 
-static OpenScoreController* m_openController = new OpenScoreController();
-static UserScoresConfiguration* m_userScoresConfiguration = new UserScoresConfiguration();
+static OpenScoreController* s_openController = new OpenScoreController();
+static UserScoresConfiguration* s_userScoresConfiguration = new UserScoresConfiguration();
 
 static void userscores_init_qrc()
 {
@@ -47,8 +49,8 @@ std::string UserScoresModule::moduleName() const
 
 void UserScoresModule::registerExports()
 {
-    ioc()->registerExport<IOpenScoreController>(moduleName(), m_openController);
-    ioc()->registerExport<IUserScoresConfiguration>(moduleName(), m_userScoresConfiguration);
+    ioc()->registerExport<IOpenScoreController>(moduleName(), s_openController);
+    ioc()->registerExport<IUserScoresConfiguration>(moduleName(), s_userScoresConfiguration);
     ioc()->registerExport<ITemplatesRepository>(moduleName(), new TemplatesRepository());
 }
 
@@ -71,10 +73,12 @@ void UserScoresModule::registerUiTypes()
     qmlRegisterType<RecentScoresModel>("MuseScore.UserScores", 1, 0, "RecentScoresModel");
     qmlRegisterType<NewScoreModel>("MuseScore.UserScores", 1, 0, "NewScoreModel");
     qmlRegisterType<ScoreThumbnail>("MuseScore.UserScores", 1, 0, "ScoreThumbnail");
+
+    framework::ioc()->resolve<framework::IUiEngine>(moduleName())->addSourceImportPath(userscores_QML_IMPORT);
 }
 
 void UserScoresModule::onInit()
 {
-    m_userScoresConfiguration->init();
-    m_openController->init();
+    s_userScoresConfiguration->init();
+    s_openController->init();
 }


### PR DESCRIPTION
The problem - Qml is in the resources, so when the Qml changes, the project is compiled and linked - this takes a long time.
The resolve is to be able to change Qml, run the application without compiling, and load Qml from source files (not resources).

For loading Qml from source files to work, need to set the QML_LOAD_FROM_SOURCE option in the project settings, and build the project. After that, you can change Qml, and just run the application (small triangle in the creator)

![image](https://user-images.githubusercontent.com/3818029/91955892-22ef9480-ed04-11ea-9249-f4f51b569f7c.png)
