### PR TITLE
[MU3] Fix #310821: Chord Symbol on drum stave sounds as percussion

### DIFF
--- a/libmscore/instrument.h
+++ b/libmscore/instrument.h
@@ -189,6 +189,8 @@ public:
       bool userBankController() const           { return _userBankController; }
       void setUserBankController(bool val);
 
+      bool isHarmonyChannel() const { return _name == Channel::HARMONY_NAME; }
+
       QList<NamedEventList> midiActions;
       QList<MidiArticulation> articulation;
 

--- a/libmscore/part.cpp
+++ b/libmscore/part.cpp
@@ -606,6 +606,8 @@ void Part::updateHarmonyChannels(bool isDoOnInstrumentChanged, bool checkRemoval
             Channel* c = new Channel(*instr->channel(0));
             // default to program 0, which is piano in General MIDI
             c->setProgram(0);
+            if (c->bank() == 128) // drumset?
+                  c->setBank(0);
             c->setName(Channel::HARMONY_NAME);
             instr->appendChannel(c);
             onInstrumentChanged();

--- a/mscore/mixer/mixerdetails.cpp
+++ b/mscore/mixer/mixerdetails.cpp
@@ -163,9 +163,11 @@ void MixerDetails::updateFromTrack()
       Channel* chan = _mti->focusedChan();
 
       //Check if drumkit
-      const bool drum = midiMap->part()->instrument()->useDrumset();
+      const bool isHarmonyChannel = chan->isHarmonyChannel();
+      const bool drum = midiMap->part()->instrument()->useDrumset() && !isHarmonyChannel;
       drumkitCheck->blockSignals(true);
       drumkitCheck->setChecked(drum);
+      drumkitCheck->setEnabled(!isHarmonyChannel);
       drumkitCheck->blockSignals(false);
 
       //Populate patch combo


### PR DESCRIPTION
This is just a (very) partial fix, it does playback chord symbols on drum staves as Piano, but doesn't show the correct sound in Mixer (shows "Standard" rather then "Grand Piano"), doesn't allow changes to the sound to another instrument, on trying to change it reverts the sound to Percussion and (probably) doesn't fix existing scores.

See https://musescore.org/en/node/310821