### PR TITLE
add extended fermata symbols to MusicXML I/O

### DIFF
--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -1722,18 +1722,24 @@ static void fermata(const Fermata* const a, XmlWriter& xml)
       SymId id = a->symId();
       if (id == SymId::fermataAbove || id == SymId::fermataBelow)
             xml.tagE(tagName);
-      // MusicXML does not support the very short fermata nor short fermata (Henze),
-      // export as short fermata (better than not exporting at all)
-      else if (id == SymId::fermataShortAbove || id == SymId::fermataShortBelow
-               || id == SymId::fermataShortHenzeAbove || id == SymId::fermataShortHenzeBelow
-               || id == SymId::fermataVeryShortAbove || id == SymId::fermataVeryShortBelow)
+      else if (id == SymId::fermataShortAbove || id == SymId::fermataShortBelow) {
             xml.tag(tagName, "angled");
-      // MusicXML does not support the very long fermata  nor long fermata (Henze),
-      // export as long fermata (better than not exporting at all)
-      else if (id == SymId::fermataLongAbove || id == SymId::fermataLongBelow
-               || id == SymId::fermataLongHenzeAbove || id == SymId::fermataLongHenzeBelow
-               || id == SymId::fermataVeryLongAbove || id == SymId::fermataVeryLongBelow)
+      }
+      else if (id == SymId::fermataLongAbove || id == SymId::fermataLongBelow) {
             xml.tag(tagName, "square");
+      }
+      else if (id == SymId::fermataVeryShortAbove || id == SymId::fermataVeryShortBelow) {
+            xml.tag(tagName, "double-angled");
+      }
+      else if (id == SymId::fermataVeryLongAbove || id == SymId::fermataVeryLongBelow) {
+            xml.tag(tagName, "double-square");
+      }
+      else if (id == SymId::fermataLongHenzeAbove || id == SymId::fermataLongHenzeBelow) {
+            xml.tag(tagName, "double-dot");
+      }
+      else if (id == SymId::fermataShortHenzeAbove || id == SymId::fermataShortHenzeBelow) {
+            xml.tag(tagName, "half-curve");
+      }
       else
             qDebug("unknown fermata sim id %d", int(id));
       }

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -6259,6 +6259,14 @@ void MusicXMLParserNotations::fermata()
             notation.setSymId(SymId::fermataShortAbove);
       else if (fermataText == "square")
             notation.setSymId(SymId::fermataLongAbove);
+      else if (fermataText == "double-angled")
+            notation.setSymId(SymId::fermataVeryShortAbove);
+      else if (fermataText == "double-square")
+            notation.setSymId(SymId::fermataVeryLongAbove);
+      else if (fermataText == "double-dot")
+            notation.setSymId(SymId::fermataLongHenzeAbove);
+      else if (fermataText == "half-curve")
+            notation.setSymId(SymId::fermataShortHenzeAbove);
 
       if (notation.symId() != SymId::noSym) {
             notation.setText(fermataText);


### PR DESCRIPTION
This PR adds import/export for fermata symbols that were added to MusicXML 3.1 here: https://github.com/w3c/musicxml/pull/152/files

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
