### PR TITLE
Fix #312959: Implement New Navigation Commands (Frames/Sections/Playback Cursor)

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2315,8 +2315,8 @@ Element* Score::move(const QString& cmd)
                                     }
                         break;
                         }
-                  case ElementType::HBOX: Q_FALLTHROUGH();
-                  case ElementType::VBOX: Q_FALLTHROUGH();
+                  case ElementType::HBOX: // fallthrough
+                  case ElementType::VBOX: // fallthrough
                   case ElementType::TBOX:
                         box = toBox(el);
                         break;

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2443,6 +2443,16 @@ Element* Score::move(const QString& cmd)
             auto measureBase = cr ? cr->measure()->findMeasureBase() : box->findMeasureBase();
             el = measureBase ? cmdNextPrevFrame(measureBase, false) : nullptr;
             }
+      else if (cmd == "next-section") {
+            if (!(el = box))
+                  el = cr;
+            el = cmdNextPrevSection(el, true);
+            }
+      else if (cmd == "prev-section") {
+            if (!(el = box))
+                  el = cr;
+            el = cmdNextPrevSection(el, false);
+            }
       else if (cmd == "next-track" && cr) {
             el = nextTrack(cr);
             if (noteEntryMode())

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2410,12 +2410,16 @@ Element* Score::move(const QString& cmd)
 
             }
       else if (cmd == "next-measure") {
+            if (box && box->nextMeasure() && box->nextMeasure()->first())
+                  el = box->nextMeasure()->first()->nextChordRest(0, false);
             if (cr)
                   el = nextMeasure(cr);
             if (el && noteEntryMode())
                   _is.moveInputPos(el);
             }
       else if (cmd == "prev-measure") {
+            if (box && box->prevMeasure() && box->prevMeasure()->first())
+                  el = box->prevMeasure()->first()->nextChordRest(0, false);
             if (cr)
                   el = prevMeasure(cr);
             if (el && noteEntryMode())

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -4073,6 +4073,22 @@ ChordRest* Score::cmdNextPrevSystem(ChordRest* cr, bool next)
       }
 
 //---------------------------------------------------------
+//   cmdNextPrevFrame
+//   Return next/previous [Vertical/Horizontal/Text] frame
+//   to be used as a navigation command
+//---------------------------------------------------------
+
+Box* Score::cmdNextPrevFrame(MeasureBase* currentMeasureBase, bool next) const
+      {
+            Box* selectedBox { nullptr };
+            while (!selectedBox && (currentMeasureBase = (next ? currentMeasureBase->next() : currentMeasureBase->prev()))) {
+                  if (currentMeasureBase->isBox())
+                        selectedBox = toBox(currentMeasureBase);
+                  }
+            return selectedBox;
+      }
+
+//---------------------------------------------------------
 //   setSoloMute
 //   called once at opening file, adds soloMute marks
 //---------------------------------------------------------

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -4080,12 +4080,124 @@ ChordRest* Score::cmdNextPrevSystem(ChordRest* cr, bool next)
 
 Box* Score::cmdNextPrevFrame(MeasureBase* currentMeasureBase, bool next) const
       {
-            Box* selectedBox { nullptr };
-            while (!selectedBox && (currentMeasureBase = (next ? currentMeasureBase->next() : currentMeasureBase->prev()))) {
-                  if (currentMeasureBase->isBox())
-                        selectedBox = toBox(currentMeasureBase);
+      Box* selectedBox { nullptr };
+      while (!selectedBox && (currentMeasureBase = (next ? currentMeasureBase->next() : currentMeasureBase->prev()))) {
+            if (currentMeasureBase->isBox())
+                  selectedBox = toBox(currentMeasureBase);
+            }
+      return selectedBox;
+      }
+
+//---------------------------------------------------------
+//   cmdNextPrevSection
+//    Return [Box* or ChordRest*] of next/previous section
+//---------------------------------------------------------
+
+Element* Score::cmdNextPrevSection(Element* el, bool dir) const
+      {
+      auto currentMeasureBase = el->findMeasureBase();
+      auto destination = currentMeasureBase;
+      if (currentMeasureBase) {
+            // -----------------------
+            // Next Section of Score
+            // -----------------------
+            if (dir) {
+                  if ((destination = getNextPrevSectionBreak(currentMeasureBase, true))) {
+                        el = getScoreElementOfMeasureBase(destination->next());
+                        }
                   }
-            return selectedBox;
+            // -------------------------
+            // Previous Section of Score
+            // -------------------------
+            else {
+                  auto currentSegment = el->isChordRest() ? toChordRest(el)->segment() : nullptr;
+                  if ((destination = getNextPrevSectionBreak(currentMeasureBase, false))) {
+                        if (currentSegment) {
+                              if ((el = getScoreElementOfMeasureBase((score()->first() == destination) ? destination : destination->next()))) {
+                                    if (el->isChordRest() && (toChordRest(el)->segment() == currentSegment)) {
+                                          if ((destination = getNextPrevSectionBreak(destination, false))) {
+                                                el = !(destination->sectionBreak()) ? destination : getScoreElementOfMeasureBase(destination->next());
+                                                }
+                                          }
+                                    }
+                              }
+                        else if ((score()->first() != currentMeasureBase) && (el = getScoreElementOfMeasureBase(destination->next()))) {
+                              if (el->findMeasureBase() == currentMeasureBase) {
+                                    if ((destination = getNextPrevSectionBreak(destination, false))) {
+                                          el = !(destination->sectionBreak()) ? el : getScoreElementOfMeasureBase(destination->next());
+                                          }
+                                    }
+                              }
+                        }
+                  }
+            }
+      return el;
+      }
+
+//---------------------------------------------------------
+//   getNextPrevSectionBreak
+//    Condition: MeasureBase* must be valid before call
+//    If no previous section break exists selects first
+//    MeasureBase within score
+//---------------------------------------------------------
+
+MeasureBase* Score::getNextPrevSectionBreak(MeasureBase* mb, bool dir) const
+      {
+      auto destination = mb;
+      if (destination) {
+            if (dir) {
+                  // Find next section break
+                  auto endOfSection { false };
+                  while (!endOfSection) {
+                        if ((destination = destination->next()))
+                              endOfSection = destination->sectionBreak();
+                        else break;
+                        }
+                  }
+            else {
+                  // Find previous section break
+                  auto inCurrentSection { true };
+                  while (inCurrentSection && destination) {
+                        if (destination->index()) {
+                              // Safety: SegFaults if invoking prev() when index=0
+                              //         even when MeasureBase* is valid!
+                              destination = destination->prev();
+                              inCurrentSection = !(destination->sectionBreak());
+                              }
+                        else destination = nullptr;
+                        }
+                  if (inCurrentSection || !destination)
+                        destination = score()->first();
+                  }
+            }
+      return destination;
+      }
+
+
+//---------------------------------------------------------
+//   getScoreElementOfMeasureBase
+//    Helper function
+//    Get an Element* as Box or ChordRest depending on
+//    MeasureBase
+//---------------------------------------------------------
+
+Element* Score::getScoreElementOfMeasureBase(MeasureBase* mb) const
+      {
+      Element* el { nullptr };
+      ChordRest* cr { nullptr };
+      const Measure* currentMeasure { nullptr };
+      if (mb) {
+            if (mb->isBox())
+                  el = toBox(mb);
+            else if ((currentMeasure = mb->findMeasure())) {
+                  // Accommodate for MMRest
+                  if (score()->styleB(Sid::createMultiMeasureRests) && currentMeasure->hasMMRest())
+                        currentMeasure = currentMeasure->mmRest1();
+                  if ((cr = currentMeasure->first()->nextChordRest(0, false)))
+                        el = cr;
+                  }
+            }
+      return el;
       }
 
 //---------------------------------------------------------

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -848,6 +848,7 @@ class Score : public QObject, public ScoreElement {
       Element* nextElement();
       Element* prevElement();
       ChordRest* cmdNextPrevSystem(ChordRest*, bool);
+      Box* cmdNextPrevFrame(MeasureBase*, bool) const ;
 
       void cmd(const QAction*, EditData&);
       int fileDivision(int t) const { return ((qint64)t * MScore::division + _fileDivision/2) / _fileDivision; }

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -849,6 +849,9 @@ class Score : public QObject, public ScoreElement {
       Element* prevElement();
       ChordRest* cmdNextPrevSystem(ChordRest*, bool);
       Box* cmdNextPrevFrame(MeasureBase*, bool) const;
+      Element* cmdNextPrevSection(Element*, bool) const;
+      MeasureBase* getNextPrevSectionBreak(MeasureBase*, bool) const;
+      Element* getScoreElementOfMeasureBase(MeasureBase*) const;
 
       void cmd(const QAction*, EditData&);
       int fileDivision(int t) const { return ((qint64)t * MScore::division + _fileDivision/2) / _fileDivision; }

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -848,7 +848,7 @@ class Score : public QObject, public ScoreElement {
       Element* nextElement();
       Element* prevElement();
       ChordRest* cmdNextPrevSystem(ChordRest*, bool);
-      Box* cmdNextPrevFrame(MeasureBase*, bool) const ;
+      Box* cmdNextPrevFrame(MeasureBase*, bool) const;
 
       void cmd(const QAction*, EditData&);
       int fileDivision(int t) const { return ((qint64)t * MScore::division + _fileDivision/2) / _fileDivision; }

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2312,6 +2312,8 @@ void ScoreView::cmd(const char* s)
               "prev-system",
               "next-frame",
               "prev-frame",
+              "next-section",
+              "prev-section",
               "empty-trailing-measure",
               "top-staff"}, [](ScoreView* cv, const QByteArray& cmd) {
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2310,6 +2310,8 @@ void ScoreView::cmd(const char* s)
               "prev-measure",
               "next-system",
               "prev-system",
+              "next-frame",
+              "prev-frame",
               "empty-trailing-measure",
               "top-staff"}, [](ScoreView* cv, const QByteArray& cmd) {
 

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1042,6 +1042,13 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
+         "prev-frame",
+         QT_TRANSLATE_NOOP("action","Previous Frame"),
+         QT_TRANSLATE_NOOP("action","Go to previous frame ")
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
          "prev-track",
          QT_TRANSLATE_NOOP("action","Previous Staff or Voice"),
          QT_TRANSLATE_NOOP("action","Previous staff or voice")
@@ -1066,6 +1073,13 @@ Shortcut Shortcut::_sc[] = {
          "next-system",
          QT_TRANSLATE_NOOP("action","Next System"),
          QT_TRANSLATE_NOOP("action","Go to next system")
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
+         "next-frame",
+         QT_TRANSLATE_NOOP("action","Next Frame"),
+         QT_TRANSLATE_NOOP("action","Go to next frame ")
          },
       {
          MsWidget::SCORE_TAB,

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1044,7 +1044,7 @@ Shortcut Shortcut::_sc[] = {
          STATE_NORMAL | STATE_NOTE_ENTRY,
          "prev-frame",
          QT_TRANSLATE_NOOP("action","Previous Frame"),
-         QT_TRANSLATE_NOOP("action","Go to previous frame ")
+         QT_TRANSLATE_NOOP("action","Go to previous frame")
          },
       {
          MsWidget::SCORE_TAB,
@@ -1079,7 +1079,7 @@ Shortcut Shortcut::_sc[] = {
          STATE_NORMAL | STATE_NOTE_ENTRY,
          "next-frame",
          QT_TRANSLATE_NOOP("action","Next Frame"),
-         QT_TRANSLATE_NOOP("action","Go to next frame ")
+         QT_TRANSLATE_NOOP("action","Go to next frame")
          },
       {
          MsWidget::SCORE_TAB,

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1105,6 +1105,13 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
+         "playback-position",
+         QT_TRANSLATE_NOOP("action","Playback Cursor Position"),
+         QT_TRANSLATE_NOOP("action","Go to recent playback cursor position")
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
          "empty-trailing-measure",
          QT_TRANSLATE_NOOP("action","First Empty Trailing Measure"),
          QT_TRANSLATE_NOOP("action","Go to first empty trailing measure")

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1049,6 +1049,13 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
+         "prev-section",
+         QT_TRANSLATE_NOOP("action","Previous Section"),
+         QT_TRANSLATE_NOOP("action","Go to previous section")
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
          "prev-track",
          QT_TRANSLATE_NOOP("action","Previous Staff or Voice"),
          QT_TRANSLATE_NOOP("action","Previous staff or voice")
@@ -1080,6 +1087,13 @@ Shortcut Shortcut::_sc[] = {
          "next-frame",
          QT_TRANSLATE_NOOP("action","Next Frame"),
          QT_TRANSLATE_NOOP("action","Go to next frame")
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
+         "next-section",
+         QT_TRANSLATE_NOOP("action","Next Section"),
+         QT_TRANSLATE_NOOP("action","Go to next section")
          },
       {
          MsWidget::SCORE_TAB,


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/312959

Included herein are the following commands:

**[Next/previous section]**
This includes frames so that if a traversed section has a frame, that frame will be the new position: else, the first chord-rest of traversed section will be.

**[Next/previous frame]**
This only traverses frames [horizontal/vertical/text], having no regard of section breaks. This also updates the [next/previous measure] commands to allow getting out of a frame and into the next or previous measure, as  nothing would happen before these commands existed.

**[Go to recent playback cursor position]**
This takes into consideration current track (voice/instrument), but if a ChordRest exists in a given segment where the initial track doesn't, it will take the user there. I decided to not have this take the user to a non-musical sounding element since the playback cursor only traverses chord/rest elements. In that sense, this won't do exactly what was desired by @MarcSabatella, i.e., take the user to the beginning barline of a next measure for score accessibility read-out purposes after a section break is met with. For that, if a frame exists, a [next section] command would work and then [alt+right] to traverse elements, and if not, [next section] + [alt-left] to read the elements before the first chordrest of the new section. If this command is issued at the end of a section after stopping playback, current selection will be at the next measure's first chord-rest rather than first element. Hopefully it gets some use. Still open to suggestions, but this currently seems, imho, to be the most "generically acceptable" way for this command.
Included is a demonstration .gif of **[Go to recent playback cursor position]**:

![GotoPlayCursor](https://user-images.githubusercontent.com/7139517/99634996-37375980-29f6-11eb-88e5-131ca7d34d52.gif)



- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
