### PR TITLE
[MU3] Fix #276840: Change of soundfont is cumbersome

### DIFF
--- a/audio/midi/fluid/fluid_gui.ui
+++ b/audio/midi/fluid/fluid_gui.ui
@@ -33,31 +33,31 @@
       <number>0</number>
      </property>
      <item>
-       <widget class="QToolButton" name="soundFontTop">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="focusPolicy">
-         <enum>Qt::TabFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Move SoundFont to Top</string>
-        </property>
-        <property name="accessibleDescription">
-         <string/>
-        </property>
-        <property name="text">
-         <string notr="true"/>
-        </property>
-        <property name="icon">
-         <iconset resource="../mscore/musescore.qrc">
-          <normaloff>:/data/icons/arrowsMoveToTop.svg</normaloff>:/data/icons/arrowsMoveToTop.svg</iconset>
-        </property>
-       </widget>
-      </item>
+      <widget class="QToolButton" name="soundFontTop">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>Move SoundFont to Top</string>
+       </property>
+       <property name="accessibleDescription">
+        <string/>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../mscore/musescore.qrc">
+         <normaloff>:/data/icons/arrowsMoveToTop.svg</normaloff>:/data/icons/arrowsMoveToTop.svg</iconset>
+       </property>
+      </widget>
+     </item>
      <item>
       <widget class="QToolButton" name="soundFontUp">
        <property name="sizePolicy">
@@ -79,7 +79,7 @@
         <string notr="true"/>
        </property>
        <property name="icon">
-        <iconset resource="../mscore/musescore.qrc">
+        <iconset resource="../../../mscore/musescore.qrc">
          <normaloff>:/data/icons/arrow_up.svg</normaloff>:/data/icons/arrow_up.svg</iconset>
        </property>
       </widget>
@@ -102,8 +102,34 @@
         <string notr="true"/>
        </property>
        <property name="icon">
-        <iconset resource="../mscore/musescore.qrc">
+        <iconset resource="../../../mscore/musescore.qrc">
          <normaloff>:/data/icons/arrow_down.svg</normaloff>:/data/icons/arrow_down.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="soundFontBottom">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>Move SoundFont to Bottom</string>
+       </property>
+       <property name="accessibleDescription">
+        <string/>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../mscore/musescore.qrc">
+         <normaloff>:/data/icons/arrowsMoveToBottom.svg</normaloff>:/data/icons/arrowsMoveToBottom.svg</iconset>
        </property>
       </widget>
      </item>
@@ -151,7 +177,7 @@
   </layout>
  </widget>
  <resources>
-  <include location="../mscore/musescore.qrc"/>
+  <include location="../../../mscore/musescore.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/audio/midi/fluid/fluidgui.cpp
+++ b/audio/midi/fluid/fluidgui.cpp
@@ -114,6 +114,7 @@ FluidGui::FluidGui(Synthesizer* s)
       connect(soundFontTop,    SIGNAL(clicked()), SLOT(soundFontTopClicked()));
       connect(soundFontUp,     SIGNAL(clicked()), SLOT(soundFontUpClicked()));
       connect(soundFontDown,   SIGNAL(clicked()), SLOT(soundFontDownClicked()));
+      connect(soundFontBottom, SIGNAL(clicked()), SLOT(soundFontBottomClicked()));
       connect(soundFontAdd,    SIGNAL(clicked()), SLOT(soundFontAddClicked()));
       connect(soundFontDelete, SIGNAL(clicked()), SLOT(soundFontDeleteClicked()));
       connect(soundFonts,      SIGNAL(itemSelectionChanged ()),  SLOT(updateUpDownButtons()));
@@ -124,16 +125,17 @@ FluidGui::FluidGui(Synthesizer* s)
       _progressTimer = new QTimer(this);
       connect(_progressTimer, SIGNAL(timeout()), this, SLOT(updateProgress()));
       connect(soundFonts, SIGNAL(itemSelectionChanged()), this, SLOT(updateUpDownButtons()));
-      
+
+      soundFontTop->setIcon(*icons[int(Ms::Icons::arrowsMoveToTop_ICON)]);
       soundFontUp->setIcon(*icons[int(Icons::arrowUp_ICON)]);
       soundFontDown->setIcon(*icons[int(Icons::arrowDown_ICON)]);
-      soundFontTop->setIcon(*icons[int(Ms::Icons::arrowsMoveToTop_ICON)]);
-      
+      soundFontBottom->setIcon(*icons[int(Ms::Icons::arrowsMoveToBottom_ICON)]);
+
       //update sfs
       QStringList sfonts = fluid()->soundFonts();
       soundFonts->clear();
       soundFonts->addItems(sfonts);
-      
+
       updateUpDownButtons();
       }
 
@@ -159,7 +161,7 @@ void FluidGui::moveSoundfontInTheList(int currentIdx, int targetIdx)
       QStringList sfonts = fluid()->soundFonts();
       for (auto sfName : sfonts)
             fluid()->removeSoundFont(sfName);
-      
+
       sfonts.move(currentIdx, targetIdx);
       fluid()->loadSoundFonts(sfonts);
       sfonts = fluid()->soundFonts();
@@ -170,13 +172,23 @@ void FluidGui::moveSoundfontInTheList(int currentIdx, int targetIdx)
       }
 
 void FluidGui::soundFontTopClicked()
-       {
-       int row = soundFonts->currentRow();
-       if (row <= 0)
-             return;
-       
-       moveSoundfontInTheList(row, 0);
-       }
+      {
+      int row = soundFonts->currentRow();
+      if (row <= 0)
+            return;
+
+      moveSoundfontInTheList(row, 0);
+      }
+
+void FluidGui::soundFontBottomClicked()
+      {
+      int rows = soundFonts->count();
+      int row = soundFonts->currentRow();
+      if (row + 1 >= rows)
+            return;
+
+      moveSoundfontInTheList(row, rows - 1);
+      }
 
 //---------------------------------------------------------
 //   soundFontUpClicked
@@ -187,7 +199,7 @@ void FluidGui::soundFontUpClicked()
       int row = soundFonts->currentRow();
       if (row <= 0)
             return;
-      
+
       moveSoundfontInTheList(row, row - 1);
       }
 
@@ -230,9 +242,10 @@ void FluidGui::updateUpDownButtons()
       {
       int rows = soundFonts->count();
       int row = soundFonts->currentRow();
-      soundFontUp->setEnabled(row > 0);
       soundFontTop->setEnabled(row > 0);
-      soundFontDown->setEnabled((row != -1) && (row < (rows-1)));
+      soundFontUp->setEnabled(row > 0);
+      soundFontDown->setEnabled((row != -1) && (row < (rows - 1)));
+      soundFontBottom->setEnabled((row != -1) && (row < (rows - 1)));
       soundFontDelete->setEnabled(row != -1);
       }
 

--- a/audio/midi/fluid/fluidgui.h
+++ b/audio/midi/fluid/fluidgui.h
@@ -65,6 +65,7 @@ class FluidGui : public Ms::SynthesizerGui, Ui::FluidGui {
 
    private slots:
       void soundFontTopClicked();
+      void soundFontBottomClicked();
       void soundFontUpClicked();
       void soundFontDownClicked();
       void soundFontAddClicked();

--- a/audio/midi/fluid/fluidgui.h
+++ b/audio/midi/fluid/fluidgui.h
@@ -61,6 +61,7 @@ class FluidGui : public Ms::SynthesizerGui, Ui::FluidGui {
       QTimer * _progressTimer;
       std::list<struct SfNamePath> _sfToLoad;
       void loadSf();
+      void loadSoundFontsAsync(QStringList sfonts);
       void moveSoundfontInTheList(int currentIdx, int targetIdx);
 
    private slots:

--- a/audio/midi/zerberus/zerberus.cpp
+++ b/audio/midi/zerberus/zerberus.cpp
@@ -294,7 +294,7 @@ void Zerberus::allNotesOff(int channel)
 
 bool Zerberus::loadSoundFonts(const QStringList& sl)
       {
-      foreach (const QString& s, sl) {
+      for (const QString& s : sl) {
             if (!loadInstrument(s))
                   return false;
             }

--- a/audio/midi/zerberus/zerberus_gui.ui
+++ b/audio/midi/zerberus/zerberus_gui.ui
@@ -28,35 +28,35 @@
    </property>
    <item row="0" column="1">
     <layout class="QVBoxLayout" name="verticalLayout_6">
-	 <property name="spacing">
+     <property name="spacing">
       <number>0</number>
      </property>
      <item>
-       <widget class="QToolButton" name="soundFontTop">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="focusPolicy">
-         <enum>Qt::TabFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Move SoundFont to Top</string>
-        </property>
-        <property name="accessibleDescription">
-         <string/>
-        </property>
-        <property name="text">
-         <string notr="true"/>
-        </property>
-        <property name="icon">
-         <iconset resource="../mscore/musescore.qrc">
-          <normaloff>:/data/icons/object-select.svg</normaloff>:/data/icons/object-select.svg</iconset>
-        </property>
-       </widget>
-      </item>
+      <widget class="QToolButton" name="soundFontTop">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>Move SoundFont to Top</string>
+       </property>
+       <property name="accessibleDescription">
+        <string/>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../mscore/musescore.qrc">
+         <normaloff>:/data/icons/arrowsMoveToTop.svg</normaloff>:/data/icons/arrowsMoveToTop.svg</iconset>
+       </property>
+      </widget>
+     </item>
      <item>
       <widget class="QToolButton" name="soundFontUp">
        <property name="sizePolicy">
@@ -78,8 +78,8 @@
         <string notr="true"/>
        </property>
        <property name="icon">
-        <iconset resource="../mscore/musescore.qrc">
-         <normaloff>:/data/icons/arrowsMoveToTop.svg</normaloff>:/data/icons/arrowsMoveToTop.svg</iconset>
+        <iconset resource="../../../mscore/musescore.qrc">
+         <normaloff>:/data/icons/arrow_up.svg</normaloff>:/data/icons/arrow_up.svg</iconset>
        </property>
       </widget>
      </item>
@@ -101,8 +101,34 @@
         <string notr="true"/>
        </property>
        <property name="icon">
-        <iconset resource="../mscore/musescore.qrc">
+        <iconset resource="../../../mscore/musescore.qrc">
          <normaloff>:/data/icons/arrow_down.svg</normaloff>:/data/icons/arrow_down.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="soundFontBottom">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>Move SoundFont to Bottom</string>
+       </property>
+       <property name="accessibleDescription">
+        <string/>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../mscore/musescore.qrc">
+         <normaloff>:/data/icons/arrowsMoveToBottom.svg</normaloff>:/data/icons/arrowsMoveToBottom.svg</iconset>
        </property>
       </widget>
      </item>
@@ -148,13 +174,12 @@
     </layout>
    </item>
    <item row="0" column="0">
-    <widget class="QListWidget" name="files">
-    </widget>
+    <widget class="QListWidget" name="files"/>
    </item>
   </layout>
  </widget>
  <resources>
-  <include location="../mscore/musescore.qrc"/>
+  <include location="../../../mscore/musescore.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/audio/midi/zerberus/zerberusgui.cpp
+++ b/audio/midi/zerberus/zerberusgui.cpp
@@ -99,6 +99,7 @@ ZerberusGui::ZerberusGui(Ms::Synthesizer* s)
       connect(soundFontTop,    SIGNAL(clicked()), SLOT(soundFontTopClicked()));
       connect(soundFontUp,     SIGNAL(clicked()), SLOT(soundFontUpClicked()));
       connect(soundFontDown,   SIGNAL(clicked()), SLOT(soundFontDownClicked()));
+      connect(soundFontBottom, SIGNAL(clicked()), SLOT(soundFontBottomClicked()));
       connect(soundFontAdd, SIGNAL(clicked()), SLOT(soundFontAddClicked()));
       connect(soundFontDelete, SIGNAL(clicked()), SLOT(soundFontDeleteClicked()));
       connect(&_futureWatcher, SIGNAL(finished()), this, SLOT(onSoundFontLoaded()));
@@ -108,11 +109,12 @@ ZerberusGui::ZerberusGui(Ms::Synthesizer* s)
       _progressTimer = new QTimer(this);
       connect(_progressTimer, SIGNAL(timeout()), this, SLOT(updateProgress()));
       connect(files, SIGNAL(itemSelectionChanged()), this, SLOT(updateButtons()));
-      
+
+      soundFontTop->setIcon(*Ms::icons[int(Ms::Icons::arrowsMoveToTop_ICON)]);
       soundFontUp->setIcon(*Ms::icons[int(Ms::Icons::arrowUp_ICON)]);
       soundFontDown->setIcon(*Ms::icons[int(Ms::Icons::arrowDown_ICON)]);
-      soundFontTop->setIcon(*Ms::icons[int(Ms::Icons::arrowsMoveToTop_ICON)]);
-      
+      soundFontBottom->setIcon(*Ms::icons[int(Ms::Icons::arrowsMoveToBottom_ICON)]);
+
       updateButtons();
       }
 
@@ -125,20 +127,30 @@ void ZerberusGui::moveSoundfontInTheList(int currentIdx, int targetIdx)
       QStringList sfonts = zerberus()->soundFonts();
       sfonts.move(currentIdx, targetIdx);
       zerberus()->removeSoundFonts(zerberus()->soundFonts());
-      
+
       loadSoundFontsAsync(sfonts);
       files->setCurrentRow(targetIdx);
       emit sfChanged();
       }
 
 void ZerberusGui::soundFontTopClicked()
-       {
-       int row = files->currentRow();
-       if (row <= 0)
-             return;
-       
-       moveSoundfontInTheList(row, 0);
-       }
+      {
+      int row = files->currentRow();
+      if (row <= 0)
+            return;
+
+      moveSoundfontInTheList(row, 0);
+      }
+
+void ZerberusGui::soundFontBottomClicked()
+      {
+      int rows = files->count();
+      int row = files->currentRow();
+      if (row + 1 >= rows)
+            return;
+
+      moveSoundfontInTheList(row, rows - 1);
+      }
 
 //---------------------------------------------------------
 //   soundFontUpClicked
@@ -168,7 +180,7 @@ void ZerberusGui::soundFontDownClicked()
       }
 
 //---------------------------------------------------------
-//   loadSounfFontsAsync
+//   loadSoundFontsAsync
 //---------------------------------------------------------
 
 void ZerberusGui::loadSoundFontsAsync(QStringList sfonts)
@@ -312,7 +324,8 @@ void ZerberusGui::updateButtons()
       int row = files->currentRow();
       soundFontTop->setEnabled(row > 0);
       soundFontUp->setEnabled(row > 0);
-      soundFontDown->setEnabled((row != -1) && (row < (rows-1)));
+      soundFontDown->setEnabled((row != -1) && (row < (rows - 1)));
+      soundFontBottom->setEnabled((row != -1) && row < (rows - 1));
       soundFontDelete->setEnabled(row != -1);
       }
 

--- a/audio/midi/zerberus/zerberusgui.cpp
+++ b/audio/midi/zerberus/zerberusgui.cpp
@@ -285,7 +285,7 @@ void ZerberusGui::soundFontAddClicked()
       QFileInfoList l = Zerberus::sfzFiles();
 
       SfzListDialog ld(this);
-      foreach (const QFileInfo& fi, l)
+      for (const QFileInfo& fi : l)
             ld.add(fi.fileName(), fi.absoluteFilePath());
       if (!ld.exec())
             return;

--- a/audio/midi/zerberus/zerberusgui.h
+++ b/audio/midi/zerberus/zerberusgui.h
@@ -68,6 +68,7 @@ class ZerberusGui : public Ms::SynthesizerGui, Ui::ZerberusGui {
       
    private slots:
       void soundFontTopClicked();
+      void soundFontBottomClicked();
       void soundFontUpClicked();
       void soundFontDownClicked();
       void soundFontAddClicked();

--- a/mscore/data/icons/arrowsMoveToBottom.svg
+++ b/mscore/data/icons/arrowsMoveToBottom.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0rc1 (09960d6f05, 2020-04-09)"
+   sodipodi:docname="arrowsMoveToBottom.svg"
+   id="svg13"
+   version="1.1"
+   fill="none"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24">
+  <metadata
+     id="metadata17">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     inkscape:current-layer="svg13"
+     inkscape:window-maximized="0"
+     inkscape:window-y="0"
+     inkscape:window-x="0"
+     inkscape:cy="12"
+     inkscape:cx="12"
+     inkscape:zoom="9.8333333"
+     showgrid="false"
+     id="namedview15"
+     inkscape:window-height="866"
+     inkscape:window-width="1590"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <g
+     transform="matrix(1,0,0,-1,0,25.69384)"
+     id="g6"
+     clip-path="url(#clip0)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path2"
+       fill="#3B3F45"
+       d="m 19.2,34.7077 -7.2001,7.2 -7.19999,-7.2 c -0.72,-0.72 -1.86462,-0.72 -2.58462,0 -0.72,0.72 -0.72,1.8646 0,2.5846 l 8.47381,8.4739 c 0.72,0.72 1.8831,0.72 2.6031,0 l 8.4924,-8.4739 c 0.72,-0.72 0.72,-1.8646 0,-2.5846 -0.72,-0.72 -1.8646,-0.72 -2.5846,0 z m 0,-12.1846 -7.2001,-7.2 -7.19999,7.2 c -0.72,0.72 -1.86462,0.72 -2.58462,0 -0.72,-0.72 -0.72,-1.8646 0,-2.5846 l 8.47381,-8.4739 c 0.72,-0.72 1.8831,-0.72 2.6031,0 l 8.4924,8.4739 c 0.72,0.72 0.72,1.8646 0,2.5846 -0.72,0.72 -1.8646,0.72 -2.5846,0 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4"
+       fill="#3B3F45"
+       d="m 19.2,25.4769 -7.2001,7.2 -7.19999,-7.2 c -0.72,-0.72 -1.86462,-0.72 -2.58462,0 -0.72,0.72 -0.72,1.8646 0,2.5846 l 8.47381,8.4739 c 0.72,0.72 1.8831,0.72 2.6031,0 l 8.4924,-8.4739 c 0.72,-0.72 0.72,-1.8646 0,-2.5846 -0.72,-0.72 -1.8646,-0.72 -2.5846,0 z m 0,-12.1846 -7.2001,-7.19996 -7.19999,7.19996 c -0.72,0.72 -1.86462,0.72 -2.58462,0 -0.72,-0.72 -0.72,-1.8646 0,-2.5846 L 10.6891,2.23384 c 0.72,-0.72 1.8831,-0.72 2.6031,0 l 8.4924,8.47386 c 0.72,0.72 0.72,1.8646 0,2.5846 -0.72,0.72 -1.8646,0.72 -2.5846,0 z" />
+  </g>
+  <defs
+     id="defs11">
+    <clipPath
+       id="clip0">
+      <rect
+         id="rect8"
+         fill="white"
+         height="24"
+         width="24" />
+    </clipPath>
+  </defs>
+</svg>

--- a/mscore/icons.cpp
+++ b/mscore/icons.cpp
@@ -166,7 +166,8 @@ static const char* iconNames[] = {
       "bug.svg",
       "bin.svg",
       "note_timewise.svg",
-      "arrowsMoveToTop.svg"
+      "arrowsMoveToTop.svg",
+      "arrowsMoveToBottom.svg",
       };
 
 //---------------------------------------------------------

--- a/mscore/icons.h
+++ b/mscore/icons.h
@@ -60,7 +60,7 @@ enum class Icons : short { Invalid_ICON = -1,
       arrowUp_ICON, arrowDown_ICON,
       mail_ICON, bug_ICON, bin_ICON,
       noteTimewise_ICON,
-      arrowsMoveToTop_ICON,
+      arrowsMoveToTop_ICON, arrowsMoveToBottom_ICON,
       voice1_ICON, voice2_ICON, voice3_ICON, voice4_ICON,
       ICONS
       };

--- a/mscore/musescore.qrc
+++ b/mscore/musescore.qrc
@@ -199,6 +199,7 @@
         <file>data/icons/triangleDown.svg</file>
         <file>data/icons/triangleUp.svg</file>
         <file>data/icons/arrowsMoveToTop.svg</file>
+        <file>data/icons/arrowsMoveToBottom.svg</file>
         <file>data/win_opengl_buglist.json</file>
         <file>data/icons/bin.svg</file>
         <file>data/icons/braces.svg</file>


### PR DESCRIPTION
* Part 1: Append added soundfont to the list rather than insert at the top ___(TODO)___
* Part 2.a): Implement 'Move To Bottom" buttons for Synthesizer (Fluid and Zerberus)
* Part 2.b): Show progress indicator when moving soundfonts (similar to when adding one, rather than appearing to hang)
* Part 3: Delay the soundfont loading until OK gets clicked ___(TODO, might not happen)___

Resolves https://musescore.org/en/node/276840