### PR TITLE
Resizing vbox accordingly to the content size

### DIFF
--- a/libmscore/box.cpp
+++ b/libmscore/box.cpp
@@ -321,6 +321,16 @@ void Box::add(Element* e)
       MeasureBase::add(e);
       }
 
+QRectF Box::contentRect() const
+      {
+      QRectF result;
+
+      for (const Element* element : el())
+            result = result.united(element->bbox());
+
+      return result;
+      }
+
 //---------------------------------------------------------
 //   getProperty
 //---------------------------------------------------------
@@ -724,6 +734,16 @@ VBox::VBox(Score* score)
       setLineBreak(true);
       }
 
+qreal VBox::minHeight() const
+      {
+      return point(Spatium(10));
+      }
+
+qreal VBox::maxHeight() const
+      {
+      return point(Spatium(30));
+      }
+
 //---------------------------------------------------------
 //   layout
 //---------------------------------------------------------
@@ -731,11 +751,25 @@ VBox::VBox(Score* score)
 void VBox::layout()
       {
       setPos(QPointF());
+
       if (system())
             bbox().setRect(0.0, 0.0, system()->width(), point(boxHeight()));
       else
             bbox().setRect(0.0, 0.0, 50, 50);
-      Box::layout();
+
+      for (Element* e : el()) {
+            if (!e->isLayoutBreak())
+                  e->layout();
+            }
+
+      qreal contentHeight = contentRect().height();
+
+      if (contentHeight < minHeight())
+            contentHeight = minHeight();
+
+      setHeight(contentHeight);
+
+      MeasureBase::layout();
       }
 
 //---------------------------------------------------------

--- a/libmscore/box.cpp
+++ b/libmscore/box.cpp
@@ -203,7 +203,7 @@ void Box::writeProperties(XmlWriter& xml) const
       {
       for (Pid id : {
          Pid::BOX_HEIGHT, Pid::BOX_WIDTH, Pid::TOP_GAP, Pid::BOTTOM_GAP,
-         Pid::LEFT_MARGIN, Pid::RIGHT_MARGIN, Pid::TOP_MARGIN, Pid::BOTTOM_MARGIN }) {
+         Pid::LEFT_MARGIN, Pid::RIGHT_MARGIN, Pid::TOP_MARGIN, Pid::BOTTOM_MARGIN, Pid::BOX_AUTOSIZE }) {
             writeProperty(xml, id);
             }
       Element::writeProperties(xml);
@@ -257,6 +257,8 @@ bool Box::readProperties(XmlReader& e)
             _topMargin = e.readDouble();
       else if (tag == "bottomMargin")
             _bottomMargin = e.readDouble();
+      else if (tag == "boxAutoSize")
+            _isAutoSizeEnabled = e.readBool();
       else if (tag == "Text") {
             Text* t;
             if (isTBox()) {
@@ -354,6 +356,8 @@ QVariant Box::getProperty(Pid propertyId) const
                   return _topMargin;
             case Pid::BOTTOM_MARGIN:
                   return _bottomMargin;
+            case Pid::BOX_AUTOSIZE:
+                  return _isAutoSizeEnabled;
             default:
                   return MeasureBase::getProperty(propertyId);
             }
@@ -391,6 +395,9 @@ bool Box::setProperty(Pid propertyId, const QVariant& v)
             case Pid::BOTTOM_MARGIN:
                   _bottomMargin = v.toDouble();
                   break;
+            case Pid::BOX_AUTOSIZE:
+                  _isAutoSizeEnabled = v.toBool();
+                  break;
             default:
                   return MeasureBase::setProperty(propertyId, v);
             }
@@ -419,6 +426,8 @@ QVariant Box::propertyDefault(Pid id) const
             case Pid::TOP_MARGIN:
             case Pid::BOTTOM_MARGIN:
                   return 0.0;
+            case Pid::BOX_AUTOSIZE:
+                  return false;
             default:
                   return MeasureBase::propertyDefault(id);
             }
@@ -732,6 +741,7 @@ VBox::VBox(Score* score)
       initElementStyle(&boxStyle);
       setBoxHeight(Spatium(10.0));
       setLineBreak(true);
+      setAutoSizeEnabled(score->mscVersion() >= 302); // enable auto-size feature only for newest scores by default
       }
 
 qreal VBox::minHeight() const
@@ -742,6 +752,16 @@ qreal VBox::minHeight() const
 qreal VBox::maxHeight() const
       {
       return point(Spatium(30));
+      }
+
+QVariant VBox::getProperty(Pid propertyId) const
+      {
+      switch (propertyId) {
+            case Pid::BOX_AUTOSIZE:
+                  return isAutoSizeEnabled();
+            default:
+                  return Box::getProperty(propertyId);
+      }
       }
 
 //---------------------------------------------------------
@@ -762,12 +782,14 @@ void VBox::layout()
                   e->layout();
             }
 
-      qreal contentHeight = contentRect().height();
+      if (getProperty(Pid::BOX_AUTOSIZE).toBool()) {
+            qreal contentHeight = contentRect().height();
 
-      if (contentHeight < minHeight())
-            contentHeight = minHeight();
+            if (contentHeight < minHeight())
+                  contentHeight = minHeight();
 
-      setHeight(contentHeight);
+            setHeight(contentHeight);
+            }
 
       MeasureBase::layout();
       }

--- a/libmscore/box.h
+++ b/libmscore/box.h
@@ -41,6 +41,7 @@ class Box : public MeasureBase {
       qreal _rightMargin            { 0.0   };       // inner margins in metric mm
       qreal _topMargin              { 0.0   };
       qreal _bottomMargin           { 0.0   };
+      bool _isAutoSizeEnabled       { false };
       bool editMode                 { false };
 
    public:
@@ -81,6 +82,8 @@ class Box : public MeasureBase {
       void setTopGap(qreal val)       { _topGap = val;        }
       qreal bottomGap() const         { return _bottomGap;    }
       void setBottomGap(qreal val)    { _bottomGap = val;     }
+      bool isAutoSizeEnabled() const  { return _isAutoSizeEnabled; }
+      void setAutoSizeEnabled(const bool val) { _isAutoSizeEnabled = val; }
       void copyValues(Box* origin);
 
       virtual QVariant getProperty(Pid propertyId) const override;
@@ -147,6 +150,7 @@ class VBox : public Box {
       qreal minHeight() const;
       qreal maxHeight() const;
 
+      QVariant getProperty(Pid propertyId) const override;
       void layout() override;
 
       std::vector<QPointF> gripsPositions(const EditData&) const override;

--- a/libmscore/box.h
+++ b/libmscore/box.h
@@ -64,6 +64,7 @@ class Box : public MeasureBase {
       virtual Element* drop(EditData&) override;
       virtual void add(Element* e) override;
 
+      QRectF contentRect() const;
       Spatium boxWidth() const        { return _boxWidth;     }
       void setBoxWidth(Spatium val)   { _boxWidth = val;      }
       Spatium boxHeight() const       { return _boxHeight;    }
@@ -142,6 +143,9 @@ class VBox : public Box {
 
       VBox* clone() const override      { return new VBox(*this); }
       ElementType type() const override { return ElementType::VBOX; }
+
+      qreal minHeight() const;
+      qreal maxHeight() const;
 
       void layout() override;
 

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -109,6 +109,7 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::BOX_HEIGHT,              false, "height",                P_TYPE::SPATIUM,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "height")           },
 
       { Pid::BOX_WIDTH,               false, "width",                 P_TYPE::SPATIUM,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "width")            },
+      { Pid::BOX_AUTOSIZE,            false, "boxAutoSize",           P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("prooertyName", "autosize frame")   },
       { Pid::TOP_GAP,                 false, "topGap",                P_TYPE::SP_REAL,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "top gap")          },
       { Pid::BOTTOM_GAP,              false, "bottomGap",             P_TYPE::SP_REAL,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "bottom gap")       },
       { Pid::LEFT_MARGIN,             false, "leftMargin",            P_TYPE::REAL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "left margin")      },

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -114,8 +114,8 @@ enum class Pid {
       GROW_LEFT,
       GROW_RIGHT,
       BOX_HEIGHT,
-
       BOX_WIDTH,
+      BOX_AUTOSIZE,
       TOP_GAP,
       BOTTOM_GAP,
       LEFT_MARGIN,

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -1804,7 +1804,11 @@ void TextBase::layout1()
                         // consider inner margins of frame
                         Box* b = toBox(parent());
                         yoff = b->topMargin()  * DPMM;
-                        h  = b->height() - yoff - b->bottomMargin() * DPMM;
+
+                        if (b->height() < bb.bottom())
+                              h = b->height() / 2 + bb.height();
+                        else
+                              h  = b->height() - yoff - b->bottomMargin() * DPMM;
                         }
                   else if (parent()->isPage()) {
                         Page* p = toPage(parent());

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -569,7 +569,8 @@ InspectorVBox::InspectorVBox(QWidget* parent)
             { Pid::RIGHT_MARGIN,  0, vb.rightMargin,  vb.resetRightMargin  },
             { Pid::TOP_MARGIN,    0, vb.topMargin,    vb.resetTopMargin    },
             { Pid::BOTTOM_MARGIN, 0, vb.bottomMargin, vb.resetBottomMargin },
-            { Pid::BOX_HEIGHT,    0, vb.height,       0                    }
+            { Pid::BOX_HEIGHT,    0, vb.height,       0                    },
+            { Pid::BOX_AUTOSIZE,  0, vb.enableAutoSize, vb.resetAutoSize   }
             };
       pList = { { vb.title, vb.panel } };
       mapSignals();

--- a/mscore/inspector/inspector_vbox.ui
+++ b/mscore/inspector/inspector_vbox.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>265</width>
-    <height>239</height>
+    <height>263</height>
    </rect>
   </property>
   <property name="accessibleName">
@@ -415,6 +415,26 @@
        <widget class="Line" name="line">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QCheckBox" name="enableAutoSize">
+        <property name="text">
+         <string>Enable Auto-Size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="2">
+       <widget class="Ms::ResetButton" name="resetAutoSize" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'AutoSize&quot; value</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Now the height of the vbox depends on the size of its content.

Earlier, on some scores, the title page might look like this:

![изображение](https://user-images.githubusercontent.com/57620349/97451231-37cf5980-193c-11eb-8fff-5c7d3adb6df1.png)

And here is what we have now:

![Peek 2020-10-22 22-35](https://user-images.githubusercontent.com/57620349/97451358-5897af00-193c-11eb-92ef-d335b7689351.gif)

