### PR TITLE
Fix #309874: In triplet in last Half Note of 6/4, changing last Quarter Note in triplet to Eight causes corruption

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -984,7 +984,14 @@ Fraction Score::makeGap(Segment* segment, int track, const Fraction& _sd, Tuplet
                   Fraction rd = td - sd;
                   Fraction tick = cr->tick() + actualTicks(sd, tuplet, timeStretch);
 
-                  std::vector<TDuration> dList = toRhythmicDurationList(rd, true, tick - measure->tick(), sigmap()->timesig(tick).nominal(), measure, 0);
+                  std::vector<TDuration> dList;
+                  if (tuplet || staff(track / VOICES)->isLocalTimeSignature(tick)) {
+                        dList = toDurationList(rd, false);
+                        std::reverse(dList.begin(), dList.end());
+                        }
+                  else {
+                        dList = toRhythmicDurationList(rd, true, tick - measure->tick(), sigmap()->timesig(tick).nominal(), measure, 0);
+                        }
                   if (dList.empty())
                         break;
 

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -333,7 +333,14 @@ Rest* Score::setRest(const Fraction& _tick, int track, const Fraction& _l, bool 
                   //
                   // compute list of durations which will fit l
                   //
-                  std::vector<TDuration> dList = toRhythmicDurationList(f, true, tick - measure->tick(), sigmap()->timesig(tick).nominal(), measure, useDots ? 1 : 0);
+                  std::vector<TDuration> dList;
+                  if (tuplet || staff->isLocalTimeSignature(tick)) {
+                        dList = toDurationList(l, useDots);
+                        std::reverse(dList.begin(), dList.end());
+                        }
+                  else {
+                        dList = toRhythmicDurationList(f, true, tick - measure->tick(), sigmap()->timesig(tick).nominal(), measure, useDots ? 1 : 0);
+                        }
                   if (dList.empty())
                         return 0;
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/309874.

A change was made in PR #6123 to use `toRhythmicDurationList()` rather than `toDurationList()` in `Score::setRest()`, so that compound beats are split correctly in the case of a compound meter. But this splitting of compound beats should not happen when setting rests withing a tuplet. The solution here is to simply use the original `toDurationList()` function if `tuplet` is not NULL.