### PR TITLE
[MU3] Fix #277279: Lack of Capabilities in the Custom Time Signature Creator

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -821,6 +821,7 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
                         nsig->undoChangeProperty(Pid::TIMESIG_TYPE, int(ts->timeSigType()));
                         nsig->undoChangeProperty(Pid::NUMERATOR_STRING, ts->numeratorString());
                         nsig->undoChangeProperty(Pid::DENOMINATOR_STRING, ts->denominatorString());
+                        nsig->undoChangeProperty(Pid::PARSER_STRING, ts->parserString());
                         nsig->undoChangeProperty(Pid::TIMESIG_STRETCH, QVariant::fromValue(ts->stretch()));
                         nsig->undoChangeProperty(Pid::GROUPS, QVariant::fromValue(ts->groups()));
                         nsig->setSelected(false);
@@ -894,6 +895,7 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
                               nsig->undoChangeProperty(Pid::TIMESIG, QVariant::fromValue(ts->sig()));
                               nsig->undoChangeProperty(Pid::NUMERATOR_STRING, ts->numeratorString());
                               nsig->undoChangeProperty(Pid::DENOMINATOR_STRING, ts->denominatorString());
+                              nsig->undoChangeProperty(Pid::PARSER_STRING, ts->parserString());
 
                               // HACK do it twice to accommodate undo
                               nsig->undoChangeProperty(Pid::TIMESIG_TYPE, int(ts->timeSigType()));

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -138,6 +138,7 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::ACCIDENTAL_TYPE,         true,  "subtype",               P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "type")             },
       { Pid::NUMERATOR_STRING,        false, "textN",                 P_TYPE::STRING,              DUMMY_QT_TRANSLATE_NOOP("propertyName", "numerator string") },
       { Pid::DENOMINATOR_STRING,      false, "textD",                 P_TYPE::STRING,              DUMMY_QT_TRANSLATE_NOOP("propertyName", "denominator string") },
+      { Pid::PARSER_STRING,           false, "textP",                 P_TYPE::STRING,              DUMMY_QT_TRANSLATE_NOOP("propertyName", "parser string") },
       { Pid::FBPREFIX,                false, "prefix",                P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "prefix")           },
       { Pid::FBDIGIT,                 false, "digit",                 P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "digit")            },
       { Pid::FBSUFFIX,                false, "suffix",                P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "suffix")           },

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -144,6 +144,7 @@ enum class Pid {
       ACCIDENTAL_TYPE,
       NUMERATOR_STRING,
       DENOMINATOR_STRING,
+      PARSER_STRING,
       FBPREFIX,             // used for FiguredBassItem
       FBDIGIT,              //    "           "
       FBSUFFIX,             //    "           "

--- a/libmscore/sym.cpp
+++ b/libmscore/sym.cpp
@@ -2865,7 +2865,39 @@ const std::array<const char*, int(SymId::lastSym)+1> Sym::symNames = { {
       "braceLarge",
       "braceLarger",
 
-//    MuseScore-local symbols, precomposed symbols to mimic some Emmentaler glyphs
+//    SMuFL stylistic alternates for Large Time Signatures
+
+      "timeSig0Large",
+      "timeSig1Large",
+      "timeSig2Large",
+      "timeSig3Large",
+      "timeSig4Large",
+      "timeSig5Large",
+      "timeSig6Large",
+      "timeSig7Large",
+      "timeSig8Large",
+      "timeSig9Large",
+      "timeSigCommonLarge",
+      "timeSigCutCommonLarge",
+      "timeSigFractionHalfLarge",
+      "timeSigFractionOneThirdLarge",
+      "timeSigFractionQuarterLarge",
+      "timeSigFractionThreeQuartersLarge",
+      "timeSigFractionTwoThirdsLarge",
+      "timeSigOpenPendereckiLarge",
+      "timeSigParensLeftLarge",
+      "timeSigParensLeftSmallLarge",
+      "timeSigParensRightLarge",
+      "timeSigParensRightSmallLarge",
+      "timeSigPlusLarge",
+      "timeSigPlusSmallLarge",
+      "timeSigEqualsLarge",
+      "timeSigMultiplyLarge",
+      "timeSigMinusLarge",
+      "timeSigCommaLarge",
+      "timeSigXLarge",
+
+//    MuseScore local symbols, precomposed symbols to mimic some emmentaler glyphs
 
       "ornamentPrallMordent",       // ornamentPrecompTrillWithMordent ?
       "ornamentUpPrall",            // ornamentPrecompSlideTrillDAnglebert ?
@@ -6638,6 +6670,122 @@ void ScoreFont::load()
                   {     QString("brace"),
                         QString("braceLarger"),
                         SymId::braceLarger
+                  },
+                  {     QString("timeSig0"),
+                        QString("timeSig0Large"),
+                        SymId::timeSig0Large
+                  },
+                  {     QString("timeSig1"),
+                        QString("timeSig1Large"),
+                        SymId::timeSig1Large
+                  },
+                  {     QString("timeSig2"),
+                        QString("timeSig2Large"),
+                        SymId::timeSig2Large
+                  },
+                  {     QString("timeSig3"),
+                        QString("timeSig3Large"),
+                        SymId::timeSig3Large
+                  },
+                  {     QString("timeSig4"),
+                        QString("timeSig4Large"),
+                        SymId::timeSig4Large
+                  },
+                  {     QString("timeSig5"),
+                        QString("timeSig5Large"),
+                        SymId::timeSig5Large
+                  },
+                  {     QString("timeSig6"),
+                        QString("timeSig6Large"),
+                        SymId::timeSig6Large
+                  },
+                  {     QString("timeSig7"),
+                        QString("timeSig7Large"),
+                        SymId::timeSig7Large
+                  },
+                  {     QString("timeSig8"),
+                        QString("timeSig8Large"),
+                        SymId::timeSig8Large
+                  },
+                  {     QString("timeSig9"),
+                        QString("timeSig9Large"),
+                        SymId::timeSig9Large
+                  },
+                  {     QString("timeSigCommon"),
+                        QString("timeSigCommonLarge"),
+                        SymId::timeSigCommonLarge
+                  },
+                  {     QString("timeSigCutCommon"),
+                        QString("timeSigCutCommonLarge"),
+                        SymId::timeSigCutCommonLarge
+                  },
+                  {     QString("timeSigFractionHalf"),
+                        QString("timeSigFractionHalfLarge"),
+                        SymId::timeSigFractionHalfLarge
+                  },
+                  {     QString("timeSigFractionOneThird"),
+                        QString("timeSigFractionOneThirdLarge"),
+                        SymId::timeSigFractionOneThirdLarge
+                  },
+                  {     QString("timeSigFractionQuarter"),
+                        QString("timeSigFractionQuarterLarge"),
+                        SymId::timeSigFractionQuarterLarge
+                  },
+                  {     QString("timeSigFractionThreeQuarters"),
+                        QString("timeSigFractionThreeQuartersLarge"),
+                        SymId::timeSigFractionThreeQuartersLarge
+                  },
+                  {     QString("timeSigFractionTwoThirds"),
+                        QString("timeSigFractionTwoThirdsLarge"),
+                        SymId::timeSigFractionTwoThirdsLarge
+                  },
+                  {     QString("timeSigOpenPenderecki"),
+                        QString("timeSigOpenPendereckiLarge"),
+                        SymId::timeSigOpenPendereckiLarge
+                  },
+                  {     QString("timeSigParensLeft"),
+                        QString("timeSigParensLeftLarge"),
+                        SymId::timeSigParensLeftLarge
+                  },
+                  {     QString("timeSigParensLeftSmall"),
+                        QString("timeSigParensLeftSmallLarge"),
+                        SymId::timeSigParensLeftSmallLarge
+                  },
+                  {     QString("timeSigParensRight"),
+                        QString("timeSigParensRightLarge"),
+                        SymId::timeSigParensRightLarge
+                  },
+                  {     QString("timeSigParensRightSmall"),
+                        QString("timeSigParensRightSmallLarge"),
+                        SymId::timeSigParensRightSmallLarge
+                  },
+                  {     QString("timeSigPlus"),
+                        QString("timeSigPlusLarge"),
+                        SymId::timeSigPlusLarge
+                  },
+                  {     QString("timeSigPlusSmall"),
+                        QString("timeSigPlusSmallLarge"),
+                        SymId::timeSigPlusSmallLarge
+                  },
+                  {     QString("timeSigEquals"),
+                        QString("timeSigEqualsLarge"),
+                        SymId::timeSigEqualsLarge
+                  },
+                  {     QString("timeSigMultiply"),
+                        QString("timeSigMultiplyLarge"),
+                        SymId::timeSigMultiplyLarge
+                  },
+                  {     QString("timeSigMinus"),
+                        QString("timeSigMinusLarge"),
+                        SymId::timeSigMinusLarge
+                  },
+                  {     QString("timeSigComma"),
+                        QString("timeSigCommaLarge"),
+                        SymId::timeSigCommaLarge
+                  },
+                  {     QString("timeSigX"),
+                        QString("timeSigXLarge"),
+                        SymId::timeSigXLarge
                   }
             };
 

--- a/libmscore/sym.h
+++ b/libmscore/sym.h
@@ -2858,7 +2858,39 @@ enum class SymId {
       braceLarge,
       braceLarger,
 
-//    MuseScore-local symbols, precomposed symbols to mimic some Emmentaler glyphs
+//    SMuFL stylistic alternates for Large Time Signatures
+
+      timeSig0Large,
+      timeSig1Large,
+      timeSig2Large,
+      timeSig3Large,
+      timeSig4Large,
+      timeSig5Large,
+      timeSig6Large,
+      timeSig7Large,
+      timeSig8Large,
+      timeSig9Large,
+      timeSigCommonLarge,
+      timeSigCutCommonLarge,
+      timeSigFractionHalfLarge,
+      timeSigFractionOneThirdLarge,
+      timeSigFractionQuarterLarge,
+      timeSigFractionThreeQuartersLarge,
+      timeSigFractionTwoThirdsLarge,
+      timeSigOpenPendereckiLarge,
+      timeSigParensLeftLarge,
+      timeSigParensLeftSmallLarge,
+      timeSigParensRightLarge,
+      timeSigParensRightSmallLarge,
+      timeSigPlusLarge,
+      timeSigPlusSmallLarge,
+      timeSigEqualsLarge,
+      timeSigMultiplyLarge,
+      timeSigMinusLarge,
+      timeSigCommaLarge,
+      timeSigXLarge,
+
+//    MuseScore local symbols, precomposed symbols to mimic some emmentaler glyphs
 
       ornamentPrallMordent,
       ornamentUpPrall,

--- a/libmscore/timesig.h
+++ b/libmscore/timesig.h
@@ -43,14 +43,14 @@ enum class TimeSigType : char {
 class TimeSig final : public Element {
       QString _numeratorString;     // calculated from actualSig() if !customText
       QString _denominatorString;
+      QString _parserString;         // Parsed single text field for custom text
 
-      std::vector<SymId> ns;
-      std::vector<SymId> ds;
+      std::vector<std::vector<SymId>> ns;
+      std::vector<std::vector<SymId>> ds;
 
-      QPointF pz;
-      QPointF pn;
-      QPointF pointLargeLeftParen;
-      QPointF pointLargeRightParen;
+      std::vector<QPointF> pns;
+      std::vector<QPointF> pds;
+
       Fraction _sig;
       Fraction _stretch;      // localSig / globalSig
       Groups _groups;
@@ -105,6 +105,9 @@ class TimeSig final : public Element {
 
       QString denominatorString() const  { return _denominatorString; }
       void setDenominatorString(const QString&);
+
+      QString parserString() const        { return _parserString;       }
+      void setParserString(const QString& a);
 
       void setLargeParentheses(bool v)    { _largeParentheses = v;    }
 

--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -1000,43 +1000,81 @@ Segment* skipTuplet(Tuplet* tuplet)
 
 std::vector<SymId> toTimeSigString(const QString& s)
       {
+      return toTimeSigString(s, false);       
+      }
+
+std::vector<SymId> toTimeSigString(const QString& s, bool isSingleLine)
+      {
       struct Dict {
             QChar code;
             SymId id;
             };
       static const std::vector<Dict> dict = {
-            { 43,    SymId::timeSigPlusSmall        },  // '+'
-            { 48,    SymId::timeSig0                },  // '0'
-            { 49,    SymId::timeSig1                },  // '1'
-            { 50,    SymId::timeSig2                },  // '2'
-            { 51,    SymId::timeSig3                },  // '3'
-            { 52,    SymId::timeSig4                },  // '4'
-            { 53,    SymId::timeSig5                },  // '5'
-            { 54,    SymId::timeSig6                },  // '6'
-            { 55,    SymId::timeSig7                },  // '7'
-            { 56,    SymId::timeSig8                },  // '8'
-            { 57,    SymId::timeSig9                },  // '9'
-            { 67,    SymId::timeSigCommon           },  // 'C'
-            { 40,    SymId::timeSigParensLeftSmall  },  // '('
-            { 41,    SymId::timeSigParensRightSmall },  // ')'
-            { 162,   SymId::timeSigCutCommon        },  // '¢'
-            { 189,   SymId::timeSigFractionHalf     },
-            { 188,   SymId::timeSigFractionQuarter  },
-            { 59664, SymId::mensuralProlation1      },
-            { 79,    SymId::mensuralProlation2      },  // 'O'
-            { 59665, SymId::mensuralProlation2      },
-            { 216,   SymId::mensuralProlation3      },  // 'Ø'
-            { 59666, SymId::mensuralProlation3      },
-            { 59667, SymId::mensuralProlation4      },
-            { 59668, SymId::mensuralProlation5      },
-            { 59670, SymId::mensuralProlation7      },
-            { 59671, SymId::mensuralProlation8      },
-            { 59673, SymId::mensuralProlation10     },
-            { 59674, SymId::mensuralProlation11     },
+            //code     id           
+            { 43,    SymId::timeSigPlusSmall             },  // '+'
+            { 48,    SymId::timeSig0                     },  // '0'
+            { 49,    SymId::timeSig1                     },  // '1'
+            { 50,    SymId::timeSig2                     },  // '2'
+            { 51,    SymId::timeSig3                     },  // '3'
+            { 52,    SymId::timeSig4                     },  // '4'
+            { 53,    SymId::timeSig5                     },  // '5'
+            { 54,    SymId::timeSig6                     },  // '6'
+            { 55,    SymId::timeSig7                     },  // '7'
+            { 56,    SymId::timeSig8                     },  // '8'
+            { 57,    SymId::timeSig9                     },  // '9'
+            { 67,    SymId::timeSigCommon                },  // 'C'
+            { 40,    SymId::timeSigParensLeftSmall       },  // '('
+            { 41,    SymId::timeSigParensRightSmall      },  // ')'
+            { 162,   SymId::timeSigCutCommon             },  // '¢'
+            { 59664, SymId::mensuralProlation1           },
+            { 79,    SymId::mensuralProlation2           },  // 'O'
+            { 59665, SymId::mensuralProlation2           },
+            { 216,   SymId::mensuralProlation3           },  // 'Ø'
+            { 59666, SymId::mensuralProlation3           },
+            { 59667, SymId::mensuralProlation4           },
+            { 59668, SymId::mensuralProlation5           },
+            { 59670, SymId::mensuralProlation7           },
+            { 59671, SymId::mensuralProlation8           },
+            { 59673, SymId::mensuralProlation10          },
+            { 59674, SymId::mensuralProlation11          },
+            { 188,   SymId::timeSigFractionQuarter       },  // '¼'
+            { 57495, SymId::timeSigFractionQuarter       }, 
+            { 189,   SymId::timeSigFractionHalf          },  // '½'
+            { 57496, SymId::timeSigFractionHalf          },
+            { 57497, SymId::timeSigFractionThreeQuarters },
+            { 190,   SymId::timeSigFractionThreeQuarters }, // '¾'
+            { 57498, SymId::timeSigFractionOneThird      },
+            { 57499, SymId::timeSigFractionTwoThirds     },
+            { 88,    SymId::timeSigX                     }, // 'X'
+            { 126,   SymId::timeSigOpenPenderecki        }, // '~'
+            { 32,    SymId::space                        }, // ' '
+            { 119,   SymId::metNoteWhole                 }, // 'w'
+            { 104,   SymId::metNoteHalfDown              }, // 'h'
+            { 113,   SymId::metNoteQuarterDown           }, // 'q'
+            { 101,   SymId::metNote8thDown               }, // 'e'
+            { 115,   SymId::metNote16thDown              }, // 's'
+            { 46,    SymId::metAugmentationDot           }, // '.'
+            { 61,    SymId::timeSigEquals                }, // '='
+            { 42,    SymId::timeSigMultiply              }, // '*'
+            { 120,   SymId::timeSigMultiply              }, // 'x'
+            { 45,    SymId::timeSigMinus                 }, // '-'
+            { 44,    SymId::timeSigComma                 }, // ','
+            { 57492, SymId::timeSigParensLeft            }, // E094 (big left parenthesis)
+            { 57493, SymId::timeSigParensRight           }, // E095 (big right parenthesis)
+            { 57484, SymId::timeSigPlus                  }, // E08C (big plus)
             };
 
+      QString str = s;
+
+      // Use large parentheses and '+' glyphs if in single line
+      if (isSingleLine) {
+            str.replace("(","\uE094"); 
+            str.replace(")","\uE095"); 
+            str.replace("+","\uE08C"); 
+            }
+      
       std::vector<SymId> d;
-      for (auto c : s) {
+      for (auto c : str) {
             for (const Dict& e : dict) {
                   if (c == e.code) {
                         d.push_back(e.id);

--- a/libmscore/utils.h
+++ b/libmscore/utils.h
@@ -88,6 +88,7 @@ extern int step2pitch(int step);
 
 extern Segment* skipTuplet(Tuplet* tuplet);
 extern std::vector<SymId> toTimeSigString(const QString&);
+extern std::vector<SymId> toTimeSigString(const QString& s, bool isSingleLine);
 extern Fraction actualTicks(Fraction duration, Tuplet* tuplet, Fraction timeStretch);
 
 }     // namespace Ms

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -916,15 +916,21 @@ InspectorTimeSig::InspectorTimeSig(QWidget* parent)
             { Pid::LEADING_SPACE,  1, s.leadingSpace,   s.resetLeadingSpace  },
             { Pid::SHOW_COURTESY,  0, t.showCourtesy,   t.resetShowCourtesy  },
             { Pid::SCALE,          0, t.scale,          t.resetScale         },
+            { Pid::PARSER_STRING,  0, t.pText,          t.resetPText         },
 //          { Pid::TIMESIG,        0, t.timesigZ,       t.resetTimesig       },
 //          { Pid::TIMESIG,        0, t.timesigN,       t.resetTimesig       },
 //          { Pid::TIMESIG_GLOBAL, 0, t.globalTimesigZ, t.resetGlobalTimesig },
-//          { Pid::TIMESIG_GLOBAL, 0, t.globalTimesigN, t.resetGlobalTimesig }
+//          { Pid::TIMESIG_GLOBAL, 0, t.globalTimesigN, t.resetGlobalTimesig },
             };
       const std::vector<InspectorPanel> ppList = {
             { s.title, s.panel },
             { t.title, t.panel }
             };
+      // Validator (should be in sync with validator in timedialog.cpp and timesigproperties.cpp)
+      QRegExp rx("[0-9+CO()|=,x ~X\\*\\-\\[\\]\\.\\/\\x00A2\\x00D8\\x00BC\\x00BD\\x00BE\\xE097\\xE098\\xE099\\xE09A\\xE09B\\xE09C\\xE09D]*");
+      QValidator *validator = new QRegExpValidator(rx, this);
+      t.pText->setValidator(validator);
+
       mapSignals(iiList, ppList);
       connect(t.properties, SIGNAL(clicked()), SLOT(propertiesClicked()));
       }

--- a/mscore/inspector/inspector_timesig.ui
+++ b/mscore/inspector/inspector_timesig.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>218</width>
-    <height>143</height>
+    <height>177</height>
    </rect>
   </property>
   <property name="accessibleName">
@@ -79,6 +79,48 @@
       <property name="spacing">
        <number>3</number>
       </property>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Scale:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Ms::ScaleSelect" name="scale" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Scale</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="Ms::ResetButton" name="resetPText" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Show courtesy' value</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0" colspan="2">
        <widget class="QCheckBox" name="showCourtesy">
         <property name="focusPolicy">
@@ -86,6 +128,36 @@
         </property>
         <property name="text">
          <string>Show courtesy</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Text (appearance):</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QLineEdit" name="pText">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="Ms::ResetButton" name="resetScale" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Scale' values</string>
         </property>
        </widget>
       </item>
@@ -102,43 +174,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Scale:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="Ms::ScaleSelect" name="scale" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Scale</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="Ms::ResetButton" name="resetScale" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Scale' values</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="3">
+      <item row="5" column="0" colspan="3">
        <widget class="QPushButton" name="properties">
         <property name="text">
          <string>Properties</string>

--- a/mscore/noteGroups.cpp
+++ b/mscore/noteGroups.cpp
@@ -37,10 +37,8 @@ Score* NoteGroups::createScore(int n, TDuration::DurationType t, std::vector<Cho
       c.move(0, Fraction(0,1));
       c.addKeySig(Key::C);
       TimeSig* nts = c.addTimeSig(_sig);
-      if (!_z.isEmpty())
-            nts->setNumeratorString(_z);
-      if (!_n.isEmpty())
-            nts->setDenominatorString(_n);
+      if (!_p.isEmpty())
+            nts->setParserString(_p);
       GroupNode node {0, 0};
       Groups ng;
       ng.push_back(node);
@@ -106,11 +104,10 @@ NoteGroups::NoteGroups(QWidget* parent)
 //   setSig
 //---------------------------------------------------------
 
-void NoteGroups::setSig(Fraction sig, const Groups& g, const QString& z, const QString& n)
+void NoteGroups::setSig(Fraction sig, const Groups& g, const QString& p)
       {
       _sig    = sig;
-      _z      = z;
-      _n      = n;
+      _p      = p;
       _groups = g;
       chords8.clear();
       chords16.clear();
@@ -149,7 +146,7 @@ Groups NoteGroups::groups()
 
 void NoteGroups::resetClicked()
       {
-      setSig(_sig, _groups, _z, _n);
+      setSig(_sig, _groups, _p);
       }
 
 //---------------------------------------------------------

--- a/mscore/noteGroups.h
+++ b/mscore/noteGroups.h
@@ -34,7 +34,7 @@ class NoteGroups : public QGroupBox, Ui::NoteGroups {
       std::vector<Chord*> chords32;
       Groups _groups;
       Fraction _sig;
-      QString _z, _n;
+      QString _p;
 
       Score* createScore(int n, TDuration::DurationType t, std::vector<Chord*>* chords);
       void updateBeams(Chord*, Beam::Mode);
@@ -46,7 +46,7 @@ class NoteGroups : public QGroupBox, Ui::NoteGroups {
 
    public:
       NoteGroups(QWidget* parent);
-      void setSig(Fraction sig, const Groups&, const QString& zText, const QString& nText);
+      void setSig(Fraction sig, const Groups&, const QString& pText);
       Groups groups();
       };
 

--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -487,6 +487,7 @@ void ScoreView::editTimeSigProperties(TimeSig* ts)
             ts->undoChangeProperty(Pid::SHOW_COURTESY, r->showCourtesySig());
             ts->undoChangeProperty(Pid::NUMERATOR_STRING, r->numeratorString());
             ts->undoChangeProperty(Pid::DENOMINATOR_STRING, r->denominatorString());
+            ts->undoChangeProperty(Pid::PARSER_STRING, r->parserString());
             ts->undoChangeProperty(Pid::GROUPS, QVariant::fromValue<Groups>(r->groups()));
 
             if (r->sig() != ts->sig()) {

--- a/mscore/timedialog.cpp
+++ b/mscore/timedialog.cpp
@@ -48,13 +48,19 @@ TimeDialog::TimeDialog(QWidget* parent)
       sp->setReadOnly(false);
       sp->setSelectable(true);
 
+      // (should be in sync with validator in timeproperties.cpp and inspector.cpp)
+      QRegExp rx("[0-9+CO()|=,x ~X\\*\\-\\[\\]\\.\\/\\x00A2\\x00D8\\x00BC\\x00BD\\x00BE\\xE097\\xE098\\xE099\\xE09A\\xE09B\\xE09C\\xE09D]*");
+      QValidator *validator = new QRegExpValidator(rx, this);
+      //zText->setValidator(validator);
+      pText->setValidator(validator);
+
+
       connect(zNominal,  SIGNAL(valueChanged(int)), SLOT(zChanged(int)));
       connect(nNominal,  SIGNAL(currentIndexChanged(int)), SLOT(nChanged(int)));
       connect(sp,        SIGNAL(boxClicked(int)),   SLOT(paletteChanged(int)));
       connect(sp,        SIGNAL(changed()),         SLOT(setDirty()));
       connect(addButton, SIGNAL(clicked()),         SLOT(addClicked()));
-      connect(zText,     SIGNAL(textChanged(const QString&)),    SLOT(textChanged()));
-      connect(nText,     SIGNAL(textChanged(const QString&)),    SLOT(textChanged()));
+      connect(pText,     SIGNAL(textChanged(const QString&)),    SLOT(textChanged()));
 
       _timePalette = new PaletteScrollArea(sp);
       QSizePolicy policy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -67,7 +73,7 @@ TimeDialog::TimeDialog(QWidget* parent)
 
       if (useFactorySettings || !sp->read(dataPath + "/timesigs")) {
             Fraction sig(4,4);
-            groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text());
+            groups->setSig(sig, Groups::endings(sig), pText->text());
             }
       for (int i = 0; i < sp->size(); ++i)      // cells can be changed
             sp->setCellReadOnly(i, false);
@@ -88,11 +94,8 @@ void TimeDialog::addClicked()
       ts->setGroups(groups->groups());
 
       // check for special text
-      if ((QString("%1").arg(zNominal->value()) != zText->text())
-         || (QString("%1").arg(denominator()) != nText->text())) {
-            ts->setNumeratorString(zText->text());
-            ts->setDenominatorString(nText->text());
-            }
+      if (!pText->text().isEmpty())
+            ts->setParserString(pText->text());
       // extend palette:
       sp->append(ts, "");
       sp->setSelected(sp->size() - 1);
@@ -129,7 +132,7 @@ void TimeDialog::zChanged(int val)
       {
       Q_UNUSED(val);
       Fraction sig(zNominal->value(), denominator());
-      groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text());
+      groups->setSig(sig, Groups::endings(sig), pText->text());
       }
 
 //---------------------------------------------------------
@@ -140,7 +143,7 @@ void TimeDialog::nChanged(int val)
       {
       Q_UNUSED(val);
       Fraction sig(zNominal->value(), denominator());
-      groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text());
+      groups->setSig(sig, Groups::endings(sig), pText->text());
       }
 
 //---------------------------------------------------------
@@ -191,16 +194,14 @@ void TimeDialog::paletteChanged(int idx)
       if (!e || e->type() != ElementType::TIMESIG) {
             zNominal->setEnabled(false);
             nNominal->setEnabled(false);
-            zText->setEnabled(false);
-            nText->setEnabled(false);
+            pText->setEnabled(false);
             groups->setEnabled(false);
             addButton->setEnabled(false);
             return;
             }
       zNominal->setEnabled(true);
       nNominal->setEnabled(true);
-      zText->setEnabled(true);
-      nText->setEnabled(true);
+      pText->setEnabled(true);
       groups->setEnabled(true);
       addButton->setEnabled(true);
 
@@ -210,9 +211,8 @@ void TimeDialog::paletteChanged(int idx)
             g = Groups::endings(sig);
       zNominal->setValue(sig.numerator());
       nNominal->setCurrentIndex(denominator2Idx(sig.denominator()));
-      zText->setText(e->numeratorString());
-      nText->setText(e->denominatorString());
-      groups->setSig(sig, g, zText->text(), nText->text());
+      pText->setText(e->parserString());
+      groups->setSig(sig, g, pText->text());
       }
 
 //---------------------------------------------------------
@@ -222,7 +222,7 @@ void TimeDialog::paletteChanged(int idx)
 void TimeDialog::textChanged()
       {
       Fraction sig(zNominal->value(), denominator());
-      groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text());
+      groups->setSig(sig, Groups::endings(sig), pText->text());
       }
 
 

--- a/mscore/timedialog.ui
+++ b/mscore/timedialog.ui
@@ -156,53 +156,27 @@
             </widget>
            </item>
            <item>
-            <widget class="QLineEdit" name="zText">
+            <widget class="QLineEdit" name="pText">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
+             <property name="minimumSize">
+              <size>
+               <width>160</width>
+               <height>0</height>
+              </size>
+             </property>
              <property name="maximumSize">
               <size>
-               <width>60</width>
+               <width>800</width>
                <height>16777215</height>
               </size>
              </property>
              <property name="text">
-              <string>4</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="label_8">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>/</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="nText">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>60</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>4</string>
+              <string/>
              </property>
             </widget>
            </item>

--- a/mscore/timesigproperties.h
+++ b/mscore/timesigproperties.h
@@ -38,6 +38,9 @@ class TimeSigProperties : public QDialog, public Ui::TimeSigProperties {
    public slots:
       virtual void accept();
 
+   //private slots:
+      void textChanged();
+
    public:
       TimeSigProperties(TimeSig*, QWidget* parent = 0);
       };

--- a/mscore/timesigproperties.ui
+++ b/mscore/timesigproperties.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>779</width>
-    <height>560</height>
+    <width>731</width>
+    <height>539</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -204,35 +204,14 @@
            <property name="verticalSpacing">
             <number>0</number>
            </property>
-           <item row="3" column="0">
+           <item row="4" column="0">
             <widget class="QRadioButton" name="otherButton">
              <property name="text">
               <string>Other:</string>
              </property>
             </widget>
            </item>
-           <item row="0" column="0">
-            <widget class="QRadioButton" name="textButton">
-             <property name="layoutDirection">
-              <enum>Qt::LeftToRight</enum>
-             </property>
-             <property name="text">
-              <string>Text:</string>
-             </property>
-            </widget>
-           </item>
            <item row="2" column="0">
-            <widget class="QRadioButton" name="allaBreveButton">
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/timesig_allabreve.svg</normaloff>:/data/icons/timesig_allabreve.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
             <widget class="QRadioButton" name="fourfourButton">
              <property name="text">
               <string notr="true"/>
@@ -243,37 +222,7 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
-            <layout class="QHBoxLayout" name="horizontalLayout">
-             <item>
-              <widget class="QLineEdit" name="zText"/>
-             </item>
-             <item>
-              <widget class="QLabel" name="label">
-               <property name="text">
-                <string>/</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLineEdit" name="nText"/>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_2">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </item>
-           <item row="3" column="1">
+           <item row="4" column="1">
             <layout class="QHBoxLayout" name="horizontalLayout_4">
              <item>
               <widget class="QComboBox" name="otherCombo">
@@ -299,6 +248,44 @@
               </spacer>
              </item>
             </layout>
+           </item>
+           <item row="0" column="1">
+            <layout class="QHBoxLayout" name="horizontalLayout">
+             <item>
+              <widget class="QLineEdit" name="pText">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="3" column="0">
+            <widget class="QRadioButton" name="allaBreveButton">
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/timesig_allabreve.svg</normaloff>:/data/icons/timesig_allabreve.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <layout class="QHBoxLayout" name="horizontalLayout_5"/>
+           </item>
+           <item row="0" column="0">
+            <widget class="QRadioButton" name="textButton">
+             <property name="layoutDirection">
+              <enum>Qt::LeftToRight</enum>
+             </property>
+             <property name="text">
+              <string>Text:</string>
+             </property>
+            </widget>
            </item>
           </layout>
          </widget>
@@ -347,8 +334,7 @@
   <tabstop>zActual</tabstop>
   <tabstop>nActual</tabstop>
   <tabstop>textButton</tabstop>
-  <tabstop>zText</tabstop>
-  <tabstop>nText</tabstop>
+  <tabstop>pText</tabstop>
   <tabstop>fourfourButton</tabstop>
   <tabstop>allaBreveButton</tabstop>
   <tabstop>otherButton</tabstop>


### PR DESCRIPTION
Resolves: *https://musescore.org/en/node/277279* 
Lack of Capabilities in the Custom Time Signature Creator
*https://musescore.org/en/node/279745* 
Allow periods in custom time signatures
*https://musescore.org/en/node/277665*
Cannot use a decimal dot or vulgar fractures like ½ for time signatures

See other requests:
*https://musescore.org/en/node/312343* Time SIgnature Palette: Parenthesis
*https://musescore.org/en/node/312343* 3/4 Time Signature with Secondary 6/8 in parenthesis
*https://musescore.org/en/node/305902* Dual Time Signatures

This PR replaces the _appearance_ numerator/denominator fields with a single parsed text that allows more capabilites to the appearance of time signatures. These changes were made in the Time Signature creator (timedialog), Time Signature properties, and additionally added to the time signature Inspector directly, which is the faster way to enter text and change the appearance of a time signature (can be done locally if a single t/s is selected pressing CTRL).

This single field is properly parsed to identify "blocks" of time signatures (numerator/denominator) as well as complementary glyphs such as Operators +=-x and Parentheses ( ). In the absence of a denominator, the glyphs are drawn vertically centered, as current, and the Plus and Parentheses glyphs are replaced by the large versions.

Examples:
"2/4"
"3/4(6/8)"
"3+2/8"
"2/8+5/8"
"C"
"4/4=C"

![image](https://user-images.githubusercontent.com/2843953/100013581-d6bc6980-2db3-11eb-9856-4c7d2d3ca6ad.png)

**(NOTE: The 'Large Time Signature' feature from the inspector and at the end of the video below was removed from this PR, for a future work)**

In action:
![parser_ts_inspector2](https://user-images.githubusercontent.com/2843953/100015717-2c464580-2db7-11eb-8f24-52aad4022a50.gif)

**Bracketed special characters:**

- To enter fractional glyphs, use brackets: ex. 3[1/2]/4
-  Note value glyphs like quarter, dotted quarter, can be entered in denominators (Carl Off style time signatures) by using numbers and dots within brackets: [2] [4] [8] and [16] where [8] is an eight note, [4.] is a dotted quarter note. Ex: 3/[8.]
- Other (unrecognized) texts between brackets will be discarded.

- Other glyphs include  Open Penderecki time signature ( type  '~' ) Open X time signature (type uppercase 'X') Comma ',' and period or augmentation dot '.'
- Spaces can be added to improve visual and will force separation of 'blocks'.

Additional notes:
- All Time Signature 'official' SMuFL glyphs have been enabled (see https://w3c.github.io/smufl/gitbook/tables/time-signatures.html)
- Big parentheses ( ) (SymId::timeSigParensLeft / Right) are not well implemented in Emmentaler and Gonville fonts. Emmentaler has bad bboxes/metrics, and in Gonville these glyphs are identical to the smaller SymId::timeSigParensLeftSmall. (both cases might need special handling or fontworks)
- The 'Narrow' glyphs from SMuFL have not been activated because they are just the common font time signatures being condensed horizontally, which can be achieved via the time signature Scaling in the inspector.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [NA] I created the test (mtest, vtest, script test) to verify the changes I made
