### PR TITLE
fix #312608: stems too short on chords outside staff

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1400,8 +1400,11 @@ qreal Chord::defaultStemLength() const
                   if (sel > staffHlfHgt)                    // if stem ends below ('>') staff mid position,
                         sel = staffHlfHgt;                  // stretch it to mid position
                   stemLen = sel - dy;                       // actual stem length
-                  if (-stemLen < shortest)                  // is stem too short,
-                        stemLen = -shortest;                // lengthen it to shortest possible length
+                  qreal exposedLen = sel - ul * .5;         // portion extending above top note of chord
+                  if (-exposedLen < shortest) {             // if stem too short,
+                        qreal diff = shortest + exposedLen;
+                        stemLen -= diff;                    // lengthen it to shortest possible length
+                        }
                   }
             else {                        // stem down
                   qreal uy  = ul * .5;                      // note-side vert. pos.
@@ -1413,8 +1416,11 @@ qreal Chord::defaultStemLength() const
                   if (sel < staffHlfHgt)                    // if stem ends above ('<') staff mid position,
                         sel = staffHlfHgt;                  // stretch it to mid position
                   stemLen = sel - uy;                       // actual stem length
-                  if (stemLen < shortest)                   // if stem too short,
-                        stemLen = shortest;                 // lengthen it to shortest possible position
+                  qreal exposedLen = sel - dl * .5;         // portion extending below bottom note of chord
+                  if (exposedLen < shortest) {              // if stem too short,
+                        qreal diff = shortest - exposedLen;
+                        stemLen += diff;                    // lengthen it to shortest possible length
+                        }
                   }
             }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/312608

The stem shortening code (for notes outside the staff
whose stems point outwards) tries to enforce a minimum length.
However, this is applied too literally - it checks the full stem length.
So for *chords* as opposed to single notes, it often doesn't apply -
the portion of the the stem inside the chord already exceeds that.

Fix is to adjust the shortening code to check the "exposed" portion
of the stem only - the part extending further from the staff.
If *that* part is less than the "shortest stem" setting,
then we should extend the stem by the difference.