### PR TITLE
Fix #310492: Cutaway hides staves with cross-staff notes | collect_ar…

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2743,6 +2743,7 @@ bool Measure::isEmpty(int staffIdx) const
       {
       int strack;
       int etrack;
+      bool hasStaves = score()->staff(staffIdx)->part()->staves()->size() > 1; 
       if (staffIdx < 0) {
             strack = 0;
             etrack = score()->nstaves() * VOICES;
@@ -2756,6 +2757,19 @@ bool Measure::isEmpty(int staffIdx) const
                   Element* e = s->element(track);
                   if (e && !e->isRest())
                         return false;
+                  // Check for cross-staff chords
+                  if (hasStaves) {
+                        if (strack >= VOICES) {
+                              e = s->element(track - VOICES);
+                              if (e && !e->isRest() && e->vStaffIdx() == staffIdx)
+                                    return false;
+                              }
+                        if (etrack < score()->nstaves() * VOICES) {
+                              e = s->element(track + VOICES);
+                              if (e && !e->isRest() && e->vStaffIdx() == staffIdx)
+                                    return false;
+                              }
+                        }
                   }
             for (Element* a : s->annotations()) {
                   if (!a || a->systemFlag() || !a->visible() || a->isFermata())


### PR DESCRIPTION
…tifacts

Resolves: *https://musescore.org/en/node/310492*

- Measures with cross-staff notes are now 'non empty' so they show up in cutaway scores.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
