### PR TITLE
[MU4] Fixed build MacOS on CI

### DIFF
--- a/.github/workflows/ci_macos_mu4.yml
+++ b/.github/workflows/ci_macos_mu4.yml
@@ -68,7 +68,7 @@ jobs:
         bash ./build/ci/macos/checkcodestyle.sh  
     - name: Setup environment
       run: |
-        sudo bash ./build/ci/macos/setup.sh
+        bash ./build/ci/macos/setup.sh
     - name: Build          
       run: |
         T_ID=${{ secrets.TELEMETRY_TRACK_ID }}; if [ -z "$T_ID" ]; then T_ID="-"; fi

--- a/build/ci/linux/setup.sh
+++ b/build/ci/linux/setup.sh
@@ -130,8 +130,7 @@ cmake_dir="cmake/${cmake_version}"
 if [[ ! -d "${cmake_dir}" ]]; then
   mkdir -p "${cmake_dir}"
   cmake_url="https://cmake.org/files/v${cmake_version%.*}/cmake-${cmake_version}-Linux-x86_64.tar.gz"
-  wget -q --show-progress --no-check-certificate -O - "${cmake_url}" \
-    | tar --strip-components=1 -xz -C "${cmake_dir}"
+  wget -q --show-progress --no-check-certificate -O - "${cmake_url}" | tar --strip-components=1 -xz -C "${cmake_dir}"
 fi
 echo export PATH="${PWD%/}/${cmake_dir}/bin:\${PATH}" >> ${ENV_FILE}
 export PATH="${PWD%/}/${cmake_dir}/bin:${PATH}"

--- a/build/ci/macos/setup.sh
+++ b/build/ci/macos/setup.sh
@@ -16,13 +16,6 @@ brew update
 # additional dependencies
 brew install jack lame
 
-# TODO Find out why
-#hack to fix macOS build
-# brew uninstall wget
-# brew install wget
-# brew uninstall --ignore-dependencies python2
-# brew install python2
-
 BREW_CELLAR=$(brew --cellar)
 BREW_PREFIX=$(brew --prefix)
 


### PR DESCRIPTION
I'll deal with error handling separately later.
Instead of my function (exit_if_err), we can `set -e` or `trap 'do_something' ERR` (https://stackoverflow.com/questions/19622198/what-does-set-e-mean-in-a-bash-script)
But now I can't just do it like that, because there is some code that returns an error as expected.
For example, in `package_mac`, an attempt is made to remove an old artifact, but it is never on the CI, so the expected error "file not found"