### PR TITLE
Fix #310373: Update Diatonic Shortcuts Keeping Degree Alterations

### DIFF
--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -701,8 +701,11 @@ void Score::transposeDiatonicAlterations(TransposeDirection direction)
       {
       // Transpose current selection diatonically (up/down) while keeping degree alterations
       // Note: Score::transpose() absolutely requires valid selection before invocation.
-      if (!selection().isNone())
+      if (!selection().isNone()) {
             transpose(TransposeMode::DIATONICALLY, direction, Key::C, 1, true, true, true);
+            setPlayNote(true); // For when selection is a single note, also playback that note
+            setSelectionChanged(true); // This will update the on-screen keyboard
+            }
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/310373

[Keep Degree Alteration] version of Diatonic Up/Down now plays back sound when only one note is being altered, and selection now is updated so that for instance the on-screen keyboard will be updated when doing so. Original PR didn't take these into consideration.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
