### PR TITLE
fix #308694 fixed open files with the path name that contains non-ASC…

### DIFF
--- a/mscore/exportaudio.cpp
+++ b/mscore/exportaudio.cpp
@@ -17,6 +17,8 @@
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
 
+#include <QFile>
+
 #include "config.h"
 #ifdef HAS_AUDIOFILE
 #include <sndfile.h>
@@ -223,6 +225,7 @@ bool MuseScore::saveAudio(Score* score, const QString& name)
             SF_INFO info;
             SNDFILE *sf = nullptr;
             const QString filename;
+            QFile file;
       public:
             SoundFileDevice(int sampleRate, int format, const QString& name)
                   : filename(name) {
@@ -254,7 +257,12 @@ bool MuseScore::saveAudio(Score* score, const QString& name)
                   if ((mode & QIODevice::WriteOnly) == 0) {
                         return false;
                         }
-                  sf     = sf_open(qPrintable(filename), SFM_WRITE, &info);
+
+                  file.setFileName(filename);
+                  if (!file.open(mode)) {
+                        return false;
+                        }
+                  sf = sf_open_fd(file.handle(), SFM_WRITE, &info, false);
                   if (sf == nullptr) {
                         qDebug("open soundfile failed: %s", sf_strerror(sf));
                         return false;
@@ -266,6 +274,7 @@ bool MuseScore::saveAudio(Score* score, const QString& name)
                         qDebug("close soundfile failed");
                         }
                   sf = nullptr;
+                  file.close();
                   QIODevice::close();
                   }
             };


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/308694

