### PR TITLE
[MU4] Fix #127341: Implements portamento for fluid

### DIFF
--- a/audio/exports/exportmidi.cpp
+++ b/audio/exports/exportmidi.cpp
@@ -347,6 +347,11 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
                         continue;
                     }
 
+                    if (!exportRPNs && event.type() == ME_CONTROLLER && event.portamento()) {
+                        // ignore portamento control events if exportRPN isn't switched on
+                        continue;
+                    }
+
                     char eventPort    = cs->masterScore()->midiPort(event.channel());
                     char eventChannel = cs->masterScore()->midiChannel(event.channel());
                     if (port != eventPort || channel != eventChannel) {
@@ -354,8 +359,14 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
                     }
 
                     if (event.type() == ME_NOTEON) {
-                        track.insert(pauseMap.addPauseTicks(i->first), MidiEvent(ME_NOTEON, channel,
-                                                                                 event.pitch(), event.velo()));
+                        // use the note values instead of the event values if portamento is suppressed
+                        if (!exportRPNs && event.portamento()) {
+                            track.insert(pauseMap.addPauseTicks(i->first), MidiEvent(ME_NOTEON, channel,
+                                                                                     event.note()->pitch(), event.velo()));
+                        } else {
+                            track.insert(pauseMap.addPauseTicks(i->first), MidiEvent(ME_NOTEON, channel,
+                                                                                     event.pitch(), event.velo()));
+                        }
                     } else if (event.type() == ME_CONTROLLER) {
                         track.insert(pauseMap.addPauseTicks(i->first), MidiEvent(ME_CONTROLLER, channel,
                                                                                  event.controller(), event.value()));

--- a/audio/midi/event.h
+++ b/audio/midi/event.h
@@ -24,6 +24,11 @@ class Score;
 
 enum class BeatType : char;
 
+// 4 is the default for the majority of synthesisers, aka VSTis
+const int PITCH_BEND_SENSITIVITY = 4;
+
+const int MIDI_ON_SIGNAL = 127;
+
 //---------------------------------------------------------
 //   Event types
 //---------------------------------------------------------
@@ -89,43 +94,44 @@ enum {
 //---------------------------------------------------------
 
 enum CntrType {
-    CTRL_HBANK              = 0x00,
-    CTRL_LBANK              = 0x20,
+    CTRL_HBANK               = 0x00,
+    CTRL_LBANK               = 0x20,
 
-    CTRL_HDATA              = 0x06,
-    CTRL_LDATA              = 0x26,
+    CTRL_HDATA               = 0x06,
+    CTRL_LDATA               = 0x26,
 
-    CTRL_HNRPN              = 0x63,
-    CTRL_LNRPN              = 0x62,
+    CTRL_HNRPN               = 0x63,
+    CTRL_LNRPN               = 0x62,
 
-    CTRL_HRPN               = 0x65,
-    CTRL_LRPN               = 0x64,
+    CTRL_HRPN                = 0x65,
+    CTRL_LRPN                = 0x64,
 
-    CTRL_MODULATION         = 0x01,
-    CTRL_BREATH             = 0x02,
-    CTRL_FOOT               = 0x04,
-    CTRL_PORTAMENTO_TIME    = 0x05,
-    CTRL_VOLUME             = 0x07,
-    CTRL_PANPOT             = 0x0a,
-    CTRL_EXPRESSION         = 0x0b,
-    CTRL_SUSTAIN            = 0x40,
-    CTRL_PORTAMENTO         = 0x41,
-    CTRL_SOSTENUTO          = 0x42,
-    CTRL_SOFT_PEDAL         = 0x43,
-    CTRL_HARMONIC_CONTENT   = 0x47,
-    CTRL_RELEASE_TIME       = 0x48,
-    CTRL_ATTACK_TIME        = 0x49,
+    CTRL_MODULATION          = 0x01,
+    CTRL_BREATH              = 0x02,
+    CTRL_FOOT                = 0x04,
+    CTRL_PORTAMENTO_TIME_MSB = 0x05,
+    CTRL_VOLUME              = 0x07,
+    CTRL_PANPOT              = 0x0a,
+    CTRL_EXPRESSION          = 0x0b,
+    CTRL_PORTAMENTO_TIME_LSB = 0x25,
+    CTRL_SUSTAIN             = 0x40,
+    CTRL_PORTAMENTO          = 0x41,
+    CTRL_SOSTENUTO           = 0x42,
+    CTRL_SOFT_PEDAL          = 0x43,
+    CTRL_HARMONIC_CONTENT    = 0x47,
+    CTRL_RELEASE_TIME        = 0x48,
+    CTRL_ATTACK_TIME         = 0x49,
 
-    CTRL_BRIGHTNESS         = 0x4a,
-    CTRL_PORTAMENTO_CONTROL = 0x54,
-    CTRL_REVERB_SEND        = 0x5b,
-    CTRL_CHORUS_SEND        = 0x5d,
-    CTRL_VARIATION_SEND     = 0x5e,
+    CTRL_BRIGHTNESS          = 0x4a,
+    CTRL_PORTAMENTO_CONTROL  = 0x54,
+    CTRL_REVERB_SEND         = 0x5b,
+    CTRL_CHORUS_SEND         = 0x5d,
+    CTRL_VARIATION_SEND      = 0x5e,
 
-    CTRL_ALL_SOUNDS_OFF     = 0x78,   // 120
-    CTRL_RESET_ALL_CTRL     = 0x79,   // 121
-    CTRL_LOCAL_OFF          = 0x7a,   // 122
-    CTRL_ALL_NOTES_OFF      = 0x7b,    // 123
+    CTRL_ALL_SOUNDS_OFF      = 0x78,   // 120
+    CTRL_RESET_ALL_CTRL      = 0x79,   // 121
+    CTRL_LOCAL_OFF           = 0x7a,   // 122
+    CTRL_ALL_NOTES_OFF       = 0x7b,   // 123
 
     // special midi events are mapped to internal
     // controller
@@ -249,6 +255,7 @@ class NPlayEvent : public PlayEvent
     const Harmony* _harmony{ nullptr };
     int _origin = -1;
     int _discard = 0;
+    bool _portamento = false;
 
 public:
     NPlayEvent()
@@ -269,6 +276,14 @@ public:
     void setDiscard(int d) { _discard = d; }
     int discard() const { return _discard; }
     bool isMuted() const;
+    void setPortamento(bool p) { _portamento = p; }
+    bool portamento() const
+    {
+        return _portamento == true
+               || (this->type() == ME_CONTROLLER
+                   && (this->controller() == CTRL_PORTAMENTO || this->controller() == CTRL_PORTAMENTO_CONTROL
+                       || this->controller() == CTRL_PORTAMENTO_TIME_MSB || this->controller() == CTRL_PORTAMENTO_TIME_LSB));
+    }
 };
 
 //---------------------------------------------------------

--- a/audio/midi/fluid/chan.cpp
+++ b/audio/midi/fluid/chan.cpp
@@ -197,6 +197,14 @@ int Channel::getCC(int num)
     return ((num >= 0) && (num < 128)) ? cc[num] : 0;
 }
 
+int Channel::getFromKeyPortamento()
+{
+    if (synth) {
+        return synth->getFromKeyPortamento();
+    }
+    return -1;
+}
+
 //---------------------------------------------------------
 //   pitchBend
 //---------------------------------------------------------

--- a/audio/midi/fluid/fluid.cpp
+++ b/audio/midi/fluid/fluid.cpp
@@ -38,6 +38,12 @@ namespace FluidS {
 
 bool Fluid::initialized = false;
 
+/* better than a macro to determine inappropriate values for notes*/
+bool validNote(const int input)
+{
+    return input < 255 && input > -1;
+}
+
 /* default modulators
  * SF2.01 page 52 ff:
  *
@@ -100,6 +106,9 @@ void Fluid::init(float sampleRate)
         _tuning[i] = i * 100.0;
     }
     _masterTuning = 440.0;
+
+    fromkey_portamento = Channel::INVALID_NOTE;
+    lastNote = Channel::INVALID_NOTE;
 
     for (int i = 0; i < 512; i++) {
         freeVoices.append(new Voice(this));
@@ -327,6 +336,37 @@ void Fluid::pitch_wheel_sens(int chan, int val)
 {
     /* set the pitch-bend value in the channel */
     channel[chan]->pitchWheelSens(val);
+}
+
+/*
+ * setFromKeyPortamento
+ * requires an input for a default value, usually the TPC
+ */
+void Fluid::setFromKeyPortamento(int chan, int defaultValue)
+{
+    int ptc = get_cc(chan, PORTAMENTO_CTRL);
+    if (validNote(ptc)) {
+        resetPortamento(chan);
+        fromkey_portamento = ptc;
+        /*
+        // Assumedly this fixed some sort of bug in FluidSynth2
+        if (!validNote(defaultValue))
+            defaultValue = ptc;*/
+    } else {
+        /* determines and returns fromkey portamento */
+        fromkey_portamento = Channel::INVALID_NOTE;
+
+        if (portamentoTime(chan)) {
+            /* Portamento when Portamento pedal is On */
+            /* 'fromkey portamento'is determined from the portamento mode
+             and the most recent note played (prev_note)*/
+            if (validNote(defaultValue)) {
+                fromkey_portamento = ptc;
+            } else {
+                fromkey_portamento = lastNote;
+            }
+        }
+    }
 }
 
 /*

--- a/audio/midi/fluid/fluid.h
+++ b/audio/midi/fluid/fluid.h
@@ -221,6 +221,10 @@ class Channel
     Preset* _preset;
 
 public:
+    enum {
+        INVALID_NOTE = -1
+    };
+
     int channum;
     short channel_pressure;
     short pitch_bend;
@@ -286,6 +290,7 @@ public:
     int channelPressure() const { return channel_pressure; }
     void setKeyPressure(int key, int val);
     int keyPressure(int key) const { return key_pressure[key]; }
+    int getFromKeyPortamento();
 };
 
 // subsystems:
@@ -320,6 +325,9 @@ class Fluid : public Synthesizer
 
     //the variable is used to stop loading samples from the sf files
     bool _globalTerminate = false;
+
+    int fromkey_portamento = Channel::INVALID_NOTE;
+    int lastNote = Channel::INVALID_NOTE;
 
 protected:
     int _state;                           // the synthesizer state
@@ -372,6 +380,11 @@ public:
     void update_presets();
 
     int get_cc(int chan, int num) const { return channel[chan]->cc[num]; }
+    void resetPortamento(int chan) const { channel[chan]->cc[PORTAMENTO_CTRL] = Channel::INVALID_NOTE; }
+    int portamentoTime(int chan) const
+    {
+        return get_cc(chan, PORTAMENTO_TIME_MSB) * 128 + get_cc(chan, PORTAMENTO_TIME_LSB);
+    }
 
     void system_reset();
     void program_change(int chan, int prognum);
@@ -423,6 +436,9 @@ public:
 
     bool globalTerminate() { return _globalTerminate; }
     void setGlobalTerminate(bool terminate = true) { _globalTerminate = terminate; }
+    int getFromKeyPortamento() { return fromkey_portamento; }
+    void setFromKeyPortamento(int chan, int defaultValue);
+    void setLastNote(int last_note) { this->lastNote = last_note; }
 
     friend class Voice;
     friend class Preset;

--- a/audio/midi/fluid/sfont.cpp
+++ b/audio/midi/fluid/sfont.cpp
@@ -212,6 +212,9 @@ bool Preset::noteon(Fluid* synth, unsigned id, int chan, int key, int vel, doubl
             Instrument* inst = preset_zone->get_inst();
             Zone* global_inst_zone = inst->get_global_zone();
 
+            /* set portamento attributes*/
+            synth->setFromKeyPortamento(chan, key);
+
             /* run thru all the zones of this instrument */
             for (Zone* inst_zone : inst->get_zone()) {
                 /* make sure this instrument zone has a valid sample */
@@ -362,7 +365,7 @@ bool Preset::noteon(Fluid* synth, unsigned id, int chan, int key, int vel, doubl
 
                     /* add the synthesis process to the synthesis loop. */
                     synth->start_voice(voice);
-
+                    synth->setLastNote(key);
                     /* Store the ID of the first voice that was created by this noteon event.
                      * Exclusive class may only terminate older voices.
                      * That avoids killing voices, which have just been created.

--- a/audio/midi/fluid/voice.h
+++ b/audio/midi/fluid/voice.h
@@ -138,6 +138,10 @@ public:
     int loopstart;
     int loopend;
 
+    /* Stuff needed for portamento calculations */
+    float pitchoffset;        /* the portamento range in midicents */
+    float pitchinc;           /* the portamento increment in midicents */
+
     /* vol env */
     fluid_env_data_t volenv_data[FLUID_VOICE_ENVLAST];
     unsigned int volenv_count;
@@ -268,6 +272,10 @@ public:
     int dsp_float_interpolate_linear(unsigned);
     int dsp_float_interpolate_4th_order(unsigned);
     int dsp_float_interpolate_7th_order(unsigned);
+
+    void updatePortamento(int fromKey, int toKey);
+    float fluid_voice_calculate_pitch(int key);
+    void setPortamento(unsigned int countinc, float pitchoffset);
 };
 }
 

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -728,6 +728,8 @@ QVariant propertyFromString(Pid id, QString value)
             return QVariant(int(GlissandoStyle::BLACK_KEYS));
         } else if (value == "diatonic") {
             return QVariant(int(GlissandoStyle::DIATONIC));
+        } else if (value == "portamento") {
+            return QVariant(int(GlissandoStyle::PORTAMENTO));
         } else {       // e.g., normally "Chromatic"
             return QVariant(int(GlissandoStyle::CHROMATIC));
         }
@@ -1038,6 +1040,8 @@ QString propertyToString(Pid id, QVariant value, bool mscx)
             return "whitekeys";
         case GlissandoStyle::DIATONIC:
             return "diatonic";
+        case GlissandoStyle::PORTAMENTO:
+            return "portamento";
         case GlissandoStyle::CHROMATIC:
             return "Chromatic";
         }

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -246,9 +246,21 @@ void Score::updateChannel()
 }
 
 //---------------------------------------------------------
+//   Converts midi time (noteoff - noteon) to milliseconds
+//---------------------------------------------------------
+int toMilliseconds(float tempo, float midiTime)
+{
+    float ticksPerSecond = (float)MScore::division * tempo;
+    int time = (int)((midiTime / ticksPerSecond) * 1000.0f);
+    if (time > 0x7fff) { //maximum possible value
+        time = 0x7fff;
+    }
+    return time;
+}
+
+//---------------------------------------------------------
 //   playNote
 //---------------------------------------------------------
-
 static void playNote(EventMap* events, const Note* note, int channel, int pitch,
                      int velo, int onTime, int offTime, int staffIdx)
 {
@@ -263,6 +275,47 @@ static void playNote(EventMap* events, const Note* note, int channel, int pitch,
     if (offTime < onTime) {
         offTime = onTime;
     }
+
+    // adds portamento for continuous glissando
+    for (Spanner* spanner : note->spannerFor()) {
+        if (spanner->type() == ElementType::GLISSANDO) {
+            Glissando* glissando = toGlissando(spanner);
+            GlissandoStyle glissandoStyle = glissando->glissandoStyle();
+            if (glissandoStyle == GlissandoStyle::PORTAMENTO) {
+                //Changes the notes pitch to the next note's pitch, note-on is the eventual pitch
+                Note* nextNote = toNote(spanner->endElement());
+                ev.setPitch(nextNote->pitch());
+
+                int time = toMilliseconds(note->score()->tempo(note->tick()), offTime - onTime);
+                int lsb = (time & 0x00FF);
+                time = (time >> 8);
+                int msb = (time & 0x00FF);
+
+                NPlayEvent portamentoOn(ME_CONTROLLER, channel, CTRL_PORTAMENTO, MIDI_ON_SIGNAL);
+                portamentoOn.setOriginatingStaff(staffIdx);
+                NPlayEvent portamentoControl(ME_CONTROLLER, channel, CTRL_PORTAMENTO_CONTROL, pitch);
+                portamentoControl.setOriginatingStaff(staffIdx);
+                NPlayEvent portamentoTimeMSB(ME_CONTROLLER, channel, CTRL_PORTAMENTO_TIME_MSB, msb);
+                portamentoTimeMSB.setOriginatingStaff(staffIdx);
+                NPlayEvent portamentoTimeLSB(ME_CONTROLLER, channel, CTRL_PORTAMENTO_TIME_LSB, lsb);
+                portamentoTimeLSB.setOriginatingStaff(staffIdx);
+
+                ev.setPortamento(true);
+                if (onTime == 0) {
+                    onTime++;
+                }
+                events->insert(std::pair<int, NPlayEvent>(onTime - 1, portamentoOn));
+                events->insert(std::pair<int, NPlayEvent>(onTime - 1, portamentoControl));
+                events->insert(std::pair<int, NPlayEvent>(onTime - 1, portamentoTimeMSB));
+                events->insert(std::pair<int, NPlayEvent>(onTime - 1, portamentoTimeLSB));
+
+                NPlayEvent portamentoOff(ME_CONTROLLER, channel, CTRL_PORTAMENTO, 0);
+                portamentoOff.setOriginatingStaff(staffIdx);
+                events->insert(std::pair<int, NPlayEvent>(offTime, portamentoOff));
+            }
+        }
+    }
+
     events->insert(std::pair<int, NPlayEvent>(onTime, ev));
     ev.setVelo(0);
     events->insert(std::pair<int, NPlayEvent>(offTime, ev));
@@ -1893,6 +1946,10 @@ void renderGlissando(NoteEventList* events, Note* notestart)
             Glissando* glissando = toGlissando(spanner);
             GlissandoStyle glissandoStyle = glissando->glissandoStyle();
             Element* ee = spanner->endElement();
+            // handle this elsewhere in a different way
+            if (glissandoStyle == GlissandoStyle::PORTAMENTO) {
+                continue;
+            }
             // only consider glissando connected to NOTE.
             if (glissando->playGlissando() && ElementType::NOTE == ee->type()) {
                 std::vector<int> body;

--- a/libmscore/types.h
+++ b/libmscore/types.h
@@ -378,7 +378,7 @@ enum class GlissandoType {
 
 enum class GlissandoStyle {
     ///.\{
-    CHROMATIC, WHITE_KEYS, BLACK_KEYS, DIATONIC
+    CHROMATIC, WHITE_KEYS, BLACK_KEYS, DIATONIC, PORTAMENTO
     ///\}
 };
 

--- a/mu4/inspector/view/qml/MuseScore/Inspector/general/playback/internal/GlissandoExpandableBlank.qml
+++ b/mu4/inspector/view/qml/MuseScore/Inspector/general/playback/internal/GlissandoExpandableBlank.qml
@@ -30,7 +30,8 @@ ExpandableBlank {
                 { text: "Chromatic", value: Glissando.STYLE_CHROMATIC },
                 { text: "White keys", value: Glissando.STYLE_WHITE_KEYS },
                 { text: "Black keys", value: Glissando.STYLE_BLACK_KEYS },
-                { text: "Diatonic", value: Glissando.STYLE_DIATONIC }
+                { text: "Diatonic", value: Glissando.STYLE_DIATONIC },
+                { text: "Portamento", value: Glissando.STYLE_PORTAENTO }
             ]
 
             currentIndex: root.model && !root.model.styleType.isUndefined ? indexOfValue(root.model.styleType.value) : -1


### PR DESCRIPTION
Resolves https://musescore.org/en/node/127341

to replace/rebase @MichaelFroelich's #4824 resp. #5853, but for master.
It uses the old fluidsynth, not the new one though, porting it to that is beyond my paygrade...,