### PR TITLE
[MU3] Add an <unsorted> section to the default <custom> score order.

### DIFF
--- a/libmscore/scoreOrder.cpp
+++ b/libmscore/scoreOrder.cpp
@@ -362,6 +362,20 @@ QString ScoreOrder::getFamilyName(const InstrumentTemplate* instrTemplate, bool 
       }
 
 //---------------------------------------------------------
+//   createUnsortedGroup
+//---------------------------------------------------------
+
+void ScoreOrder::createUnsortedGroup()
+      {
+      _unsorted  = new ScoreGroup(QString("<unsorted>"), "", "");
+      _unsorted->bracket            = false;
+      _unsorted->showSystemMarkings = false;
+      _unsorted->barLineSpan        = false;
+      _unsorted->thinBracket        = false;
+      groups.append(_unsorted);
+      }
+
+//---------------------------------------------------------
 //   getId
 //---------------------------------------------------------
 
@@ -477,14 +491,8 @@ void ScoreOrder::read(XmlReader& e)
             else
                   e.unknown();
             }
-      if (!_unsorted) {
-            _unsorted  = new ScoreGroup(QString("<unsorted>"), "", "");
-            _unsorted->bracket            = false;
-            _unsorted->showSystemMarkings = false;
-            _unsorted->barLineSpan        = false;
-            _unsorted->thinBracket        = false;
-            groups.append(_unsorted);
-            }
+      if (!_unsorted)
+            createUnsortedGroup();
       }
 
 //---------------------------------------------------------
@@ -717,7 +725,7 @@ ScoreOrderList::ScoreOrderList()
       {
       _orders.clear();
       ScoreOrder* custom = new ScoreOrder(QString("<custom>"), qApp->translate("OrderXML", "Custom"));
-      custom->groups.append(new ScoreGroup(QString("<unsorted>"), QString(""), QString("")));
+      custom->createUnsortedGroup();
       addScoreOrder(custom);
       }
 

--- a/libmscore/scoreOrder.h
+++ b/libmscore/scoreOrder.h
@@ -91,6 +91,7 @@ class ScoreOrder {
       void readFamily(XmlReader& e, const QString section, bool br, bool ssm, bool bls, bool tbr);
       void readSection(XmlReader& e);
       QString getFamilyName(const InstrumentTemplate *instrTemplate, bool soloist) const;
+      void createUnsortedGroup();
 
 
    public:
@@ -124,6 +125,8 @@ class ScoreOrder {
       bool isScoreOrder(const Score* score) const;
 
       void dump() const;
+
+      friend class ScoreOrderList;
       };
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://trello.com/c/HgpFok0n/36-when-custom-ordering-is-selected-adding-instruments-causes-a-crash

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
