### PR TITLE
Remove setInvisibleRecursive workaround for Palettes

### DIFF
--- a/mu4/palette/qml/MuseScore/Palette/PaletteTree.qml
+++ b/mu4/palette/qml/MuseScore/Palette/PaletteTree.qml
@@ -349,10 +349,6 @@ ListView {
             property int rowIndex: index
             property var modelIndex: paletteTree.model.modelIndex(index, 0)
 
-            Component.onDestruction: {
-                Utils.setInvisibleRecursive(this);
-            }
-
             onActiveFocusChanged: {
                 if (activeFocus)
                     paletteTree.currentTreeItem = this;
@@ -697,10 +693,6 @@ ListView {
                     paletteName: model.display
                     paletteIsCustom: model.custom
                     paletteEditingEnabled: model.editable
-
-                    Component.onDestruction: {
-                        Utils.setInvisibleRecursive(this);
-                    }
 
                     onVisibleChanged: {
                         // build pool model on first popup appearance

--- a/mu4/palette/qml/MuseScore/Palette/utils.js
+++ b/mu4/palette/qml/MuseScore/Palette/utils.js
@@ -40,14 +40,3 @@ function dropEventMimeData(drag) {
 function removeSelectedItems(paletteController, selectionModel, parentIndex) {
     paletteController.removeSelection(selectionModel.selectedIndexes, parentIndex);
 }
-
-function setInvisibleRecursive(item) {
-    var children = item.children; // list of children if item is Item
-    if (!children)
-        children = item.contentChildren; // list of children if item is Popup
-
-    for (var i = 0; i < children.length; ++i)
-        setInvisibleRecursive(children[i]);
-
-    item.visible = false;
-}


### PR DESCRIPTION
`setInvisibleRecursive` was introduced in #5828 as a workaround for a crash which happened with Qt 5.9 but has never been reported to happen with Qt 5.12. Most likely this is due to a change of accessibility backend in Qt 5.11 so this workaround has been disabled for newer versions of Qt. 484f8dce06cfe8ad50453505fd40de8841f64916 removed the outdated code after moving to Qt 5.15 but `setInvisibleRecursive` was instead enabled for all versions of Qt, see [this my comment](https://github.com/musescore/MuseScore/commit/484f8dce06cfe8ad50453505fd40de8841f64916#r43114408). This PR removes `setInvisibleRecursive` entirely, as it was probably intended in 484f8dce06cfe8ad50453505fd40de8841f64916.