### PR TITLE
Speed up MSVC builds and tidy msvc_build.bat script (3.x)

### DIFF
--- a/msvc_build.bat
+++ b/msvc_build.bat
@@ -16,11 +16,11 @@ REM
 REM INSTALL 64-bit:
 REM    "msvc_build.bat install" put all required files of 64-bit Release build to install folder (msvc.install_x64)
 REM    "msvc_build.bat installdebug" put all required files of 64-bit Debug build to install folder (msvc.install_x64)
-REM    "msvc_build.bat installrelwithdebinfo" put all required files of 64-bit RelWithDebInfo build to install folder (msvc.install_x64) 
+REM    "msvc_build.bat installrelwithdebinfo" put all required files of 64-bit RelWithDebInfo build to install folder (msvc.install_x64)
 REM
 REM INSTALL 32-bit:
-REM    "msvc_build.bat install 32" put all required files of 32-bit Release build to install folder (msvc.install_x86) 
-REM    "msvc_build.bat installdebug 32" put all required files of 32-bit Debug build to install folder (msvc.install_x86) 
+REM    "msvc_build.bat install 32" put all required files of 32-bit Release build to install folder (msvc.install_x86)
+REM    "msvc_build.bat installdebug 32" put all required files of 32-bit Debug build to install folder (msvc.install_x86)
 REM    "msvc_build.bat installrelwithdebinfo 32" put all required files of 32-bit RelWithDebInfo build to install folder (msvc.install_x86)
 REM
 REM PACKAGE:
@@ -33,11 +33,11 @@ REM
 REM Windows Portable build is triggered by defining BUILD_WIN_PORTABLE environment variable to "ON" before launching this script, e.g.
 REM SET BUILD_WIN_PORTABLE=ON
 
-SETLOCAL ENABLEEXTENSIONS
+SETLOCAL ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
 
 IF "%GENERATOR_NAME%"=="" (
    CALL :FIND_GENERATOR
-)  
+)
 
 IF "%GENERATOR_NAME%"=="" (
    ECHO "No supported version of Microsoft Visual Studio (2017 or 2019) found."
@@ -73,17 +73,17 @@ IF "%2"=="32" (
 IF NOT "%3"=="" (
    SET BUILD_NUMBER="%3"
    SET BUILD_AUTOUPDATE="ON"
-   )
+)
 
 ECHO "BUILD_WIN_PORTABLE: %BUILD_WIN_PORTABLE%"
 IF "%BUILD_WIN_PORTABLE%"=="ON" (
     SET "INSTALL_FOLDER=MuseScorePortable\App\MuseScore"
     SET "BUILD_AUTOUPDATE=OFF"
     SET "WIN_PORTABLE_OPT=-DBUILD_PORTABLEAPPS=ON"
-    )
+)
 
-ECHO "INSTALL_FOLDER: %INSTALL_FOLDER%"    
-ECHO "WIN_PORTABLE_OPT: %WIN_PORTABLE_OPT%"    
+ECHO "INSTALL_FOLDER: %INSTALL_FOLDER%"
+ECHO "WIN_PORTABLE_OPT: %WIN_PORTABLE_OPT%"
 
 IF /I "%1"=="release" (
    SET CONFIGURATION_STR="release"
@@ -98,40 +98,40 @@ IF /I "%1"=="debug" (
 IF /I "%1"=="relwithdebinfo" (
    SET CONFIGURATION_STR="relwithdebinfo"
    GOTO :BUILD
-   )
+)
 
 IF /I "%1"=="install" (
    SET "BUILD_FOLDER=%BUILD_FOLDER%_%ARCH%"
    SET CONFIGURATION_STR="release"
    GOTO :INSTALL
-   )
+)
 
 IF /I "%1"=="installdebug" (
    SET "BUILD_FOLDER=%BUILD_FOLDER%_%ARCH%"
    SET CONFIGURATION_STR="debug"
    GOTO :INSTALL
-   )
+)
 
 IF /I "%1"=="installrelwithdebinfo" (
    SET "BUILD_FOLDER=%BUILD_FOLDER%_%ARCH%"
    SET CONFIGURATION_STR="relwithdebinfo"
    GOTO :INSTALL
-   )
+)
 
 IF /I "%1"=="package" (
    cd "%BUILD_FOLDER%_%ARCH%"
    cmake --build . --config RelWithDebInfo --target package
    GOTO :END
-   )
+)
 
 IF /I "%1"=="clean" (
    for /d %%G in ("msvc.*") do rd /s /q "%%~G"
    for /d %%G in ("MuseScorePortable") do rd /s /q "%%~G"
    GOTO :END
-   ) ELSE (
+) ELSE (
    echo No valid parameters are set
    GOTO :END
-   )
+)
 
 :FIND_GENERATOR
 
@@ -140,7 +140,7 @@ IF /I "%1"=="clean" (
 
    REM vswhere.exe is a helper utility that is automatically installed with VS2017 and later (and always at a fixed location).
    SET VSWHERE="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-   IF NOT EXIST %VSWHERE% EXIT /B
+   IF NOT EXIST %VSWHERE% EXIT /B !ERRORLEVEL!
 
    REM Try Visual Studio 2019 first.
    CALL :FIND_GENERATOR_VERSION %VSWHERE% 16 2019
@@ -148,7 +148,7 @@ IF /I "%1"=="clean" (
    REM Fall back to Visual Studio 2017.
    IF "%GENERATOR_NAME%"=="" CALL :FIND_GENERATOR_VERSION %VSWHERE% 15 2017
 
-   EXIT /B
+   EXIT /B !ERRORLEVEL!
 
 :FIND_GENERATOR_VERSION
 
@@ -159,7 +159,7 @@ IF /I "%1"=="clean" (
       IF "%%I"=="%2" SET GENERATOR_NAME=Visual Studio %2 %3
    )
 
-   EXIT /B
+   EXIT /B !ERRORLEVEL!
 
 :BUILD
    echo Generator is: %GENERATOR_NAME%
@@ -168,36 +168,48 @@ IF /I "%1"=="clean" (
    echo Build folder is: %BUILD_FOLDER%
    IF NOT "%BUILD_WIN_PORTABLE%"=="ON" (
       SET "INSTALL_FOLDER=%INSTALL_FOLDER%_%ARCH%"
-      )
+   )
    echo Install folder is: %INSTALL_FOLDER%
-   if not exist "%BUILD_FOLDER%\nul" mkdir "%BUILD_FOLDER%"
-   if not exist "%INSTALL_FOLDER%\nul" mkdir "%INSTALL_FOLDER%"
-   echo Building CMake configuration...
+   if not exist "%BUILD_FOLDER%\" mkdir "%BUILD_FOLDER%"
+   if not exist "%INSTALL_FOLDER%\" mkdir "%INSTALL_FOLDER%"
 
 IF NOT "%MSCORE_STABLE_BUILD%" == "" (
     IF NOT "%CRASH_LOG_SERVER_URL%" == "" (
         IF "%BUILD_FOR_WINSTORE%" == "OFF" (
             SET CRASH_REPORT_URL_OPT=-DCRASH_REPORT_URL=%CRASH_LOG_SERVER_URL% -DBUILD_CRASH_REPORTER=ON
-            )
-        )
-
-    IF NOT "%TELEMETRY_TRACK_ID%" == "" (
-        SET TELEMETRY_TRACK_ID_OPT=-DTELEMETRY_TRACK_ID=%TELEMETRY_TRACK_ID%
         )
     )
 
+    IF NOT "%TELEMETRY_TRACK_ID%" == "" (
+        SET TELEMETRY_TRACK_ID_OPT=-DTELEMETRY_TRACK_ID=%TELEMETRY_TRACK_ID%
+    )
+)
+
 IF "%MUSESCORE_BUILD_CONFIG%" == "" (
     SET MUSESCORE_BUILD_CONFIG="dev"
-    )   
+)
 
 SET "INSTALL_FOLDER=%INSTALL_FOLDER:\=/%"
 REM -DCMAKE_BUILD_NUMBER=%BUILD_NUMBER% -DCMAKE_BUILD_AUTOUPDATE=%BUILD_AUTOUPDATE% %CRASH_REPORT_URL_OPT% are used for CI only
    cd "%BUILD_FOLDER%"
-   cmake -G "%GENERATOR_NAME%" -A "%PLATFORM_NAME%" -DCMAKE_INSTALL_PREFIX=../%INSTALL_FOLDER% -DCMAKE_BUILD_TYPE=%CONFIGURATION_STR% -DMUSESCORE_BUILD_CONFIG=%MUSESCORE_BUILD_CONFIG% -DMUSESCORE_REVISION=%MUSESCORE_REVISION% -DBUILD_FOR_WINSTORE=%BUILD_FOR_WINSTORE% -DBUILD_64=%BUILD_64% -DCMAKE_BUILD_NUMBER=%BUILD_NUMBER% -DBUILD_AUTOUPDATE=%BUILD_AUTOUPDATE% %CRASH_REPORT_URL_OPT% %TELEMETRY_TRACK_ID_OPT% %WIN_PORTABLE_OPT% ..
+   IF EXIST "CMakeCache.txt" (
+      echo Using existing CMake configuration to save time.
+      echo To force reconfiguration, delete CMakeCache.txt or run "msvc_build.bat clean".
+      echo You only need to do this if you want to use different build options to before.
+      REM Note: If a CMakeLists.txt file was edited then the build system will detect it
+      REM and run CMake again automatically with the same options as before.
+   ) ELSE (
+      echo Building CMake configuration...
+      cmake -G "%GENERATOR_NAME%" -A "%PLATFORM_NAME%" -DCMAKE_INSTALL_PREFIX=../%INSTALL_FOLDER% -DCMAKE_BUILD_TYPE=%CONFIGURATION_STR% -DMUSESCORE_BUILD_CONFIG=%MUSESCORE_BUILD_CONFIG% -DMUSESCORE_REVISION=%MUSESCORE_REVISION% -DBUILD_FOR_WINSTORE=%BUILD_FOR_WINSTORE% -DBUILD_64=%BUILD_64% -DCMAKE_BUILD_NUMBER=%BUILD_NUMBER% -DBUILD_AUTOUPDATE=%BUILD_AUTOUPDATE% %CRASH_REPORT_URL_OPT% %TELEMETRY_TRACK_ID_OPT% %WIN_PORTABLE_OPT% ..
+      IF !ERRORLEVEL! NEQ 0 (
+         set OLD_ERRORLEVEL=!ERRORLEVEL!
+         del /f "CMakeCache.txt"
+         exit /b !OLD_ERRORLEVEL!
+      )
+   )
    echo Building MuseScore...
    cmake --build . --config %CONFIGURATION_STR% --target mscore
    GOTO :END
-   )
 
 :INSTALL
    cd "%BUILD_FOLDER%"
@@ -206,5 +218,4 @@ REM -DCMAKE_BUILD_NUMBER=%BUILD_NUMBER% -DCMAKE_BUILD_AUTOUPDATE=%BUILD_AUTOUPDA
    GOTO :END
 
 :END
-
-ENDLOCAL
+exit /b !ERRORLEVEL!


### PR DESCRIPTION
Backport PR #6839 to the 3.x branch.

Speed improvements:

- CMake configuration is only done on the first build.

- Avoid building if configuration was unsuccessful (fail fast).

- Preserve %ERRORLEVEL% on exit (avoid running subsequent commands).

Other improvements:

- Remove check for "nul" directory as this doesn't work on modern
  Windows. It is now possible to check for the directory itself.

- Use K&R braces/parentheses everywhere (i.e. not banner style).

- Strip trailing whitespace.