### PR TITLE
[MU3] Enforce `QT_MIN_VERSION`

### DIFF
--- a/build/FindQt5.cmake
+++ b/build/FindQt5.cmake
@@ -36,6 +36,8 @@ if (WIN32)
       )
 endif(WIN32)
 
+find_package(Qt5Core ${QT_MIN_VERSION} REQUIRED)
+
 foreach(_component ${_components})
   find_package(Qt5${_component})
   list(APPEND QT_LIBRARIES ${Qt5${_component}_LIBRARIES})


### PR DESCRIPTION
the previous method of only setting QT_MIN_VERSION just worked for Qt 4...

3.x counterpart for master's #6785