### PR TITLE
Fix #272172: Remove tuplets after inserting measures causes corruption/crash

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1027,8 +1027,10 @@ void Measure::moveTicks(const Fraction& diff)
                         if (e) {
                               ChordRest* cr = toChordRest(e);
                               Tuplet* tuplet = cr->tuplet();
-                              if (tuplet && tuplets.count(tuplet) == 0)
+                              if (tuplet && tuplets.count(tuplet) == 0) {
+                                    tuplet->setTick(tuplet->tick() + diff);
                                     tuplets.insert(tuplet);
+                                    }
                               }
                         }
                   }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/272172.

This issue was originally fixed with #3662, but later reintroduced with https://github.com/musescore/MuseScore/commit/ec3be9a when the most crucial line from the fix was removed. (See https://musescore.org/en/node/311919#comment-1033994). This adds that line back in, thereby solving the issue once again.