### PR TITLE
Fix #311340: Save online via command line (--save-online)

### DIFF
--- a/build/Linux+BSD/mscore.1.in
+++ b/build/Linux+BSD/mscore.1.in
@@ -3,7 +3,7 @@
 .\"	mirabilos <m@mirbsd.org>
 .\" Published under the same terms as MuseScore itself.
 .\"-
-.Dd October 19, 2020
+.Dd November 6, 2020
 .Dt @MAN_MSCORE_UPPER@ 1
 .Os MuseScore
 .Sh NAME@Variables_substituted_by_CMAKE_on_installation@
@@ -46,6 +46,7 @@
 .Op Fl \-raw\-diff
 .Op Fl \-revert\-settings
 .Op Fl \-run\-test\-script
+.Op Fl \-save\-online
 .Op Fl \-score\-media
 .Op Fl \-highlight\-config
 .Op Fl \-score\-mp3
@@ -247,6 +248,11 @@ Don't use Bravura as fallback musical font
 Print a raw diff between the given scores
 .It Fl \-run\-test\-script
 Run script tests listed in the command line arguments
+.It Fl \-save\-online
+Upload score(s) to its source URL. There must already be an online score at
+that URL, and the user must be signed-in to the account it belongs to. The
+online score will be replaced with the uploaded file, but the title and
+description of the online score's webpage will not change.
 .It Fl \-score\-media
 Export all media (except MP3) for a given score
 as a single JSON document to stdout

--- a/mscore/cloud/uploadscoredialog.cpp
+++ b/mscore/cloud/uploadscoredialog.cpp
@@ -70,8 +70,8 @@ UploadScoreDialog::UploadScoreDialog(CloudManager* loginManager)
     connect(_loginManager, SIGNAL(uploadSuccess(QString,QString,QString)), this,
             SLOT(uploadSuccess(QString,QString,QString)));
     connect(_loginManager, SIGNAL(uploadError(QString)), this, SLOT(uploadError(QString)));
-    connect(_loginManager, SIGNAL(getScoreSuccess(QString,QString,bool,QString,QString,QString)), this,
-            SLOT(onGetScoreSuccess(QString,QString,bool,QString,QString,QString)));
+    connect(_loginManager, SIGNAL(getScoreSuccess(mu::cloud::ScoreInfo)), this,
+            SLOT(onGetScoreSuccess(mu::cloud::ScoreInfo)));
     connect(_loginManager, SIGNAL(getScoreError(QString)), this, SLOT(onGetScoreError(QString)));
     connect(_loginManager, SIGNAL(tryLoginSuccess()), this, SLOT(display()));
     connect(_loginManager, &CloudManager::mediaUploadSuccess, this,
@@ -249,15 +249,14 @@ void UploadScoreDialog::display()
 //   onGetScoreSuccess
 //---------------------------------------------------------
 
-void UploadScoreDialog::onGetScoreSuccess(const QString& t, const QString& /*desc*/, bool /*priv*/,
-                                          const QString& /*lic*/, const QString& /*tag*/, const QString& url)
+void UploadScoreDialog::onGetScoreSuccess(const mu::cloud::ScoreInfo& scoreInfo)
 {
     // fill with score info
-    title->setText(t);
+    title->setText(scoreInfo.title);
     updateExistingCb->setChecked(true);
     updateExistingCb->setVisible(true);
     linkToScore->setVisible(true);
-    linkToScore->setText("[<a href=\"" + url + "\">" + tr("Link") + "</a>]");
+    linkToScore->setText("[<a href=\"" + scoreInfo.url + "\">" + tr("Link") + "</a>]");
     showOrHideUploadAudio();
     setVisible(true);
 }

--- a/mscore/cloud/uploadscoredialog.h
+++ b/mscore/cloud/uploadscoredialog.h
@@ -14,6 +14,7 @@
 #define __UPLOADSCOREDIALOG_H__
 
 #include "ui_uploadscoredialog.h"
+#include "../../mu4/cloud/cloudtypes.h"
 
 namespace Ms {
 class CloudManager;
@@ -37,8 +38,7 @@ private slots:
     void buttonBoxClicked(QAbstractButton* button);
     void uploadSuccess(const QString& url, const QString& nid, const QString& vid);
     void uploadError(const QString& error);
-    void onGetScoreSuccess(const QString& title, const QString& description, bool priv, const QString& license,const QString& tags,
-                           const QString& url);
+    void onGetScoreSuccess(const mu::cloud::ScoreInfo& scoreInfo);
     void onGetScoreError(const QString& error);
     void logout();
     void display();

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -16,6 +16,8 @@
 
 #include <QFileInfo>
 
+#include "mu4/cloud/internal/cloudmanager.h"
+
 #include "config.h"
 #include "globals.h"
 #include "musescore.h"
@@ -3548,6 +3550,81 @@ QByteArray MuseScore::exportPdfAsJSON(Score* score)
     }
 
     return pdfData.toBase64();
+}
+
+//---------------------------------------------------------
+//   parseSourceUrl
+//---------------------------------------------------------
+
+static void parseSourceUrl(const QString& sourceUrl, int& uid, int& nid)
+{
+    if (!sourceUrl.isEmpty()) {
+        QStringList sl = sourceUrl.split("/");
+        if (sl.length() >= 1) {
+            nid = sl.last().toInt();
+            if (sl.length() >= 3) {
+                uid = sl.at(sl.length() - 3).toInt();
+            }
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   saveOnline
+//---------------------------------------------------------
+
+bool MuseScore::saveOnline(const QStringList& inFilePaths)
+{
+    if (!_loginManager->syncGetUser()) {
+        return false;
+    }
+
+    bool all_successful = true;
+
+    for (auto path : inFilePaths) {
+        Score* score = mscore->readScore(path);
+        if (!score) {
+            all_successful = false;
+            continue;
+        }
+
+        int uid = 0;
+        int nid = 0;
+        parseSourceUrl(score->metaTag("source"), uid, nid);
+
+        if (nid <= 0) {
+            qCritical() << qUtf8Printable(tr("Error: '%1' tag missing or badly formed in %2").arg("source").arg(path));
+            all_successful = false;
+            continue;
+        }
+
+        if (uid && uid != _loginManager->accountInfo().id) {
+            qCritical() << qUtf8Printable(tr("Error: You are not the owner of the online score for %1").arg(path));
+            all_successful = false;
+            continue;
+        }
+
+        if (!_loginManager->syncGetScoreInfo(nid)) {
+            all_successful = false;
+            continue;
+        }
+        mu::cloud::ScoreInfo scoreInfo = _loginManager->scoreInfo();
+
+        QString tempPath = QDir::tempPath() + QString("/temp_%1.mscz").arg(QRandomGenerator::global()->generate() % 100000);
+        if (!mscore->saveAs(score, true, tempPath, "mscz")) {
+            all_successful = false;
+            continue;
+        }
+
+        if (!_loginManager->syncUpload(tempPath, nid, scoreInfo.title)) { // keep same title
+            all_successful = false;
+            continue;
+        }
+
+        qInfo() << qUtf8Printable(tr("Uploaded score")) << path;
+    }
+
+    return all_successful;
 }
 
 //---------------------------------------------------------

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -746,6 +746,7 @@ public:
     bool savePositions(Score*, QIODevice*, bool segments);
     bool saveMetadataJSON(Score*, const QString& name);
     QJsonObject saveMetadataJSON(Score*);
+    bool saveOnline(const QStringList& inFilePaths);
 
     /////The methods are used in the musescore.com backend
     bool exportAllMediaFiles(const QString& inFilePath, const QString& highlightConfigPath, const QString& outFilePath = "/dev/stdout");

--- a/mu4/cloud/cloudtypes.h
+++ b/mu4/cloud/cloudtypes.h
@@ -48,7 +48,36 @@ struct AccountInfo {
         return !userName.isEmpty();
     }
 };
-}
-}
+
+struct ScoreInfo {
+    int id = 0;
+    QString title;
+    QString description;
+    bool isPrivate = false;
+    QString license;
+    QStringList tags;
+    QString url;
+
+    bool operator==(const ScoreInfo& another) const
+    {
+        bool equals = true;
+
+        equals &= (id == another.id);
+        equals &= (description == another.description);
+        equals &= (isPrivate == another.isPrivate);
+        equals &= (license == another.license);
+        equals &= (tags == another.tags);
+        equals &= (url == another.url);
+
+        return equals;
+    }
+
+    bool isValid() const
+    {
+        return id > 0 && !title.isEmpty();
+    }
+};
+} // namespace cloud
+} // namespace mu
 
 #endif // MU_CLOUD_ACCOUNTTYPES_H

--- a/mu4/cloud/internal/cloudmanager.h
+++ b/mu4/cloud/internal/cloudmanager.h
@@ -22,6 +22,7 @@
 
 namespace Ms {
 class ApiRequest;
+class AsyncWait;
 
 //---------------------------------------------------------
 //   LoginManager
@@ -54,6 +55,7 @@ class CloudManager : public QObject
     QString m_refreshToken;
 
     mu::cloud::AccountInfo m_accountInfo;
+    mu::cloud::ScoreInfo m_scoreInfo;
 
     QString m_updateScoreDataPath;
 
@@ -62,6 +64,7 @@ class CloudManager : public QObject
     int m_uploadTryCount = 0;
 
     QProgressDialog* m_progressDialog = nullptr;
+    AsyncWait* m_asyncWait = nullptr;
 
     void onReplyFinished(ApiRequest*, RequestType);
     void handleReply(QNetworkReply*, RequestType);
@@ -88,8 +91,7 @@ signals:
     void getUserError(const QString& error);
     void getUserSuccess();
     void getScoreError(const QString& error);
-    void getScoreSuccess(const QString& title, const QString& description, bool priv, const QString& license,const QString& tags,
-                         const QString& url);
+    void getScoreSuccess(const mu::cloud::ScoreInfo& scoreInfo);
     void uploadError(const QString& error);
     void uploadSuccess(const QString& url, const QString& nid, const QString& vid);
     void tryLoginSuccess();
@@ -124,7 +126,13 @@ public:
     void getScoreInfo(int nid);
     void getMediaUrl(const QString& nid, const QString& vid, const QString& format);
 
+    // Synchronous methods
+    bool syncGetUser();
+    bool syncGetScoreInfo(int nid);
+    bool syncUpload(const QString& path, int nid, const QString& title);
+
     mu::cloud::AccountInfo accountInfo() const { return m_accountInfo; }
+    mu::cloud::ScoreInfo scoreInfo() const { return m_scoreInfo; }
 };
 }
 

--- a/mu4/cloud/internal/cloudmanager_p.h
+++ b/mu4/cloud/internal/cloudmanager_p.h
@@ -158,6 +158,35 @@ public:
 #endif
 
 //---------------------------------------------------------
+//   AsyncWait
+//---------------------------------------------------------
+
+class AsyncWait : public QEventLoop
+{
+    Q_OBJECT
+    QString m_errorMsg;
+
+public:
+    AsyncWait(QObject* parent = nullptr)
+        : QEventLoop(parent) {}
+    QString errorMsg() { return m_errorMsg; }
+
+public slots:
+
+    void success()
+    {
+        m_errorMsg = QString();
+        emit exit(0);
+    }
+
+    void failure(QString msg)
+    {
+        m_errorMsg = msg;
+        emit exit(1);
+    }
+};
+
+//---------------------------------------------------------
 //   HttpStatus
 //---------------------------------------------------------
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/311340

Adds `--save-online` option for command line:

```bash
mscore --save-online score1.mscz score2.mscx
```

Feature is useful for updating scores that are stored in a shared Git repository, or other location where they are editable by multiple people, but where only one person has permission to upload and publish to Musescore.com.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
