### PR TITLE
Fix #299196  Fix #312393 - Missing space between key signature and first note if time signature is hidden

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -4283,12 +4283,14 @@ void Measure::computeMinWidth(Segment* s, qreal x, bool isSystemHeader)
 
       while (s) {
             s->rxpos() = x;
-            if (!s->enabled() || !s->visible()) {
+            if (!s->enabled() || !s->visible() || s->allElementsInvisible()) {
                   s->setWidth(0);
                   s = s->next();
                   continue;
                   }
             Segment* ns = s->nextActive();
+            while (ns && ns->allElementsInvisible())
+                  ns = ns->nextActive();
             // end barline might be disabled
             // but still consider it for spacing of previous segment
             if (!ns)
@@ -4327,7 +4329,6 @@ void Measure::computeMinWidth(Segment* s, qreal x, bool isSystemHeader)
 
                         if (ps == fs)
                               ww = std::max(ww, ns->minLeft(ls) - s->x());
-
                         if (ww > w) {
                               // overlap !
                               // distribute extra space between segments ps - ss;

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -1063,6 +1063,24 @@ bool Segment::hasElements(int minTrack, int maxTrack) const
       }
 
 //---------------------------------------------------------
+//   allElementsInvisible
+///  return true if all elements in the segment are invisible
+//---------------------------------------------------------
+
+bool Segment::allElementsInvisible() const
+      {
+      if (isType(SegmentType::BarLineType | SegmentType::ChordRest | SegmentType::Breath))
+            return false;
+
+      for (Element* e : _elist) {
+            if (e && e->visible())
+                  return false;
+            }
+
+      return true;
+      }
+
+//---------------------------------------------------------
 //   hasAnnotationOrElement
 ///  return true if an annotation of type type or and element is found in the track range
 //---------------------------------------------------------

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -1073,7 +1073,7 @@ bool Segment::allElementsInvisible() const
             return false;
 
       for (Element* e : _elist) {
-            if (e && e->visible())
+            if (e && e->visible() && !qFuzzyCompare(e->width(), 0.0))
                   return false;
             }
 

--- a/libmscore/segment.h
+++ b/libmscore/segment.h
@@ -177,6 +177,7 @@ class Segment final : public Element {
       std::vector<Element*> findAnnotations(ElementType type, int minTrack, int maxTrack);
       bool hasElements() const;
       bool hasElements(int minTrack, int maxTrack) const;
+      bool allElementsInvisible() const;
 
       qreal dotPosX(int staffIdx) const          { return _dotPosX[staffIdx];  }
       void setDotPosX(int staffIdx, qreal val)   { _dotPosX[staffIdx] = val;   }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/299196
Resolves: https://musescore.org/en/node/312393

When calculating the minimum measure width in <code>Measure::computeMinWidth()</code>, skip segments when all elements in that are invisible or have a zero width too.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
