### PR TITLE
Make sure initElementStyle() is called after initialising the member

### DIFF
--- a/libmscore/articulation.cpp
+++ b/libmscore/articulation.cpp
@@ -42,13 +42,13 @@ static const ElementStyle articulationStyle {
 Articulation::Articulation(Score* s)
    : Element(s, ElementFlag::MOVABLE)
       {
-      initElementStyle(&articulationStyle);
       _symId         = SymId::noSym;
       _anchor        = ArticulationAnchor::TOP_STAFF;
       _direction     = Direction::AUTO;
       _up            = true;
       _ornamentStyle = MScore::OrnamentStyle::DEFAULT;
       setPlayArticulation(true);
+      initElementStyle(&articulationStyle);
       }
 
 Articulation::Articulation(SymId id, Score* s)

--- a/libmscore/dynamic.cpp
+++ b/libmscore/dynamic.cpp
@@ -144,12 +144,12 @@ int Dynamic::findInString(const QString& s, int& length, QString& type)
 Dynamic::Dynamic(Score* s)
    : TextBase(s, Tid::DYNAMICS, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
       {
-      initElementStyle(&dynamicsStyle);
       _velocity    = -1;
       _dynRange    = Range::PART;
       _dynamicType = Type::OTHER;
       _changeInVelocity = 128;
       _velChangeSpeed = Speed::NORMAL;
+      initElementStyle(&dynamicsStyle);
       }
 
 Dynamic::Dynamic(const Dynamic& d)

--- a/libmscore/fermata.cpp
+++ b/libmscore/fermata.cpp
@@ -41,11 +41,11 @@ static const ElementStyle fermataStyle {
 Fermata::Fermata(Score* s)
    : Element(s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
       {
-      initElementStyle(&fermataStyle);
       setPlacement(Placement::ABOVE);
       _symId         = SymId::noSym;
       _timeStretch   = 1.0;
       setPlay(true);
+      initElementStyle(&fermataStyle);
       }
 
 Fermata::Fermata(SymId id, Score* s)

--- a/libmscore/textline.cpp
+++ b/libmscore/textline.cpp
@@ -66,8 +66,6 @@ void TextLineSegment::layout()
 TextLine::TextLine(Score* s)
    : TextLineBase(s)
       {
-      initElementStyle(&textLineStyle);
-
       setBeginText("");
       setContinueText("");
       setEndText("");
@@ -80,6 +78,8 @@ TextLine::TextLine(Score* s)
       setEndHookType(HookType::NONE);
       setBeginHookHeight(Spatium(1.5));
       setEndHookHeight(Spatium(1.5));
+
+      initElementStyle(&textLineStyle);
 
       resetProperty(Pid::BEGIN_TEXT_PLACE);
       resetProperty(Pid::CONTINUE_TEXT_PLACE);


### PR DESCRIPTION
Resolves: no issue

Make sure <code>initElementStyle()</code> is called after initialising the member to provide style settings are overwritten by the member initialisation.
This is the result of a check when a similar issue was found in <code>Beam</code>, see also #6754 

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
