### PR TITLE
Plugin API: add/restore more properties

### DIFF
--- a/libmscore/harmony.h
+++ b/libmscore/harmony.h
@@ -66,12 +66,6 @@ struct TextSegment {
 struct RenderAction;
 class HDegree;
 
-enum class HarmonyType {
-      STANDARD,
-      ROMAN,
-      NASHVILLE
-      };
-
 class Harmony final : public TextBase {
       int _rootTpc;                       // root note for chord
       int _baseTpc;                       // bass note or chord base; used for "slash" chords

--- a/libmscore/types.h
+++ b/libmscore/types.h
@@ -375,6 +375,18 @@ enum class GlissandoStyle {
       };
 
 //---------------------------------------------------------
+//   HarmonyType
+//---------------------------------------------------------
+
+enum class HarmonyType {
+      ///.\{
+      STANDARD,
+      ROMAN,
+      NASHVILLE
+      ///\}
+      };
+
+//---------------------------------------------------------
 //   Placement
 //---------------------------------------------------------
 
@@ -599,6 +611,7 @@ Q_ENUM_NS(Align);
 Q_ENUM_NS(NoteType);
 Q_ENUM_NS(PlayEventType);
 Q_ENUM_NS(AccidentalType);
+Q_ENUM_NS(HarmonyType);
 #endif
 
 //hack: to force the build system to run moc on this file

--- a/mscore/plugin/api/elements.cpp
+++ b/mscore/plugin/api/elements.cpp
@@ -310,8 +310,11 @@ Element* wrap(Ms::Element* e, Ownership own)
             case ElementType::PAGE:
                   return wrap<Page>(toPage(e), own);
             default:
-                  if (e->isDurationElement())
+                  if (e->isDurationElement()) {
+                        if (e->isChordRest())
+                              return wrap<ChordRest>(toChordRest(e), own);
                         return wrap<DurationElement>(toDurationElement(e), own);
+                        }
                   break;
             }
       return wrap<Element>(e, own);

--- a/mscore/plugin/api/elements.h
+++ b/mscore/plugin/api/elements.h
@@ -373,6 +373,12 @@ class Element : public Ms::PluginAPI::ScoreElement {
       API_PROPERTY( posAbove,                POS_ABOVE                 )
       API_PROPERTY_T( int, voice,            VOICE                     )
       API_PROPERTY_READ_ONLY( position,      POSITION                  ) // TODO: needed?
+      /**
+       * For chord symbols, chord symbol type, one of
+       * PluginAPI::PluginAPI::HarmonyType values.
+       * \since MuseScore 3.6
+       */
+      API_PROPERTY( harmonyType,             HARMONY_TYPE              )
 
       qreal offsetX() const { return element()->offset().x() / element()->spatium(); }
       qreal offsetY() const { return element()->offset().y() / element()->spatium(); }

--- a/mscore/plugin/api/elements.h
+++ b/mscore/plugin/api/elements.h
@@ -775,11 +775,26 @@ class Measure : public Element {
 
       // TODO: to MeasureBase?
 //       Q_PROPERTY(bool         lineBreak         READ lineBreak   WRITE undoSetLineBreak)
+      /// Next measure.
       Q_PROPERTY(Ms::PluginAPI::Measure* nextMeasure       READ nextMeasure)
-//       Q_PROPERTY(Ms::Measure* nextMeasureMM     READ nextMeasureMM)
+      /// Next measure, accounting for multimeasure rests.
+      /// This property may differ from \ref nextMeasure if multimeasure rests
+      /// are enabled. If next measure is a multimeasure rest, this property
+      /// points to the multimeasure rest measure while \ref nextMeasure in the
+      /// same case will point to the first underlying empty measure. Therefore
+      /// if visual properties of a measure are needed (as opposed to logical
+      /// score structure) this property should be preferred.
+      /// \see \ref Score.firstMeasureMM
+      /// \since MuseScore 3.6
+      Q_PROPERTY(Ms::PluginAPI::Measure* nextMeasureMM     READ nextMeasureMM)
 //       Q_PROPERTY(bool         pageBreak         READ pageBreak   WRITE undoSetPageBreak)
+      /// Previous measure.
       Q_PROPERTY(Ms::PluginAPI::Measure* prevMeasure       READ prevMeasure)
-//       Q_PROPERTY(Ms::Measure* prevMeasureMM     READ prevMeasureMM)
+      /// Previous measure, accounting for multimeasure rests.
+      /// See \ref nextMeasureMM for a reference on multimeasure rests.
+      /// \see \ref Score.lastMeasureMM
+      /// \since MuseScore 3.6
+      Q_PROPERTY(Ms::PluginAPI::Measure* prevMeasureMM     READ prevMeasureMM)
 
       /// List of measure-related elements: layout breaks, jump/repeat markings etc.
       /// \since MuseScore 3.3
@@ -798,6 +813,9 @@ class Measure : public Element {
 
       Measure* prevMeasure() { return wrap<Measure>(measure()->prevMeasure(), Ownership::SCORE); }
       Measure* nextMeasure() { return wrap<Measure>(measure()->nextMeasure(), Ownership::SCORE); }
+
+      Measure* prevMeasureMM() { return wrap<Measure>(measure()->prevMeasureMM(), Ownership::SCORE); }
+      Measure* nextMeasureMM() { return wrap<Measure>(measure()->nextMeasureMM(), Ownership::SCORE); }
 
       QQmlListProperty<Element> elements() { return wrapContainerProperty<Element>(this, measure()->el()); }
       /// \endcond

--- a/mscore/plugin/api/part.h
+++ b/mscore/plugin/api/part.h
@@ -80,9 +80,9 @@ class Part : public Ms::PluginAPI::ScoreElement {
       /// \since MuseScore 3.2.1
       Q_PROPERTY(QString                        partName             READ partName)
       /// Whether part is shown or hidden.
-      /// Note that this property was writeable in MuseScore v2.x
+      /// This property is writeable since MuseScore 3.6 (and was writable in MuseScore 2.x)
       /// \since MuseScore 3.2.1
-      Q_PROPERTY(bool                           show                 READ show)
+      Q_PROPERTY(bool                           show                 READ show            WRITE setShow)
 
       /**
        * List of instruments in this part.
@@ -112,6 +112,7 @@ class Part : public Ms::PluginAPI::ScoreElement {
       QString shortName() const { return part()->shortName(); }
       QString partName() const { return part()->partName(); }
       bool show() const { return part()->show(); }
+      void setShow(bool val) { set(Pid::VISIBLE, val); }
 
       InstrumentListProperty instruments();
       /// \endcond

--- a/mscore/plugin/api/qmlpluginapi.cpp
+++ b/mscore/plugin/api/qmlpluginapi.cpp
@@ -52,6 +52,7 @@ Enum* PluginAPI::noteValueTypeEnum = nullptr;
 Enum* PluginAPI::segmentTypeEnum = nullptr;
 Enum* PluginAPI::spannerAnchorEnum = nullptr;
 Enum* PluginAPI::symIdEnum = nullptr;
+Enum* PluginAPI::harmonyTypeEnum = nullptr;
 
 //---------------------------------------------------------
 //   PluginAPI

--- a/mscore/plugin/api/qmlpluginapi.h
+++ b/mscore/plugin/api/qmlpluginapi.h
@@ -16,6 +16,7 @@
 #include "config.h"
 #include "../qmlplugin.h"
 #include "enums.h"
+#include "libmscore/harmony.h"
 #include "libmscore/lyrics.h"
 #include "libmscore/mscore.h"
 #include "libmscore/utils.h"
@@ -162,6 +163,9 @@ class PluginAPI : public Ms::QmlPlugin {
       /// Contains Ms::SymId enumeration values
       /// \since MuseScore 3.5
       DECLARE_API_ENUM( SymId,            symIdEnum,              Ms::SymId                 )
+      /// Contains Ms::HarmonyType enumeration values
+      /// \since MuseScore 3.6
+      DECLARE_API_ENUM( HarmonyType,      harmonyTypeEnum,        Ms::HarmonyType           )
 
       QFile logFile;
 

--- a/mscore/plugin/api/score.h
+++ b/mscore/plugin/api/score.h
@@ -48,7 +48,11 @@ class Score : public Ms::PluginAPI::ScoreElement {
       Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::Excerpt>  excerpts   READ excerpts)
       /** First measure of the score (read only) */
       Q_PROPERTY(Ms::PluginAPI::Measure*        firstMeasure      READ firstMeasure)
-      /** First multimeasure rest measure of the score (read only).\n \since MuseScore 3.2 */
+      /**
+       * First multimeasure rest measure of the score (read only).
+       * \see \ref Measure.nextMeasureMM
+       * \since MuseScore 3.2
+       */
       Q_PROPERTY(Ms::PluginAPI::Measure*        firstMeasureMM    READ firstMeasureMM)
       /** Number of harmony items (chord symbols) in the score (read only).\n \since MuseScore 3.2 */
       Q_PROPERTY(int                            harmonyCount      READ harmonyCount)
@@ -61,7 +65,11 @@ class Score : public Ms::PluginAPI::ScoreElement {
       Q_PROPERTY(int                            keysig            READ keysig)
       /** Last measure of the score (read only) */
       Q_PROPERTY(Ms::PluginAPI::Measure*        lastMeasure       READ lastMeasure)
-      /** Last multimeasure rest measure of the score (read only).\n \since MuseScore 3.2 */
+      /**
+       * Last multimeasure rest measure of the score (read only).
+       * \see \ref Measure.prevMeasureMM
+       * \since MuseScore 3.2
+       */
       Q_PROPERTY(Ms::PluginAPI::Measure*        lastMeasureMM     READ lastMeasureMM)
       /** Last score segment (read only) */
       Q_PROPERTY(Ms::PluginAPI::Segment*        lastSegment       READ lastSegment) // TODO: make it function? Was property in 2.X, but firstSegment is a function...


### PR DESCRIPTION
This pull request contains changes adding some more object properties for plugin API. Most of these properties (except `harmonyType`) were available for plugins in MuseScore 2.x and have not yet been implemented in MuseScore 3. Commits in this PR can be applied independently so some of them can be moved to separate pull requests if needed.

Resolved issues:
 - https://musescore.org/en/node/289728 — stem/hook/beam/stemSlash properties.
 - https://musescore.org/en/node/309285 — `harmonyType` property to make it possible for plugins to create chord symbols of Roman/Nashville type.
 - https://musescore.org/en/node/301171 — a writable `Part.show` property to enable plugins to hide or show certain parts.
 - Part of discussion in https://musescore.org/en/node/311950#comment-1034538: as I mentioned there, `nextMeasureMM`/`prevMeasureMM` (also available in MuseScore 2.x) are needed for plugins to be able to get visual properties of all measures.