### PR TITLE
[MU3] Fix #312869: Crash when deleting or changing a time signature in a multimeasure rest

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -940,7 +940,8 @@ void Score::cmdRemoveTimeSig(TimeSig* ts)
       Score* rScore = masterScore();
       Measure* rm = rScore->tick2measure(m->tick());
       Segment* rs = rm->findSegment(SegmentType::TimeSig, s->tick());
-      rScore->undoRemoveElement(rs);
+      if (rs)
+            rScore->undoRemoveElement(rs);
 
       Measure* pm = m->prevMeasure();
       Fraction ns(pm ? pm->timesig() : Fraction(4,4));
@@ -5099,6 +5100,8 @@ void Score::undoAddCR(ChordRest* cr, Measure* measure, const Fraction& tick)
 
 void Score::undoRemoveElement(Element* element)
       {
+      if (!element)
+            return;
       QList<Segment*> segments;
       for (ScoreElement* ee : element->linkList()) {
             Element* e = static_cast<Element*>(ee);


### PR DESCRIPTION
Resolves https://musescore.org/en/node/312869.
One of the two changes would be enough. If I had to pick just one of them, the 2nd is the more general approach.
Probably needed for master too, I'll deal with it when this PR here passed muster ;-)