### PR TITLE
fix #311950: Unknown units for x/y/sx/sy in spos/mpos files

### DIFF
--- a/build/Linux+BSD/mscore.1.in
+++ b/build/Linux+BSD/mscore.1.in
@@ -3,7 +3,7 @@
 .\"	mirabilos <m@mirbsd.org>
 .\" Published under the same terms as MuseScore itself.
 .\"-
-.Dd October 19, 2020
+.Dd November 1, 2020
 .Dt @MAN_MSCORE_UPPER@ 1
 .Os MuseScore
 .Sh NAME@Variables_substituted_by_CMAKE_on_installation@
@@ -339,6 +339,10 @@ internal file sanity check log (JSON)
 MPEG Layer III (lossy compressed audio)
 .It Li mpos
 measure positions (XML)
+.Pq legacy format
+.It Li mpx
+measure positions (XML)
+.Pq pixel offsets
 .It Li mscx
 uncompressed MuseScore file
 .It Li mscz
@@ -358,6 +362,10 @@ Individual files, one per score page, with a hyphen-minus followed
 by the page number placed before the file extension, will be generated.
 .It Li spos
 segment positions (XML)
+.Pq legacy format
+.It Li spx
+segment positions (XML)
+.Pq pixel offsets
 .It Li svg
 scalable vector graphics (image)
 .It Li wav

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1822,6 +1822,39 @@ void Chord::layout()
       }
 
 //---------------------------------------------------------
+//   sposBBox
+//---------------------------------------------------------
+
+QRectF Chord::sposBBox() const
+      {
+      QRectF box = ChordRest::sposBBox();
+
+      for (Note* note : _notes)
+            box |= note->sposBBox();
+
+      for (LedgerLine* ll = _ledgerLines; ll; ll = ll->next())
+            box |= ll->sposBBox();
+
+#define ADDBOX(e) if (e) box |= (e)->sposBBox()
+      ADDBOX(_stem);
+      ADDBOX(_hook);
+      ADDBOX(_stemSlash);
+      ADDBOX(_arpeggio);
+#undef ADDBOX
+
+      if (_tremolo && !_tremolo->twoNotes())
+            box |= _tremolo->abbox();
+
+      for (Chord* c : qAsConst(_graceNotes))
+            box |= c->sposBBox();
+
+      for (Articulation* a : _articulations)
+            box |= a->sposBBox();
+
+      return box;
+}
+
+//---------------------------------------------------------
 //   layoutPitched
 //---------------------------------------------------------
 

--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -118,6 +118,7 @@ class Chord final : public ChordRest {
       void layoutArpeggio2();
       void layoutSpanners();
       void layoutSpanners(System* system, const Fraction& stick);
+      virtual QRectF sposBBox() const override;
 
       std::vector<Note*>& notes()                 { return _notes; }
       const std::vector<Note*>& notes() const     { return _notes; }

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1388,5 +1388,23 @@ void ChordRest::undoAddAnnotation(Element* a)
       score()->undoAddElement(a);
       }
 
-}
+//---------------------------------------------------------
+//   sposBBox
+//---------------------------------------------------------
+QRectF ChordRest::sposBBox() const
+      {
+      QRectF box = Element::sposBBox();
 
+      for (Element* e : el())
+            box |= e->sposBBox();
+
+      for (Lyrics* l : _lyrics)
+            box |= l->sposBBox();
+
+      if (_tabDur)
+            box |= _tabDur->sposBBox();
+
+      return box;
+      }
+
+}

--- a/libmscore/chordrest.h
+++ b/libmscore/chordrest.h
@@ -179,6 +179,7 @@ class ChordRest : public DurationElement {
       virtual Shape shape() const override;
       virtual void layoutStem1() {};
       virtual void computeUp()   { _up = true; };
+      virtual QRectF sposBBox() const override;
 
       bool isFullMeasureRest() const { return _durationType == TDuration::DurationType::V_MEASURE; }
       virtual void removeMarkings(bool keepTremolo = false);

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -279,6 +279,7 @@ class Element : public ScoreElement {
       virtual qreal width() const                 { return bbox().width();     }
       virtual void setWidth(qreal v)              { _bbox.setWidth(v);         }
       QRectF abbox() const                        { return bbox().translated(pagePos());   }
+      virtual QRectF sposBBox() const             { return abbox();                        }
       QRectF pageBoundingRect() const             { return bbox().translated(pagePos());   }
       QRectF canvasBoundingRect() const           { return bbox().translated(canvasPos()); }
       virtual void setbbox(const QRectF& r) const { _bbox = r;           }

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2123,6 +2123,26 @@ void Note::layout2()
       }
 
 //---------------------------------------------------------
+//   sposBBox
+//---------------------------------------------------------
+
+QRectF Note::sposBBox() const
+      {
+      QRectF box = Element::sposBBox();
+
+      if (_accidental)
+            box |= _accidental->sposBBox();
+
+      for (auto e : _el)
+            box |= e->sposBBox();
+
+      for (NoteDot* dot : _dots)
+            box |= dot->sposBBox();
+
+      return box;
+}
+
+//---------------------------------------------------------
 //   dotIsUp
 //---------------------------------------------------------
 

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -327,6 +327,7 @@ class Note final : public Element {
 
       void layout() override;
       void layout2();
+      virtual QRectF sposBBox() const override;
       //setter is used only in drumset tools to setup the notehead preview in the drumset editor and the palette
       void setCachedNoteheadSym(SymId i) { _cachedNoteheadSym = i; };
       void scanElements(void* data, void (*func)(void*, Element*), bool all = true) override;

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -442,7 +442,21 @@ void Rest::layout()
       }
 
 //---------------------------------------------------------
-//   layout
+//   sposBBox
+//---------------------------------------------------------
+
+QRectF Rest::sposBBox() const
+      {
+      QRectF box = ChordRest::sposBBox();
+
+      for (NoteDot* dot : _dots)
+            box |= dot->sposBBox();
+
+      return box;
+}
+
+//---------------------------------------------------------
+//   layoutDots
 //---------------------------------------------------------
 
 void Rest::layoutDots()

--- a/libmscore/rest.h
+++ b/libmscore/rest.h
@@ -108,6 +108,7 @@ class Rest : public ChordRest {
       QString accessibleInfo() const override;
       QString screenReaderInfo() const override;
       Shape shape() const override;
+      virtual QRectF sposBBox() const override;
       void editDrag(EditData& editData) override;
       };
 

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -2296,4 +2296,22 @@ qreal Segment::minHorizontalDistance(Segment* ns, bool systemHeaderGap) const
       return w;
       }
 
+//---------------------------------------------------------
+//   sposBBox
+//---------------------------------------------------------
+QRectF Segment::sposBBox() const
+      {
+      QRectF box = Element::sposBBox();
+
+      for (Element* e : _annotations)
+            if (e && e->isHarmony())
+                  box |= e->sposBBox();
+
+      for (Element* e : _elist)
+            if (e)
+                  box |= e->sposBBox();
+
+      return box;
+      }
+
 }           // namespace Ms

--- a/libmscore/segment.h
+++ b/libmscore/segment.h
@@ -227,6 +227,7 @@ class Segment final : public Element {
       qreal minLeft() const;
       qreal minHorizontalDistance(Segment*, bool isSystemGap) const;
       qreal minHorizontalCollidingDistance(Segment* ns) const;
+      virtual QRectF sposBBox() const override;
 
       // some helper function
       ChordRest* cr(int track) const        { return toChordRest(_elist[track]); }

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -2131,10 +2131,20 @@ bool MuseScore::saveAs(Score* cs_, bool saveCopy, const QString& path, const QSt
             // save positions of segments
             rv = savePositions(cs_, fn, true);
             }
+      else if (ext == "spx") {
+            cs_->switchToPageMode();
+            // save positions of segments
+            rv = savePositions(cs_, fn, true, false);
+            }
       else if (ext == "mpos") {
             cs_->switchToPageMode();
             // save positions of measures
             rv = savePositions(cs_, fn, false);
+            }
+      else if (ext == "mpx") {
+            cs_->switchToPageMode();
+            // save positions of measures
+            rv = savePositions(cs_, fn, false, false);
             }
       else if (ext == "mlog") {
             rv = cs_->sanityCheck(fn);
@@ -2809,8 +2819,8 @@ bool MuseScore::savePng(Score* score, QIODevice* device, int pageNumber, bool dr
             }
       else
             r = page->abbox();
-      int w = lrint(r.width()  * convDpi / DPI);
-      int h = lrint(r.height() * convDpi / DPI);
+      int w = qCeil(r.width()  * convDpi / DPI);
+      int h = qCeil(r.height() * convDpi / DPI);
 
       QImage printer(w, h, f);
       printer.setDotsPerMeterX(lrint((convDpi * 1000) / INCH));

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -3745,8 +3745,12 @@ static bool doConvert(Score *cs, const QString& fn)
 #endif
       else if (fn.endsWith(".spos"))
             return mscore->savePositions(cs, fn, true);
+      else if (fn.endsWith(".spx"))
+            return mscore->savePositions(cs, fn, true, false);
       else if (fn.endsWith(".mpos"))
             return mscore->savePositions(cs, fn, false);
+      else if (fn.endsWith(".mpx"))
+            return mscore->savePositions(cs, fn, false, false);
       else if (fn.endsWith(".mlog"))
             return cs->sanityCheck(fn);
       else if (fn.endsWith(".metajson"))

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -744,8 +744,8 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       bool savePng(Score*, const QString& name);
       bool saveMidi(Score*, const QString& name);
       bool saveMidi(Score*, QIODevice*);
-      bool savePositions(Score*, const QString& name, bool segments);
-      bool savePositions(Score*, QIODevice*, bool segments);
+      bool savePositions(Score*, const QString& name, bool segments, bool legacyExport = true);
+      bool savePositions(Score*, QIODevice*, bool segments, bool legacyExport = true);
       bool saveMetadataJSON(Score*, const QString& name);
       QJsonObject saveMetadataJSON(Score*);
 

--- a/mscore/savePositions.cpp
+++ b/mscore/savePositions.cpp
@@ -76,8 +76,12 @@ bool MuseScore::savePositions(Score* score, QIODevice* device, bool segments, bo
             for (Segment* s = score->firstMeasureMM()->first(SegmentType::ChordRest);
                s; s = s->next1MM(SegmentType::ChordRest)) {
 
+                  // offset into the page, round down
+                  int x = qFloor((s->pagePos().x() + left_distance) * ndpi);
+                  int y = qFloor(s->pagePos().y() * ndpi);
+
                   // width/height, round up
-                  qreal sx   = 0;
+                  qreal sx = 0;
                   qreal right_distance = 0;
                   qreal left_distance = 0;
                   int tracks = score->nstaves() * VOICES;
@@ -90,10 +94,6 @@ bool MuseScore::savePositions(Score* score, QIODevice* device, bool segments, bo
                               left_distance = qMin(left_distance, e->offset().x());
                               }
                         }
-
-                  // offset into the page, round down
-                  int x = qFloor((s->pagePos().x() + left_distance) * ndpi);
-                  int y = qFloor(s->pagePos().y() * ndpi);
 
                   // width = smallest element + largest offset
                   int w    = qCeil((right_distance + abs(left_distance)) * ndpi);
@@ -175,4 +175,3 @@ bool MuseScore::savePositions(Score* score, const QString& name, bool segments, 
       return savePositions(score, &fp, segments, legacyExport);
       }
 }
-

--- a/mscore/savePositions.cpp
+++ b/mscore/savePositions.cpp
@@ -75,29 +75,15 @@ bool MuseScore::savePositions(Score* score, QIODevice* device, bool segments, bo
       if (segments) {
             for (Segment* s = score->firstMeasureMM()->first(SegmentType::ChordRest);
                s; s = s->next1MM(SegmentType::ChordRest)) {
+                  QRectF b = s->sposBBox();
 
                   // offset into the page, round down
-                  int x = qFloor((s->pagePos().x() + left_distance) * ndpi);
-                  int y = qFloor(s->pagePos().y() * ndpi);
+                  int x    = qFloor(b.x() * ndpi);
+                  int y    = qFloor(b.y() * ndpi);
 
                   // width/height, round up
-                  qreal sx = 0;
-                  qreal right_distance = 0;
-                  qreal left_distance = 0;
-                  int tracks = score->nstaves() * VOICES;
-                  for (int track = 0; track < tracks; track++) {
-                        Element* e = s->element(track);
-                        if (e) {
-                              // compute the element with the largest offset to the right (end)
-                              right_distance = qMax(right_distance, e->offset().x() + e->shape().right());
-                              // compute the element with the smallest offset to the right (start, left if negative)
-                              left_distance = qMin(left_distance, e->offset().x());
-                              }
-                        }
-
-                  // width = smallest element + largest offset
-                  int w    = qCeil((right_distance + abs(left_distance)) * ndpi);
-                  int h    = qCeil(s->measure()->system()->height() * ndpi);
+                  int w    = qCeil(b.width() * ndpi);
+                  int h    = qCeil(b.height() * ndpi);
 
                   Page* p  = s->measure()->system()->page();
                   int page = score->pageIdx(p);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/311950 and https://musescore.org/en/node/312022

Mainly discussed there: https://musescore.org/en/node/311914 and https://musescore.org/en/node/307253

Introduce mposx/sposx file format for export job that don't apply that ndpi factor to the pixel distance, that solution would avoid any breaking change for current systems using the mpos/spos file format and allow others users to exploit those files coordinates if needed.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
