### PR TITLE
Fix #310602 - Adding a tie from grace note to note goes wrong way at times

### DIFF
--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -779,11 +779,11 @@ Note* searchTieNote(Note* note)
       int etrack   = strack + part->staves()->size() * VOICES;
 
       if (chord->isGraceBefore()) {
+            int index = chord->graceIndex();
             chord = toChord(chord->parent());
 
             // try to tie to next grace note
 
-            int index = chord->graceIndex();
             for (Chord* c : chord->graceNotes()) {
                   if (c->graceIndex() == index + 1) {
                         note2 = c->findNote(note->pitch());


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/310602

use the <code>graceIndex</code> of the selected grace note instead of the parent chord.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
