### PR TITLE
[MU4] Fixed settings init

### DIFF
--- a/framework/ui/internal/uiconfiguration.cpp
+++ b/framework/ui/internal/uiconfiguration.cpp
@@ -19,11 +19,11 @@ static const Settings::Key MUSICAL_FONT_SIZE_KEY(module_name, "ui/theme/musicalF
 
 UiConfiguration::UiConfiguration()
 {
-    settings()->addItem(THEME_TYPE_KEY, Val(static_cast<int>(ThemeType::LIGHT_THEME)));
-    settings()->addItem(FONT_FAMILY_KEY, Val("FreeSans"));
-    settings()->addItem(FONT_SIZE_KEY, Val(12));
-    settings()->addItem(MUSICAL_FONT_FAMILY_KEY, Val("Leland"));
-    settings()->addItem(MUSICAL_FONT_SIZE_KEY, Val(12));
+    settings()->setDefaultValue(THEME_TYPE_KEY, Val(static_cast<int>(ThemeType::LIGHT_THEME)));
+    settings()->setDefaultValue(FONT_FAMILY_KEY, Val("FreeSans"));
+    settings()->setDefaultValue(FONT_SIZE_KEY, Val(12));
+    settings()->setDefaultValue(MUSICAL_FONT_FAMILY_KEY, Val("Leland"));
+    settings()->setDefaultValue(MUSICAL_FONT_SIZE_KEY, Val(12));
 
     settings()->valueChanged(THEME_TYPE_KEY).onReceive(nullptr, [this](const Val& val) {
                 m_currentThemeTypeChannel.send(static_cast<ThemeType>(val.toInt()));

--- a/framework/vst/internal/vstconfiguration.cpp
+++ b/framework/vst/internal/vstconfiguration.cpp
@@ -34,7 +34,7 @@ const std::string VSTConfiguration::DEFAULT_PATHS = "";
 
 void VSTConfiguration::init()
 {
-    settings()->addItem(SEARCH_PATHS, Val(VSTConfiguration::DEFAULT_PATHS));
+    settings()->setDefaultValue(SEARCH_PATHS, Val(VSTConfiguration::DEFAULT_PATHS));
 }
 
 std::string VSTConfiguration::searchPaths() const

--- a/mu4/appshell/appshell.cpp
+++ b/mu4/appshell/appshell.cpp
@@ -59,9 +59,11 @@ int AppShell::run(int argc, char** argv, std::function<void()> moduleSetup)
     QCoreApplication::setOrganizationDomain("musescore.org");
     QCoreApplication::setApplicationVersion(QString::fromStdString(framework::Version::fullVersion()));
 
-    moduleSetup();
-
+    //! NOTE: need to init settings before init of modules,
+    //! because modules can use settings in the moment of their init
     framework::settings()->load();
+
+    moduleSetup();
 
     QQmlApplicationEngine* engine = new QQmlApplicationEngine();
     //! NOTE Move ownership to UiEngine

--- a/mu4/appshell/settings/settingslistmodel.cpp
+++ b/mu4/appshell/settings/settingslistmodel.cpp
@@ -37,10 +37,10 @@ QVariant SettingListModel::data(const QModelIndex& index, int role) const
 
     const Settings::Item& item = m_items.at(index.row());
     switch (role) {
-    case SectionRole: return QString::fromStdString(item.key.module);
+    case SectionRole: return QString::fromStdString(item.key.moduleName);
     case KeyRole: return QString::fromStdString(item.key.key);
-    case TypeRole: return typeToString(item.val.type());
-    case ValRole: return item.val.toQVariant();
+    case TypeRole: return typeToString(item.value.type());
+    case ValRole: return item.value.toQVariant();
     }
     return QVariant();
 }
@@ -67,7 +67,8 @@ void SettingListModel::load()
 
     m_items.clear();
 
-    const std::map<Settings::Key, Settings::Item>& items = settings()->items();
+    Settings::Items items = settings()->items();
+
     for (auto it = items.cbegin(); it != items.cend(); ++it) {
         m_items << it->second;
     }
@@ -79,11 +80,11 @@ void SettingListModel::changeVal(int idx, QVariant newVal)
 {
     LOGD() << "changeVal index: " << idx << ", newVal: " << newVal;
     Settings::Item& item = m_items[idx];
-    Val::Type type = item.val.type();
-    item.val = Val::fromQVariant(newVal);
-    item.val.setType(type);
+    Val::Type type = item.value.type();
+    item.value = Val::fromQVariant(newVal);
+    item.value.setType(type);
 
-    settings()->setValue(item.key, item.val);
+    settings()->setValue(item.key, item.value);
 
     emit dataChanged(index(idx), index(idx));
 }

--- a/mu4/importexport/internal/importexportconfiguration.cpp
+++ b/mu4/importexport/internal/importexportconfiguration.cpp
@@ -40,19 +40,19 @@ static const Settings::Key EXPORT_PNG_USE_TRASNPARENCY_KEY(module_name, "export/
 
 void ImportexportConfiguration::init()
 {
-    settings()->addItem(SHORTEST_NOTE_KEY, Val(Ms::MScore::division / 4));
+    settings()->setDefaultValue(SHORTEST_NOTE_KEY, Val(Ms::MScore::division / 4));
 
-    settings()->addItem(IMPORT_OVERTUNE_CHARSET_KEY, Val("GBK"));
-    settings()->addItem(IMPORT_GUITARPRO_CHARSET_KEY, Val("UTF-8"));
+    settings()->setDefaultValue(IMPORT_OVERTUNE_CHARSET_KEY, Val("GBK"));
+    settings()->setDefaultValue(IMPORT_GUITARPRO_CHARSET_KEY, Val("UTF-8"));
 
-    settings()->addItem(MUSICXML_IMPORT_BREAKS_KEY, Val(true));
-    settings()->addItem(MUSICXML_IMPORT_LAYOUT_KEY, Val(true));
-    settings()->addItem(MUSICXML_EXPORT_LAYOUT_KEY, Val(true));
-    settings()->addItem(MUSICXML_EXPORT_BREAKS_TYPE_KEY, Val(static_cast<int>(MusicxmlExportBreaksType::All)));
+    settings()->setDefaultValue(MUSICXML_IMPORT_BREAKS_KEY, Val(true));
+    settings()->setDefaultValue(MUSICXML_IMPORT_LAYOUT_KEY, Val(true));
+    settings()->setDefaultValue(MUSICXML_EXPORT_LAYOUT_KEY, Val(true));
+    settings()->setDefaultValue(MUSICXML_EXPORT_BREAKS_TYPE_KEY, Val(static_cast<int>(MusicxmlExportBreaksType::All)));
 
-    settings()->addItem(EXPORT_PNG_DPI_RESOLUTION_KEY, Val(Ms::DPI));
-    settings()->addItem(EXPORT_PNG_USE_TRASNPARENCY_KEY, Val(true));
-    settings()->addItem(EXPORT_PDF_DPI_RESOLUTION_KEY, Val(Ms::DPI));
+    settings()->setDefaultValue(EXPORT_PNG_DPI_RESOLUTION_KEY, Val(Ms::DPI));
+    settings()->setDefaultValue(EXPORT_PNG_USE_TRASNPARENCY_KEY, Val(true));
+    settings()->setDefaultValue(EXPORT_PDF_DPI_RESOLUTION_KEY, Val(Ms::DPI));
 }
 
 int ImportexportConfiguration::midiShortestNote() const

--- a/mu4/languages/internal/languagesconfiguration.cpp
+++ b/mu4/languages/internal/languagesconfiguration.cpp
@@ -37,7 +37,7 @@ static const Settings::Key LANGUAGE("ui", "ui/application/language");
 
 void LanguagesConfiguration::init()
 {
-    settings()->addItem(LANGUAGE, Val("system"));
+    settings()->setDefaultValue(LANGUAGE, Val("system"));
     settings()->valueChanged(LANGUAGES_JSON).onReceive(nullptr, [this](const Val& val) {
         LanguagesHash languagesHash = parseLanguagesConfig(val.toQString().toLocal8Bit());
         m_languagesHashChanged.send(languagesHash);

--- a/mu4/notation/internal/notationconfiguration.cpp
+++ b/mu4/notation/internal/notationconfiguration.cpp
@@ -60,33 +60,33 @@ static const Settings::Key IS_MIDI_INPUT_ENABLED(module_name, "io/midi/enableInp
 
 void NotationConfiguration::init()
 {
-    settings()->addItem(ANCHORLINE_COLOR, Val(QColor("#C31989")));
+    settings()->setDefaultValue(ANCHORLINE_COLOR, Val(QColor("#C31989")));
 
-    settings()->addItem(BACKGROUND_COLOR, Val(QColor("#142433")));
+    settings()->setDefaultValue(BACKGROUND_COLOR, Val(QColor("#142433")));
     settings()->valueChanged(BACKGROUND_COLOR).onReceive(nullptr, [this](const Val& val) {
         LOGD() << "BACKGROUND_COLOR changed: " << val.toString();
         m_backgroundColorChanged.send(val.toQColor());
     });
 
-    settings()->addItem(FOREGROUND_COLOR, Val(QColor("#f9f9f9")));
+    settings()->setDefaultValue(FOREGROUND_COLOR, Val(QColor("#f9f9f9")));
     settings()->valueChanged(FOREGROUND_COLOR).onReceive(nullptr, [this](const Val& val) {
         LOGD() << "FOREGROUND_COLOR changed: " << val.toString();
         m_foregroundColorChanged.send(foregroundColor());
     });
 
-    settings()->addItem(FOREGROUND_USE_USER_COLOR, Val(true));
+    settings()->setDefaultValue(FOREGROUND_USE_USER_COLOR, Val(true));
     settings()->valueChanged(FOREGROUND_USE_USER_COLOR).onReceive(nullptr, [this](const Val& val) {
         LOGD() << "FOREGROUND_USE_USER_COLOR changed: " << val.toString();
         m_foregroundColorChanged.send(foregroundColor());
     });
 
-    settings()->addItem(CURRENT_ZOOM, Val(100));
+    settings()->setDefaultValue(CURRENT_ZOOM, Val(100));
     settings()->valueChanged(CURRENT_ZOOM).onReceive(nullptr, [this](const Val& val) {
         m_currentZoomChanged.send(val.toInt());
     });
 
-    settings()->addItem(SELECTION_PROXIMITY, Val(6));
-    settings()->addItem(IS_MIDI_INPUT_ENABLED, Val(false));
+    settings()->setDefaultValue(SELECTION_PROXIMITY, Val(6));
+    settings()->setDefaultValue(IS_MIDI_INPUT_ENABLED, Val(false));
 
     // libmscore
     preferences().setBackupDirPath(globalConfiguration()->backupPath().toQString());

--- a/mu4/palette/internal/paletteconfiguration.cpp
+++ b/mu4/palette/internal/paletteconfiguration.cpp
@@ -26,8 +26,9 @@
 using namespace mu::palette;
 using namespace mu::framework;
 
-static const Settings::Key PALETTE_SCALE("palette", "application/paletteScale");
-static const Settings::Key PALETTE_USE_SINGLE("palette", "application/useSinglePalette");
+static const std::string MODULE_NAME("palette");
+static const Settings::Key PALETTE_SCALE(MODULE_NAME, "application/paletteScale");
+static const Settings::Key PALETTE_USE_SINGLE(MODULE_NAME, "application/useSinglePalette");
 
 double PaletteConfiguration::paletteScaling() const
 {

--- a/mu4/userscores/internal/userscoresconfiguration.cpp
+++ b/mu4/userscores/internal/userscoresconfiguration.cpp
@@ -36,7 +36,7 @@ static const QString DEFAULT_FILE_SUFFIX(".mscz");
 
 void UserScoresConfiguration::init()
 {
-    settings()->addItem(USER_SCORES_PATH, Val(globalConfiguration()->sharePath().toStdString() + "Scores"));
+    settings()->setDefaultValue(USER_SCORES_PATH, Val(globalConfiguration()->sharePath().toStdString() + "Scores"));
     settings()->valueChanged(RECENT_LIST).onReceive(nullptr, [this](const Val& val) {
         LOGD() << "RECENT_LIST changed: " << val.toString();
 


### PR DESCRIPTION
Init of settings and init of modules depend on each other cyclically: for correctly init of settings need to call addItem from modules, but for correctly init of modules need to init settings before. I refactored settings to break that dependency. Now settings will be inited at first and after that will be inited modules using already ready settings

- moved init of settings before init of modules as was before
- refactored settings to remove dependency from init of modules