### PR TITLE
Fix #312279 - C time signature does not update

### DIFF
--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -497,10 +497,10 @@ void ScoreView::editTimeSigProperties(TimeSig* ts)
       TimeSigProperties tsp(r);
 
       if (tsp.exec()) {
+            ts->undoChangeProperty(Pid::TIMESIG_TYPE, int(r->timeSigType()));
             ts->undoChangeProperty(Pid::SHOW_COURTESY, r->showCourtesySig());
             ts->undoChangeProperty(Pid::NUMERATOR_STRING, r->numeratorString());
             ts->undoChangeProperty(Pid::DENOMINATOR_STRING, r->denominatorString());
-            ts->undoChangeProperty(Pid::TIMESIG_TYPE, int(r->timeSigType()));
             ts->undoChangeProperty(Pid::GROUPS, QVariant::fromValue<Groups>(r->groups()));
 
             if (r->sig() != ts->sig()) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/312279

Change timesig type before changing numerator/denumerator string because these strings can only be change when timesig type is normal.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
