### PR TITLE
[MU4] Added logger

### DIFF
--- a/build/ci/windows/build.bat
+++ b/build/ci/windows/build.bat
@@ -55,17 +55,18 @@ SET MSCORE_STABLE_BUILD="TRUE"
 SET "JACK_DIR=C:\Program Files (x86)\Jack"
 SET "QT_DIR=C:\Qt\5.15.1"
 
-IF %TARGET_PROCESSOR_BITS% == 32 ( 
-    ::SET "PATH=%QT_DIR%\msvc2015\bin;%JACK_DIR%;%PATH%"
-    ECHO "error: Not installed Qt 32"
-    EXIT /b 1
-) ELSE (
-    SET "PATH=%QT_DIR%\msvc2019_64\bin;%JACK_DIR%;%PATH%"
-)
+@REM IF %TARGET_PROCESSOR_BITS% == 32 ( 
+@REM     ::SET "PATH=%QT_DIR%\msvc2015\bin;%JACK_DIR%;%PATH%"
+@REM     ECHO "error: Not installed Qt 32"
+@REM     EXIT /b 1
+@REM ) ELSE (
+SET "PATH=%QT_DIR%\msvc2019_64\bin;%JACK_DIR%;%PATH%"
+@REM )
 
 :: Undefined CRASH_LOG_SERVER_URL if is it empty
-IF %CRASH_LOG_SERVER_URL% == "" ( SET CRASH_LOG_SERVER_URL=)
-IF %CRASH_LOG_SERVER_URL% == "''" ( SET CRASH_LOG_SERVER_URL=)
+@REM IF %CRASH_LOG_SERVER_URL% == "" ( SET CRASH_LOG_SERVER_URL=)
+@REM IF %CRASH_LOG_SERVER_URL% == "''" ( SET CRASH_LOG_SERVER_URL=)
+SET CRASH_LOG_SERVER_URL="ggg"
 
 :: At the moment not compiling yet.
 SET BUILD_VST=OFF 

--- a/framework/global/CMakeLists.txt
+++ b/framework/global/CMakeLists.txt
@@ -21,10 +21,16 @@ set(MODULE global)
 
 include(${CMAKE_CURRENT_LIST_DIR}/modularity/modularity.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/async/async.cmake)
+include(${PROJECT_SOURCE_DIR}/thirdparty/haw_logger/logger/logger.cmake)
+
+set(MODULE_DEF
+    -DHAW_LOGGER_QT_SUPPORT
+)
 
 set(MODULE_SRC
     ${MODULARITY_SRC}
     ${ASYNC_SRC}
+    ${HAW_LOGGER_SRC}
     ${CMAKE_CURRENT_LIST_DIR}/globalmodule.cpp
     ${CMAKE_CURRENT_LIST_DIR}/globalmodule.h
     ${CMAKE_CURRENT_LIST_DIR}/iinteractive.h
@@ -32,6 +38,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/io/path.cpp
     ${CMAKE_CURRENT_LIST_DIR}/io/path.h
     ${CMAKE_CURRENT_LIST_DIR}/log.h
+    ${CMAKE_CURRENT_LIST_DIR}/logstream.h
     ${CMAKE_CURRENT_LIST_DIR}/dataformatter.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dataformatter.h
     ${CMAKE_CURRENT_LIST_DIR}/val.cpp
@@ -63,6 +70,15 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/globalconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/interactive.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/interactive.h
-    )
+)
+
+set(FS_LIB )
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(FS_LIB stdc++fs)
+endif()
+
+set(MODULE_LINK
+    ${FS_LIB}
+)
 
 include(${PROJECT_SOURCE_DIR}/build/module.cmake)

--- a/framework/global/globalmodule.cpp
+++ b/framework/global/globalmodule.cpp
@@ -23,6 +23,10 @@
 #include "modularity/ioc.h"
 #include "internal/globalconfiguration.h"
 
+#include "log.h"
+#include "thirdparty/haw_logger/logger/logdefdest.h"
+#include "version.h"
+
 #include "internal/interactive.h"
 #include "invoker.h"
 
@@ -30,6 +34,8 @@
 #include "async/processevents.h"
 
 using namespace mu::framework;
+
+static std::shared_ptr<GlobalConfiguration> s_globalConf = std::make_shared<GlobalConfiguration>();
 
 static Invoker s_asyncInvoker;
 
@@ -40,25 +46,37 @@ std::string GlobalModule::moduleName() const
 
 void GlobalModule::registerExports()
 {
-    ioc()->registerExport<IGlobalConfiguration>(moduleName(), new GlobalConfiguration());
+    ioc()->registerExport<IGlobalConfiguration>(moduleName(), s_globalConf);
     ioc()->registerExport<IInteractive>(moduleName(), new Interactive());
 }
 
 void GlobalModule::onInit()
 {
+    //! --- Setup logger ---
+    using namespace haw::logger;
+    Logger* logger = Logger::instance();
+    logger->clearDests();
+
+    //! Console
+    logger->addDest(new ConsoleLogDest(LogLayout("${time} | ${type|5} | ${thread} | ${tag|10} | ${message}")));
+
+    //! File, this creates a file named "data/logs/MuseScore_yyMMdd.log"
+    std::string logsPath = s_globalConf->logsPath().c_str();
+    LOGI() << "logs path: " << logsPath;
+    logger->addDest(new FileLogDest(logsPath, "MuseScore", "log",
+                                    LogLayout("${datetime} | ${type|5} | ${thread} | ${tag|10} | ${message}")));
+
+#ifndef NDEBUG
+    logger->setLevel(haw::logger::Debug);
+#else
+    logger->setLevel(haw::logger::Normal);
+#endif
+
+    LOGI() << "=== Started MuseScore " << framework::Version::fullVersion() << " ===";
+
     Invoker::setup();
 
     mu::async::onMainThreadInvoke([](const std::function<void()>& f) {
         s_asyncInvoker.invoke(f);
     });
-
-//    static QTimer asyncInvoker;
-//    asyncInvoker.setInterval(1);
-//    asyncInvoker.setSingleShot(false);
-
-//    QObject::connect(&asyncInvoker, &QTimer::timeout, []() {
-//        mu::async::processEvents();
-//    });
-
-//    asyncInvoker.start();
 }

--- a/framework/global/iglobalconfiguration.h
+++ b/framework/global/iglobalconfiguration.h
@@ -33,6 +33,7 @@ public:
 
     virtual io::path sharePath() const = 0;
     virtual io::path dataPath() const = 0;
+    virtual io::path logsPath() const = 0;
     virtual io::path backupPath() const = 0;
 
     virtual bool useFactorySettings() const = 0;

--- a/framework/global/internal/globalconfiguration.cpp
+++ b/framework/global/internal/globalconfiguration.cpp
@@ -79,6 +79,11 @@ QString GlobalConfiguration::getSharePath() const
 #endif
 }
 
+io::path GlobalConfiguration::logsPath() const
+{
+    return dataPath() + "/logs";
+}
+
 io::path GlobalConfiguration::backupPath() const
 {
     return settings()->value(BACKUP_PATH).toString();

--- a/framework/global/internal/globalconfiguration.h
+++ b/framework/global/internal/globalconfiguration.h
@@ -30,6 +30,7 @@ public:
 
     io::path sharePath() const override;
     io::path dataPath() const override;
+    io::path logsPath() const override;
     io::path backupPath() const override;
 
     bool useFactorySettings() const override;

--- a/framework/global/io/path.h
+++ b/framework/global/io/path.h
@@ -20,7 +20,7 @@
 #define MU_IO_PATH_H
 
 #include <QString>
-#include <QDebug>
+#include "framework/global/logstream.h"
 
 namespace mu {
 namespace io {
@@ -53,10 +53,10 @@ private:
     QByteArray m_path;
 };
 
-inline QDebug operator<<(QDebug debug, const mu::io::path& p)
+inline mu::log::Stream& operator<<(mu::log::Stream& s, const mu::io::path& p)
 {
-    debug << p.c_str();
-    return debug;
+    s << p.c_str();
+    return s;
 }
 
 std::string syffix(const path& path);

--- a/framework/global/log.h
+++ b/framework/global/log.h
@@ -20,26 +20,10 @@
 #ifndef MU_FRAMEWORK_LOG_H
 #define MU_FRAMEWORK_LOG_H
 
-#include <QDebug>
-#include <thread>
-#include "runtime.h"
-
-inline QDebug operator<<(QDebug debug, const std::string& s)
-{
-    debug << s.c_str();
-    return debug;
-}
-
-inline QDebug operator<<(QDebug debug, const std::thread::id& id)
-{
-    debug << mu::runtime::toString(id);
-    return debug;
-}
-
-#define LOGD() qDebug() << "[" << mu::runtime::threadName() << "]"
-#define LOGI() qInfo() << "[" << mu::runtime::threadName() << "]"
-#define LOGW() qWarning() << "[" << mu::runtime::threadName() << "]"
-#define LOGE() qCritical() << "[" << mu::runtime::threadName() << "]"
+#ifndef HAW_LOGGER_QT_SUPPORT
+#define HAW_LOGGER_QT_SUPPORT
+#endif
+#include "thirdparty/haw_logger/logger/log_base.h"
 
 #define IF_ASSERT_FAILED_X(cond, msg) if (!(cond)) { \
         LOGE() << "\"ASSERT FAILED!\":" << msg << __FILE__ << __LINE__; \
@@ -54,8 +38,6 @@ inline QDebug operator<<(QDebug debug, const std::thread::id& id)
 } \
     if (!(cond)) \
 
-#define NOT_IMPLEMENTED LOGE() << "NOT IMPLEMENTED "
-#define NOT_SUPPORTED LOGE() << "NOT SUPPORTED "
 #define UNUSED(x) (void)x;
 
 #endif // MU_FRAMEWORK_LOG_H

--- a/framework/global/logstream.h
+++ b/framework/global/logstream.h
@@ -16,29 +16,12 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#include "version.h"
+#ifndef MU_LOGSTREAM_H
+#define MU_LOGSTREAM_H
 
-#include "config.h"
-#include "stringutils.h"
-
-using namespace mu::framework;
-
-bool Version::unstable()
-{
-#ifdef MSCORE_UNSTABLE
-    return true;
-#else
-    return false;
-#endif
+#include "thirdparty/haw_logger/logger/logstream.h"
+namespace mu::log {
+using Stream = haw::logger::Stream;
 }
 
-std::string Version::fullVersion()
-{
-    std::string version(VERSION);
-    std::string versionLabel(VERSION_LABEL);
-    strings::replace(versionLabel, " ", "");
-    if (!versionLabel.empty()) {
-        version.append("-").append(versionLabel);
-    }
-    return version;
-}
+#endif // MU_LOGSTREAM_H

--- a/mu4/appshell/appshell.cpp
+++ b/mu4/appshell/appshell.cpp
@@ -59,8 +59,6 @@ int AppShell::run(int argc, char** argv, std::function<void()> moduleSetup)
     QCoreApplication::setOrganizationDomain("musescore.org");
     QCoreApplication::setApplicationVersion(QString::fromStdString(framework::Version::fullVersion()));
 
-    qSetMessagePattern("%{function}: %{message}");
-
     moduleSetup();
 
     framework::settings()->load();

--- a/thirdparty/haw_logger/.gitignore
+++ b/thirdparty/haw_logger/.gitignore
@@ -1,0 +1,3 @@
+*.user
+build.*
+build-*

--- a/thirdparty/haw_logger/LICENSE
+++ b/thirdparty/haw_logger/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Igor Korsukov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/thirdparty/haw_logger/README.md
+++ b/thirdparty/haw_logger/README.md
@@ -1,0 +1,28 @@
+Simple logger
+-------------
+
+Simple, convinient, thread safe and flexible logger with Qt support
+(ported from https://github.com/igorkorsukov/qzebradev)
+
+Features:
+* Stream input
+* Many destinations 
+* Log levels, messages types, messages tags
+* Very small overhead for disabled debug (with use macro) 
+* Catch Qt messages
+* Custom output format
+* Custom messages types
+* Filter by type
+
+[Example](tests/main.cpp)
+
+To use Logger within your software project include the Logger source into your project
+
+Source:
+* logger.h/cpp - logger and base stuff
+* logdefdest.h/cpp - default destinations for console and file 
+* log_example.h - macro for simple use logger
+
+or include `logger.cmake` in the cmake project
+
+Change log_example.h as you see fit

--- a/thirdparty/haw_logger/logger/helpful.cpp
+++ b/thirdparty/haw_logger/logger/helpful.cpp
@@ -1,0 +1,61 @@
+#include "helpful.h"
+
+using namespace haw::logger;
+
+static const std::string Colon("::");
+static const char ArgBegin('(');
+static const char Space(' ');
+
+std::string Helpful::className(const std::string& sig)
+{
+    std::size_t endFunc = sig.find_first_of(ArgBegin);
+    if (endFunc == std::string::npos) {
+        return sig;
+    }
+
+    std::size_t beginFunc = sig.find_last_of(Colon, endFunc);
+    if (beginFunc == std::string::npos) {
+        return std::string();
+    }
+
+    std::size_t beginClassColon = sig.find_last_of(Colon, beginFunc - 2);
+    std::size_t beginClassSpace = sig.find_last_of(Space, beginFunc - 2);
+
+    std::size_t beginClass = std::string::npos;
+    if (beginClassColon == std::string::npos) {
+        beginClass = beginClassSpace;
+    } else if (beginClassSpace == std::string::npos) {
+        beginClass = beginClassColon;
+    } else {
+        beginClass = std::max(beginClassColon, beginClassSpace);
+    }
+
+    if (beginClass == std::string::npos) {
+        beginClass = 0;
+    } else {
+        beginClass += 1;
+    }
+
+    return sig.substr(beginClass, (beginFunc - 1 - beginClass));
+}
+
+std::string Helpful::methodName(const std::string& sig)
+{
+    std::size_t endFunc = sig.find_first_of(ArgBegin);
+    if (endFunc == std::string::npos) {
+        return sig;
+    }
+
+    std::size_t beginFunc = sig.find_last_of(Colon, endFunc);
+    if (beginFunc == std::string::npos) {
+        beginFunc = sig.find_last_of(Space, endFunc);
+    }
+
+    if (beginFunc == std::string::npos) {
+        beginFunc = 0;
+    } else {
+        beginFunc += 1;
+    }
+
+    return sig.substr(beginFunc, (endFunc - beginFunc));
+}

--- a/thirdparty/haw_logger/logger/helpful.h
+++ b/thirdparty/haw_logger/logger/helpful.h
@@ -1,0 +1,13 @@
+#ifndef HAW_HELPFUL_H
+#define HAW_HELPFUL_H
+
+#include <string>
+
+namespace haw::logger {
+struct Helpful {
+    static std::string className(const std::string& sig);
+    static std::string methodName(const std::string& sig);
+};
+}
+
+#endif // HAW_HELPFUL_H

--- a/thirdparty/haw_logger/logger/log_base.h
+++ b/thirdparty/haw_logger/logger/log_base.h
@@ -1,0 +1,43 @@
+#ifndef HAW_LOG_H
+#define HAW_LOG_H
+
+#include "helpful.h"
+#include "logger.h"
+
+#ifndef FUNC_INFO
+#if defined(_MSC_VER)
+    #define FUNC_INFO __FUNCSIG__
+#else
+    #define FUNC_INFO __PRETTY_FUNCTION__
+#endif
+#endif
+
+//! Format
+#define CLASSNAME(sig) haw::logger::Helpful::className(sig)
+#define FUNCNAME(sig) haw::logger::Helpful::methodName(sig)
+
+//! Log
+
+#ifndef LOG_TAG
+#define LOG_TAG CLASSNAME(FUNC_INFO)
+#endif
+
+#define IF_LOGLEVEL(level)  if (haw::logger::Logger::instance()->isLevel(level))
+
+#define LOG_STREAM(type, tag) haw::logger::LogInput(type, tag).stream()
+#define LOG(type, tag)  LOG_STREAM(type, tag) << FUNCNAME(FUNC_INFO) << ": "
+
+#define LOGE()      IF_LOGLEVEL(haw::logger::Normal) LOG(haw::logger::Logger::ERROR, LOG_TAG)
+#define LOGW()      IF_LOGLEVEL(haw::logger::Normal) LOG(haw::logger::Logger::WARN, LOG_TAG)
+#define LOGI()      IF_LOGLEVEL(haw::logger::Normal) LOG(haw::logger::Logger::INFO, LOG_TAG)
+#define LOGD()      IF_LOGLEVEL(haw::logger::Debug) LOG(haw::logger::Logger::DEBUG, LOG_TAG)
+
+//! Helps
+#define DEPRECATED LOGD() << "This function deprecated!!"
+#define DEPRECATED_USE(use) LOGD() << "This function deprecated!! Use:" << use
+#define NOT_IMPLEMENTED LOGW() << "Not implemented!!"
+#define NOT_IMPL_RETURN NOT_IMPLEMENTED return
+#define NOT_SUPPORTED LOGW() << "Not supported!!"
+#define NOT_SUPPORTED_USE(use) LOGW() << "Not supported!! Use:" << use
+
+#endif // HAW_LOG_H

--- a/thirdparty/haw_logger/logger/logdefdest.cpp
+++ b/thirdparty/haw_logger/logger/logdefdest.cpp
@@ -1,0 +1,126 @@
+#include "logdefdest.h"
+
+#include <iostream>
+#include <cassert>
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#error compiler must either support c++17
+#endif
+
+using namespace haw::logger;
+
+MemLogDest::MemLogDest(const LogLayout& l)
+    : LogDest(l)
+{
+}
+
+std::string MemLogDest::name() const
+{
+    return "MemLogDest";
+}
+
+void MemLogDest::write(const LogMsg& logMsg)
+{
+    m_stream << m_layout.output(logMsg) << std::endl;
+}
+
+std::string MemLogDest::content() const
+{
+    return m_stream.str();
+}
+
+// FileLogDest
+FileLogDest::FileLogDest(const std::string& path, const std::string& name, const std::string& ext, const LogLayout& l)
+    : LogDest(l), m_path(path), m_name(name), m_ext(ext)
+{
+    rotate();
+}
+
+FileLogDest::~FileLogDest()
+{
+    if (m_file.is_open()) {
+        m_file.close();
+    }
+}
+
+std::string FileLogDest::name() const
+{
+    return "FileLogDest";
+}
+
+void FileLogDest::rotate()
+{
+    if (m_file.is_open()) {
+        m_file.close();
+    }
+
+    fs::path path = m_path;
+    if (!fs::exists(path)) {
+        bool ok = fs::create_directories(path);
+        assert(ok);
+        if (!ok) {
+            std::clog << "failed create dir: " << path << std::endl;
+            return;
+        }
+    }
+
+    auto formatDate = [](const Date& d) {
+                          std::string str;
+                          str.reserve(10);
+
+                          str.append(std::to_string(d.year + 1900));
+
+                          if (d.mon < 11) {
+                              str.push_back('0');
+                          }
+                          str.append(std::to_string(d.mon + 1));
+
+                          if (d.day < 10) {
+                              str.push_back('0');
+                          }
+                          str.append(std::to_string(d.day));
+
+                          return str;
+                      };
+
+    m_rotateDate = DateTime::now().date;
+    std::string dateStr = formatDate(m_rotateDate);
+    std::string filePath = m_path + "/" + m_name + '_' + dateStr + '.' + m_ext;
+
+    m_file.open(filePath, std::ios_base::out | std::ios_base::app);
+    if (!m_file.is_open()) {
+        std::clog << "failed open log file: " << path << std::endl;
+    }
+}
+
+void FileLogDest::write(const LogMsg& logMsg)
+{
+    if (m_rotateDate != logMsg.datetime.date) {
+        rotate();
+    }
+
+    m_file << m_layout.output(logMsg) << std::endl;
+    m_file.flush();
+}
+
+// OutputDest
+ConsoleLogDest::ConsoleLogDest(const LogLayout& l)
+    : LogDest(l)
+{
+}
+
+std::string ConsoleLogDest::name() const
+{
+    return "ConsoleLogDest";
+}
+
+void ConsoleLogDest::write(const LogMsg& logMsg)
+{
+    std::clog << m_layout.output(logMsg) << std::endl;
+}

--- a/thirdparty/haw_logger/logger/logdefdest.h
+++ b/thirdparty/haw_logger/logger/logdefdest.h
@@ -1,0 +1,54 @@
+#ifndef HAW_DEFLOGDEST_H
+#define HAW_DEFLOGDEST_H
+
+#include <fstream>
+#include <ctime>
+
+#include "logger.h"
+
+namespace haw::logger {
+class MemLogDest : public LogDest
+{
+public:
+    MemLogDest(const LogLayout& l);
+
+    std::string name() const;
+    void write(const LogMsg& logMsg);
+
+    std::string content() const;
+
+private:
+    std::stringstream m_stream;
+};
+
+class FileLogDest : public LogDest
+{
+public:
+    FileLogDest(const std::string& path, const std::string& name, const std::string& ext, const LogLayout& l);
+    ~FileLogDest();
+
+    std::string name() const;
+    void write(const LogMsg& logMsg);
+
+private:
+
+    void rotate();
+
+    Date m_rotateDate;
+    std::ofstream m_file;
+    std::string m_path;
+    std::string m_name;
+    std::string m_ext;
+};
+
+class ConsoleLogDest : public LogDest
+{
+public:
+    explicit ConsoleLogDest(const LogLayout& l);
+
+    std::string name() const;
+    void write(const LogMsg& logMsg);
+};
+}
+
+#endif // HAW_DEFLOGDEST_H

--- a/thirdparty/haw_logger/logger/logger.cmake
+++ b/thirdparty/haw_logger/logger/logger.cmake
@@ -1,0 +1,15 @@
+
+set(HAW_LOGGER_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/log_base.h
+    ${CMAKE_CURRENT_LIST_DIR}/logstream.h
+    ${CMAKE_CURRENT_LIST_DIR}/logger.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/logger.h
+    ${CMAKE_CURRENT_LIST_DIR}/logdefdest.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/logdefdest.h
+    ${CMAKE_CURRENT_LIST_DIR}/helpful.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/helpful.h
+)
+
+set(HAW_LOGGER_INC
+    ${CMAKE_CURRENT_LIST_DIR}
+)

--- a/thirdparty/haw_logger/logger/logger.cpp
+++ b/thirdparty/haw_logger/logger/logger.cpp
@@ -1,0 +1,418 @@
+#include "logger.h"
+
+#include <chrono>
+#include <ctime>
+#include <algorithm>
+#include <cassert>
+
+#include "logdefdest.h"
+#include "helpful.h"
+
+using namespace haw::logger;
+
+const Type Logger::ERROR("ERROR");
+const Type Logger::WARN("WARN");
+const Type Logger::INFO("INFO");
+const Type Logger::DEBUG("DEBUG");
+
+// Layout ---------------------------------
+
+static const std::string DATETIME_PATTERN("${datetime}");
+static const std::string TIME_PATTERN("${time}");
+static const std::string TYPE_PATTERN("${type}");
+static const std::string TAG_PATTERN("${tag}");
+static const std::string THREAD_PATTERN("${thread}");
+static const std::string MESSAGE_PATTERN("${message}");
+
+static const char ZERO('0');
+static const char COLON(':');
+static const char DOT('.');
+static const char HYPEN('-');
+static const char T('T');
+static const char SPACE(' ');
+
+static const std::string MAIN_THREAD("main_thread");
+
+static std::string leftJustified(const std::string& in, size_t width)
+{
+    std::string out = in;
+    if (width > out.size()) {
+        out.resize(width, ' ');
+    }
+    return out;
+}
+
+DateTime DateTime::now()
+{
+    using namespace std::chrono;
+    milliseconds ms_d = duration_cast< milliseconds >(system_clock::now().time_since_epoch());
+
+    std::time_t sec = static_cast<std::time_t>(ms_d.count() / 1000);
+    std::tm* tm = std::localtime(&sec);
+    assert(tm);
+    if (!tm) {
+        return DateTime();
+    }
+
+    DateTime dt;
+    dt.date.year = tm->tm_year + 1900;
+    dt.date.mon = tm->tm_mon + 1;
+    dt.date.day = tm->tm_mday;
+    dt.time.hour = tm->tm_hour;
+    dt.time.min = tm->tm_min;
+    dt.time.sec = tm->tm_sec;
+    dt.time.msec = ms_d.count() - (sec * 1000);
+
+    return dt;
+}
+
+LogLayout::LogLayout(const std::string& format)
+    : m_format(format)
+{
+    m_mainThread = std::this_thread::get_id();
+    m_patterns = patterns(format);
+}
+
+LogLayout::~LogLayout()
+{
+}
+
+std::vector<LogLayout::Pattern> LogLayout::patterns(const std::string& format)
+{
+    std::vector<std::string> ps = {
+        DATETIME_PATTERN,
+        TIME_PATTERN,
+        TYPE_PATTERN,
+        TAG_PATTERN,
+        THREAD_PATTERN,
+        MESSAGE_PATTERN
+    };
+
+    std::vector<LogLayout::Pattern> patterns;
+    for (const std::string& pstr : ps) {
+        Pattern p = parcePattern(format, pstr);
+        if (p.index > -1) {
+            patterns.push_back(std::move(p));
+        }
+    }
+
+    std::sort(patterns.begin(), patterns.end(), [](const LogLayout::Pattern& f, const LogLayout::Pattern& s) {
+        return f.index < s.index;
+    });
+
+    return patterns;
+}
+
+LogLayout::Pattern LogLayout::parcePattern(const std::string& format, const std::string& pattern)
+{
+    Pattern p;
+    p.pattern = pattern;
+
+    std::string beginPattern(pattern.substr(0, pattern.size() - 1));
+    std::string::size_type beginPatternIndex = format.find(beginPattern);
+    if (beginPatternIndex != std::string::npos) {
+        p.index = beginPatternIndex;
+        std::string::size_type last = beginPatternIndex + beginPattern.size();
+
+        std::string::size_type filterIndex = std::string::npos;
+        std::string::size_type endPatternIndex = std::string::npos;
+        while (1) {
+            if (!(last < format.size())) {
+                break;
+            }
+
+            char c = format.at(last);
+            if (c == '|') {
+                filterIndex = last;
+            } else if (c == '}') {
+                endPatternIndex = last;
+                break;
+            }
+
+            ++last;
+        }
+
+        if (filterIndex != std::string::npos) {
+            std::string filter = format.substr(filterIndex + 1, endPatternIndex - filterIndex - 1);
+            p.minWidth = std::stoi(filter);
+        }
+
+        p.count = endPatternIndex - beginPatternIndex + 1;
+
+        std::string::size_type beforeEndPatternIndex = std::string::npos;
+        std::string::size_type beforeBeginPatterIndex = format.find_last_of("${", p.index - 1);
+        if (beforeBeginPatterIndex != std::string::npos) {
+            beforeEndPatternIndex = format.find_first_of('}', beforeBeginPatterIndex) + 1;
+        }
+
+        p.beforeStr = format.substr(beforeEndPatternIndex, p.index - beforeEndPatternIndex);
+    }
+
+    return p;
+}
+
+std::string LogLayout::output(const LogMsg& logMsg) const
+{
+    std::string str;
+    str.reserve(100);
+    for (const Pattern& p : m_patterns) {
+        str.append(p.beforeStr).append(formatPattern(logMsg, p));
+    }
+    return str;
+}
+
+std::string LogLayout::formatPattern(const LogMsg& logMsg, const Pattern& p) const
+{
+    if (DATETIME_PATTERN == p.pattern) {
+        return leftJustified(formatDateTime(logMsg.datetime), p.minWidth);
+    } else if (TIME_PATTERN == p.pattern) {
+        return leftJustified(formatTime(logMsg.datetime.time), p.minWidth);
+    } else if (TYPE_PATTERN == p.pattern) {
+        return leftJustified(logMsg.type, p.minWidth);
+    } else if (TAG_PATTERN == p.pattern) {
+        return leftJustified(logMsg.tag, p.minWidth);
+    } else if (THREAD_PATTERN == p.pattern) {
+        return leftJustified(formatThread(logMsg.thread), p.minWidth);
+    } else if (MESSAGE_PATTERN == p.pattern) {
+        return leftJustified(logMsg.message, p.minWidth);
+    }
+
+    return p.pattern;
+}
+
+std::string LogLayout::formatDateTime(const DateTime& dt) const
+{
+    std::string str;
+    str.reserve(22);
+    str.append(formatDate(dt.date));
+    str.push_back(T);
+    str.append(formatTime(dt.time));
+    return str;
+}
+
+std::string LogLayout::formatDate(const Date& d) const
+{
+    std::string str;
+    str.reserve(10);
+
+    str.append(std::to_string(d.year)).push_back(HYPEN);
+
+    if (d.mon < 10) {
+        str.push_back(ZERO);
+    }
+    str.append(std::to_string(d.mon)).push_back(HYPEN);
+
+    if (d.day < 10) {
+        str.push_back(ZERO);
+    }
+    str.append(std::to_string(d.day));
+
+    return str;
+}
+
+std::string LogLayout::formatTime(const Time& t) const
+{
+    std::string str;
+    str.reserve(12);
+
+    if (t.hour < 10) {
+        str.push_back(ZERO);
+    }
+    str.append(std::to_string(t.hour)).push_back(COLON);
+
+    if (t.min < 10) {
+        str.push_back(ZERO);
+    }
+    str.append(std::to_string(t.min)).push_back(COLON);
+
+    if (t.sec < 10) {
+        str.push_back(ZERO);
+    }
+    str.append(std::to_string(t.sec)).push_back(DOT);
+
+    if (t.msec < 100) {
+        str.push_back(ZERO);
+    }
+
+    if (t.msec < 10) {
+        str.push_back(ZERO);
+    }
+    str.append(std::to_string(t.msec));
+
+    return str;
+}
+
+std::string LogLayout::formatThread(const std::thread::id& thID) const
+{
+    if (m_mainThread == thID) {
+        return MAIN_THREAD;
+    }
+    std::ostringstream ss;
+    ss << thID;
+    return ss.str();
+}
+
+std::string LogLayout::format() const
+{
+    return m_format;
+}
+
+// LogDest ---------------------------------
+
+LogDest::LogDest(const LogLayout& l)
+    : m_layout(l)
+{}
+
+LogDest::~LogDest()
+{}
+
+LogLayout LogDest::layout() const
+{
+    return m_layout;
+}
+
+// Logger ---------------------------------
+Logger::Logger()
+{
+    setupDefault();
+}
+
+Logger::~Logger()
+{
+#ifdef HAW_LOGGER_QT_SUPPORT
+    setIsCatchQtMsg(false);
+#endif
+    clearDests();
+}
+
+void Logger::setupDefault()
+{
+    clearDests();
+    addDest(new ConsoleLogDest(LogLayout("${time} | ${type|5} | ${thread} | ${tag|10} | ${message}")));
+
+    m_level = Normal;
+
+    m_types.clear();
+    m_types.push_back(ERROR);
+    m_types.push_back(WARN);
+    m_types.push_back(INFO);
+    m_types.push_back(DEBUG);
+
+#ifdef HAW_LOGGER_QT_SUPPORT
+    setIsCatchQtMsg(true);
+#endif
+}
+
+void Logger::write(const LogMsg& logMsg)
+{
+    std::lock_guard locker(m_mutex);
+    if (isAsseptMsg(logMsg.type)) {
+        for (LogDest* dest : m_dests) {
+            dest->write(logMsg);
+        }
+    }
+}
+
+bool Logger::isAsseptMsg(const Type& type) const
+{
+    return m_level == Full || m_level == Normal || isType(type);
+}
+
+bool Logger::isType(const Type& type) const
+{
+    if (std::find(m_types.begin(), m_types.end(), type) != m_types.end()) {
+        return true;
+    }
+    return false;
+}
+
+void Logger::addDest(LogDest* dest)
+{
+    assert(dest);
+    m_dests.push_back(dest);
+}
+
+std::vector<LogDest*> Logger::dests() const
+{
+    return m_dests;
+}
+
+void Logger::clearDests()
+{
+    for (LogDest* d : m_dests) {
+        delete d;
+    }
+    m_dests.clear();
+}
+
+void Logger::setLevel(const Level level)
+{
+    m_level = level;
+}
+
+Level Logger::level() const
+{
+    return m_level;
+}
+
+std::vector<Type> Logger::types() const
+{
+    return m_types;
+}
+
+void Logger::setTypes(const std::vector<Type>& types)
+{
+    m_types = types;
+}
+
+void Logger::setType(const Type& type, bool enb)
+{
+    if (enb) {
+        if (!isType(type)) {
+            m_types.push_back(type);
+        }
+    } else {
+        m_types.erase(std::remove(m_types.begin(), m_types.end(), type), m_types.end());
+    }
+}
+
+#ifdef HAW_LOGGER_QT_SUPPORT
+void Logger::logMsgHandler(QtMsgType type, const QMessageLogContext& ctx, const QString& s)
+{
+    if (type == QtDebugMsg && !Logger::instance()->isLevel(Debug)) {
+        return;
+    }
+
+    static std::string Qt("Qt");
+
+    std::string msg;
+    if (ctx.function) {
+        std::string sig = ctx.function;
+        msg = Helpful::methodName(sig) + ": " + s.toStdString();
+    } else {
+        msg = s.toStdString();
+    }
+
+    LogMsg logMsg(qtMsgTypeToString(type), Qt, msg);
+
+    Logger::instance()->write(logMsg);
+}
+
+Type Logger::qtMsgTypeToString(enum QtMsgType defType)
+{
+    switch (defType) {
+    case QtDebugMsg: return DEBUG;
+    case QtWarningMsg: return WARN;
+    case QtCriticalMsg: return ERROR;
+    case QtFatalMsg: return ERROR;
+    default: return INFO;
+    }
+}
+
+void Logger::setIsCatchQtMsg(bool arg)
+{
+    QtMessageHandler h = arg ? logMsgHandler : 0;
+    qInstallMessageHandler(h);
+}
+
+#endif

--- a/thirdparty/haw_logger/logger/logger.h
+++ b/thirdparty/haw_logger/logger/logger.h
@@ -1,0 +1,205 @@
+#ifndef HAW_LOGGER_H
+#define HAW_LOGGER_H
+
+#include <string>
+#include <thread>
+#include <vector>
+#include <mutex>
+
+#include "logstream.h"
+
+#undef ERROR
+#undef WARN
+#undef INFO
+#undef DEBUG
+
+namespace haw::logger {
+//! Types
+using Type = std::string;
+
+enum Level {
+    Off     = 0,
+    Normal  = 1,
+    Debug   = 2,
+    Full    = 3
+};
+
+struct Date
+{
+    int day = 0;
+    int mon = 0;
+    int year = 0;
+
+    inline bool operator ==(const Date& d) const
+    {
+        return day == d.day && mon == d.mon && year == d.year;
+    }
+
+    inline bool operator !=(const Date& d) const { return !this->operator ==(d); }
+};
+
+struct Time
+{
+    int msec = 0;
+    int sec = 0;
+    int min = 0;
+    int hour = 0;
+};
+
+struct DateTime
+{
+    Date date;
+    Time time;
+
+    static DateTime now();
+};
+
+//! Message --------------------------------
+class LogMsg
+{
+public:
+
+    LogMsg() = default;
+
+    LogMsg(const Type& l, const std::string& t)
+        : type(l), tag(t), datetime(DateTime::now()),
+        thread(std::this_thread::get_id()) {}
+
+    LogMsg(const Type& l, const std::string& t, const std::string& m)
+        : type(l), tag(t), message(m), datetime(DateTime::now()),
+        thread(std::this_thread::get_id()) {}
+
+    Type type;
+    std::string tag;
+    std::string message;
+    DateTime datetime;
+    std::thread::id thread;
+};
+
+//! Layout ---------------------------------
+class LogLayout
+{
+public:
+    explicit LogLayout(const std::string& format);
+    virtual ~LogLayout();
+
+    struct Pattern {
+        std::string pattern;
+        std::string beforeStr;
+        size_t index = std::string::npos;
+        size_t count = 0;
+        size_t minWidth = 0;
+        Pattern() = default;
+    };
+
+    std::string format() const;
+
+    virtual std::string output(const LogMsg& logMsg) const;
+
+    virtual std::string formatPattern(const LogMsg& logMsg, const Pattern& p) const;
+    virtual std::string formatDateTime(const DateTime& datetime) const;
+    virtual std::string formatDate(const Date& date) const;
+    virtual std::string formatTime(const Time& time) const;
+    virtual std::string formatThread(const std::thread::id& thID) const;
+
+    static Pattern parcePattern(const std::string& format, const std::string& pattern);
+    static std::vector<Pattern> patterns(const std::string& format);
+
+private:
+    std::string m_format;
+    std::vector<Pattern> m_patterns;
+    std::thread::id m_mainThread;
+};
+
+//! Destination ----------------------------
+class LogDest
+{
+public:
+    explicit LogDest(const LogLayout& l);
+    virtual ~LogDest();
+
+    virtual std::string name() const = 0;
+    virtual void write(const LogMsg& logMsg) = 0;
+
+    LogLayout layout() const;
+
+protected:
+    LogLayout m_layout;
+};
+
+//! Logger ---------------------------------
+class Logger
+{
+public:
+
+    static Logger* instance()
+    {
+        static Logger l;
+        return &l;
+    }
+
+    static const Type ERROR;
+    static const Type WARN;
+    static const Type INFO;
+    static const Type DEBUG;
+
+    void setupDefault();
+
+    void setLevel(Level level);
+    Level level() const;
+    inline bool isLevel(Level level) const { return level <= m_level && level != Off; }
+
+    std::vector<Type> types() const;
+    void setTypes(const std::vector<Type>& types);
+    void setType(const Type& type, bool enb);
+    bool isType(const Type& type) const;
+
+    bool isAsseptMsg(const Type& type) const;
+
+#ifdef HAW_LOGGER_QT_SUPPORT
+    static void setIsCatchQtMsg(bool arg);
+#endif
+
+    void write(const LogMsg& logMsg);
+
+    void addDest(LogDest* dest);
+    std::vector<LogDest*> dests() const;
+    void clearDests();
+
+private:
+    Logger();
+    ~Logger();
+
+#ifdef HAW_LOGGER_QT_SUPPORT
+    static void logMsgHandler(QtMsgType, const QMessageLogContext&, const QString&);
+    static Type qtMsgTypeToString(enum QtMsgType defType);
+#endif
+
+    Level m_level = Normal;
+    std::vector<LogDest*> m_dests;
+    std::vector<Type> m_types;
+    std::mutex m_mutex;
+};
+
+//! LogInput ---------------------------------
+class LogInput
+{
+public:
+    explicit LogInput(const Type& type, const std::string& tag)
+        : m_msg(type, tag) {}
+
+    ~LogInput()
+    {
+        m_msg.message = m_stream.str();
+        Logger::instance()->write(m_msg);
+    }
+
+    Stream& stream() { return m_stream; }
+
+private:
+    LogMsg m_msg;
+    Stream m_stream;
+};
+}
+
+#endif // HAW_LOGGER_H

--- a/thirdparty/haw_logger/logger/logstream.h
+++ b/thirdparty/haw_logger/logger/logstream.h
@@ -1,0 +1,82 @@
+#ifndef HAW_LOGSTREAM_H
+#define HAW_LOGSTREAM_H
+
+#include <sstream>
+#include <thread>
+
+#ifdef HAW_LOGGER_QT_SUPPORT
+#include <QDebug>
+#endif
+
+namespace haw::logger {
+class Stream
+{
+public:
+    Stream() = default;
+
+    inline Stream& operator<<(bool t) { m_ss << t; return *this; }
+    inline Stream& operator<<(char t) { m_ss << t; return *this; }
+    inline Stream& operator<<(signed short t) { m_ss << t; return *this; }
+    inline Stream& operator<<(unsigned short t) { m_ss << t; return *this; }
+    inline Stream& operator<<(char16_t t) { m_ss << t; return *this; }
+    inline Stream& operator<<(char32_t t) { m_ss << t; return *this; }
+    inline Stream& operator<<(signed int t) { m_ss << t; return *this; }
+    inline Stream& operator<<(unsigned int t) { m_ss << t; return *this; }
+    inline Stream& operator<<(signed long t) { m_ss << t; return *this; }
+    inline Stream& operator<<(unsigned long t) { m_ss << t; return *this; }
+    inline Stream& operator<<(float t) { m_ss << t; return *this; }
+    inline Stream& operator<<(double t) { m_ss << t; return *this; }
+    inline Stream& operator<<(const void* t) { m_ss << t; return *this; }
+    inline Stream& operator<<(const char* t) { m_ss << t; return *this; }
+
+    inline Stream& operator<<(const std::string& t) { m_ss << t; return *this; }
+    inline Stream& operator<<(const std::thread::id& t) { m_ss << t; return *this; }
+
+    template<typename T>
+    inline Stream& operator<<(const std::vector<T>& t)
+    {
+        m_ss << '[';
+        for (size_t i = 0; i < t.size(); ++i) {
+            m_ss << t[i];
+            if (i < t.size() - 1) {
+                m_ss << ',';
+            }
+        }
+        m_ss << ']';
+        return *this;
+    }
+
+#ifdef HAW_LOGGER_QT_SUPPORT
+    inline Stream& operator<<(qint64 t) { qt_to_ss(t); return *this; }
+    inline Stream& operator<<(quint64 t) { qt_to_ss(t); return *this; }
+    inline Stream& operator<<(QChar t) { qt_to_ss(t); return *this; }
+    inline Stream& operator<<(const QString& t) { qt_to_ss(t); return *this; }
+    inline Stream& operator<<(const QStringRef& t) { qt_to_ss(t); return *this; }
+    inline Stream& operator<<(QStringView t) { qt_to_ss(t); return *this; }
+    inline Stream& operator<<(QLatin1String t) { qt_to_ss(t); return *this; }
+    inline Stream& operator<<(const QByteArray& t) { qt_to_ss(t); return *this; }
+    inline Stream& operator<<(const QVariant& t) { qt_to_ss(t); return *this; }
+
+#endif
+
+    inline std::string str() const { return m_ss.str(); }
+
+private:
+
+#ifdef HAW_LOGGER_QT_SUPPORT
+    template<typename T>
+    inline void qt_to_ss(const T& t)
+    {
+        QString str;
+        QDebug q(&str);
+        q << t;
+        m_ss << str.toStdString();
+    }
+
+#endif
+
+    std::stringstream m_ss;
+};
+}
+
+#endif //HAW_LOGSTREAM_H

--- a/thirdparty/haw_logger/tests/CMakeLists.txt
+++ b/thirdparty/haw_logger/tests/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(haw_logger LANGUAGES CXX)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Qt5Core)
+
+add_definitions(-DHAW_LOGGER_QT_SUPPORT)
+include(${CMAKE_CURRENT_LIST_DIR}/../log/logger.cmake)
+
+include_directories(${HAW_LOGGER_INC})
+
+add_executable(haw_logger
+    main.cpp
+    ${HAW_LOGGER_SRC}
+)
+
+target_link_libraries(haw_logger
+    stdc++fs
+    pthread
+    Qt${QT_VERSION_MAJOR}::Core
+)

--- a/thirdparty/haw_logger/tests/main.cpp
+++ b/thirdparty/haw_logger/tests/main.cpp
@@ -1,0 +1,130 @@
+#include <iostream>
+#include <thread>
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+
+#include <QDebug>
+
+#include "logdefdest.h"
+#include "log.h"
+
+class Example
+{
+public:
+    Example() = default;
+
+    void example()
+    {
+        using namespace haw::logger;
+
+        Logger* logger = Logger::instance();
+        logger->setupDefault();
+
+        //! Default output to console, catch Qt messages
+
+        LOGE() << "This is error";
+        LOGW() << "This is warning";
+        LOGI() << "This is info";
+        LOGD() << "This is debug"; //! NOTE Default not output
+
+        std::thread t1([]() { LOGI() << "From thread"; });
+        t1.join();
+
+        qCritical() << "This is qCritical";
+        qWarning() << "This is qWarning";
+        qDebug() << "This is qDebug"; //! NOTE Default not output
+
+        /*
+        15:21:53.454 | ERROR | main_thread     | Example    | example: This is error
+        15:21:53.454 | WARN  | main_thread     | Example    | example: This is warning
+        15:21:53.454 | INFO  | main_thread     | Example    | example: This is info
+        15:21:53.454 | INFO  | 139855304345344 | Example    | example: From thread
+        15:21:53.455 | ERROR | main_thread     | Qt         | example: This is qCritical
+        15:21:53.455 | WARN  | main_thread     | Qt         | example: This is qWarning
+        */
+
+        //! Set tag (default class name)
+
+        #undef LOG_TAG
+        #define LOG_TAG "MYTAG"
+
+        LOGI() << "This is info with tag";
+        /*
+        15:21:53.455 | INFO  | main_thread     | MYTAG      | example: This is info with tag
+        */
+
+        //! Set log level
+        logger->setLevel(haw::logger::Debug);
+
+        LOGD() << "This is debug";
+        qDebug() << "This is qDebug";
+
+        /*
+        15:34:54.257 | DEBUG | main_thread     | MYTAG      | example: This is debug
+        15:34:54.257 | DEBUG | main_thread     | Qt         | example: This is qDebug
+        */
+
+        //! --- Setup logger ---
+        //! Destination and format
+        logger->clearDests();
+
+        //! Console
+        logger->addDest(new ConsoleLogDest(LogLayout("${time} | ${type|5} | ${thread} | ${tag|10} | ${message}")));
+
+        std::string pwd = fs::current_path();
+        //! File,this creates a file named "apppath/logs/myapp_yyMMdd.log"
+        std::string logPath = pwd + "/logs";
+        logger->addDest(new FileLogDest(logPath, "myapp", "log",
+                                        LogLayout("${datetime} | ${type|5} | ${thread} | ${tag|10} | ${message}")));
+
+        /** NOTE Layout have a tags
+        "${datetime}"   - yyyy-MM-ddThh:mm:ss.zzz
+        "${time}"       - hh:mm:ss.zzz
+        "${type}"       - type
+        "${tag}"        - tag
+        "${thread}"     - thread, the main thread output as "main" otherwise hex
+        "${message}"    - message
+        |N - min field width
+         */
+
+        //! Level
+        logger->setLevel(haw::logger::Debug);
+
+        //! Catch Qt message
+        logger->setIsCatchQtMsg(true);
+
+        //! Custom types
+        logger->setType("MYTRACE", true);
+
+        //! Add to log.h
+        #define MYTRACE() IF_LOGLEVEL(haw::logger::Debug) LOG("MYTRACE", LOG_TAG)
+
+        MYTRACE() << "This my trace";
+
+        /*
+        15:34:54.257 | MYTRACE | main_thread     | MYTAG      | example: This my trace
+        */
+
+        //! That type does not output
+        logger->setType("MYTRACE", false); //! NOTE Type must be a debug level
+
+        MYTRACE() << "This my trace"; //! NOTE Not output
+
+        //! Custom LogLayout - inherits of the LogLayout and override method "output"
+        //! Custom LogDest - inherits of the LogDest and override method "write"
+        //! Custom log macro - see log.h
+    }
+};
+
+int main(int argc, char* argv[])
+{
+    std::clog << "Hello World, I am Logger\n";
+
+    Example t;
+    t.example();
+
+#undef LOG_TAG
+#define LOG_TAG CLASSNAME(FUNC_INFO)
+
+    LOGI() << "Good bye!";
+}


### PR DESCRIPTION
Example output:
```
13:22:44.978 | ERROR | main_thread | AccountController | init: Error while init
13:22:44.980 | DEBUG | main_thread | ShortcutsRegister | expandStandartKeys: added 3 shortcut, because they are alternative shortcuts for the given standard keys
13:22:44.980 | WARN  | main_thread | ExtensionsConfiguration | fileList: 401The file does not exist
13:22:44.980 | WARN  | main_thread | ExtensionsConfiguration | fileList: 401The file does not exist
13:22:44.982 | WARN  | main_thread | WorkspaceManager | setupCurrentWorkspace: filed get workspace: , will use Basic
13:22:45.182 | INFO  | main_thread | AudioEngine | init: success inited audio engine
13:22:45.185 | DEBUG | main_thread | FluidSynth | init: synth inited
```

Currently, log files stored in the `data/logs`
for example `HOME/.local/share/MuseScore/MuseScore4Development/logs`

