### PR TITLE
Fix warning of usage a deprecated method in a deprecated midi::Event

### DIFF
--- a/framework/midi/midievent.h
+++ b/framework/midi/midievent.h
@@ -244,18 +244,6 @@ struct Event {
         return EventType::ME_INVALID;
     }
 
-    [[deprecated]] void setType(EventType type)
-    {
-        std::set<EventType> supportedTypes
-            = { EventType::ME_NOTEOFF, EventType::ME_NOTEON, EventType::ME_POLYAFTER, EventType::ME_CONTROLLER, EventType::ME_PROGRAM,
-                EventType::ME_AFTERTOUCH, EventType::ME_PITCHBEND };
-        assert(supportedTypes.find(type) != supportedTypes.end());
-
-        Opcode code = static_cast<Opcode>(type >> 4);
-        setMessageType(MessageType::ChannelVoice10);
-        setOpcode(code);
-    }
-
     channel_t channel() const
     {
         assertChannelVoice();
@@ -1024,6 +1012,19 @@ private:
     {
         size_t scaleBits = (srcBits - dstBits);
         return srcVal >> scaleBits;
+    }
+
+    //TODO: remove with deprecated constructors
+    void setType(EventType type)
+    {
+        std::set<EventType> supportedTypes
+            = { EventType::ME_NOTEOFF, EventType::ME_NOTEON, EventType::ME_POLYAFTER, EventType::ME_CONTROLLER, EventType::ME_PROGRAM,
+                EventType::ME_AFTERTOUCH, EventType::ME_PITCHBEND };
+        assert(supportedTypes.find(type) != supportedTypes.end());
+
+        Opcode code = static_cast<Opcode>(type >> 4);
+        setMessageType(MessageType::ChannelVoice10);
+        setOpcode(code);
     }
 
     std::array<uint32_t, 4> m_data = { { 0, 0, 0, 0 } };

--- a/mu4/notation/internal/notationparts.cpp
+++ b/mu4/notation/internal/notationparts.cpp
@@ -1249,13 +1249,11 @@ MidiActionList NotationParts::convertedMidiActions(const QList<Ms::NamedEventLis
         action.description = coreAction.descr;
 
         for (const Ms::MidiCoreEvent& midiCoreEvent: coreAction.events) {
-            midi::Event midiEvent;
-            midiEvent.setChannel(midiCoreEvent.channel());
-            midiEvent.setType(static_cast<midi::EventType>(midiCoreEvent.type()));
-
-            //!FIXME
-            //midiEvent.a = midiCoreEvent.dataA();
-            //midiEvent.b = midiCoreEvent.dataB();
+            midi::Event midiEvent(midiCoreEvent.channel(),
+                                  static_cast<midi::EventType>(midiCoreEvent.type()),
+                                  midiCoreEvent.dataA(),
+                                  midiCoreEvent.dataB()
+                                  );
 
             action.events.push_back(midiEvent);
         }


### PR DESCRIPTION
- fixed usage of deprecated midi::Event::setType
- midi::Event::setType is private now and can not be used outside the class

Inhouse team.
