### PR TITLE
fix #309456 Workspace settings are independent of the selected language

### DIFF
--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -1410,7 +1410,7 @@ void PreferenceDialog::apply()
 
       if(uiStyleThemeChanged) {
             WorkspacesManager::retranslateAll();
-            preferences.setPreference(PREF_APP_WORKSPACE, WorkspacesManager::currentWorkspace()->name());
+            preferences.setPreference(PREF_APP_WORKSPACE, WorkspacesManager::currentWorkspace()->translatableName());
             WorkspacesManager::currentWorkspace()->save();
             emit mscore->workspacesChanged();
             }

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -230,7 +230,7 @@ void MuseScore::changeWorkspace(Workspace* p, bool first)
 
       connect(getPaletteWorkspace(), &PaletteWorkspace::userPaletteChanged, WorkspacesManager::currentWorkspace(), QOverload<>::of(&Workspace::setDirty), Qt::UniqueConnection);
 
-      preferences.setPreference(PREF_APP_WORKSPACE, p->name());
+      preferences.setPreference(PREF_APP_WORKSPACE, p->translatableName());
       emit mscore->workspacesChanged();
       }
 
@@ -1094,7 +1094,7 @@ void Workspace::ensureWorkspaceSaved()
             Q_ASSERT(!_readOnly);
 
             WorkspacesManager::refreshWorkspaces();
-            preferences.setPreference(PREF_APP_WORKSPACE, name());
+            preferences.setPreference(PREF_APP_WORKSPACE, translatableName());
             emit mscore->workspacesChanged();
             }
       else

--- a/mscore/workspacedialog.cpp
+++ b/mscore/workspacedialog.cpp
@@ -154,7 +154,7 @@ void WorkspaceDialog::accepted()
             preferences.updateLocalPreferences();
             }
             
-      preferences.setPreference(PREF_APP_WORKSPACE, WorkspacesManager::currentWorkspace()->name());
+      preferences.setPreference(PREF_APP_WORKSPACE, WorkspacesManager::currentWorkspace()->translatableName());
       emit mscore->workspacesChanged();
       close();
       }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/309456

![Peek 2020-09-03 17-09](https://user-images.githubusercontent.com/10116828/92133752-09844080-ee09-11ea-87bd-772f4280ac5d.gif)
