### PR TITLE
[MU3] Porting some master changes/PRs to 3.x

### DIFF
--- a/libmscore/joinMeasure.cpp
+++ b/libmscore/joinMeasure.cpp
@@ -53,7 +53,7 @@ void Score::cmdJoinMeasure(Measure* m1, Measure* m2)
                   s->setEndElement(0);
             }
 
-      deleteMeasures(m1, m2);
+      deleteMeasures(m1, m2, true);
 
       MeasureBase* next = m2->next();
       const Fraction newTimesig = m1->timesig();

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -683,7 +683,7 @@ class Score : public QObject, public ScoreElement {
       void undoPropertyChanged(ScoreElement*, Pid, const QVariant& v, PropertyFlags ps = PropertyFlags::NOSTYLE);
       inline virtual UndoStack* undoStack() const;
       void undo(UndoCommand*, EditData* = 0) const;
-      void undoRemoveMeasures(Measure*, Measure*);
+      void undoRemoveMeasures(Measure*, Measure*, bool preserveTies = false);
       void undoAddBracket(Staff* staff, int level, BracketType type, int span);
       void undoRemoveBracket(Bracket*);
       void undoInsertTime(const Fraction& tick, const Fraction& len);
@@ -734,7 +734,7 @@ class Score : public QObject, public ScoreElement {
       NoteVal noteValForPosition(Position pos, AccidentalType at, bool &error);
 
       void deleteItem(Element*);
-      void deleteMeasures(MeasureBase* firstMeasure, MeasureBase* lastMeasure);
+      void deleteMeasures(MeasureBase* firstMeasure, MeasureBase* lastMeasure, bool preserveTies = false);
       void cmdDeleteSelection();
       void cmdFullMeasureRest();
 

--- a/libmscore/splitMeasure.cpp
+++ b/libmscore/splitMeasure.cpp
@@ -88,7 +88,7 @@ void Score::splitMeasure(Segment* segment)
 
       MeasureBase* nm = measure->next();
 
-      undoRemoveMeasures(measure, measure);
+      undoRemoveMeasures(measure, measure, true);
       undoInsertTime(measure->tick(), -measure->ticks());
 
       // create empty measures:


### PR DESCRIPTION
* #6442 - [Fix #98816](https://musescore.org/en/node/98816) and [fix #117351](https://musescore.org/en/node/117351): Decouple tie direction from _notes order, and compare strings (not lines) in tabs
* #5566 - [Fix #277800](https://musescore.org/en/node/277800): Allow to preserve ties when replacing measures (by removing and inserting them)