### PR TITLE
Fix build

### DIFF
--- a/mtest/scripting/tst_scripting.cpp
+++ b/mtest/scripting/tst_scripting.cpp
@@ -16,7 +16,7 @@
 #include "libmscore/mscore.h"
 #include "libmscore/musescoreCore.h"
 #include "libmscore/undo.h"
-#include "mscore/plugin/qmlplugin.h"
+#include "mu4/plugins/api/qmlplugin.h"
 #include "mscore/plugin/qmlpluginengine.h"
 
 #define DIR QString("scripting/")


### PR DESCRIPTION
In https://github.com/musescore/MuseScore/commit/1ba60614468aafdf8f6c2236dd1536570cdaaf50, `mscore/plugin/qmlplugin.h` was moved to `mu4/plugins/api/qmlplugin.h`, but there was one place in the code that was not updated to reflect this change.