### PR TITLE
Fix #312357: Line breaks in instrument name make status bar's height change

### DIFF
--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -292,7 +292,7 @@ void ScoreAccessibility::currentInfoChanged()
                         rez = QString("%1; %2").arg(rez).arg(staff);
                         }
                   else {
-                        rez = QString("%1; %2 (%3)").arg(rez).arg(staff).arg(staffName);
+                        rez = QString("%1; %2 (%3)").arg(rez).arg(staff).arg(staffName.replace('\n', ' ')); // no newlines in the status bar
                         }
                   if (e->staffIdx() != oldStaff)
                         optimizedStaff = QString("%1 (%2)").arg(staff).arg(staffName);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/312357

For the Status Bar, line breaks in instrument names are now replaced by spaces, to make sure that the status bar text will never contain more than one line. Otherwise, the height of the status bar may change, which is not desirable.

<img width="883" alt="Newlines in Statusbar" src="https://user-images.githubusercontent.com/48658420/98163584-4ccf5e00-1ee3-11eb-9042-05234a333e78.png">

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
