### PR TITLE
fix #311405 Workspace reset to Basic

### DIFF
--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -1409,7 +1409,7 @@ void PreferenceDialog::apply()
 
       if(uiStyleThemeChanged) {
             WorkspacesManager::retranslateAll();
-            preferences.setPreference(PREF_APP_WORKSPACE, WorkspacesManager::currentWorkspace()->translatableName());
+            preferences.setPreference(PREF_APP_WORKSPACE, WorkspacesManager::currentWorkspace()->id());
             WorkspacesManager::currentWorkspace()->save();
             emit mscore->workspacesChanged();
             }

--- a/mscore/workspace.h
+++ b/mscore/workspace.h
@@ -76,6 +76,7 @@ class Workspace : public QObject {
       Workspace(const QString& n, const QString& p, bool d, bool r)
          : _name(n), _path(p), _dirty(d), _readOnly(r) {}
 
+      QString id() const;
       QString path() const           { return _path;  }
       void setPath(const QString& s) { _path = s;     }
       QString name() const           { return _name;  }

--- a/mscore/workspacecombobox.cpp
+++ b/mscore/workspacecombobox.cpp
@@ -81,7 +81,7 @@ void WorkspaceComboBox::updateWorkspaces()
       int curIdx = -1;
       for (Workspace* p : pl) {
             addItem(qApp->translate("Ms::Workspace", p->name().toUtf8()), p->path());
-            if (p->name() == preferences.getString(PREF_APP_WORKSPACE))
+            if (p->id() == preferences.getString(PREF_APP_WORKSPACE))
                   curIdx = idx;
             ++idx;
             }

--- a/mscore/workspacedialog.cpp
+++ b/mscore/workspacedialog.cpp
@@ -153,8 +153,8 @@ void WorkspaceDialog::accepted()
             mscore->changeWorkspace(newWorkspace);
             preferences.updateLocalPreferences();
             }
-            
-      preferences.setPreference(PREF_APP_WORKSPACE, WorkspacesManager::currentWorkspace()->translatableName());
+
+      preferences.setPreference(PREF_APP_WORKSPACE, WorkspacesManager::currentWorkspace()->id());
       emit mscore->workspacesChanged();
       close();
       }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/311405

Translations for the installed languages are available for default workspaces(Basic, Advanced). Translations are not available for user-created workspaces. Therefore, you need to check the availability of translations. If there is no translation, then you need to search by name, otherwise by translation.