### PR TITLE
[MU3] Indicate pitch and on/off time in the status line

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -3018,6 +3018,14 @@ QString Note::accessibleInfo() const
       QString duration = chord()->durationUserName();
       QString voice = QObject::tr("Voice: %1").arg(QString::number(track() % VOICES + 1));
       QString pitchName;
+      QString pitchOffset;
+      QString onofftime;
+      if (!_playEvents.empty()) {
+            int on = _playEvents[0].ontime();
+            int off = _playEvents[0].offtime();
+            if (on != 0 || off != NoteEvent::NOTE_LENGTH)
+                  onofftime = QObject::tr(" (on %1‰ off %2‰)").arg(on).arg(off);
+            }
       const Drumset* drumset = part()->instrument()->drumset();
       if (fixed() && headGroup() == NoteHead::Group::HEAD_SLASH)
             pitchName = chord()->noStem() ? QObject::tr("Beat slash") : QObject::tr("Rhythm slash");
@@ -3025,9 +3033,18 @@ QString Note::accessibleInfo() const
             pitchName = qApp->translate("drumset", drumset->name(pitch()).toUtf8().constData());
       else if (staff()->isTabStaff(tick()))
             pitchName = QObject::tr("%1; String: %2; Fret: %3").arg(tpcUserName(false)).arg(QString::number(string() + 1)).arg(QString::number(fret()));
-      else
+      else {
             pitchName = tpcUserName(false);
-      return QObject::tr("%1; Pitch: %2; Duration: %3%4").arg(noteTypeUserName()).arg(pitchName).arg(duration).arg((chord()->isGrace() ? "" : QString("; %1").arg(voice)));
+            if (tuning() != 0)
+                  pitchOffset = QString::asprintf("%+.3f", tuning());
+            if (!concertPitch()) {
+                  // tpcUserName equivalent for getting the sounding pitch
+                  QString soundingPitch = propertyUserValue(Pid::TPC1) + QString::number(((_pitch + ottaveCapoFret() - int(tpc2alter(tpc()))) / 12) - 1);
+                  // almost the same string as below
+                  return QObject::tr("%1; Pitch: %2 (sounding as %3%4); Duration: %5%6%7").arg(noteTypeUserName()).arg(pitchName).arg(soundingPitch).arg(pitchOffset).arg(duration).arg(onofftime).arg((chord()->isGrace() ? "" : QString("; %1").arg(voice)));
+                  }
+            }
+      return QObject::tr("%1; Pitch: %2%3; Duration: %4%5%6").arg(noteTypeUserName()).arg(pitchName).arg(pitchOffset).arg(duration).arg(onofftime).arg((chord()->isGrace() ? "" : QString("; %1").arg(voice)));
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
- indicate sounding pitch if the global concert pitch toggle is off and the current instrument has an actual pitch, i.e. not beat/rhythm slashes or drums; this will show the identical pitch for nōn-transposing instruments by design (to show we’re currently in transposing pitch mode, but the current instrument is not transposing) which helps debugging
- indicate tuning (if any) after the sounding pitch (either mode)
- show on/off times if at least one of them is nōn-standard

The first change partially addresses node #283120.
The on/off time was requested in node #290900#comment-927933
(velocity is too hard, sorry about that).

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
