### PR TITLE
fix #312854: [MusicXML] musicxml from new version of Finale imports a…

### DIFF
--- a/importexport/musicxml/importmxmlpass1.cpp
+++ b/importexport/musicxml/importmxmlpass1.cpp
@@ -1282,7 +1282,7 @@ void MusicXMLParserPass1::credit(CreditWordsList& credits)
       QString justify;
       QString halign;
       QString valign;
-      QString crtype;
+      QStringList crtypes;
       QString crwords;
       while (_e.readNextStartElement()) {
             if (_e.name() == "credit-words") {
@@ -1299,15 +1299,17 @@ void MusicXMLParserPass1::credit(CreditWordsList& credits)
                   crwords += nextPartOfFormattedString(_e);
                   }
             else if (_e.name() == "credit-type") {
-                  // multiple credit-type elements may be present in theory
-                  // in practice, no instances observed, use only the first
-                  if (crtype == "")
-                        crtype = _e.readElementText();
+                  // multiple credit-type elements may be present, supported by
+                  // e.g. Finale v26.3 for Mac.
+                  crtypes += _e.readElementText();
                   }
             else
                   skipLogCurrElem();
             }
       if (crwords != "") {
+            // as the meaning of multiple credit-types is undocumented,
+            // use credit-type only if exactly one was found
+            QString crtype = (crtypes.size() == 1) ? crtypes.at(0) : "";
             CreditWords* cw = new CreditWords(page, crtype, defaultx, defaulty, fontSize, justify, halign, valign, crwords);
             credits.append(cw);
             }

--- a/mtest/musicxml/visual/testCreditType.xml
+++ b/mtest/musicxml/visual/testCreditType.xml
@@ -66,12 +66,21 @@
     <credit-type>subtitle</credit-type>
     <credit-words default-x="1134.19" default-y="1626.67" justify="right" valign="top" font-size="24">Subtitle right</credit-words>
     </credit>
+  <credit page="2">
+    <credit-type>page number</credit-type>
+    <credit-type>title</credit-type>
+    <credit-words default-x="1134.19" default-y="1626.67" justify="right" valign="top" font-size="12">Title with page number (2)</credit-words>
+    </credit>
   <credit page="1">
     <credit-type>rights</credit-type>
     <credit-words default-x="595.44" default-y="113.386" justify="center" valign="bottom" font-size="12">This file has a title frame containing title, subtitle, composer and lyricist credit-words in unusual locations.
 </credit-words>
     <credit-words>As these all have an associated credit-type element, the detected style (shown in the inspector) should still be correct.
 </credit-words>
+    </credit>
+  <credit page="2">
+    <credit-type>rights</credit-type>
+    <credit-words default-x="595.44" default-y="113.386" justify="center" valign="bottom">Copyright</credit-words>
     </credit>
   <part-list>
     <score-part id="P1">
@@ -90,7 +99,7 @@
       </score-part>
     </part-list>
   <part id="P1">
-    <measure number="1" width="239.74">
+    <measure number="1" width="1077.49">
       <print>
         <system-layout>
           <system-margins>
@@ -114,6 +123,22 @@
           <line>2</line>
           </clef>
         </attributes>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2" width="197.60">
+      <print new-page="yes">
+        <system-layout>
+          <system-margins>
+            <left-margin>0.00</left-margin>
+            <right-margin>879.89</right-margin>
+            </system-margins>
+          <top-system-distance>98.70</top-system-distance>
+          </system-layout>
+        </print>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>


### PR DESCRIPTION
…s blank sheet

Resolves: https://musescore.org/en/node/312854

Support credit containing multiple credit-types. Before the fix, this made the parser
go out of sync, causing it to ignore the remainder of the file.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
