### PR TITLE
Fix line-break issue with linux build  [missing separator line 62 of build.make]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ clean:
 	-rm -rf win32build win32install
 
 revision:
-	@git rev-parse --short=7 HEAD > local_build_revision.env	
+	@git rev-parse --short=7 HEAD | tr -d '\n' > local_build_revision.env
 
 version:
 	@echo ${VERSION}


### PR DESCRIPTION
Resolves: 3.x at the moment (2020.11.15-16) will not build in Qt Creator within Linux environment with an error having to do with `[[*** missing separator line 62 of build.make]]`

Figured out that what's happening is the revision number is being got by a git command and fed into the local  .env file, but in doing this an extra linebreak is added. When this file is read within the Make process, it utilizes this line and screws up the process. 

Anyone with a linux machine should experience this problem as it is. By removing the extra linebreak before piping into the file, all is well. Didn't file an issue on the tracker because figured this could be kept within github domain only.