### PR TITLE
[MU4] Fixed build mu3 mode on CI

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -93,7 +93,8 @@ jobs:
       if: env.DO_BUILD == 'true'
       run: |
         T_ID=${{ secrets.TELEMETRY_TRACK_ID }}; if [ -z "$T_ID" ]; then T_ID="''"; fi
-        sudo bash ./build/ci/linux/build.sh -n ${{ github.run_id }} --telemetry $T_ID
+        if [ "$BUILD_MODE" != "nightly_build" ]; then MU4_BUILD_OPT="--build_mu4 OFF"; fi
+        sudo bash ./build/ci/linux/build.sh -n ${{ github.run_id }} --telemetry $T_ID $MU4_BUILD_OPT
     - name: Package 
       if: env.DO_BUILD == 'true'
       run: |

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -91,7 +91,8 @@ jobs:
       if: env.DO_BUILD == 'true'   
       run: |
         T_ID=${{ secrets.TELEMETRY_TRACK_ID }}; if [ -z "$T_ID" ]; then T_ID="''"; fi
-        bash ./build/ci/macos/build.sh -n ${{ github.run_id }} --telemetry $T_ID
+        if [ "$BUILD_MODE" != "nightly_build" ]; then MU4_BUILD_OPT="--build_mu4 OFF"; fi
+        bash ./build/ci/macos/build.sh -n ${{ github.run_id }} --telemetry $T_ID $MU4_BUILD_OPT
     - name: Package 
       if: env.DO_BUILD == 'true'
       run: |

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -90,7 +90,8 @@ jobs:
       run: |
         IF ${{ secrets.TELEMETRY_TRACK_ID != 0 }} == true ( SET T_ID=${{ secrets.TELEMETRY_TRACK_ID }} ) ELSE ( SET T_ID="''" )
         IF ${{ secrets.CRASH_LOG_SERVER_URL != 0 }} == true ( SET C_URL=${{ secrets.CRASH_LOG_SERVER_URL }} ) ELSE ( SET C_URL="''" )
-        build\ci\windows\build.bat -n ${{ github.run_id }} --telemetry %T_ID% --crashurl %C_URL%
+        IF "%BUILD_MODE%"" != "nightly_build" (SET MU4_BUILD_OPT="--build_mu4 OFF" )
+        build\ci\windows\build.bat -n ${{ github.run_id }} --telemetry %T_ID% --crashurl %C_URL% %MU4_BUILD_OPT%
     - name: Package 
       if: env.DO_BUILD == 'true'
       shell: cmd


### PR DESCRIPTION
Another mistake
Workflows `ci_linux.yml`, `ci_macos.yml`, and `ci_windows.yml` used for two goals:
1. Builds `master` in the MU3 mode (to check that nothing is broken)
2. Builds `3.x` nightly builds 

For the first goal, need pass option `--build_mu4=OFF`  in the build.sh script.
But the second goal, there is do checkout on 3.x branch, and in the build.sh script in the 3.x branch doesn't have the option `--build_mu4`, so will be an error and nightly build will fail. 
This is what I recently fixed.
But I broke build in the mu3 mode.

Now fixed both goals

I think, better have separate workflows for each goal. 
But now, this does not matter, I hope we delete mu3 code (and mode) from master come soon.