### PR TITLE
fix #309040: Apply rest collision avoidance only with auto placement

### DIFF
--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -584,7 +584,7 @@ int Rest::computeLineOffset(int lines)
             int line = up ? 10 : -10;
 
             // For compatibility reasons apply automatic collision avoidance only if y-offset is unchanged 
-            if (qFuzzyIsNull(offset().y())) {
+            if (qFuzzyIsNull(offset().y()) && autoplace()) {
                   int firstTrack = staffIdx() * 4;
                   int extraOffsetForFewLines = lines < 5 ? 2 : 0;
                   bool isMeasureRest = durationType().type() == TDuration::DurationType::V_MEASURE;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/309040

Disable auto collision avoidance for rests when the rests auto placement is not enabled

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
