### PR TITLE
Fix #312442: Fix palette search shortcut functionality

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4032,8 +4032,10 @@ bool MuseScoreApplication::event(QEvent* event)
 
 void MuseScore::focusScoreView()
       {
-      if (currentScoreView())
+      if (currentScoreView()) {
+            currentScoreView()->activateWindow();
             currentScoreView()->setFocus();
+            }
       else
             mscore->setFocus();
       }

--- a/mscore/palette/palettewidget.cpp
+++ b/mscore/palette/palettewidget.cpp
@@ -26,6 +26,7 @@
 #include "qml/nativetooltip.h"
 
 #include <QQmlContext>
+#include <QTimer>
 
 namespace Ms {
 
@@ -119,10 +120,13 @@ void PaletteWidget::setupStyle()
 
 void PaletteWidget::activateSearchBox()
       {
+      int delay = isFloating() ? 300 : 0;
       ensureQmlViewFocused();
-      const bool invoked = QMetaObject::invokeMethod(rootObject(), "requestPaletteSearch");
-      Q_UNUSED(invoked);
-      Q_ASSERT(invoked);
+      QTimer::singleShot(delay, this, [&](){
+          const bool invoked = QMetaObject::invokeMethod(rootObject(), "requestPaletteSearch");
+          Q_UNUSED(invoked);
+          Q_ASSERT(invoked);
+          });
       }
 
 //---------------------------------------------------------

--- a/mscore/palette/palettewidget.cpp
+++ b/mscore/palette/palettewidget.cpp
@@ -120,7 +120,9 @@ void PaletteWidget::setupStyle()
 void PaletteWidget::activateSearchBox()
       {
       ensureQmlViewFocused();
-      qmlInterface->requestPaletteSearch();
+      const bool invoked = QMetaObject::invokeMethod(rootObject(), "requestPaletteSearch");
+      Q_UNUSED(invoked);
+      Q_ASSERT(invoked);
       }
 
 //---------------------------------------------------------

--- a/mscore/palette/palettewidget.h
+++ b/mscore/palette/palettewidget.h
@@ -69,8 +69,6 @@ class PaletteQmlInterface : public QObject
 
       void notifyElementDraggedToScoreView() { emit elementDraggedToScoreView(); }
 
-      void requestPaletteSearch() { emit paletteSearchRequested(); }
-
       Q_INVOKABLE Qt::KeyboardModifiers keyboardModifiers() const { return QGuiApplication::keyboardModifiers(); }
       };
 

--- a/mscore/qml/palettes/Palette.qml
+++ b/mscore/qml/palettes/Palette.qml
@@ -767,7 +767,7 @@ GridView {
                 // force not hiding palette cell if it is being dragged to a score
                 enabled: paletteCell.paletteDrag
                 target: mscore
-                function onElementDraggedToScoreView() { paletteCell.paletteDrag = false }
+                onElementDraggedToScoreView: paletteCell.paletteDrag = false
             }
         } // end ItemDelegate
     } // end DelegateModel

--- a/mscore/qml/palettes/PaletteTree.qml
+++ b/mscore/qml/palettes/PaletteTree.qml
@@ -772,7 +772,7 @@ ListView {
 
     Connections {
         target: palettesWidget
-        function onHasFocusChanged() {
+        onHasFocusChanged: {
             if (!palettesWidget.hasFocus) {
                 paletteSelectionModel.clearSelection();
                 expandedPopupIndex = null;

--- a/mscore/qml/palettes/PalettesWidget.qml
+++ b/mscore/qml/palettes/PalettesWidget.qml
@@ -30,7 +30,6 @@ Item {
     id: palettesWidget
 
     readonly property PaletteWorkspace paletteWorkspace: mscore.paletteWorkspace
-
     readonly property bool hasFocus: Window.activeFocusItem
 
     implicitHeight: 4 * palettesWidgetHeader.implicitHeight
@@ -40,6 +39,10 @@ Item {
 
     function applyCurrentPaletteElement() {
         paletteTree.applyCurrentElement();
+    }
+
+    function requestPaletteSearch () {
+        palettesWidgetHeader.paletteSearchRequested()
     }
 
     FocusChainBreak { id: focusBreaker }

--- a/mscore/qml/palettes/PalettesWidgetHeader.qml
+++ b/mscore/qml/palettes/PalettesWidgetHeader.qml
@@ -35,6 +35,11 @@ Item {
 
     implicitHeight: childrenRect.height
 
+    function paletteSearchRequested () {
+        searchTextInput.forceActiveFocus()
+        searchTextInput.selectAll()
+    }
+
     RowLayout {
         width: parent.width
 
@@ -180,14 +185,6 @@ Item {
                 if (!paletteOptionsPopup.inMenuAction)
                     paletteOptionsPopup.visible = false;
             }
-        }
-    }
-
-    Connections {
-        target: mscore
-        onPaletteSearchRequested: {
-            searchTextInput.forceActiveFocus()
-            searchTextInput.selectAll()
         }
     }
 }

--- a/mscore/qml/palettes/PalettesWidgetHeader.qml
+++ b/mscore/qml/palettes/PalettesWidgetHeader.qml
@@ -178,7 +178,7 @@ Item {
 
     Connections {
         target: palettesWidget
-        function onHasFocusChanged() {
+        onHasFocusChanged: {
             if (!palettesWidget.hasFocus) {
                 if (!palettesListPopup.inMenuAction)
                     palettesListPopup.visible = false;

--- a/mscore/qml/palettes/PalettesWidgetHeader.qml
+++ b/mscore/qml/palettes/PalettesWidgetHeader.qml
@@ -185,7 +185,7 @@ Item {
 
     Connections {
         target: mscore
-        function onPaletteSearchRequested() {
+        onPaletteSearchRequested: {
             searchTextInput.forceActiveFocus()
             searchTextInput.selectAll()
         }

--- a/mscore/qmldockwidget.cpp
+++ b/mscore/qmldockwidget.cpp
@@ -211,8 +211,10 @@ QQuickView* QmlDockWidget::getView()
 
 void QmlDockWidget::ensureQmlViewFocused()
       {
-      if (_view && !_view->activeFocusItem())
+      if (_view && !_view->activeFocusItem()) {
+            widget()->activateWindow();
             widget()->setFocus();
+            }
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/312442

From 3.5.1 to 3.5.2, there was a mishap for palette search functionality coming from fixing warnings for Qt 5.15 - https://github.com/musescore/MuseScore/pull/6627/

Update: As per conversation, this PR reverts the changes as mentioned in #6627 related to the function() keyword, but also in separate commit reforms the palette search functionality to make use of the function() keyword. 

Update: "While I'm up," I've decided to revisit palette search functionality since when the palette search widget is "floating", the keyboard shortcut doesn't work (wasn't a reversion... it just never worked appropriately). After trial/error, I learned that somehow the main paletteWidget "steals" focus after the focus upon the searchText in QML while floating, but it doesn't when docked. Adding a timer takes care of this. There may be a better way, but for now to have this actually working is what counts.  There's the additional problem that while floating, the ESCAPE key doesn't actually exit from the palette widget and resume focus back upon the score! These two problems I have resolved and am adding one additional/separate commit within this PR. 


- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [  ] I created the test (mtest, vtest, script test) to verify the changes I made
