### PR TITLE
Fix #310248 - Correct Actual Duration of Split Measures +collect_arti…

### DIFF
--- a/libmscore/splitMeasure.cpp
+++ b/libmscore/splitMeasure.cpp
@@ -104,8 +104,27 @@ void Score::splitMeasure(Segment* segment)
       Fraction ticks2 = measure->ticks() - ticks1;
       m1->setTimesig(measure->timesig());
       m2->setTimesig(measure->timesig());
-      m1->adjustToLen(ticks1.reduced(), false);
-      m2->adjustToLen(ticks2.reduced(), false);
+      ticks1.reduce();
+      ticks2.reduce();
+      // Now make sure this reduction doesn't go 'beyond' the original measure's
+      // actual denominator for both resultant measures.
+      if (ticks1.denominator() < measure->ticks().denominator()) {
+            if (measure->ticks().denominator() % m1->timesig().denominator() == 0) {
+                  int mult = measure->ticks().denominator() / ticks1.denominator();
+                  // *= operator audomatically reduces via GCD, so rather do literal multiplication:
+                  ticks1.setDenominator(ticks1.denominator() * mult);
+                  ticks1.setNumerator(ticks1.numerator() * mult);
+                  }
+            }
+      if (ticks2.denominator() < measure->ticks().denominator()) {
+            if (measure->ticks().denominator() % m2->timesig().denominator() == 0) {
+                  int mult = measure->ticks().denominator() / ticks2.denominator();
+                  ticks2.setDenominator(ticks2.denominator() * mult);
+                  ticks2.setNumerator(ticks2.numerator() * mult);
+                  }
+            }
+      m1->adjustToLen(ticks1, false);
+      m2->adjustToLen(ticks2, false);
       range.write(this, m1->tick());
 
       // Restore ties the the beginning of the split measure.

--- a/mtest/libmscore/split/split01-ref.mscx
+++ b/mtest/libmscore/split/split01-ref.mscx
@@ -67,7 +67,7 @@
           <text>Split Measure</text>
           </Text>
         </VBox>
-      <Measure len="1/2">
+      <Measure len="2/4">
         <voice>
           <Clef>
             <concertClefType>G</concertClefType>
@@ -97,7 +97,7 @@
             </Chord>
           </voice>
         </Measure>
-      <Measure len="1/2">
+      <Measure len="2/4">
         <voice>
           <Chord>
             <durationType>quarter</durationType>

--- a/mtest/libmscore/split/split02-ref.mscx
+++ b/mtest/libmscore/split/split02-ref.mscx
@@ -67,7 +67,7 @@
           <text>Split Measure+Slur</text>
           </Text>
         </VBox>
-      <Measure len="1/2">
+      <Measure len="2/4">
         <voice>
           <Clef>
             <concertClefType>G</concertClefType>
@@ -107,7 +107,7 @@
             </Chord>
           </voice>
         </Measure>
-      <Measure len="1/2">
+      <Measure len="2/4">
         <voice>
           <Chord>
             <durationType>quarter</durationType>

--- a/mtest/libmscore/split/split03-ref.mscx
+++ b/mtest/libmscore/split/split03-ref.mscx
@@ -67,7 +67,7 @@
           <text>Split Measure</text>
           </Text>
         </VBox>
-      <Measure len="1/2">
+      <Measure len="2/4">
         <voice>
           <Clef>
             <concertClefType>G</concertClefType>
@@ -109,7 +109,7 @@
             </Chord>
           </voice>
         </Measure>
-      <Measure len="1/2">
+      <Measure len="2/4">
         <voice>
           <Chord>
             <durationType>quarter</durationType>

--- a/mtest/libmscore/split/split04-ref.mscx
+++ b/mtest/libmscore/split/split04-ref.mscx
@@ -67,7 +67,7 @@
           <text>Split Measure</text>
           </Text>
         </VBox>
-      <Measure len="1/2">
+      <Measure len="2/4">
         <voice>
           <Clef>
             <concertClefType>G</concertClefType>
@@ -107,7 +107,7 @@
             </Chord>
           </voice>
         </Measure>
-      <Measure len="1/2">
+      <Measure len="2/4">
         <voice>
           <Chord>
             <durationType>quarter</durationType>

--- a/mtest/libmscore/split/split05-ref.mscx
+++ b/mtest/libmscore/split/split05-ref.mscx
@@ -67,7 +67,7 @@
           <text>Split Measure + Slur at end</text>
           </Text>
         </VBox>
-      <Measure len="1/2">
+      <Measure len="2/4">
         <voice>
           <Clef>
             <concertClefType>G</concertClefType>
@@ -97,7 +97,7 @@
             </Chord>
           </voice>
         </Measure>
-      <Measure len="1/2">
+      <Measure len="2/4">
         <voice>
           <Chord>
             <durationType>quarter</durationType>

--- a/mtest/libmscore/split/split06-ref.mscx
+++ b/mtest/libmscore/split/split06-ref.mscx
@@ -117,7 +117,7 @@
             </Chord>
           </voice>
         </Measure>
-      <Measure len="1/2">
+      <Measure len="2/4">
         <voice>
           <Tempo>
             <tempo>1.66667</tempo>
@@ -147,7 +147,7 @@
             </Chord>
           </voice>
         </Measure>
-      <Measure len="1/2">
+      <Measure len="2/4">
         <voice>
           <Chord>
             <durationType>quarter</durationType>

--- a/mtest/libmscore/split/split07-ref.mscx
+++ b/mtest/libmscore/split/split07-ref.mscx
@@ -67,7 +67,7 @@
           <text>Split Measure + Slur at end</text>
           </Text>
         </VBox>
-      <Measure len="1/2">
+      <Measure len="2/4">
         <voice>
           <Clef>
             <concertClefType>G</concertClefType>
@@ -97,7 +97,7 @@
             </Chord>
           </voice>
         </Measure>
-      <Measure len="1/2">
+      <Measure len="2/4">
         <voice>
           <Chord>
             <durationType>quarter</durationType>

--- a/mtest/libmscore/split/split08-ref.mscx
+++ b/mtest/libmscore/split/split08-ref.mscx
@@ -67,7 +67,7 @@
           <text>Split Measure + Slur after</text>
           </Text>
         </VBox>
-      <Measure len="1/2">
+      <Measure len="2/4">
         <voice>
           <Clef>
             <concertClefType>G</concertClefType>
@@ -97,7 +97,7 @@
             </Chord>
           </voice>
         </Measure>
-      <Measure len="1/2">
+      <Measure len="2/4">
         <voice>
           <Chord>
             <durationType>quarter</durationType>

--- a/mtest/libmscore/split/split183846-irregular-verylong-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-verylong-ref.mscx
@@ -133,7 +133,7 @@
         </Instrument>
       </Part>
     <Staff id="1">
-      <Measure len="35/4">
+      <Measure len="70/8">
         <voice>
           <KeySig>
             <accidental>3</accidental>
@@ -182,7 +182,7 @@
             </Rest>
           </voice>
         </Measure>
-      <Measure len="45/4">
+      <Measure len="90/8">
         <voice>
           <Chord>
             <durationType>half</durationType>

--- a/mtest/libmscore/split/split183846-irregular-wn-wr-wn-hr-qr-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-wn-wr-wn-hr-qr-ref.mscx
@@ -134,7 +134,7 @@
         </Instrument>
       </Part>
     <Staff id="1">
-      <Measure len="2/1">
+      <Measure len="8/4">
         <voice>
           <TimeSig>
             <sigN>4</sigN>

--- a/mtest/libmscore/split/split183846-irregular-wr-wn-wr-hn-qn-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-wr-wn-wr-hn-qn-ref.mscx
@@ -134,7 +134,7 @@
         </Instrument>
       </Part>
     <Staff id="1">
-      <Measure len="3/1">
+      <Measure len="12/4">
         <voice>
           <TimeSig>
             <sigN>4</sigN>

--- a/mtest/libmscore/split/split184061-other-inst-only-one-tie-ref.mscx
+++ b/mtest/libmscore/split/split184061-other-inst-only-one-tie-ref.mscx
@@ -133,6 +133,7 @@
           <gateTime>100</gateTime>
           </Articulation>
         <Channel>
+          <controller ctrl="32" value="17"/>
           <program value="73"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/split/split184061-other-inst-only-one-tie-ref.mscx
+++ b/mtest/libmscore/split/split184061-other-inst-only-one-tie-ref.mscx
@@ -133,7 +133,6 @@
           <gateTime>100</gateTime>
           </Articulation>
         <Channel>
-          <controller ctrl="32" value="17"/>
           <program value="73"/>
           </Channel>
         </Instrument>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/310248

Split measures did a blind reduction of fractions. This should make them more intelligible. For example, 4/4 split in half will be 2/4 instead of 1/2. Another test I ran was 12/8: split so there was [1/8] + [11/8] after and then split that [11/8] at [4/8] and the remainder came out fine as [7/8]. As it was originally, this would've resulted in [11/8] and [1/2] again

I tested this and it works fine, but I didn't extensively test it, so I hope someone else is willing to spend some time
verifying there's no problems. I added +collect_artifacts to the title for this purpose so maybe someone can just download the appImage and check it out

Update: mtests/split "-ref" files needed to be updated, so I manually ran the split actions on the original files and saved over the -ref.mscx files.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
