### PR TITLE
InstrumentOrdering updates

### DIFF
--- a/libmscore/instrtemplate.cpp
+++ b/libmscore/instrtemplate.cpp
@@ -771,6 +771,25 @@ InstrumentIndex searchTemplateIndexForTrackName(const QString& trackName)
       }
 
 //---------------------------------------------------------
+//   searchTemplateIndexForId
+//---------------------------------------------------------
+
+InstrumentIndex searchTemplateIndexForId(const QString& id)
+      {
+      int instIndex = 0;
+      int grpIndex = 0;
+      for (InstrumentGroup* g : instrumentGroups) {
+            for (InstrumentTemplate* it : g->instrumentTemplates) {
+                  if (it->id == id)
+                        return InstrumentIndex(grpIndex, instIndex, it);
+                  ++instIndex;
+                  }
+            ++grpIndex;
+            }
+      return InstrumentIndex(-1, -1, nullptr);
+      }
+
+//---------------------------------------------------------
 //   linkGenre
 //      link the current instrument template to the genre list specified by "genre"
 //      Each genre is a list of pointers to instrument templates

--- a/libmscore/instrtemplate.h
+++ b/libmscore/instrtemplate.h
@@ -159,6 +159,7 @@ extern bool saveInstrumentTemplates(const QString& instrTemplates);
 extern InstrumentTemplate* searchTemplate(const QString& name);
 extern InstrumentTemplate* searchTemplateForMusicXmlId(const QString& mxmlId);
 extern InstrumentIndex searchTemplateIndexForTrackName(const QString& trackName);
+extern InstrumentIndex searchTemplateIndexForId(const QString& id);
 extern InstrumentGroup* searchInstrumentGroup(const QString& name);
 extern ClefType defaultClef(int patch);
 

--- a/libmscore/instrument.cpp
+++ b/libmscore/instrument.cpp
@@ -94,8 +94,9 @@ bool MidiArticulation::operator==(const MidiArticulation& i) const
 //   Instrument
 //---------------------------------------------------------
 
-Instrument::Instrument()
+Instrument::Instrument(QString id)
       {
+      _id = id;
       Channel* a = new Channel;
       a->setName(Channel::DEFAULT_NAME);
       _channel.append(a);
@@ -111,6 +112,7 @@ Instrument::Instrument()
 
 Instrument::Instrument(const Instrument& i)
       {
+      _id           = i._id;
       _longNames    = i._longNames;
       _shortNames   = i._shortNames;
       _trackName    = i._trackName;
@@ -139,6 +141,7 @@ void Instrument::operator=(const Instrument& i)
       _channel.clear();
       delete _drumset;
 
+      _id           = i._id;
       _longNames    = i._longNames;
       _shortNames   = i._shortNames;
       _trackName    = i._trackName;
@@ -214,7 +217,10 @@ void StaffName::read(XmlReader& e)
 
 void Instrument::write(XmlWriter& xml, const Part* part) const
       {
-      xml.stag("Instrument");
+      if (_id.isEmpty())
+            xml.stag("Instrument");
+      else
+            xml.stag(QString("Instrument id=\"%1\"").arg(_id));
       _longNames.write(xml, "longName");
       _shortNames.write(xml, "shortName");
 //      if (!_trackName.empty())
@@ -286,6 +292,7 @@ void Instrument::read(XmlReader& e, Part* part)
       bool readSingleNoteDynamics = false;
 
       _channel.clear();       // remove default channel
+      _id = e.attribute("id");
       while (e.readNextStartElement()) {
             const QStringRef& tag(e.name());
             if (tag == "singleNoteDynamics") {
@@ -1480,7 +1487,7 @@ void Instrument::setTrackName(const QString& s)
 
 Instrument Instrument::fromTemplate(const InstrumentTemplate* t)
       {
-      Instrument instr;
+      Instrument instr(t->id);
       instr.setAmateurPitchRange(t->minPitchA, t->maxPitchA);
       instr.setProfessionalPitchRange(t->minPitchP, t->maxPitchP);
       for (StaffName sn : t->longNames)
@@ -1502,6 +1509,25 @@ Instrument Instrument::fromTemplate(const InstrumentTemplate* t)
       instr.setStringData(t->stringData);
       instr.setSingleNoteDynamics(t->singleNoteDynamics);
       return instr;
+      }
+
+//---------------------------------------------------------
+//  updateInstrumentId
+//---------------------------------------------------------
+
+void Instrument::updateInstrumentId()
+      {
+      if (!_id.isEmpty() || _instrumentId.isEmpty())
+            return;
+
+      for (InstrumentGroup* g : instrumentGroups) {
+            for (InstrumentTemplate* it : g->instrumentTemplates) {
+                  if (it->musicXMLid == instrumentId()) {
+                        _id = it->id;
+                        return;
+                        }
+                  }
+            }
       }
 
 //---------------------------------------------------------

--- a/libmscore/instrument.h
+++ b/libmscore/instrument.h
@@ -254,6 +254,7 @@ class Instrument {
       StaffNameList _longNames;
       StaffNameList _shortNames;
       QString _trackName;
+      QString _id;
 
       char _minPitchA, _maxPitchA, _minPitchP, _maxPitchP;
       Interval _transpose;
@@ -271,7 +272,7 @@ class Instrument {
       bool _singleNoteDynamics;
 
    public:
-      Instrument();
+      Instrument(QString id="");
       Instrument(const Instrument&);
       void operator=(const Instrument&);
       ~Instrument();
@@ -288,6 +289,7 @@ class Instrument {
       bool operator==(const Instrument&) const;
       bool isDifferentInstrument(const Instrument& i) const;
 
+      QString getId() const                                 { return _id;         }
       void setMinPitchP(int v)                               { _minPitchP = v;     }
       void setMaxPitchP(int v)                               { _maxPitchP = v;     }
       void setMinPitchA(int v)                               { _minPitchA = v;     }
@@ -344,6 +346,8 @@ class Instrument {
       QString trackName() const;
       void setTrackName(const QString& s);
       static Instrument fromTemplate(const InstrumentTemplate* t);
+
+      void updateInstrumentId();
 
       bool singleNoteDynamics() const           { return _singleNoteDynamics; }
       void setSingleNoteDynamics(bool val)      { _singleNoteDynamics = val; }

--- a/libmscore/read302.cpp
+++ b/libmscore/read302.cpp
@@ -278,6 +278,12 @@ bool Score::read(XmlReader& e)
                   }
             }
 #endif
+      // Make sure every instrument has an instrumentId set.
+      for (Part* part : parts()) {
+            const InstrumentList* il = part->instruments();
+            for (auto it = il->begin(); it != il->end(); it++)
+                  static_cast<Instrument*>(it->second)->updateInstrumentId();
+            }
       if (order) {
             ScoreOrder* defined = scoreOrders.findByName(order->getName());
             if (defined)

--- a/libmscore/scoreOrder.h
+++ b/libmscore/scoreOrder.h
@@ -110,20 +110,19 @@ class ScoreOrder {
       void setCustomised();
 
       ScoreGroup* getGroup(const QString family, const QString instrumentGroup) const;
-      ScoreGroup* getGroup(const QString instrumentName, bool soloist) const;
+      ScoreGroup* getGroup(const QString instrumentId, bool soloist) const;
 
       void read(XmlReader& e);
       void write(XmlWriter& xml) const;
 
-      int instrumentIndex(const QString name, bool soloist) const;
-      bool instrumentInUnsortedSection(const QString name, bool soloist) const;
+      int instrumentIndex(const QString id, bool soloist) const;
+      bool instrumentInUnsortedSection(const QString id, bool soloist) const;
 
       void updateInstruments(const Score* score);
       void setBracketsAndBarlines(Score* score);
       bool isScoreOrder(const QList<int>& indices) const;
       bool isScoreOrder(const Score* score) const;
 
-      void debug(const QString& name, bool soloist) const;
       void dump() const;
       };
 

--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -313,6 +313,15 @@ void StaffListItem::staffTypeChanged(int idx)
       }
 
 //---------------------------------------------------------
+//   id
+//---------------------------------------------------------
+
+QString PartListItem::id() const
+      {
+      return it ? it->id : part->instrument()->getId();
+      }
+
+//---------------------------------------------------------
 //   name
 //---------------------------------------------------------
 
@@ -624,8 +633,8 @@ int InstrumentsWidget::findPrvItem(PartListItem* pli, int number)
       {
       ScoreOrder* order = getScoreOrder();
 
-      int orderNumber = order->instrumentIndex(pli->name(), pli->isSoloist());
-      bool unsorted = order->instrumentInUnsortedSection(pli->name(), pli->isSoloist());
+      int orderNumber = order->instrumentIndex(pli->id(), pli->isSoloist());
+      bool unsorted = order->instrumentInUnsortedSection(pli->id(), pli->isSoloist());
       int currow { 0 };
       if (unsorted)
             currow = partiturList->currentIndex().row();
@@ -636,12 +645,12 @@ int InstrumentsWidget::findPrvItem(PartListItem* pli, int number)
             PartListItem* p = (PartListItem*)item;
             if (p->op == ListItemOp::I_DELETE)
                   continue;
-            if (order->instrumentIndex(pli->name(), p->isSoloist()) == orderNumber)
+            if (order->instrumentIndex(p->id(), p->isSoloist()) == orderNumber)
                   {
                   if (idx > currow)
                         return idx;
                   }
-            if (order->instrumentIndex(pli->name(), p->isSoloist()) > orderNumber)
+            if (order->instrumentIndex(p->id(), p->isSoloist()) > orderNumber)
                   return idx;
             }
       return last;
@@ -1342,7 +1351,7 @@ bool InstrumentsWidget::isScoreOrder(const ScoreOrder* order) const
             PartListItem* pli = (PartListItem*)item;
             if (pli->op == ListItemOp::I_DELETE)
                   continue;
-            indices << order->instrumentIndex(pli->name(), pli->isSoloist());
+            indices << order->instrumentIndex(pli->id(), pli->isSoloist());
             }
       return order->isScoreOrder(indices);
       }

--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -949,7 +949,6 @@ void InstrumentsWidget::on_upButton_clicked()
                   }
             }
       updatePartIdx();
-//      setCustomScoreOrder();
       }
 
 //---------------------------------------------------------
@@ -1015,7 +1014,6 @@ void InstrumentsWidget::on_downButton_clicked()
                   }
             }
       updatePartIdx();
-//      setCustomScoreOrder();
       }
 
 //---------------------------------------------------------
@@ -1364,7 +1362,9 @@ void InstrumentsWidget::init()
       addLinkedStaffButton->setEnabled(false);
       addStaffButton->setEnabled(false);
 
+      int curIndex = scoreOrderComboBox->currentIndex();
       _model->rebuildData();
+      scoreOrderComboBox->setCurrentIndex(curIndex);
 
       // get last saved, user-selected instrument genre and set filter to it
       QSettings settings;
@@ -1393,15 +1393,6 @@ void InstrumentsWidget::setMakeSoloistButtonText()
       else
             makeSoloistButton->setText(InstrumentsWidget::tr("Make soloist"));
       partiturList->resizeColumnToContents(0);
-      }
-
-//---------------------------------------------------------
-//   setCustomScoreOrder
-//---------------------------------------------------------
-
-void InstrumentsWidget::setCustomScoreOrder()
-      {
-      scoreOrderComboBox->setCurrentIndex(0);
       }
 
 //---------------------------------------------------------

--- a/mscore/instrwidget.h
+++ b/mscore/instrwidget.h
@@ -72,6 +72,7 @@ class PartListItem : public QTreeWidgetItem {
       PartListItem(const InstrumentTemplate* i);
       PartListItem(const InstrumentTemplate* i, QTreeWidget* lv);
       PartListItem(const InstrumentTemplate* i, QTreeWidget* lv, QTreeWidgetItem* prv);
+      QString id() const;
       QString name() const;
       bool visible() const;
       void setVisible(bool val);

--- a/mscore/instrwidget.h
+++ b/mscore/instrwidget.h
@@ -192,7 +192,6 @@ class InstrumentsWidget : public QWidget, public Ui::InstrumentsWidget {
       void updatePartIdx();
       void init();
       void setMakeSoloistButtonText();
-      void setCustomScoreOrder();
       void createInstruments(Score*);
       void numberInstrumentNames(Score*);
       void setScoreOrder(ScoreOrder* order);

--- a/mtest/guitarpro/UncompletedMeasure.gpx-ref.mscx
+++ b/mtest/guitarpro/UncompletedMeasure.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Clean Guitar</trackName>
-      <Instrument>
+      <Instrument id="electric-guitar-treble-clef">
         <longName>Electric Guitar</longName>
         <shortName>El. Guit.</shortName>
         <trackName>Electric Guitar (Treble Clef)</trackName>
@@ -197,7 +197,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="electric-guitar-treble-clef">
           <longName>Electric Guitar</longName>
           <shortName>El. Guit.</shortName>
           <trackName>Electric Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/accent.gpx-ref.mscx
+++ b/mtest/guitarpro/accent.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -226,7 +226,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/arpeggio.gpx-ref.mscx
+++ b/mtest/guitarpro/arpeggio.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -240,7 +240,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/artificial-harmonic.gpx-ref.mscx
+++ b/mtest/guitarpro/artificial-harmonic.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Electric Guitar</trackName>
-      <Instrument>
+      <Instrument id="electric-guitar-treble-clef">
         <longName>Electric Guitar</longName>
         <shortName>El. Guit.</shortName>
         <trackName>Electric Guitar (Treble Clef)</trackName>
@@ -369,7 +369,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="electric-guitar-treble-clef">
           <longName>Electric Guitar</longName>
           <shortName>El. Guit.</shortName>
           <trackName>Electric Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/basic-bend.gpx-ref.mscx
+++ b/mtest/guitarpro/basic-bend.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -228,7 +228,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/brush.gpx-ref.mscx
+++ b/mtest/guitarpro/brush.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -240,7 +240,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/clefs.gpx-ref.mscx
+++ b/mtest/guitarpro/clefs.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Acoustic Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>
@@ -259,7 +259,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="piano">
           <longName>Piano</longName>
           <shortName>Pno.</shortName>
           <trackName>Piano</trackName>

--- a/mtest/guitarpro/copyright.gpx-ref.mscx
+++ b/mtest/guitarpro/copyright.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -222,7 +222,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/crescendo-diminuendo.gpx-ref.mscx
+++ b/mtest/guitarpro/crescendo-diminuendo.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -284,7 +284,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/dead-note.gpx-ref.mscx
+++ b/mtest/guitarpro/dead-note.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -224,7 +224,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/dotted-gliss.gpx-ref.mscx
+++ b/mtest/guitarpro/dotted-gliss.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Guitar 1</trackName>
-      <Instrument>
+      <Instrument id="electric-guitar-treble-clef">
         <longName>Electric Guitar</longName>
         <shortName>El. Guit.</shortName>
         <trackName>Electric Guitar (Treble Clef)</trackName>
@@ -266,7 +266,7 @@ Innuendo</text>
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="electric-guitar-treble-clef">
           <longName>Electric Guitar</longName>
           <shortName>El. Guit.</shortName>
           <trackName>Electric Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/dotted-tuplets.gpx-ref.mscx
+++ b/mtest/guitarpro/dotted-tuplets.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Bells</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -286,7 +286,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/double-bar.gpx-ref.mscx
+++ b/mtest/guitarpro/double-bar.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -252,7 +252,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/dynamic.gpx-ref.mscx
+++ b/mtest/guitarpro/dynamic.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -341,7 +341,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/fade-in.gpx-ref.mscx
+++ b/mtest/guitarpro/fade-in.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -224,7 +224,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/fingering.gpx-ref.mscx
+++ b/mtest/guitarpro/fingering.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -367,7 +367,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/free-time.gpx-ref.mscx
+++ b/mtest/guitarpro/free-time.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Electric Guitar</trackName>
-      <Instrument>
+      <Instrument id="electric-guitar-treble-clef">
         <longName>Electric Guitar</longName>
         <shortName>El. Guit.</shortName>
         <trackName>Electric Guitar (Treble Clef)</trackName>
@@ -258,7 +258,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="electric-guitar-treble-clef">
           <longName>Electric Guitar</longName>
           <shortName>El. Guit.</shortName>
           <trackName>Electric Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/heavy-accent.gpx-ref.mscx
+++ b/mtest/guitarpro/heavy-accent.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -223,7 +223,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/high-pitch.gpx-ref.mscx
+++ b/mtest/guitarpro/high-pitch.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 3</trackName>
-      <Instrument>
+      <Instrument id="bass-guitar">
         <longName>Bass Guitar</longName>
         <shortName>B. Guit.</shortName>
         <trackName>Bass Guitar</trackName>
@@ -363,7 +363,7 @@ Puki Kuki</text>
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="bass-guitar">
           <longName>Bass Guitar</longName>
           <shortName>B. Guit.</shortName>
           <trackName>Bass Guitar</trackName>

--- a/mtest/guitarpro/keysig.gpx-ref.mscx
+++ b/mtest/guitarpro/keysig.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Electric Guitar</trackName>
-      <Instrument>
+      <Instrument id="electric-guitar-treble-clef">
         <longName>Electric Guitar</longName>
         <shortName>El. Guit.</shortName>
         <trackName>Electric Guitar (Treble Clef)</trackName>
@@ -2016,7 +2016,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="electric-guitar-treble-clef">
           <longName>Electric Guitar</longName>
           <shortName>El. Guit.</shortName>
           <trackName>Electric Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/let-ring.gpx-ref.mscx
+++ b/mtest/guitarpro/let-ring.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Electric Guitar</trackName>
-      <Instrument>
+      <Instrument id="electric-guitar-treble-clef">
         <longName>Electric Guitar</longName>
         <shortName>El. Guit.</shortName>
         <trackName>Electric Guitar (Treble Clef)</trackName>
@@ -239,7 +239,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="electric-guitar-treble-clef">
           <longName>Electric Guitar</longName>
           <shortName>El. Guit.</shortName>
           <trackName>Electric Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/mordents.gpx-ref.mscx
+++ b/mtest/guitarpro/mordents.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -230,7 +230,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/multivoices.gpx-ref.mscx
+++ b/mtest/guitarpro/multivoices.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Nylon Guitar</trackName>
-      <Instrument>
+      <Instrument id="guitar-nylon-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Guitar (Treble Clef)</trackName>
@@ -401,7 +401,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-nylon-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/ottava1.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava1.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Nylon Guitar</trackName>
-      <Instrument>
+      <Instrument id="guitar-nylon-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Guitar (Treble Clef)</trackName>
@@ -381,7 +381,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-nylon-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/ottava2.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava2.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Nylon Guitar</trackName>
-      <Instrument>
+      <Instrument id="guitar-nylon-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Guitar (Treble Clef)</trackName>
@@ -108,7 +108,7 @@
           </StaffType>
         </Staff>
       <trackName>Electric Guitar</trackName>
-      <Instrument>
+      <Instrument id="electric-guitar-treble-clef">
         <longName>Electric Guitar</longName>
         <shortName>El. Guit.</shortName>
         <trackName>Electric Guitar (Treble Clef)</trackName>
@@ -559,7 +559,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-nylon-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Guitar (Treble Clef)</trackName>
@@ -1009,7 +1009,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="electric-guitar-treble-clef">
           <longName>Electric Guitar</longName>
           <shortName>El. Guit.</shortName>
           <trackName>Electric Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/ottava3.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava3.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Nylon Guitar</trackName>
-      <Instrument>
+      <Instrument id="guitar-nylon-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Guitar (Treble Clef)</trackName>
@@ -108,7 +108,7 @@
           </StaffType>
         </Staff>
       <trackName>Electric Guitar</trackName>
-      <Instrument>
+      <Instrument id="electric-guitar-treble-clef">
         <longName>Electric Guitar</longName>
         <shortName>El. Guit.</shortName>
         <trackName>Electric Guitar (Treble Clef)</trackName>
@@ -323,7 +323,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-nylon-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Guitar (Treble Clef)</trackName>
@@ -529,7 +529,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="electric-guitar-treble-clef">
           <longName>Electric Guitar</longName>
           <shortName>El. Guit.</shortName>
           <trackName>Electric Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/ottava4.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava4.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Nylon Guitar</trackName>
-      <Instrument>
+      <Instrument id="guitar-nylon-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Guitar (Treble Clef)</trackName>
@@ -108,7 +108,7 @@
           </StaffType>
         </Staff>
       <trackName>Electric Guitar</trackName>
-      <Instrument>
+      <Instrument id="electric-guitar-treble-clef">
         <longName>Electric Guitar</longName>
         <shortName>El. Guit.</shortName>
         <trackName>Electric Guitar (Treble Clef)</trackName>
@@ -593,7 +593,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-nylon-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Guitar (Treble Clef)</trackName>
@@ -1043,7 +1043,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="electric-guitar-treble-clef">
           <longName>Electric Guitar</longName>
           <shortName>El. Guit.</shortName>
           <trackName>Electric Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/ottava5.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava5.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Nylon Guitar</trackName>
-      <Instrument>
+      <Instrument id="guitar-nylon-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Guitar (Treble Clef)</trackName>
@@ -108,7 +108,7 @@
           </StaffType>
         </Staff>
       <trackName>Electric Guitar</trackName>
-      <Instrument>
+      <Instrument id="electric-guitar-treble-clef">
         <longName>Electric Guitar</longName>
         <shortName>El. Guit.</shortName>
         <trackName>Electric Guitar (Treble Clef)</trackName>
@@ -422,7 +422,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-nylon-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Guitar (Treble Clef)</trackName>
@@ -688,7 +688,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="electric-guitar-treble-clef">
           <longName>Electric Guitar</longName>
           <shortName>El. Guit.</shortName>
           <trackName>Electric Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/palm-mute.gpx-ref.mscx
+++ b/mtest/guitarpro/palm-mute.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Electric Guitar</trackName>
-      <Instrument>
+      <Instrument id="electric-guitar-treble-clef">
         <longName>Electric Guitar</longName>
         <shortName>El. Guit.</shortName>
         <trackName>Electric Guitar (Treble Clef)</trackName>
@@ -239,7 +239,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="electric-guitar-treble-clef">
           <longName>Electric Guitar</longName>
           <shortName>El. Guit.</shortName>
           <trackName>Electric Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/pick-up-down.gpx-ref.mscx
+++ b/mtest/guitarpro/pick-up-down.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -230,7 +230,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/repeated-bars.gpx-ref.mscx
+++ b/mtest/guitarpro/repeated-bars.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Electric Guitar</trackName>
-      <Instrument>
+      <Instrument id="electric-guitar-treble-clef">
         <longName>Electric Guitar</longName>
         <shortName>El. Guit.</shortName>
         <trackName>Electric Guitar (Treble Clef)</trackName>
@@ -231,7 +231,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="electric-guitar-treble-clef">
           <longName>Electric Guitar</longName>
           <shortName>El. Guit.</shortName>
           <trackName>Electric Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/repeats.gpx-ref.mscx
+++ b/mtest/guitarpro/repeats.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -250,7 +250,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/rest-centered.gpx-ref.mscx
+++ b/mtest/guitarpro/rest-centered.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Electric Guitar</trackName>
-      <Instrument>
+      <Instrument id="electric-guitar-treble-clef">
         <longName>Electric Guitar</longName>
         <shortName>El. Guit.</shortName>
         <trackName>Electric Guitar (Treble Clef)</trackName>
@@ -207,7 +207,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="electric-guitar-treble-clef">
           <longName>Electric Guitar</longName>
           <shortName>El. Guit.</shortName>
           <trackName>Electric Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/sforzato.gpx-ref.mscx
+++ b/mtest/guitarpro/sforzato.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -214,7 +214,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/slur.gpx-ref.mscx
+++ b/mtest/guitarpro/slur.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -244,7 +244,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/slur_hammer_slur.gpx-ref.mscx
+++ b/mtest/guitarpro/slur_hammer_slur.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Nylon Guitar</trackName>
-      <Instrument>
+      <Instrument id="guitar-nylon-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Guitar (Treble Clef)</trackName>
@@ -268,7 +268,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-nylon-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/slur_over_3_measures.gpx-ref.mscx
+++ b/mtest/guitarpro/slur_over_3_measures.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Nylon Guitar</trackName>
-      <Instrument>
+      <Instrument id="guitar-nylon-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Guitar (Treble Clef)</trackName>
@@ -305,7 +305,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-nylon-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/slur_slur_hammer.gpx-ref.mscx
+++ b/mtest/guitarpro/slur_slur_hammer.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Nylon Guitar</trackName>
-      <Instrument>
+      <Instrument id="guitar-nylon-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Guitar (Treble Clef)</trackName>
@@ -300,7 +300,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-nylon-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/slur_voices.gpx-ref.mscx
+++ b/mtest/guitarpro/slur_voices.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Nylon Guitar</trackName>
-      <Instrument>
+      <Instrument id="guitar-nylon-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Guitar (Treble Clef)</trackName>
@@ -896,7 +896,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-nylon-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/tap-slap-pop.gpx-ref.mscx
+++ b/mtest/guitarpro/tap-slap-pop.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Steel Guitar</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -227,7 +227,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/tempo.gpx-ref.mscx
+++ b/mtest/guitarpro/tempo.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-nylon-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Guitar (Treble Clef)</trackName>
@@ -335,7 +335,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-nylon-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/testIrrTuplet.gpx-ref.mscx
+++ b/mtest/guitarpro/testIrrTuplet.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Gtr 2</trackName>
-      <Instrument>
+      <Instrument id="electric-guitar-treble-clef">
         <longName>Electric Guitar</longName>
         <shortName>El. Guit.</shortName>
         <trackName>Electric Guitar (Treble Clef)</trackName>
@@ -260,7 +260,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="electric-guitar-treble-clef">
           <longName>Electric Guitar</longName>
           <shortName>El. Guit.</shortName>
           <trackName>Electric Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/text.gpx-ref.mscx
+++ b/mtest/guitarpro/text.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Electric Guitar</trackName>
-      <Instrument>
+      <Instrument id="electric-guitar-treble-clef">
         <longName>Electric Guitar</longName>
         <shortName>El. Guit.</shortName>
         <trackName>Electric Guitar (Treble Clef)</trackName>
@@ -226,7 +226,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="electric-guitar-treble-clef">
           <longName>Electric Guitar</longName>
           <shortName>El. Guit.</shortName>
           <trackName>Electric Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/tremolos.gpx-ref.mscx
+++ b/mtest/guitarpro/tremolos.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -234,7 +234,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/trill.gpx-ref.mscx
+++ b/mtest/guitarpro/trill.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Electric Guitar</trackName>
-      <Instrument>
+      <Instrument id="electric-guitar-treble-clef">
         <longName>Electric Guitar</longName>
         <shortName>El. Guit.</shortName>
         <trackName>Electric Guitar (Treble Clef)</trackName>
@@ -232,7 +232,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="electric-guitar-treble-clef">
           <longName>Electric Guitar</longName>
           <shortName>El. Guit.</shortName>
           <trackName>Electric Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/tuplets.gpx-ref.mscx
+++ b/mtest/guitarpro/tuplets.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Steel Guitar</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -577,7 +577,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/tuplets2.gpx-ref.mscx
+++ b/mtest/guitarpro/tuplets2.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Guitar</trackName>
-      <Instrument>
+      <Instrument id="guitar-nylon-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Guitar (Treble Clef)</trackName>
@@ -774,7 +774,7 @@ solo concert</text>
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-nylon-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/turn.gpx-ref.mscx
+++ b/mtest/guitarpro/turn.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -230,7 +230,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/vibrato.gpx-ref.mscx
+++ b/mtest/guitarpro/vibrato.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Electric Guitar</trackName>
-      <Instrument>
+      <Instrument id="electric-guitar-treble-clef">
         <longName>Electric Guitar</longName>
         <shortName>El. Guit.</shortName>
         <trackName>Electric Guitar (Treble Clef)</trackName>
@@ -354,7 +354,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="electric-guitar-treble-clef">
           <longName>Electric Guitar</longName>
           <shortName>El. Guit.</shortName>
           <trackName>Electric Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/volume-swell.gpx-ref.mscx
+++ b/mtest/guitarpro/volume-swell.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -224,7 +224,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/guitarpro/wah.gpx-ref.mscx
+++ b/mtest/guitarpro/wah.gpx-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Track 1</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel-treble-clef">
         <longName>Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar (Treble Clef)</trackName>
@@ -230,7 +230,7 @@
             </StaffType>
           </Staff>
         <trackName></trackName>
-        <Instrument>
+        <Instrument id="guitar-steel-treble-clef">
           <longName>Guitar</longName>
           <shortName>Guit.</shortName>
           <trackName>Acoustic Guitar (Treble Clef)</trackName>

--- a/mtest/importmidi/chord_1_tick_long.mscx
+++ b/mtest/importmidi/chord_1_tick_long.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/chord_big_error.mscx
+++ b/mtest/importmidi/chord_big_error.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/chord_collect.mscx
+++ b/mtest/importmidi/chord_collect.mscx
@@ -30,7 +30,7 @@
         <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Acoustic Guitar</trackName>
-      <Instrument>
+      <Instrument id="guitar-steel">
         <longName>Acoustic Guitar</longName>
         <shortName>Guit.</shortName>
         <trackName>Acoustic Guitar</trackName>

--- a/mtest/importmidi/chord_legato.mscx
+++ b/mtest/importmidi/chord_legato.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/chord_small_error.mscx
+++ b/mtest/importmidi/chord_small_error.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/clef_melody.mscx
+++ b/mtest/importmidi/clef_melody.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/clef_prev.mscx
+++ b/mtest/importmidi/clef_prev.mscx
@@ -30,7 +30,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/clef_tied.mscx
+++ b/mtest/importmidi/clef_tied.mscx
@@ -30,7 +30,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/division.mscx
+++ b/mtest/importmidi/division.mscx
@@ -38,7 +38,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/human_4-4.mscx
+++ b/mtest/importmidi/human_4-4.mscx
@@ -30,7 +30,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano, Track 1</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano, Track 1</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/human_tempo.mscx
+++ b/mtest/importmidi/human_tempo.mscx
@@ -36,7 +36,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano, PIANO                               </trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano, PIANO                               </longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/instrument_3staff_organ.mscx
+++ b/mtest/importmidi/instrument_3staff_organ.mscx
@@ -43,7 +43,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Organ, Manual</trackName>
-      <Instrument>
+      <Instrument id="organ">
         <longName>Organ, Manual</longName>
         <shortName>Org.</shortName>
         <trackName>Organ</trackName>

--- a/mtest/importmidi/instrument_channels.mscx
+++ b/mtest/importmidi/instrument_channels.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Violins</trackName>
-      <Instrument>
+      <Instrument id="violins">
         <longName>Violins</longName>
         <shortName>Vlns.</shortName>
         <trackName>Violins</trackName>
@@ -109,7 +109,7 @@
           </StaffType>
         </Staff>
       <trackName>B♭ Trumpet</trackName>
-      <Instrument>
+      <Instrument id="bb-trumpet">
         <longName>B♭ Trumpet</longName>
         <shortName>B♭ Tpt.</shortName>
         <trackName>B♭ Trumpet</trackName>
@@ -181,7 +181,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Trombone</trackName>
-      <Instrument>
+      <Instrument id="trombone">
         <longName>Trombone</longName>
         <shortName>Tbn.</shortName>
         <trackName>Trombone</trackName>

--- a/mtest/importmidi/instrument_clef.mscx
+++ b/mtest/importmidi/instrument_clef.mscx
@@ -31,7 +31,7 @@
         <defaultTransposingClef>F</defaultTransposingClef>
         </Staff>
       <trackName>Electric Bass</trackName>
-      <Instrument>
+      <Instrument id="electric-bass">
         <longName>Electric Bass</longName>
         <shortName>El. B.</shortName>
         <trackName>Electric Bass</trackName>

--- a/mtest/importmidi/instrument_grand.mscx
+++ b/mtest/importmidi/instrument_grand.mscx
@@ -37,7 +37,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>String Synthesizer</trackName>
-      <Instrument>
+      <Instrument id="string-synthesizer">
         <longName>String Synthesizer</longName>
         <shortName>Synth.</shortName>
         <trackName>String Synthesizer</trackName>
@@ -114,7 +114,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/instrument_grand2.mscx
+++ b/mtest/importmidi/instrument_grand2.mscx
@@ -37,7 +37,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Electric Piano</trackName>
-      <Instrument>
+      <Instrument id="electric-piano">
         <longName>Electric Piano</longName>
         <shortName>El. Pno.</shortName>
         <trackName>Electric Piano</trackName>
@@ -107,7 +107,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/lyrics_time_0.mscx
+++ b/mtest/importmidi/lyrics_time_0.mscx
@@ -37,7 +37,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano, untitled</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano, untitled</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/lyrics_voice_1.mscx
+++ b/mtest/importmidi/lyrics_voice_1.mscx
@@ -37,7 +37,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano, untitled</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano, untitled</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/m1.mscx
+++ b/mtest/importmidi/m1.mscx
@@ -37,7 +37,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/m2.mscx
+++ b/mtest/importmidi/m2.mscx
@@ -37,7 +37,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/m3.mscx
+++ b/mtest/importmidi/m3.mscx
@@ -37,7 +37,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/m4.mscx
+++ b/mtest/importmidi/m4.mscx
@@ -37,7 +37,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/m5.mscx
+++ b/mtest/importmidi/m5.mscx
@@ -37,7 +37,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/meter_12-8.mscx
+++ b/mtest/importmidi/meter_12-8.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/meter_15-8.mscx
+++ b/mtest/importmidi/meter_15-8.mscx
@@ -31,7 +31,7 @@
         <defaultTransposingClef>F</defaultTransposingClef>
         </Staff>
       <trackName>Electric Bass</trackName>
-      <Instrument>
+      <Instrument id="electric-bass">
         <longName>Electric Bass</longName>
         <shortName>El. B.</shortName>
         <trackName>Electric Bass</trackName>

--- a/mtest/importmidi/meter_4-4.mscx
+++ b/mtest/importmidi/meter_4-4.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/meter_9-8.mscx
+++ b/mtest/importmidi/meter_9-8.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/meter_central_long_note.mscx
+++ b/mtest/importmidi/meter_central_long_note.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/meter_central_long_rest.mscx
+++ b/mtest/importmidi/meter_central_long_rest.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/meter_chord_example.mscx
+++ b/mtest/importmidi/meter_chord_example.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/meter_dot_tie.mscx
+++ b/mtest/importmidi/meter_dot_tie.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/meter_dots_example1.mscx
+++ b/mtest/importmidi/meter_dots_example1.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/meter_dots_example2.mscx
+++ b/mtest/importmidi/meter_dots_example2.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/meter_dots_example3.mscx
+++ b/mtest/importmidi/meter_dots_example3.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/meter_first_2_8th_rests_compound.mscx
+++ b/mtest/importmidi/meter_first_2_8th_rests_compound.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/meter_half_rest_3-4.mscx
+++ b/mtest/importmidi/meter_half_rest_3-4.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/meter_last_quarter_rest_compound.mscx
+++ b/mtest/importmidi/meter_last_quarter_rest_compound.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/meter_rests.mscx
+++ b/mtest/importmidi/meter_rests.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/meter_two_beats_over.mscx
+++ b/mtest/importmidi/meter_two_beats_over.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/min_duration.mscx
+++ b/mtest/importmidi/min_duration.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/perc_drums.mscx
+++ b/mtest/importmidi/perc_drums.mscx
@@ -31,7 +31,7 @@
         <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Drumset, drum</trackName>
-      <Instrument>
+      <Instrument id="drumset">
         <longName>Drumset, drum</longName>
         <shortName>D. Set</shortName>
         <trackName>Drumset</trackName>

--- a/mtest/importmidi/perc_no_grand_staff.mscx
+++ b/mtest/importmidi/perc_no_grand_staff.mscx
@@ -32,7 +32,7 @@
         <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Tambourine</trackName>
-      <Instrument>
+      <Instrument id="tambourine">
         <longName>Tambourine</longName>
         <shortName>Tamb.</shortName>
         <trackName>Tambourine</trackName>
@@ -103,7 +103,7 @@
         <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Drumset</trackName>
-      <Instrument>
+      <Instrument id="drumset">
         <longName>Drumset</longName>
         <shortName>D. Set</shortName>
         <trackName>Drumset</trackName>

--- a/mtest/importmidi/perc_remove_ties.mscx
+++ b/mtest/importmidi/perc_remove_ties.mscx
@@ -31,7 +31,7 @@
         <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Drumset, Drum Set</trackName>
-      <Instrument>
+      <Instrument id="drumset">
         <longName>Drumset, Drum Set</longName>
         <shortName>D. Set</shortName>
         <trackName>Drumset</trackName>

--- a/mtest/importmidi/perc_respect_beat.mscx
+++ b/mtest/importmidi/perc_respect_beat.mscx
@@ -32,7 +32,7 @@
         <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Concert Snare Drum</trackName>
-      <Instrument>
+      <Instrument id="snare-drum">
         <longName>Concert Snare Drum</longName>
         <shortName>Con. Sn.</shortName>
         <trackName>Concert Snare Drum</trackName>

--- a/mtest/importmidi/perc_short_notes.mscx
+++ b/mtest/importmidi/perc_short_notes.mscx
@@ -31,7 +31,7 @@
         <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Drumset</trackName>
-      <Instrument>
+      <Instrument id="drumset">
         <longName>Drumset</longName>
         <shortName>D. Set</shortName>
         <trackName>Drumset</trackName>

--- a/mtest/importmidi/perc_triplet.mscx
+++ b/mtest/importmidi/perc_triplet.mscx
@@ -32,7 +32,7 @@
         <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Concert Snare Drum</trackName>
-      <Instrument>
+      <Instrument id="snare-drum">
         <longName>Concert Snare Drum</longName>
         <shortName>Con. Sn.</shortName>
         <trackName>Concert Snare Drum</trackName>

--- a/mtest/importmidi/perc_tuplet_simplify.mscx
+++ b/mtest/importmidi/perc_tuplet_simplify.mscx
@@ -31,7 +31,7 @@
         <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Drumset</trackName>
-      <Instrument>
+      <Instrument id="drumset">
         <longName>Drumset</longName>
         <shortName>D. Set</shortName>
         <trackName>Drumset</trackName>

--- a/mtest/importmidi/perc_tuplet_simplify2.mscx
+++ b/mtest/importmidi/perc_tuplet_simplify2.mscx
@@ -31,7 +31,7 @@
         <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Drumset</trackName>
-      <Instrument>
+      <Instrument id="drumset">
         <longName>Drumset</longName>
         <shortName>D. Set</shortName>
         <trackName>Drumset</trackName>

--- a/mtest/importmidi/perc_tuplet_voice.mscx
+++ b/mtest/importmidi/perc_tuplet_voice.mscx
@@ -31,7 +31,7 @@
         <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Drumset</trackName>
-      <Instrument>
+      <Instrument id="drumset">
         <longName>Drumset</longName>
         <shortName>D. Set</shortName>
         <trackName>Drumset</trackName>

--- a/mtest/importmidi/pickup.mscx
+++ b/mtest/importmidi/pickup.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/pickup_long.mscx
+++ b/mtest/importmidi/pickup_long.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Horn in F</trackName>
-      <Instrument>
+      <Instrument id="horn">
         <longName>Horn in F</longName>
         <shortName>F Hn.</shortName>
         <trackName>Horn in F</trackName>

--- a/mtest/importmidi/pickup_turn_off.mscx
+++ b/mtest/importmidi/pickup_turn_off.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Soprano, Staff</trackName>
-      <Instrument>
+      <Instrument id="soprano">
         <longName>Soprano, Staff</longName>
         <shortName>S.</shortName>
         <trackName>Soprano</trackName>

--- a/mtest/importmidi/quant_dotted_4th.mscx
+++ b/mtest/importmidi/quant_dotted_4th.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/simplify_16th_staccato.mscx
+++ b/mtest/importmidi/simplify_16th_staccato.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/simplify_32nd_staccato.mscx
+++ b/mtest/importmidi/simplify_32nd_staccato.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/simplify_4th_dotted_tied.mscx
+++ b/mtest/importmidi/simplify_4th_dotted_tied.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/simplify_8th_dont.mscx
+++ b/mtest/importmidi/simplify_8th_dont.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/simplify_8th_dotted_no_staccato.mscx
+++ b/mtest/importmidi/simplify_8th_dotted_no_staccato.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/simplify_dotted_3-4.mscx
+++ b/mtest/importmidi/simplify_dotted_3-4.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/simplify_staccato_9-8.mscx
+++ b/mtest/importmidi/simplify_staccato_9-8.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/simplify_triplet_staccato.mscx
+++ b/mtest/importmidi/simplify_triplet_staccato.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/split_2_melodies.mscx
+++ b/mtest/importmidi/split_2_melodies.mscx
@@ -36,7 +36,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/split_acid.mscx
+++ b/mtest/importmidi/split_acid.mscx
@@ -37,7 +37,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/split_nontuplet.mscx
+++ b/mtest/importmidi/split_nontuplet.mscx
@@ -36,7 +36,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/split_octave.mscx
+++ b/mtest/importmidi/split_octave.mscx
@@ -36,7 +36,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/split_tuplet.mscx
+++ b/mtest/importmidi/split_tuplet.mscx
@@ -36,7 +36,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/swing_clef.mscx
+++ b/mtest/importmidi/swing_clef.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/swing_shuffle.mscx
+++ b/mtest/importmidi/swing_shuffle.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/swing_triplets.mscx
+++ b/mtest/importmidi/swing_triplets.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/timesig_changes.mscx
+++ b/mtest/importmidi/timesig_changes.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano, untitled</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano, untitled</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_16th_8th.mscx
+++ b/mtest/importmidi/tuplet_16th_8th.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_2_voices_3_5_tuplets.mscx
+++ b/mtest/importmidi/tuplet_2_voices_3_5_tuplets.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_2_voices_tuplet_non.mscx
+++ b/mtest/importmidi/tuplet_2_voices_tuplet_non.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_3-4.mscx
+++ b/mtest/importmidi/tuplet_3-4.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_3_5_7_tuplets.mscx
+++ b/mtest/importmidi/tuplet_3_5_7_tuplets.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_5_5_tuplets_rests.mscx
+++ b/mtest/importmidi/tuplet_5_5_tuplets_rests.mscx
@@ -37,7 +37,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_7_staccato.mscx
+++ b/mtest/importmidi/tuplet_7_staccato.mscx
@@ -30,7 +30,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_duplet.mscx
+++ b/mtest/importmidi/tuplet_duplet.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_mars.mscx
+++ b/mtest/importmidi/tuplet_mars.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_nonuplet_3-4.mscx
+++ b/mtest/importmidi/tuplet_nonuplet_3-4.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_nonuplet_4-4.mscx
+++ b/mtest/importmidi/tuplet_nonuplet_4-4.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_off_time_other_bar.mscx
+++ b/mtest/importmidi/tuplet_off_time_other_bar.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_off_time_other_bar2.mscx
+++ b/mtest/importmidi/tuplet_off_time_other_bar2.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_quadruplet.mscx
+++ b/mtest/importmidi/tuplet_quadruplet.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_septuplet.mscx
+++ b/mtest/importmidi/tuplet_septuplet.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_tied_3_5_tuplets.mscx
+++ b/mtest/importmidi/tuplet_tied_3_5_tuplets.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_tied_3_5_tuplets2.mscx
+++ b/mtest/importmidi/tuplet_tied_3_5_tuplets2.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_triplet.mscx
+++ b/mtest/importmidi/tuplet_triplet.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_triplet_first_tied.mscx
+++ b/mtest/importmidi/tuplet_triplet_first_tied.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_triplet_first_tied2.mscx
+++ b/mtest/importmidi/tuplet_triplet_first_tied2.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_triplet_last_tied.mscx
+++ b/mtest/importmidi/tuplet_triplet_last_tied.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/tuplet_triplets_mixed.mscx
+++ b/mtest/importmidi/tuplet_triplets_mixed.mscx
@@ -37,7 +37,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/voice_acid.mscx
+++ b/mtest/importmidi/voice_acid.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/voice_central.mscx
+++ b/mtest/importmidi/voice_central.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/voice_intersect.mscx
+++ b/mtest/importmidi/voice_intersect.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/importmidi/voice_tuplet.mscx
+++ b/mtest/importmidi/voice_tuplet.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/breath/breath01-ref.mscx
+++ b/mtest/libmscore/breath/breath01-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Flute</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName>Flute</trackName>
@@ -79,7 +79,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/breath/breath02-ref.mscx
+++ b/mtest/libmscore/breath/breath02-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Flute</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName>Flute</trackName>
@@ -79,7 +79,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/chordsymbol/realize-3note-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-3note-ref.mscx
@@ -34,7 +34,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/chordsymbol/realize-4note-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-4note-ref.mscx
@@ -34,7 +34,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/chordsymbol/realize-6note-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-6note-ref.mscx
@@ -34,7 +34,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/chordsymbol/realize-close-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-close-ref.mscx
@@ -34,7 +34,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/chordsymbol/realize-concert-pitch-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-concert-pitch-ref.mscx
@@ -33,7 +33,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/chordsymbol/realize-drop2-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-drop2-ref.mscx
@@ -34,7 +34,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/chordsymbol/realize-jazz-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-jazz-ref.mscx
@@ -34,7 +34,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/chordsymbol/realize-override-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-override-ref.mscx
@@ -32,7 +32,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/clef/clef-2-ref.mscx
+++ b/mtest/libmscore/clef/clef-2-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/clef/clef-3-ref.mscx
+++ b/mtest/libmscore/clef/clef-3-ref.mscx
@@ -32,7 +32,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/clef_courtesy/clef_courtesy04-ref.mscx
+++ b/mtest/libmscore/clef_courtesy/clef_courtesy04-ref.mscx
@@ -85,7 +85,7 @@
           </StaffType>
         </Staff>
       <trackName>Flute</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <trackName>Flute</trackName>
         <minPitchP>59</minPitchP>
         <maxPitchP>98</maxPitchP>

--- a/mtest/libmscore/copypaste/copypaste23-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste23-ref.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Flute</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName>Flute</trackName>

--- a/mtest/libmscore/copypaste/copypaste24-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste24-ref.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Flute</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName>Flute</trackName>

--- a/mtest/libmscore/copypaste/copypaste25-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste25-ref.mscx
@@ -33,7 +33,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/copypaste/copypaste26-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste26-ref.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/copypaste/copypaste_tuplet_01-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste_tuplet_01-ref.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Flute</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName>Flute</trackName>

--- a/mtest/libmscore/copypaste/copypaste_tuplet_02-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste_tuplet_02-ref.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Flute</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName>Flute</trackName>

--- a/mtest/libmscore/earlymusic/mensurstrich01-ref.mscx
+++ b/mtest/libmscore/earlymusic/mensurstrich01-ref.mscx
@@ -31,7 +31,7 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName>Voice</trackName>
-      <Instrument>
+      <Instrument id="voice">
         <longName>Voice</longName>
         <shortName>Vo.</shortName>
         <trackName>Voice</trackName>
@@ -80,7 +80,7 @@
           </StaffType>
         </Staff>
       <trackName>Voice</trackName>
-      <Instrument>
+      <Instrument id="voice">
         <longName>Voice</longName>
         <shortName>Vo.</shortName>
         <trackName>Voice</trackName>

--- a/mtest/libmscore/earlymusic/mensurstrich01.mscx
+++ b/mtest/libmscore/earlymusic/mensurstrich01.mscx
@@ -30,7 +30,7 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName>Voice</trackName>
-      <Instrument>
+      <Instrument id="voice">
         <longName>Voice</longName>
         <shortName>Vo.</shortName>
         <trackName>Voice</trackName>
@@ -79,7 +79,7 @@
           </StaffType>
         </Staff>
       <trackName>Voice</trackName>
-      <Instrument>
+      <Instrument id="voice">
         <longName>Voice</longName>
         <shortName>Vo.</shortName>
         <trackName>Voice</trackName>

--- a/mtest/libmscore/exchangevoices/exchangevoices-gliss-ref.mscx
+++ b/mtest/libmscore/exchangevoices/exchangevoices-gliss-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/exchangevoices/exchangevoices-slurs-ref.mscx
+++ b/mtest/libmscore/exchangevoices/exchangevoices-slurs-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/implode_explode/implode1-ref.mscx
+++ b/mtest/libmscore/implode_explode/implode1-ref.mscx
@@ -35,7 +35,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>
@@ -87,7 +87,7 @@
           </StaffType>
         </Staff>
       <trackName>Flute</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName>Flute</trackName>
@@ -138,7 +138,7 @@
           </StaffType>
         </Staff>
       <trackName>B♭ Trumpet</trackName>
-      <Instrument>
+      <Instrument id="bb-trumpet">
         <longName>B♭ Trumpet</longName>
         <shortName>B♭ Tpt.</shortName>
         <trackName>B♭ Trumpet</trackName>
@@ -197,7 +197,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Tenor Trombone</trackName>
-      <Instrument>
+      <Instrument id="tenor-trombone">
         <longName>Tenor Trombone</longName>
         <shortName>T. Tbn.</shortName>
         <trackName>Tenor Trombone</trackName>

--- a/mtest/libmscore/implode_explode/implode1.mscx
+++ b/mtest/libmscore/implode_explode/implode1.mscx
@@ -35,7 +35,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>
@@ -87,7 +87,7 @@
           </StaffType>
         </Staff>
       <trackName>Flute</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName>Flute</trackName>
@@ -138,7 +138,7 @@
           </StaffType>
         </Staff>
       <trackName>B♭ Trumpet</trackName>
-      <Instrument>
+      <Instrument id="bb-trumpet">
         <longName>B♭ Trumpet</longName>
         <shortName>B♭ Tpt.</shortName>
         <trackName>B♭ Trumpet</trackName>
@@ -197,7 +197,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Tenor Trombone</trackName>
-      <Instrument>
+      <Instrument id="tenor-trombone">
         <longName>Tenor Trombone</longName>
         <shortName>T. Tbn.</shortName>
         <trackName>Tenor Trombone</trackName>

--- a/mtest/libmscore/instrumentchange/copy-ref.mscx
+++ b/mtest/libmscore/instrumentchange/copy-ref.mscx
@@ -132,7 +132,7 @@
       <Measure>
         <voice>
           <InstrumentChange>
-            <Instrument>
+            <Instrument id="bb-trumpet">
               <longName>B♭ Trumpet</longName>
               <shortName>B♭ Tpt.</shortName>
               <trackName>B♭ Trumpet</trackName>
@@ -353,7 +353,7 @@
       <Measure>
         <voice>
           <InstrumentChange>
-            <Instrument>
+            <Instrument id="bb-trumpet">
               <longName>B♭ Trumpet</longName>
               <shortName>B♭ Tpt.</shortName>
               <trackName>B♭ Trumpet</trackName>

--- a/mtest/libmscore/keysig/concert-pitch-01-ref.mscx
+++ b/mtest/libmscore/keysig/concert-pitch-01-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Alto Saxophone</trackName>
-      <Instrument>
+      <Instrument id="alto-saxophone">
         <longName>Alto Saxophone</longName>
         <shortName>A. Sax.</shortName>
         <trackName>Alto Saxophone</trackName>
@@ -83,7 +83,7 @@
         <defaultTransposingClef>G</defaultTransposingClef>
         </Staff>
       <trackName>Tenor Saxophone</trackName>
-      <Instrument>
+      <Instrument id="tenor-saxophone">
         <longName>Tenor Saxophone</longName>
         <shortName>T. Sax.</shortName>
         <trackName>Tenor Saxophone</trackName>

--- a/mtest/libmscore/keysig/concert-pitch-02-ref.mscx
+++ b/mtest/libmscore/keysig/concert-pitch-02-ref.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Alto Saxophone</trackName>
-      <Instrument>
+      <Instrument id="alto-saxophone">
         <longName>Alto Saxophone</longName>
         <shortName>A. Sax.</shortName>
         <trackName>Alto Saxophone</trackName>
@@ -82,7 +82,7 @@
         <defaultTransposingClef>G</defaultTransposingClef>
         </Staff>
       <trackName>Tenor Saxophone</trackName>
-      <Instrument>
+      <Instrument id="tenor-saxophone">
         <longName>Tenor Saxophone</longName>
         <shortName>T. Sax.</shortName>
         <trackName>Tenor Saxophone</trackName>

--- a/mtest/libmscore/keysig/preferSharpFlat-1-ref.mscx
+++ b/mtest/libmscore/keysig/preferSharpFlat-1-ref.mscx
@@ -35,7 +35,7 @@
         </Staff>
       <trackName>D♭ Piccolo</trackName>
       <preferSharpFlat>flats</preferSharpFlat>
-      <Instrument>
+      <Instrument id="piccolo">
         <longName>D♭ Piccolo</longName>
         <shortName>D♭ Picc.</shortName>
         <trackName>D♭ Piccolo</trackName>

--- a/mtest/libmscore/keysig/preferSharpFlat-2-ref.mscx
+++ b/mtest/libmscore/keysig/preferSharpFlat-2-ref.mscx
@@ -33,7 +33,7 @@
         </Staff>
       <trackName>Horn in D</trackName>
       <preferSharpFlat>flats</preferSharpFlat>
-      <Instrument>
+      <Instrument id="c-horn-alto">
         <longName>Horn in D</longName>
         <shortName>D Hn.</shortName>
         <trackName>Horn in D</trackName>

--- a/mtest/libmscore/measure/measurenumber-1-ref.mscx
+++ b/mtest/libmscore/measure/measurenumber-1-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/measure/measurenumber-2-ref.mscx
+++ b/mtest/libmscore/measure/measurenumber-2-ref.mscx
@@ -31,7 +31,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/measure/measurenumber-3-ref.mscx
+++ b/mtest/libmscore/measure/measurenumber-3-ref.mscx
@@ -32,7 +32,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/measure/measurenumber-4-ref.mscx
+++ b/mtest/libmscore/measure/measurenumber-4-ref.mscx
@@ -33,7 +33,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/measure/measurenumber-5-ref.mscx
+++ b/mtest/libmscore/measure/measurenumber-5-ref.mscx
@@ -32,7 +32,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/measure/measurenumber-6-ref.mscx
+++ b/mtest/libmscore/measure/measurenumber-6-ref.mscx
@@ -33,7 +33,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/measure/measurenumber-7-ref.mscx
+++ b/mtest/libmscore/measure/measurenumber-7-ref.mscx
@@ -34,7 +34,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/note/tpc-transpose-ref.mscx
+++ b/mtest/libmscore/note/tpc-transpose-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>B♭ Clarinet</trackName>
-      <Instrument>
+      <Instrument id="bb-clarinet">
         <longName>B♭ Clarinet</longName>
         <shortName>B♭ Cl.</shortName>
         <trackName>B♭ Clarinet</trackName>

--- a/mtest/libmscore/note/tpc-transpose2-ref.mscx
+++ b/mtest/libmscore/note/tpc-transpose2-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Alto Saxophone</trackName>
-      <Instrument>
+      <Instrument id="alto-saxophone">
         <longName>Alto Saxophone</longName>
         <shortName>A. Sax.</shortName>
         <trackName>Alto Saxophone</trackName>

--- a/mtest/libmscore/parts/part-54346-parts.mscx
+++ b/mtest/libmscore/parts/part-54346-parts.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>B♭ Trumpet</trackName>
-      <Instrument>
+      <Instrument id="bb-trumpet">
         <longName>B♭ Trumpet</longName>
         <shortName>B♭ Tpt.</shortName>
         <trackName>B♭ Trumpet</trackName>
@@ -84,7 +84,7 @@
           </StaffType>
         </Staff>
       <trackName>C Trumpet</trackName>
-      <Instrument>
+      <Instrument id="c-trumpet">
         <longName>C Trumpet</longName>
         <shortName>C Tpt.</shortName>
         <trackName>C Trumpet</trackName>
@@ -291,7 +291,7 @@
             </StaffType>
           </Staff>
         <trackName>B♭ Trumpet</trackName>
-        <Instrument>
+        <Instrument id="bb-trumpet">
           <longName>B♭ Trumpet</longName>
           <shortName>B♭ Tpt.</shortName>
           <trackName>B♭ Trumpet</trackName>
@@ -469,7 +469,7 @@
             </StaffType>
           </Staff>
         <trackName>C Trumpet</trackName>
-        <Instrument>
+        <Instrument id="c-trumpet">
           <longName>C Trumpet</longName>
           <shortName>C Tpt.</shortName>
           <trackName>C Trumpet</trackName>

--- a/mtest/libmscore/parts/part-54346.mscx
+++ b/mtest/libmscore/parts/part-54346.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>B♭ Trumpet</trackName>
-      <Instrument>
+      <Instrument id="bb-trumpet">
         <longName>B♭ Trumpet</longName>
         <shortName>B♭ Tpt.</shortName>
         <trackName>B♭ Trumpet</trackName>
@@ -84,7 +84,7 @@
           </StaffType>
         </Staff>
       <trackName>C Trumpet</trackName>
-      <Instrument>
+      <Instrument id="c-trumpet">
         <longName>C Trumpet</longName>
         <shortName>C Tpt.</shortName>
         <trackName>C Trumpet</trackName>

--- a/mtest/libmscore/parts/part-stemless-parts.mscx
+++ b/mtest/libmscore/parts/part-stemless-parts.mscx
@@ -32,7 +32,7 @@
           </StaffType>
         </Staff>
       <trackName>Flute</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName>Flute</trackName>
@@ -95,7 +95,7 @@
           </StaffType>
         </Staff>
       <trackName>Oboe</trackName>
-      <Instrument>
+      <Instrument id="oboe">
         <longName>Oboe</longName>
         <shortName>Ob.</shortName>
         <trackName>Oboe</trackName>
@@ -502,7 +502,7 @@
             </StaffType>
           </Staff>
         <trackName>Flute</trackName>
-        <Instrument>
+        <Instrument id="flute">
           <longName>Flute</longName>
           <shortName>Fl.</shortName>
           <trackName>Flute</trackName>
@@ -791,7 +791,7 @@
             </StaffType>
           </Staff>
         <trackName>Oboe</trackName>
-        <Instrument>
+        <Instrument id="oboe">
           <longName>Oboe</longName>
           <shortName>Ob.</shortName>
           <trackName>Oboe</trackName>

--- a/mtest/libmscore/parts/part-stemless.mscx
+++ b/mtest/libmscore/parts/part-stemless.mscx
@@ -32,7 +32,7 @@
           </StaffType>
         </Staff>
       <trackName>Flute</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName>Flute</trackName>
@@ -95,7 +95,7 @@
           </StaffType>
         </Staff>
       <trackName>Oboe</trackName>
-      <Instrument>
+      <Instrument id="oboe">
         <longName>Oboe</longName>
         <shortName>Ob.</shortName>
         <trackName>Oboe</trackName>

--- a/mtest/libmscore/parts/voices-ref.mscx
+++ b/mtest/libmscore/parts/voices-ref.mscx
@@ -38,7 +38,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>
@@ -96,7 +96,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Trombone</trackName>
-      <Instrument>
+      <Instrument id="trombone">
         <longName>Trombone</longName>
         <shortName>Tbn.</shortName>
         <trackName>Trombone</trackName>
@@ -1090,7 +1090,7 @@
           <defaultClef>F</defaultClef>
           </Staff>
         <trackName>Piano</trackName>
-        <Instrument>
+        <Instrument id="piano">
           <longName>Piano</longName>
           <shortName>Pno.</shortName>
           <trackName>Piano</trackName>
@@ -1940,7 +1940,7 @@
           <defaultClef>F</defaultClef>
           </Staff>
         <trackName>Trombone</trackName>
-        <Instrument>
+        <Instrument id="trombone">
           <longName>Trombone</longName>
           <shortName>Tbn.</shortName>
           <trackName>Trombone</trackName>
@@ -2482,7 +2482,7 @@
           <defaultClef>F</defaultClef>
           </Staff>
         <trackName>Trombone</trackName>
-        <Instrument>
+        <Instrument id="trombone">
           <longName>Trombone</longName>
           <shortName>Tbn.</shortName>
           <trackName>Trombone</trackName>

--- a/mtest/libmscore/readwriteundoreset/barlines.mscx
+++ b/mtest/libmscore/readwriteundoreset/barlines.mscx
@@ -35,7 +35,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/readwriteundoreset/mmrestBarlineTextLinks-disable-mmrest-ref.mscx
+++ b/mtest/libmscore/readwriteundoreset/mmrestBarlineTextLinks-disable-mmrest-ref.mscx
@@ -32,7 +32,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/readwriteundoreset/mmrestBarlineTextLinks-recreate-mmrest-ref.mscx
+++ b/mtest/libmscore/readwriteundoreset/mmrestBarlineTextLinks-recreate-mmrest-ref.mscx
@@ -33,7 +33,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/readwriteundoreset/mmrestBarlineTextLinks.mscx
+++ b/mtest/libmscore/readwriteundoreset/mmrestBarlineTextLinks.mscx
@@ -33,7 +33,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/readwriteundoreset/slurs.mscx
+++ b/mtest/libmscore/readwriteundoreset/slurs.mscx
@@ -37,7 +37,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/rhythmicGrouping/group8ths4-4-ref.mscx
+++ b/mtest/libmscore/rhythmicGrouping/group8ths4-4-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <trackName>Piano</trackName>
         <minPitchP>21</minPitchP>
         <maxPitchP>108</maxPitchP>
@@ -80,7 +80,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <trackName>Piano</trackName>
         <minPitchP>21</minPitchP>
         <maxPitchP>108</maxPitchP>

--- a/mtest/libmscore/rhythmicGrouping/group8thsCompound-ref.mscx
+++ b/mtest/libmscore/rhythmicGrouping/group8thsCompound-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <trackName>Piano</trackName>
         <minPitchP>21</minPitchP>
         <maxPitchP>108</maxPitchP>
@@ -78,7 +78,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <trackName>Piano</trackName>
         <minPitchP>21</minPitchP>
         <maxPitchP>108</maxPitchP>

--- a/mtest/libmscore/rhythmicGrouping/group8thsSimple-ref.mscx
+++ b/mtest/libmscore/rhythmicGrouping/group8thsSimple-ref.mscx
@@ -30,7 +30,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <trackName>Piano</trackName>
         <minPitchP>21</minPitchP>
         <maxPitchP>108</maxPitchP>
@@ -80,7 +80,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <trackName>Piano</trackName>
         <minPitchP>21</minPitchP>
         <maxPitchP>108</maxPitchP>

--- a/mtest/libmscore/rhythmicGrouping/groupConflicts-ref.mscx
+++ b/mtest/libmscore/rhythmicGrouping/groupConflicts-ref.mscx
@@ -79,7 +79,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Desired</longName>
         <shortName>Desired</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/rhythmicGrouping/groupVoices-ref.mscx
+++ b/mtest/libmscore/rhythmicGrouping/groupVoices-ref.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Flauta</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flauta</longName>
         <shortName>Fl.</shortName>
         <trackName>Flauta</trackName>

--- a/mtest/libmscore/spanners/glissando-cloning01-ref.mscx
+++ b/mtest/libmscore/spanners/glissando-cloning01-ref.mscx
@@ -36,7 +36,7 @@
           </StaffType>
         </Staff>
       <trackName>Flute</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName>Flute</trackName>

--- a/mtest/libmscore/spanners/glissando-cloning02-ref.mscx
+++ b/mtest/libmscore/spanners/glissando-cloning02-ref.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Flute</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName>Flute</trackName>
@@ -159,7 +159,7 @@
             </StaffType>
           </Staff>
         <trackName>Flute</trackName>
-        <Instrument>
+        <Instrument id="flute">
           <longName>Flute</longName>
           <shortName>Fl.</shortName>
           <trackName>Flute</trackName>

--- a/mtest/libmscore/spanners/glissando-cloning03-ref.mscx
+++ b/mtest/libmscore/spanners/glissando-cloning03-ref.mscx
@@ -36,7 +36,7 @@
           </StaffType>
         </Staff>
       <trackName>Flute</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName>Flute</trackName>

--- a/mtest/libmscore/spanners/glissando-cloning04-ref.mscx
+++ b/mtest/libmscore/spanners/glissando-cloning04-ref.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Flute</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName>Flute</trackName>
@@ -155,7 +155,7 @@
             </StaffType>
           </Staff>
         <trackName>Flute</trackName>
-        <Instrument>
+        <Instrument id="flute">
           <longName>Flute</longName>
           <shortName>Fl.</shortName>
           <trackName>Flute</trackName>

--- a/mtest/libmscore/spanners/glissando-cloning05-ref.mscx
+++ b/mtest/libmscore/spanners/glissando-cloning05-ref.mscx
@@ -41,7 +41,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>
@@ -276,7 +276,7 @@
           <defaultClef>F</defaultClef>
           </Staff>
         <trackName>Piano</trackName>
-        <Instrument>
+        <Instrument id="piano">
           <longName>Piano</longName>
           <shortName>Pno.</shortName>
           <trackName>Piano</trackName>

--- a/mtest/libmscore/spanners/glissando-crossstaff01-ref.mscx
+++ b/mtest/libmscore/spanners/glissando-crossstaff01-ref.mscx
@@ -37,7 +37,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/spanners/glissando-graces01-ref.mscx
+++ b/mtest/libmscore/spanners/glissando-graces01-ref.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Flute</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName>Flute</trackName>

--- a/mtest/libmscore/spanners/glissando01-ref.mscx
+++ b/mtest/libmscore/spanners/glissando01-ref.mscx
@@ -37,7 +37,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/spanners/linecolor01-ref.mscx
+++ b/mtest/libmscore/spanners/linecolor01-ref.mscx
@@ -32,7 +32,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/spanners/lyricsline02-ref.mscx
+++ b/mtest/libmscore/spanners/lyricsline02-ref.mscx
@@ -33,7 +33,7 @@
           </StaffType>
         </Staff>
       <trackName>Voice</trackName>
-      <Instrument>
+      <Instrument id="voice">
         <longName>Voice</longName>
         <shortName>Vo.</shortName>
         <trackName>Voice</trackName>

--- a/mtest/libmscore/spanners/lyricsline02.mscx
+++ b/mtest/libmscore/spanners/lyricsline02.mscx
@@ -33,7 +33,7 @@
           </StaffType>
         </Staff>
       <trackName>Voice</trackName>
-      <Instrument>
+      <Instrument id="voice">
         <longName>Voice</longName>
         <shortName>Vo.</shortName>
         <trackName>Voice</trackName>

--- a/mtest/libmscore/spanners/lyricsline03-ref.mscx
+++ b/mtest/libmscore/spanners/lyricsline03-ref.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Voice</trackName>
-      <Instrument>
+      <Instrument id="voice">
         <longName>Voice</longName>
         <shortName>Vo.</shortName>
         <trackName>Voice</trackName>

--- a/mtest/libmscore/spanners/lyricsline03.mscx
+++ b/mtest/libmscore/spanners/lyricsline03.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Voice</trackName>
-      <Instrument>
+      <Instrument id="voice">
         <longName>Voice</longName>
         <shortName>Vo.</shortName>
         <trackName>Voice</trackName>

--- a/mtest/libmscore/spanners/lyricsline04-ref.mscx
+++ b/mtest/libmscore/spanners/lyricsline04-ref.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Voice</trackName>
-      <Instrument>
+      <Instrument id="voice">
         <longName>Voice</longName>
         <shortName>Vo.</shortName>
         <trackName>Voice</trackName>

--- a/mtest/libmscore/spanners/lyricsline04.mscx
+++ b/mtest/libmscore/spanners/lyricsline04.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Voice</trackName>
-      <Instrument>
+      <Instrument id="voice">
         <longName>Voice</longName>
         <shortName>Vo.</shortName>
         <trackName>Voice</trackName>

--- a/mtest/libmscore/spanners/lyricsline05-ref.mscx
+++ b/mtest/libmscore/spanners/lyricsline05-ref.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Voice</trackName>
-      <Instrument>
+      <Instrument id="voice">
         <longName>Voice</longName>
         <shortName>Vo.</shortName>
         <trackName>Voice</trackName>

--- a/mtest/libmscore/spanners/lyricsline05.mscx
+++ b/mtest/libmscore/spanners/lyricsline05.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Voice</trackName>
-      <Instrument>
+      <Instrument id="voice">
         <longName>Voice</longName>
         <shortName>Vo.</shortName>
         <trackName>Voice</trackName>

--- a/mtest/libmscore/spanners/smallstaff01-ref.mscx
+++ b/mtest/libmscore/spanners/smallstaff01-ref.mscx
@@ -33,7 +33,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/split/split184061-other-inst-only-one-tie-ref.mscx
+++ b/mtest/libmscore/split/split184061-other-inst-only-one-tie-ref.mscx
@@ -95,7 +95,7 @@
           </StaffType>
         </Staff>
       <trackName>Flute</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName>Flute</trackName>

--- a/mtest/libmscore/splitstaff/splitstaff03-ref.mscx
+++ b/mtest/libmscore/splitstaff/splitstaff03-ref.mscx
@@ -29,7 +29,7 @@
           </StaffType>
         </Staff>
       <trackName>Flute</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName>Flute</trackName>
@@ -83,7 +83,7 @@
           </StaffType>
         </Staff>
       <trackName>Harp</trackName>
-      <Instrument>
+      <Instrument id="harp">
         <longName>Harp</longName>
         <shortName>Hrp.</shortName>
         <trackName>Harp</trackName>
@@ -134,7 +134,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Violoncello</trackName>
-      <Instrument>
+      <Instrument id="violoncello">
         <longName>Violoncello</longName>
         <shortName>Vlc.</shortName>
         <trackName>Violoncello</trackName>

--- a/mtest/libmscore/splitstaff/splitstaff04-ref.mscx
+++ b/mtest/libmscore/splitstaff/splitstaff04-ref.mscx
@@ -34,7 +34,7 @@
           </StaffType>
         </Staff>
       <trackName>Voice</trackName>
-      <Instrument>
+      <Instrument id="voice">
         <longName>Voice</longName>
         <shortName>Vo.</shortName>
         <trackName>Voice</trackName>

--- a/mtest/libmscore/splitstaff/splitstaff05-ref.mscx
+++ b/mtest/libmscore/splitstaff/splitstaff05-ref.mscx
@@ -34,7 +34,7 @@
           </StaffType>
         </Staff>
       <trackName>Voice</trackName>
-      <Instrument>
+      <Instrument id="voice">
         <longName>Voice</longName>
         <shortName>Vo.</shortName>
         <trackName>Voice</trackName>

--- a/mtest/libmscore/timesig/timesig-09-ref.mscx
+++ b/mtest/libmscore/timesig/timesig-09-ref.mscx
@@ -32,7 +32,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/timesig/timesig-09.mscx
+++ b/mtest/libmscore/timesig/timesig-09.mscx
@@ -32,7 +32,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/tools/undoAddLineBreaks01-ref.mscx
+++ b/mtest/libmscore/tools/undoAddLineBreaks01-ref.mscx
@@ -31,7 +31,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/tools/undoAddLineBreaks02-ref.mscx
+++ b/mtest/libmscore/tools/undoAddLineBreaks02-ref.mscx
@@ -31,7 +31,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/tuplet/save-load.mscx
+++ b/mtest/libmscore/tuplet/save-load.mscx
@@ -32,7 +32,7 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/tuplet/split1-ref.mscx
+++ b/mtest/libmscore/tuplet/split1-ref.mscx
@@ -42,7 +42,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/tuplet/split2-ref.mscx
+++ b/mtest/libmscore/tuplet/split2-ref.mscx
@@ -42,7 +42,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/tuplet/split3-ref.mscx
+++ b/mtest/libmscore/tuplet/split3-ref.mscx
@@ -42,7 +42,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/tuplet/split4-ref.mscx
+++ b/mtest/libmscore/tuplet/split4-ref.mscx
@@ -42,7 +42,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>

--- a/mtest/libmscore/unrollrepeats/clef-key-ts-ref.mscx
+++ b/mtest/libmscore/unrollrepeats/clef-key-ts-ref.mscx
@@ -32,7 +32,7 @@
           </StaffType>
         </Staff>
       <trackName>Voice</trackName>
-      <Instrument>
+      <Instrument id="voice">
         <longName>Voice</longName>
         <shortName>Vo.</shortName>
         <trackName>Voice</trackName>
@@ -84,7 +84,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Violoncello</trackName>
-      <Instrument>
+      <Instrument id="violoncello">
         <longName>Violoncello</longName>
         <shortName>Vc.</shortName>
         <trackName>Violoncello</trackName>
@@ -1359,7 +1359,7 @@
           <defaultClef>F</defaultClef>
           </Staff>
         <trackName>Violoncello</trackName>
-        <Instrument>
+        <Instrument id="violoncello">
           <longName>Violoncello</longName>
           <shortName>Vc.</shortName>
           <trackName>Violoncello</trackName>

--- a/mtest/libmscore/unrollrepeats/pickup-measure-ref.mscx
+++ b/mtest/libmscore/unrollrepeats/pickup-measure-ref.mscx
@@ -32,7 +32,7 @@
           </StaffType>
         </Staff>
       <trackName>Flute</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName>Flute</trackName>


### PR DESCRIPTION
This PR solves a few issues found in the score ordering:

 - In the <code>InstrumentsWidget</code>, the field <code>Ordering</code> was initial empty. This causes a crash later on. Now the field will show the first score order, which is <code>Orchestra</code>
- In the original PR, <code>trackName</code> was used for score ordering. However, this can be translated so no instrument could be found for ordering. The result was a crash. Now the <code>instrumentId</code> from <code>instruments.xml</code> is used, and now also stored in the score file. This makes score ordering independent from any translation or rename of instrument used. As a consequence several reference file are updated to include this <code>instrumentId</code>.
- For backwards compatibility, during the load of a score file, every instrument is checked for <code>instrumentId</code>. If this <code>instrumentId</code> is not found, <code>MusicXMLId</code> is used to find the <code>instrumentId</code>.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
