### PR TITLE
Fix #310223: Select Similar Beat not working with shortened measures

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -351,12 +351,15 @@ Fraction Element::playTick() const
 
 Fraction Element::beat() const
       {
+      // Returns an appropriate fraction of ticks for use as a "Beat" reference
+      // in the Select All Similar filter.
       int bar, beat, ticks;
       TimeSigMap* tsm = score()->sigmap();
       tsm->tickValues(tick().ticks(), &bar, &beat, &ticks);
       int ticksB = ticks_beat(tsm->timesig(tick().ticks()).timesig().denominator());
 
-      return Fraction((beat + 1 + ticks), ticksB);
+      Fraction complexFraction((++beat * ticksB) + ticks, ticksB);
+      return complexFraction.reduced();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/310223

Although **Select All Similar Beat** filtration worked as planned normally, it wasn't working with measures that had been "split" on certain occasions mentioned by Mike320 in the linked post. Turns out that the "ticks" of a beat varied when split, so instead of 480 ticks in one instance, it would be 960 for a split measure. Since I was comparing fractions generally speaking, they no longer equivocated when they should have been. I also tidied up the logic a bit to be more correct overall, even though it worked normally as it was "for the most part". Upon testing, I find no fault, but any testing of this would be appreciated. Thanks to Mike for finding this problem, as I failed to test its use case upon multiple split measures and had assumed that there'd be no problem when in fact there was. 

**Details**: Numerator now contains the full tick count of a beat + its remainder of ticks for the fraction (e.g. if beat is 1.5 and the amount of ticks for a beat is 480, then the numerator will be [(480*1) + 240] and the denominator will be 480. Doing this allows for fraction reduction, and doing so eliminates the problem of equivalent checking when denominators are different due to the size of a beat in ticks variating with split measures, the main cause of this particular bug. 

P.S. I've noticed that in splitting measures, it seems a measure reduction occurs. like a 3/4 measure split at the last beat doesn't give 2/4 but 1/2! This in turn will make it look like the Beat filter isn't working properly at times when it fact it is (like the second quarter note of 1/2 won't be beat 2 but 1.5!

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
