### PR TITLE
[MU4] honour symbol advance width from font when drawing accidentals (improve font rendering)

### DIFF
--- a/libmscore/accidental.cpp
+++ b/libmscore/accidental.cpp
@@ -364,6 +364,7 @@ void Accidental::layout()
     setMag(m);
 
     m = magS();
+    qreal x = 0.0;
 
     if (_bracket != AccidentalBracket::NONE) {
         SymId id = SymId::noSym;
@@ -383,15 +384,16 @@ void Accidental::layout()
         SymElement se(id, 0.0, _bracket == AccidentalBracket::BRACE ? spatium() * 0.4 : 0.0);
         el.append(se);
         r |= symBbox(id);
+        x += symAdvance(id);
     }
 
     SymId s = symbol();
-    qreal x = r.x() + r.width();
     SymElement e(s, x, 0.0);
     el.append(e);
     r |= symBbox(s).translated(x, 0.0);
 
     if (_bracket != AccidentalBracket::NONE) {
+        x += symAdvance(s);
         SymId id = SymId::noSym;
         switch (_bracket) {
         case AccidentalBracket::PARENTHESIS:
@@ -406,7 +408,6 @@ void Accidental::layout()
         case AccidentalBracket::NONE: // can't happen
             break;
         }
-        x = r.x() + r.width();
         SymElement se(id, x, _bracket == AccidentalBracket::BRACE ? spatium() * 0.4 : 0.0);
         el.append(se);
         r |= symBbox(id).translated(x, 0.0);


### PR DESCRIPTION
Companion PR to #6742 (3.x) for master, without the JSON whitespace changes

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
