### PR TITLE
Fix #302990: Set Style Edit dialog to be non-modal to allow score traversal when s…

### DIFF
--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -47,7 +47,8 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       buttonApplyToAllParts = buttonBox->addButton(tr("Apply to all Parts"), QDialogButtonBox::ApplyRole);
       //buttonApplyToAllParts->setEnabled(!cs->isMaster()); // set in showEvent() now
       buttonTogglePagelist->setIcon(QIcon(*icons[int(Icons::goNext_ICON)]));
-      setModal(true);
+      // Allow user to scroll/zoom score while selecting style options:
+      setModal(false);
 
       // create button groups for every set of radio button widgets
       // use this group widgets in list styleWidgets

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6483,7 +6483,7 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
                   _styleDlg = new EditStyle { cs, this };
             else
                   _styleDlg->setScore(cs);
-            _styleDlg->exec();
+            _styleDlg->show();
             }
       else if (cmd == "edit-info") {
             MetaEditDialog med(cs, 0);


### PR DESCRIPTION
…howing

Resolves: https://musescore.org/en/node/302990

This allows the main MuseScore window to be operable while having the Styles dialogue opened 
(`Format → Styles`). The dialogue still retains its "on top" attribute, but the user can now zoom the score or scroll while making changes to the styles. This in turn can help see specific elements that may be covered due to the nature of the dialogue's dimensions.
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
