### PR TITLE
fix #311520: harmony playback preferences not honored until toggled

### DIFF
--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -96,6 +96,8 @@ QColor  MScore::dropColor;
 bool    MScore::warnPitchRange;
 int     MScore::pedalEventsMinTicks;
 
+bool    MScore::harmonyPlayDisableCompatibility;
+bool    MScore::harmonyPlayDisableNew;
 bool    MScore::playRepeats;
 bool    MScore::panPlayback;
 int     MScore::playbackSpeedIncrement;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -323,6 +323,8 @@ class MScore {
       static bool warnPitchRange;
       static int pedalEventsMinTicks;
 
+      static bool harmonyPlayDisableCompatibility;
+      static bool harmonyPlayDisableNew;
       static bool playRepeats;
       static bool panPlayback;
       static int playbackSpeedIncrement;

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -2770,8 +2770,7 @@ static void readStyle(MStyle* style, XmlReader& e)
 //TODO                  style->convertToUnit(tag, val);
             }
 
-      QSettings settings;
-      bool disableHarmonyPlay = settings.value("score/harmony/play/disableCompatibility").toBool() && !MScore::testMode;
+      bool disableHarmonyPlay = MScore::harmonyPlayDisableCompatibility && !MScore::testMode;
       if (disableHarmonyPlay) {
             style->set(Sid::harmonyPlay, false);
             }

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -3700,8 +3700,7 @@ static void readStyle(MStyle* style, XmlReader& e)
                   }
             }
 
-      QSettings settings;
-      bool disableHarmonyPlay = settings.value("score/harmony/play/disableCompatibility").toBool() && !MScore::testMode;
+      bool disableHarmonyPlay = MScore::harmonyPlayDisableCompatibility && !MScore::testMode;
       if (disableHarmonyPlay) {
             style->set(Sid::harmonyPlay, false);
             }

--- a/libmscore/read301.cpp
+++ b/libmscore/read301.cpp
@@ -45,8 +45,7 @@ bool Score::read(XmlReader& e)
       // note: older templates get the default values for older scores
       // these can be forced back in MuseScore::getNewFile() if necessary
       QString programVersion = masterScore()->mscoreVersion();
-      QSettings settings;
-      bool disableHarmonyPlay = settings.value("score/harmony/play/disableCompatibility").toBool() && !MScore::testMode;
+      bool disableHarmonyPlay = MScore::harmonyPlayDisableCompatibility && !MScore::testMode;
       if (!programVersion.isEmpty() && programVersion < "3.5" && disableHarmonyPlay) {
             style().set(Sid::harmonyPlay, false);
             }

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -584,13 +584,16 @@ MasterScore* MuseScore::getNewFile()
                   delete score;
                   return 0;
                   }
-            if (preferences.getBool(PREF_SCORE_HARMONY_PLAY_DISABLE_NEW)) {
+            if (MScore::harmonyPlayDisableNew) {
                   tscore->style().set(Sid::harmonyPlay, false);
                   }
-            else if (preferences.getBool(PREF_SCORE_HARMONY_PLAY_DISABLE_COMPATIBILITY)) {
+            else if (MScore::harmonyPlayDisableCompatibility) {
                   // if template was older, then harmonyPlay may have been forced off by the compatibility preference
-                  // that's not appropriatew when creating new scores, even from old templates, so return it to default
-                  tscore->style().set(Sid::harmonyPlay, MScore::defaultStyle().value(Sid::harmonyPlay));
+                  // that's not appropriate when creating new scores from old templates
+                  // if template was pre-3.5, return harmonyPlay to default
+                  QString programVersion = tscore->mscoreVersion();
+                  if (!programVersion.isEmpty() && programVersion < "3.5")
+                        tscore->style().set(Sid::harmonyPlay, MScore::defaultStyle().value(Sid::harmonyPlay));
                   }
             score->setStyle(tscore->style());
 
@@ -642,7 +645,7 @@ MasterScore* MuseScore::getNewFile()
             }
       else {
             score = new MasterScore(MScore::defaultStyle());
-            if (preferences.getBool(PREF_SCORE_HARMONY_PLAY_DISABLE_NEW)) {
+            if (MScore::harmonyPlayDisableNew) {
                   score->style().set(Sid::harmonyPlay, false);
                   }
             newWizard->createInstruments(score);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -411,6 +411,8 @@ void updateExternalValuesFromPreferences() {
       MScore::defaultColor = preferences.getColor(PREF_UI_SCORE_DEFAULTCOLOR);
       MScore::defaultPlayDuration = preferences.getInt(PREF_SCORE_NOTE_DEFAULTPLAYDURATION);
       MScore::panPlayback = preferences.getBool(PREF_APP_PLAYBACK_PANPLAYBACK);
+      MScore::harmonyPlayDisableCompatibility = preferences.getBool(PREF_SCORE_HARMONY_PLAY_DISABLE_COMPATIBILITY);
+      MScore::harmonyPlayDisableNew = preferences.getBool(PREF_SCORE_HARMONY_PLAY_DISABLE_NEW);
       MScore::playRepeats = preferences.getBool(PREF_APP_PLAYBACK_PLAYREPEATS);
       MScore::playbackSpeedIncrement = preferences.getInt(PREF_APP_PLAYBACK_SPEEDINCREMENT);
       MScore::warnPitchRange = preferences.getBool(PREF_SCORE_NOTE_WARNPITCHRANGE);

--- a/mtest/testscript/scripts/#120271-parts-spanners-elongation.mscx
+++ b/mtest/testscript/scripts/#120271-parts-spanners-elongation.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>29165bb</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/#173381-mmrest-copy.mscx
+++ b/mtest/testscript/scripts/#173381-mmrest-copy.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>a86e19c</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/#173381-mmrest-repeat-1.mscx
+++ b/mtest/testscript/scripts/#173381-mmrest-repeat-1.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>a86e19c</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/#173381-mmrest-repeat-2.mscx
+++ b/mtest/testscript/scripts/#173381-mmrest-repeat-2.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>a86e19c</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/#280574-ctrl-del-corruption.mscx
+++ b/mtest/testscript/scripts/#280574-ctrl-del-corruption.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>6187abc</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/#295357-lyric-offset-part.mscx
+++ b/mtest/testscript/scripts/#295357-lyric-offset-part.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.3.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>6c0bef1</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/283943-delete-measure-at-glissando-end.mscx
+++ b/mtest/testscript/scripts/283943-delete-measure-at-glissando-end.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.3.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>14e9f7e</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/290096-remove-beat-parts-corruption.mscx
+++ b/mtest/testscript/scripts/290096-remove-beat-parts-corruption.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.4.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>042303c</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/basic_note_input.mscx
+++ b/mtest/testscript/scripts/basic_note_input.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>d4d1d69</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/excerptchange.mscx
+++ b/mtest/testscript/scripts/excerptchange.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>8920c76</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/exchange-voice-part.mscx
+++ b/mtest/testscript/scripts/exchange-voice-part.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/exchange-voice-part~undo.mscx
+++ b/mtest/testscript/scripts/exchange-voice-part~undo.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/init/twoStavesWithNotesAndMore.mscx
+++ b/mtest/testscript/scripts/init/twoStavesWithNotesAndMore.mscx
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
+  <programVersion>3.5.0</programVersion>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>
     <currentLayer>0</currentLayer>

--- a/mtest/testscript/scripts/inspector.mscx
+++ b/mtest/testscript/scripts/inspector.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>ecd264d</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/note_input_arrows.mscx
+++ b/mtest/testscript/scripts/note_input_arrows.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>b30c360</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/note_input_aug_dots.mscx
+++ b/mtest/testscript/scripts/note_input_aug_dots.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>b30c360</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/note_input_different.mscx
+++ b/mtest/testscript/scripts/note_input_different.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>b30c360</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/note_input_flip.mscx
+++ b/mtest/testscript/scripts/note_input_flip.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>b30c360</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/note_input_flip_even_odd.mscx
+++ b/mtest/testscript/scripts/note_input_flip_even_odd.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>b30c360</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/note_input_quarter.mscx
+++ b/mtest/testscript/scripts/note_input_quarter.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>b30c360</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/note_input_rests.mscx
+++ b/mtest/testscript/scripts/note_input_rests.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>b30c360</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/note_input_select_undo.mscx
+++ b/mtest/testscript/scripts/note_input_select_undo.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>100d297</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/note_input_slurs.mscx
+++ b/mtest/testscript/scripts/note_input_slurs.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>b30c360</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/note_input_tie.mscx
+++ b/mtest/testscript/scripts/note_input_tie.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>b30c360</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/note_input_voices.mscx
+++ b/mtest/testscript/scripts/note_input_voices.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>b30c360</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette.mscx
+++ b/mtest/testscript/scripts/palette.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>ef842d4</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette_accidentals_1.mscx
+++ b/mtest/testscript/scripts/palette_accidentals_1.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette_arpeggio_gliss_1.mscx
+++ b/mtest/testscript/scripts/palette_arpeggio_gliss_1.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette_articulations_1.mscx
+++ b/mtest/testscript/scripts/palette_articulations_1.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette_articulations_2.mscx
+++ b/mtest/testscript/scripts/palette_articulations_2.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette_barlines_1.mscx
+++ b/mtest/testscript/scripts/palette_barlines_1.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette_beams_1.mscx
+++ b/mtest/testscript/scripts/palette_beams_1.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette_breaks_1.mscx
+++ b/mtest/testscript/scripts/palette_breaks_1.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette_breath_and_pause_1.mscx
+++ b/mtest/testscript/scripts/palette_breath_and_pause_1.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette_clefs_1.mscx
+++ b/mtest/testscript/scripts/palette_clefs_1.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette_clefs_2.mscx
+++ b/mtest/testscript/scripts/palette_clefs_2.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette_grace_notes_1.mscx
+++ b/mtest/testscript/scripts/palette_grace_notes_1.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette_gracenotes_1.mscx
+++ b/mtest/testscript/scripts/palette_gracenotes_1.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette_gracenotes_2.mscx
+++ b/mtest/testscript/scripts/palette_gracenotes_2.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette_keysigs_1.mscx
+++ b/mtest/testscript/scripts/palette_keysigs_1.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette_keysigs_2.mscx
+++ b/mtest/testscript/scripts/palette_keysigs_2.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette_keysigs_3.mscx
+++ b/mtest/testscript/scripts/palette_keysigs_3.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette_lines_1.mscx
+++ b/mtest/testscript/scripts/palette_lines_1.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>
     <currentLayer>0</currentLayer>

--- a/mtest/testscript/scripts/palette_noteheads_1.mscx
+++ b/mtest/testscript/scripts/palette_noteheads_1.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette_ornaments_1.mscx
+++ b/mtest/testscript/scripts/palette_ornaments_1.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette_timesigs_1.mscx
+++ b/mtest/testscript/scripts/palette_timesigs_1.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/palette_tremolo_1.mscx
+++ b/mtest/testscript/scripts/palette_tremolo_1.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/paste_excceed_scoreLen_MMrest.mscx
+++ b/mtest/testscript/scripts/paste_excceed_scoreLen_MMrest.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/repeat-sel-end-score.mscx
+++ b/mtest/testscript/scripts/repeat-sel-end-score.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>cc16e73</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/timewise-input.mscx
+++ b/mtest/testscript/scripts/timewise-input.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.0.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>1fbfc93</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/ux_replace_slurs_on_copy.mscx
+++ b/mtest/testscript/scripts/ux_replace_slurs_on_copy.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>50ba733</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/ux_replace_slurs_on_copy_diffstaves.mscx
+++ b/mtest/testscript/scripts/ux_replace_slurs_on_copy_diffstaves.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>a9d043a</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/ux_replace_slurs_on_copy_diffstaves~undo.mscx
+++ b/mtest/testscript/scripts/ux_replace_slurs_on_copy_diffstaves~undo.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>a9d043a</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>

--- a/mtest/testscript/scripts/ux_replace_slurs_on_copy~undo.mscx
+++ b/mtest/testscript/scripts/ux_replace_slurs_on_copy~undo.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.01">
-  <programVersion>3.1.0</programVersion>
+  <programVersion>3.5.0</programVersion>
   <programRevision>a9d043a</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/311520

The new preferences for disabling playback of chord symbols work fine,
only ater you've toggled them at least once, which forces them
to be written to the ".ini" file.
Otherwise, they are not being initialized correctly.
This is apparently from the use of QSettings to access the preferences
from code within the libmscore folder.
This technique is used at least one other place,
but it is apparently not reliable with respect to default values.

This commit adds new members of MScore class
so mscore can write them and libmscore can read them.
That is the approach used by most other preferences
that need to be accessed from libmscore.

In addition, there was a logic error
when creating a new score from a template.
There was code to handle new scores created from *old* templates,
so they wouldn't have chord symbols forced off
by the compatibility setting.
This code was erroneously being triggered for new templates as well,
making it impossible to disable chord symbol playback via a template.
That is fixed by performing the same version check used
when reading the template.