### PR TITLE
Fix #312489 Harmony duration interpretation

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3195,8 +3195,8 @@ void Score::cmdRealizeChordSymbols(bool literal, Voicing voicing, HDuration dura
                   continue;
             RealizedHarmony r = h->getRealizedHarmony();
             Segment* seg = h->parent()->isSegment() ? toSegment(h->parent()) : toSegment(h->parent()->parent());
-            Fraction duration = r.getActualDuration(durationType);
             Fraction tick = seg->tick();
+            Fraction duration = r.getActualDuration(tick.ticks(), durationType);
             bool concertPitch = styleB(Sid::concertPitch);
 
             Chord* chord = new Chord(this); //chord template

--- a/libmscore/fret.h
+++ b/libmscore/fret.h
@@ -141,7 +141,7 @@ class FretDiagram final : public Element {
       // Markers stored as K: string, V: marker struct
       MarkerMap _markers;
 
-      Harmony* _harmony  { 0 };
+      Harmony* _harmony  { nullptr };
 
       qreal stringLw;
       qreal nutLw;

--- a/libmscore/harmony.h
+++ b/libmscore/harmony.h
@@ -129,7 +129,7 @@ class Harmony final : public TextBase {
 
       Harmony* findNext() const;
       Harmony* findPrev() const;
-      Fraction ticksTilNext(bool stopAtMeasureEnd = false) const;
+      Fraction ticksTillNext(int utick, bool stopAtMeasureEnd = false) const;
       Segment* getParentSeg() const;
 
       const ChordDescription* descr() const;

--- a/libmscore/realizedharmony.cpp
+++ b/libmscore/realizedharmony.cpp
@@ -231,12 +231,15 @@ void RealizedHarmony::update(int rootTpc, int bassTpc, int transposeOffset /*= 0
 ///    which returns the HDuration, which is the duration
 ///    setting.
 ///
-///    Specifying a parameter finds a duration based on the
-///    passed duration type while not specifying a parameter
-///    uses the setting set by the user for the specific
-///    harmony object.
+///    As the duration may depend on playback order the
+///    utick is required as a reference point
+///
+///    Specifying the durationType will overwrite the
+///    setting set by the user for the specific harmony object.
+///    Don't specify it (or as HDuration::INVALID) to honor
+///    the user setting.
 //--------------------------------------------------
-Fraction RealizedHarmony::getActualDuration(HDuration durationType) const
+Fraction RealizedHarmony::getActualDuration(int utick, HDuration durationType) const
       {
       HDuration dur;
       if (durationType != HDuration::INVALID)
@@ -246,10 +249,10 @@ Fraction RealizedHarmony::getActualDuration(HDuration durationType) const
       switch (dur)
             {
             case HDuration::UNTIL_NEXT_CHORD_SYMBOL:
-                  return _harmony->ticksTilNext(false);
+                  return _harmony->ticksTillNext(utick, false);
                   break;
             case HDuration::STOP_AT_MEASURE_END:
-                  return _harmony->ticksTilNext(true);
+                  return _harmony->ticksTillNext(utick, true);
                   break;
             case HDuration::SEGMENT_DURATION: {
                   Segment* s = _harmony->getParentSeg();

--- a/libmscore/realizedharmony.h
+++ b/libmscore/realizedharmony.h
@@ -101,7 +101,7 @@ class RealizedHarmony {
 
       void update(int rootTpc, int bassTpc, int transposeOffset = 0); //updates the notes map
 
-      Fraction getActualDuration(HDuration durationType = HDuration::INVALID) const;
+      Fraction getActualDuration(int utick, HDuration durationType = HDuration::INVALID) const;
 
    private:
       PitchMap getIntervals(int rootTpc, bool literal = true) const;

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -637,7 +637,7 @@ static void renderHarmony(EventMap* events, Measure const * m, Harmony* h, int t
 
       NPlayEvent ev(ME_NOTEON, channel->channel(), 0, velocity);
       ev.setHarmony(h);
-      Fraction duration = r.getActualDuration();
+      Fraction duration = r.getActualDuration(h->tick().ticks() + tickOffset);
 
       int onTime = h->tick().ticks() + tickOffset;
       int offTime = onTime + duration.ticks();

--- a/libmscore/repeatlist.cpp
+++ b/libmscore/repeatlist.cpp
@@ -21,6 +21,7 @@
 #include "types.h"
 #include "volta.h"
 
+#include <algorithm>
 #include <list>
 #include <utility> // std::pair
 
@@ -242,6 +243,17 @@ int RepeatList::utime2utick(qreal t) const
             qFatal("time %f not found in RepeatList", t);
             }
       return 0;
+      }
+
+///
+/// \brief Lookup the RepeatSegment containing the given utick
+///
+QList<RepeatSegment*>::const_iterator RepeatList::findRepeatSegmentFromUTick(int utick) const
+      {
+      return std::lower_bound(this->cbegin(), this->cend(), utick, [](RepeatSegment const * rs, int utick) {
+            // Skip RS where endtick is less than us
+            return utick > (rs->utick + rs->len());
+            });
       }
 
 //---------------------------------------------------------

--- a/libmscore/repeatlist.h
+++ b/libmscore/repeatlist.h
@@ -91,6 +91,8 @@ class RepeatList: public QList<RepeatSegment*>
       qreal utick2utime(int) const;
       void updateTempo();
       int ticks() const;
+
+      QList<RepeatSegment*>::const_iterator findRepeatSegmentFromUTick(int utick) const;
       };
 
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/312489

Makes the Harmony realization follow the repeatlist order when determining the next Harmony element

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [N/A] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
