### PR TITLE
Settings field for multimeasure rests is too small

### DIFF
--- a/mscore/editstyle.h
+++ b/mscore/editstyle.h
@@ -25,6 +25,8 @@
 #include "libmscore/mscore.h"
 #include "libmscore/style.h"
 
+class QScrollArea;
+
 namespace Ms {
 
 class Score;
@@ -56,14 +58,12 @@ typedef QWidget* EditStyle::* EditStylePage;
 class EditStyle : public QDialog, private Ui::EditStyleBase {
       Q_OBJECT
 
-      Score* cs;
-      QPushButton* buttonApplyToAllParts;
-      QButtonGroup* stemGroups[VOICES];
+      Score* cs = nullptr;
+      QPushButton* buttonApplyToAllParts = nullptr;
       QVector<StyleWidget> styleWidgets;
-      QButtonGroup* keySigNatGroup;
-      QButtonGroup* clefTypeGroup;
-      bool isTooBig;
-      bool hasShown;
+      QScrollArea* scrollArea = nullptr;
+      bool isTooBig = false;
+      bool hasShown = false;
 
       virtual void showEvent(QShowEvent*);
       virtual void hideEvent(QHideEvent*);
@@ -72,6 +72,8 @@ class EditStyle : public QDialog, private Ui::EditStyleBase {
 
       void applyToAllParts();
       const StyleWidget& styleWidget(Sid) const;
+
+      void adjustPagesStackSize(int currentPageIndex);
 
       static const std::map<ElementType, EditStylePage> PAGES;
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/304834

**Before:**
![before1](https://user-images.githubusercontent.com/67867444/92128132-5c0e2e80-ee02-11ea-90fc-273a912e2c36.png)

**After:**
![after](https://user-images.githubusercontent.com/67867444/92128141-60d2e280-ee02-11ea-8594-41e72f264789.png)
