### PR TITLE
fix compiler warnings (3.x)

### DIFF
--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -1735,7 +1735,7 @@ static void fermata(const Fermata* const a, XmlWriter& xml)
                || id == SymId::fermataVeryLongAbove || id == SymId::fermataVeryLongBelow)
             xml.tag(tagName, "square");
       else
-            qDebug("unknown fermata sim id %d", id);
+            qDebug("unknown fermata sim id %d", int(id));
       }
 
 //---------------------------------------------------------
@@ -2761,7 +2761,7 @@ void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technic
                 && symIdToOrnam(sid) == ""
                 && symIdToTechn(sid) == ""
                 && !isLaissezVibrer(sid)) {
-                  qDebug("unknown chord attribute %d %s", sid, qPrintable(a->userName()));
+                  qDebug("unknown chord attribute %d %s", int(sid), qPrintable(a->userName()));
                   }
             }
       }

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -3025,9 +3025,9 @@ NotesColors MuseScore::readNotesColors(const QString& filePath) const
     NotesColors result;
 
     for (const QJsonValue& colorObj: colors) {
-        QJsonObject obj = colorObj.toObject();
-        QJsonArray notesIndexes = obj.value("notes").toArray();
-        QColor notesColor = QColor(obj.value("color").toString());
+        QJsonObject cobj = colorObj.toObject();
+        QJsonArray notesIndexes = cobj.value("notes").toArray();
+        QColor notesColor = QColor(cobj.value("color").toString());
 
         for (const QJsonValue& index: notesIndexes) {
             result.insert(index.toInt(), notesColor);

--- a/mscore/inspector/inspector_ambitus.ui
+++ b/mscore/inspector/inspector_ambitus.ui
@@ -884,22 +884,6 @@
   <connection>
    <sender>hasLine</sender>
    <signal>toggled(bool)</signal>
-   <receiver>label_10</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>44</x>
-     <y>137</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>50</x>
-     <y>149</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>hasLine</sender>
-   <signal>toggled(bool)</signal>
    <receiver>lineWidth</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>

--- a/mscore/inspector/inspector_fermata.ui
+++ b/mscore/inspector/inspector_fermata.ui
@@ -211,22 +211,6 @@
   <connection>
    <sender>playArticulation</sender>
    <signal>toggled(bool)</signal>
-   <receiver>label_2</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>40</x>
-     <y>91</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>44</x>
-     <y>108</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>playArticulation</sender>
-   <signal>toggled(bool)</signal>
    <receiver>timeStretch</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>

--- a/mscore/inspector/inspector_glissando.ui
+++ b/mscore/inspector/inspector_glissando.ui
@@ -420,22 +420,6 @@
   <connection>
    <sender>playGlissando</sender>
    <signal>toggled(bool)</signal>
-   <receiver>label_2</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>33</x>
-     <y>268</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>35</x>
-     <y>292</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>playGlissando</sender>
-   <signal>toggled(bool)</signal>
    <receiver>glissandoStyle</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>

--- a/mscore/inspector/inspector_hairpin.ui
+++ b/mscore/inspector/inspector_hairpin.ui
@@ -511,22 +511,6 @@
   <connection>
    <sender>singleNoteDynamics</sender>
    <signal>toggled(bool)</signal>
-   <receiver>label_7</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>83</x>
-     <y>325</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>83</x>
-     <y>346</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>singleNoteDynamics</sender>
-   <signal>toggled(bool)</signal>
    <receiver>veloChangeMethod</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>

--- a/mscore/inspector/inspector_trill.ui
+++ b/mscore/inspector/inspector_trill.ui
@@ -278,22 +278,6 @@
   <connection>
    <sender>playArticulation</sender>
    <signal>toggled(bool)</signal>
-   <receiver>label_3</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>42</x>
-     <y>147</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>49</x>
-     <y>164</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>playArticulation</sender>
-   <signal>toggled(bool)</signal>
    <receiver>ornamentStyle</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>


### PR DESCRIPTION
One of which is new (exportxml.cpp, only shows in (MinGW) Debug builds), but most of which have been fixed the same way in master already recently (file.cpp, shows in MSVC) and some even very long ago (those for *.ui files, only show in MSVC and when building with Qt 5.15, but are genuine issues, these slots lost their context)