### PR TITLE
Fix #309188: Merge rests also in voices 3+4

### DIFF
--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -533,20 +533,18 @@ int Rest::computeLineOffset(int lines)
             }
 
       if (offsetVoices && staff()->mergeMatchingRests()) {
-            // automatically merge matching rests in voices 1 & 2 if nothing in any other voice
+            // automatically merge matching rests if nothing in any other voice
             // this is not always the right thing to do do, but is useful in choral music
-            // and perhaps could be made enabled via a staff property
-            // so choral staves can be treated differently than others
+            // and can be enabled via a staff property
             bool matchFound = false;
-            bool nothingElse = true;
             int baseTrack = staffIdx() * VOICES;
             for (int v = 0; v < VOICES; ++v) {
                   if (v == voice())
                         continue;
                   Element* e = s->element(baseTrack + v);
-                  if (v <= 1) {
-                        // try to find match in other voice (1 or 2)
-                        if (e && e->type() == ElementType::REST) {
+                  // try to find match in any other voice
+                  if (e) {
+                        if (e->type() == ElementType::REST) {
                               Rest* r = toRest(e);
                               if (r->globalTicks() == globalTicks()) {
                                     matchFound = true;
@@ -554,17 +552,11 @@ int Rest::computeLineOffset(int lines)
                                     }
                               }
                         // no match found; no sense looking for anything else
+                        matchFound = false;
                         break;
                         }
-                  else {
-                        // if anything in another voice, do not merge
-                        if (e) {
-                              nothingElse = false;
-                              break;
-                              }
-                        }
                   }
-            if (matchFound && nothingElse)
+            if (matchFound)
                   offsetVoices = false;
             }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/309188

Merge rests in any voice, not just voices 1+2

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
