### PR TITLE
fix compiler warning reg. deprecation in a `+` operator

### DIFF
--- a/framework/global/io/path.h
+++ b/framework/global/io/path.h
@@ -40,7 +40,7 @@ struct path {
     inline bool operator==(const path& other) const { return m_path == other.m_path; }
 
     inline path operator+(const path& other) const { path p = *this; p.m_path += other.m_path; return p; }
-    inline path operator+(const QString& other) const { path p = *this; p.m_path += other; return p; }
+    inline path operator+(const QString& other) const { path p = *this; p.m_path += other.toUtf8(); return p; }
     inline path operator+(const char* other) const { path p = *this; p.m_path += other; return p; }
 
     QString toQString() const;


### PR DESCRIPTION
in a better way than my attempt in #6548, which then got reverted in #6631, actually in the same way as used for the corresponding `=` operator.

Eliminates 115 warnings ;-)