### PR TITLE
[MU3] measure numbers not showing when first staff is cutaway.

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -544,10 +544,7 @@ void Measure::layoutMeasureNumber()
       if (!nas) {
             //find first non invisible staff
             for (unsigned staffIdx = 0; staffIdx < _mstaves.size(); ++staffIdx) {
-                  MStaff* ms = _mstaves[staffIdx];
-                  SysStaff* ss  = system()->staff(staffIdx);
-                  Staff* staff = score()->staff(staffIdx);
-                  if (ms->visible() && staff->show() && ss->show()) {
+                  if (visible(staffIdx)) {
                         nn = staffIdx;
                         break;
                         }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/313524

There was already a function that does all the checks to figure out if a staff is hidden or not.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
