### PR TITLE
fix #311289: crash on insert of measure in front of melisma end

### DIFF
--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -570,6 +570,10 @@ bool Lyrics::setProperty(Pid propertyId, const QVariant& v)
                         // clear melismaEnd flag from previous end cr
                         // this might be premature, as there may be other melismas ending there
                         // but flag will be generated correctly on layout
+                        // TODO: after inserting a measure,
+                        // endTick info is wrong.
+                        // Somehow we need to fix this.
+                        // See https://musescore.org/en/node/285304 and https://musescore.org/en/node/311289
                         ChordRest* ecr = score()->findCR(endTick(), track());
                         if (ecr)
                               ecr->setMelismaEnd(false);

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3916,6 +3916,8 @@ ChordRest* Score::findCR(Fraction tick, int track) const
             else if (el)
                   s = ns;
             }
+      if (!s)
+            return nullptr;
       Element* el = s->element(track);
       if (el && el->isRest() && toRest(el)->isGap())
             s = 0;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/311289

Code added recently manage melisma ends better triggers a crash
when inserting a measure in front of the melisma end.
The crash is a null pointer dereference and is easily fixed here.
However, it should be noted that the melisma is at that point
in a somewhat inconsistent state, and things like undo
won't actually work properly.
This was the case before the change that triggered the crash as well.
Ultimately we probably really need to update the end tick
on the lyrics with the melisma.
See also https://musescore.org/en/node/285304.