### PR TITLE
fix typo introduced when manually merging PR #6243

### DIFF
--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -506,11 +506,11 @@ int Rest::computeLineOffset(int lines)
                                 line = nline - extraOffsetForFewLines;
                                 if (note->accidentalType() != AccidentalType::NONE) {
                                     line--;
-                                } else if (!up && nline >= line) {
-                                    line = nline + extraOffsetForFewLines;
-                                    if (note->accidentalType() != AccidentalType::NONE) {
-                                        line++;
-                                    }
+                                }
+                            } else if (!up && nline >= line) {
+                                line = nline + extraOffsetForFewLines;
+                                if (note->accidentalType() != AccidentalType::NONE) {
+                                    line++;
                                 }
                             }
                         }


### PR DESCRIPTION

This bug was found by CppCheck as an "always false" condition.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [N/A] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
