### PR TITLE
[MU4] Fix adjusting size of dockpanel

### DIFF
--- a/framework/ui/view/qmldialog.cpp
+++ b/framework/ui/view/qmldialog.cpp
@@ -78,6 +78,7 @@ void QmlDialog::componentComplete()
         m_view->setContent(QUrl(), m_content, obj);
 
         m_dialog->resize(m_view->size());
+        m_dialog->setMinimumSize(width(), height());
         widget->setParent(m_dialog);
         QHBoxLayout* layout = new QHBoxLayout(m_dialog);
         layout->setMargin(0);

--- a/mu4/appshell/dockwindow/dockpanel.cpp
+++ b/mu4/appshell/dockwindow/dockpanel.cpp
@@ -39,18 +39,25 @@ DockPanel::~DockPanel()
 
 void DockPanel::onComponentCompleted()
 {
-    m_dock.panel->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
-    m_dock.panel->setFeatures(QDockWidget::DockWidgetMovable);
-    m_dock.panel->setObjectName("w_" + objectName());
-    m_dock.panel->setWidget(view());
-    m_dock.panel->setMinimumWidth(width());
-    m_dock.panel->setWindowTitle(m_title);
-    m_dock.panel->setStyleSheet(qss.arg(color().name()));
+    panel()->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
+    panel()->setFeatures(QDockWidget::DockWidgetMovable);
+    panel()->setObjectName("w_" + objectName());
+    panel()->setWidget(view());
+    panel()->setWindowTitle(m_title);
+    panel()->setStyleSheet(qss.arg(color().name()));
+
+    m_preferedWidth = width();
+
+    if (minimumWidth() == 0) {
+        panel()->setMinimumWidth(width());
+    }
+
+    panel()->setMaximumWidth(width());
 }
 
 void DockPanel::updateStyle()
 {
-    m_dock.panel->setStyleSheet(qss.arg(color().name()));
+    panel()->setStyleSheet(qss.arg(color().name()));
 }
 
 DockPanel::Widget DockPanel::widget() const
@@ -101,4 +108,29 @@ void DockPanel::setTabifyObjectName(QString tabify)
 
     m_dock.tabifyObjectName = tabify;
     emit tabifyObjectNameChanged(m_dock.tabifyObjectName);
+}
+
+int DockPanel::minimumWidth() const
+{
+    return panel()->minimumWidth();
+}
+
+int DockPanel::preferedWidth() const
+{
+    return m_preferedWidth;
+}
+
+void DockPanel::setMinimumWidth(int width)
+{
+    if (panel()->minimumWidth() == width) {
+        return;
+    }
+
+    panel()->setMinimumWidth(width);
+    emit minimumWidthChanged(width);
+}
+
+QDockWidget* DockPanel::panel() const
+{
+    return m_dock.panel;
 }

--- a/mu4/appshell/dockwindow/dockpanel.cpp
+++ b/mu4/appshell/dockwindow/dockpanel.cpp
@@ -51,8 +51,6 @@ void DockPanel::onComponentCompleted()
     if (minimumWidth() == 0) {
         panel()->setMinimumWidth(width());
     }
-
-    panel()->setMaximumWidth(width());
 }
 
 void DockPanel::updateStyle()

--- a/mu4/appshell/dockwindow/dockpanel.h
+++ b/mu4/appshell/dockwindow/dockpanel.h
@@ -29,17 +29,22 @@ namespace dock {
 class DockPanel : public DockView
 {
     Q_OBJECT
+
     Q_PROPERTY(QString title READ title WRITE setTitle NOTIFY titleChanged)
     Q_PROPERTY(Qt::DockWidgetArea area READ area WRITE setArea NOTIFY areaChanged)
     Q_PROPERTY(QString tabifyObjectName READ tabifyObjectName WRITE setTabifyObjectName NOTIFY tabifyObjectNameChanged)
+    Q_PROPERTY(int minimumWidth READ minimumWidth WRITE setMinimumWidth NOTIFY minimumWidthChanged)
 
 public:
     explicit DockPanel(QQuickItem* parent = nullptr);
-    ~DockPanel();
+    ~DockPanel() override;
 
     QString title() const;
     Qt::DockWidgetArea area() const;
     QString tabifyObjectName() const;
+
+    int minimumWidth() const;
+    int preferedWidth() const;
 
     struct Widget {
         QDockWidget* panel = nullptr;
@@ -53,20 +58,25 @@ public slots:
     void setTitle(QString title);
     void setArea(Qt::DockWidgetArea area);
     void setTabifyObjectName(QString tabifyObjectName);
+    void setMinimumWidth(int width);
 
 signals:
     void titleChanged(QString title);
     void areaChanged(Qt::DockWidgetArea area);
     void tabifyObjectNameChanged(QString tabifyObjectName);
+    void minimumWidthChanged(int width);
 
 protected:
     void onComponentCompleted() override;
     void updateStyle() override;
 
 private:
+    QDockWidget* panel() const;
 
     Widget m_dock;
     QString m_title;
+
+    int m_preferedWidth = 0;
 };
 }
 }

--- a/mu4/appshell/dockwindow/dockwindow.cpp
+++ b/mu4/appshell/dockwindow/dockwindow.cpp
@@ -342,6 +342,7 @@ void DockWindow::setCurrentPageUri(QString uri)
 
     if (m_isComponentComplete) {
         togglePage(page(m_currentPageUri), page(uri));
+        adjustPanelsSize(page(uri));
     }
 
     m_currentPageUri = uri;

--- a/mu4/appshell/dockwindow/dockwindow.cpp
+++ b/mu4/appshell/dockwindow/dockwindow.cpp
@@ -31,6 +31,8 @@
 #include "eventswatcher.h"
 #include "modularity/ioc.h"
 
+#include "framework/global/widgetstatestore.h"
+
 using namespace mu::dock;
 
 static const QString windowQss = QString("QMainWindow { background: %1; } "
@@ -47,6 +49,7 @@ DockWindow::DockWindow(QQuickItem* parent)
 
     setFlag(QQuickItem::ItemHasContents, true);
     m_window = new QMainWindow();
+    m_window->setObjectName("mainWindow");
     m_window->setMinimumSize(800, 600);
     setWidth(1024);
     setHeight(800);
@@ -65,6 +68,8 @@ DockWindow::DockWindow(QQuickItem* parent)
     m_statusbar = new QStatusBar(m_window);
     m_statusbar->setSizeGripEnabled(false);
     m_window->setStatusBar(m_statusbar);
+
+    WidgetStateStore::restoreGeometry(m_window);
 
     connect(m_pages.notifier(), &framework::QmlListPropertyNotifier::appended, this, &DockWindow::onPageAppended);
     connect(this, &DockWindow::colorChanged, this, &DockWindow::updateStyle);
@@ -95,6 +100,8 @@ void DockWindow::onMainWindowEvent(QEvent* e)
         QResizeEvent* re = static_cast<QResizeEvent*>(e);
         setSize(QSizeF(re->size()));
         adjustPanelsSize(currentPage());
+    } else if (QEvent::Close == e->type()) {
+        WidgetStateStore::saveGeometry(m_window);
     }
 }
 

--- a/mu4/appshell/dockwindow/dockwindow.h
+++ b/mu4/appshell/dockwindow/dockwindow.h
@@ -78,15 +78,15 @@ private slots:
     void updateStyle();
 
 private:
-
     void componentComplete() override;
 
     DockPage* page(const QString& uri) const;
     DockPage* currentPage() const;
 
     void togglePage(DockPage* old, DockPage* current);
-    void hidePage(DockPage* p);
-    void showPage(DockPage* p);
+    void hidePage(DockPage* page);
+    void showPage(DockPage* page);
+    void adjustPanelsSize(DockPage* page);
 
     QMainWindow* m_window = nullptr;
     EventsWatcher* m_eventsWatcher = nullptr;

--- a/mu4/appshell/qml/HomePage/HomePage.qml
+++ b/mu4/appshell/qml/HomePage/HomePage.qml
@@ -28,6 +28,8 @@ DockPage {
             objectName: "resourcesPanel"
 
             width: 292
+            minimumWidth: 76
+
             color: ui.theme.backgroundPrimaryColor
 
             Rectangle {


### PR DESCRIPTION
- need to hide the home menu when the size of the application window is minimum
- implemented saving and restoring geometry of the main window
- adjust panels size when current page is changed
- restricted the minimum size of qml dialog