### PR TITLE
[MU4] Parts stabilization

### DIFF
--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -495,7 +495,7 @@ void Excerpt::processLinkedClone(Element* ne, Score* score, int strack)
 //   cloneStaves
 //---------------------------------------------------------
 
-void Excerpt::cloneStaves(Score* oscore, Score* score, const QList<int>& map, QMultiMap<int, int>& trackList)
+void Excerpt::cloneStaves(Score* oscore, Score* score, const QList<int>& sourceStavesIndexes, QMultiMap<int, int>& trackList)
 {
     TieMap tieMap;
 
@@ -530,8 +530,8 @@ void Excerpt::cloneStaves(Score* oscore, Score* score, const QList<int>& map, QM
             nm->setNoOffset(m->noOffset());
             nm->setBreakMultiMeasureRest(m->breakMultiMeasureRest());
 
-            for (int dstStaffIdx = 0; dstStaffIdx < map.size(); ++dstStaffIdx) {
-                nm->setStaffStemless(dstStaffIdx, m->stemless(map[dstStaffIdx]));
+            for (int dstStaffIdx = 0; dstStaffIdx < sourceStavesIndexes.size(); ++dstStaffIdx) {
+                nm->setStaffStemless(dstStaffIdx, m->stemless(sourceStavesIndexes[dstStaffIdx]));
             }
 //TODO                  nm->setEndBarLineType(
 //                     m->endBarLineType(),
@@ -541,6 +541,11 @@ void Excerpt::cloneStaves(Score* oscore, Score* score, const QList<int>& map, QM
 
             // Fraction ts = nm->len();
             int tracks = oscore->nstaves() * VOICES;
+
+            if (sourceStavesIndexes.isEmpty() && trackList.isEmpty()) {
+                tracks = 0;
+            }
+
             for (int srcTrack = 0; srcTrack < tracks; ++srcTrack) {
                 TupletMap tupletMap;            // tuplets cannot cross measure boundaries
 
@@ -801,9 +806,9 @@ void Excerpt::cloneStaves(Score* oscore, Score* score, const QList<int>& map, QM
         nmbl->add(nmb);
     }
 
-    int n = map.size();
+    int n = sourceStavesIndexes.size();
     for (int dstStaffIdx = 0; dstStaffIdx < n; ++dstStaffIdx) {
-        Staff* srcStaff = oscore->staff(map[dstStaffIdx]);
+        Staff* srcStaff = oscore->staff(sourceStavesIndexes[dstStaffIdx]);
         Staff* dstStaff = score->staff(dstStaffIdx);
 
         Measure* m = oscore->firstMeasure();
@@ -832,7 +837,7 @@ void Excerpt::cloneStaves(Score* oscore, Score* score, const QList<int>& map, QM
             }
             int eIdx = sIdx + span;
             for (int staffIdx = sIdx; staffIdx < eIdx; ++staffIdx) {
-                if (!map.contains(staffIdx)) {
+                if (!sourceStavesIndexes.contains(staffIdx)) {
                     --span;
                 }
             }

--- a/libmscore/excerpt.h
+++ b/libmscore/excerpt.h
@@ -70,7 +70,7 @@ public:
     static QList<Excerpt*> createAllExcerpt(MasterScore* score);
     static QString createName(const QString& partName, QList<Excerpt*>&);
     static void createExcerpt(Excerpt*);
-    static void cloneStaves(Score* oscore, Score* score, const QList<int>& map, QMultiMap<int, int>& allTracks);
+    static void cloneStaves(Score* oscore, Score* score, const QList<int>& sourceStavesIndexes, QMultiMap<int, int>& allTracks);
     static void cloneStaff(Staff* ostaff, Staff* nstaff);
     static void cloneStaff2(Staff* ostaff, Staff* nstaff, const Fraction& startTick, const Fraction& endTick);
     static void processLinkedClone(Element* ne, Score* score, int strack);

--- a/mu4/instruments/qml/MuseScore/Instruments/InstrumentsPanel.qml
+++ b/mu4/instruments/qml/MuseScore/Instruments/InstrumentsPanel.qml
@@ -28,9 +28,11 @@ Item {
 
         InstrumentsControlPanel {
             Layout.fillWidth: true
+            Layout.alignment: Qt.AlignTop
 
             isMovingUpAvailable: instrumentTreeModel.isMovingUpAvailable
             isMovingDownAvailable: instrumentTreeModel.isMovingDownAvailable
+            isAddingAvailable: instrumentTreeModel.isAddingAvailable
             isRemovingAvailable: instrumentTreeModel.isRemovingAvailable
 
             onAddRequested: {
@@ -51,14 +53,14 @@ Item {
         }
 
         StyledTextLabel {
-            Layout.topMargin: 12
             Layout.fillWidth: true
             Layout.fillHeight: true
+            Layout.topMargin: 12
             Layout.leftMargin: 20
             Layout.rightMargin: 20
 
             text: qsTrc("instruments", "There are no instruments in your score. To choose some, press <b>Add</b>, or use the shortcut <b>‘i’</b>")
-            visible: instrumentsTreeView.isEmpty
+            visible: instrumentTreeModel.isEmpty && instrumentTreeModel.isAddingAvailable
 
             verticalAlignment: Qt.AlignTop
             wrapMode: Text.WordWrap
@@ -70,8 +72,7 @@ Item {
             Layout.fillWidth: true
             Layout.fillHeight: true
 
-            property alias isEmpty: instrumentTreeModel.isEmpty
-            visible: !isEmpty
+            visible: !instrumentTreeModel.isEmpty
 
             model: InstrumentPanelTreeModel {
                 id: instrumentTreeModel

--- a/mu4/instruments/qml/MuseScore/Instruments/internal/InstrumentsControlPanel.qml
+++ b/mu4/instruments/qml/MuseScore/Instruments/internal/InstrumentsControlPanel.qml
@@ -9,8 +9,8 @@ RowLayout {
 
     property bool isMovingUpAvailable: false
     property bool isMovingDownAvailable: false
-    property bool isRearrangementAvailable: false
     property bool isRemovingAvailable: false
+    property bool isAddingAvailable: value
 
     signal addRequested()
     signal moveUpRequested()
@@ -21,7 +21,10 @@ RowLayout {
 
     FlatButton {
         Layout.fillWidth: true
+
         text: qsTrc("instruments", "Add")
+
+        enabled: root.isAddingAvailable
 
         onClicked: {
             root.addRequested()

--- a/mu4/instruments/view/instrumentpaneltreemodel.cpp
+++ b/mu4/instruments/view/instrumentpaneltreemodel.cpp
@@ -70,10 +70,12 @@ InstrumentPanelTreeModel::~InstrumentPanelTreeModel()
 void InstrumentPanelTreeModel::clear()
 {
     beginResetModel();
+    m_selectionModel->clear();
     deleteItems();
     endResetModel();
 
     emit isEmptyChanged();
+    emit isAddingAvailableChanged(false);
 }
 
 void InstrumentPanelTreeModel::deleteItems()
@@ -120,6 +122,9 @@ void InstrumentPanelTreeModel::load()
     });
 
     endResetModel();
+
+    emit isEmptyChanged();
+    emit isAddingAvailableChanged(true);
 }
 
 IDList InstrumentPanelTreeModel::currentNotationPartIdList() const
@@ -399,6 +404,11 @@ bool InstrumentPanelTreeModel::isMovingDownAvailable() const
 bool InstrumentPanelTreeModel::isRemovingAvailable() const
 {
     return m_isRemovingAvailable;
+}
+
+bool InstrumentPanelTreeModel::isAddingAvailable() const
+{
+    return m_notationParts != nullptr;
 }
 
 bool InstrumentPanelTreeModel::isEmpty() const

--- a/mu4/instruments/view/instrumentpaneltreemodel.cpp
+++ b/mu4/instruments/view/instrumentpaneltreemodel.cpp
@@ -62,20 +62,31 @@ InstrumentPanelTreeModel::InstrumentPanelTreeModel(QObject* parent)
     });
 }
 
+InstrumentPanelTreeModel::~InstrumentPanelTreeModel()
+{
+    deleteItems();
+}
+
 void InstrumentPanelTreeModel::clear()
 {
     beginResetModel();
-    m_rootItem->deleteLater();
+    deleteItems();
     endResetModel();
 
     emit isEmptyChanged();
+}
+
+void InstrumentPanelTreeModel::deleteItems()
+{
+    delete m_rootItem;
+    m_rootItem = nullptr;
 }
 
 void InstrumentPanelTreeModel::load()
 {
     beginResetModel();
 
-    m_rootItem = new RootTreeItem(m_masterNotationParts, this);
+    m_rootItem = new RootTreeItem(m_masterNotationParts);
 
     async::NotifyList<const Part*> allParts = m_masterNotationParts->partList();
     IDList notationPartIdList = currentNotationPartIdList();
@@ -392,7 +403,7 @@ bool InstrumentPanelTreeModel::isRemovingAvailable() const
 
 bool InstrumentPanelTreeModel::isEmpty() const
 {
-    return m_rootItem ? m_rootItem->isEmpty() : false;
+    return m_rootItem ? m_rootItem->isEmpty() : true;
 }
 
 void InstrumentPanelTreeModel::setIsRemovingAvailable(bool isRemovingAvailable)
@@ -421,11 +432,11 @@ void InstrumentPanelTreeModel::updateRearrangementAvailability()
 
     bool isRearrangementAvailable = true;
 
-    QMutableListIterator<QModelIndex> i(selectedIndexList);
+    QMutableListIterator<QModelIndex> it(selectedIndexList);
 
-    while (i.hasNext() && selectedIndexList.count() > 1) {
-        int nextRow = i.next().row();
-        int previousRow = i.peekPrevious().row();
+    while (it.hasNext() && selectedIndexList.count() > 1) {
+        int nextRow = it.next().row();
+        int previousRow = it.peekPrevious().row();
 
         isRearrangementAvailable = (nextRow - previousRow <= 1);
 

--- a/mu4/instruments/view/instrumentpaneltreemodel.h
+++ b/mu4/instruments/view/instrumentpaneltreemodel.h
@@ -56,6 +56,7 @@ public:
     };
 
     explicit InstrumentPanelTreeModel(QObject* parent = nullptr);
+    ~InstrumentPanelTreeModel() override;
 
     Q_INVOKABLE void load();
     Q_INVOKABLE void selectRow(const QModelIndex& rowIndex, const bool isMultipleSelectionModeOn);
@@ -101,6 +102,8 @@ private slots:
 
 private:
     void clear();
+    void deleteItems();
+
     bool removeRows(int row, int count, const QModelIndex& parent) override;
 
     notation::IDList currentNotationPartIdList() const;

--- a/mu4/instruments/view/instrumentpaneltreemodel.h
+++ b/mu4/instruments/view/instrumentpaneltreemodel.h
@@ -45,33 +45,15 @@ class InstrumentPanelTreeModel : public QAbstractItemModel, public async::Asynca
     INJECT(instruments, framework::IInteractive, interactive)
 
     Q_PROPERTY(QItemSelectionModel * selectionModel READ selectionModel NOTIFY selectionChanged)
-    Q_PROPERTY(bool isMovingUpAvailable READ isMovingUpAvailable WRITE setIsMovingUpAvailable NOTIFY isMovingUpAvailableChanged)
-    Q_PROPERTY(bool isMovingDownAvailable READ isMovingDownAvailable WRITE setIsMovingDownAvailable NOTIFY isMovingDownAvailableChanged)
-    Q_PROPERTY(bool isRemovingAvailable READ isRemovingAvailable WRITE setIsRemovingAvailable NOTIFY isRemovingAvailableChanged)
+    Q_PROPERTY(bool isMovingUpAvailable READ isMovingUpAvailable NOTIFY isMovingUpAvailableChanged)
+    Q_PROPERTY(bool isMovingDownAvailable READ isMovingDownAvailable NOTIFY isMovingDownAvailableChanged)
+    Q_PROPERTY(bool isRemovingAvailable READ isRemovingAvailable NOTIFY isRemovingAvailableChanged)
+    Q_PROPERTY(bool isAddingAvailable READ isAddingAvailable NOTIFY isAddingAvailableChanged)
     Q_PROPERTY(bool isEmpty READ isEmpty NOTIFY isEmptyChanged)
 
 public:
-    enum RoleNames {
-        ItemRole = Qt::UserRole + 1
-    };
-
     explicit InstrumentPanelTreeModel(QObject* parent = nullptr);
     ~InstrumentPanelTreeModel() override;
-
-    Q_INVOKABLE void load();
-    Q_INVOKABLE void selectRow(const QModelIndex& rowIndex, const bool isMultipleSelectionModeOn);
-    Q_INVOKABLE void addInstruments();
-    Q_INVOKABLE void moveSelectedRowsUp();
-    Q_INVOKABLE void moveSelectedRowsDown();
-    Q_INVOKABLE void removeSelectedRows();
-
-    bool isMovingUpAvailable() const;
-    bool isMovingDownAvailable() const;
-    bool isRemovingAvailable() const;
-    bool isEmpty() const;
-
-    Q_INVOKABLE bool moveRows(const QModelIndex& sourceParent, int sourceRow, int count, const QModelIndex& destinationParent,
-                              int destinationChild) override;
 
     QModelIndex index(int row, int column, const QModelIndex& parent) const override;
     QModelIndex parent(const QModelIndex& child) const override;
@@ -81,16 +63,26 @@ public:
     QHash<int, QByteArray> roleNames() const override;
 
     QItemSelectionModel* selectionModel() const;
+    bool isMovingUpAvailable() const;
+    bool isMovingDownAvailable() const;
+    bool isRemovingAvailable() const;
+    bool isAddingAvailable() const;
+    bool isEmpty() const;
 
-public slots:
-    void setIsMovingUpAvailable(bool isMovingUpAvailable);
-    void setIsMovingDownAvailable(bool isMovingDownAvailable);
-    void setIsRemovingAvailable(bool isRemovingAvailable);
+    Q_INVOKABLE void load();
+    Q_INVOKABLE void selectRow(const QModelIndex& rowIndex, const bool isMultipleSelectionModeOn);
+    Q_INVOKABLE void addInstruments();
+    Q_INVOKABLE void moveSelectedRowsUp();
+    Q_INVOKABLE void moveSelectedRowsDown();
+    Q_INVOKABLE void removeSelectedRows();
 
+    Q_INVOKABLE bool moveRows(const QModelIndex& sourceParent, int sourceRow, int count, const QModelIndex& destinationParent,
+                              int destinationChild) override;
 signals:
     void selectionChanged();
     void isMovingUpAvailableChanged(bool isMovingUpAvailable);
     void isMovingDownAvailableChanged(bool isMovingDownAvailable);
+    void isAddingAvailableChanged(bool isAddingAvailable);
     void isRemovingAvailableChanged(bool isRemovingAvailable);
     void isEmptyChanged();
 
@@ -101,8 +93,16 @@ private slots:
     void updateRemovingAvailability();
 
 private:
+    enum RoleNames {
+        ItemRole = Qt::UserRole + 1
+    };
+
     void clear();
     void deleteItems();
+
+    void setIsMovingUpAvailable(bool isMovingUpAvailable);
+    void setIsMovingDownAvailable(bool isMovingDownAvailable);
+    void setIsRemovingAvailable(bool isRemovingAvailable);
 
     bool removeRows(int row, int count, const QModelIndex& parent) override;
 

--- a/mu4/notation/internal/masternotation.cpp
+++ b/mu4/notation/internal/masternotation.cpp
@@ -562,12 +562,7 @@ void MasterNotation::initExcerpts()
         auto excerpts = Excerpt::createAllExcerpt(master);
 
         for (Excerpt* excerpt : excerpts) {
-            Score* score = new Score(excerpt->oscore());
-            excerpt->setPartScore(score);
-            score->style().set(Sid::createMultiMeasureRests, true);
-            auto excerptCmdFake = new AddExcerpt(excerpt);
-            excerptCmdFake->redo(nullptr);
-            Excerpt::createExcerpt(excerpt);
+            initExcerpt(excerpt);
         }
     }
 
@@ -615,20 +610,24 @@ void MasterNotation::removeMissingExcerpts(const ExcerptNotationList& allExcerpt
 
 void MasterNotation::createNewExcerpts(const ExcerptNotationList& allExcerpts)
 {
-    MasterScore* master = masterScore();
-    if (!master) {
-        return;
-    }
-
     for (IExcerptNotationPtr excerptNotation : allExcerpts) {
         bool isNewExcerpt = std::find(m_excerpts.val.begin(), m_excerpts.val.end(), excerptNotation) == m_excerpts.val.end();
         bool isEmpty = excerptNotation->parts()->partList().empty();
 
         if (isNewExcerpt && isEmpty) {
-            Excerpt* excerpt = new Excerpt(master);
-            excerpt->setPartScore(new Score(master));
+            Excerpt* excerpt = new Excerpt(masterScore());
+            initExcerpt(excerpt);
             static_cast<ExcerptNotation*>(excerptNotation.get())->setExcerpt(excerpt);
-            Excerpt::createExcerpt(excerpt);
         }
     }
+}
+
+void MasterNotation::initExcerpt(Excerpt* excerpt)
+{
+    Score* score = new Score(masterScore());
+    excerpt->setPartScore(score);
+    score->style().set(Sid::createMultiMeasureRests, true);
+    auto excerptCmdFake = new AddExcerpt(excerpt);
+    excerptCmdFake->redo(nullptr);
+    Excerpt::createExcerpt(excerpt);
 }

--- a/mu4/notation/internal/masternotation.h
+++ b/mu4/notation/internal/masternotation.h
@@ -64,18 +64,11 @@ private:
     mu::RetVal<Ms::MasterScore*> newScore(const ScoreCreateOptions& scoreInfo);
 
     void initExcerpts();
+    void initExcerpt(Ms::Excerpt* excerpt);
 
     void removeMissingExcerpts(const ExcerptNotationList& allExcerpts);
     void createNewExcerpts(const ExcerptNotationList& allExcerpts);
 
-    void initParts(Ms::MasterScore* score, const QList<instruments::InstrumentTemplate>& instrumentTemplates);
-    void initStaff(Ms::Staff* staff, const instruments::InstrumentTemplate& instrumentTemplate,const instruments::StaffType* staffType,
-                   int cidx);
-
-    Ms::Instrument instrumentFromTemplate(const instruments::InstrumentTemplate& instrumentTemplate) const;
-    void numberInstrumentNames(Ms::MasterScore* score);
-
-private:
     ValCh<ExcerptNotationList> m_excerpts;
 };
 }

--- a/mu4/notation/internal/notationinteraction.h
+++ b/mu4/notation/internal/notationinteraction.h
@@ -143,6 +143,7 @@ private:
 
     void applyDropPaletteElement(Ms::Score* score, Ms::Element* target, Ms::Element* e, Qt::KeyboardModifiers modifiers,
                                  QPointF pt = QPointF(), bool pasteMode = false);
+
     void doAddSlur(const Ms::Slur* slurTemplate = nullptr);
 
     bool needEndTextEditing(const std::vector<Element*>& newSelectedElements) const;

--- a/mu4/notation/notationtypes.h
+++ b/mu4/notation/notationtypes.h
@@ -41,8 +41,7 @@
 
 #include "instruments/instrumentstypes.h"
 
-namespace mu {
-namespace notation {
+namespace mu::notation {
 using Element = Ms::Element;
 using ElementType = Ms::ElementType;
 using Note = Ms::Note;
@@ -313,8 +312,7 @@ inline bool isNotesIntervalValid(int interval)
 
 inline bool isVoiceIndexValid(int voiceIndex)
 {
-    return voiceIndex >= 0 && voiceIndex < VOICES;
-}
+    return 0 <= voiceIndex && voiceIndex < VOICES;
 }
 }
 

--- a/mu4/notation/qml/MuseScore/NotationScene/internal/PartDelegate.qml
+++ b/mu4/notation/qml/MuseScore/NotationScene/internal/PartDelegate.qml
@@ -17,7 +17,7 @@ Item {
 
     signal copyPartRequested()
     signal removePartRequested()
-    signal voicesVisibilityChangeRequested()
+    signal voiceVisibilityChangeRequested(var voiceIndex, var voiceVisible)
     signal partClicked()
 
     height: 42
@@ -131,8 +131,8 @@ Item {
         x: showVoicesPopupButton.x + showVoicesPopupButton.width / 2 - width / 2
         y: showVoicesPopupButton.y + showVoicesPopupButton.height
 
-        onVoicesVisibilityChangeRequested: {
-            root.voicesVisibilityChangeRequested()
+        onVoiceVisibilityChangeRequested: {
+            root.voiceVisibilityChangeRequested(voiceIndex, voiceVisible)
         }
     }
 

--- a/mu4/notation/qml/MuseScore/NotationScene/internal/PartsView.qml
+++ b/mu4/notation/qml/MuseScore/NotationScene/internal/PartsView.qml
@@ -85,8 +85,8 @@ Item {
                 root.model.setPartTitle(model.index, title)
             }
 
-            onVoicesVisibilityChangeRequested: {
-                root.model.setVoicesVisibility(model.index, voicesVisibility)
+            onVoiceVisibilityChangeRequested: {
+                root.model.setVoiceVisible(model.index, voiceIndex, voiceVisible)
             }
 
             onRemovePartRequested: {

--- a/mu4/notation/qml/MuseScore/NotationScene/internal/VoicesPopup.qml
+++ b/mu4/notation/qml/MuseScore/NotationScene/internal/VoicesPopup.qml
@@ -7,7 +7,7 @@ StyledPopup {
     id: root
 
     property var voicesVisibility: [] // array of bool
-    signal voicesVisibilityChangeRequested()
+    signal voiceVisibilityChangeRequested(var voiceIndex, var voiceVisible)
 
     height: contentColumn.implicitHeight + bottomPadding + topPadding
     width: contentColumn.implicitWidth + leftPadding + rightPadding
@@ -36,7 +36,7 @@ StyledPopup {
                 onClicked: {
                     checked = !checked
                     root.voicesVisibility[model.index] = checked
-                    root.voicesVisibilityChangeRequested()
+                    root.voiceVisibilityChangeRequested(model.index, checked)
                 }
             }
         }

--- a/mu4/notation/view/partlistmodel.h
+++ b/mu4/notation/view/partlistmodel.h
@@ -53,11 +53,11 @@ public:
     Q_INVOKABLE void openSelectedParts();
     Q_INVOKABLE void apply();
 
-    Q_INVOKABLE void selectPart(int index);
-    Q_INVOKABLE void removePart(int index);
-    Q_INVOKABLE void setPartTitle(int index, const QString& title);
-    Q_INVOKABLE void setVoicesVisibility(int index, const QVariantList& visibility);
-    Q_INVOKABLE void copyPart(int index);
+    Q_INVOKABLE void selectPart(int partIndex);
+    Q_INVOKABLE void removePart(int partIndex);
+    Q_INVOKABLE void setPartTitle(int partIndex, const QString& title);
+    Q_INVOKABLE void setVoiceVisible(int partIndex, int voiceIndex, bool visible);
+    Q_INVOKABLE void copyPart(int partIndex);
 
 signals:
     void selectionChanged();
@@ -68,14 +68,13 @@ private:
 
     void setTitle(INotationPtr notation, const QString& title);
 
-    bool isIndexValid(int index) const;
+    bool isNotationIndexValid(int index) const;
+
     IMasterNotationPtr masterNotation() const;
     QList<int> selectedRows() const;
 
     void insertNotation(int destinationIndex, INotationPtr notation);
     void notifyAboutNotationChanged(int index);
-
-    void applyVoicesVisibility(INotationPtr notation) const;
 
     enum Roles {
         RoleTitle = Qt::UserRole + 1,
@@ -87,7 +86,6 @@ private:
 
     QItemSelectionModel* m_selectionModel = nullptr;
     QList<INotationPtr> m_notations;
-    QHash<QString /* notation key */, QVariantList /* voices */> m_updatedVoicesVisibility;
     INotationPtr m_currentNotation;
 };
 }


### PR DESCRIPTION
- fixed crash after closing notation via the X button
- fixed updating the state of the instruments panel controls when there is no opened notation
- implemented applying of voices visibility after clicking of checkboxes in the voices popup
- fixed crash while creating an empty excerpt
- fixed adding parts to an empty excerpt