### PR TITLE
Register MuseScore for its backup files

### DIFF
--- a/build/Linux+BSD/musescore.xml.in
+++ b/build/Linux+BSD/musescore.xml.in
@@ -25,6 +25,28 @@
         </magic>
     </mime-type>
 
+    <mime-type type="application/x-musescore">
+        <comment>MuseScore compressed backup score</comment>
+        <glob pattern="*.mscz,"/>
+        <sub-class-of type="application/zip"/>
+        <icon name="application-x-musescore@MSCORE_INSTALL_SUFFIX@"/>
+    </mime-type>
+
+    <mime-type type="application/x-musescore+xml">
+        <comment>MuseScore uncompressed backup score</comment>
+        <glob pattern="*.mscx,"/>
+        <sub-class-of type="application/xml"/>
+        <root-XML namespaceURI="" localName="museScore"/>
+        <icon name="application-x-musescore@MSCORE_INSTALL_SUFFIX@+xml"/>
+        <magic>
+            <match type="string" value="&lt;?xml" offset="0">
+                <match type="string" value="&lt;museScore" offset="0:128">
+                    <match type="string" value="&lt;Score" offset="0:512"/>
+                </match>
+            </match>
+        </magic>
+    </mime-type>
+
     <!-- MuseScore internal formats -->
 
     <mime-type type="application/x-musescore.drumset+xml">

--- a/build/MacOSXBundleInfo.plist.in
+++ b/build/MacOSXBundleInfo.plist.in
@@ -54,6 +54,50 @@
 				</array>
 			</dict>
 		</dict>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>org.musescore.mscx,</string>
+			<key>UTTypeDescription</key>
+			<string>MuseScore Backup File</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.content</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mscx,</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/x-musescore+xml</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>org.musescore.mscz,</string>
+			<key>UTTypeDescription</key>
+			<string>MuseScore Compressed Backup File</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.content</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mscz,</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/x-musescore</string>
+				</array>
+			</dict>
+		</dict>
 	</array>
 	<key>CFBundleDocumentTypes</key>
 	<array>
@@ -85,6 +129,50 @@
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>mscz</string>
+			</array>
+			<key>CFBundleTypeIconFile</key>
+			<string>musescoreDocument.icns</string>
+			<key>CFBundleTypeMIMETypes</key>
+			<array>
+				<string>application/x-musescore</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSTypeIsPackage</key>
+			<true/>
+			<key>LSIsAppleDefaultForType</key>
+			<true/>
+			<key>LSHandlerRank</key>
+   			<string>Owner</string>
+		</dict>
+		<dict>
+		    <key>CFBundleTypeName</key>
+			<string>MuseScore Backup File</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>mscx,</string>
+			</array>
+			<key>CFBundleTypeIconFile</key>
+			<string>musescoreDocument.icns</string>
+			<key>CFBundleTypeMIMETypes</key>
+			<array>
+				<string>application/x-musescore+xml</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSTypeIsPackage</key>
+			<false/>
+			<key>LSIsAppleDefaultForType</key>
+			<true/>
+			<key>LSHandlerRank</key>
+   			<string>Owner</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Compressed MuseScore Backup File</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>mscz,</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
 			<string>musescoreDocument.icns</string>

--- a/build/packaging/WIX.template.in
+++ b/build/packaging/WIX.template.in
@@ -77,11 +77,15 @@
             
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\FileAssociations" Name=".mscz" Value="MuseScore.mscz" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\FileAssociations" Name=".mscx" Value="MuseScore.mscx" Type="string" />
+            <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\FileAssociations" Name=".mscz," Value="MuseScore.mscz," Type="string" />
+            <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\FileAssociations" Name=".mscx," Value="MuseScore.mscx," Type="string" />
             
             <!-- TODO add more types?-->
             
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\MIMEAssociations" Name="application/x-musescore" Value="MuseScore.mscz" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\MIMEAssociations" Name="application/x-musescore+xml" Value="MuseScore.mscx" Type="string" />
+            <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\MIMEAssociations" Name="application/x-musescore" Value="MuseScore.mscz," Type="string" />
+            <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\MIMEAssociations" Name="application/x-musescore+xml" Value="MuseScore.mscx," Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\shell\open\command" Value="&quot;[INSTALL_ROOT]bin\$(var.ExeName)&quot; &quot;%1&quot;" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\RegisteredApplications" Name="$(var.ProdName)" Value="SOFTWARE\$(var.ShortProdName)\Capabilities" Type="string" />
 
@@ -92,6 +96,8 @@
             <!-- Extend to the "open with" list + Win7 jump menu pinning  -->
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".mscz" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".mscx" Value="" Type="string" />
+            <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".mscz," Value="" Type="string" />
+            <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".mscx," Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".xml" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".musicxml" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".mxl" Value="" Type="string" />
@@ -132,6 +138,22 @@
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\MuseScore.mscx" Value="MuseScore File" Type="string" />
             <ProgId Id="MuseScore.mscx" Description="MuseScore File" Advertise="no" Icon="$(var.ExeId)" IconIndex="1">
                 <Extension Id="mscx" Advertise="no">
+                    <Verb Id="open" TargetFile="$(var.ExeId)" Command="Open" Argument="&quot;%1&quot;" />
+                    <MIME Advertise="no" ContentType="application/x-musescore+xml" Default="no" />
+                </Extension>
+            </ProgId>
+
+            <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\MuseScore.mscz," Value="Compressed MuseScore Backup File" Type="string"/>
+            <ProgId Id="MuseScore.mscz," Description="Compressed Backup MuseScore File" Advertise="no" Icon="$(var.ExeId)" IconIndex="1">
+                <Extension Id="mscz," Advertise="no">
+                    <Verb Id="open" TargetFile="$(var.ExeId)" Command="Open" Argument="&quot;%1&quot;" />
+                    <MIME Advertise="no" ContentType="application/x-musescore" Default="yes" />
+                </Extension>
+            </ProgId>
+
+            <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\MuseScore.mscx," Value="MuseScore Backup File" Type="string" />
+            <ProgId Id="MuseScore.mscx," Description="MuseScore Backup File" Advertise="no" Icon="$(var.ExeId)" IconIndex="1">
+                <Extension Id="mscx," Advertise="no">
                     <Verb Id="open" TargetFile="$(var.ExeId)" Command="Open" Argument="&quot;%1&quot;" />
                     <MIME Advertise="no" ContentType="application/x-musescore+xml" Default="no" />
                 </Extension>


### PR DESCRIPTION
As 3.5.0 introduced the ability to 'import' backup files, IMHO it should also do this on double click, so this PR should make it into 3.5.1