### PR TITLE
Fix #257581, Fix #64636  - Changes to Measure properties are not propagated between score and existing linked parts

### DIFF
--- a/libmscore/read302.cpp
+++ b/libmscore/read302.cpp
@@ -24,6 +24,7 @@
 #include "excerpt.h"
 #include "spanner.h"
 #include "scoreOrder.h"
+#include "measurebase.h"
 
 #ifdef OMR
 #include "omr/omr.h"
@@ -192,6 +193,7 @@ bool Score::read(XmlReader& e)
                         ex->setPartScore(s);
                         e.setLastMeasure(nullptr);
                         s->read(e);
+                        s->linkMeasures(m);
                         ex->setTracks(e.tracks());
                         m->addExcerpt(ex);
                         }
@@ -307,6 +309,27 @@ bool Score::read(XmlReader& e)
 
 //      createPlayEvents();
       return true;
+      }
+
+//---------------------------------------------------------
+// linkMeasures
+//---------------------------------------------------------
+
+void Score::linkMeasures(Score* score)
+      {
+      MeasureBase *mbMaster = score->first();
+      for (MeasureBase* mb = first(); mb; mb = mb->next()) {
+            if (!mb->isMeasure())
+                  continue;
+            while (mbMaster && !mbMaster->isMeasure())
+                  mbMaster = mbMaster->next();
+            if (!mbMaster) {
+                  qDebug("Measures in MasterScore and Score are not in sync.");
+                  break;
+                  }
+            mb->linkTo(mbMaster);
+            mbMaster = mbMaster->next();
+            }
       }
 
 //---------------------------------------------------------

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -609,6 +609,7 @@ class Score : public QObject, public ScoreElement {
       void addMeasure(MeasureBase*, MeasureBase*);
       void readStaff(XmlReader&);
       bool read(XmlReader&);
+      void linkMeasures(Score* score);
 
       Excerpt* excerpt()            { return _excerpt; }
       void setExcerpt(Excerpt* e)   { _excerpt = e;     }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/257581
Resolves: https://musescore.org/en/node/64636

When reading a mscx file containing parts, link all measures of the part to the corresponding measure in the MasterScore.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
