### PR TITLE
Add Ease in and ease out to all glissandi styles

### DIFF
--- a/libmscore/CMakeLists.txt
+++ b/libmscore/CMakeLists.txt
@@ -45,7 +45,7 @@ add_library (
 
       types.h accidental.h ambitus.h arpeggio.h articulation.h audio.h bagpembell.h barline.h beam.h bend.h
       box.h bracket.h bracketItem.h breath.h bsp.h bsymbol.h changeMap.h chord.h chordline.h chordlist.h chordrest.h clef.h
-      cleflist.h connector.h drumset.h dsp.h duration.h durationtype.h dynamic.h element.h
+      cleflist.h connector.h drumset.h dsp.h duration.h durationtype.h dynamic.h easeInOut.h element.h
       elementmap.h excerpt.h fermata.h fifo.h figuredbass.h fingering.h fraction.h fret.h glissando.h groups.h hairpin.h
       harmony.h hook.h icon.h image.h imageStore.h iname.h input.h instrchange.h instrtemplate.h instrument.h interval.h
       jump.h key.h keylist.h keysig.h lasso.h layout.h layoutbreak.h ledgerline.h letring.h line.h location.h
@@ -63,7 +63,7 @@ add_library (
       bracket.cpp breath.cpp bsp.cpp changeMap.cpp chord.cpp chordline.cpp
       chordlist.cpp chordrest.cpp clef.cpp cleflist.cpp
       drumset.cpp durationtype.cpp dynamic.cpp dynamichairpingroup.cpp edit.cpp noteentry.cpp
-      element.cpp elementgroup.cpp excerpt.cpp
+      easeInOut.cpp element.cpp elementgroup.cpp excerpt.cpp
       fifo.cpp fret.cpp glissando.cpp hairpin.cpp
       harmony.cpp hook.cpp image.cpp iname.cpp instrchange.cpp
       instrtemplate.cpp instrument.cpp interval.cpp

--- a/libmscore/easeInOut.cpp
+++ b/libmscore/easeInOut.cpp
@@ -1,0 +1,111 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+/**
+ \file
+ Implementation of classe easeInOut for implementing transfer curve with
+ parametrerable ease-In and ease-Out.
+*/
+
+#include "easeInOut.h"
+
+namespace Ms {
+
+//-------------------------------------------------------------------------------------------------
+// The following function is inspired by "A Primer on Bézier Curve"sections 17 and 23 by Pomax:
+// https://pomax.github.io/bezierinfo/
+// However, the fuction is greatly specialized, simplified and optimized for use as an ease-in and
+// ease-out transfer curve for bends, glissandi and portamenti in MuseScore. The function computes
+// Y from X by performing a cubic root finding to compute t from X on the X component of the
+// transfer curve and then a cubic Bezier evaluation to compute Y from t on the Y component of the
+// transfer curve. The code could be simplified because the Bezier curve is constrained as a well
+// defined transfer function. It is not suitable for general or arbitrary Bezier curve work. -YP
+//-------------------------------------------------------------------------------------------------
+qreal EaseInOut::tFromX(const qreal x) const {
+      const qreal pi = 3.14159265358979323846;
+      qreal c = -x;
+      qreal w1 = _easeIn - x;
+      qreal w2 = 1.0 - _easeOut - x;
+      qreal d = x + 3.0 * w1 - 3.0 * w2 + (1.0 - x);
+      qreal a = (-3.0 * x - 6.0 * w1 + 3 * w2) / d;
+      qreal b = (3.0 * x + 3.0 * w1) / d;
+      c = -x / d;
+      qreal a2 = a * a;
+      qreal p = (3.0 * b - a2) / 3.0;
+      qreal q = (2.0 * a2 * a - 9.0 * a * b + 27.0 * c) / 27.0;
+      qreal discr = (q * q) / 4.0 + (p * p * p) / 27.0;
+      qreal t = 0.0;
+      // Crazy idea to first test the least probable case with such an expensive test but...
+      if (qFuzzyCompare(discr, 0.0)) {
+            // Case that happens extremely rarely --> 2 roots.
+            qreal q2 = q / 2.0;
+            qreal u = q2 < 0.0 ? std::pow(-q2, 1.0 / 3.0) : -std::pow(q2, 1.0 / 3.0);
+            // Find the only root that is within the 0 to 1 interval.
+            t = 2.0 * u - a / 3.0;
+            if (0.0 > t || t > 1.0) {
+                  t = -u - a / 3.0;
+                  }
+            }
+      else if (discr < 0.0) {
+            // Case that happens about 75% of the time --> 3 roots.
+            qreal mp3 = -p / 3.0;
+            qreal r = std::sqrt(mp3 * mp3 * mp3);
+            qreal phi = std::acos(std::min(std::max(-1.0, -q / (2.0 * r)), 1.0));
+            qreal t1 = 2.0 * std::pow(r, 1.0 / 3.0);
+            // Find the only root that is within the 0 to 1 interval.
+            t = t1 * std::cos(phi / 3.0) - a / 3.0;
+            if (0.0 > t || t > 1.0) {
+                  t = t1 * std::cos((phi + 2.0 * pi) / 3.0) - a / 3.0;
+                  if (0.0 > t || t > 1.0) {
+                        t = t1 * std::cos((phi + 4.0 * pi) / 3.0) - a / 3.0;
+                  }
+            }
+      }
+      else if (discr > 0.0) {
+            // Case that happens about 25% of the time --> 1 root.
+            qreal q2 = q / 2.0;
+            qreal sd = std::sqrt(discr);
+            qreal u = std::pow(-q2 + sd, 1.0 / 3.0);
+            qreal v = std::pow(q2 + sd, 1.0 / 3.0);
+            t = u - v - a / 3.0;
+            }
+      return t;
+      }
+
+//-------------------------------------------------------------------------------------------------
+// This function is even more simplified and optimized because all the Bezier control points are
+// constant. Thus, when computing the Y root there is only one case and the math simplifies to the
+// following simple expression.
+//-------------------------------------------------------------------------------------------------
+qreal EaseInOut::tFromY(const qreal y) const {
+      return 0.5 + std::cos((4.0 * M_PI + std::acos(1.0 - 2.0 * y)) / 3.0);
+      }
+
+//-------------------------------------------------------------------------------------------------
+// Given a number of note to place within the given duration, return the list of on-times for each
+// note given the current ease-in and ease-out parameters. The first note is at time 0 while the 
+//-------------------------------------------------------------------------------------------------
+void EaseInOut::timeList(const int nbNotes, const int duration, QList<int>* times) const {
+      qreal nNotes = qreal(nbNotes);
+      qreal space = qreal(duration);
+      if (_easeIn == 0.0 && _easeOut == 0.0) {
+            for (int n = 0; n <= nbNotes; n++) {
+                  times->push_back(static_cast<int>(std::lround((static_cast<qreal>(n) / nNotes) * space)));
+                  }
+      } else {
+            for (int n = 0; n <= nbNotes; n++) {
+                  times->push_back(static_cast<int>(std::lround(XfromY(static_cast<qreal>(n) / nNotes) * space)));
+                 }
+            }
+      }
+
+}

--- a/libmscore/easeInOut.h
+++ b/libmscore/easeInOut.h
@@ -1,0 +1,50 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#ifndef __EASEINOUT_H__
+#define __EASEINOUT_H__
+
+namespace Ms {
+
+//---------------------------------------------------------
+//   @@ EaseInOut
+///   \brief Specialized transfer curve using an underlying Bezier curve.
+/// 
+///   The second and third control points of the Bezier curve are moveable
+///   along the x axis according to two parameters 'EaseIn' and 'EaseOut',
+///   which results in a transfer curve that goes from a straight line to an S
+///   shaped curve.
+//---------------------------------------------------------
+
+class EaseInOut final {
+      qreal       _easeIn;
+      qreal       _easeOut;
+
+public:
+      typedef std::tuple<qreal, qreal> Ease2D;
+
+      EaseInOut() : _easeIn(0.0), _easeOut(1.0) {}
+      EaseInOut(qreal easeIn, qreal easeOut) : _easeIn(easeIn), _easeOut(easeOut) {}
+
+      void SetEases(qreal easeIn, qreal easeOut) { _easeIn = easeIn; _easeOut = easeOut; }
+      qreal EvalX(const qreal t) const          { qreal tCompl = 1.0 - t;  return (3.0 * _easeIn * tCompl * tCompl + (3.0 - 3.0 * _easeOut * tCompl - 2.0 * t) * t) * t; }
+      qreal EvalY(const qreal t) const          { return -(t * t) * (2.0 * t - 3.0); }
+      Ease2D Eval(const qreal t) const          { return {EvalX(t), EvalY(t)}; }
+      qreal tFromX(const qreal x) const;
+      qreal tFromY(const qreal y) const;
+      qreal YfromX(const qreal x) const         { return EvalY(tFromX(x)); }
+      qreal XfromY(const qreal y) const         { return EvalX(tFromY(y)); }
+      void timeList(const int nbNotes, const int duration, QList<int>* times) const;
+};
+
+}     // namespace Ms
+#endif

--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -144,7 +144,9 @@ Element* GlissandoSegment::propertyDelegate(Pid pid)
             case Pid::GLISS_TYPE:
             case Pid::GLISS_TEXT:
             case Pid::GLISS_SHOW_TEXT:
-            case Pid::GLISSANDO_STYLE:
+            case Pid::GLISS_STYLE:
+            case Pid::GLISS_EASEIN:
+            case Pid::GLISS_EASEOUT:
             case Pid::PLAY:
             case Pid::FONT_FACE:
             case Pid::FONT_SIZE:
@@ -161,7 +163,7 @@ Element* GlissandoSegment::propertyDelegate(Pid pid)
 //=========================================================
 
 Glissando::Glissando(Score* s)
-  : SLine(s, ElementFlag::MOVABLE)
+   : SLine(s, ElementFlag::MOVABLE)
       {
       setAnchor(Spanner::Anchor::NOTE);
       setDiagonal(true);
@@ -170,9 +172,11 @@ Glissando::Glissando(Score* s)
 
       resetProperty(Pid::GLISS_SHOW_TEXT);
       resetProperty(Pid::PLAY);
-      resetProperty(Pid::GLISSANDO_STYLE);
+      resetProperty(Pid::GLISS_STYLE);
       resetProperty(Pid::GLISS_TYPE);
       resetProperty(Pid::GLISS_TEXT);
+      resetProperty(Pid::GLISS_EASEIN);
+      resetProperty(Pid::GLISS_EASEOUT);
       }
 
 Glissando::Glissando(const Glissando& g)
@@ -183,6 +187,8 @@ Glissando::Glissando(const Glissando& g)
       _fontSize       = g._fontSize;
       _glissandoType  = g._glissandoType;
       _glissandoStyle = g._glissandoStyle;
+      _easeIn         = g._easeIn;
+      _easeOut        = g._easeOut;
       _showText       = g._showText;
       _playGlissando  = g._playGlissando;
       _fontStyle      = g._fontStyle;
@@ -286,10 +292,9 @@ void Glissando::layout()
          // but ignore graces after, as they are not the first note of the system,
          // even if their segment is the first segment of the system
          && !(cr2->noteType() == NoteType::GRACE8_AFTER
-            || cr2->noteType() == NoteType::GRACE16_AFTER || cr2->noteType() == NoteType::GRACE32_AFTER)
+         || cr2->noteType() == NoteType::GRACE16_AFTER || cr2->noteType() == NoteType::GRACE32_AFTER)
          // also ignore if cr1 is a child of cr2, which means cr1 is a grace-before of cr2
-         && !(cr1->parent() == cr2))
-            {
+         && !(cr1->parent() == cr2)) {
             segm2->rxpos() -= GLISS_STARTOFSYSTEM_WIDTH * _spatium;
             segm2->rxpos2()+= GLISS_STARTOFSYSTEM_WIDTH * _spatium;
             }
@@ -382,7 +387,7 @@ void Glissando::write(XmlWriter& xml) const
       if (_showText && !_text.isEmpty())
             xml.tag("text", _text);
 
-      for (auto id : { Pid::GLISS_TYPE, Pid::PLAY, Pid::GLISSANDO_STYLE } )
+      for (auto id : { Pid::GLISS_TYPE, Pid::PLAY, Pid::GLISS_STYLE, Pid::GLISS_EASEIN, Pid::GLISS_EASEOUT })
             writeProperty(xml, id);
 
       SLine::writeProperties(xml);
@@ -410,7 +415,11 @@ void Glissando::read(XmlReader& e)
             else if (tag == "subtype")
                   _glissandoType = GlissandoType(e.readInt());
             else if (tag == "glissandoStyle")
-                  readProperty(e, Pid::GLISSANDO_STYLE);
+                  readProperty(e, Pid::GLISS_STYLE);
+            else if (tag == "easeInSpin")
+                  _easeIn = e.readInt();
+            else if (tag == "easeOutSpin")
+                  _easeOut = e.readInt();
             else if (tag == "play")
                   setPlayGlissando(e.readBool());
             else if (readStyledProperty(e, tag))
@@ -619,8 +628,12 @@ QVariant Glissando::getProperty(Pid propertyId) const
                   return text();
             case Pid::GLISS_SHOW_TEXT:
                   return showText();
-            case Pid::GLISSANDO_STYLE:
+            case Pid::GLISS_STYLE:
                   return int(glissandoStyle());
+            case Pid::GLISS_EASEIN:
+                  return easeIn();
+            case Pid::GLISS_EASEOUT:
+                  return easeOut();
             case Pid::PLAY:
                   return bool(playGlissando());
             case Pid::FONT_FACE:
@@ -651,8 +664,14 @@ bool Glissando::setProperty(Pid propertyId, const QVariant& v)
             case Pid::GLISS_SHOW_TEXT:
                   setShowText(v.toBool());
                   break;
-            case Pid::GLISSANDO_STYLE:
+            case Pid::GLISS_STYLE:
                   setGlissandoStyle(GlissandoStyle(v.toInt()));
+                  break;
+            case Pid::GLISS_EASEIN:
+                  setEaseIn(v.toInt());
+                  break;
+            case Pid::GLISS_EASEOUT:
+                  setEaseOut(v.toInt());
                   break;
             case Pid::PLAY:
                   setPlayGlissando(v.toBool());
@@ -686,8 +705,11 @@ QVariant Glissando::propertyDefault(Pid propertyId) const
                   return int(GlissandoType::STRAIGHT);
             case Pid::GLISS_SHOW_TEXT:
                   return true;
-            case Pid::GLISSANDO_STYLE:
+            case Pid::GLISS_STYLE:
                   return int(GlissandoStyle::CHROMATIC);
+            case Pid::GLISS_EASEIN:
+            case Pid::GLISS_EASEOUT:
+                  return 0;
             case Pid::PLAY:
                   return true;
             default:

--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -292,7 +292,7 @@ void Glissando::layout()
          // but ignore graces after, as they are not the first note of the system,
          // even if their segment is the first segment of the system
          && !(cr2->noteType() == NoteType::GRACE8_AFTER
-         || cr2->noteType() == NoteType::GRACE16_AFTER || cr2->noteType() == NoteType::GRACE32_AFTER)
+            || cr2->noteType() == NoteType::GRACE16_AFTER || cr2->noteType() == NoteType::GRACE32_AFTER)
          // also ignore if cr1 is a child of cr2, which means cr1 is a grace-before of cr2
          && !(cr1->parent() == cr2)) {
             segm2->rxpos() -= GLISS_STARTOFSYSTEM_WIDTH * _spatium;

--- a/libmscore/glissando.h
+++ b/libmscore/glissando.h
@@ -56,6 +56,8 @@ class Glissando final : public SLine {
       M_PROPERTY(bool, showText, setShowText)
       M_PROPERTY(bool, playGlissando, setPlayGlissando)
       M_PROPERTY(FontStyle, fontStyle, setFontStyle)
+      M_PROPERTY(int, easeIn, setEaseIn)
+      M_PROPERTY(int, easeOut, setEaseOut)
 
       static const std::array<const char *, 2> glissandoTypeNames;
 

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -179,10 +179,13 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::REPEAT_START,            true,  0,                       P_TYPE::BOOL,                ""                                                    },
       { Pid::REPEAT_JUMP,             true,  0,                       P_TYPE::BOOL,                ""                                                    },
       { Pid::MEASURE_NUMBER_MODE,     false, "measureNumberMode",     P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "measure number mode") },
+
       { Pid::GLISS_TYPE,              false, "subtype",               P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "subtype")          },
       { Pid::GLISS_TEXT,              false, 0,                       P_TYPE::STRING,              DUMMY_QT_TRANSLATE_NOOP("propertyName", "text")             },
-
       { Pid::GLISS_SHOW_TEXT,         false, 0,                       P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "showing text")     },
+      { Pid::GLISS_STYLE,             true,  "glissandoStyle",        P_TYPE::GLISS_STYLE,         DUMMY_QT_TRANSLATE_NOOP("propertyName", "glissando style") },
+      { Pid::GLISS_EASEIN,            false, "easeInSpin",            P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "ease in")          },
+      { Pid::GLISS_EASEOUT,           false, "easeOutSpin",           P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "ease out")         },
       { Pid::DIAGONAL,                false, 0,                       P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "diagonal")         },
       { Pid::GROUPS,                  false, 0,                       P_TYPE::GROUPS,              DUMMY_QT_TRANSLATE_NOOP("propertyName", "groups")           },
       { Pid::LINE_STYLE,              false, "lineStyle",             P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "line style")       },
@@ -227,7 +230,6 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::ROLE,                    false, "role",                  P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "role")             },
       { Pid::TRACK,                   false, 0,                       P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "track")            },
 
-      { Pid::GLISSANDO_STYLE,         true,  "glissandoStyle",        P_TYPE::GLISSANDO_STYLE,     DUMMY_QT_TRANSLATE_NOOP("propertyName", "glissando style")  },
       { Pid::FRET_STRINGS,            true,  "strings",               P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "strings")          },
       { Pid::FRET_FRETS,              true,  "frets",                 P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "frets")            },
       { Pid::FRET_NUT,                true,  "showNut",               P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "show nut")         },
@@ -454,14 +456,14 @@ QVariant propertyFromString(Pid id, QString value)
             case P_TYPE::FONT:
             case P_TYPE::STRING:
                   return value;
-            case P_TYPE::GLISSANDO_STYLE: {
+            case P_TYPE::GLISS_STYLE: {
                   if ( value == "whitekeys")
                         return QVariant(int(GlissandoStyle::WHITE_KEYS));
                   else if ( value == "blackkeys")
                         return QVariant(int(GlissandoStyle::BLACK_KEYS));
                   else if ( value == "diatonic")
                         return QVariant(int(GlissandoStyle::DIATONIC));
-                  else if ( value == "portamento") 
+                  else if ( value == "portamento")
                         return QVariant(int(GlissandoStyle::PORTAMENTO));
                   else // e.g., normally "Chromatic"
                         return QVariant(int(GlissandoStyle::CHROMATIC));
@@ -593,7 +595,7 @@ QVariant propertyFromString(Pid id, QString value)
                         qDebug("bad align text <%s>", qPrintable(sl[1]));
                         return QVariant();
                         }
-                  return  int(align);
+                  return int(align);
                   }
             case P_TYPE::CHANGE_METHOD:
                   return QVariant(int(ChangeMap::nameToChangeMethod(value)));
@@ -640,7 +642,7 @@ QVariant readProperty(Pid id, XmlReader& e)
             case P_TYPE::FONT:
             case P_TYPE::STRING:
                   return QVariant(e.readElementText());
-            case P_TYPE::GLISSANDO_STYLE:
+            case P_TYPE::GLISS_STYLE:
             case P_TYPE::ORNAMENT_STYLE:
             case P_TYPE::DIRECTION:
             case P_TYPE::DIRECTION_H:
@@ -754,7 +756,7 @@ QString propertyToString(Pid id, QVariant value, bool mscx)
                               return "default";
                         }
                   break;
-            case P_TYPE::GLISSANDO_STYLE:
+            case P_TYPE::GLISS_STYLE:
                   switch (GlissandoStyle(value.toInt())) {
                         case GlissandoStyle::BLACK_KEYS:
                               return "blackkeys";

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -185,10 +185,13 @@ enum class Pid {
       REPEAT_START,
       REPEAT_JUMP,
       MEASURE_NUMBER_MODE,
+
       GLISS_TYPE,
       GLISS_TEXT,
-
       GLISS_SHOW_TEXT,
+      GLISS_STYLE,
+      GLISS_EASEIN,
+      GLISS_EASEOUT,
       DIAGONAL,
       GROUPS,
       LINE_STYLE,
@@ -233,7 +236,6 @@ enum class Pid {
       ROLE,
       TRACK,
 
-      GLISSANDO_STYLE,
       FRET_STRINGS,
       FRET_FRETS,
       FRET_NUT,
@@ -355,7 +357,7 @@ enum class Pid {
       START_WITH_MEASURE_ONE,
 
       PATH, // for ChordLine to make its shape changes undoable
-      
+
       PREFER_SHARP_FLAT,
 
       END
@@ -391,7 +393,7 @@ enum class P_TYPE : char {
       GROUPS,
       SYMID,
       INT_LIST,
-      GLISSANDO_STYLE,
+      GLISS_STYLE,
       BARLINE_TYPE,
       HEAD_TYPE,        // enum class Notehead::Type
       HEAD_GROUP,       // enum class Notehead::Group

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -52,6 +52,7 @@
 #include "utils.h"
 #include "sym.h"
 #include "synthesizerstate.h"
+#include "easeInOut.h"
 #include "global/log.h"
 
 #include "audio/midi/event.h"
@@ -234,6 +235,16 @@ int toMilliseconds(float tempo, float midiTime) {
       }
 
 //---------------------------------------------------------
+//   Detects if a note is a start of a glissando
+//---------------------------------------------------------
+bool isGlissandoFor(const Note* note) {
+      for (Spanner* spanner : note->spannerFor())
+            if (spanner->type() == ElementType::GLISSANDO)
+                  return true;
+      return false;
+      }
+
+//---------------------------------------------------------
 //   playNote
 //---------------------------------------------------------
 static void playNote(EventMap* events, const Note* note, int channel, int pitch,
@@ -248,46 +259,41 @@ static void playNote(EventMap* events, const Note* note, int channel, int pitch,
       ev.setNote(note);
       if (offTime < onTime)
             offTime = onTime;
+      events->insert(std::pair<int, NPlayEvent>(onTime, ev));
       // adds portamento for continuous glissando
       for (Spanner* spanner : note->spannerFor()) {
             if (spanner->type() == ElementType::GLISSANDO) {
                   Glissando *glissando = toGlissando(spanner);
-                  GlissandoStyle glissandoStyle = glissando->glissandoStyle();
-                  if (glissandoStyle == GlissandoStyle::PORTAMENTO) {
-                        //Changes the notes pitch to the next note's pitch, note-on is the eventual pitch
+                  if (glissando->glissandoStyle() == GlissandoStyle::PORTAMENTO) {
                         Note* nextNote = toNote(spanner->endElement());
-                        ev.setPitch(nextNote->pitch());
-
-                        int time = toMilliseconds(note->score()->tempo(note->tick()), offTime - onTime);
-                        int lsb = (time & 0x00FF);
-                        time = (time >> 8);
-                        int msb = (time & 0x00FF);
-
-                        NPlayEvent portamentoOn(ME_CONTROLLER, channel, CTRL_PORTAMENTO, MIDI_ON_SIGNAL);
-                        portamentoOn.setOriginatingStaff(staffIdx);
-                        NPlayEvent portamentoControl(ME_CONTROLLER, channel, CTRL_PORTAMENTO_CONTROL, pitch);
-                        portamentoControl.setOriginatingStaff(staffIdx);
-                        NPlayEvent portamentoTimeMSB(ME_CONTROLLER, channel, CTRL_PORTAMENTO_TIME_MSB, msb);
-                        portamentoTimeMSB.setOriginatingStaff(staffIdx);
-                        NPlayEvent portamentoTimeLSB(ME_CONTROLLER, channel, CTRL_PORTAMENTO_TIME_LSB, lsb);
-                        portamentoTimeLSB.setOriginatingStaff(staffIdx);
-                        
-                        ev.setPortamento(true);
-                        if (onTime == 0)
-                              onTime++;
-                        events->insert(std::pair<int, NPlayEvent>(onTime-1, portamentoOn));
-                        events->insert(std::pair<int, NPlayEvent>(onTime-1, portamentoControl));
-                        events->insert(std::pair<int, NPlayEvent>(onTime-1, portamentoTimeMSB));
-                        events->insert(std::pair<int, NPlayEvent>(onTime-1, portamentoTimeLSB));
-
-                        NPlayEvent portamentoOff(ME_CONTROLLER, channel, CTRL_PORTAMENTO, 0);
-                        portamentoOff.setOriginatingStaff(staffIdx);
-                        events->insert(std::pair<int, NPlayEvent>(offTime, portamentoOff));
+                        double pitchDelta = (static_cast<double>(nextNote->pitch()) - pitch) * 50.0;
+                        double timeDelta = static_cast<double>(offTime - onTime);
+                        double timeStep = timeDelta / pitchDelta * 20.0;
+                        double t = 0.0;
+                        QList<int> onTimes;
+                        EaseInOut easeInOut(static_cast<qreal>(glissando->easeIn()) / 100.0,
+                              static_cast<qreal>(glissando->easeOut()) / 100.0);
+                        easeInOut.timeList(static_cast<int>((timeDelta + timeStep * 0.5) / timeStep), int(timeDelta), &onTimes);
+                        double nTimes = static_cast<double>(onTimes.size() - 1);
+                        for (double time : onTimes) {
+                              int p = int(pitch + (t / nTimes) * pitchDelta);
+                              int timeStamp = std::min(onTime + int(time), offTime - 1);
+                              int midiPitch = (p * 16384) / 1200 + 8192;
+                              NPlayEvent evb(ME_PITCHBEND, channel, midiPitch % 128, midiPitch / 128);
+                              evb.setOriginatingStaff(staffIdx);
+                              events->insert(std::pair<int, NPlayEvent>(timeStamp, evb));
+                              t += 1.0;
+                              }
+                        ev.setVelo(0);
+                        events->insert(std::pair<int, NPlayEvent>(offTime, ev));
+                        NPlayEvent evb(ME_PITCHBEND, channel, 0, 64); // 0:64 is 8192 - no pitch bend
+                        evb.setOriginatingStaff(staffIdx);
+                        events->insert(std::pair<int, NPlayEvent>(offTime, evb));
+                        return;
+                        }
                   }
             }
-      }
 
-      events->insert(std::pair<int, NPlayEvent>(onTime, ev));
       ev.setVelo(0);
       events->insert(std::pair<int, NPlayEvent>(offTime, ev));
       }
@@ -319,7 +325,7 @@ static void collectNote(EventMap* events, int channel, const Note* note, qreal v
             Note* n = note->tieFor()->endNote();
             while (n) {
                   NoteEventList nel = n->playEvents();
-                  if (nel.size() == 1) {
+                  if (nel.size() == 1 && !isGlissandoFor(n)) {
                         // add value of this note to main note
                         // if we wish to suppress first note of ornament,
                         // then do this regardless of number of NoteEvents
@@ -350,7 +356,7 @@ static void collectNote(EventMap* events, int channel, const Note* note, qreal v
             // its length was already added to previous note
             // if we wish to suppress first note of ornament
             // then change "nels == 1" to "i == 0", and change "break" to "continue"
-            if (tieBack && nels == 1)
+            if (tieBack && nels == 1 && !isGlissandoFor(note))
                   break;
             int p = pitch + e.pitch();
             if (p < 0)
@@ -714,18 +720,18 @@ void MidiRenderer::collectMeasureEventsSimple(EventMap* events, Measure const * 
                   SndConfig config;       // dummy
 
                   if (!graceNotesMerged(chord))
-                      for (Chord* c : chord->graceNotesBefore())
-                          for (const Note* note : c->notes())
-                              collectNote(events, channel, note, veloMultiplier, tickOffset, st1, config);
+                        for (Chord* c : chord->graceNotesBefore())
+                              for (const Note* note : c->notes())
+                                    collectNote(events, channel, note, veloMultiplier, tickOffset, st1, config);
 
                   for (const Note* note : chord->notes())
                         collectNote(events, channel, note, veloMultiplier, tickOffset, st1, config);
 
                   if (!graceNotesMerged(chord))
-                      for (Chord* c : chord->graceNotesAfter())
-                          for (const Note* note : c->notes())
-                              collectNote(events, channel, note, veloMultiplier, tickOffset, st1, config);
-                 }
+                        for (Chord* c : chord->graceNotesAfter())
+                              for (const Note* note : c->notes())
+                                    collectNote(events, channel, note, veloMultiplier, tickOffset, st1, config);
+                  }
             }
       }
 
@@ -1059,7 +1065,7 @@ void MidiRenderer::renderSpanners(const Chunk& chunk, EventMap* events)
       const int tick1 = chunk.tick1();
       const int tick2 = chunk.tick2();
 
-      std::map<int, std::vector<std::pair<int, std::pair<bool, int>>>> channelPedalEvents;
+      std::map<int, std::vector<std::pair<int, std::pair<bool, int> > > > channelPedalEvents;
       for (const auto& sp : score->spannerMap().map()) {
             Spanner* s = sp.second;
 
@@ -1068,31 +1074,31 @@ void MidiRenderer::renderSpanners(const Chunk& chunk, EventMap* events)
             int channel = s->part()->instrument(s->tick())->channel(idx)->channel();
 
             if (s->isPedal() || s->isLetRing()) {
-                  channelPedalEvents.insert({channel, std::vector<std::pair<int, std::pair<bool, int>>>()});
-                  std::vector<std::pair<int, std::pair<bool, int>>> pedalEventList = channelPedalEvents.at(channel);
-                  std::pair<int, std::pair<bool, int>> lastEvent;
+                  channelPedalEvents.insert({channel, std::vector<std::pair<int, std::pair<bool, int> > >()});
+                  std::vector<std::pair<int, std::pair<bool, int> > > pedalEventList = channelPedalEvents.at(channel);
+                  std::pair<int, std::pair<bool, int> > lastEvent;
 
                   if (!pedalEventList.empty())
                         lastEvent = pedalEventList.back();
                   else
-                        lastEvent = std::pair<int, std::pair<bool, int>>(0, std::pair<bool, int>(true, staff));
+                        lastEvent = std::pair<int, std::pair<bool, int> >(0, std::pair<bool, int>(true, staff));
 
                   int st = s->tick().ticks();
                   if (st >= tick1 && st < tick2) {
                         // Handle "overlapping" pedal segments (usual case for connected pedal line)
                         if (lastEvent.second.first == false && lastEvent.first >= (st + tickOffset + 2)) {
                               channelPedalEvents.at(channel).pop_back();
-                              channelPedalEvents.at(channel).push_back(std::pair<int, std::pair<bool, int>>(st + tickOffset + (2 - MScore::pedalEventsMinTicks), std::pair<bool, int>(false, staff)));
+                              channelPedalEvents.at(channel).push_back(std::pair<int, std::pair<bool, int> >(st + tickOffset + (2 - MScore::pedalEventsMinTicks), std::pair<bool, int>(false, staff)));
                               }
                         int a = st + tickOffset + 2;
-                        channelPedalEvents.at(channel).push_back(std::pair<int, std::pair<bool, int>>(a, std::pair<bool, int>(true, staff)));
+                        channelPedalEvents.at(channel).push_back(std::pair<int, std::pair<bool, int> >(a, std::pair<bool, int>(true, staff)));
                         }
                   if (s->tick2().ticks() >= tick1 && s->tick2().ticks() <= tick2) {
                         int t = s->tick2().ticks() + tickOffset + (2 - MScore::pedalEventsMinTicks);
                         const RepeatSegment& lastRepeat = *score->repeatList().back();
                         if (t > lastRepeat.utick + lastRepeat.len())
                               t = lastRepeat.utick + lastRepeat.len();
-                        channelPedalEvents.at(channel).push_back(std::pair<int, std::pair<bool, int>>(t, std::pair<bool, int>(false, staff)));
+                        channelPedalEvents.at(channel).push_back(std::pair<int, std::pair<bool, int> >(t, std::pair<bool, int>(false, staff)));
                         }
                   }
             else if (s->isVibrato()) {
@@ -1374,7 +1380,7 @@ void renderArpeggio(Chord *chord, QList<NoteEventList> & ell)
 
             auto tempoRatio = chord->score()->tempomap()->tempo(chord->tick().ticks()) / Score::defaultTempo();
             int ot = (l * j * 1000) / chord->upNote()->playTicks() *
-                        tempoRatio * chord->arpeggio()->Stretch();
+               tempoRatio * chord->arpeggio()->Stretch();
 
             events->append(NoteEvent(0, ot, 1000 - ot));
             j++;
@@ -1578,7 +1584,7 @@ bool renderNoteArticulation(NoteEventList* events, Note* note, bool chromatic, i
             ;
       else {
             // for slow tempos, such as adagio, we may need to speed up the tremblement frequency, i.e., decrease the ticks per note, to make it sound reasonable.
-            ticksPerNote = requestedTicksPerNote ;
+            ticksPerNote = requestedTicksPerNote;
             while (ticksPerNote > maxTicksPerNote) {
                   ticksPerNote /= 2;
                   }
@@ -1663,16 +1669,37 @@ bool renderNoteArticulation(NoteEventList* events, Note* note, bool chromatic, i
             ontime = makeEvent(prefix[j], ontime, tieForward(j,prefix));
 
       if (b > 0) {
-            // render the body, but not the final repetition
-            for (int r = 0; r < numrepeat-1; r++) {
-                  for (int j=0; j < b; j++)
-                        ontime = makeEvent(body[j], ontime, millespernote);
+            // Check that we are doing a glissando
+            bool isGlissando = false;
+            QList<int> onTimes;
+            for (Spanner* spanner : note->spannerFor()) {
+                  if (spanner->type() == ElementType::GLISSANDO) {
+                        Glissando* glissando = toGlissando(spanner);
+                        EaseInOut easeInOut(static_cast<qreal>(glissando->easeIn())/100.0,
+                              static_cast<qreal>(glissando->easeOut())/100.0);
+                        easeInOut.timeList(b, millespernote * b, &onTimes);
+                        isGlissando = true;
+                        break;
+                        }
                   }
-            // render the final repetition of body, but not the final note of the repition
-            for (int j = 0; j < b - 1; j++)
-                  ontime = makeEvent(body[j], ontime, millespernote);
-            // render the final note of the final repeat of body
-            ontime = makeEvent(body[b-1], ontime, millespernote+sustain);
+            if (isGlissando) {
+                  // render the body, i.e. the glissando
+                  for (int j = 0; j < b - 1; j++)
+                        makeEvent(body[j], onTimes[j], onTimes[j + 1] - onTimes[j]);
+                  makeEvent(body[b - 1], onTimes[b-1], (millespernote * b - onTimes[b-1]) + sustain);
+                  }
+            else {
+                  // render the body, but not the final repetition
+                  for (int r = 0; r < numrepeat - 1; r++) {
+                        for (int j = 0; j < b; j++)
+                              ontime = makeEvent(body[j], ontime, millespernote);
+                        }
+                  // render the final repetition of body, but not the final note of the repetition
+                  for (int j = 0; j < b - 1; j++)
+                        ontime = makeEvent(body[j], ontime, millespernote);
+                  // render the final note of the final repeat of body
+                  ontime = makeEvent(body[b - 1], ontime, millespernote + sustain);
+                  }
             }
       // render the suffix
       for (int j = 0; j < s; j++)
@@ -1769,11 +1796,11 @@ bool renderNoteArticulation(NoteEventList* events, Note * note, bool chromatic, 
 
       std::vector<int> emptypattern = {};
       for (auto& oe : excursions) {
-            if (oe.atype == articulationType && ( 0 == oe.ostyles.size()
-                  || oe.ostyles.end() != oe.ostyles.find(ornamentStyle))) {
-                     return renderNoteArticulation(events, note, chromatic, oe.duration,
-                                                   oe.prefix, oe.body, oe.repeatp, oe.sustainp, oe.suffix);
-                     }
+            if (oe.atype == articulationType && (0 == oe.ostyles.size()
+               || oe.ostyles.end() != oe.ostyles.find(ornamentStyle))) {
+                  return renderNoteArticulation(events, note, chromatic, oe.duration,
+                     oe.prefix, oe.body, oe.repeatp, oe.sustainp, oe.suffix);
+                  }
             }
       return false;
       }
@@ -1785,10 +1812,10 @@ bool renderNoteArticulation(NoteEventList* events, Note * note, bool chromatic, 
 bool renderNoteArticulation(NoteEventList* events, Note * note, bool chromatic, Trill::Type trillType, MScore::OrnamentStyle ornamentStyle)
       {
       std::map<Trill::Type,SymId> articulationMap = {
-            {Trill::Type::TRILL_LINE,      SymId::ornamentTrill      }
-           ,{Trill::Type::UPPRALL_LINE,    SymId::ornamentUpPrall    }
-           ,{Trill::Type::DOWNPRALL_LINE,  SymId::ornamentPrecompMordentUpperPrefix  }
-           ,{Trill::Type::PRALLPRALL_LINE, SymId::ornamentTrill      }
+             {Trill::Type::TRILL_LINE,      SymId::ornamentTrill      }
+            ,{Trill::Type::UPPRALL_LINE,    SymId::ornamentUpPrall    }
+            ,{Trill::Type::DOWNPRALL_LINE,  SymId::ornamentPrecompMordentUpperPrefix  }
+            ,{Trill::Type::PRALLPRALL_LINE, SymId::ornamentTrill      }
             };
       auto it = articulationMap.find(trillType);
       if (it == articulationMap.cend())
@@ -2020,8 +2047,8 @@ static QList<NoteEventList> renderChord(Chord* chord, int gateTime, int ontime, 
                   el->append(NoteEvent(0, ontime, 1000 - ontime - trailtime));
                   }
             if (trailtime == 0) // if trailtime is non-zero that means we have graceNotesAfter, so we don't need additional gate time.
-                for (NoteEvent& e : ell[i])
-                      e.setLen(e.len() * gateTime / 100);
+                  for (NoteEvent& e : ell[i])
+                        e.setLen(e.len() * gateTime / 100);
             }
       return ell;
       }
@@ -2040,7 +2067,7 @@ void Score::createGraceNotesPlayEvents(const Fraction& tick, Chord* chord, int& 
       QVector<Chord*> gna = chord->graceNotesAfter();
       int nb = gnb.size();
       int na = gna.size();
-      if (0 == nb + na){
+      if (0 == nb + na) {
             return; // return immediately if no grace notes to deal with
             }
       // return immediately if the chord has a trill or articulation which effectively plays the graces notes.
@@ -2363,8 +2390,8 @@ void MidiRenderer::renderChunk(const Chunk& chunk, EventMap* events, const Conte
             if (i->second.type() == ME_CONTROLLER) {
                   auto& event = i->second;
                   if (event.channel() == lastChannel &&
-                      event.controller() == lastController &&
-                      event.value() == lastValue) {
+                     event.controller() == lastController &&
+                     event.value() == lastValue) {
                         i = events->erase(i);
                         }
                   else {
@@ -2426,7 +2453,7 @@ bool MidiRenderer::canBreakChunk(const Measure* last)
             for (const Staff* staff : score->staves()) {
                   if (next->isRepeatMeasure(staff))
                         return false;
-            }
+                  }
 
       return true;
       }
@@ -2490,7 +2517,9 @@ MidiRenderer::Chunk MidiRenderer::getChunkAt(int utick)
       {
       updateState();
 
-      auto it = std::upper_bound(chunks.begin(), chunks.end(), utick, [](int utick, const Chunk& ch) { return utick < ch.utick1(); });
+      auto it = std::upper_bound(chunks.begin(), chunks.end(), utick, [](int utick, const Chunk& ch) {
+                  return utick < ch.utick1();
+                  });
       if (it == chunks.begin())
             return Chunk();
       --it;

--- a/mscore/inspector/inspectorGlissando.cpp
+++ b/mscore/inspector/inspectorGlissando.cpp
@@ -28,7 +28,9 @@ InspectorGlissando::InspectorGlissando(QWidget* parent)
             { Pid::GLISS_TYPE,      0, g.type,           g.resetType           },
             { Pid::GLISS_TEXT,      0, g.text,           g.resetText           },
             { Pid::GLISS_SHOW_TEXT, 0, g.showText,       g.resetShowText       },
-            { Pid::GLISSANDO_STYLE, 0, g.glissandoStyle, g.resetGlissandoStyle },
+            { Pid::GLISS_STYLE,     0, g.glissandoStyle, g.resetGlissandoStyle },
+            { Pid::GLISS_EASEIN,    0, g.easeInSpin,     g.resetEaseIn         },
+            { Pid::GLISS_EASEOUT,   0, g.easeOutSpin,    g.resetEaseOut        },
             { Pid::PLAY,            0, g.playGlissando,  g.resetPlayGlissando  },
             { Pid::FONT_FACE,       0, g.fontFace,       g.resetFontFace       },
             { Pid::FONT_SIZE,       0, g.fontSize,       g.resetFontSize       },
@@ -54,6 +56,8 @@ void InspectorGlissando::setElement()
             }
       if (!g.showText->isChecked())
             g.textWidget->setVisible(false);
+      g.easeInSlider->setSliderPosition(g.easeInSpin->value());
+      g.easeOutSlider->setSliderPosition(g.easeOutSpin->value());
       }
 }
 

--- a/mscore/inspector/inspector_glissando.ui
+++ b/mscore/inspector/inspector_glissando.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>349</width>
-    <height>260</height>
+    <height>253</height>
    </rect>
   </property>
   <property name="accessibleName">
@@ -391,6 +391,107 @@
         </layout>
        </widget>
       </item>
+      <item row="11" column="0" colspan="3">
+       <widget class="QWidget" name="textWidget" native="true">
+        <layout class="QGridLayout" name="gridLayout_4">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <property name="spacing">
+          <number>3</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="easeInLabel">
+           <property name="text">
+            <string>Ease In:</string>
+           </property>
+           <property name="buddy">
+            <cstring>easeInSlider</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QSlider" name="easeInSlider">
+           <property name="maximum">
+            <number>100</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QSpinBox" name="easeInSpin">
+           <property name="maximum">
+            <number>100</number>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="3">
+          <widget class="Ms::ResetButton" name="resetEaseIn" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="accessibleName">
+            <string>Reset 'Ease In' value</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="easeOutLabel">
+           <property name="text">
+            <string>Ease Out:</string>
+           </property>
+           <property name="buddy">
+            <cstring>easeOutSlider</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QSlider" name="easeOutSlider">
+           <property name="maximum">
+            <number>100</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QSpinBox" name="easeOutSpin">
+           <property name="maximum">
+            <number>100</number>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="3">
+          <widget class="Ms::ResetButton" name="resetEaseOut" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="accessibleName">
+            <string>Reset 'Ease Out' value</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -467,6 +568,70 @@
     <hint type="destinationlabel">
      <x>41</x>
      <y>168</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>easeInSlider</sender>
+   <signal>sliderMoved(int)</signal>
+   <receiver>easeInSpin</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>180</x>
+     <y>204</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>207</x>
+     <y>211</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>easeOutSlider</sender>
+   <signal>sliderMoved(int)</signal>
+   <receiver>easeOutSpin</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>174</x>
+     <y>231</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>208</x>
+     <y>234</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>easeInSpin</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>easeInSlider</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>272</x>
+     <y>205</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>172</x>
+     <y>202</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>easeOutSpin</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>easeOutSlider</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>284</x>
+     <y>231</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>181</x>
+     <y>223</y>
     </hint>
    </hints>
   </connection>

--- a/mscore/plugin/api/elements.h
+++ b/mscore/plugin/api/elements.h
@@ -261,6 +261,9 @@ class Element : public Ms::PluginAPI::ScoreElement {
       API_PROPERTY( glissType,               GLISS_TYPE                )
       API_PROPERTY( glissText,               GLISS_TEXT                )
       API_PROPERTY( glissShowText,           GLISS_SHOW_TEXT           )
+      API_PROPERTY( glissandoStyle,          GLISS_STYLE               )
+      API_PROPERTY( glissEaseIn,             GLISS_EASEIN              )
+      API_PROPERTY( glissEaseOut,            GLISS_EASEOUT             )
       API_PROPERTY( diagonal,                DIAGONAL                  )
       API_PROPERTY( groups,                  GROUPS                    )
       API_PROPERTY( lineStyle,               LINE_STYLE                )
@@ -299,7 +302,6 @@ class Element : public Ms::PluginAPI::ScoreElement {
       API_PROPERTY( durationType,            DURATION_TYPE             )
       API_PROPERTY( role,                    ROLE                      )
       API_PROPERTY_T( int, track,            TRACK                     )
-      API_PROPERTY( glissandoStyle,          GLISSANDO_STYLE           )
       API_PROPERTY( fretStrings,             FRET_STRINGS              )
       API_PROPERTY( fretFrets,               FRET_FRETS                )
       /*API_PROPERTY( fretBarre,               FRET_BARRE                )*/


### PR DESCRIPTION
Resolves: [Glissando portamento playback on 3.5-dev issues](https://musescore.org/en/node/302937)

Linearly interpolated glissandi don't sound natural. It does not replicate the starting and ending inertia of the glissando movement. It does not allow expressive glissandi execution. The ease-in and ease-out properties can be set to values from 0 to 100 for interpolation that go from linear to 'S' of different shapes. While implementing this, I fixed two issues.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
