### PR TITLE
fix #312083: tempofield in new score wizard not accessible

### DIFF
--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -57,6 +57,7 @@ TimesigWizard::TimesigWizard(QWidget* parent)
       connect(tsCutTime,    SIGNAL(toggled(bool)), SLOT(cutTimeToggled(bool)));
       connect(tsFraction,   SIGNAL(toggled(bool)), SLOT(fractionToggled(bool)));
       pickupMeasure->setChecked(false); // checked in the UI file to enable screen reader on pickup duration controls
+      tempoGroup->setChecked(false);
 
       tsCommonTime->setIcon(*icons[int(Icons::timesig_common_ICON)]);
       tsCutTime->setIcon(*icons[int(Icons::timesig_allabreve_ICON)]);

--- a/mscore/timesigwizard.ui
+++ b/mscore/timesigwizard.ui
@@ -427,7 +427,7 @@
       <bool>true</bool>
      </property>
      <property name="checked">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <layout class="QHBoxLayout">
       <item>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/312083

A quirk in Qt prevents screen readers from recognizing UI elements
that are part of groups that were disabled in the UI file.
Fix is to enable the group in the UI file
but then disable it in the code.