### PR TITLE
CLI Save Online: Avoid spamming system temporary directory

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -3557,6 +3557,13 @@ bool MuseScore::saveOnline(const QStringList& inFilePaths)
         return false;
     }
 
+    QTemporaryDir tempDir;
+    if (!tempDir.isValid()) {
+        qCritical() << qUtf8Printable(tr("Error: %1").arg(tempDir.errorString()));
+        return false;
+    }
+    QString tempPath = tempDir.path() + "/score.mscz";
+
     bool all_successful = true;
 
     for (auto path : inFilePaths) {
@@ -3588,7 +3595,6 @@ bool MuseScore::saveOnline(const QStringList& inFilePaths)
         }
         mu::cloud::ScoreInfo scoreInfo = _loginManager->scoreInfo();
 
-        QString tempPath = QDir::tempPath() + QString("/temp_%1.mscz").arg(QRandomGenerator::global()->generate() % 100000);
         if (!mscore->saveAs(score, true, tempPath, "mscz")) {
             all_successful = false;
             continue;


### PR DESCRIPTION
Resolves: *no issue in tracker*

Uses QTemporaryDir to ensure that the created file paths are unique and that they are deleted when the program exits. Avoids creating more than one temporary file regardless of how many scores are uploaded.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [N/A] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
