### PR TITLE
Added schedule for 3.x nightly builds

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -3,10 +3,9 @@ name: CI_Linux
 on:
   pull_request:
     branches:
-    - master
-  # At the moment, night builds for mu3 are not being built     
-  # schedule:
-  #   - cron: '0 4 */1 * *' # At 04:00 on every day-of-month
+    - master  
+  schedule:               # Schedule 3.x nightly build! (not master MU3)  
+    - cron: '0 4 */1 * *' # At 04:00 on every day-of-month
   workflow_dispatch:
     inputs:
       build_mode:
@@ -22,10 +21,14 @@ jobs:
       uses: styfle/cancel-workflow-action@0.5.0
       with:
         access_token: ${{ github.token }}
-    - name: Clone repository
+    - name: Clone repository (default)
+      if: ${{ github.event_name != 'schedule' }}
+      uses: actions/checkout@v2
+    - name: Clone repository (3.x for build nightly )
+      if: ${{ github.event_name == 'schedule' }}
       uses: actions/checkout@v2
       with:
-        fetch-depth: 3
+        ref: 3.x
     - name: "Configure workflow"
       run: |
         sudo bash ./build/ci/tools/make_build_mode_env.sh -e ${{ github.event_name }} -m ${{ github.event.inputs.build_mode }}
@@ -63,7 +66,8 @@ jobs:
     - name: Publish package
       if: env.DO_PUBLISH == 'true'
       run: |
-        sudo bash ./build/ci/tools/osuosl/publish.sh -s ${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }} --os linux -v 4
+        if [ "$BUILD_MODE" == "nightly_build" ]; then VER=3; else VER=4; fi
+        sudo bash ./build/ci/tools/osuosl/publish.sh -s ${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }} --os linux -v $VER
     - name: Upload artifacts on GitHub
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -5,8 +5,8 @@ on:
   # pull_request:
   #   branches:
   #   - master
-  # schedule:
-  #   - cron: '0 4 */1 * *' # At 04:00 on every day-of-month 
+  schedule:               # Schedule 3.x nightly build! (not master MU3)  
+    - cron: '0 4 */1 * *' # At 04:00 on every day-of-month
   workflow_dispatch:
     inputs:
       build_mode:
@@ -25,10 +25,14 @@ jobs:
       uses: styfle/cancel-workflow-action@0.5.0
       with:
         access_token: ${{ github.token }}
-    - name: Clone repository
+    - name: Clone repository (default)
+      if: ${{ github.event_name != 'schedule' }}
+      uses: actions/checkout@v2
+    - name: Clone repository (3.x for build nightly )
+      if: ${{ github.event_name == 'schedule' }}
       uses: actions/checkout@v2
       with:
-        fetch-depth: 3
+        ref: 3.x
     - name: "Configure workflow"
       run: |
         bash ./build/ci/tools/make_build_mode_env.sh -e ${{ github.event_name }} -m ${{ github.event.inputs.build_mode }}
@@ -85,7 +89,8 @@ jobs:
     - name: Publish package
       if: env.DO_PUBLISH == 'true'
       run: |
-        sudo bash ./build/ci/tools/osuosl/publish.sh -s ${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }} --os macos -v 4
+        if [ "$BUILD_MODE" == "nightly_build" ]; then VER=3; else VER=4; fi
+        sudo bash ./build/ci/tools/osuosl/publish.sh -s ${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }} --os macos -v $VER
     - name: Upload artifacts on GitHub
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -5,8 +5,8 @@ on:
   # pull_request:
   #   branches:
   #   - master
-  # schedule:
-  #   - cron: '0 4 */1 * *' # At 04:00 on every day-of-month
+  schedule:               # Schedule 3.x nightly build! (not master MU3)  
+    - cron: '0 4 */1 * *' # At 04:00 on every day-of-month
   workflow_dispatch:
     inputs:
       build_mode:
@@ -22,13 +22,17 @@ jobs:
       uses: styfle/cancel-workflow-action@0.5.0
       with:
         access_token: ${{ github.token }}
-    - name: Clone repository
+    - name: Clone repository (default)
+      if: ${{ github.event_name != 'schedule' }}
       uses: actions/checkout@v2
       with:
-        fetch-depth: 3
-    - name: Fetch submodules
-      run: |
-        git submodule update --init --recursive
+        submodules: 'true'
+    - name: Clone repository (3.x for build nightly )
+      if: ${{ github.event_name == 'schedule' }}
+      uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+        ref: 3.x
     - name: "Configure workflow"
       shell: bash
       run: |
@@ -70,7 +74,8 @@ jobs:
       if: env.DO_PUBLISH == 'true'
       shell: bash
       run: |
-        bash ./build/ci/tools/osuosl/publish.sh -s ${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }} --os windows -v 4
+        if [ "$BUILD_MODE" == "nightly_build" ]; then VER=3; else VER=4; fi
+        bash ./build/ci/tools/osuosl/publish.sh -s ${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }} --os windows -v $VER
     - name: Upload artifacts on GitHub
       if: ${{ always() }}
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
schedule triggering only for master branch, but we need to schedule 3.x nightly builds. 
This is the solution - schedule triggering in the master, run checkout to 3.x branch, and run 3.x scripts for building