### PR TITLE
Fix #312146 - "Flatten all Beams" setting ignored on reload

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -58,7 +58,6 @@ struct BeamFragment {
 Beam::Beam(Score* s)
    : Element(s)
       {
-      initElementStyle(&beamStyle);
       _direction       = Direction::AUTO;
       _up              = true;
       _distribute      = false;
@@ -73,6 +72,7 @@ Beam::Beam(Score* s)
       maxMove          = 0;
       _isGrace         = false;
       _cross           = false;
+      initElementStyle(&beamStyle);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/312146

No longer overwrite <code>Beam::_noSlope</code> after setting the style value.

Is issue is a regression caused by [fixed some issues from PVS-Studio report (step1)](https://github.com/musescore/MuseScore/commit/68b3415c475805ad49839ea65609dfbda796f602?branch=68b3415c475805ad49839ea65609dfbda796f602) which set in the <code>Beam</code>  the variable <code>_noSlope</code> back to <code>false</code>, overwriting the style value.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
