### PR TITLE
[MU3] Added index.html for ftp, setup schedule

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -6,7 +6,7 @@ on:
     - 3.x
     - my/3.x
   schedule:
-    - cron:  '*/40 * * * *' # 40 minutes for test 
+    - cron:  '0 4 */1 * *' # At 04:00 on every day-of-month
   workflow_dispatch:
     inputs:
       build_mode:

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -6,7 +6,7 @@ on:
     - 3.x
     - my/3.x
   schedule:
-    - cron: '*/40 * * * *' # 40 minutes for test 
+    - cron: '0 4 */1 * *' # At 04:00 on every day-of-month
   workflow_dispatch:
     inputs:
       build_mode:

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -6,7 +6,7 @@ on:
     - 3.x
     - my/3.x
   schedule:
-    - cron: '*/40 * * * *' # 40 minutes for test 
+    - cron: '0 4 */1 * *' # At 04:00 on every day-of-month
   workflow_dispatch:
     inputs:
       build_mode:

--- a/build/ci/tools/osuosl/index.html
+++ b/build/ci/tools/osuosl/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>Development builds for MuseScore</title>
+
+</head>
+<body>
+
+<h1>Development builds of MuseScore</h1>
+<p>The development builds allow you to test the very latest developments, including new features and bug fixes. The goal is to catch new bugs, crashes, and regressions before they reach the prerelease or stable versions. For more information, see <a href="https://musescore.org/en/developers-handbook/comparison-stable-beta-and-development-versions">Comparison of stable, beta, and nightly versions</a>. You can report any regressions or bugs you find via <code>Help &gt; Report a Bug</code> within the nightly build.</p>
+<p>A development build can run side-by-side with other versions of MuseScore on the same computer. If you change preferences in the nightly build, it does not affect your preferences in the prerelease or stable versions of MuseScore. The development builds use a cymbal icon (a play on the fact that nightly builds are likely to suspend and crash) to visually differentiate them from normal versions of MuseScore. If this sounds scary to you, instead use the latest stable version of MuseScore from <a href="https://www.musescore.org/">musescore.org</a>.</p>
+<h2>Windows</h2>
+<h3>3.x</h3>
+<ul>
+<li><a href="windows/3x/nightly/?C=M;O=D">nightly</a></li>
+<li><a href="windows/3x/testing/?C=M;O=D">beta</a></li>
+<li><a href="windows/3x/stable/?C=M;O=D">stable</a></li>
+</ul>
+<h3>4.x (master)</h3>
+<ul>
+<li><a href="windows/4x/nightly/?C=M;O=D">nightly</a></li>
+<li><a href="windows/4x/testing/?C=M;O=D">beta</a></li>
+<li><a href="windows/4x/stable/?C=M;O=D">stable</a></li>
+</ul>
+<h2>Linux</h2>
+<h3>3.x</h3>
+<ul>
+<li><a href="linux/3x/nightly/?C=M;O=D">nightly</a></li>
+<li><a href="linux/3x/testing/?C=M;O=D">beta</a></li>
+<li><a href="linux/3x/stable/?C=M;O=D">stable</a></li>
+</ul>
+<h3>4.x (master)</h3>
+<ul>
+<li><a href="linux/4x/nightly/?C=M;O=D">nightly</a></li>
+<li><a href="linux/4x/testing/?C=M;O=D">beta</a></li>
+<li><a href="linux/4x/stable/?C=M;O=D">stable</a></li>
+</ul>
+<h2>MacOS</h2>
+<h3>3.x</h3>
+<ul>
+<li><a href="macos/3x/nightly/?C=M;O=D">nightly</a></li>
+<li><a href="macos/3x/testing/?C=M;O=D">beta</a></li>
+<li><a href="macos/3x/stable/?C=M;O=D">stable</a></li>
+</ul>
+<h3>4.x (master)</h3>
+<ul>
+<li><a href="macos/4x/nightly/?C=M;O=D">nightly</a></li>
+<li><a href="macos/4x/testing/?C=M;O=D">beta</a></li>
+<li><a href="macos/4x/stable/?C=M;O=D">stable</a></li>
+</ul>
+</body>
+</html>

--- a/build/ci/tools/osuosl/publish.sh
+++ b/build/ci/tools/osuosl/publish.sh
@@ -63,6 +63,11 @@ if [ "$BUILD_MODE" == "nightly_build" ]; then
     ssh -i $SSH_KEY musescore-nightlies@ftp-osl.osuosl.org "cd ~/ftp/$FTP_PATH; ls MuseScoreNightly* -t | tail -n +41 | xargs rm -f"
 fi
 
+# Sending index.html
+# !! The page is automatically sending to the FTP only in the master
+# scp -oStrictHostKeyChecking=no -C -i $SSH_KEY build/ci/tools/osuosl/index.html musescore-nightlies@ftp-osl.osuosl.org:~/ftp/
+
+# Trigger 
 ssh -o StrictHostKeyChecking=no -i $SSH_KEY musescore-nightlies@ftp-osl.osuosl.org "~/trigger-musescore-nightlies"
 
 


### PR DESCRIPTION
I added a html page. This is a static page. 
Clicking the link will open a page listing the files and sorting them as desired. 
We still need to work on the design and content of the page.
Now we can always give a link to this page.
https://ftp.osuosl.org/pub/musescore-nightlies/
