### PR TITLE
fix #308726: Avoid rest offsets with slash notation

### DIFF
--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -532,6 +532,18 @@ int Rest::computeLineOffset(int lines)
                   }
             }
 
+      if (offsetVoices) {
+            // if the staff contains slash notation then don't offset voices
+            int baseTrack = staffIdx() * VOICES;
+            for (int v = 0; v < VOICES; ++v) {
+                  Element* e = s->element(baseTrack + v);
+                  if (e && e->isChord() && toChord(e)->slash()) {
+                        offsetVoices = false;
+                        break;
+                        }
+                  }
+            }
+
       if (offsetVoices && staff()->mergeMatchingRests()) {
             // automatically merge matching rests in voices 1 & 2 if nothing in any other voice
             // this is not always the right thing to do do, but is useful in choral music


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/308726

Do not offset rests if slash notation is active anywhere in the chord 

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
