### PR TITLE
Fix #313613: Note value shortcuts on text input

### DIFF
--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -425,7 +425,37 @@ bool TextBase::edit(EditData& ed)
                         case Qt::Key_H:
                               s = "\u266e"; // Unicode natural
                               break;
-                         case Qt::Key_Space:
+                        case Qt::Key_1:
+                              s = "\u1d163"; // Unicode 64th note
+                              break;
+                        case Qt::Key_2:
+                              s = "\u1d162"; // Unicode 32th note
+                              break;
+                        case Qt::Key_3:
+                              s = "\u1d161"; // Unicode 16th note
+                              break;
+                        case Qt::Key_4:
+                              s = "\u1d160"; // Unicode 8th note
+                              break;
+                        case Qt::Key_5:
+                              s = "\u1d15f"; // Unicode quarter note
+                              break;
+                        case Qt::Key_6:
+                              s = "\u1d15e"; // Unicode half note
+                              break;
+                        case Qt::Key_7:
+                              s = "\u1d15d"; // Unicode whole note
+                              break;
+                        case Qt::Key_8:
+                              s = "\u1d15c"; // Unicode double whole note
+                              break;
+                        case Qt::Key_9:
+                              s = "\u1d1b7"; // Unicode longa note
+                              break;
+                        case Qt::Key_Period:
+                              s = "\u1d16d"; // Unicode combining augmentation dot
+                              break;
+                        case Qt::Key_Space:
                               insertSym(ed, SymId::space);
                               return true;
                         case Qt::Key_F:


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/313613

Shortcuts for note durations would allow changing metronome marks more easily.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [ ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
