### PR TITLE
[MU4] New score wizard stabilization

### DIFF
--- a/framework/uicomponents/qml/MuseScore/UiComponents/StyledComboBox.qml
+++ b/framework/uicomponents/qml/MuseScore/UiComponents/StyledComboBox.qml
@@ -14,6 +14,8 @@ ComboBox {
     property var value
     property var maxVisibleItemCount: 6
 
+    opacity: root.enabled ? 1 : ui.theme.itemOpacityDisabled
+
     function valueFromModel(index, roleName) {
 
         // Simple models (like JS array) with single predefined role name - modelData

--- a/mu4/instruments/instrumentstypes.h
+++ b/mu4/instruments/instrumentstypes.h
@@ -72,22 +72,24 @@ struct MidiAction
 };
 using MidiActionList = QList<MidiAction>;
 
-using MidiArticulationHash = QHash<QString /*id*/, MidiArticulation>;
+using MidiArticulationMap = QMap<QString /*id*/, MidiArticulation>;
 
 struct InstrumentGroup
 {
     QString id;
     QString name;
-    bool extended;
+    bool extended = false;
 };
-using InstrumentGroupHash = QHash<QString /*id*/, InstrumentGroup>;
+
+using InstrumentGroupList = QList<InstrumentGroup>;
+using InstrumentGroupMap = QMap<QString /*id*/, InstrumentGroup>;
 
 struct InstrumentGenre
 {
     QString id;
     QString name;
 };
-using InstrumentGenreHash = QHash<QString /*id*/, InstrumentGenre>;
+using InstrumentGenreMap = QMap<QString /*id*/, InstrumentGenre>;
 
 struct Transposition
 {
@@ -157,15 +159,15 @@ struct InstrumentTemplate
     bool isValid() const { return !id.isEmpty(); }
 };
 
-using InstrumentTemplateHash = QHash<QString /*id*/, InstrumentTemplate>;
+using InstrumentTemplateMap = QMap<QString /*id*/, InstrumentTemplate>;
 using InstrumentTemplateList = QList<InstrumentTemplate>;
 
 struct InstrumentsMeta
 {
-    InstrumentTemplateHash instrumentTemplates;
-    InstrumentGroupHash groups;
-    InstrumentGenreHash genres;
-    MidiArticulationHash articulations;
+    InstrumentTemplateMap instrumentTemplates;
+    InstrumentGroupMap groups;
+    InstrumentGenreMap genres;
+    MidiArticulationMap articulations;
 };
 }
 

--- a/mu4/instruments/instrumentstypes.h
+++ b/mu4/instruments/instrumentstypes.h
@@ -29,8 +29,7 @@
 #include "libmscore/instrument.h"
 #include "framework/midi/miditypes.h"
 
-namespace mu {
-namespace instruments {
+namespace mu::instruments {
 static constexpr int MAX_STAVES  = 4;
 
 using Interval = Ms::Interval;
@@ -168,7 +167,6 @@ struct InstrumentsMeta
     InstrumentGenreHash genres;
     MidiArticulationHash articulations;
 };
-}
 }
 
 Q_DECLARE_METATYPE(mu::instruments::Instrument)

--- a/mu4/instruments/internal/instrumentsreader.h
+++ b/mu4/instruments/internal/instrumentsreader.h
@@ -43,7 +43,7 @@ private:
     struct GroupMeta
     {
         InstrumentGroup group;
-        InstrumentTemplateHash templates;
+        InstrumentTemplateMap templates;
     };
 
     void loadGroupMeta(Ms::XmlReader& reader, InstrumentsMeta& generalMeta) const;

--- a/mu4/instruments/internal/instrumentsreader.h
+++ b/mu4/instruments/internal/instrumentsreader.h
@@ -46,7 +46,7 @@ private:
         InstrumentTemplateHash templates;
     };
 
-    GroupMeta readGroupMeta(Ms::XmlReader& reader, InstrumentsMeta& generalMeta) const;
+    void loadGroupMeta(Ms::XmlReader& reader, InstrumentsMeta& generalMeta) const;
     MidiArticulation readArticulation(Ms::XmlReader& reader) const;
     InstrumentGenre readGenre(Ms::XmlReader& reader) const;
     InstrumentTemplate readInstrumentTemplate(Ms::XmlReader& reader, InstrumentsMeta& generalMeta) const;
@@ -57,6 +57,7 @@ private:
     StringData readStringData(Ms::XmlReader& reader) const;
 
     void fillByDeffault(Instrument& instrument) const;
+    void initInstrument(Instrument& sourceInstrument, const Instrument& destinationInstrument) const;
 };
 }
 }

--- a/mu4/instruments/internal/instrumentsrepository.cpp
+++ b/mu4/instruments/internal/instrumentsrepository.cpp
@@ -63,7 +63,7 @@ void InstrumentsRepository::load()
     for (const io::path& path: instrumentsPaths) {
         RetVal<std::vector<io::path> > files = fileSystem()->scanFiles(path, { QString("*.xml") }, IFileSystem::ScanMode::IncludeSubdirs);
         if (!files.ret) {
-            LOGW() << files.ret.code() << files.ret.text();
+            LOGE() << files.ret.toString();
         }
 
         for (const io::path& file: files.val) {
@@ -75,25 +75,26 @@ void InstrumentsRepository::load()
         RetVal<InstrumentsMeta> metaInstrument = reader()->readMeta(file);
 
         if (!metaInstrument.ret) {
+            LOGE() << metaInstrument.ret.toString();
             continue;
         }
 
-        const InstrumentTemplateHash& templates = metaInstrument.val.instrumentTemplates;
+        const InstrumentTemplateMap& templates = metaInstrument.val.instrumentTemplates;
         for (auto it = templates.cbegin(); it != templates.cend(); ++it) {
             m_instrumentsMeta.instrumentTemplates.insert(it.key(), it.value());
         }
 
-        const MidiArticulationHash& acticulations = metaInstrument.val.articulations;
+        const MidiArticulationMap& acticulations = metaInstrument.val.articulations;
         for (auto it = acticulations.cbegin(); it != acticulations.cend(); ++it) {
             m_instrumentsMeta.articulations.insert(it.key(), it.value());
         }
 
-        const InstrumentGenreHash& genres = metaInstrument.val.genres;
+        const InstrumentGenreMap& genres = metaInstrument.val.genres;
         for (auto it = genres.cbegin(); it != genres.cend(); ++it) {
             m_instrumentsMeta.genres.insert(it.key(), it.value());
         }
 
-        const InstrumentGroupHash& groups = metaInstrument.val.groups;
+        const InstrumentGroupMap& groups = metaInstrument.val.groups;
         for (auto it = groups.cbegin(); it != groups.cend(); ++it) {
             m_instrumentsMeta.groups.insert(it.key(), it.value());
         }

--- a/mu4/instruments/qml/MuseScore/Instruments/ChooseInstrumentsPage.qml
+++ b/mu4/instruments/qml/MuseScore/Instruments/ChooseInstrumentsPage.qml
@@ -79,6 +79,10 @@ Rectangle {
                 instrumentsModel.setSearchText(search)
                 Qt.callLater(familyView.selectFirstGroup)
             }
+
+            onSelectInstrumentRequested: {
+                instrumentsModel.selectInstrument(instrumentId, transposition)
+            }
         }
 
         SeparatorLine { orientation: Qt.Vertical }

--- a/mu4/instruments/qml/MuseScore/Instruments/InstrumentsView.qml
+++ b/mu4/instruments/qml/MuseScore/Instruments/InstrumentsView.qml
@@ -13,6 +13,8 @@ Item {
 
     property bool isInstrumentSelected: privateProperties.currentInstrumentIndex != -1
 
+    signal selectInstrumentRequested(var instrumentId, var transposition)
+
     QtObject {
         id: privateProperties
 
@@ -103,6 +105,11 @@ Item {
 
                 onClicked: {
                     privateProperties.currentInstrumentIndex = index
+                }
+
+                onDoubleClicked: {
+                    var currentSelection = root.currentInstrument()
+                    root.selectInstrumentRequested(currentSelection.instrument.id, currentSelection.transposition)
                 }
             }
 

--- a/mu4/instruments/qml/MuseScore/Instruments/SelectedInstrumentsView.qml
+++ b/mu4/instruments/qml/MuseScore/Instruments/SelectedInstrumentsView.qml
@@ -124,6 +124,10 @@ Item {
                 onClicked: {
                     root.currentInstrumentIndex = index
                 }
+
+                onDoubleClicked: {
+                    root.unselectInstrumentRequested(modelData.id)
+                }
             }
         }
     }

--- a/mu4/instruments/view/instrumentlistmodel.h
+++ b/mu4/instruments/view/instrumentlistmodel.h
@@ -79,6 +79,7 @@ private:
     void setInstrumentsMeta(const InstrumentsMeta& meta);
     QVariantList allInstrumentsGroupList() const;
     QVariantMap allInstrumentsItem() const;
+    InstrumentGroupList sortedGroupList() const;
 
     QVariantMap defaultInstrumentTranspositionItem() const;
 

--- a/mu4/userscores/qml/MuseScore/UserScores/internal/MeasuresSettings.qml
+++ b/mu4/userscores/qml/MuseScore/UserScores/internal/MeasuresSettings.qml
@@ -93,15 +93,10 @@ FlatButton {
                 }
             }
 
-            Rectangle {
-                anchors.left: parent.left
-                anchors.right: parent.right
-
-                height: 2
-
-                color: ui.theme.buttonColor
+            SeparatorLine {
+                anchors.leftMargin: -(parent.anchors.leftMargin + popup.leftPadding)
+                anchors.rightMargin: -(parent.anchors.rightMargin + popup.rightPadding)
             }
-
 
             Column {
                 anchors.left: parent.left

--- a/mu4/userscores/qml/MuseScore/UserScores/internal/MeasuresSettings.qml
+++ b/mu4/userscores/qml/MuseScore/UserScores/internal/MeasuresSettings.qml
@@ -81,7 +81,7 @@ FlatButton {
                     numerator: root.model.pickupTimeSignature.numerator
                     denominator: root.model.pickupTimeSignature.denominator
                     availableDenominators: root.model.timeSignatureDenominators()
-                    active: withPickupMeasure.checked
+                    enabled: withPickupMeasure.checked
 
                     onNumeratorSelected: {
                         root.model.setPickupTimeSignatureNumerator(value)

--- a/mu4/userscores/qml/MuseScore/UserScores/internal/TempoSettings.qml
+++ b/mu4/userscores/qml/MuseScore/UserScores/internal/TempoSettings.qml
@@ -67,13 +67,9 @@ FlatButton {
                 }
             }
 
-            Rectangle {
-                anchors.left: parent.left
-                anchors.right: parent.right
-
-                height: 2
-
-                color: ui.theme.buttonColor
+            SeparatorLine {
+                anchors.leftMargin: -(parent.anchors.leftMargin + popup.leftPadding)
+                anchors.rightMargin: -(parent.anchors.rightMargin + popup.rightPadding)
             }
 
             ListView {

--- a/mu4/userscores/qml/MuseScore/UserScores/internal/TimeSignatureFraction.qml
+++ b/mu4/userscores/qml/MuseScore/UserScores/internal/TimeSignatureFraction.qml
@@ -8,7 +8,6 @@ Row {
     property var numerator: 0
     property var denominator: 0
     property var availableDenominators: null
-    property bool active: true
 
     signal numeratorSelected(var value)
     signal denominatorSelected(var value)
@@ -19,8 +18,6 @@ Row {
         id: control
 
         implicitWidth: 80
-
-        enabled: root.active
 
         iconMode: iconModeEnum.hidden
         currentValue: root.numerator
@@ -48,8 +45,6 @@ Row {
         id: timeComboBox
 
         implicitWidth: 90
-
-        enabled: root.active
 
         textRoleName: "text"
         valueRoleName: "value"

--- a/mu4/userscores/qml/MuseScore/UserScores/internal/TimeSignatureSettings.qml
+++ b/mu4/userscores/qml/MuseScore/UserScores/internal/TimeSignatureSettings.qml
@@ -97,7 +97,7 @@ FlatButton {
             numerator: root.model.timeSignature.numerator
             denominator: root.model.timeSignature.denominator
             availableDenominators: root.model.timeSignatureDenominators()
-            active: (root.model.timeSignatureType === AdditionalInfoModel.Fraction)
+            enabled: (root.model.timeSignatureType === AdditionalInfoModel.Fraction)
 
             onNumeratorSelected: {
                 root.model.setTimeSignatureNumerator(value)

--- a/mu4/userscores/view/templatepaintview.cpp
+++ b/mu4/userscores/view/templatepaintview.cpp
@@ -122,6 +122,9 @@ void TemplatePaintView::load(const QString& templatePath)
     Ret ret = m_notation->load(m_templatePath);
     if (!ret) {
         LOGE() << ret.toString();
+        m_notation = nullptr;
+        update();
+        return;
     }
 
     scaleCanvas(INITIAL_SCALE_FACTOR);

--- a/mu4/userscores/view/templatesmodel.cpp
+++ b/mu4/userscores/view/templatesmodel.cpp
@@ -17,7 +17,12 @@ void TemplatesModel::load()
         LOGE() << templates.ret.toString();
     }
 
-    m_allTemplates = templates.val;
+    for (const Template& templ : templates.val) {
+        if (!templ.title.isEmpty()) {
+             m_allTemplates << templ;
+        }
+    }
+
     m_visibleTemplates = m_allTemplates;
 
     for (const Template& templ: m_allTemplates) {

--- a/mu4/userscores/view/templatesmodel.cpp
+++ b/mu4/userscores/view/templatesmodel.cpp
@@ -19,7 +19,7 @@ void TemplatesModel::load()
 
     for (const Template& templ : templates.val) {
         if (!templ.title.isEmpty()) {
-             m_allTemplates << templ;
+            m_allTemplates << templ;
         }
     }
 


### PR DESCRIPTION
- fixed init tag for preventing an occurring of empty instruments in the new score wizard
- not need to show templates without titles (technical templates like 00-Blank)
- fixed separators
- fixed disabling of StyledComboBox
- fixed crash when in search field input empty string 
- select and unselect instruments on double click
- fixed instruments ordering