### PR TITLE
[MU4] Fix io::path

### DIFF
--- a/framework/global/io/path.h
+++ b/framework/global/io/path.h
@@ -40,7 +40,7 @@ struct path {
     inline bool operator==(const path& other) const { return m_path == other.m_path; }
 
     inline path operator+(const path& other) const { path p = *this; p.m_path += other.m_path; return p; }
-    inline path operator+(const QString& other) const { path p = *this; QString(p.m_path) += other; return p; }
+    inline path operator+(const QString& other) const { path p = *this; p.m_path += other; return p; }
     inline path operator+(const char* other) const { path p = *this; p.m_path += other; return p; }
 
     QString toQString() const;


### PR DESCRIPTION
- reverted fix of warning because it broke operator+
https://github.com/musescore/MuseScore/commit/e9087010f8775b9014334e1582d54d3315666993