### PR TITLE
fix 313004: don't reading sounding pitch for non-tranposing instruments

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -838,7 +838,7 @@ QString Note::tpcUserName(const bool explicitAccidental) const
       if (tuning() != 0)
             pitchOffset = QString::asprintf("%+.3f", tuning());
 
-      if (!concertPitch()) {
+      if (!concertPitch() && transposition()) {
             QString soundingPitch = tpcUserName(tpc1(), ppitch(), explicitAccidental);
             return QObject::tr("%1 (sounding as %2%3)").arg(pitchName).arg(soundingPitch).arg(pitchOffset);
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/313004

A recent change to accessibility info (for status bar and
screen readers) caused the "sounding pitch" to be added
for all instruments, not just transposing ones.
It's important not to read this info when not needed,
because it slows down score reading by screen reader.

Fix is to simply check transposition before adding the info.
