### PR TITLE
[MU3] Fix #313019: Default Files in Preferences -> Score are misaligned

### DIFF
--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -90,7 +90,7 @@
       <string>Preferences Tab Manager</string>
      </property>
      <property name="currentIndex">
-      <number>3</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tabGeneral">
       <property name="accessibleName">
@@ -2684,6 +2684,9 @@
             <property name="text">
              <string>Instrument list 2:</string>
             </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
            </widget>
           </item>
           <item row="0" column="2">
@@ -2714,6 +2717,9 @@
             <property name="text">
              <string>Instrument list 1:</string>
             </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
            </widget>
           </item>
           <item row="2" column="0">
@@ -2721,12 +2727,18 @@
             <property name="text">
              <string>Score order list 1:</string>
             </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
            </widget>
           </item>
           <item row="3" column="0">
            <widget class="QLabel" name="label_11">
             <property name="text">
              <string>Score order list 2:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
also reset initial Tab back to General

Resolves https://musescore.org/en/node/313019