### PR TITLE
[MU3] Fix #312254: Add alternative choice of “To Coda”

### DIFF
--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -4735,7 +4735,8 @@ static void directionMarker(XmlWriter& xml, const Marker* const m)
             words = "Fine";
             sound = "fine=\"yes\"";
             }
-      else if (mtp == Marker::Type::TOCODA) {
+      else if (mtp == Marker::Type::TOCODA ||
+               mtp == Marker::Type::TOCODASYM) {
             if (m->xmlText() == "")
                   words = "To Coda";
             else
@@ -4810,8 +4811,9 @@ static void repeatAtMeasureStart(XmlWriter& xml, Attributes& attr, const Measure
                               attr.doAttr(xml, false);
                               directionMarker(xml, mk);
                               }
-                        else if (   mtp == Marker::Type::FINE
-                                    || mtp == Marker::Type::TOCODA
+                        else if (   mtp == Marker::Type::FINE ||
+                                    mtp == Marker::Type::TOCODA ||
+                                    mtp == Marker::Type::TOCODASYM
                                     ) {
                               // ignore
                               }
@@ -4846,7 +4848,9 @@ static void repeatAtMeasureStop(XmlWriter& xml, const Measure* const m, int stra
                         // filter out the markers at measure stop
                         const Marker* const mk = toMarker(e);
                         Marker::Type mtp = mk->markerType();
-                        if (mtp == Marker::Type::FINE || mtp == Marker::Type::TOCODA) {
+                        if (mtp == Marker::Type::FINE ||
+                            mtp == Marker::Type::TOCODA ||
+                            mtp == Marker::Type::TOCODASYM) {
                               directionMarker(xml, mk);
                               }
                         else if (mtp == Marker::Type::SEGNO || mtp == Marker::Type::CODA) {

--- a/libmscore/marker.cpp
+++ b/libmscore/marker.cpp
@@ -29,14 +29,15 @@ static const ElementStyle markerStyle {
 
 //must be in sync with Marker::Type enum
 const MarkerTypeItem markerTypeTable[] = {
-      { Marker::Type::SEGNO   , QT_TRANSLATE_NOOP("markerType", "Segno")          },
-      { Marker::Type::VARSEGNO, QT_TRANSLATE_NOOP("markerType", "Segno variation")},
-      { Marker::Type::CODA    , QT_TRANSLATE_NOOP("markerType", "Coda")           },
-      { Marker::Type::VARCODA , QT_TRANSLATE_NOOP("markerType", "Varied coda")    },
-      { Marker::Type::CODETTA , QT_TRANSLATE_NOOP("markerType", "Codetta")        },
-      { Marker::Type::FINE    , QT_TRANSLATE_NOOP("markerType", "Fine")           },
-      { Marker::Type::TOCODA  , QT_TRANSLATE_NOOP("markerType", "To Coda")        },
-      { Marker::Type::USER    , QT_TRANSLATE_NOOP("markerType", "Custom")         }
+      { Marker::Type::SEGNO    , QT_TRANSLATE_NOOP("markerType", "Segno")           },
+      { Marker::Type::VARSEGNO , QT_TRANSLATE_NOOP("markerType", "Segno variation") },
+      { Marker::Type::CODA     , QT_TRANSLATE_NOOP("markerType", "Coda")            },
+      { Marker::Type::VARCODA  , QT_TRANSLATE_NOOP("markerType", "Varied coda")     },
+      { Marker::Type::CODETTA  , QT_TRANSLATE_NOOP("markerType", "Codetta")         },
+      { Marker::Type::FINE     , QT_TRANSLATE_NOOP("markerType", "Fine")            },
+      { Marker::Type::TOCODA   , QT_TRANSLATE_NOOP("markerType", "To Coda")         },
+      { Marker::Type::TOCODASYM, QT_TRANSLATE_NOOP("markerType", "To Coda (Symbol)")},
+      { Marker::Type::USER     , QT_TRANSLATE_NOOP("markerType", "Custom")          }
       };
 
 int markerTypeTableSize()
@@ -103,6 +104,12 @@ void Marker::setMarkerType(Type t)
 
             case Type::TOCODA:
                   txt = "To Coda";
+                  initTid(Tid::REPEAT_RIGHT, true);
+                  setLabel("coda");
+                  break;
+
+            case Type::TOCODASYM:
+                  txt = "To <font size=\"20\"/><sym>coda</sym>";
                   initTid(Tid::REPEAT_RIGHT, true);
                   setLabel("coda");
                   break;

--- a/libmscore/marker.h
+++ b/libmscore/marker.h
@@ -31,9 +31,10 @@ class Marker final : public TextBase {
             VARSEGNO,
             CODA,
             VARCODA,
-            CODETTA,
+            CODETTA, // not in SMuFL, but still needed for 1.x compatibility, rendered as a double coda
             FINE,
             TOCODA,
+            TOCODASYM,
             USER
             };
 

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -694,7 +694,7 @@ PalettePanel* MuseScore::newRepeatsPalettePanel()
       sp->append(rm, qApp->translate("symUserNames", Sym::symUserNames[int(SymId::repeat1Bar)]));
 
       for (int i = 0; i < markerTypeTableSize(); i++) {
-            if (markerTypeTable[i].type == Marker::Type::CODETTA) //not in smufl
+            if (markerTypeTable[i].type == Marker::Type::CODETTA) // not in SMuFL
                   continue;
 
             Marker* mk = new Marker(gscore);

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -1434,7 +1434,9 @@ void Timeline::jumpMarkerMeta(Segment* seg, int* stagger, int pos)
             for (TextFragment tf : tf_list)
                   text.push_back(tf.text);
             measure = marker->measure();
-            if (marker->markerType() == Marker::Type::FINE || marker->markerType() == Marker::Type::TOCODA) {
+            if (marker->markerType() == Marker::Type::FINE ||
+                marker->markerType() == Marker::Type::TOCODA ||
+                marker->markerType() == Marker::Type::TOCODASYM) {
                   elementType = ElementType::MARKER;
                   std::get<2>(_repeatInfo) = std::get<3>(_repeatInfo);
                   std::get<3>(_repeatInfo) = nullptr;

--- a/mtest/mscore/palette/tst_palette.cpp
+++ b/mtest/mscore/palette/tst_palette.cpp
@@ -65,11 +65,12 @@ void TestPaletteModel::testDuplicateItemNames()
       for (auto name = paletteItemNames.begin(); name != paletteItemNames.end(); ++name) {
             if (name.value().size() != 1) {
                   // Exceptions - allowed duplicates
-                  if (name.key().endsWith(" repeat sign") // repeat barlines in "Barlines" and "Repeats & Jumps" palette
-                      || name.key() == "Open" // articulations in "Articulations" and channel switch text in "Text" palette
-                      || name.key() == "Line" // bracket type in "Brackets" and line type in "Lines" palette
-                      //|| name.key() == "Caesura" // 2 different Caesuras in the "Breaths & Pauses" palette (so far Master palette only)
-                      || name.key().startsWith("Add parentheses to ") // "Noteheads" and "Accidentals" palette
+                  if (name.key().endsWith(" repeat sign") || // repeat barlines in "Barlines" and "Repeats & Jumps" palette
+                      //name.key().startsWith("To Coda") || // 2 different "To Coda" in "Repeats & Jumps" palette (so far Master palette only)
+                      name.key() == "Open" || // articulations in "Articulations" and channel switch text in "Text" palette
+                      name.key() == "Line" || // bracket type in "Brackets" and line type in "Lines" palette
+                      //name.key() == "Caesura" || // 2 different Caesuras in the "Breaths & Pauses" palette (so far Master palette only)
+                      name.key().startsWith("Add parentheses to ") // "Noteheads" and "Accidentals" palette
                       )
                         continue;
                   duplicates = true;

--- a/share/workspaces/Basic.xml
+++ b/share/workspaces/Basic.xml
@@ -704,25 +704,11 @@
             <label>segno</label>
             </Marker>
           </Cell>
-        <Cell name="Segno variation">
-          <Marker>
-            <style>Repeat Text Left</style>
-            <text><sym>segnoSerpent1</sym></text>
-            <label>varsegno</label>
-            </Marker>
-          </Cell>
         <Cell name="Coda">
           <Marker>
             <style>Repeat Text Left</style>
             <text><sym>coda</sym></text>
             <label>codab</label>
-            </Marker>
-          </Cell>
-        <Cell name="Varied coda">
-          <Marker>
-            <style>Repeat Text Left</style>
-            <text><sym>codaSquare</sym></text>
-            <label>varcoda</label>
             </Marker>
           </Cell>
         <Cell name="Fine">


### PR DESCRIPTION
Add a "To `<sym>coda</sym>`" to master "Repeats and Jumps" palette .
The "To " part of it is sort of needed to tell it from the plain Coda in the palettes (so to not have to rely on the tool tip only), but is likely to not be wanted in score, so needs to get deleted there manually.
Seems we need to hardcode the size of the Coda symbol.

Removing some rather rare symbols from the Basis workspace's "Repeats
and Jumps" palette, namely "Segno variation" and "Varied coda".

Resolves https://musescore.org/en/node/312254

Port to MuseScore 4 needed too I guess, I'll take care of it once this PR passed muster ;-)