### PR TITLE
[MU4] Added Score View Mode

### DIFF
--- a/framework/uicomponents/qml/MuseScore/UiComponents/StyledComboBox.qml
+++ b/framework/uicomponents/qml/MuseScore/UiComponents/StyledComboBox.qml
@@ -8,6 +8,7 @@ ComboBox {
 
     property bool isExpanded: false
     property bool isIndeterminate: false
+    property bool opensUpward: false
     property alias textRoleName: root.textRole
     property string valueRoleName: "valueRole"
     property var value
@@ -173,7 +174,7 @@ ComboBox {
     popup: Popup {
         id: popup
 
-        y: 0
+        y: root.opensUpward ? -(contentListView.height - contentListView.contentHeight) : 0
 
         padding: 0
         margins: 0

--- a/mu4/appshell/qml/NotationPage/NotationStatusBar.qml
+++ b/mu4/appshell/qml/NotationPage/NotationStatusBar.qml
@@ -11,7 +11,15 @@ Rectangle {
         anchors.verticalCenter: parent.verticalCenter
     }
 
+    ViewModeControl {
+        id: viewModeControl
+        anchors.right: zoomControl.left
+        anchors.rightMargin: 20
+        anchors.verticalCenter: parent.verticalCenter
+    }
+
     ZoomControl {
+        id: zoomControl
         anchors.right: parent.right
         anchors.rightMargin: 20
         anchors.verticalCenter: parent.verticalCenter

--- a/mu4/notation/CMakeLists.txt
+++ b/mu4/notation/CMakeLists.txt
@@ -109,6 +109,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/notationviewinputcontroller.h
     ${CMAKE_CURRENT_LIST_DIR}/view/zoomcontrolmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/zoomcontrolmodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/viewmodecontrolmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/viewmodecontrolmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/notationaccessibilitymodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/notationaccessibilitymodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/notationtoolbarmodel.cpp

--- a/mu4/notation/inotation.h
+++ b/mu4/notation/inotation.h
@@ -45,6 +45,8 @@ public:
     virtual Meta metaInfo() const = 0;
 
     virtual void setViewSize(const QSizeF& vs) = 0;
+    virtual void setViewMode(const ViewMode& vm) = 0;
+    virtual ViewMode viewMode() const = 0;
     virtual void paint(QPainter* painter) = 0;
     virtual QRectF previewRect() const = 0;
 

--- a/mu4/notation/internal/notation.cpp
+++ b/mu4/notation/internal/notation.cpp
@@ -52,14 +52,28 @@ Notation::Notation(Score* score)
     m_playback = new NotationPlayback(this);
     m_elements = new NotationElements(this);
 
-    m_interaction->noteAdded().onNotify(this, [this]() { notifyAboutNotationChanged(); });
-    m_interaction->dragChanged().onNotify(this, [this]() { notifyAboutNotationChanged(); });
-    m_interaction->textEditingChanged().onNotify(this, [this]() { notifyAboutNotationChanged(); });
-    m_interaction->dropChanged().onNotify(this, [this]() { notifyAboutNotationChanged(); });
+    m_interaction->noteAdded().onNotify(this, [this]() {
+        notifyAboutNotationChanged();
+    });
+    m_interaction->dragChanged().onNotify(this, [this]() {
+        notifyAboutNotationChanged();
+    });
+    m_interaction->textEditingChanged().onNotify(this, [this]() {
+        notifyAboutNotationChanged();
+    });
+    m_interaction->dropChanged().onNotify(this, [this]() {
+        notifyAboutNotationChanged();
+    });
 
-    m_midiInput->noteChanged().onNotify(this, [this]() { notifyAboutNotationChanged(); });
-    m_style->styleChanged().onNotify(this, [this]() { notifyAboutNotationChanged(); });
-    m_parts->partsChanged().onNotify(this, [this]() { notifyAboutNotationChanged(); });
+    m_midiInput->noteChanged().onNotify(this, [this]() {
+        notifyAboutNotationChanged();
+    });
+    m_style->styleChanged().onNotify(this, [this]() {
+        notifyAboutNotationChanged();
+    });
+    m_parts->partsChanged().onNotify(this, [this]() {
+        notifyAboutNotationChanged();
+    });
 
     if (score) {
         setScore(score);
@@ -121,6 +135,26 @@ Meta Notation::metaInfo() const
 void Notation::setViewSize(const QSizeF& vs)
 {
     m_viewSize = vs;
+}
+
+void Notation::setViewMode(const ViewMode& viewMode)
+{
+    if (!m_score) {
+        return;
+    }
+
+    score()->setLayoutMode(viewMode);
+    score()->doLayout();
+    notifyAboutNotationChanged();
+}
+
+ViewMode Notation::viewMode() const
+{
+    if (!m_score) {
+        return ViewMode::PAGE;
+    }
+
+    return score()->layoutMode();
 }
 
 QRectF Notation::previewRect() const

--- a/mu4/notation/internal/notation.h
+++ b/mu4/notation/internal/notation.h
@@ -45,6 +45,8 @@ public:
     Meta metaInfo() const override;
 
     void setViewSize(const QSizeF& vs) override;
+    void setViewMode(const ViewMode& viewMode) override;
+    ViewMode viewMode() const override;
     void paint(QPainter* painter) override;
     QRectF previewRect() const override;
 

--- a/mu4/notation/internal/notationactions.cpp
+++ b/mu4/notation/internal/notationactions.cpp
@@ -135,6 +135,17 @@ const std::vector<Action> NotationActions::m_actions = {
     Action("load-style",
            QT_TRANSLATE_NOOP("action", "Load Style"),
            ShortcutContext::NotationActive
+           ),
+    Action("view-mode-page",
+           QT_TRANSLATE_NOOP("action", "Page View"),
+           ShortcutContext::NotationActive),
+    Action("view-mode-continuous",
+           QT_TRANSLATE_NOOP("action", "Continuous View"),
+           ShortcutContext::NotationActive
+           ),
+    Action("view-mode-single",
+           QT_TRANSLATE_NOOP("action", "Single Page"),
+           ShortcutContext::NotationActive
            )
 };
 

--- a/mu4/notation/notationmodule.cpp
+++ b/mu4/notation/notationmodule.cpp
@@ -39,6 +39,7 @@
 #include "view/notationpaintview.h"
 #include "view/notationaccessibilitymodel.h"
 #include "view/zoomcontrolmodel.h"
+#include "view/viewmodecontrolmodel.h"
 #include "view/notationtoolbarmodel.h"
 #include "view/notationswitchlistmodel.h"
 #include "view/partlistmodel.h"
@@ -111,6 +112,7 @@ void NotationModule::registerUiTypes()
     qmlRegisterType<NotationToolBarModel>("MuseScore.NotationScene", 1, 0, "NotationToolBarModel");
     qmlRegisterType<NotationAccessibilityModel>("MuseScore.NotationScene", 1, 0, "NotationAccessibilityModel");
     qmlRegisterType<ZoomControlModel>("MuseScore.NotationScene", 1, 0, "ZoomControlModel");
+    qmlRegisterType<ViewModeControlModel>("MuseScore.NotationScene", 1, 0, "ViewModeControlModel");
     qmlRegisterType<NotationSwitchListModel>("MuseScore.NotationScene", 1, 0, "NotationSwitchListModel");
     qmlRegisterType<PartListModel>("MuseScore.NotationScene", 1, 0, "PartListModel");
 

--- a/mu4/notation/notationscene.qrc
+++ b/mu4/notation/notationscene.qrc
@@ -5,6 +5,7 @@
         <file>view/resources/icons/go-next.svg</file>
         <file>view/resources/icons/go-previous.svg</file>
         <file>qml/MuseScore/NotationScene/ZoomControl.qml</file>
+        <file>qml/MuseScore/NotationScene/ViewModeControl.qml</file>
         <file>qml/MuseScore/NotationScene/NotationAccessibilityInfo.qml</file>
         <file>qml/MuseScore/NotationScene/NotationSwitchButton.qml</file>
         <file>qml/MuseScore/NotationScene/NotationSwitchPanel.qml</file>

--- a/mu4/notation/notationtypes.h
+++ b/mu4/notation/notationtypes.h
@@ -32,6 +32,7 @@
 #include "libmscore/part.h"
 #include "libmscore/staff.h"
 #include "libmscore/stafftype.h"
+#include "libmscore/score.h"
 
 #include "instruments/instrumentstypes.h"
 
@@ -42,6 +43,7 @@ using ElementType = Ms::ElementType;
 using DurationType = Ms::TDuration::DurationType;
 using SelectType = Ms::SelectType;
 using Pad = Ms::Pad;
+using ViewMode = Ms::LayoutMode;  // Accomodate inconsistent convention from v3
 using PitchMode = Ms::UpDownMode;
 using StyleId = Ms::Sid;
 using Key = Ms::Key;
@@ -54,13 +56,15 @@ using StaffType = Ms::StaffTypes;
 using StaffList = QList<const Staff*>;
 using PartList = QList<const Part*>;
 
-enum class DragMode {
+enum class DragMode
+{
     BothXY = 0,
     OnlyX,
     OnlyY
 };
 
-enum class MoveDirection {
+enum class MoveDirection
+{
     Undefined = 0,
     Left,
     Right,
@@ -68,7 +72,8 @@ enum class MoveDirection {
     Down
 };
 
-enum class MoveSelectionType {
+enum class MoveSelectionType
+{
     Undefined = 0,
     Element,
     Chord,
@@ -117,6 +122,12 @@ struct ScoreCreateOptions {
 
     io::path templatePath;
     instruments::InstrumentList instruments;
+};
+
+struct ViewModeOption {
+    QString displayString;
+    QString actionString;
+    ViewMode viewMode;
 };
 }
 }

--- a/mu4/notation/qml/MuseScore/NotationScene/ViewModeControl.qml
+++ b/mu4/notation/qml/MuseScore/NotationScene/ViewModeControl.qml
@@ -1,0 +1,24 @@
+import QtQuick 2.7
+import MuseScore.NotationScene 1.0
+import MuseScore.UiComponents 1.0
+import MuseScore.Ui 1.0
+
+StyledComboBox {
+    id: root
+    
+    opensUpward: true
+    maxVisibleItemCount: 3
+
+    textRoleName: "nameRole"
+    valueRoleName: "idRole"
+    currentIndex: indexOfValue(model.currentViewModeId)
+    onValueChanged: model.currentViewModeId = value
+    
+    model: ViewModeControlModel {
+        id: model
+    }
+
+    Component.onCompleted: {
+        model.load()
+    }
+}

--- a/mu4/notation/qml/MuseScore/NotationScene/qmldir
+++ b/mu4/notation/qml/MuseScore/NotationScene/qmldir
@@ -1,6 +1,7 @@
 module MuseScore.NotationScene
 NotationView 1.0 NotationView.qml
 ZoomControl 1.0 ZoomControl.qml
+ViewModeControl 1.0 ViewModeControl.qml
 NotationAccessibilityInfo 1.0 NotationAccessibilityInfo.qml
 NotationSwitchPanel 1.0 NotationSwitchPanel.qml
 NotationSwitchButton 1.0 NotationSwitchButton.qml

--- a/mu4/notation/view/notationviewinputcontroller.cpp
+++ b/mu4/notation/view/notationviewinputcontroller.cpp
@@ -39,7 +39,21 @@ NotationViewInputController::NotationViewInputController(IControlledView* view)
     if (dispatcher()) {
         dispatcher()->reg(this, "zoomin", this, &NotationViewInputController::zoomIn);
         dispatcher()->reg(this, "zoomout", this, &NotationViewInputController::zoomOut);
+        dispatcher()->reg(this, "view-mode-page", [this]() {
+            setViewMode(ViewMode::PAGE);
+        });
+        dispatcher()->reg(this, "view-mode-continuous", [this]() {
+            setViewMode(ViewMode::LINE);
+        });
+        dispatcher()->reg(this, "view-mode-single", [this]() {
+            setViewMode(ViewMode::SYSTEM);
+        });
     }
+}
+
+std::shared_ptr<INotation> NotationViewInputController::currentNotation() const
+{
+    return globalContext()->currentNotation();
 }
 
 void NotationViewInputController::zoomIn()
@@ -83,6 +97,16 @@ void NotationViewInputController::setZoom(int zoomPercentage, const QPoint& pos)
     configuration()->setCurrentZoom(correctedZoom);
 
     m_view->setZoom(zoomPercentage, pos);
+}
+
+void NotationViewInputController::setViewMode(const ViewMode& viewMode)
+{
+    auto notation = currentNotation();
+    if (!notation) {
+        return;
+    }
+
+    notation->setViewMode(viewMode);
 }
 
 bool NotationViewInputController::canReceiveAction(const ActionName&) const

--- a/mu4/notation/view/notationviewinputcontroller.h
+++ b/mu4/notation/view/notationviewinputcontroller.h
@@ -24,6 +24,7 @@
 #include "../inotationconfiguration.h"
 #include "actions/iactionsdispatcher.h"
 #include "actions/actionable.h"
+#include "context/iglobalcontext.h"
 #include "notation/inotationinteraction.h"
 #include "notation/inotationplayback.h"
 #include "playback/iplaybackcontroller.h"
@@ -59,6 +60,7 @@ class NotationViewInputController : public actions::Actionable
     INJECT(notation, INotationConfiguration, configuration)
     INJECT(notation, actions::IActionsDispatcher, dispatcher)
     INJECT(notation, playback::IPlaybackController, playbackController)
+    INJECT(notation, context::IGlobalContext, globalContext)
 
 public:
     NotationViewInputController(IControlledView* view);
@@ -77,11 +79,15 @@ public:
     void dropEvent(QDropEvent* ev);
 
 private:
+    std::shared_ptr<INotation> currentNotation() const;
+
     void zoomIn();
     void zoomOut();
 
     int currentZoomIndex() const;
     void setZoom(int zoomPercentage, const QPoint& pos = QPoint());
+
+    void setViewMode(const ViewMode& viewMode);
 
     bool canReceiveAction(const actions::ActionName& actionName) const override;
 

--- a/mu4/notation/view/viewmodecontrolmodel.cpp
+++ b/mu4/notation/view/viewmodecontrolmodel.cpp
@@ -1,0 +1,114 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#include "viewmodecontrolmodel.h"
+#include "notationtypes.h"
+
+using namespace mu::notation;
+
+ViewModeControlModel::ViewModeControlModel(QObject* parent)
+    : QAbstractListModel(parent)
+{
+    m_roleNames.insert(IdRole, "idRole");
+    m_roleNames.insert(NameRole, "nameRole");
+    m_viewModeOptions << ViewModeOption { "Page View", "view-mode-page", ViewMode::PAGE }
+                      << ViewModeOption { "Continuous View", "view-mode-continuous", ViewMode::LINE }
+                      << ViewModeOption { "Single Page", "view-mode-single", ViewMode::SYSTEM };
+}
+
+void ViewModeControlModel::load()
+{
+    onNotationChanged();
+    m_notationChanged = globalContext()->currentNotationChanged();
+    m_notationChanged.onNotify(this, [this]() {
+        onNotationChanged();
+    });
+}
+
+int ViewModeControlModel::getIdFromViewMode(const ViewMode& viewMode)
+{
+    for (int i = 0; i < m_viewModeOptions.length(); ++i) {
+        if (m_viewModeOptions.at(i).viewMode == viewMode) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+int ViewModeControlModel::rowCount(const QModelIndex&) const
+{
+    return m_viewModeOptions.count();
+}
+
+QVariant ViewModeControlModel::data(const QModelIndex& index, int role) const
+{
+    if (!index.isValid() || index.row() >= rowCount() || m_viewModeOptions.isEmpty()) {
+        return QVariant();
+    }
+
+    int viewModeId = index.row();
+
+    switch (role) {
+    case IdRole: return viewModeId;
+    case NameRole: return m_viewModeOptions.at(viewModeId).displayString;
+    default: return QVariant();
+    }
+}
+
+QHash<int, QByteArray> ViewModeControlModel::roleNames() const
+{
+    return m_roleNames;
+}
+
+int ViewModeControlModel::currentViewModeId() const
+{
+    return m_currentViewModeId;
+}
+
+void ViewModeControlModel::setCurrentViewModeId(int newViewModeId)
+{
+    if (m_currentViewModeId != newViewModeId) {
+        dispatcher()->dispatch(actions::namefromQString(m_viewModeOptions.at(newViewModeId).actionString));
+        m_currentViewModeId = newViewModeId; // can remove once notify works
+    }
+}
+
+void ViewModeControlModel::onNotationChanged()
+{
+    std::shared_ptr<INotation> notation = globalContext()->currentNotation();
+
+    //! NOTE Unsubscribe from previous notation, if it was
+    m_notationChanged.resetOnNotify(this);
+    updateState();
+}
+
+void ViewModeControlModel::updateState()
+{
+    auto notation = globalContext()->currentNotation();
+    if (!notation) {
+        return;
+    }
+
+    int newViewModeId = getIdFromViewMode(notation->viewMode());
+    if (m_currentViewModeId != newViewModeId) {
+        m_currentViewModeId = newViewModeId;
+    }
+
+    emit currentViewModeIdChanged(m_currentViewModeId);
+}

--- a/mu4/notation/view/viewmodecontrolmodel.h
+++ b/mu4/notation/view/viewmodecontrolmodel.h
@@ -1,0 +1,85 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef MU_NOTATION_VIEWMODECONTROLMODEL_H
+#define MU_NOTATION_VIEWMODECONTROLMODEL_H
+
+#include <QtQml>
+#include <QList>
+#include <QHash>
+#include <QAbstractListModel>
+
+#include "modularity/ioc.h"
+#include "actions/iactionsdispatcher.h"
+#include "inotationconfiguration.h"
+#include "context/iglobalcontext.h"
+#include "async/asyncable.h"
+#include "notation/notationtypes.h"
+
+namespace mu {
+namespace notation {
+class ViewModeControlModel : public QAbstractListModel, public async::Asyncable
+{
+    Q_OBJECT
+
+    INJECT(notation, actions::IActionsDispatcher, dispatcher);
+    INJECT(notation, context::IGlobalContext, globalContext);
+
+    Q_PROPERTY(int currentViewModeId READ currentViewModeId WRITE setCurrentViewModeId NOTIFY currentViewModeIdChanged)
+
+public:
+    enum NoleNames {
+        IdRole = Qt::UserRole + 1,
+        NameRole
+    };
+
+    explicit ViewModeControlModel(QObject* parent = nullptr);
+
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+    int currentViewModeId() const;
+
+    Q_INVOKABLE void load();
+
+    void updateState();
+
+signals:
+    void currentViewModeIdChanged(int viewModeId);
+
+public slots:
+    void setCurrentViewModeId(int newViewModeId);
+
+private:
+
+    int getIdFromViewMode(const ViewMode& viewMode);
+    void onNotationChanged();
+
+    int m_currentViewModeId = 0;  // default to page view
+
+    QList<ViewModeOption> m_viewModeOptions;
+    QHash<int, QByteArray> m_roleNames;
+
+    async::Notification m_notationChanged;
+};
+}
+}
+
+#endif // MU_NOTATION_VIEWMODECONTROLMODEL_H


### PR DESCRIPTION
*Score View Mode combo box and functionality added to MU4 UI. Currently, the combo box opens downward (off the screen) despite adjustments to the StyledComboBox element. Need to look into DockStatusBar widget to see if that is preventing expected behavior.*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
