### PR TITLE
[MU4] Return dependencies on mops

### DIFF
--- a/build/module.cmake
+++ b/build/module.cmake
@@ -113,8 +113,8 @@ if (LOCAL_MODULE_BUILD_PCH)
 
     # MSVC does not depend on mops1 & mops2 for PCH
     if (NOT MSVC)
-#        ADD_DEPENDENCIES(${MODULE} mops1)
-#        ADD_DEPENDENCIES(${MODULE} mops2)
+        ADD_DEPENDENCIES(${MODULE} mops1)
+        ADD_DEPENDENCIES(${MODULE} mops2)
     endif (NOT MSVC)
 else (LOCAL_MODULE_BUILD_PCH)
     set_target_properties(${MODULE} PROPERTIES COMPILE_FLAGS "-include ${PROJECT_SOURCE_DIR}/all.h")

--- a/libmscore/CMakeLists.txt
+++ b/libmscore/CMakeLists.txt
@@ -160,6 +160,6 @@ vstudio_pch( libmscore )
 
 # MSVC does not depend on mops1 & mops2 for PCH
 if (NOT MSVC)
-#   ADD_DEPENDENCIES(libmscore mops1)
-#   ADD_DEPENDENCIES(libmscore mops2)
+   ADD_DEPENDENCIES(libmscore mops1)
+   ADD_DEPENDENCIES(libmscore mops2)
 endif (NOT MSVC)


### PR DESCRIPTION
I don't know what it is or why.
But when building, I constantly do not build a project because of these - cyclic dependencies.
I have to comment every time.
I accidentally merge it with commented out.
I'm bringing it back until the time comes when we sort it all out.