### PR TITLE
fix #309872 Fixed search barline pixmaps by translated name

### DIFF
--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -883,10 +883,10 @@ Timeline::Timeline(TDockWidget* dockWidget, QWidget* parent)
       QPixmap* endBarlinePixmap = new QPixmap(endBarline);
       QPixmap* doubleBarlinePixmap = new QPixmap(doubleBarline);
 
-      _barlines[BarLine::userTypeName(BarLineType::START_REPEAT)] = startRepeatPixmap;
-      _barlines[BarLine::userTypeName(BarLineType::END_REPEAT)] = endRepeatPixmap;
-      _barlines[BarLine::userTypeName(BarLineType::END)] = endBarlinePixmap;
-      _barlines[BarLine::userTypeName(BarLineType::DOUBLE)] = doubleBarlinePixmap;
+      _barlines[BarLineType::START_REPEAT] = startRepeatPixmap;
+      _barlines[BarLineType::END_REPEAT] = endRepeatPixmap;
+      _barlines[BarLineType::END] = endBarlinePixmap;
+      _barlines[BarLineType::DOUBLE] = doubleBarlinePixmap;
 
       }
 
@@ -1441,14 +1441,24 @@ bool Timeline::addMetaValue(int x, int pos, QString metaText, int row, ElementTy
       qreal textWidth = graphicsTextItem->boundingRect().width();
 
       QGraphicsPixmapItem* graphicsPixmapItem = nullptr;
+
+      std::map<QString, BarLineType> barLineTypes = {
+          { BarLine::userTypeName(BarLineType::START_REPEAT), BarLineType::START_REPEAT },
+          { BarLine::userTypeName(BarLineType::END_REPEAT), BarLineType::END_REPEAT },
+          { BarLine::userTypeName(BarLineType::END), BarLineType::END },
+          { BarLine::userTypeName(BarLineType::DOUBLE), BarLineType::DOUBLE },
+      };
+
+      BarLineType barLineType = barLineTypes[metaText];
+
       if (_isBarline)
-            graphicsPixmapItem = new QGraphicsPixmapItem(*_barlines[metaText]);
+          graphicsPixmapItem = new QGraphicsPixmapItem(*_barlines[barLineType]);
 
       if (graphicsPixmapItem) {
             textWidth = 10;
             if (textWidth > _gridWidth) {
                   textWidth = _gridWidth;
-                  if (metaText == BarLine::userTypeName(BarLineType::END_REPEAT) && std::get<4>(_repeatInfo))
+                  if (barLineType == BarLineType::END_REPEAT && std::get<4>(_repeatInfo))
                         textWidth /= 2;
                   }
             }
@@ -1457,9 +1467,9 @@ bool Timeline::addMetaValue(int x, int pos, QString metaText, int row, ElementTy
             textWidth = getWidth() - x;
 
       // Adjust x for end repeats
-      if ((metaText == BarLine::userTypeName(BarLineType::END_REPEAT) ||
-           metaText == BarLine::userTypeName(BarLineType::END) ||
-           metaText == BarLine::userTypeName(BarLineType::DOUBLE) ||
+      if ((barLineType == BarLineType::END_REPEAT ||
+           barLineType == BarLineType::END ||
+           barLineType == BarLineType::DOUBLE ||
            std::get<2>(_repeatInfo))
           && !_collapsedMeta) {
             if (std::get<0>(_repeatInfo) > 0)
@@ -1484,7 +1494,7 @@ bool Timeline::addMetaValue(int x, int pos, QString metaText, int row, ElementTy
             // Exact values required for repeat pixmap to work visually
             if (textWidth != 10)
                   graphicsPixmapItem = new QGraphicsPixmapItem();
-            if (metaText == BarLine::userTypeName(BarLineType::START_REPEAT))
+            if (barLineType == BarLineType::START_REPEAT)
                   std::get<4>(_repeatInfo) = true;
             graphicsPixmapItem->setX(x + 2);
             graphicsPixmapItem->setY(_gridHeight * row + verticalScrollBar()->value() + 3);
@@ -1552,7 +1562,7 @@ bool Timeline::addMetaValue(int x, int pos, QString metaText, int row, ElementTy
       _metaRows.push_back(pairTimeRect);
       _metaRows.push_back(pairTimeText);
 
-      if (metaText == BarLine::userTypeName(BarLineType::END_REPEAT))
+      if (barLineType == BarLineType::END_REPEAT)
             std::get<0>(_repeatInfo)++;
 
       return true;

--- a/mscore/timeline.h
+++ b/mscore/timeline.h
@@ -135,7 +135,7 @@ class Timeline : public QGraphicsView {
       std::tuple<int, qreal, Element*, Element*, bool> _repeatInfo;
       std::tuple<QGraphicsItem*, int, QColor> _oldHoverInfo;
 
-      std::map<QString, QPixmap*> _barlines;
+      std::map<BarLineType, QPixmap*> _barlines;
       bool _isBarline { false };
 
       TDockWidget* _scrollArea { nullptr };


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/309872

The barLine list is initialized when the application starts and depends on the selected language. After changing the language, the pixmaps cannot be found because they have the keys to the old language.
The barLine is type-specific, not translated text. The type is determined each time when pixmaps are requested.