### PR TITLE
Fix #310906 - Staff/Part dialog changes not dirty when activated via double click

### DIFF
--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -463,9 +463,12 @@ void ScoreView::elementPropertyAction(const QString& cmd, Element* e)
                   if (m)
                         tick = m->tick();
                   }
+            score()->startCmd();
             EditStaff editStaff(e->staff(), tick, 0);
             connect(&editStaff, SIGNAL(instrumentChanged()), mscore, SLOT(instrumentChanged()));
             editStaff.exec();
+            if (score()->undoStack()->active())
+                  score()->endCmd();
             }
       else if (cmd.startsWith("layer-")) {
             int n = cmd.mid(6).toInt();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/310906

Enable undo/redo for this command. Sets also the dirty flag.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
