### PR TITLE
Fix #311084 - Wrong curly bracket scaling when using MuseJazz

### DIFF
--- a/libmscore/bracket.cpp
+++ b/libmscore/bracket.cpp
@@ -242,11 +242,11 @@ void Bracket::draw(QPainter* painter) const
                         }
                   else {
                         qreal h        = 2 * h2;
-                        qreal mag      = h / 100;
+                        qreal mag      = h / (100 * magS());
                         painter->setPen(curColor());
                         painter->save();
                         painter->scale(_magx, mag);
-                        drawSymbol(_braceSymbol, painter, QPointF(0, 100));
+                        drawSymbol(_braceSymbol, painter, QPointF(0, 100 * magS()));
                         painter->restore();
                         }
                   }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/311084

Restore scaling caused by the parameters <code>Staff space</code>. This was inadvertently removed by solving scaling due to  scaled staves (PR #6496).

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
