### PR TITLE
fix debug build under Windows

### DIFF
--- a/build/module.cmake
+++ b/build/module.cmake
@@ -68,7 +68,7 @@ target_include_directories(${MODULE} PUBLIC
 
 string(TOLOWER ${CMAKE_BUILD_TYPE} build_mode )
 if (build_mode STREQUAL "debug")
-    set(MODULE_DEF ${MODULE_DEF} -D_DEBUG)
+    # set(MODULE_DEF ${MODULE_DEF} -D_DEBUG) # This caused debug build failure under Windows
 else()
     set(MODULE_DEF ${MODULE_DEF} -DNDEBUG)
 endif()


### PR DESCRIPTION
This PR fixes the link step of a debug build under Windows, done by using msvc_build.bat debug.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [N/A] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
