### PR TITLE
debug builds crash on scores with drum staff

### DIFF
--- a/audio/midi/fluid/voice.cpp
+++ b/audio/midi/fluid/voice.cpp
@@ -1816,7 +1816,7 @@ void Sample::optimize()
             s->loopstart = s->start;
             }
 
-      IF_ASSERT_FAILED(s->loopend <= s->end) {
+      if (s->loopend > s->end) {
             s->loopend = s->end;
             }
 


### PR DESCRIPTION
Not needed for the master branch, which doesn't have that `IF_ASSERT_FAILED`