### PR TITLE
[MU4] Require Qt 5.15 as the minimum

### DIFF
--- a/build/FindQt5.cmake
+++ b/build/FindQt5.cmake
@@ -36,6 +36,8 @@ if (WIN32)
       )
 endif(WIN32)
 
+find_package(Qt5Core ${QT_MIN_VERSION} REQUIRED)
+
 foreach(_component ${_components})
   find_package(Qt5${_component})
   list(APPEND QT_LIBRARIES ${Qt5${_component}_LIBRARIES})


### PR DESCRIPTION
for real this time, the previous method of only setting `QT_MIN_VERSION` just worked for Qt 4...

See also 484f8dc (PR #6588)
Counterpart to 3.x's #6786