### PR TITLE
Fix #12552: Slash in filename on Mac appears as colon

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -4770,7 +4770,13 @@ void MasterScore::setName(const QString& ss)
 
 QString MasterScore::title() const
       {
+#ifdef Q_OS_MAC
+      // macOS has an issue with slashes and colons
+      // https://musescore.org/en/node/12552#comment-1027472
+      return fileInfo()->completeBaseName().replace(':', '/');
+#else
       return fileInfo()->completeBaseName();
+#endif
       }
 
 QString Score::title() const

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -410,8 +410,8 @@ bool MasterScore::saveFile(bool generateBackup)
             }
 #endif
       else {
-           QString fileName = info.completeBaseName() + ".mscx";
-           rv = Score::saveCompressedFile(&temp, fileName, false);
+            QString fileName = info.completeBaseName() + ".mscx";
+            rv = Score::saveCompressedFile(&temp, fileName, false);
             }
 
       if (!rv) {

--- a/mscore/drumroll.cpp
+++ b/mscore/drumroll.cpp
@@ -193,7 +193,11 @@ void DrumrollEditor::setStaff(Staff* st)
       {
       staff = st;
       _score = staff->score();
-      setWindowTitle(tr("<%1> Staff: %2").arg(_score->masterScore()->fileInfo()->completeBaseName()).arg(st->idx()));
+      QString filename = _score->masterScore()->fileInfo()->completeBaseName();
+#ifdef Q_OS_MAC
+      filename = filename.replace(':', '/');
+#endif
+      setWindowTitle(tr("<%1> Staff: %2").arg(filename).arg(st->idx()));
       TempoMap* tl = _score->tempomap();
       TimeSigMap*  sl = _score->sigmap();
       for (int i = 0; i < 3; ++i)

--- a/mscore/editdrumset.cpp
+++ b/mscore/editdrumset.cpp
@@ -568,9 +568,10 @@ void EditDrumset::load()
       while (e.readNextStartElement()) {
             if (e.name() == "museScore") {
                   if (e.attribute("version") != MSC_VERSION) {
-                        QMessageBox::StandardButton b = QMessageBox::warning(this, tr("Drumset file too old"),
-                                                                             tr("MuseScore may not be able to load this drumset file."),
-                                                                             QMessageBox::Cancel|QMessageBox::Ignore, QMessageBox::Cancel);
+                        QMessageBox::StandardButton b = QMessageBox::warning(this,
+                           tr("Drumset file too old"),
+                           tr("MuseScore may not be able to load this drumset file."),
+                           QMessageBox::Cancel | QMessageBox::Ignore, QMessageBox::Cancel);
                         if (b != QMessageBox::Ignore) // covers Cancel and Esc
                               return;
                         }

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -253,9 +253,14 @@ static bool readScoreError(const QString& name, Score::FileError error, bool ask
 bool MuseScore::checkDirty(MasterScore* s)
       {
       if (s->dirty() || (s->created() && !s->startedEmpty())) {
+            QString fn = s->fileInfo()->completeBaseName();
+#ifdef Q_OS_MAC
+            // macOS has an issue with slashes and colons
+            // https://musescore.org/en/node/12552#comment-1027472
+            fn = fn.replace(':', '/');
+#endif
             QMessageBox::StandardButton n = QMessageBox::warning(this, tr("MuseScore"),
-               tr("Save changes to the score \"%1\"\n"
-               "before closing?").arg(s->fileInfo()->completeBaseName()),
+               tr("Save changes to the score \"%1\"\nbefore closing?").arg(fn),
                QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel,
                QMessageBox::Save);
             if (n == QMessageBox::Save) {
@@ -501,9 +506,15 @@ bool MuseScore::saveFile(MasterScore* score)
       updateWindowTitle(score);
       scoreCmpTool->updateScoreVersions(score);
       int idx = scoreList.indexOf(score->masterScore());
-      tab1->setTabText(idx, score->fileInfo()->completeBaseName());
+      QString tabText = score->fileInfo()->completeBaseName();
+#ifdef Q_OS_MAC
+      // macOS has an issue with slashes and colons
+      // https://musescore.org/en/node/12552#comment-1027472
+      tabText = tabText.replace(':', '/');
+#endif
+      tab1->setTabText(idx, tabText);
       if (tab2)
-            tab2->setTabText(idx, score->fileInfo()->completeBaseName());
+            tab2->setTabText(idx, tabText);
       QString tmp = score->tmpName();
       if (!tmp.isEmpty()) {
             QFile f(tmp);

--- a/mscore/pianoroll/pianoroll.cpp
+++ b/mscore/pianoroll/pianoroll.cpp
@@ -586,7 +586,11 @@ void PianorollEditor::setStaff(Staff* st)
             }
       staff = st;
       if (staff) {
-            setWindowTitle(tr("<%1> Staff: %2").arg(_score->masterScore()->fileInfo()->completeBaseName()).arg(st->idx()));
+            QString filename = _score->masterScore()->fileInfo()->completeBaseName();
+#ifdef Q_OS_MAC
+            filename = filename.replace(':', '/');
+#endif
+            setWindowTitle(tr("<%1> Staff: %2").arg(filename).arg(st->idx()));
             TempoMap* tl = _score->tempomap();
             TimeSigMap*  sl = _score->sigmap();
             for (int i = 0; i < 3; ++i)

--- a/mscore/plugin/pluginCreator.cpp
+++ b/mscore/plugin/pluginCreator.cpp
@@ -441,7 +441,11 @@ void PluginCreator::load()
             }
       created = false;
       setState(PCState::CLEAN);
-      setTitle( fi.completeBaseName() );
+      QString fn = fi.completeBaseName();
+#ifdef Q_OS_MAC
+      fn = fn.replace(':', '/');
+#endif
+      setTitle(fn);
       setToolTip(path);
       raise();
       }
@@ -471,7 +475,11 @@ void PluginCreator::doSavePlugin(bool saveas)
             textEdit->document()->setModified(false);
             created = false;
             setState(PCState::CLEAN);
-            setTitle( fi.completeBaseName() );
+            QString fn = fi.completeBaseName();
+#ifdef Q_OS_MAC
+            fn = fn.replace(':', '/');
+#endif
+            setTitle(fn);
             setToolTip(path);
             }
       else {

--- a/mscore/plugin/pluginManager.cpp
+++ b/mscore/plugin/pluginManager.cpp
@@ -236,7 +236,11 @@ void PluginManager::loadList(bool forceRefresh)
             Shortcut* s = &d.shortcut;
             localShortcuts[s->key()] = new Shortcut(*s);
             if (saveLoaded.contains(d.path)) d.load = true;
-            QListWidgetItem* item = new QListWidgetItem(QFileInfo(d.path).completeBaseName(),  pluginListWidget);
+            QString name = QFileInfo(d.path).completeBaseName();
+#ifdef Q_OS_MAC
+            name = name.replace(':', '/');
+#endif
+            QListWidgetItem* item = new QListWidgetItem(name,  pluginListWidget);
             item->setFlags(item->flags() | Qt::ItemIsEnabled);
             item->setCheckState(d.load ? Qt::Checked : Qt::Unchecked);
             item->setData(Qt::UserRole, i);
@@ -305,7 +309,11 @@ void PluginManager::pluginListWidgetItemChanged(QListWidgetItem* item, QListWidg
       int idx = item->data(Qt::UserRole).toInt();
       const PluginDescription& d = _pluginList[idx];
       QFileInfo fi(d.path);
-      pluginName->setText(fi.completeBaseName());
+      QString fn = fi.completeBaseName();
+#ifdef Q_OS_MAC
+      fn = fn.replace(':', '/');
+#endif
+      pluginName->setText(fn);
       pluginPath->setText(fi.absolutePath());
       pluginVersion->setText(d.version);
       pluginShortcut->setText(d.shortcut.keysToString());

--- a/mscore/scoreBrowser.cpp
+++ b/mscore/scoreBrowser.cpp
@@ -207,6 +207,11 @@ void ScoreBrowser::setScores(QFileInfoList& s)
                   if (!st.isEmpty() && st[0].isNumber() && _stripNumbers)
                         st = st.mid(3);
                   st = st.replace('_', ' ');
+#ifdef Q_OS_MAC
+                  // macOS has an issue with slashes and colons
+                  // https://musescore.org/en/node/12552#comment-1027472
+                  st = st.replace(':', '/');
+#endif
                   QLabel* label = new QLabel(st);
                   QFont f = label->font();
                   f.setBold(true);

--- a/mscore/scorePreview.cpp
+++ b/mscore/scorePreview.cpp
@@ -52,7 +52,11 @@ void ScorePreview::setScore(const QString& s)
 void ScorePreview::setScore(const ScoreInfo& si)
       {
       scoreInfo = si;
-      name->setText(si.completeBaseName());
+      QString filename = si.completeBaseName();
+#ifdef Q_OS_MAC
+      filename = filename.replace(':', '/');
+#endif
+      name->setText(filename);
       creationDate->setText(si.created().toString());
       fileSize->setText(QString("%1 KiB").arg(si.size() / 1024));
       name->setEnabled(true);

--- a/mscore/scoretab.cpp
+++ b/mscore/scoretab.cpp
@@ -317,9 +317,14 @@ void ScoreTab::setCurrent(int n)
                         return;
                         }
                   tab2->blockSignals(true);
-                  tab2->addTab(score->fileInfo()->completeBaseName().replace("&","&&") + (score->dirty() ? "*" : ""));
+                  QString name = score->fileInfo()->completeBaseName().replace("&", "&&");
+#ifdef Q_OS_MAC
+                  name = name.replace(':', '/');
+#endif
+                  if (score->dirty()) name += "*";
+                  tab2->addTab(name);
                   for (const Excerpt* excerpt : excerpts)
-                        tab2->addTab(excerpt->title().replace("&","&&"));
+                        tab2->addTab(excerpt->title().replace("&", "&&"));
                   tab2->setCurrentIndex(tsv->part);
                   tab2->blockSignals(false);
                   tab2->setVisible(true);
@@ -369,7 +374,11 @@ void ScoreTab::updateExcerpts()
       QList<Excerpt*>& excerpts = score->excerpts();
       if (!excerpts.isEmpty()) {
             tab2->blockSignals(true);
-            tab2->addTab(score->fileInfo()->completeBaseName().replace("&","&&") + (score->dirty() ? "*" : ""));
+            QString name = score->fileInfo()->completeBaseName().replace("&", "&&");
+#ifdef Q_OS_MAC
+            name = name.replace(':', '/');
+#endif
+            if (score->dirty()) name += "*";
             for (const Excerpt* excerpt : excerpts)
                   tab2->addTab(excerpt->title().replace("&","&&"));
             tab2->blockSignals(false);
@@ -438,8 +447,15 @@ void ScoreTab::setExcerpt(int n)
 void ScoreTab::insertTab(MasterScore* s)
       {
       int idx = scoreList->indexOf(s);
+      QString tabText = s->fileInfo()->completeBaseName().replace("&", "&&");
+#ifdef Q_OS_MAC
+      // macOS has an issue with slashes and colons
+      // https://musescore.org/en/node/12552#comment-1027472
+      tabText = tabText.replace(':', '/');
+#endif
+      if (s->dirty()) tabText.append("*");
       tab->blockSignals(true);
-      tab->insertTab(idx, s->fileInfo()->completeBaseName().replace("&","&&") + (s->dirty() ? "*" : ""));
+      tab->insertTab(idx, tabText);
       tab->setTabData(idx, QVariant::fromValue<void*>(new TabScoreView(s)));
       tab->blockSignals(false);
       emit tabInserted(idx);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/12552

On macOS, you can type a slash in a filename. Internally, macOS handles it as a colon, but to the users it normally shows it as a slash. 
However, in MuseScore, this wasn't the case; MuseScore consequently showed a colon. In this PR, I solved this.

There where two things about which I have tried to be very careful:
- I only changed the code which shows filenames to the user, for example in the window title. Code that handles filenames internally should not be touched. Otherwise, it would give problems with file paths of course.
- I made sure that my changes only affect macOS, not other OSs, by using `#ifdef Q_OS_MAC`.

![Slash/colon issue fixed, in several places](https://musescore.org/sites/musescore.org/files/2020-09/Slash%20colon%20fixed.png)

---
- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
