### PR TITLE
Algorithm for spreading staves/systems over a page

### DIFF
--- a/libmscore/layout.h
+++ b/libmscore/layout.h
@@ -13,10 +13,65 @@
 #ifndef __LAYOUT_H__
 #define __LAYOUT_H__
 
+#include "system.h"
+
 namespace Ms {
 
 class Segment;
 class Page;
+
+//---------------------------------------------------------
+//   VerticalStretchData
+//    helper class for spreading staves over a page
+//---------------------------------------------------------
+
+class VerticalGapData {
+   private:
+      bool      _systemSpace    { false   };
+      bool      _fixedHeight    { false   };
+      qreal     _spacing        { 0.0     };
+      qreal     _maxSpacing     { 0.0     };
+      qreal     _addedSpace     { 0.0     };
+      qreal     _copyAddedSpace { 0.0     };
+   public:
+      System*   system          { nullptr };
+      SysStaff* sysStaff        { nullptr };
+      Staff*    staff           { nullptr };
+      qreal     factor          { 1.0     };
+
+      VerticalGapData(System* sys, Staff* st, SysStaff* sst, qreal y);
+
+      void setVBox();
+      void addSpaceBetweenSections();
+      void addSpaceAroundVBox(bool above);
+      void addSpaceAroundNormalBracket();
+      void addSpaceAroundCurlyBracket();
+      void insideCurlyBracket();
+      bool isSystemGap() const;
+
+      qreal normalisedSpacing() const;
+      qreal actualSpacing() const;
+      qreal addedSpace() const;
+
+      qreal nextYPos(bool first) const;
+      qreal yBottom() const;
+      qreal addSpacing(qreal step);
+      qreal addNormalisedSpacing(qreal step);
+      bool canAddSpace() const;
+      void restore();
+      };
+
+//---------------------------------------------------------
+//   VerticalStretchDataList
+//    helper class for spreading staves over a page
+//---------------------------------------------------------
+
+class VerticalGapDataList : public QList<VerticalGapData*> {
+   public:
+      ~VerticalGapDataList();
+      qreal sumStretchFactor() const;
+      qreal smallest(qreal limit=-1.0) const;
+      };
 
 //---------------------------------------------------------
 //   LayoutContext

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -3037,6 +3037,8 @@ Score::FileError MasterScore::read114(XmlReader& e)
             return FileError::FILE_BAD_FORMAT;
             }
 
+      setEnableVerticalSpread(false);
+
       for (Staff* s : staves()) {
             int idx   = s->idx();
             int track = idx * VOICES;
@@ -3262,6 +3264,7 @@ Score::FileError MasterScore::read114(XmlReader& e)
             if (!excerpt->parts().isEmpty()) {
                   _excerpts.push_back(excerpt);
                   Score* nscore = new Score(this);
+                  nscore->setEnableVerticalSpread(false);
                   excerpt->setPartScore(nscore);
                   nscore->style().set(Sid::createMultiMeasureRests, true);
                   Excerpt::createExcerpt(excerpt);

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -3878,6 +3878,7 @@ static bool readScore(Score* score, XmlReader& e)
                         e.clearUserTextStyles();
                         MasterScore* m = score->masterScore();
                         Score* s = new Score(m, MScore::baseStyle());
+                        s->setEnableVerticalSpread(false);
                         Excerpt* ex = new Excerpt(m);
 
                         ex->setPartScore(s);
@@ -4082,6 +4083,9 @@ Score::FileError MasterScore::read206(XmlReader& e)
                   revisions()->add(revision);
                   }
             }
+
+      setEnableVerticalSpread(false);
+
       int id = 1;
       for (LinkedElements* le : e.linkIds())
             le->setLid(this, id++);

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3431,6 +3431,48 @@ void Score::selectSimilarInRange(Element* e)
       }
 
 //---------------------------------------------------------
+//   enableVerticalSpread
+//---------------------------------------------------------
+
+bool Score::enableVerticalSpread() const
+      {
+      return styleB(Sid::enableVerticalSpread) && (layoutMode() != LayoutMode::SYSTEM);
+      }
+
+//---------------------------------------------------------
+//   setEnableVerticalSpread
+//---------------------------------------------------------
+
+void Score::setEnableVerticalSpread(bool val)
+      {
+      setStyleValue(Sid::enableVerticalSpread, val);
+      }
+
+//---------------------------------------------------------
+//   minSystemDistance
+//---------------------------------------------------------
+
+qreal Score::minSystemDistance() const
+      {
+      if (enableVerticalSpread())
+            return styleP(Sid::minStaffSpread) * styleD(Sid::spreadSystem);
+      else
+            return styleP(Sid::minSystemDistance);
+      }
+
+//---------------------------------------------------------
+//   maxSystemDistance
+//---------------------------------------------------------
+
+qreal Score::maxSystemDistance() const
+      {
+      if (enableVerticalSpread())
+            return styleP(Sid::maxSystemSpread);
+      else
+            return styleP(Sid::maxSystemDistance);
+      }
+
+//---------------------------------------------------------
 //   lassoSelect
 //---------------------------------------------------------
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -963,6 +963,11 @@ class Score : public QObject, public ScoreElement {
       bool isPalette() const { return _isPalette; }
       void setPaletteMode(bool palette) { _isPalette = palette; }
 
+      bool enableVerticalSpread() const;
+      void setEnableVerticalSpread(bool val);
+      qreal minSystemDistance() const;
+      qreal maxSystemDistance() const;
+
       void lassoSelect(const QRectF&);
       void lassoSelectEnd();
 

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -77,6 +77,15 @@ static const StyleType styleTypes[] {
       { Sid::minSystemDistance,       "minSystemDistance",       Spatium(8.5)  },
       { Sid::maxSystemDistance,       "maxSystemDistance",       Spatium(15.0) },
 
+      { Sid::enableVerticalSpread,    "enableVerticalSpread",    false         },
+      { Sid::spreadSystem,            "spreadSystem",            2.5           },
+      { Sid::spreadSquareBracket,     "spreadSquareBracket",     1.0           },
+      { Sid::spreadCurlyBracket,      "spreadCurlyBracket",      1.0           },
+      { Sid::maxSystemSpread,         "maxSystemSpread",         Spatium(35.0) },
+      { Sid::minStaffSpread,          "minSpreadSpread",         Spatium(1.0)  },
+      { Sid::maxStaffSpread,          "maxSpreadSpread",         Spatium(20.0) },
+      { Sid::maxAkkoladeDistance,     "maxAkkoladeDistance",     Spatium(6.5)  },
+
       { Sid::lyricsPlacement,         "lyricsPlacement",         int(Placement::BELOW)  },
       { Sid::lyricsPosAbove,          "lyricsPosAbove",          QPointF(0.0, -2.0) },
       { Sid::lyricsPosBelow,          "lyricsPosBelow",          QPointF(.0, 3.0) },

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -66,9 +66,17 @@ enum class Sid {
       staffLowerBorder,
       staffDistance,
       akkoladeDistance,
-
       minSystemDistance,
       maxSystemDistance,
+
+      enableVerticalSpread,
+      spreadSystem,
+      spreadSquareBracket,
+      spreadCurlyBracket,
+      maxSystemSpread,
+      minStaffSpread,
+      maxStaffSpread,
+      maxAkkoladeDistance,
 
       lyricsPlacement,
       lyricsPosAbove,

--- a/libmscore/system.h
+++ b/libmscore/system.h
@@ -123,6 +123,9 @@ public:
       Page* page() const                    { return (Page*)parent(); }
 
       void layoutSystem(qreal, const bool isFirstSystem = false);
+      void setMeasureHeight(qreal height);
+      void layoutBracketsVertical();
+      void layoutInstrumentNames();
 
       void addBrackets(Measure* measure);
 

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -107,12 +107,20 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       { Sid::ottavaLineStyle,         false, ottavaLineStyle,         resetOttavaLineStyle },
       { Sid::pedalLineStyle,          false, pedalLineStyle,          resetPedalLineStyle  },
 
-      { Sid::staffUpperBorder,        false, staffUpperBorder,        resetStaffUpperBorder  },
-      { Sid::staffLowerBorder,        false, staffLowerBorder,        resetStaffLowerBorder  },
-      { Sid::staffDistance,           false, staffDistance,           resetStaffDistance     },
-      { Sid::akkoladeDistance,        false, akkoladeDistance,        resetAkkoladeDistance  },
-      { Sid::minSystemDistance,       false, minSystemDistance,       resetMinSystemDistance },
-      { Sid::maxSystemDistance,       false, maxSystemDistance,       resetMaxSystemDistance },
+      { Sid::staffUpperBorder,        false, staffUpperBorder,        resetStaffUpperBorder    },
+      { Sid::staffLowerBorder,        false, staffLowerBorder,        resetStaffLowerBorder    },
+      { Sid::staffDistance,           false, staffDistance,           resetStaffDistance       },
+      { Sid::akkoladeDistance,        false, akkoladeDistance,        resetAkkoladeDistance    },
+      { Sid::enableVerticalSpread,    false, enableVerticalSpread,    0                        },
+      { Sid::minSystemDistance,       false, minSystemDistance,       resetMinSystemDistance   },
+      { Sid::maxSystemDistance,       false, maxSystemDistance,       resetMaxSystemDistance   },
+      { Sid::spreadSystem,            false, spreadSystem,            resetSpreadSystem        },
+      { Sid::spreadSquareBracket,     false, spreadSquareBracket,     resetSpreadSquareBracket },
+      { Sid::spreadCurlyBracket,      false, spreadCurlyBracket,      resetSpreadCurlyBracket  },
+      { Sid::maxSystemSpread,         false, maxSystemSpread,         resetMaxSystemSpread     },
+      { Sid::minStaffSpread,          false, minStaffSpread,          resetMinStaffSpread      },
+      { Sid::maxStaffSpread,          false, maxStaffSpread,          resetMaxStaffSpread      },
+      { Sid::maxAkkoladeDistance,     false, maxAkkoladeDistance,     resetMaxAkkoladeDistance },
 
       { Sid::lyricsPlacement,         false, lyricsPlacement,         resetLyricsPlacement         },
       { Sid::lyricsPosAbove,          false, lyricsPosAbove,          resetLyricsPosAbove          },
@@ -531,6 +539,7 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       showFooter->setToolTipDuration(5000);
 
       connect(buttonBox,           SIGNAL(clicked(QAbstractButton*)), SLOT(buttonClicked(QAbstractButton*)));
+      connect(enableVerticalSpread,SIGNAL(toggled(bool)),             SLOT(toggleVerticalJustificationStaves(bool)));
       connect(headerOddEven,       SIGNAL(toggled(bool)),             SLOT(toggleHeaderOddEven(bool)));
       connect(footerOddEven,       SIGNAL(toggled(bool)),             SLOT(toggleFooterOddEven(bool)));
       connect(chordDescriptionFileButton, SIGNAL(clicked()),          SLOT(selectChordDescriptionFile()));
@@ -1221,6 +1230,7 @@ void EditStyle::setValues()
 
       toggleHeaderOddEven(lstyle.value(Sid::headerOddEven).toBool());
       toggleFooterOddEven(lstyle.value(Sid::footerOddEven).toBool());
+      toggleVerticalJustificationStaves(lstyle.value(Sid::enableVerticalSpread).toBool());
       }
 
 //---------------------------------------------------------
@@ -1309,6 +1319,38 @@ void EditStyle::setChordStyle(bool checked)
             cs->update();
             }
       //formattingGroup->setEnabled(cs->style().chordList()->autoAdjust());
+      }
+
+//---------------------------------------------------------
+//   enableStyleWidget
+//---------------------------------------------------------
+
+void EditStyle::enableStyleWidget(const Sid idx, bool enable)
+      {
+      const StyleWidget& sw { styleWidget(idx) };
+      static_cast<QWidget*>(sw.widget)->setEnabled(enable);
+      if (sw.reset)
+            sw.reset->setEnabled(enable && !cs->style().isDefault(idx));
+      }
+
+//---------------------------------------------------------
+//   toggleVerticalJustificationStaves
+//---------------------------------------------------------
+
+void EditStyle::toggleVerticalJustificationStaves(bool checked)
+      {
+      enableStyleWidget(Sid::staffDistance, !checked);
+      enableStyleWidget(Sid::akkoladeDistance, !checked);
+      enableStyleWidget(Sid::minSystemDistance, !checked);
+      enableStyleWidget(Sid::maxSystemDistance, !checked);
+
+      enableStyleWidget(Sid::spreadSystem, checked);
+      enableStyleWidget(Sid::spreadSquareBracket, checked);
+      enableStyleWidget(Sid::spreadCurlyBracket, checked);
+      enableStyleWidget(Sid::maxSystemSpread, checked);
+      enableStyleWidget(Sid::minStaffSpread, checked);
+      enableStyleWidget(Sid::maxStaffSpread, checked);
+      enableStyleWidget(Sid::maxAkkoladeDistance, checked);
       }
 
 //---------------------------------------------------------

--- a/mscore/editstyle.h
+++ b/mscore/editstyle.h
@@ -80,6 +80,8 @@ class EditStyle : public QDialog, private Ui::EditStyleBase {
    private slots:
       void selectChordDescriptionFile();
       void setChordStyle(bool);
+      void enableStyleWidget(const Sid idx, bool enable);
+      void toggleVerticalJustificationStaves(bool);
       void toggleHeaderOddEven(bool);
       void toggleFooterOddEven(bool);
       void buttonClicked(QAbstractButton*);

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -228,6 +228,9 @@
       </item>
      </widget>
      <widget class="QStackedWidget" name="pageStack">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
       <property name="sizePolicy">
        <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
         <horstretch>0</horstretch>
@@ -907,7 +910,23 @@
            <bool>false</bool>
           </property>
           <layout class="QGridLayout" name="gridLayout_8">
-           <item row="4" column="5">
+           <item row="4" column="3">
+            <widget class="QLabel" name="label_191">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Max. system distance:</string>
+             </property>
+             <property name="buddy">
+              <cstring>maxSystemDistance</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="15" column="4">
             <widget class="QDoubleSpinBox" name="frameSystemDistance">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -929,8 +948,42 @@
              </property>
             </widget>
            </item>
-           <item row="4" column="4">
-            <widget class="QLabel" name="label_75">
+           <item row="3" column="5">
+            <widget class="QToolButton" name="resetAkkoladeDistance">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Grand staff distance' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="5">
+            <widget class="QToolButton" name="resetMinStaffSpread">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Min. staff distance' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="15" column="0">
+            <widget class="QLabel" name="label_74">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -938,14 +991,30 @@
               </sizepolicy>
              </property>
              <property name="text">
-              <string>Vertical frame bottom margin:</string>
+              <string>Vertical frame top margin:</string>
              </property>
              <property name="buddy">
-              <cstring>frameSystemDistance</cstring>
+              <cstring>systemFrameDistance</cstring>
              </property>
             </widget>
            </item>
-           <item row="1" column="5">
+           <item row="7" column="4">
+            <widget class="QDoubleSpinBox" name="maxSystemSpread"/>
+           </item>
+           <item row="1" column="0" colspan="2">
+            <widget class="QCheckBox" name="enableVerticalSpread">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="text">
+              <string>Enable vertical adjustment of staves</string>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="4">
             <widget class="QDoubleSpinBox" name="akkoladeDistance">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -970,59 +1039,8 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="3">
-            <widget class="QToolButton" name="resetStaffDistance">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Staff distance' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="6">
-            <widget class="QToolButton" name="resetStaffLowerBorder">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Music bottom margin' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="6">
-            <widget class="QToolButton" name="resetAkkoladeDistance">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Grand staff distance' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="4">
-            <widget class="QLabel" name="label_191">
+           <item row="4" column="0">
+            <widget class="QLabel" name="label_73">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -1030,181 +1048,14 @@
               </sizepolicy>
              </property>
              <property name="text">
-              <string>Max. system distance:</string>
+              <string>Min. system distance:</string>
              </property>
              <property name="buddy">
-              <cstring>maxSystemDistance</cstring>
+              <cstring>minSystemDistance</cstring>
              </property>
             </widget>
            </item>
-           <item row="0" column="3">
-            <widget class="QToolButton" name="resetStaffUpperBorder">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Music top margin' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="4">
-            <widget class="QLabel" name="label_70">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Grand staff distance:</string>
-             </property>
-             <property name="buddy">
-              <cstring>akkoladeDistance</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="5">
-            <widget class="QDoubleSpinBox" name="maxSystemDistance">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="suffix">
-              <string>sp</string>
-             </property>
-             <property name="decimals">
-              <number>1</number>
-             </property>
-             <property name="minimum">
-              <double>0.000000000000000</double>
-             </property>
-             <property name="maximum">
-              <double>1000.000000000000000</double>
-             </property>
-             <property name="singleStep">
-              <double>0.500000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="3">
-            <widget class="QToolButton" name="resetSystemFrameDistance">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Vertical frame top margin' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="4">
-            <widget class="QLabel" name="label_78">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Music bottom margin:</string>
-             </property>
-             <property name="buddy">
-              <cstring>staffLowerBorder</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="3">
-            <widget class="QToolButton" name="resetMinSystemDistance">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Min. system distance' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="3">
-            <widget class="QToolButton" name="resetLastSystemFillThreshold">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Last system fill threshold' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="5">
-            <widget class="QDoubleSpinBox" name="staffLowerBorder">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="suffix">
-              <string>sp</string>
-             </property>
-             <property name="decimals">
-              <number>1</number>
-             </property>
-             <property name="minimum">
-              <double>-1000.000000000000000</double>
-             </property>
-             <property name="maximum">
-              <double>1000.000000000000000</double>
-             </property>
-             <property name="singleStep">
-              <double>0.500000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="6">
-            <widget class="QToolButton" name="resetMaxSystemDistance">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Max. system distance' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="6">
+           <item row="15" column="5">
             <widget class="QToolButton" name="resetFrameSystemDistance">
              <property name="toolTip">
               <string>Reset to default</string>
@@ -1221,73 +1072,41 @@
              </property>
             </widget>
            </item>
-           <item row="4" column="2">
-            <widget class="QDoubleSpinBox" name="systemFrameDistance">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
+           <item row="17" column="2">
+            <widget class="QToolButton" name="resetLastSystemFillThreshold">
+             <property name="toolTip">
+              <string>Reset to default</string>
              </property>
-             <property name="suffix">
-              <string>sp</string>
+             <property name="accessibleName">
+              <string>Reset 'Last system fill threshold' value</string>
              </property>
-             <property name="decimals">
-              <number>1</number>
+             <property name="text">
+              <string notr="true"/>
              </property>
-             <property name="minimum">
-              <double>-100.000000000000000</double>
-             </property>
-             <property name="singleStep">
-              <double>0.500000000000000</double>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
              </property>
             </widget>
            </item>
-           <item row="5" column="2">
-            <widget class="QSpinBox" name="lastSystemFillThreshold">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
+           <item row="15" column="2">
+            <widget class="QToolButton" name="resetSystemFrameDistance">
+             <property name="toolTip">
+              <string>Reset to default</string>
              </property>
-             <property name="suffix">
-              <string notr="true">%</string>
+             <property name="accessibleName">
+              <string>Reset 'Vertical frame top margin' value</string>
              </property>
-             <property name="maximum">
-              <number>100</number>
+             <property name="text">
+              <string notr="true"/>
              </property>
-             <property name="value">
-              <number>70</number>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
              </property>
             </widget>
            </item>
-           <item row="2" column="2">
-            <widget class="QDoubleSpinBox" name="minSystemDistance">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="suffix">
-              <string>sp</string>
-             </property>
-             <property name="decimals">
-              <number>1</number>
-             </property>
-             <property name="minimum">
-              <double>-1000.000000000000000</double>
-             </property>
-             <property name="maximum">
-              <double>1000.000000000000000</double>
-             </property>
-             <property name="singleStep">
-              <double>0.500000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="2">
+           <item row="3" column="1">
             <widget class="QDoubleSpinBox" name="staffDistance">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -1312,7 +1131,546 @@
              </property>
             </widget>
            </item>
+           <item row="15" column="3">
+            <widget class="QLabel" name="label_75">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Vertical frame bottom margin:</string>
+             </property>
+             <property name="buddy">
+              <cstring>frameSystemDistance</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="4">
+            <widget class="QDoubleSpinBox" name="minStaffSpread">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="minimum">
+              <double>-1000.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>1000.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.500000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="9" column="3">
+            <widget class="QLabel" name="label_155">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Max. staff distance:</string>
+             </property>
+             <property name="buddy">
+              <cstring>maxAkkoladeDistance</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="4">
+            <widget class="QDoubleSpinBox" name="staffLowerBorder">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="minimum">
+              <double>-1000.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>1000.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.500000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_69">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Staff distance:</string>
+             </property>
+             <property name="buddy">
+              <cstring>staffDistance</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="0">
+            <widget class="QLabel" name="label_154">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="frameShadow">
+              <enum>QFrame::Sunken</enum>
+             </property>
+             <property name="text">
+              <string>Factor distance above/below [ bracket:</string>
+             </property>
+             <property name="buddy">
+              <cstring>spreadSquareBracket</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="3">
+            <widget class="QLabel" name="label_78">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Music bottom margin:</string>
+             </property>
+             <property name="buddy">
+              <cstring>staffLowerBorder</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="17" column="0">
+            <widget class="QLabel" name="label_77">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Last system fill threshold:</string>
+             </property>
+             <property name="buddy">
+              <cstring>lastSystemFillThreshold</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="3">
+            <widget class="QLabel" name="label_156">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Min. staff distance:</string>
+             </property>
+             <property name="buddy">
+              <cstring>minStaffSpread</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="5">
+            <widget class="QToolButton" name="resetMaxSystemDistance">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Max. system distance' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="23" column="0" colspan="2">
+            <widget class="QCheckBox" name="genCourtesyKeysig">
+             <property name="text">
+              <string>Create courtesy key signatures</string>
+             </property>
+            </widget>
+           </item>
+           <item row="17" column="1">
+            <widget class="QSpinBox" name="lastSystemFillThreshold">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="suffix">
+              <string notr="true">%</string>
+             </property>
+             <property name="maximum">
+              <number>100</number>
+             </property>
+             <property name="value">
+              <number>70</number>
+             </property>
+            </widget>
+           </item>
+           <item row="21" column="0" colspan="2">
+            <widget class="QCheckBox" name="genCourtesyClef">
+             <property name="text">
+              <string>Create courtesy clefs</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QDoubleSpinBox" name="minSystemDistance">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="minimum">
+              <double>-1000.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>1000.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.500000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="5">
+            <widget class="QToolButton" name="resetStaffLowerBorder">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Music bottom margin' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="5">
+            <widget class="QToolButton" name="resetMaxSystemSpread">
+             <property name="accessibleName">
+              <string>Reset 'Max. system distance' value</string>
+             </property>
+             <property name="text">
+              <string notr="true">...</string>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="2">
+            <widget class="QToolButton" name="resetMinSystemDistance">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Min. system distance' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="3">
+            <widget class="QLabel" name="label_70">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Grand staff distance:</string>
+             </property>
+             <property name="buddy">
+              <cstring>akkoladeDistance</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="18" column="0">
+            <spacer name="verticalSpacer_9">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Fixed</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="7" column="1">
+            <widget class="QDoubleSpinBox" name="spreadSystem">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="suffix">
+              <string/>
+             </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="minimum">
+              <double>1.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>1000.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.500000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_76">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Music top margin:</string>
+             </property>
+             <property name="buddy">
+              <cstring>staffUpperBorder</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="15" column="1">
+            <widget class="QDoubleSpinBox" name="systemFrameDistance">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="minimum">
+              <double>-100.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.500000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="2">
+            <widget class="QToolButton" name="resetStaffDistance">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Staff distance' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="2">
+            <widget class="QToolButton" name="resetSpreadSquareBracket">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Factor distance within system' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="0">
+            <widget class="QLabel" name="label_153">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="frameShadow">
+              <enum>QFrame::Sunken</enum>
+             </property>
+             <property name="text">
+              <string>Factor distance between systems:</string>
+             </property>
+             <property name="buddy">
+              <cstring>spreadSystem</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="2">
+            <widget class="QToolButton" name="resetSpreadSystem">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Factor distance between systems' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="9" column="5">
+            <widget class="QToolButton" name="resetMaxStaffSpread">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Max. staff distance' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="22" column="0" colspan="2">
+            <widget class="QCheckBox" name="genCourtesyTimesig">
+             <property name="text">
+              <string>Create courtesy time signatures</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0" colspan="6">
+            <widget class="QFrame" name="frame">
+             <property name="frameShape">
+              <enum>QFrame::HLine</enum>
+             </property>
+             <property name="frameShadow">
+              <enum>QFrame::Sunken</enum>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="3">
+            <widget class="QLabel" name="label_159">
+             <property name="text">
+              <string>Max. system distance:</string>
+             </property>
+             <property name="buddy">
+              <cstring>maxSystemSpread</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="9" column="4">
+            <widget class="QDoubleSpinBox" name="maxStaffSpread">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="minimum">
+              <double>-1000.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>1000.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.500000000000000</double>
+             </property>
+            </widget>
+           </item>
            <item row="0" column="2">
+            <widget class="QToolButton" name="resetStaffUpperBorder">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Music top margin' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
             <widget class="QDoubleSpinBox" name="staffUpperBorder">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -1337,103 +1695,7 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
-            <widget class="QLabel" name="label_76">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Music top margin:</string>
-             </property>
-             <property name="buddy">
-              <cstring>staffUpperBorder</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QLabel" name="label_69">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Staff distance:</string>
-             </property>
-             <property name="buddy">
-              <cstring>staffDistance</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QLabel" name="label_73">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Min. system distance:</string>
-             </property>
-             <property name="buddy">
-              <cstring>minSystemDistance</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <widget class="QLabel" name="label_74">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Vertical frame top margin:</string>
-             </property>
-             <property name="buddy">
-              <cstring>systemFrameDistance</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="1">
-            <widget class="QLabel" name="label_77">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Last system fill threshold:</string>
-             </property>
-             <property name="buddy">
-              <cstring>lastSystemFillThreshold</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="1">
-            <spacer name="verticalSpacer_9">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeType">
-              <enum>QSizePolicy::Fixed</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item row="3" column="1" colspan="6">
+           <item row="12" column="0" rowspan="3" colspan="6">
             <widget class="QFrame" name="frame_3">
              <property name="frameShape">
               <enum>QFrame::HLine</enum>
@@ -1443,38 +1705,162 @@
              </property>
             </widget>
            </item>
-           <item row="7" column="1" colspan="3">
-            <widget class="QCheckBox" name="genClef">
-             <property name="text">
-              <string>Create clef for all systems</string>
-             </property>
-            </widget>
-           </item>
-           <item row="8" column="1" colspan="3">
+           <item row="20" column="0" colspan="2">
             <widget class="QCheckBox" name="genKeysig">
              <property name="text">
               <string>Create key signature for all systems</string>
              </property>
             </widget>
            </item>
-           <item row="9" column="1" colspan="3">
-            <widget class="QCheckBox" name="genCourtesyClef">
-             <property name="text">
-              <string>Create courtesy clefs</string>
+           <item row="2" column="0" colspan="6">
+            <widget class="QFrame" name="frame_2">
+             <property name="frameShape">
+              <enum>QFrame::HLine</enum>
+             </property>
+             <property name="frameShadow">
+              <enum>QFrame::Sunken</enum>
              </property>
             </widget>
            </item>
-           <item row="10" column="1" colspan="3">
-            <widget class="QCheckBox" name="genCourtesyTimesig">
-             <property name="text">
-              <string>Create courtesy time signatures</string>
+           <item row="8" column="1">
+            <widget class="QDoubleSpinBox" name="spreadSquareBracket">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="suffix">
+              <string/>
+             </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="minimum">
+              <double>1.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>1000.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.500000000000000</double>
              </property>
             </widget>
            </item>
-           <item row="11" column="1" colspan="3">
-            <widget class="QCheckBox" name="genCourtesyKeysig">
+           <item row="4" column="4">
+            <widget class="QDoubleSpinBox" name="maxSystemDistance">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="minimum">
+              <double>0.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>1000.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.500000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="19" column="0" colspan="2">
+            <widget class="QCheckBox" name="genClef">
              <property name="text">
-              <string>Create courtesy key signatures</string>
+              <string>Create clef for all systems</string>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="3">
+            <widget class="QLabel" name="label_160">
+             <property name="text">
+              <string>Max. grand staff distance:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="0">
+            <widget class="QLabel" name="label_157">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="frameShadow">
+              <enum>QFrame::Sunken</enum>
+             </property>
+             <property name="text">
+              <string>Factor distance above/below { bracket:</string>
+             </property>
+             <property name="buddy">
+              <cstring>spreadCurlyBracket</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="1">
+            <widget class="QDoubleSpinBox" name="spreadCurlyBracket">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="suffix">
+              <string/>
+             </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="minimum">
+              <double>1.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>1000.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.500000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="2">
+            <widget class="QToolButton" name="resetSpreadCurlyBracket">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Factor distance staves grouped by [ bracket' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="4">
+            <widget class="QDoubleSpinBox" name="maxAkkoladeDistance"/>
+           </item>
+           <item row="10" column="5">
+            <widget class="QToolButton" name="resetMaxAkkoladeDistance">
+             <property name="accessibleName">
+              <string>Reset 'Max. grand staff distance' value</string>
+             </property>
+             <property name="text">
+              <string notr="true">...</string>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
              </property>
             </widget>
            </item>
@@ -1482,14 +1868,14 @@
          </widget>
         </item>
         <item>
-         <spacer>
+         <spacer name="verticalSpacer_35">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>137</width>
-            <height>21</height>
+            <width>20</width>
+            <height>40</height>
            </size>
           </property>
          </spacer>
@@ -11148,28 +11534,14 @@
   <tabstop>resetAutoplaceVerticalAlignRange</tabstop>
   <tabstop>minVerticalDistance</tabstop>
   <tabstop>resetMinVerticalDistance</tabstop>
-  <tabstop>staffUpperBorder</tabstop>
-  <tabstop>resetStaffUpperBorder</tabstop>
-  <tabstop>staffLowerBorder</tabstop>
-  <tabstop>resetStaffLowerBorder</tabstop>
-  <tabstop>staffDistance</tabstop>
-  <tabstop>resetStaffDistance</tabstop>
-  <tabstop>akkoladeDistance</tabstop>
-  <tabstop>resetAkkoladeDistance</tabstop>
-  <tabstop>minSystemDistance</tabstop>
-  <tabstop>resetMinSystemDistance</tabstop>
-  <tabstop>maxSystemDistance</tabstop>
-  <tabstop>resetMaxSystemDistance</tabstop>
-  <tabstop>systemFrameDistance</tabstop>
-  <tabstop>resetSystemFrameDistance</tabstop>
-  <tabstop>frameSystemDistance</tabstop>
-  <tabstop>resetFrameSystemDistance</tabstop>
-  <tabstop>lastSystemFillThreshold</tabstop>
-  <tabstop>resetLastSystemFillThreshold</tabstop>
   <tabstop>genClef</tabstop>
   <tabstop>genKeysig</tabstop>
   <tabstop>genCourtesyClef</tabstop>
   <tabstop>genCourtesyTimesig</tabstop>
+  <tabstop>genCourtesyKeysig</tabstop>
+  <tabstop>genClef</tabstop>
+  <tabstop>genKeysig</tabstop>
+  <tabstop>genCourtesyClef</tabstop>
   <tabstop>genCourtesyKeysig</tabstop>
   <tabstop>smallStaffSize</tabstop>
   <tabstop>resetSmallStaffSize</tabstop>

--- a/mscore/migration/handlers/staffverticaljustificationhandler.cpp
+++ b/mscore/migration/handlers/staffverticaljustificationhandler.cpp
@@ -1,8 +1,11 @@
 #include "staffverticaljustificationhandler.h"
 
-bool StaffVerticalJustificationHandler::handle(Ms::Score* /*score*/)
+bool StaffVerticalJustificationHandler::handle(Ms::Score* score)
       {
-      // TODO
+      if (!score) {
+            return false;
+      }
+      score->undoChangeStyleVal(Ms::Sid::enableVerticalSpread, true);
 
       return true;
       }

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -8000,6 +8000,7 @@ void MuseScore::init(QStringList& argv)
                   MScore::defaultStyle().set(Sid::pageWidth,  psf.width());
                   MScore::defaultStyle().set(Sid::pageHeight, psf.height());
                   MScore::defaultStyle().set(Sid::pagePrintableWidth, psf.width()-20.0/INCH);
+                  MScore::defaultStyle().set(Sid::enableVerticalSpread, true);
                   }
             }
 #endif


### PR DESCRIPTION
This PR implements [automatic vertical justification of staves](https://trello.com/c/feV4aI2I/6-implement-automatic-vertical-justification-of-staves) of the [MuseScore Engraving Push](https://trello.com/b/JVGhCNm6/musescore-engraving-push)

The algorithm
-------------
After the normal layout of a page, a new algorithm tries the spread the staves in such way the space between the lowest staff and the bottom margin of the page is used too by adding extra space between the staves.
Not all gaps between the staves will get the same amount of space but the algorithm distinguishes 3 types of gaps:

1) Gaps between the systems.

2) Gaps between the staves within a system, grouped by a [ bracket.

3) Gaps between the staves witinh a system, but outside a [ bracket.

The space between the lowest staff and the bottom margin of the page is divided over these gaps using a weight factor for each of these types of gaps.

For an example of how this algorithm works, see these 2 pages of a score:

![before](https://user-images.githubusercontent.com/48352523/92203993-be0e7880-ee82-11ea-8710-1d2cebaf6a93.png)

This pages contains 12 staves in 2 systems.
The applied weight factors were the defaults and the number of gaps to which the factors apply:

 1. Between systems: 6<br>1 gap (between the systems).
 2. Within systems, grouped by a [ bracket: 1.5<br>2 * 1 gap:
  between <code>Vln.</code> and <code>Vc.</code>
 3. Within systems, not grouped by a [ bracket: 3<br>2 * 4 gaps
  between <code>A. Sax.</code> and <code>Fl.</code>
  between <code>Fl.</code> and <code>Vln.</code>
  between <code>Vc.</code> and <code>Pno</code>
  between the two staves of the <code>Pno.</code>

Please note that the gap above the first staff of the system is not taken into account, this space remains unchanged.
At the bottom of the page, there is quite some space left between the lowest staff of the second system and the bottom music margin. The algorithm is designed to reduce this empty space by adding extra space between the gaps:
<code>"space left" * "weight factor for gap" / "sum of all weight factors on page"</code>

So, the between each <code>A. Sax.</code> and <code>Fl.</code>, <code>3/33 * "space left"</code>, so roughly 9% of the space left is added. Between the systems, 18% is added.

While adding this extra space, the maximum distance is obeyed. As a result, the algorithm can run in multiple passes. The algorithm stops:

 - When there is no space left,
 - All gaps reached their maximum distance or
 - After 10 passes (preventing an endless loop).

When calculating the <code>"sum of all weight factors on page"</code>, gaps which are already at their maximum space are ignored.

The passes won't actually changes anything, just an offset for each staff is calculated. When the algorithm finished the extra distance is applied to all staves.

The end result will looks like:

![after](https://user-images.githubusercontent.com/48352523/92204041-de3e3780-ee82-11ea-8d17-1b3ce00ba4b1.png)

New style properties
--------------------
To control the algorithm 5 new style properties are introduced:

 1. <code>spreadFactorSystem</code> (default: 6.0)<br>This parameter specifies the weight factor for the space between system.<br>On the form this is the property <code>Factor distance between systems</code>

 2. <code>spreadFactorSpacing</code> (default: 3.0)<br>This parameter specifies the weight factor for the space between staves within a system. On the form this is the property <code>Factor distance within system</code>

 3. <code>spreadFactorGroup</code> (default: 1.5)</br>This parameter specifies the weight factor for the space between staves within a system *and* grouped by a [  bracket.<br>On the form this is the property <code>Factor distance staves grouped by [ bracket</code>

 4. <code>maxStaffDistance</code> (default: 9.5)</br>This parameter specifies the maximum staff distance between staved within a system.<br>On the form this is the property <code>Max. staff distance</code>

 5. <code>maxAkkoladeDistance</code> (default: 6.5)</br>This parameter specifies the maximum distance between staves belonging to the same instrument. Usually these staves are group by a brace (<code>{</code>) but also when staves are added to an instrument, this parameter defines the maximum distance between the staves of the instrument.<br>On the form this is the property<code>Max. grand staff distance:</code>

All these parameters are on the <code>Page</code> page of the <code>Style</code> form.

The algorithm is disabled if all 3 spread factors, <code>spreadFactorSystem</code>, <code>spreadFactorSpacing</code> and <code>spreadFactorGroup</code> are 0.0.

Compatibility
-------------
When loading a score, there is no way to tell whether this is an old score without using the new spreading algorithm, or a new score using the spreading algorithm using the default properties.
To prevent the spreading algorithm is activated on old scores, a new tag <code>verticalAdjustStaves</code> is written in new scores. The absens of this tag indicates the score is an old score and during load, all spread factors (<code>spreadFactorSystem</code>, <code>spreadFactorSpacing</code> and <code>spreadFactorGroup</code>) are set to 0.0, hence disabling the algorithm.

This is also the reason why this PR is that big, all references had to modified.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
