### PR TITLE
Fix #310775 - Changing voice of only note with grace notes leads to crash

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -4535,7 +4535,8 @@ void Score::changeVoice(int voice)
                                     r->setTuplet(chord->tuplet());
                                     r->setParent(s);
                                     // if there were grace notes, move them
-                                    for (Chord* gc : chord->graceNotes()) {
+                                    while (!chord->graceNotes().empty()) {
+                                          Chord* gc = chord->graceNotes().first();
                                           Chord* ngc = new Chord(*gc);
                                           undoRemoveElement(gc);
                                           ngc->setParent(dstChord);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/310349

The root cause of the crash was deleting elements in a for loop which was iterating over a list with elements to be deleted.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
