### PR TITLE
Improves recognition of instrument when loading a pre-3.6 score.

### DIFF
--- a/libmscore/instrument.h
+++ b/libmscore/instrument.h
@@ -289,7 +289,7 @@ class Instrument {
       bool operator==(const Instrument&) const;
       bool isDifferentInstrument(const Instrument& i) const;
 
-      QString getId() const                                 { return _id;         }
+      QString getId() const                                  { return _id;         }
       void setMinPitchP(int v)                               { _minPitchP = v;     }
       void setMaxPitchP(int v)                               { _maxPitchP = v;     }
       void setMinPitchA(int v)                               { _minPitchA = v;     }

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1580,7 +1580,7 @@ static void distributeStaves(Page* page)
                               }
                         --brackSpanNormal;
 
-                        const bool sameInstrument { staff->part()->instrumentId() == prvPart };
+                        const bool sameInstrument { staff->part()->instrument()->getId() == prvPart };
                         if (!curlyBracket && sameInstrument) {
                               if (prevVgd)
                                     prevVgd->addSpaceAroundCurlyBracket();  // Above { bracket.
@@ -1598,7 +1598,7 @@ static void distributeStaves(Page* page)
                               vbox = false;
                               }
 
-                        prvPart = staff->part()->instrumentId();
+                        prvPart = staff->part()->instrument()->getId();
                         prevYBottom = vgd->nextYPos(vgdl.size() == 0);
                         yBottom     = vgd->yBottom();
 

--- a/libmscore/scoreOrder.cpp
+++ b/libmscore/scoreOrder.cpp
@@ -429,23 +429,24 @@ void ScoreOrder::setCustomised()
 ScoreGroup* ScoreOrder::getGroup(const QString family, const QString instrumentGroup) const
       {
       if (family.isEmpty())
-            return nullptr;
+            return _unsorted;
 
-      ScoreGroup* unsorted { _unsorted };
+      ScoreGroup* unsorted { nullptr };
       for (ScoreGroup* sg : groups) {
-            if (sg->id() == family)
+            if (!sg->isUnsorted() && (sg->id() == family))
                   return sg;
             if (sg->isUnsorted(instrumentGroup))
                   unsorted = sg;
-            if (sg->isUnsorted() && !unsorted)
-                  unsorted = sg;
             }
-      return unsorted;
+      return unsorted ? unsorted : _unsorted;
       }
 
 ScoreGroup* ScoreOrder::getGroup(const QString id, const bool soloist) const
       {
       InstrumentIndex ii = searchTemplateIndexForId(id);
+      if (!ii.instrTemplate)
+            return _unsorted;
+
       QString family { getFamilyName(ii.instrTemplate, soloist) };
       return getGroup(family, instrumentGroups[ii.groupIndex]->id);
       }
@@ -589,6 +590,9 @@ void ScoreOrder::setBracketsAndBarlines(Score* score)
       for (Part* part : score->parts())
             {
             InstrumentIndex ii = searchTemplateIndexForId(part->instrument()->getId());
+            if (!ii.instrTemplate)
+                  continue;
+
             QString family { getFamilyName(ii.instrTemplate, part->soloist()) };
             ScoreGroup* sg = getGroup(family, instrumentGroups[ii.groupIndex]->id);
 

--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -647,7 +647,7 @@ int InstrumentsWidget::findPrvItem(PartListItem* pli, int number)
                   continue;
             if (order->instrumentIndex(p->id(), p->isSoloist()) == orderNumber)
                   {
-                  if (idx > currow)
+                  if ((currow >= 0) && (idx > currow))
                         return idx;
                   }
             if (order->instrumentIndex(p->id(), p->isSoloist()) > orderNumber)

--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -11804,9 +11804,6 @@ Aeolus organ synthesizer, currently disabled -->
                   <musicXMLid>strings.group</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
                   <clef staff="2">F</clef>
                   <aPitchRange>24-108</aPitchRange>
                   <pPitchRange>24-108</pPitchRange>


### PR DESCRIPTION
Resolves: https://trello.com/c/lXc1BqEB/18-imagepng

In case the instrument in the score file has <ocde>MusicXMLid</code> with value <code>strings.group</code>, the value of controller 132 is used to  find the correct strings group. This prevents all <code>Violons</code>, <code>Violas</code>, <code>Violoncellos</code> and <code>Contrabasses</code> are mapped onto <code>Strings</code> which causes wrong brackets to be generated.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
