### PR TITLE
fix #310869: crash on DPI change in preferences

### DIFF
--- a/mscore/preferenceslistwidget.cpp
+++ b/mscore/preferenceslistwidget.cpp
@@ -403,12 +403,12 @@ void DoublePreferenceItem::apply()
                   double newValue = _editorComboBox->currentData().toDouble();
                   _initialValue = newValue;
                   PreferenceItem::apply(newValue);
+                  _initialEditorIndex = _editorComboBox->currentIndex();
                   }
             else if (_editorSpinBox) {
                   double newValue = _editorSpinBox->value();
                   _initialValue = newValue;
                   PreferenceItem::apply(newValue);
-                  _initialEditorIndex = _editorComboBox->currentIndex();
                   }
             }
       }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/310869

The crash is a null pointer dereference.
We are processing a spin box but referencing a combo box.
This appear to me to have been a copy/paste error.
Comparing against similar code to handle "int" spin boxes,
it seems this line shouldn't be needed at all,
so I have removed it.