### PR TITLE
Fix #310969 - Multiple slashes appear on beamed acciaccaturas if the beam height is adjusted

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -490,15 +490,12 @@ void Beam::layoutGraceNotes()
                   }
             }
 
-      int idx = (_direction == Direction::AUTO || _direction == Direction::DOWN) ? 0 : 1;
       slope   = 0.0;
 
-      if (!_userModified[idx]) {
-            for (ChordRest* cr : _elements) {
-                  cr->setUp(_up);
-                  if (cr->isChord())
-                        toChord(cr)->layoutStem1();            /* create stems needed to calculate horizontal spacing */
-                  }
+      for (ChordRest* cr : _elements) {
+            cr->setUp(_up);
+            if (cr->isChord())
+                  toChord(cr)->layoutStem1();            /* create stems needed to calculate horizontal spacing */
             }
       }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/310969

When loading a score with adjusted beam heights, the second note had no beam because the stem wasn't generated yet, this is done later in the process, so every stem got a slash. This explain why any change later removed the second slash, now both grace notes had a beam.

The reason for the missing beam was a missing stem because <code>Beam::layoutGraceNote()s</code> didn't call <code>Chord::layoutStem1()</code> when the bea height was adjusted. This test shouldn't be there (and is removed).

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
