### PR TITLE
Fix #313195: Add Synalepha shortcut

### DIFF
--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -223,6 +223,7 @@ bool TextBase::edit(EditData& ed)
       QString s         = ed.s;
       bool ctrlPressed  = ed.modifiers & Qt::ControlModifier;
       bool shiftPressed = ed.modifiers & Qt::ShiftModifier;
+      bool altPressed   = ed.modifiers & Qt::AltModifier;
 
       QTextCursor::MoveMode mm = shiftPressed ? QTextCursor::KeepAnchor : QTextCursor::MoveAnchor;
 
@@ -425,7 +426,7 @@ bool TextBase::edit(EditData& ed)
                         case Qt::Key_H:
                               s = "\u266e"; // Unicode natural
                               break;
-                         case Qt::Key_Space:
+                        case Qt::Key_Space:
                               insertSym(ed, SymId::space);
                               return true;
                         case Qt::Key_F:
@@ -452,6 +453,12 @@ bool TextBase::edit(EditData& ed)
                               // so Shift+Ctrl+Z works
                               insertSym(ed, SymId::dynamicZ);
                               return true;
+                        }
+                  }
+            if (ctrlPressed && altPressed) {
+                  if (ed.key == Qt::Key_hyphen) {
+                        insertSym(ed, SymId::lyricsElision);
+                        return true;
                         }
                   }
             }


### PR DESCRIPTION
Resolves: *https://musescore.org/en/node/313195*

Synalephas are common enough to have their own dedicated shortcut. ~~As suggested by @jeetee , I added an action to the shortcut.cpp listing.~~ I changed the textedit.cpp file.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [ ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [ ] I made sure the code compiles on my machine
- [ ] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
