### PR TITLE
Fix a bug in audio export.

### DIFF
--- a/mscore/exportaudio.cpp
+++ b/mscore/exportaudio.cpp
@@ -156,7 +156,7 @@ bool MuseScore::saveAudio(Score* score, QIODevice *device, std::function<bool(fl
                         playTime  += n;
                         frames    -= n;
                         const NPlayEvent& e = playPos->second;
-                        if (e.isChannelEvent()) {
+                        if (!e.discard() && e.isChannelEvent()) {
                               int channelIdx = e.channel();
                               const Channel* c = score->masterScore()->midiMapping(channelIdx)->articulation();
                               if (!c->mute()) {

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7294,7 +7294,7 @@ bool MuseScore::saveMp3(Score* score, QIODevice* device, bool& wasCanceled)
                               frames    -= n;
                               }
                         const NPlayEvent& e = playPos->second;
-                        if (e.isChannelEvent()) {
+                        if (!e.discard() && e.isChannelEvent()) {
                               int channelIdx = e.channel();
                               Channel* c = score->masterScore()->midiMapping(channelIdx)->articulation();
                               if (!c->mute()) {


### PR DESCRIPTION
Same note with different length in different voices exported wrong.
Fix for: *.mp3, *.flac, *.ogg and *.wav exports

Resolves: https://musescore.com/groups/improving-musescore-com/discuss/5080619

inhouse team