### PR TITLE
Fix #313433: Update line-style bracket to not extend vertically beyond staff/system

### DIFF
--- a/libmscore/bracket.cpp
+++ b/libmscore/bracket.cpp
@@ -283,7 +283,7 @@ void Bracket::draw(QPainter* painter) const
                   qreal w = 0.67 * score()->styleP(Sid::bracketWidth);
                   QPen pen(curColor(), w, Qt::SolidLine, Qt::FlatCap);
                   painter->setPen(pen);
-                  qreal bd = _spatium * .25;
+                  qreal bd = score()->styleP(Sid::staffLineWidth) * 0.5;
                   painter->drawLine(QLineF(0.0, -bd, 0.0, h + bd));
                   }
                   break;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/313433

See the link for description as relates to default vertical height of line-style bracket.

This sets the vertical height of a line-style bracket to be equivalent to the staff/system rather than having it be a little bit more (was 1/4th extra of the score's spatium).

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made