### PR TITLE
[MU4→3] honour symbol advance width from font when drawing accidentals (improve font rendering)

### DIFF
--- a/libmscore/accidental.cpp
+++ b/libmscore/accidental.cpp
@@ -360,6 +360,7 @@ void Accidental::layout()
       setMag(m);
 
       m = magS();
+      qreal x = 0.0;
 
       if (_bracket != AccidentalBracket::NONE) {
             SymId id = SymId::noSym;
@@ -379,15 +380,16 @@ void Accidental::layout()
             SymElement se(id, 0.0, _bracket == AccidentalBracket::BRACE ? spatium() * 0.4 : 0.0);
             el.append(se);
             r |= symBbox(id);
+            x += symAdvance(id);
             }
 
       SymId s = symbol();
-      qreal x = r.x()+r.width();
       SymElement e(s, x, 0.0);
       el.append(e);
       r |= symBbox(s).translated(x, 0.0);
 
       if (_bracket != AccidentalBracket::NONE) {
+            x += symAdvance(s);
             SymId id = SymId::noSym;
             switch (_bracket) {
                   case AccidentalBracket::PARENTHESIS:
@@ -402,7 +404,6 @@ void Accidental::layout()
                   case AccidentalBracket::NONE: // can't happen
                         break;
                   }
-            x = r.x()+r.width();
             SymElement se(id, x, _bracket == AccidentalBracket::BRACE ? spatium() * 0.4 : 0.0);
             el.append(se);
             r |= symBbox(id).translated(x, 0.0);


### PR DESCRIPTION
Companion of https://github.com/musescore/MuseScore/pull/6748 which was accepted into master.

This was originally part of https://github.com/musescore/MuseScore/pull/6742 against 3.x but I split this off to separate the rendering fix (this PR) from the SMuFL and JSON changes.

----

[…]

Then, I found that rendering parenthesised accidentals ignored the reduced “advance” width of e.g. the ♭ accidental (compared to its bounding box width), leading to an uneven look (seemingly more space to the right than to the left). I fixed that here.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [ ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made