### PR TITLE
[MU3] FirstSystemIndentation taking care lenght instrument labels

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3697,6 +3697,7 @@ System* Score::collectSystem(LayoutContext& lc)
       Measure* measure  = _systems.empty() ? 0 : _systems.back()->lastMeasure();
       if (measure) {
             lc.firstSystem        = measure->sectionBreak() && _layoutMode != LayoutMode::FLOAT;
+            lc.firstSystemIndent  = lc.firstSystem && measure->sectionBreakElement()->firstSystemIdentation() && styleB(Sid::enableIndentationOnFirstSystem);
             lc.startWithLongNames = lc.firstSystem && measure->sectionBreakElement()->startWithLongNames();
             }
       System* system = getNextSystem(lc);
@@ -3898,7 +3899,7 @@ System* Score::collectSystem(LayoutContext& lc)
       // Relayout system decorations to reuse space properly for
       // hidden staves' instrument names or other hidden elements.
       minWidth -= system->leftMargin();
-      system->layoutSystem(layoutSystemMinWidth, lc.firstSystem);
+      system->layoutSystem(layoutSystemMinWidth, lc.firstSystem, lc.firstSystemIndent);
       minWidth += system->leftMargin();
 
       //-------------------------------------------------------
@@ -3996,6 +3997,7 @@ System* Score::collectSystem(LayoutContext& lc)
       lm  = system->lastMeasure();
       if (lm) {
             lc.firstSystem        = lm->sectionBreak() && _layoutMode != LayoutMode::FLOAT;
+            lc.firstSystemIndent  = lc.firstSystem && lm->sectionBreakElement()->firstSystemIdentation() && styleB(Sid::enableIndentationOnFirstSystem);
             lc.startWithLongNames = lc.firstSystem && lm->sectionBreakElement()->startWithLongNames();
             }
 
@@ -4982,6 +4984,16 @@ void LayoutContext::layout()
                   p->rebuildBspTree();
             }
       score->systems().append(systemList);     // TODO
+      }
+
+//---------------------------------------------------------
+//   LayoutContext::LayoutContext
+//---------------------------------------------------------
+
+LayoutContext::LayoutContext(Score* s)
+      : score(s)
+      {
+      firstSystemIndent = score && score->styleB(Sid::enableIndentationOnFirstSystem);
       }
 
 //---------------------------------------------------------

--- a/libmscore/layout.h
+++ b/libmscore/layout.h
@@ -82,6 +82,7 @@ struct LayoutContext {
       Score* score             { 0    };
       bool startWithLongNames  { true };
       bool firstSystem         { true };
+      bool firstSystemIndent   { true };
       Page* page               { 0 };
       int curPage              { 0 };      // index in Score->page()s
       Fraction tick            { 0, 1 };
@@ -103,7 +104,7 @@ struct LayoutContext {
       Fraction startTick;
       Fraction endTick;
 
-      LayoutContext(Score* s) : score(s) {}
+      LayoutContext(Score* s);
       LayoutContext(const LayoutContext&) = delete;
       LayoutContext& operator=(const LayoutContext&) = delete;
       ~LayoutContext();

--- a/libmscore/layoutbreak.cpp
+++ b/libmscore/layoutbreak.cpp
@@ -35,6 +35,7 @@ LayoutBreak::LayoutBreak(Score* score)
       _pause = 0.;
       _startWithLongNames = false;
       _startWithMeasureOne = false;
+      _firstSystemIdentation = false;
       _layoutBreakType = Type(propertyDefault(Pid::LAYOUT_BREAK).toInt());
 
       initElementStyle(&sectionBreakStyle);
@@ -42,17 +43,19 @@ LayoutBreak::LayoutBreak(Score* score)
       resetProperty(Pid::PAUSE);
       resetProperty(Pid::START_WITH_LONG_NAMES);
       resetProperty(Pid::START_WITH_MEASURE_ONE);
+      resetProperty(Pid::FIRST_SYSTEM_INDENTATION);
       lw = spatium() * 0.3;
       }
 
 LayoutBreak::LayoutBreak(const LayoutBreak& lb)
    : Element(lb)
       {
-      _layoutBreakType     = lb._layoutBreakType;
-      lw                   = lb.lw;
-      _pause               = lb._pause;
-      _startWithLongNames  = lb._startWithLongNames;
-      _startWithMeasureOne = lb._startWithMeasureOne;
+      _layoutBreakType       = lb._layoutBreakType;
+      lw                     = lb.lw;
+      _pause                 = lb._pause;
+      _startWithLongNames    = lb._startWithLongNames;
+      _startWithMeasureOne   = lb._startWithMeasureOne;
+      _firstSystemIdentation = lb._firstSystemIdentation;
       layout0();
       }
 
@@ -65,7 +68,7 @@ void LayoutBreak::write(XmlWriter& xml) const
       xml.stag(this);
       Element::writeProperties(xml);
 
-      for (auto id : { Pid::LAYOUT_BREAK, Pid::PAUSE, Pid::START_WITH_LONG_NAMES, Pid::START_WITH_MEASURE_ONE })
+      for (auto id : { Pid::LAYOUT_BREAK, Pid::PAUSE, Pid::START_WITH_LONG_NAMES, Pid::START_WITH_MEASURE_ONE, Pid::FIRST_SYSTEM_INDENTATION })
             writeProperty(xml, id);
 
       xml.etag();
@@ -87,6 +90,8 @@ void LayoutBreak::read(XmlReader& e)
                   readProperty(e, Pid::START_WITH_LONG_NAMES);
             else if (tag == "startWithMeasureOne")
                   readProperty(e, Pid::START_WITH_MEASURE_ONE);
+            else if (tag == "firstSystemIdentation")
+                  readProperty(e, Pid::FIRST_SYSTEM_INDENTATION);
             else if (!Element::readProperties(e))
                   e.unknown();
             }
@@ -251,6 +256,8 @@ QVariant LayoutBreak::getProperty(Pid propertyId) const
                   return _startWithLongNames;
             case Pid::START_WITH_MEASURE_ONE:
                   return _startWithMeasureOne;
+            case Pid::FIRST_SYSTEM_INDENTATION:
+                  return _firstSystemIdentation;
             default:
                   return Element::getProperty(propertyId);
             }
@@ -274,6 +281,9 @@ bool LayoutBreak::setProperty(Pid propertyId, const QVariant& v)
                   break;
             case Pid::START_WITH_MEASURE_ONE:
                   setStartWithMeasureOne(v.toBool());
+                  break;
+            case Pid::FIRST_SYSTEM_INDENTATION:
+                  setFirstSystemIdentation(v.toBool());
                   break;
             default:
                   if (!Element::setProperty(propertyId, v))
@@ -299,6 +309,8 @@ QVariant LayoutBreak::propertyDefault(Pid id) const
             case Pid::START_WITH_LONG_NAMES:
                   return true;
             case Pid::START_WITH_MEASURE_ONE:
+                  return true;
+            case Pid::FIRST_SYSTEM_INDENTATION:
                   return true;
             default:
                   return Element::propertyDefault(id);

--- a/libmscore/layoutbreak.h
+++ b/libmscore/layoutbreak.h
@@ -41,6 +41,7 @@ class LayoutBreak final : public Element {
       qreal _pause;
       bool _startWithLongNames;
       bool _startWithMeasureOne;
+      bool _firstSystemIdentation;
       Type _layoutBreakType;
 
       void draw(QPainter*) const override;
@@ -62,13 +63,15 @@ class LayoutBreak final : public Element {
       void write(XmlWriter&) const override;
       void read(XmlReader&) override;
 
-      Measure* measure() const            { return (Measure*)parent();   }
-      qreal pause() const                 { return _pause;               }
-      void setPause(qreal v)              { _pause = v;                  }
-      bool startWithLongNames() const     { return _startWithLongNames;  }
-      void setStartWithLongNames(bool v)  { _startWithLongNames = v;     }
-      bool startWithMeasureOne() const    { return _startWithMeasureOne; }
-      void setStartWithMeasureOne(bool v) { _startWithMeasureOne = v;    }
+      Measure* measure() const              { return (Measure*)parent();     }
+      qreal pause() const                   { return _pause;                 }
+      void setPause(qreal v)                { _pause = v;                    }
+      bool startWithLongNames() const       { return _startWithLongNames;    }
+      void setStartWithLongNames(bool v)    { _startWithLongNames = v;       }
+      bool startWithMeasureOne() const      { return _startWithMeasureOne;   }
+      void setStartWithMeasureOne(bool v)   { _startWithMeasureOne = v;      }
+      bool firstSystemIdentation() const    { return _firstSystemIdentation; }
+      void setFirstSystemIdentation(bool v) { _firstSystemIdentation = v;    }
 
       bool isPageBreak() const    { return _layoutBreakType == PAGE;    }
       bool isLineBreak() const    { return _layoutBreakType == LINE;    }

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -347,6 +347,7 @@ static constexpr PropertyMetaData propertyList[] = {
 
       { Pid::START_WITH_LONG_NAMES,   false, "startWithLongNames",    P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "start with long names")  },
       { Pid::START_WITH_MEASURE_ONE,  true,  "startWithMeasureOne",   P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "start with measure one") },
+      { Pid::FIRST_SYSTEM_INDENTATION,true,  "firstSystemIndentation",P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "first system indentation") },
 
       { Pid::PATH,                    false, "path",                  P_TYPE::PATH,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "path") },
 

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -355,6 +355,7 @@ enum class Pid {
 
       START_WITH_LONG_NAMES,
       START_WITH_MEASURE_ONE,
+      FIRST_SYSTEM_INDENTATION,
 
       PATH, // for ChordLine to make its shape changes undoable
       

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -198,7 +198,7 @@ void System::adjustStavesNumber(int nstaves)
 ///   Layout the System
 //---------------------------------------------------------
 
-void System::layoutSystem(qreal xo1, const bool isFirstSystem)
+void System::layoutSystem(qreal xo1, const bool isFirstSystem, bool firstSystemIndent)
       {
       if (_staves.empty())                 // ignore vbox
             return;
@@ -212,11 +212,6 @@ void System::layoutSystem(qreal xo1, const bool isFirstSystem)
       //---------------------------------------------------
       qreal xoff2 = 0.0; // x offset for instrument name
 
-      bool shouldApplyIndentation = isFirstSystem && score()->styleB(Sid::enableIndentationOnFirstSystem);
-
-      if (shouldApplyIndentation)
-            xoff2 = styleP(Sid::firstSystemIndentationValue) * mag();
-
       for (const Part* p : score()->parts()) {
             if (firstVisibleSysStaffOfPart(p) < 0)
                   continue;
@@ -225,10 +220,13 @@ void System::layoutSystem(qreal xo1, const bool isFirstSystem)
                         t->layout();
                         qreal w = t->width() + point(instrumentNameOffset);
                         if (w > xoff2)
-                              xoff2 = shouldApplyIndentation ? xoff2 + w : w;
+                              xoff2 = w;
                         }
                   }
             }
+
+      if (isFirstSystem && firstSystemIndent)
+            xoff2 = qMax(xoff2, styleP(Sid::firstSystemIndentationValue) * mag());
 
       //---------------------------------------------------
       //  create brackets

--- a/libmscore/system.h
+++ b/libmscore/system.h
@@ -122,7 +122,7 @@ public:
 
       Page* page() const                    { return (Page*)parent(); }
 
-      void layoutSystem(qreal, const bool isFirstSystem = false);
+      void layoutSystem(qreal, const bool isFirstSystem = false, bool firstSystemIndent = false);
       void setMeasureHeight(qreal height);
       void layoutBracketsVertical();
       void layoutInstrumentNames();

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -575,7 +575,7 @@
                  <double>0.000000000000000</double>
                 </property>
                 <property name="maximum">
-                 <double>10.000000000000000</double>
+                 <double>1000.000000000000000</double>
                 </property>
                 <property name="singleStep">
                  <double>0.500000000000000</double>

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -479,9 +479,10 @@ InspectorSectionBreak::InspectorSectionBreak(QWidget* parent)
       scb.setupUi(addWidget());
 
       iList = {
-            { Pid::PAUSE,                   0, scb.pause,               scb.resetPause               },
-            { Pid::START_WITH_LONG_NAMES,   0, scb.startWithLongNames,  scb.resetStartWithLongNames  },
-            { Pid::START_WITH_MEASURE_ONE,  0, scb.startWithMeasureOne, scb.resetStartWithMeasureOne }
+            { Pid::PAUSE,                    0, scb.pause,                  scb.resetPause                  },
+            { Pid::START_WITH_LONG_NAMES,    0, scb.startWithLongNames,     scb.resetStartWithLongNames     },
+            { Pid::START_WITH_MEASURE_ONE,   0, scb.startWithMeasureOne,    scb.resetStartWithMeasureOne    },
+            { Pid::FIRST_SYSTEM_INDENTATION, 0, scb.firstSystemIndentation, scb.resetFirstSystemIndentation }
             };
       pList = { { scb.title, scb.panel } };
       mapSignals();

--- a/mscore/inspector/inspector_sectionbreak.ui
+++ b/mscore/inspector/inspector_sectionbreak.ui
@@ -86,45 +86,6 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QCheckBox" name="startWithLongNames">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Start new section with long instrument names</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="Ms::ResetButton" name="resetStartWithLongNames" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Start new section with long instrument names' value</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="startWithMeasureOne">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Start new section with measure number one</string>
-        </property>
-       </widget>
-      </item>
       <item row="2" column="2">
        <widget class="Ms::ResetButton" name="resetStartWithMeasureOne" native="true">
         <property name="sizePolicy">
@@ -167,6 +128,66 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="startWithMeasureOne">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Start new section with measure number one</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="startWithLongNames">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Start new section with long instrument names</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="Ms::ResetButton" name="resetStartWithLongNames" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Start new section with long instrument names' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="firstSystemIndentation">
+        <property name="text">
+         <string>Start new section with first system indentation</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="Ms::ResetButton" name="resetFirstSystemIndentation" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Start new section with long instrument names' value</string>
+        </property>
+       </widget>
+      </item>
+      
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
Resolves: https://trello.com/c/055jGzml/13-first-system-indentation-should-not-apply-where-instrument-labels-are-present

First system indentation now takes the maximum of the length of the instruments labels and the style parameter <code>firstSystemIndentationValue</code>. The maximum value of this parameter is now exceeded to 1000.0 which is the same maximum used in other parameters.

<code>SectionBreak</code> also generates a first system indentation but this can be enabled/disabled per <code>SectionBreak</code>.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/WorkflowAndGuidelines/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
