### PR TITLE
[MU4] Language fix

### DIFF
--- a/mu4/extensions/internal/extensionscontroller.h
+++ b/mu4/extensions/internal/extensionscontroller.h
@@ -47,10 +47,6 @@ public:
     RetCh<Extension> extensionChanged() const override;
 
 private:
-    Ret refreshExtensions();
-
-    using Callback = std::function<void ()>;
-
     RetVal<ExtensionsHash> parseExtensionConfig(const QByteArray& json) const;
     bool isExtensionExists(const QString& extensionCode) const;
 
@@ -61,6 +57,7 @@ private:
 
     Extension::ExtensionTypes extensionTypes(const QString& extensionCode) const;
 
+    void th_refreshExtensions();
     void th_install(const QString& extensionCode, async::Channel<ExtensionProgress> progressChannel,async::Channel<Ret> finishChannel);
     void th_update(const QString& extensionCode, async::Channel<ExtensionProgress> progressChannel,async::Channel<Ret> finishChannel);
 

--- a/mu4/languages/ilanguagescontroller.h
+++ b/mu4/languages/ilanguagescontroller.h
@@ -33,8 +33,6 @@ class ILanguagesController : MODULE_EXPORT_INTERFACE
 public:
     virtual ~ILanguagesController() = default;
 
-    virtual Ret refreshLanguages() = 0;
-
     virtual ValCh<LanguagesHash> languages() const = 0;
     virtual RetCh<LanguageProgress> install(const QString& languageCode) = 0;
     virtual Ret uninstall(const QString& languageCode) = 0;

--- a/mu4/languages/internal/languagescontroller.h
+++ b/mu4/languages/internal/languagescontroller.h
@@ -43,7 +43,6 @@ class LanguagesController : public ILanguagesController, public async::Asyncable
 public:
     void init();
 
-    Ret refreshLanguages() override;
     ValCh<LanguagesHash> languages() const override;
     RetCh<LanguageProgress> install(const QString& languageCode) override;
     Ret uninstall(const QString& languageCode) override;
@@ -66,6 +65,7 @@ private:
 
     void resetLanguageByDefault();
 
+    void th_refreshLanguages();
     void th_install(const QString& languageCode, async::Channel<LanguageProgress> progressChannel,async::Channel<Ret> finishChannel);
 
 private:

--- a/mu4/languages/languagesmodule.cpp
+++ b/mu4/languages/languagesmodule.cpp
@@ -65,6 +65,6 @@ void LanguagesModule::registerUiTypes()
 
 void LanguagesModule::onInit()
 {
-    m_languagesController->init();
     m_languagesConfiguration->init();
+    m_languagesController->init();
 }

--- a/mu4/languages/languagesmodule.cpp
+++ b/mu4/languages/languagesmodule.cpp
@@ -65,6 +65,7 @@ void LanguagesModule::registerUiTypes()
 
 void LanguagesModule::onInit()
 {
+    //! NOTE: configurator must be initialized before any service that uses it
     m_languagesConfiguration->init();
     m_languagesController->init();
 }


### PR DESCRIPTION
- Fixed default language initialization. From this https://musescore.org/en/node/311755
  In the configurator, if the default language is not selected, then select the system language. But unfortunately, the request to the configurator to get the default language was earlier than setting the default language.
  First set the default language(m_languagesConfiguration->init()), then apply the language(m_languagesController->init()).
- Fixed network requests in controllers
  The network requests must be run in a different thread than the main thread, GUI thread