### PR TITLE
Fix #311661: Fix potential crash in `PianoView::updateNotes()`

### DIFF
--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -1658,6 +1658,10 @@ void PianoView::updateNotes()
       scene()->clear();
       clearNoteData();
 
+      if (!_staff) {
+            return;
+            }
+
       int staffIdx = _staff->idx();
       if (staffIdx == -1)
             return;


### PR DESCRIPTION
and in the same way as it is done in `PianoLevels::updateNotes()` and `NoteTweakerDialog::updateNotes()`

resolves https://musescore.org/en/node/311661