### PR TITLE
Fix #290946, #309133: macOS Dark Mode improvements [MU3]

### DIFF
--- a/mscore/helpBrowser.cpp
+++ b/mscore/helpBrowser.cpp
@@ -190,7 +190,7 @@ QVariant HelpView::loadResource(int type, const QUrl& name)
       if (name.scheme() == "qthelp")
             return QVariant(helpEngine->fileData(name));
 #if 0
-      if (preferences.globalStyle() == MuseScoreStyleType::DARK_FUSION) {
+      if (preferences.effectiveGlobalStyle() == MuseScoreEffectiveStyleType::DARK_FUSION) {
             QFileInfo fi(name.path());
             if (fi.fileName() == "manual.css") {
                   QUrl url(QString("file://%1/manual-dark.css").arg(fi.absolutePath()));

--- a/mscore/macos/cocoabridge.h
+++ b/mscore/macos/cocoabridge.h
@@ -27,6 +27,7 @@ class CocoaBridge
    public:
       static void setAllowsAutomaticWindowTabbing(bool flag);
       static bool isSystemDarkTheme();
+      static void setWindowAppearanceIsDark(bool flag);
 };
 
 #endif

--- a/mscore/macos/cocoabridge.h
+++ b/mscore/macos/cocoabridge.h
@@ -20,14 +20,14 @@
 #ifndef __COCOABRIDGE_H__
 #define __COCOABRIDGE_H__
 
-class CocoaBridge
-{
-      CocoaBridge() {}
-
+class CocoaBridge {
+      CocoaBridge() {};
    public:
-      static void setAllowsAutomaticWindowTabbing(bool flag);
+      static void observeDarkModeSwitches(std::function<void()> f);
+      static void removeObservers();
       static bool isSystemDarkTheme();
       static void setWindowAppearanceIsDark(bool flag);
-};
+      static void setAllowsAutomaticWindowTabbing(bool flag);
+      };
 
 #endif

--- a/mscore/macos/cocoabridge.h
+++ b/mscore/macos/cocoabridge.h
@@ -25,6 +25,7 @@ class CocoaBridge {
    public:
       static void observeDarkModeSwitches(std::function<void()> f);
       static void removeObservers();
+      static bool isSystemDarkModeSupported();
       static bool isSystemDarkTheme();
       static void setWindowAppearanceIsDark(bool flag);
       static void setAllowsAutomaticWindowTabbing(bool flag);

--- a/mscore/macos/cocoabridge.mm
+++ b/mscore/macos/cocoabridge.mm
@@ -31,3 +31,9 @@ bool  CocoaBridge::isSystemDarkTheme()
     NSString *osxMode = [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];
     return ([osxMode isEqualToString:@"Dark"]);
 }
+
+void  CocoaBridge::setWindowAppearanceIsDark(bool flag)
+{
+    if (@available(macOS 10.14, *))
+        [NSApp setAppearance:[NSAppearance appearanceNamed:flag ? NSAppearanceNameDarkAqua : NSAppearanceNameAqua]];
+}

--- a/mscore/macos/cocoabridge.mm
+++ b/mscore/macos/cocoabridge.mm
@@ -36,20 +36,27 @@ void CocoaBridge::removeObservers()
             [[NSDistributedNotificationCenter defaultCenter] removeObserver:darkModeObserverToken];
       }
 
-void CocoaBridge::setAllowsAutomaticWindowTabbing(bool flag)
-      {
-      if ([NSWindow respondsToSelector:@selector(allowsAutomaticWindowTabbing)])
-            [NSWindow setAllowsAutomaticWindowTabbing: flag];
-      }
-
 bool CocoaBridge::isSystemDarkTheme()
       {
       NSString *osxMode = [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];
       return ([osxMode isEqualToString:@"Dark"]);
       }
 
+bool CocoaBridge::isSystemDarkModeSupported()
+      {
+      if (@available(macOS 10.14, *))
+            return true;
+      return false;
+      }
+
 void CocoaBridge::setWindowAppearanceIsDark(bool flag)
       {
       if (@available(macOS 10.14, *))
             [NSApp setAppearance:[NSAppearance appearanceNamed:flag ? NSAppearanceNameDarkAqua : NSAppearanceNameAqua]];
+      }
+
+void CocoaBridge::setAllowsAutomaticWindowTabbing(bool flag)
+      {
+      if ([NSWindow respondsToSelector:@selector(allowsAutomaticWindowTabbing)])
+            [NSWindow setAllowsAutomaticWindowTabbing: flag];
       }

--- a/mscore/macos/cocoabridge.mm
+++ b/mscore/macos/cocoabridge.mm
@@ -20,20 +20,36 @@
 #include "cocoabridge.h"
 #import <Cocoa/Cocoa.h>
 
-void  CocoaBridge::setAllowsAutomaticWindowTabbing(bool flag)
-{
-    if ([NSWindow respondsToSelector:@selector(allowsAutomaticWindowTabbing)])
-        [NSWindow setAllowsAutomaticWindowTabbing: flag];
-}
+id<NSObject> darkModeObserverToken;
 
-bool  CocoaBridge::isSystemDarkTheme()
-{
-    NSString *osxMode = [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];
-    return ([osxMode isEqualToString:@"Dark"]);
-}
+void CocoaBridge::observeDarkModeSwitches(std::function<void()> f)
+      {
+      if (@available(macOS 10.14, *))
+            darkModeObserverToken = [[NSDistributedNotificationCenter defaultCenter]
+                                     addObserverForName:@"AppleInterfaceThemeChangedNotification" object:nil
+                                     queue:nil usingBlock:^(NSNotification*) {   f();   }];
+      }
 
-void  CocoaBridge::setWindowAppearanceIsDark(bool flag)
-{
-    if (@available(macOS 10.14, *))
-        [NSApp setAppearance:[NSAppearance appearanceNamed:flag ? NSAppearanceNameDarkAqua : NSAppearanceNameAqua]];
-}
+void CocoaBridge::removeObservers()
+      {
+      if (@available(macOS 10.14, *))
+            [[NSDistributedNotificationCenter defaultCenter] removeObserver:darkModeObserverToken];
+      }
+
+void CocoaBridge::setAllowsAutomaticWindowTabbing(bool flag)
+      {
+      if ([NSWindow respondsToSelector:@selector(allowsAutomaticWindowTabbing)])
+            [NSWindow setAllowsAutomaticWindowTabbing: flag];
+      }
+
+bool CocoaBridge::isSystemDarkTheme()
+      {
+      NSString *osxMode = [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];
+      return ([osxMode isEqualToString:@"Dark"]);
+      }
+
+void CocoaBridge::setWindowAppearanceIsDark(bool flag)
+      {
+      if (@available(macOS 10.14, *))
+            [NSApp setAppearance:[NSAppearance appearanceNamed:flag ? NSAppearanceNameDarkAqua : NSAppearanceNameAqua]];
+      }

--- a/mscore/mixer/mixertrackchannel.cpp
+++ b/mscore/mixer/mixertrackchannel.cpp
@@ -126,11 +126,11 @@ MixerTrackChannel::MixerTrackChannel(QWidget *parent, MixerTrackItemPtr mti) :
 void MixerTrackChannel::applyStyle()
       {
       QString style;
-      switch (preferences.globalStyle()){
-            case MuseScoreStyleType::DARK_FUSION:
+      switch (preferences.effectiveGlobalStyle()){
+            case MuseScoreEffectiveStyleType::DARK_FUSION:
                   style = _selected ? selStyleDark : unselStyleDark;
                   break;
-            case MuseScoreStyleType::LIGHT_FUSION:
+            case MuseScoreEffectiveStyleType::LIGHT_FUSION:
                   style = _selected ? selStyleLight : unselStyleLight;
                   break;
             }

--- a/mscore/mixer/mixertrackpart.cpp
+++ b/mscore/mixer/mixertrackpart.cpp
@@ -143,11 +143,11 @@ MixerTrackPart::MixerTrackPart(QWidget *parent, MixerTrackItemPtr mti, bool expa
 void MixerTrackPart::applyStyle()
       {
       QString style;
-      switch (preferences.globalStyle()){
-            case MuseScoreStyleType::DARK_FUSION:
+      switch (preferences.effectiveGlobalStyle()){
+            case MuseScoreEffectiveStyleType::DARK_FUSION:
                   style = _selected ? selStyleDark : unselStyleDark;
                   break;
-            case MuseScoreStyleType::LIGHT_FUSION:
+            case MuseScoreEffectiveStyleType::LIGHT_FUSION:
                   style = _selected ? selStyleLight : unselStyleLight;
                   break;
             }

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7421,6 +7421,11 @@ void MuseScore::updateUiStyleAndTheme()
       {
       // set UI Theme
       QApplication::setStyle(QStyleFactory::create("Fusion"));
+          
+#ifdef Q_OS_MAC
+      // On Mac, update the color of the window title bars
+      CocoaBridge::setWindowAppearanceIsDark(preferences.isThemeDark());
+#endif
 
 #if defined(WIN_PORTABLE)
       QString wd = QDir::cleanPath(QString("%1/../../../Data/%2").arg(QCoreApplication::applicationDirPath()).arg(QCoreApplication::applicationName()));

--- a/mscore/pianoroll/pianolevels.cpp
+++ b/mscore/pianoroll/pianolevels.cpp
@@ -126,8 +126,8 @@ void PianoLevels::paintEvent(QPaintEvent* e)
       QColor colGridLine;
       QColor colText;
 
-      switch (preferences.globalStyle()) {
-            case MuseScoreStyleType::DARK_FUSION:
+      switch (preferences.effectiveGlobalStyle()) {
+            case MuseScoreEffectiveStyleType::DARK_FUSION:
                   colPianoBg = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_BG_BASE_COLOR));
                   noteDeselected = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_NOTE_UNSEL_COLOR));
                   noteSelected = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_NOTE_SEL_COLOR));

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -199,8 +199,8 @@ void PianoItem::paintNoteBlock(QPainter* painter, NoteEvent* evt)
       QColor noteSelected;
       QColor tieColor;
 
-      switch (preferences.globalStyle()) {
-            case MuseScoreStyleType::DARK_FUSION:
+      switch (preferences.effectiveGlobalStyle()) {
+            case MuseScoreEffectiveStyleType::DARK_FUSION:
                   noteDeselected = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_NOTE_UNSEL_COLOR));
                   noteSelected = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_NOTE_SEL_COLOR));
                   tieColor = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_BG_TIE_COLOR));
@@ -343,8 +343,8 @@ void PianoView::drawBackground(QPainter* p, const QRectF& r)
 
       QColor colGridLine;
 
-      switch (preferences.globalStyle()) {
-            case MuseScoreStyleType::DARK_FUSION:
+      switch (preferences.effectiveGlobalStyle()) {
+            case MuseScoreEffectiveStyleType::DARK_FUSION:
                   colSelectionBox = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_SELECTION_BOX_COLOR));
 
                   colHilightKeyBg = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_BG_KEY_HIGHLIGHT_COLOR));
@@ -2092,8 +2092,8 @@ void PianoView::pasteNotes(const QString& copiedNotes, Fraction pasteStartTick, 
 void PianoView::drawDraggedNotes(QPainter* painter)
       {
       QColor noteColor;
-      switch (preferences.globalStyle()) {
-            case MuseScoreStyleType::DARK_FUSION:
+      switch (preferences.effectiveGlobalStyle()) {
+            case MuseScoreEffectiveStyleType::DARK_FUSION:
                   noteColor = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_NOTE_DRAG_COLOR));
                   break;
             default:

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -111,7 +111,7 @@ void Preferences::init(bool storeInMemoryOnly)
 #endif
 
 #if defined(Q_OS_MAC) && !defined(TESTROOT)
-      const MuseScorePreferredStyleType defaultAppGlobalStyle = MuseScorePreferredStyleType::FOLLOW_SYSTEM;
+      const MuseScorePreferredStyleType defaultAppGlobalStyle = CocoaBridge::isSystemDarkModeSupported() ? MuseScorePreferredStyleType::FOLLOW_SYSTEM : MuseScorePreferredStyleType::LIGHT_FUSION;
 #else
       const MuseScorePreferredStyleType defaultAppGlobalStyle = MuseScorePreferredStyleType::LIGHT_FUSION;
 #endif

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -111,9 +111,9 @@ void Preferences::init(bool storeInMemoryOnly)
 #endif
 
 #if defined(Q_OS_MAC) && !defined(TESTROOT)
-      const MuseScoreStyleType defaultAppGlobalStyle = CocoaBridge::isSystemDarkTheme() ? MuseScoreStyleType::DARK_FUSION : MuseScoreStyleType::LIGHT_FUSION;
+      const MuseScorePreferredStyleType defaultAppGlobalStyle = MuseScorePreferredStyleType::FOLLOW_SYSTEM;
 #else
-      const MuseScoreStyleType defaultAppGlobalStyle = MuseScoreStyleType::LIGHT_FUSION;
+      const MuseScorePreferredStyleType defaultAppGlobalStyle = MuseScorePreferredStyleType::LIGHT_FUSION;
 #endif
 
 #if defined(WIN_PORTABLE)
@@ -490,14 +490,26 @@ MusicxmlExportBreaks Preferences::musicxmlExportBreaks() const
       return preference(PREF_EXPORT_MUSICXML_EXPORTBREAKS).value<MusicxmlExportBreaks>();
       }
 
-MuseScoreStyleType Preferences::globalStyle() const
+// The "theme" the user chooses in Preferences
+MuseScorePreferredStyleType Preferences::preferredGlobalStyle() const
       {
-      return preference(PREF_UI_APP_GLOBALSTYLE).value<MuseScoreStyleType>();
+      return preference(PREF_UI_APP_GLOBALSTYLE).value<MuseScorePreferredStyleType>();
+      }
+
+// The actual "theme", resulting from the user's choice
+MuseScoreEffectiveStyleType Preferences::effectiveGlobalStyle() const
+      {
+      MuseScorePreferredStyleType s = preferredGlobalStyle();
+#ifdef Q_OS_MAC // On Mac, follow system theme if desired
+      if (s == MuseScorePreferredStyleType::FOLLOW_SYSTEM)
+            return CocoaBridge::isSystemDarkTheme() ? MuseScoreEffectiveStyleType::DARK_FUSION : MuseScoreEffectiveStyleType::LIGHT_FUSION;
+#endif
+      return MuseScoreEffectiveStyleType(s);
       }
 
 bool Preferences::isThemeDark() const
       {
-      return globalStyle() == MuseScoreStyleType::DARK_FUSION;
+      return effectiveGlobalStyle() == MuseScoreEffectiveStyleType::DARK_FUSION;
       }
 
 void Preferences::setToDefaultValue(const QString key)

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -64,9 +64,19 @@ enum {
       MIDI_REMOTES
       };
 
-enum class MuseScoreStyleType : char {
-      DARK_FUSION = 0,
-      LIGHT_FUSION
+// The "theme" the user chooses in Preferences
+enum class MuseScorePreferredStyleType : char {
+      LIGHT_FUSION = 0,
+      DARK_FUSION,
+#ifdef Q_OS_MAC
+      FOLLOW_SYSTEM,
+#endif
+      };
+
+// The actual "theme", resulting from the user's choice
+enum class MuseScoreEffectiveStyleType : char {
+      LIGHT_FUSION = 0,
+      DARK_FUSION
       };
 
 // MusicXML export break values
@@ -221,7 +231,8 @@ class Preferences {
        */
       SessionStart sessionStart() const;
       MusicxmlExportBreaks musicxmlExportBreaks() const;
-      MuseScoreStyleType globalStyle() const;
+      MuseScorePreferredStyleType preferredGlobalStyle() const;
+      MuseScoreEffectiveStyleType effectiveGlobalStyle() const;
       bool isThemeDark() const;
 
       template<typename T>
@@ -248,17 +259,32 @@ extern Preferences preferences;
 // Stream operators for enum classes
 // enum classes don't play well with QSettings without custom serialization
 inline QDataStream&
-operator<<(QDataStream &out, const Ms::MuseScoreStyleType &val)
+operator<<(QDataStream &out, const Ms::MuseScorePreferredStyleType &val)
 {
     return out << static_cast<int>(val);
 }
 
 inline QDataStream&
-operator>>(QDataStream &in, Ms::MuseScoreStyleType &val)
+operator>>(QDataStream &in, Ms::MuseScorePreferredStyleType &val)
 {
     int tmp;
     in >> tmp;
-    val = static_cast<Ms::MuseScoreStyleType>(tmp);
+    val = static_cast<Ms::MuseScorePreferredStyleType>(tmp);
+    return in;
+}
+
+inline QDataStream&
+operator<<(QDataStream &out, const Ms::MuseScoreEffectiveStyleType &val)
+{
+    return out << static_cast<int>(val);
+}
+
+inline QDataStream&
+operator>>(QDataStream &in, Ms::MuseScoreEffectiveStyleType &val)
+{
+    int tmp;
+    in >> tmp;
+    val = static_cast<Ms::MuseScoreEffectiveStyleType>(tmp);
     return in;
 }
 
@@ -307,6 +333,7 @@ class PreferenceVisitor {
 
 Q_DECLARE_METATYPE(Ms::SessionStart);
 Q_DECLARE_METATYPE(Ms::MusicxmlExportBreaks);
-Q_DECLARE_METATYPE(Ms::MuseScoreStyleType);
+Q_DECLARE_METATYPE(Ms::MuseScorePreferredStyleType);
+Q_DECLARE_METATYPE(Ms::MuseScoreEffectiveStyleType);
 
 #endif

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -69,7 +69,12 @@ PreferenceDialog::PreferenceDialog(QWidget* parent)
       setupUi(this);
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
       setModal(true);
-      shortcutsChanged        = false;
+      shortcutsChanged = false;
+
+#ifdef Q_OS_MAC // On Mac, we have an extra theme option,
+      // namely to follow the system's Dark Mode
+      styleName->addItem(QCoreApplication::translate("PrefsDialogBase", "System", nullptr));
+#endif
 
 #ifndef USE_JACK
       jackDriver->setVisible(false);
@@ -488,10 +493,10 @@ void PreferenceDialog::start()
                   new IntPreferenceItem(PREF_UI_THEME_FONTSIZE, fontSize),
                   new CustomPreferenceItem(PREF_UI_APP_GLOBALSTYLE, styleName,
                                           [&]() { // apply function
-                                                preferences.setCustomPreference<MuseScoreStyleType>(PREF_UI_APP_GLOBALSTYLE, MuseScoreStyleType(styleName->currentIndex()));
+                                                preferences.setCustomPreference<MuseScorePreferredStyleType>(PREF_UI_APP_GLOBALSTYLE, MuseScorePreferredStyleType(styleName->currentIndex()));
                                                 },
                                           [&]() { // update function
-                                                styleName->setCurrentIndex(int(preferences.globalStyle()));
+                                                styleName->setCurrentIndex(int(preferences.preferredGlobalStyle()));
                                                 }),
       };
 
@@ -557,6 +562,21 @@ PreferenceDialog::~PreferenceDialog()
       audioRelatedWidgets.clear();
 
       qDeleteAll(localShortcuts);
+      }
+
+//---------------------------------------------------------
+//   retranslate
+//---------------------------------------------------------
+
+void PreferenceDialog::retranslate()
+      {
+      retranslateUi(this);
+#ifdef Q_OS_MAC // On Mac, we have an extra theme option,
+      // namely, to follow the system's Dark Mode.
+      // Of course, we need to translate that too :)
+      styleName->setItemText(2, QCoreApplication::translate("PrefsDialogBase", "System", nullptr));
+#endif
+      updateValues();
       }
 
 //---------------------------------------------------------

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -40,6 +40,10 @@
 #include "avsomr/avsomrlocal.h"
 #endif
 
+#ifdef Q_OS_MAC
+#include "macos/cocoabridge.h"
+#endif
+
 namespace Ms {
 
 //---------------------------------------------------------
@@ -73,7 +77,8 @@ PreferenceDialog::PreferenceDialog(QWidget* parent)
 
 #ifdef Q_OS_MAC // On Mac, we have an extra theme option,
       // namely to follow the system's Dark Mode
-      styleName->addItem(QCoreApplication::translate("PrefsDialogBase", "System", nullptr));
+      if (CocoaBridge::isSystemDarkModeSupported())
+            styleName->addItem(QCoreApplication::translate("PrefsDialogBase", "System"));
 #endif
 
 #ifndef USE_JACK
@@ -574,7 +579,8 @@ void PreferenceDialog::retranslate()
 #ifdef Q_OS_MAC // On Mac, we have an extra theme option,
       // namely, to follow the system's Dark Mode.
       // Of course, we need to translate that too :)
-      styleName->setItemText(2, QCoreApplication::translate("PrefsDialogBase", "System", nullptr));
+      if (CocoaBridge::isSystemDarkModeSupported())
+            styleName->setItemText(2, QCoreApplication::translate("PrefsDialogBase", "System"));
 #endif
       updateValues();
       }

--- a/mscore/prefsdialog.h
+++ b/mscore/prefsdialog.h
@@ -112,7 +112,7 @@ class PreferenceDialog : public AbstractDialog, private Ui::PrefsDialogBase {
       void mixerPreferencesChanged(bool showMidiControls);
 
    protected:
-      virtual void retranslate() { retranslateUi(this); updateValues(); }
+      virtual void retranslate();
 
    public:
       PreferenceDialog(QWidget* parent);

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -466,12 +466,12 @@
             </property>
             <item>
              <property name="text">
-              <string>Dark</string>
+              <string>Light</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>Light</string>
+              <string>Dark</string>
              </property>
             </item>
            </widget>


### PR DESCRIPTION
Resolves: [#290946](https://musescore.org/en/node/290946) and [#309133](https://musescore.org/en/node/309133)

This PR actually solves two issues. 

1.   When you chose the Dark theme in _MuseScore_ (no matter whether the _system_ is in Dark mode or not), the window title bars remained light. Now, they will be light with the light theme and dark with the dark theme. 
    ![Window Title Bar Before-After](https://user-images.githubusercontent.com/48658420/95684092-70a6c900-0bef-11eb-8028-c726ff23c7d2.jpg)

2.   Once, I suggested to let MuseScore automatically switch its theme when the system theme is changed. Now, I got this working, without breaking things on older/other operating systems. 
    ![macOS Dark Mode On-Off](https://user-images.githubusercontent.com/48658420/95719499-2e719c00-0c70-11eb-9879-f54d2d79f6ff.gif)

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made