### PR TITLE
[MU4] Fix #312254: Add alternative choice of “To Coda”

### DIFF
--- a/libmscore/marker.cpp
+++ b/libmscore/marker.cpp
@@ -35,6 +35,7 @@ const MarkerTypeItem markerTypeTable[] = {
     { Marker::Type::CODETTA, QT_TRANSLATE_NOOP("markerType", "Codetta") },
     { Marker::Type::FINE, QT_TRANSLATE_NOOP("markerType", "Fine") },
     { Marker::Type::TOCODA, QT_TRANSLATE_NOOP("markerType", "To Coda") },
+    { Marker::Type::TOCODASYM, QT_TRANSLATE_NOOP("markerType", "To Coda (Symbol)") },
     { Marker::Type::USER, QT_TRANSLATE_NOOP("markerType", "Custom") }
 };
 
@@ -102,6 +103,12 @@ void Marker::setMarkerType(Type t)
 
     case Type::TOCODA:
         txt = "To Coda";
+        initTid(Tid::REPEAT_RIGHT, true);
+        setLabel("coda");
+        break;
+
+    case Type::TOCODASYM:
+        txt = "To <font size=\"20\"/><sym>coda</sym>";
         initTid(Tid::REPEAT_RIGHT, true);
         setLabel("coda");
         break;

--- a/libmscore/marker.h
+++ b/libmscore/marker.h
@@ -31,9 +31,10 @@ public:
         VARSEGNO,
         CODA,
         VARCODA,
-        CODETTA,
+        CODETTA, // not in SMuFL, but still needed for 1.x compatibility, rendered as a double coda
         FINE,
         TOCODA,
+        TOCODASYM,
         USER
     };
 

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -1423,7 +1423,10 @@ void Timeline::jumpMarkerMeta(Segment* seg, int* stagger, int pos)
             text.push_back(tf.text);
         }
         measure = marker->measure();
-        if (marker->markerType() == Marker::Type::FINE || marker->markerType() == Marker::Type::TOCODA) {
+        if (marker->markerType() == Marker::Type::FINE
+            || marker->markerType() == Marker::Type::TOCODA
+            || marker->markerType() == Marker::Type::TOCODASYM
+            ) {
             elementType = ElementType::MARKER;
             std::get<2>(_repeatInfo) = std::get<3>(_repeatInfo);
             std::get<3>(_repeatInfo) = nullptr;

--- a/mtest/mscore/palette/tst_palette.cpp
+++ b/mtest/mscore/palette/tst_palette.cpp
@@ -68,6 +68,7 @@ void TestPaletteModel::testDuplicateItemNames()
         if (name.value().size() != 1) {
             // Exceptions - allowed duplicates
             if (name.key().endsWith(" repeat sign") // repeat barlines in "Barlines" and "Repeats & Jumps" palette
+                //|| name.key().startsWith("To Coda") || // 2 different "To Coda" in "Repeats & Jumps" palette (so far Master palette only)
                 || name.key() == "Open" // articulations in "Articulations" and channel switch text in "Text" palette
                 || name.key() == "Line" // bracket type in "Brackets" and line type in "Lines" palette
                 //|| name.key() == "Caesura" // 2 different Caesuras in the "Breaths & Pauses" palette (so far Master palette only)

--- a/mu4/importexport/internal/musicxml/exportxml.cpp
+++ b/mu4/importexport/internal/musicxml/exportxml.cpp
@@ -4961,7 +4961,9 @@ static void directionMarker(XmlWriter& xml, const Marker* const m)
     } else if (mtp == Marker::Type::FINE) {
         words = "Fine";
         sound = "fine=\"yes\"";
-    } else if (mtp == Marker::Type::TOCODA) {
+    } else if (mtp == Marker::Type::TOCODA
+               || mtp == Marker::Type::TOCODASYM
+               ) {
         if (m->xmlText() == "") {
             words = "To Coda";
         } else {
@@ -5051,6 +5053,7 @@ static void repeatAtMeasureStart(XmlWriter& xml, Attributes& attr, const Measure
                 directionMarker(xml, mk);
             } else if (mtp == Marker::Type::FINE
                        || mtp == Marker::Type::TOCODA
+                       || mtp == Marker::Type::TOCODASYM
                        ) {
                 // ignore
             } else {
@@ -5086,7 +5089,10 @@ static void repeatAtMeasureStop(XmlWriter& xml, const Measure* const m, int stra
             // filter out the markers at measure stop
             const Marker* const mk = toMarker(e);
             Marker::Type mtp = mk->markerType();
-            if (mtp == Marker::Type::FINE || mtp == Marker::Type::TOCODA) {
+            if (mtp == Marker::Type::FINE
+                || mtp == Marker::Type::TOCODA
+                || mtp == Marker::Type::TOCODASYM
+                ) {
                 directionMarker(xml, mk);
             } else if (mtp == Marker::Type::SEGNO || mtp == Marker::Type::CODA) {
                 // ignore

--- a/mu4/palette/internal/palette/palettecreator.cpp
+++ b/mu4/palette/internal/palette/palettecreator.cpp
@@ -646,7 +646,7 @@ PalettePanel* PaletteCreator::newRepeatsPalettePanel()
     sp->append(rm, mu::qtrc("symUserNames", Sym::symUserNames[int(SymId::repeat1Bar)]));
 
     for (int i = 0; i < markerTypeTableSize(); i++) {
-        if (markerTypeTable[i].type == Marker::Type::CODETTA) {   //not in smufl
+        if (markerTypeTable[i].type == Marker::Type::CODETTA) {   // not in SMuFL
             continue;
         }
 

--- a/share/workspaces/Basic.xml
+++ b/share/workspaces/Basic.xml
@@ -704,25 +704,11 @@
             <label>segno</label>
             </Marker>
           </Cell>
-        <Cell name="Segno variation">
-          <Marker>
-            <style>Repeat Text Left</style>
-            <text><sym>segnoSerpent1</sym></text>
-            <label>varsegno</label>
-            </Marker>
-          </Cell>
         <Cell name="Coda">
           <Marker>
             <style>Repeat Text Left</style>
             <text><sym>coda</sym></text>
             <label>codab</label>
-            </Marker>
-          </Cell>
-        <Cell name="Varied coda">
-          <Marker>
-            <style>Repeat Text Left</style>
-            <text><sym>codaSquare</sym></text>
-            <label>varcoda</label>
             </Marker>
           </Cell>
         <Cell name="Fine">


### PR DESCRIPTION
Add a "To<sym>coda</</sym>" to master "Repeats and Jumps" palette.
The "To " part of it is sort of needed to tell it from the plain Coda in the palette (so to not have to rely on the tool tip only), but is likely to not be wanted in score, so needs to get deleted there manually.
Removing some rather rare symbols from the Basis workspace's "Repeats and Jumps" palette, namely "Segno variation" and "Varied coda".

Resolves: https://musescore.org/en/node/312254

Version or #6847 for master