### PR TITLE
fix #313323: bad navigation after rest with content on last track

### DIFF
--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -1402,7 +1402,7 @@ Element* Segment::nextElementOfSegment(Segment* s, Element* e, int activeStaff)
                         (!next || next->staffIdx() != activeStaff)) {
                        next = s->element(++track);
                        }
-                 if (!next)
+                 if (!next || next->staffIdx() != activeStaff)
                        return nullptr;
                  if (next->isChord())
                        return toChord(next)->notes().back();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/313323

If you use Alt+Right to navigation from a rest,
and there is no other content in higher voices on that staff
but there is a note or rest in vocie of the *last* staff,
navigation will go there.

Earlier I fixed a similar bug involving the case when starting
from a note instead of from a rest,
by checking to see that the staffIdx matches
I should have applied the same fix to the code a few lines too.
This does exactly that.

See also #5343