### PR TITLE
[MU4] Fixed font size of qml items

### DIFF
--- a/framework/ui/view/theme.cpp
+++ b/framework/ui/view/theme.cpp
@@ -215,7 +215,7 @@ QHash<int, QVariant> Theme::currentThemeProperites() const
 void Theme::initFont()
 {
     m_font.setFamily(configuration()->fontFamily());
-    m_font.setPointSize(configuration()->fontSize());
+    m_font.setPixelSize(configuration()->fontSize());
 
     configuration()->fontFamilyChanged().onReceive(this, [this](const QString& fontFamily) {
         m_font.setFamily(fontFamily);
@@ -224,7 +224,7 @@ void Theme::initFont()
     });
 
     configuration()->fontSizeChanged().onReceive(this, [this](const int fontSize) {
-        m_font.setPointSize(fontSize);
+        m_font.setPixelSize(fontSize);
 
         update();
     });
@@ -233,7 +233,7 @@ void Theme::initFont()
 void Theme::initMusicalFont()
 {
     m_musicalFont.setFamily(configuration()->musicalFontFamily());
-    m_musicalFont.setPointSize(configuration()->musicalFontSize());
+    m_musicalFont.setPixelSize(configuration()->musicalFontSize());
 
     configuration()->musicalFontFamilyChanged().onReceive(this, [this](const QString& fontFamily) {
         m_musicalFont.setFamily(fontFamily);
@@ -242,7 +242,7 @@ void Theme::initMusicalFont()
     });
 
     configuration()->musicalFontSizeChanged().onReceive(this, [this](const int fontSize) {
-        m_musicalFont.setPointSize(fontSize);
+        m_musicalFont.setPixelSize(fontSize);
 
         update();
     });

--- a/framework/uicomponents/qml/MuseScore/UiComponents/InstallationPanel.qml
+++ b/framework/uicomponents/qml/MuseScore/UiComponents/InstallationPanel.qml
@@ -111,7 +111,6 @@ PopupPanel {
             width: 585
             height: 88
 
-            font.pixelSize: 12
             opacity: 0.75
             wrapMode: Text.WordWrap
             verticalAlignment: Text.AlignTop

--- a/framework/uicomponents/qml/MuseScore/UiComponents/TextInputField.qml
+++ b/framework/uicomponents/qml/MuseScore/UiComponents/TextInputField.qml
@@ -65,7 +65,7 @@ Rectangle {
 
             font {
                 family: ui.theme.font.family
-                pointSize: ui.theme.font.pointSize
+                pixelSize: ui.theme.font.pixelSize
             }
 
             background: Item {}

--- a/mu4/extensions/qml/MuseScore/Extensions/ExtensionItem.qml
+++ b/mu4/extensions/qml/MuseScore/Extensions/ExtensionItem.qml
@@ -80,8 +80,6 @@ Rectangle {
                         }
                         return root.description.substring(0, breakIndex + 1)
                     }
-
-                    font.pixelSize: 12
                 }
             }
         }

--- a/mu4/instruments/qml/MuseScore/Instruments/internal/InstrumentsTreeItemControl.qml
+++ b/mu4/instruments/qml/MuseScore/Instruments/internal/InstrumentsTreeItemControl.qml
@@ -42,7 +42,6 @@ Rectangle {
                 horizontalAlignment: Text.AlignLeft
 
                 text: model ? model.itemRole.title : ""
-                font.pixelSize: 12
             }
         }
     }

--- a/mu4/instruments/qml/MuseScore/Instruments/internal/InstrumentsTreeItemDelegate.qml
+++ b/mu4/instruments/qml/MuseScore/Instruments/internal/InstrumentsTreeItemDelegate.qml
@@ -214,7 +214,6 @@ Item {
                 opacity: model && model.itemRole.isVisible ? 1 : 0.75
 
                 font.bold: model ? delegateType === InstrumentTreeItemType.PART && model.itemRole.isVisible : false
-                font.pixelSize: 12
             }
         }
 

--- a/mu4/notation/qml/MuseScore/NotationScene/ConcertPitchControl.qml
+++ b/mu4/notation/qml/MuseScore/NotationScene/ConcertPitchControl.qml
@@ -32,6 +32,8 @@ Row {
     }
 
     StyledTextLabel {
+        height: parent.height
+
         text: qsTrc("notation", "Concert pitch")
     }
 }

--- a/mu4/notation/qml/MuseScore/NotationScene/internal/NotationSwitchButton.qml
+++ b/mu4/notation/qml/MuseScore/NotationScene/internal/NotationSwitchButton.qml
@@ -32,7 +32,6 @@ FlatRadioButton {
             horizontalAlignment: Text.AlignLeft
 
             text: root.title + (root.needSave ? "*" : "")
-            font.pixelSize: 12
         }
 
         FlatButton {

--- a/mu4/notation/qml/MuseScore/NotationScene/internal/PartsView.qml
+++ b/mu4/notation/qml/MuseScore/NotationScene/internal/PartsView.qml
@@ -28,7 +28,6 @@ Item {
 
                 horizontalAlignment: Qt.AlignLeft
                 font.capitalization: Font.AllUppercase
-                font.pixelSize: 12
             }
 
             StyledTextLabel {
@@ -40,7 +39,6 @@ Item {
 
                 horizontalAlignment: Qt.AlignLeft
                 font.capitalization: Font.AllUppercase
-                font.pixelSize: 12
             }
         }
 

--- a/mu4/palette/qml/MuseScore/Palette/MoreElementsPopup.qml
+++ b/mu4/palette/qml/MuseScore/Palette/MoreElementsPopup.qml
@@ -259,8 +259,6 @@ StyledPopup {
             width: parent.width
             text: qsTrc("palette", "Drag items to the palette or directly on your score")
             wrapMode: Text.WordWrap
-            // make this label's font slightly smaller than other popup text
-            font.pointSize: ui.theme.font.pointSize * 0.8
         }
 
         FlatButton {

--- a/mu4/palette/qml/MuseScore/Palette/PaletteTree.qml
+++ b/mu4/palette/qml/MuseScore/Palette/PaletteTree.qml
@@ -564,7 +564,7 @@ ListView {
             }
 
             DropArea {
-                anchors { fill: parent/*; margins: 10*/ }
+                anchors.fill: parent
                 keys: [ "application/musescore/palettetree" ]
                 onEntered: {
                     const idx = control.DelegateModel.itemsIndex;

--- a/mu4/palette/qml/MuseScore/Palette/TreePaletteHeader.qml
+++ b/mu4/palette/qml/MuseScore/Palette/TreePaletteHeader.qml
@@ -78,6 +78,7 @@ Item {
             right: deleteButton.visible ? deleteButton.left : (paletteHeaderMenuButton.visible ? paletteHeaderMenuButton.left : parent.right)
         }
         text: paletteHeader.text
+        font.bold: true
     }
 
     FlatButton {

--- a/mu4/userscores/qml/MuseScore/UserScores/internal/KeySignatureListView.qml
+++ b/mu4/userscores/qml/MuseScore/UserScores/internal/KeySignatureListView.qml
@@ -50,7 +50,6 @@ GridView {
             StyledTextLabel {
                 anchors.horizontalCenter: parent.horizontalCenter
 
-                font.pixelSize: 12
                 text: modelData.title
             }
         }

--- a/mu4/userscores/qml/MuseScore/UserScores/internal/KeySignatureSettings.qml
+++ b/mu4/userscores/qml/MuseScore/UserScores/internal/KeySignatureSettings.qml
@@ -35,7 +35,6 @@ FlatButton {
         }
 
         StyledTextLabel {
-            font.pixelSize: 12
             text: model.keySignature.title
         }
     }

--- a/mu4/userscores/qml/MuseScore/UserScores/internal/ScoreItem.qml
+++ b/mu4/userscores/qml/MuseScore/UserScores/internal/ScoreItem.qml
@@ -125,7 +125,6 @@ Item {
 
                 anchors.horizontalCenter: parent.horizontalCenter
 
-                font.pixelSize: 12
                 font.capitalization: Font.AllUppercase
 
                 visible: !root.isAdd


### PR DESCRIPTION
Theme sets the font size in points but in qml (StyledTextLabel) font size was used in pixels. This leads to undefined behavior as said in qt-documentation:

>Returns the pixel size of the font if it was set with setPixelSize(). Returns -1 if the size was set with setPointSize() or setPointSizeF().

https://doc.qt.io/qt-5/qfont.html#pixelSize

- replaced setting of font size from points to pixels