### PR TITLE
[MU4] Notation context  menu

### DIFF
--- a/framework/actions/actiontypes.h
+++ b/framework/actions/actiontypes.h
@@ -26,6 +26,7 @@
 #include <QString>
 
 #include "shortcuts/shortcutstypes.h"
+#include "ui/view/iconcodes.h"
 
 namespace mu {
 namespace actions {
@@ -40,12 +41,15 @@ struct Action {
     ActionName name;
     std::string title;
     shortcuts::ShortcutContext scContext = shortcuts::ShortcutContext::Undefined;
+    framework::IconCode::Code iconCode = framework::IconCode::Code::NONE;
 
     Action() = default;
-    Action(const ActionName& n, const std::string& t, shortcuts::ShortcutContext scc)
-        : name(n), title(t), scContext(scc) {}
+    Action(const ActionName& name, const std::string& title, shortcuts::ShortcutContext shortcutContext,
+           framework::IconCode::Code iconCode = framework::IconCode::Code::NONE)
+        : name(name), title(title), scContext(shortcutContext), iconCode(iconCode) {}
     bool isValid() const { return !name.empty(); }
 };
+using ActionList = std::vector<Action>;
 
 class ActionData
 {

--- a/framework/shortcuts/internal/shortcutsregister.cpp
+++ b/framework/shortcuts/internal/shortcutsregister.cpp
@@ -143,6 +143,17 @@ const std::list<Shortcut>& ShortcutsRegister::shortcuts() const
     return m_shortcuts;
 }
 
+Shortcut ShortcutsRegister::shortcut(const std::string& actionName) const
+{
+    for (const Shortcut& shortcut: m_shortcuts) {
+        if (shortcut.action == actionName) {
+            return shortcut;
+        }
+    }
+
+    return Shortcut();
+}
+
 std::list<Shortcut> ShortcutsRegister::shortcutsForSequence(const std::string& sequence) const
 {
     std::list<Shortcut> list;

--- a/mu4/notation/CMakeLists.txt
+++ b/mu4/notation/CMakeLists.txt
@@ -93,6 +93,16 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/notationmidiinput.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/notationparts.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/notationparts.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/notationactionsrepositoryfactory.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/notationactionsrepositoryfactory.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/elementactionsrepository.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/elementactionsrepository.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/measureactionsrepository.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/measureactionsrepository.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/pageactionsrepository.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/pageactionsrepository.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/inotationactionsrepositoryfactory.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/inotationactionsrepository.h
     ${CMAKE_CURRENT_LIST_DIR}/view/notationpaintview.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/notationpaintview.h
     ${CMAKE_CURRENT_LIST_DIR}/view/notationviewinputcontroller.cpp

--- a/mu4/notation/inotationinteraction.h
+++ b/mu4/notation/inotationinteraction.h
@@ -88,6 +88,8 @@ public:
     virtual void endEditText() = 0;
     virtual void changeTextCursorPosition(const QPointF& newCursorPos) = 0;
     virtual async::Notification textEditingChanged() const = 0;
+
+    virtual void deleteSelection() = 0;
 };
 }
 }

--- a/mu4/notation/internal/elementactionsrepository.cpp
+++ b/mu4/notation/internal/elementactionsrepository.cpp
@@ -16,27 +16,19 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#ifndef MU_SHORTCUTS_ISHORTCUTSREGISTER_H
-#define MU_SHORTCUTS_ISHORTCUTSREGISTER_H
+#include "elementactionsrepository.h"
 
-#include <list>
+using namespace mu::notation;
+using namespace mu::actions;
 
-#include "modularity/imoduleexport.h"
-#include "shortcutstypes.h"
-
-namespace mu {
-namespace shortcuts {
-class IShortcutsRegister : MODULE_EXPORT_INTERFACE
+ActionList ElementActionsRepository::actions() const
 {
-    INTERFACE_ID(IShortcutsRegister)
-public:
-    virtual ~IShortcutsRegister() = default;
+    ActionList actions;
+    actions.push_back(actionRegister()->action("cut"));
+    actions.push_back(actionRegister()->action("copy"));
+    actions.push_back(actionRegister()->action("paste"));
+    actions.push_back(actionRegister()->action("swap"));
+    actions.push_back(actionRegister()->action("delete"));
 
-    virtual const std::list<Shortcut>& shortcuts() const = 0;
-    virtual Shortcut shortcut(const std::string& actionName) const = 0;
-    virtual std::list<Shortcut> shortcutsForSequence(const std::string& sequence) const = 0;
-};
+    return actions;
 }
-}
-
-#endif // MU_SHORTCUTS_ISHORTCUTSREGISTER_H

--- a/mu4/notation/internal/elementactionsrepository.h
+++ b/mu4/notation/internal/elementactionsrepository.h
@@ -16,38 +16,21 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#ifndef MU_SHORTCUTS_SHORTCUTSREGISTER_H
-#define MU_SHORTCUTS_SHORTCUTSREGISTER_H
+#ifndef MU_NOTATION_ELEMENTACTIONSREPOSITORY_H
+#define MU_NOTATION_ELEMENTACTIONSREPOSITORY_H
 
-#include <QString>
-
-#include "../ishortcutsregister.h"
 #include "modularity/ioc.h"
-#include "iglobalconfiguration.h"
+#include "actions/iactionsregister.h"
+#include "inotationactionsrepository.h"
 
-namespace mu {
-namespace shortcuts {
-class ShortcutsRegister : public IShortcutsRegister
+namespace mu::notation {
+class ElementActionsRepository : public INotationActionsRepository
 {
-    INJECT(shortcut, framework::IGlobalConfiguration, globalConfiguration)
+    INJECT(shortcuts, actions::IActionsRegister, actionRegister)
+
 public:
-
-    ShortcutsRegister() = default;
-
-    void load();
-
-    const std::list<Shortcut>& shortcuts() const override;
-    Shortcut shortcut(const std::string& actionName) const override;
-    std::list<Shortcut> shortcutsForSequence(const std::string& sequence) const override;
-
-private:
-
-    bool loadFromFile(std::list<Shortcut>& shortcuts, const io::path& path) const;
-    void expandStandartKeys(std::list<Shortcut>& shortcuts) const;
-
-    std::list<Shortcut> m_shortcuts;
+    actions::ActionList actions() const override;
 };
 }
-}
 
-#endif // MU_SHORTCUTS_SHORTCUTSREGISTER_H
+#endif // MU_NOTATION_ELEMENTACTIONSREPOSITORY_H

--- a/mu4/notation/internal/inotationactionsrepository.h
+++ b/mu4/notation/internal/inotationactionsrepository.h
@@ -16,27 +16,21 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#ifndef MU_SHORTCUTS_ISHORTCUTSREGISTER_H
-#define MU_SHORTCUTS_ISHORTCUTSREGISTER_H
-
-#include <list>
+#ifndef MU_NOTATION_INOTATIONACTIONSREPOSITORY_H
+#define MU_NOTATION_INOTATIONACTIONSREPOSITORY_H
 
 #include "modularity/imoduleexport.h"
-#include "shortcutstypes.h"
+#include "actions/actiontypes.h"
 
-namespace mu {
-namespace shortcuts {
-class IShortcutsRegister : MODULE_EXPORT_INTERFACE
+namespace mu::notation {
+class INotationActionsRepository
 {
-    INTERFACE_ID(IShortcutsRegister)
 public:
-    virtual ~IShortcutsRegister() = default;
+    virtual ~INotationActionsRepository() = default;
 
-    virtual const std::list<Shortcut>& shortcuts() const = 0;
-    virtual Shortcut shortcut(const std::string& actionName) const = 0;
-    virtual std::list<Shortcut> shortcutsForSequence(const std::string& sequence) const = 0;
+    virtual actions::ActionList actions() const = 0;
 };
-}
+using INotationActionsRepositoryPtr = std::shared_ptr<INotationActionsRepository>;
 }
 
-#endif // MU_SHORTCUTS_ISHORTCUTSREGISTER_H
+#endif // MU_NOTATION_INOTATIONACTIONSREPOSITORY_H

--- a/mu4/notation/internal/inotationactionsrepositoryfactory.h
+++ b/mu4/notation/internal/inotationactionsrepositoryfactory.h
@@ -16,27 +16,23 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#ifndef MU_SHORTCUTS_ISHORTCUTSREGISTER_H
-#define MU_SHORTCUTS_ISHORTCUTSREGISTER_H
-
-#include <list>
+#ifndef MU_NOTATION_INOTATIONACTIONSREPOSITORYFACTORY_H
+#define MU_NOTATION_INOTATIONACTIONSREPOSITORYFACTORY_H
 
 #include "modularity/imoduleexport.h"
-#include "shortcutstypes.h"
+#include "notationtypes.h"
+#include "inotationactionsrepository.h"
 
-namespace mu {
-namespace shortcuts {
-class IShortcutsRegister : MODULE_EXPORT_INTERFACE
+namespace mu::notation {
+class INotationActionsRepositoryFactory : MODULE_EXPORT_INTERFACE
 {
-    INTERFACE_ID(IShortcutsRegister)
-public:
-    virtual ~IShortcutsRegister() = default;
+    INTERFACE_ID(INotationActionsRepositoryFactory)
 
-    virtual const std::list<Shortcut>& shortcuts() const = 0;
-    virtual Shortcut shortcut(const std::string& actionName) const = 0;
-    virtual std::list<Shortcut> shortcutsForSequence(const std::string& sequence) const = 0;
+public:
+    virtual ~INotationActionsRepositoryFactory() = default;
+
+    virtual INotationActionsRepositoryPtr actionsRepository(const ElementType& elementType) const = 0;
 };
 }
-}
 
-#endif // MU_SHORTCUTS_ISHORTCUTSREGISTER_H
+#endif // MU_NOTATION_INOTATIONACTIONSREPOSITORYFACTORY_H

--- a/mu4/notation/internal/measureactionsrepository.cpp
+++ b/mu4/notation/internal/measureactionsrepository.cpp
@@ -16,27 +16,15 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#ifndef MU_SHORTCUTS_ISHORTCUTSREGISTER_H
-#define MU_SHORTCUTS_ISHORTCUTSREGISTER_H
+#include "measureactionsrepository.h"
 
-#include <list>
+#include "log.h"
 
-#include "modularity/imoduleexport.h"
-#include "shortcutstypes.h"
+using namespace mu::notation;
+using namespace mu::actions;
 
-namespace mu {
-namespace shortcuts {
-class IShortcutsRegister : MODULE_EXPORT_INTERFACE
+ActionList MeasureActionsRepository::actions() const
 {
-    INTERFACE_ID(IShortcutsRegister)
-public:
-    virtual ~IShortcutsRegister() = default;
-
-    virtual const std::list<Shortcut>& shortcuts() const = 0;
-    virtual Shortcut shortcut(const std::string& actionName) const = 0;
-    virtual std::list<Shortcut> shortcutsForSequence(const std::string& sequence) const = 0;
-};
+    NOT_IMPLEMENTED;
+    return ActionList();
 }
-}
-
-#endif // MU_SHORTCUTS_ISHORTCUTSREGISTER_H

--- a/mu4/notation/internal/measureactionsrepository.h
+++ b/mu4/notation/internal/measureactionsrepository.h
@@ -16,27 +16,17 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#ifndef MU_SHORTCUTS_ISHORTCUTSREGISTER_H
-#define MU_SHORTCUTS_ISHORTCUTSREGISTER_H
+#ifndef MU_NOTATION_MEASUREACTIONSREPOSITORY_H
+#define MU_NOTATION_MEASUREACTIONSREPOSITORY_H
 
-#include <list>
+#include "inotationactionsrepository.h"
 
-#include "modularity/imoduleexport.h"
-#include "shortcutstypes.h"
-
-namespace mu {
-namespace shortcuts {
-class IShortcutsRegister : MODULE_EXPORT_INTERFACE
+namespace mu::notation {
+class MeasureActionsRepository : public INotationActionsRepository
 {
-    INTERFACE_ID(IShortcutsRegister)
 public:
-    virtual ~IShortcutsRegister() = default;
-
-    virtual const std::list<Shortcut>& shortcuts() const = 0;
-    virtual Shortcut shortcut(const std::string& actionName) const = 0;
-    virtual std::list<Shortcut> shortcutsForSequence(const std::string& sequence) const = 0;
+    actions::ActionList actions() const override;
 };
 }
-}
 
-#endif // MU_SHORTCUTS_ISHORTCUTSREGISTER_H
+#endif // MU_NOTATION_MEASUREACTIONSREPOSITORY_H

--- a/mu4/notation/internal/notationactioncontroller.cpp
+++ b/mu4/notation/internal/notationactioncontroller.cpp
@@ -46,6 +46,10 @@ void NotationActionController::init()
     dispatcher()->reg(this, "pitch-down", [this](const ActionName& action) { moveAction(action); });
     dispatcher()->reg(this, "pitch-up-octave", [this](const ActionName& action) { moveAction(action); });
     dispatcher()->reg(this, "pitch-down-octave", [this](const ActionName& action) { moveAction(action); });
+
+    dispatcher()->reg(this, "delete", this, &NotationActionController::deleteSelection);
+
+    dispatcher()->reg(this, "edit-style", this, &NotationActionController::openPageStyle);
 }
 
 bool NotationActionController::canReceiveAction(const actions::ActionName&) const
@@ -197,4 +201,19 @@ void NotationActionController::moveText(INotationInteraction* interaction, const
     }
 
     interaction->moveText(direction, quickly);
+}
+
+void NotationActionController::deleteSelection()
+{
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+
+    interaction->deleteSelection();
+}
+
+void NotationActionController::openPageStyle()
+{
+    interactive()->open("musescore://notation/style");
 }

--- a/mu4/notation/internal/notationactioncontroller.h
+++ b/mu4/notation/internal/notationactioncontroller.h
@@ -24,6 +24,7 @@
 #include "actions/actionable.h"
 #include "context/iglobalcontext.h"
 #include "inotation.h"
+#include "iinteractive.h"
 
 namespace mu {
 namespace notation {
@@ -31,6 +32,7 @@ class NotationActionController : public actions::Actionable
 {
     INJECT(notation, actions::IActionsDispatcher, dispatcher)
     INJECT(notation, context::IGlobalContext, globalContext)
+    INJECT(notation, framework::IInteractive, interactive)
 
 public:
 
@@ -49,6 +51,9 @@ private:
 
     void moveAction(const actions::ActionName& action);
     void moveText(INotationInteraction* interaction, const actions::ActionName& action);
+
+    void deleteSelection();
+    void openPageStyle();
 };
 }
 }

--- a/mu4/notation/internal/notationactions.cpp
+++ b/mu4/notation/internal/notationactions.cpp
@@ -18,9 +18,12 @@
 //=============================================================================
 #include "notationactions.h"
 
+#include "ui/view/iconcodes.h"
+
 using namespace mu::notation;
 using namespace mu::actions;
 using namespace mu::shortcuts;
+using namespace mu::framework;
 
 //! NOTE Only actions processed by notation
 
@@ -99,6 +102,38 @@ const std::vector<Action> NotationActions::m_actions = {
            ),
     Action("pitch-up-octave",
            QT_TRANSLATE_NOOP("action", "Up Octave"),
+           ShortcutContext::NotationActive
+           ),
+    Action("cut",
+           QT_TRANSLATE_NOOP("action", "Cut"),
+           ShortcutContext::NotationActive
+           ),
+    Action("copy",
+           QT_TRANSLATE_NOOP("action", "Copy"),
+           ShortcutContext::NotationActive
+           ),
+    Action("paste",
+           QT_TRANSLATE_NOOP("action", "Paste"),
+           ShortcutContext::NotationActive
+           ),
+    Action("swap",
+           QT_TRANSLATE_NOOP("action", "Swap"),
+           ShortcutContext::NotationActive
+           ),
+    Action("delete",
+           QT_TRANSLATE_NOOP("action", "Delete"),
+           ShortcutContext::NotationActive,
+           IconCode::Code::DELETE_TANK),
+    Action("edit-style",
+           QT_TRANSLATE_NOOP("action", "Style"),
+           ShortcutContext::NotationActive
+           ),
+    Action("page-settings",
+           QT_TRANSLATE_NOOP("action", "Page Settings"),
+           ShortcutContext::NotationActive
+           ),
+    Action("load-style",
+           QT_TRANSLATE_NOOP("action", "Load Style"),
            ShortcutContext::NotationActive
            )
 };

--- a/mu4/notation/internal/notationactionsrepositoryfactory.cpp
+++ b/mu4/notation/internal/notationactionsrepositoryfactory.cpp
@@ -16,27 +16,22 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#ifndef MU_SHORTCUTS_ISHORTCUTSREGISTER_H
-#define MU_SHORTCUTS_ISHORTCUTSREGISTER_H
+#include "notationactionsrepositoryfactory.h"
 
-#include <list>
+#include "elementactionsrepository.h"
+#include "measureactionsrepository.h"
+#include "pageactionsrepository.h"
 
-#include "modularity/imoduleexport.h"
-#include "shortcutstypes.h"
+using namespace mu::notation;
 
-namespace mu {
-namespace shortcuts {
-class IShortcutsRegister : MODULE_EXPORT_INTERFACE
+INotationActionsRepositoryPtr NotationActionsRepositoryFactory::actionsRepository(const ElementType& elementType) const
 {
-    INTERFACE_ID(IShortcutsRegister)
-public:
-    virtual ~IShortcutsRegister() = default;
-
-    virtual const std::list<Shortcut>& shortcuts() const = 0;
-    virtual Shortcut shortcut(const std::string& actionName) const = 0;
-    virtual std::list<Shortcut> shortcutsForSequence(const std::string& sequence) const = 0;
-};
+    switch (elementType) {
+    case ElementType::MEASURE:
+        return std::make_shared<MeasureActionsRepository>();
+    case ElementType::PAGE:
+        return std::make_shared<PageActionsRepository>();
+    default:
+        return std::make_shared<ElementActionsRepository>();
+    }
 }
-}
-
-#endif // MU_SHORTCUTS_ISHORTCUTSREGISTER_H

--- a/mu4/notation/internal/notationactionsrepositoryfactory.h
+++ b/mu4/notation/internal/notationactionsrepositoryfactory.h
@@ -16,27 +16,17 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#ifndef MU_SHORTCUTS_ISHORTCUTSREGISTER_H
-#define MU_SHORTCUTS_ISHORTCUTSREGISTER_H
+#ifndef MU_NOTATION_NOTATIONACTIONSREPOSITORYFACTORY_H
+#define MU_NOTATION_NOTATIONACTIONSREPOSITORYFACTORY_H
 
-#include <list>
+#include "inotationactionsrepositoryfactory.h"
 
-#include "modularity/imoduleexport.h"
-#include "shortcutstypes.h"
-
-namespace mu {
-namespace shortcuts {
-class IShortcutsRegister : MODULE_EXPORT_INTERFACE
+namespace mu::notation {
+class NotationActionsRepositoryFactory : public INotationActionsRepositoryFactory
 {
-    INTERFACE_ID(IShortcutsRegister)
 public:
-    virtual ~IShortcutsRegister() = default;
-
-    virtual const std::list<Shortcut>& shortcuts() const = 0;
-    virtual Shortcut shortcut(const std::string& actionName) const = 0;
-    virtual std::list<Shortcut> shortcutsForSequence(const std::string& sequence) const = 0;
+    INotationActionsRepositoryPtr actionsRepository(const ElementType& elementType) const override;
 };
 }
-}
 
-#endif // MU_SHORTCUTS_ISHORTCUTSREGISTER_H
+#endif // MU_NOTATION_NOTATIONACTIONSREPOSITORYFACTORY_H

--- a/mu4/notation/internal/notationinteraction.cpp
+++ b/mu4/notation/internal/notationinteraction.cpp
@@ -1885,3 +1885,10 @@ mu::async::Notification NotationInteraction::textEditingChanged() const
 {
     return m_textEditingChanged;
 }
+
+void NotationInteraction::deleteSelection()
+{
+    score()->cmdDeleteSelection();
+
+    m_selectionChanged.notify();
+}

--- a/mu4/notation/internal/notationinteraction.h
+++ b/mu4/notation/internal/notationinteraction.h
@@ -105,6 +105,8 @@ public:
     void changeTextCursorPosition(const QPointF& newCursorPos) override;
     async::Notification textEditingChanged() const override;
 
+    void deleteSelection() override;
+
 private:
     Ms::Score* score() const;
 

--- a/mu4/notation/internal/pageactionsrepository.cpp
+++ b/mu4/notation/internal/pageactionsrepository.cpp
@@ -16,27 +16,17 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#ifndef MU_SHORTCUTS_ISHORTCUTSREGISTER_H
-#define MU_SHORTCUTS_ISHORTCUTSREGISTER_H
+#include "pageactionsrepository.h"
 
-#include <list>
+using namespace mu::notation;
+using namespace mu::actions;
 
-#include "modularity/imoduleexport.h"
-#include "shortcutstypes.h"
-
-namespace mu {
-namespace shortcuts {
-class IShortcutsRegister : MODULE_EXPORT_INTERFACE
+ActionList PageActionsRepository::actions() const
 {
-    INTERFACE_ID(IShortcutsRegister)
-public:
-    virtual ~IShortcutsRegister() = default;
+    ActionList actions;
+    actions.push_back(actionRegister()->action("edit-style"));
+    actions.push_back(actionRegister()->action("page-settings"));
+    actions.push_back(actionRegister()->action("load-style"));
 
-    virtual const std::list<Shortcut>& shortcuts() const = 0;
-    virtual Shortcut shortcut(const std::string& actionName) const = 0;
-    virtual std::list<Shortcut> shortcutsForSequence(const std::string& sequence) const = 0;
-};
+    return actions;
 }
-}
-
-#endif // MU_SHORTCUTS_ISHORTCUTSREGISTER_H

--- a/mu4/notation/internal/pageactionsrepository.h
+++ b/mu4/notation/internal/pageactionsrepository.h
@@ -16,38 +16,21 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#ifndef MU_SHORTCUTS_SHORTCUTSREGISTER_H
-#define MU_SHORTCUTS_SHORTCUTSREGISTER_H
+#ifndef MU_NOTATION_PAGEACTIONSREPOSITORY_H
+#define MU_NOTATION_PAGEACTIONSREPOSITORY_H
 
-#include <QString>
-
-#include "../ishortcutsregister.h"
 #include "modularity/ioc.h"
-#include "iglobalconfiguration.h"
+#include "actions/iactionsregister.h"
+#include "inotationactionsrepository.h"
 
-namespace mu {
-namespace shortcuts {
-class ShortcutsRegister : public IShortcutsRegister
+namespace mu::notation {
+class PageActionsRepository : public INotationActionsRepository
 {
-    INJECT(shortcut, framework::IGlobalConfiguration, globalConfiguration)
+    INJECT(shortcuts, actions::IActionsRegister, actionRegister)
+
 public:
-
-    ShortcutsRegister() = default;
-
-    void load();
-
-    const std::list<Shortcut>& shortcuts() const override;
-    Shortcut shortcut(const std::string& actionName) const override;
-    std::list<Shortcut> shortcutsForSequence(const std::string& sequence) const override;
-
-private:
-
-    bool loadFromFile(std::list<Shortcut>& shortcuts, const io::path& path) const;
-    void expandStandartKeys(std::list<Shortcut>& shortcuts) const;
-
-    std::list<Shortcut> m_shortcuts;
+    actions::ActionList actions() const override;
 };
 }
-}
 
-#endif // MU_SHORTCUTS_SHORTCUTSREGISTER_H
+#endif // MU_NOTATION_PAGEACTIONSREPOSITORY_H

--- a/mu4/notation/notationmodule.cpp
+++ b/mu4/notation/notationmodule.cpp
@@ -34,6 +34,7 @@
 #include "internal/notationreadersregister.h"
 #include "internal/mscznotationreader.h"
 #include "internal/msczmetareader.h"
+#include "internal/notationactionsrepositoryfactory.h"
 
 #include "view/notationpaintview.h"
 #include "view/notationaccessibilitymodel.h"
@@ -69,6 +70,7 @@ void NotationModule::registerExports()
     framework::ioc()->registerExport<INotationCreator>(moduleName(), new NotationCreator());
     framework::ioc()->registerExport<INotationConfiguration>(moduleName(), s_configuration);
     framework::ioc()->registerExport<IMsczMetaReader>(moduleName(), new MsczMetaReader());
+    framework::ioc()->registerExport<INotationActionsRepositoryFactory>(moduleName(), new NotationActionsRepositoryFactory());
 
     std::shared_ptr<INotationReadersRegister> readers = std::make_shared<NotationReadersRegister>();
     readers->reg({ "mscz", "mscx" }, std::make_shared<MsczNotationReader>());

--- a/mu4/notation/qml/MuseScore/NotationScene/NotationView.qml
+++ b/mu4/notation/qml/MuseScore/NotationScene/NotationView.qml
@@ -1,5 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Layouts 1.3
+import QtQuick.Controls 2.15
+
 import MuseScore.NotationScene 1.0
 
 FocusScope {
@@ -12,8 +14,50 @@ FocusScope {
         }
 
         NotationPaintView {
+            id: notationView
+
             Layout.fillWidth: true
             Layout.fillHeight: true
+
+            onOpenContextMenuRequested: {
+                contextMenu.clear()
+
+                for (var i in items) {
+                    var item = items[i]
+
+                    // TODO: move to a stylized menu
+                    var menuItemObj = menuItem.createObject(notationView, { name: item.name, text: item.title })
+                    menuItemObj._triggered.connect(function(name) {
+                        notationView.handleAction(name)
+                    })
+                    contextMenu.addItem(menuItemObj)
+                }
+
+                contextMenu.popup(pos.x, pos.y)
+            }
+        }
+
+        Menu {
+            id: contextMenu
+
+            // TODO: remove after replacing with a stylized menu
+            function clear() {
+                for (var i = contextMenu.contentData.length - 1; i >= 0; --i) {
+                    removeItem(i)
+                }
+            }
+
+            Component {
+                id: menuItem
+                MenuItem {
+                    property string name: ""
+                    signal _triggered(string name)
+
+                    onTriggered: {
+                        _triggered(name)
+                    }
+                }
+            }
         }
     }
 }

--- a/mu4/notation/view/notationpaintview.cpp
+++ b/mu4/notation/view/notationpaintview.cpp
@@ -84,6 +84,11 @@ NotationPaintView::~NotationPaintView()
     delete m_playbackCursor;
 }
 
+void NotationPaintView::handleAction(const QString& actionName)
+{
+    dispatcher()->dispatch(actionName.toStdString());
+}
+
 bool NotationPaintView::canReceiveAction(const actions::ActionName& action) const
 {
     if (action == "file-open") {
@@ -169,6 +174,29 @@ void NotationPaintView::showShadowNote(const QPointF& pos)
 {
     notationInteraction()->showShadowNote(pos);
     update();
+}
+
+void NotationPaintView::showContextMenu(const ElementType& elementType, const QPoint& pos)
+{
+    INotationActionsRepositoryPtr actionsRepository = actionsFactory()->actionsRepository(elementType);
+
+    QVariantList menuItems;
+
+    for (const actions::Action& action: actionsRepository->actions()) {
+        QVariantMap actionObj;
+        actionObj["name"] = QString::fromStdString(action.name);
+        actionObj["title"] = QString::fromStdString(action.title);
+        actionObj["icon"] = static_cast<int>(action.iconCode);
+
+        shortcuts::Shortcut shortcut = shortcutsRegister()->shortcut(action.name);
+        if (shortcut.isValid()) {
+            actionObj["shortcut"] = QString::fromStdString(shortcut.sequence);
+        }
+
+        menuItems << actionObj;
+    }
+
+    emit openContextMenuRequested(menuItems, pos);
 }
 
 void NotationPaintView::paint(QPainter* p)

--- a/mu4/notation/view/notationpaintview.h
+++ b/mu4/notation/view/notationpaintview.h
@@ -24,13 +24,15 @@
 #include <QTransform>
 
 #include "modularity/ioc.h"
-#include "../inotationconfiguration.h"
+#include "inotationconfiguration.h"
+#include "internal/inotationactionsrepositoryfactory.h"
 #include "iinteractive.h"
 #include "actions/iactionsdispatcher.h"
 #include "actions/actionable.h"
 #include "context/iglobalcontext.h"
 #include "async/asyncable.h"
 #include "playback/iplaybackcontroller.h"
+#include "shortcuts/ishortcutsregister.h"
 
 #include "notationviewinputcontroller.h"
 #include "playbackcursor.h"
@@ -46,10 +48,14 @@ class NotationPaintView : public QQuickPaintedItem, public IControlledView, publ
     INJECT(notation, actions::IActionsDispatcher, dispatcher)
     INJECT(notation, context::IGlobalContext, globalContext)
     INJECT(notation, playback::IPlaybackController, playbackController)
+    INJECT(notation, INotationActionsRepositoryFactory, actionsFactory)
+    INJECT(notation, shortcuts::IShortcutsRegister, shortcutsRegister)
 
 public:
     NotationPaintView();
     ~NotationPaintView();
+
+    Q_INVOKABLE void handleAction(const QString& actionName);
 
     // IControlledView
     qreal width() const override;
@@ -66,12 +72,17 @@ public:
     bool isNoteEnterMode() const override;
     void showShadowNote(const QPointF& pos) override;
 
+    void showContextMenu(const ElementType& elementType, const QPoint& pos) override;
+
     notation::INotationInteraction* notationInteraction() const override;
     notation::INotationPlayback* notationPlayback() const override;
     // -----
 
 private slots:
     void onViewSizeChanged();
+
+signals:
+    void openContextMenuRequested(const QVariantList& items, const QPoint& pos);
 
 private:
     bool canReceiveAction(const actions::ActionName& action) const override;

--- a/mu4/notation/view/notationviewinputcontroller.cpp
+++ b/mu4/notation/view/notationviewinputcontroller.cpp
@@ -160,6 +160,11 @@ void NotationViewInputController::mousePressEvent(QMouseEvent* ev)
         m_view->notationInteraction()->clearSelection();
     }
 
+    if (ev->button() == Qt::MouseButton::RightButton) {
+        ElementType type = m_interactData.hitElement ? m_interactData.hitElement->type() : ElementType::PAGE;
+        m_view->showContextMenu(type, ev->pos());
+    }
+
     if (m_interactData.hitElement) {
         playbackController()->playElementOnClick(m_interactData.hitElement);
     }

--- a/mu4/notation/view/notationviewinputcontroller.h
+++ b/mu4/notation/view/notationviewinputcontroller.h
@@ -48,6 +48,8 @@ public:
     virtual bool isNoteEnterMode() const = 0;
     virtual void showShadowNote(const QPointF& pos) = 0;
 
+    virtual void showContextMenu(const ElementType& elementType, const QPoint& pos) = 0;
+
     virtual INotationInteraction* notationInteraction() const = 0;
     virtual INotationPlayback* notationPlayback() const = 0;
 };

--- a/mu4/userscores/view/newscoremodel.h
+++ b/mu4/userscores/view/newscoremodel.h
@@ -25,7 +25,6 @@
 
 #include "actions/iactionsdispatcher.h"
 #include "iglobalconfiguration.h"
-#include "iinteractive.h"
 #include "notation/inotationcreator.h"
 #include "notation/notationtypes.h"
 #include "context/iglobalcontext.h"
@@ -41,7 +40,6 @@ class NewScoreModel : public QObject
     INJECT(scores, framework::IGlobalConfiguration, globalConfiguration)
     INJECT(scores, notation::INotationCreator, notationCreator)
     INJECT(scores, context::IGlobalContext, globalContext)
-    INJECT(scores, framework::IInteractive, interactive)
 
 public:
     explicit NewScoreModel(QObject* parent = nullptr);


### PR DESCRIPTION
Added the ability to call the context menu and handle the action. (delete selection and open page style for example)

PS: Depends on PR #6659  which implements the styled context menu.

![image](https://user-images.githubusercontent.com/10116828/96257288-62bfc200-0fba-11eb-9322-1ba736eb76ee.png)

![Peek 2020-10-13 11-01](https://user-images.githubusercontent.com/10116828/95863615-b33de200-0d64-11eb-9933-568aef41ec09.gif)
