### PR TITLE
Fix #308589 - Tuplet number

### DIFF
--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -881,7 +881,7 @@ QFont TextFragment::font(const TextBase* t) const
       font.setItalic(format.italic());
       Q_ASSERT(m > 0.0);
 
-      font.setPointSizeF(m);
+      font.setPointSizeF(m * t->mag());
       return font;
       }
 

--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -192,6 +192,16 @@ void Tuplet::layout()
                   _number->setXmlText(QString("%1").arg(_ratio.numerator()));
             else
                   _number->setXmlText(QString("%1:%2").arg(_ratio.numerator()).arg(_ratio.denominator()));
+
+            bool small = true;
+            for (const DurationElement* e : _elements) {
+                  if (e->isChordRest() && !toChordRest(e)->small()) {
+                        small = false;
+                        break;
+                        }
+                  }
+            _number->setMag(small ? score()->styleD(Sid::smallNoteMag) : 1.0);
+
             }
       else {
             if (_number) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/308589

Set the scaling of the text element of the tuplet to <code>smallNoteMag</code> if all <code>ChordRest</code>'s of the tuplet are small.
This is the same approach as used for the beam of the tuplet.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
