### PR TITLE
fix #309102: Lines: Dragging a handle causes anchor to shoot off in opposite direction

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -490,12 +490,25 @@ LineSegment* LineSegment::rebaseAnchor(Grip grip, Segment* newSeg)
                   startTick = newSeg->tick();
             }
 
-      if (l->tick() != startTick)
+      bool anchorChanged = false;
+
+      if (l->tick() != startTick) {
             l->undoChangeProperty(Pid::SPANNER_TICK, startTick);
+            anchorChanged = true;
+            }
 
-      l->undoChangeProperty(Pid::SPANNER_TICKS, endTick - startTick);
+      const Fraction ticksLength = endTick - startTick;
 
-      if (newSeg->system() == oldSystem) {
+      if (ticksLength != l->ticks()) {
+            l->undoChangeProperty(Pid::SPANNER_TICKS, ticksLength);
+            anchorChanged = true;
+            }
+
+      if (newSeg->system() != oldSystem) {
+            l->layout();
+            return left ? l->frontSegment() : l->backSegment();
+            }
+      else if (anchorChanged) {
             const QPointF delta = left ? deltaRebaseLeft(oldSeg, newSeg) : deltaRebaseRight(oldSeg, newSeg, track2staff(l->effectiveTrack2()));
             if (left) {
                   setOffset(offset() + delta);
@@ -505,10 +518,6 @@ LineSegment* LineSegment::rebaseAnchor(Grip grip, Segment* newSeg)
             else {
                   _offset2 += delta;
                   }
-            }
-      else {
-            l->layout();
-            return left ? l->frontSegment() : l->backSegment();
             }
 
       return nullptr;

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -148,6 +148,7 @@ class Measure final : public MeasureBase {
       Segment* firstEnabled() const        { return _segments.first(ElementFlag::ENABLED); }
 
       Ms::Segment* last() const            { return _segments.last(); }
+      Segment* lastEnabled() const         { return _segments.last(ElementFlag::ENABLED); }
       SegmentList& segments()              { return _segments; }
       const SegmentList& segments() const  { return _segments; }
 

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -948,7 +948,7 @@ qreal Segment::widthInStaff(int staffIdx, SegmentType t) const
       if (nextSeg)
             nextSegX = nextSeg->x();
       else {
-            Segment* lastSeg = measure()->last();
+            Segment* lastSeg = measure()->lastEnabled();
             if (lastSeg->segmentType() & t)
                   nextSegX = lastSeg->x() + lastSeg->width();
             else

--- a/libmscore/segmentlist.cpp
+++ b/libmscore/segmentlist.cpp
@@ -222,5 +222,18 @@ Segment* SegmentList::first(ElementFlag flags) const
             }
       return nullptr;
       }
+
+//---------------------------------------------------------
+//   last
+//---------------------------------------------------------
+
+Segment* SegmentList::last(ElementFlag flags) const
+      {
+      for (Segment* s = _last; s; s = s->prev()) {
+            if (s->flag(flags))
+                  return s;
+            }
+      return nullptr;
+      }
 }
 

--- a/libmscore/segmentlist.h
+++ b/libmscore/segmentlist.h
@@ -44,6 +44,7 @@ class SegmentList {
       Segment* first(ElementFlag) const;
 
       Segment* last() const                { return _last;        }
+      Segment* last(ElementFlag) const;
       Segment* firstCRSegment() const;
       void remove(Segment*);
       void push_back(Segment*);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/309102

Fixes two issues with lines dragging implementation introduced in #5763. The first commit fixes hairpin incorrectly increasing its length instead of shortening in the case reported in the issue. The second commit fixes imprecision in hairpin length change in case user drags end hairpin handle across time signature change in the same score.