### PR TITLE
Fix #313105: "No chord" MusicXML import

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -4944,14 +4944,11 @@ void MusicXMLParserPass2::harmony(const QString& partId, Measure* measure, const
                         if (_e.name() == "root-step") {
                               // attributes: print-style
                               step = _e.readElementText();
-                              /* TODO: check if this is required
-                              if (ee.hasAttribute("text")) {
-                                    QString rtext = ee.attribute("text");
-                                    if (rtext == "") {
+                              if (_e.attributes().hasAttribute("text")) {
+                                    if (_e.attributes().value("text").toString() == "") {
                                           invalidRoot = true;
+                                          }
                                     }
-                              }
-                               */
                               }
                         else if (_e.name() == "root-alter") {
                               // attributes: print-object, print-style
@@ -4978,11 +4975,13 @@ void MusicXMLParserPass2::harmony(const QString& partId, Measure* measure, const
                   // attributes: use-symbols  yes-no
                   //             text, stack-degrees, parentheses-degree, bracket-degrees,
                   //             print-style, halign, valign
-
                   kindText = _e.attributes().value("text").toString();
                   symbols = _e.attributes().value("use-symbols").toString();
                   parens = _e.attributes().value("parentheses-degrees").toString();
                   kind = _e.readElementText();
+                  if (kind == "none") {
+                        ha->setRootTpc(Tpc::TPC_INVALID);
+                        }
                   }
             else if (_e.name() == "inversion") {
                   // attributes: print-style

--- a/mtest/musicxml/io/testHarmony4.xml
+++ b/mtest/musicxml/io/testHarmony4.xml
@@ -49,7 +49,7 @@
         </attributes>
       <harmony print-frame="no">
         <root>
-          <root-step>C</root-step>
+          <root-step text="">C</root-step>
           </root>
         <kind text="N.C.">none</kind>
         </harmony>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/313105

This fix imports a MusicXML `harmony` element with `kind=none` to signify a "no chord" (invalid root) on the MuseScore sheet as per [forum discussion](https://musescore.org/en/node/313008).

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
