### PR TITLE
Fix #311924: Update selection for on-screen keyboard after issuing tr…

### DIFF
--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -624,6 +624,7 @@ void Score::transposeSemitone(int step)
             qDebug("Score::transposeSemitone: failed");
             // TODO: set error message
             }
+      else setSelectionChanged(true);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/311924

Transposition shortcuts neglected to update internal selection so that, e.g., the onscreen keyboard would be updated accordingly after issuing the command. It's not super important, but it makes it nicer overall, since it doesn't make sense to keep the range selection after transposition and yet not have the changes reflect upon the on-screen keyboard. 

So, for example, with this simple one-liner fix, highlighting a passage like so:
![Screenshot from 2020-10-18 13-35-06](https://user-images.githubusercontent.com/7139517/96385191-2372ac00-1147-11eb-8fea-ebd7bbb32807.png)


and doing a Transposition Down (or was it up?) will also update the keyboard on-screen:
![transposed](https://user-images.githubusercontent.com/7139517/96385197-2a012380-1147-11eb-8a99-fc7b9a097cd4.png)


- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
