### PR TITLE
Crash during the initialization of start center, fix 275837

### DIFF
--- a/mscore/downloadUtils.h
+++ b/mscore/downloadUtils.h
@@ -38,7 +38,7 @@ class DownloadUtils : public QObject
       void done();
 
    public slots:
-      void download(bool showProgress = false);
+      void download(bool showProgress = false, const int timeOutMSecs = 20000);
       void downloadFinished(QNetworkReply* data);
       void downloadProgress(qint64 received, qint64 total);
       };


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/278817

If there is no internet connection or an editor is blocked by firewall then we'll hang on download extensions step because of QEventLoop::exec(). The problem is that we can quit from event loop only when QNetworkReply::finished() signal will be emited.
