### PR TITLE
[MU4] Revert part of an earlier change

### DIFF
--- a/thirdparty/fluidsynth/fluidsynth-2.1.4/src/utils/fluidsynth_priv.h
+++ b/thirdparty/fluidsynth/fluidsynth-2.1.4/src/utils/fluidsynth_priv.h
@@ -39,10 +39,6 @@
 #include <math.h> // M_PI, MLN2, M_LN10
 #endif
 
-#if HAVE_UNISTD_H
-#include <unistd.h> // read, write
-#endif
-
 #if HAVE_STDLIB_H
 #include <stdlib.h> // malloc, free
 #endif


### PR DESCRIPTION
from #6716, doesn't help, still warnings about implicit declaration of `read()` and `write()`, but doesn't harm either