### PR TITLE
[MU4] Allow ledgerlines exactly as wide as the noteheads

### DIFF
--- a/libmscore/ledgerline.cpp
+++ b/libmscore/ledgerline.cpp
@@ -67,9 +67,9 @@ void LedgerLine::layout()
     }
     qreal w2 = _width * .5;
     if (vertical) {
-        bbox().setRect(-w2, -w2, _width, _len + _width);
+        bbox().setRect(-w2, 0, w2, _len);
     } else {
-        bbox().setRect(-w2, -w2, _len + _width, _width);
+        bbox().setRect(0, -w2, _len, w2);
     }
 }
 
@@ -82,7 +82,7 @@ void LedgerLine::draw(QPainter* painter) const
     if (chord()->crossMeasure() == CrossMeasure::SECOND) {
         return;
     }
-    painter->setPen(QPen(curColor(), _width));
+    painter->setPen(QPen(curColor(), _width, Qt::SolidLine, Qt::FlatCap));
     if (vertical) {
         painter->drawLine(QLineF(0.0, 0.0, 0.0, _len));
     } else {

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -136,13 +136,13 @@ static const StyleVal2 style206[] = {
     { Sid::noteBarDistance,             Spatium(1.0) },
     { Sid::measureSpacing,              QVariant(1.2) },
     { Sid::staffLineWidth,              Spatium(0.08) },        // 0.09375
-    { Sid::ledgerLineWidth,             Spatium(0.16) },       // 0.1875
-    { Sid::ledgerLineLength,            Spatium(.6) },       // notehead width + this value
+    { Sid::ledgerLineWidth,             Spatium(0.16) },        // 0.1875
+    { Sid::ledgerLineLength,            Spatium(.76) },         // notehead width + this value
     { Sid::accidentalDistance,          Spatium(0.22) },
     { Sid::accidentalNoteDistance,      Spatium(0.22) },
-    { Sid::beamWidth,                   Spatium(0.5) },             // was 0.48
-    { Sid::beamDistance,                QVariant(0.5) },            // 0.25sp
-    { Sid::beamMinLen,                  QVariant(1.32) },        // 1.316178 exactly notehead width
+    { Sid::beamWidth,                   Spatium(0.5) },         // was 0.48
+    { Sid::beamDistance,                QVariant(0.5) },        // 0.25sp
+    { Sid::beamMinLen,                  QVariant(1.32) },       // 1.316178 exactly notehead width
     { Sid::beamNoSlope,                 QVariant(false) },
     { Sid::dotMag,                      QVariant(1.0) },
     { Sid::dotNoteDistance,             QVariant(0.35) },

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -186,7 +186,7 @@ static const StyleType styleTypes[] {
     { Sid::measureSpacing,          "measureSpacing",          QVariant(1.2) },
     { Sid::staffLineWidth,          "staffLineWidth",          Spatium(0.08) },       // 0.09375
     { Sid::ledgerLineWidth,         "ledgerLineWidth",         Spatium(0.16) },       // 0.1875
-    { Sid::ledgerLineLength,        "ledgerLineLength",        Spatium(.6) },         // notehead width + this value
+    { Sid::ledgerLineLength,        "ledgerLineLength",        Spatium(.76) },        // notehead width + this value
     { Sid::accidentalDistance,      "accidentalDistance",      Spatium(0.22) },
     { Sid::accidentalNoteDistance,  "accidentalNoteDistance",  Spatium(0.22) },
 

--- a/vtest/gen-ref.bat
+++ b/vtest/gen-ref.bat
@@ -1,7 +1,7 @@
 
 rem create reference
 
-set MSCORE=..\msvc.install_x64\bin\musescore.exe
+set MSCORE=..\msvc.install_x64\bin\musescore4.exe
 set DPI=130
 
 %MSCORE% %1.mscz -r %DPI% -o %1.png

--- a/vtest/gen.bat
+++ b/vtest/gen.bat
@@ -55,7 +55,7 @@ IF NOT "%1"=="" (
    SET INSTALL_PATH=msvc.install_x64
    )
 
-set MSCORE=..\%INSTALL_PATH%\bin\musescore.exe
+set MSCORE=..\%INSTALL_PATH%\bin\musescore4.exe
 
 IF NOT EXIST ..\%INSTALL_PATH%\nul (
    echo "Current folder: ..\%INSTALL_PATH%"


### PR DESCRIPTION
and fix the vtest bat files to use MuseScore4

Counterpart to #6359