### PR TITLE
Fix #309857 - Divider not removed after undo of deleting a vertical frame

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1536,8 +1536,15 @@ static void layoutPage(Page* page, qreal restHeight)
             System* s1 = page->systems().at(i);
             System* s2 = page->systems().at(i+1);
             s1->setDistance(s2->y() - s1->y());
-            if (s1->vbox() || s2->vbox() || s1->hasFixedDownDistance())
+            if (s1->vbox() || s2->vbox() || s1->hasFixedDownDistance()) {
+                  if (s2->vbox()) {
+                        checkDivider(true, s1, 0.0, true);      // remove
+                        checkDivider(false, s1, 0.0, true);     // remove
+                        checkDivider(true, s2, 0.0, true);      // remove
+                        checkDivider(false, s2, 0.0, true);     // remove
+                        }
                   continue;
+                  }
             sList.push_back(s1);
             }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/309857

Remove SystemDividers on a System and the previous System is the system is a VBox.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
