### PR TITLE
311950 fix

### DIFF
--- a/build/Linux+BSD/mscore.1.in
+++ b/build/Linux+BSD/mscore.1.in
@@ -339,6 +339,8 @@ internal file sanity check log (JSON)
 MPEG Layer III (lossy compressed audio)
 .It Li mpos
 measure positions (XML)
+.It Li mposx
+measure positions in pixel unit (XML)
 .It Li mscx
 uncompressed MuseScore file
 .It Li mscz
@@ -358,6 +360,8 @@ Individual files, one per score page, with a hyphen-minus followed
 by the page number placed before the file extension, will be generated.
 .It Li spos
 segment positions (XML)
+.It Li spos
+segment positions in pixel unit (XML)
 .It Li svg
 scalable vector graphics (image)
 .It Li wav

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -3742,6 +3742,10 @@ static bool doConvert(Score *cs, const QString& fn)
             return mscore->savePositions(cs, fn, true);
       else if (fn.endsWith(".mpos"))
             return mscore->savePositions(cs, fn, false);
+      else if (fn.endsWith(".sposx"))
+            return mscore->savePositions(cs, fn, true, false);
+      else if (fn.endsWith(".mposx"))
+            return mscore->savePositions(cs, fn, false, false);
       else if (fn.endsWith(".mlog"))
             return cs->sanityCheck(fn);
       else if (fn.endsWith(".metajson"))

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -744,8 +744,8 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       bool savePng(Score*, const QString& name);
       bool saveMidi(Score*, const QString& name);
       bool saveMidi(Score*, QIODevice*);
-      bool savePositions(Score*, const QString& name, bool segments);
-      bool savePositions(Score*, QIODevice*, bool segments);
+      bool savePositions(Score*, const QString& name, bool segments, bool dpiScaling = true);
+      bool savePositions(Score*, QIODevice*, bool segments, bool dpiScaling = true);
       bool saveMetadataJSON(Score*, const QString& name);
       QJsonObject saveMetadataJSON(Score*);
 

--- a/mscore/savePositions.cpp
+++ b/mscore/savePositions.cpp
@@ -48,7 +48,7 @@ static void saveMeasureEvents(XmlWriter& xml, Measure* m, int offset)
 //    output in 100 dpi
 //---------------------------------------------------------
 
-bool MuseScore::savePositions(Score* score, QIODevice* device, bool segments)
+bool MuseScore::savePositions(Score* score, QIODevice* device, bool segments, bool dpiScaling)
       {
       segs.clear();
       XmlWriter xml(score, device);
@@ -57,7 +57,7 @@ bool MuseScore::savePositions(Score* score, QIODevice* device, bool segments)
       xml.stag("elements");
       int id = 0;
 
-      qreal ndpi = ((qreal) preferences.getDouble(PREF_EXPORT_PNG_RESOLUTION) / DPI) * 12.0;
+      qreal ndpi = dpiScaling ? ((qreal) preferences.getDouble(PREF_EXPORT_PNG_RESOLUTION) / DPI) * 12.0 : 1;
       if (segments) {
             for (Segment* s = score->firstMeasureMM()->first(SegmentType::ChordRest);
                s; s = s->next1MM(SegmentType::ChordRest)) {
@@ -142,7 +142,7 @@ bool MuseScore::savePositions(Score* score, QIODevice* device, bool segments)
       return true;
       }
 
-bool MuseScore::savePositions(Score* score, const QString& name, bool segments)
+bool MuseScore::savePositions(Score* score, const QString& name, bool segments, bool dpiScaling)
       {
       QFile fp(name);
       if (!fp.open(QIODevice::WriteOnly)) {

--- a/mscore/savePositions.cpp
+++ b/mscore/savePositions.cpp
@@ -149,7 +149,7 @@ bool MuseScore::savePositions(Score* score, const QString& name, bool segments, 
             qDebug("Open <%s> failed", qPrintable(name));
             return false;
             }
-      return savePositions(score, &fp, segments);
+      return savePositions(score, &fp, segments, dpiScaling);
       }
 }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/311950

Mainly discussed there: https://musescore.org/en/node/307253

Introduce mposx/sposx file format for export job that don't apply that ndpi factor to the pixel distance, that solution would avoid any breaking change for current systems using the mpos/spos file format and allow others users to exploit those files coordinates if needed.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
