### PR TITLE
fix freeze when tie has the same start and end note

### DIFF
--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -1959,7 +1959,7 @@ void renderChordArticulation(Chord* chord, QList<NoteEventList> & ell, int & gat
 
 static bool shouldRenderNote(Note* n)
       {
-      while (n->tieBack()) {
+      while (n->tieBack() && n != n->tieBack()->startNote()) {
             n = n->tieBack()->startNote();
             if (findFirstTrill(n->chord()))
                   // The previous tied note probably has events for this note too.


### PR DESCRIPTION
Resolves: https://musescore.com/groups/improving-musescore-com/discuss/5079846

The application could freeze in case of wrong ties during playback or export audio.

inhouse team.