### PR TITLE
Ease in out gliss graph

### DIFF
--- a/libmscore/easeInOut.cpp
+++ b/libmscore/easeInOut.cpp
@@ -108,4 +108,11 @@ void EaseInOut::timeList(const int nbNotes, const int duration, QList<int>* time
             }
       }
 
+qreal EaseInOut::EvalX(const qreal t) const {
+      qreal tCompl = 1.0 - t;
+      return (3.0 * _easeIn * tCompl * tCompl + (3.0 - 3.0 * _easeOut * tCompl - 2.0 * t) * t) * t;
+      }
+
 }
+
+

--- a/libmscore/easeInOut.cpp
+++ b/libmscore/easeInOut.cpp
@@ -108,11 +108,6 @@ void EaseInOut::timeList(const int nbNotes, const int duration, QList<int>* time
             }
       }
 
-qreal EaseInOut::EvalX(const qreal t) const {
-      qreal tCompl = 1.0 - t;
-      return (3.0 * _easeIn * tCompl * tCompl + (3.0 - 3.0 * _easeOut * tCompl - 2.0 * t) * t) * t;
-      }
-
 }
 
 

--- a/libmscore/easeInOut.h
+++ b/libmscore/easeInOut.h
@@ -30,15 +30,13 @@ class EaseInOut final {
       qreal       _easeOut;
 
 public:
-      typedef std::tuple<qreal, qreal> Ease2D;
-
       EaseInOut() : _easeIn(0.0), _easeOut(1.0) {}
       EaseInOut(qreal easeIn, qreal easeOut) : _easeIn(easeIn), _easeOut(easeOut) {}
 
       void SetEases(qreal easeIn, qreal easeOut) { _easeIn = easeIn; _easeOut = easeOut; }
-      qreal EvalX(const qreal t) const          { qreal tCompl = 1.0 - t;  return (3.0 * _easeIn * tCompl * tCompl + (3.0 - 3.0 * _easeOut * tCompl - 2.0 * t) * t) * t; }
+      qreal EvalX(const qreal t) const;// { qreal tCompl = 1.0 - t;  return (3.0 * _easeIn * tCompl * tCompl + (3.0 - 3.0 * _easeOut * tCompl - 2.0 * t) * t) * t; }
       qreal EvalY(const qreal t) const          { return -(t * t) * (2.0 * t - 3.0); }
-      Ease2D Eval(const qreal t) const          { return {EvalX(t), EvalY(t)}; }
+      QPointF Eval(const qreal t) const         { return {EvalX(t), EvalY(t)}; }
       qreal tFromX(const qreal x) const;
       qreal tFromY(const qreal y) const;
       qreal YfromX(const qreal x) const         { return EvalY(tFromX(x)); }

--- a/libmscore/easeInOut.h
+++ b/libmscore/easeInOut.h
@@ -34,7 +34,7 @@ public:
       EaseInOut(qreal easeIn, qreal easeOut) : _easeIn(easeIn), _easeOut(easeOut) {}
 
       void SetEases(qreal easeIn, qreal easeOut) { _easeIn = easeIn; _easeOut = easeOut; }
-      qreal EvalX(const qreal t) const;// { qreal tCompl = 1.0 - t;  return (3.0 * _easeIn * tCompl * tCompl + (3.0 - 3.0 * _easeOut * tCompl - 2.0 * t) * t) * t; }
+      qreal EvalX(const qreal t) const          { qreal tCompl = 1.0 - t;  return (3.0 * _easeIn * tCompl * tCompl + (3.0 - 3.0 * _easeOut * tCompl - 2.0 * t) * t) * t; }
       qreal EvalY(const qreal t) const          { return -(t * t) * (2.0 * t - 3.0); }
       QPointF Eval(const qreal t) const         { return {EvalX(t), EvalY(t)}; }
       qreal tFromX(const qreal x) const;

--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -293,7 +293,7 @@ void Glissando::layout()
          // but ignore graces after, as they are not the first note of the system,
          // even if their segment is the first segment of the system
          && !(cr2->noteType() == NoteType::GRACE8_AFTER
-            || cr2->noteType() == NoteType::GRACE16_AFTER || cr2->noteType() == NoteType::GRACE32_AFTER)
+         || cr2->noteType() == NoteType::GRACE16_AFTER || cr2->noteType() == NoteType::GRACE32_AFTER)
          // also ignore if cr1 is a child of cr2, which means cr1 is a grace-before of cr2
          && !(cr1->parent() == cr2)) {
             segm2->rxpos() -= GLISS_STARTOFSYSTEM_WIDTH * _spatium;

--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -293,7 +293,7 @@ void Glissando::layout()
          // but ignore graces after, as they are not the first note of the system,
          // even if their segment is the first segment of the system
          && !(cr2->noteType() == NoteType::GRACE8_AFTER
-         || cr2->noteType() == NoteType::GRACE16_AFTER || cr2->noteType() == NoteType::GRACE32_AFTER)
+            || cr2->noteType() == NoteType::GRACE16_AFTER || cr2->noteType() == NoteType::GRACE32_AFTER)
          // also ignore if cr1 is a child of cr2, which means cr1 is a grace-before of cr2
          && !(cr1->parent() == cr2)) {
             segm2->rxpos() -= GLISS_STARTOFSYSTEM_WIDTH * _spatium;

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -1871,7 +1871,6 @@ bool glissandoPitchOffsets(const Spanner* spanner, std::vector<int>& pitchOffset
                   int halfSteps = articulationExcursion(noteStart, noteEnd, lineStart - line);
                   pitch = pitchStart + halfSteps;
                   if ((direction == 1) ? (pitch < pitchEnd) : (pitch > pitchEnd))
-                  //&& (pitchOffsets.size() == 0 || halfSteps != pitchOffsets.back()))
                         pitchOffsets.push_back(halfSteps);
                   }
             return pitchOffsets.size() > 0;
@@ -1890,68 +1889,6 @@ bool glissandoPitchOffsets(const Spanner* spanner, std::vector<int>& pitchOffset
                   pitchOffsets.push_back(pitch - pitchStart);
             }
       return true;
-}
-
-bool glissandoPitchOffsetsRef(const Spanner* spanner, std::vector<int>& pitchOffsets)
-{
-      Note* notestart = toNote(spanner->startElement());
-      int Cnote = 60; // pitch of middle C
-      int pitchstart = notestart->ppitch();
-      int linestart = notestart->line();
-
-      std::set<int> blacknotes = { 1,  3,    6, 8, 10 };
-      std::set<int> whitenotes = { 0,  2, 4, 5, 7,  9, 11 };
-
-      pitchOffsets.clear();
-      if (spanner->type() == ElementType::GLISSANDO) {
-            const Glissando* glissando = toGlissando(spanner);
-            GlissandoStyle glissandoStyle = glissando->glissandoStyle();
-            Element* ee = spanner->endElement();
-            // handle this elsewhere in a different way
-            if (glissandoStyle == GlissandoStyle::PORTAMENTO)
-                  return false;
-            // only consider glissando connected to NOTE.
-            if (glissando->playGlissando() && ElementType::NOTE == ee->type()) {
-                  Note* noteend = toNote(ee);
-                  int pitchend = noteend->ppitch();
-                  bool direction = pitchend > pitchstart;
-                  if (pitchend == pitchstart)
-                        return false; // next spanner
-                  if (glissandoStyle == GlissandoStyle::DIATONIC) { // scale obeying accidentals
-                        int line;
-                        int p = pitchstart;
-                        // iterate as long as we haven't past the pitchend.
-                        for (line = linestart; (direction) ? (p < pitchend) : (p > pitchend);
-                              (direction) ? line-- : line++) {
-                              int halfsteps = articulationExcursion(notestart, noteend, linestart - line);
-                              p = pitchstart + halfsteps;
-                              if (direction ? p < pitchend : p > pitchend)
-                                    pitchOffsets.push_back(halfsteps);
-                        }
-                  } else {
-                        for (int p = pitchstart; direction ? p < pitchend : p > pitchend; p += (direction ? 1 : -1)) {
-                              bool choose = false;
-                              int mod = ((p - Cnote) + 1200) % 12;
-                              switch (glissandoStyle) {
-                              case GlissandoStyle::CHROMATIC:
-                                    choose = true;
-                                    break;
-                              case GlissandoStyle::WHITE_KEYS: // white note
-                                    choose = (whitenotes.find(mod) != whitenotes.end());
-                                    break;
-                              case GlissandoStyle::BLACK_KEYS: // black note
-                                    choose = (blacknotes.find(mod) != blacknotes.end());
-                                    break;
-                              default:
-                                    choose = false;
-                              }
-                              if (choose)
-                                    pitchOffsets.push_back(p - pitchstart);
-                        }
-                  }
-            }
-      }
-      return pitchOffsets.size() != 0;
 }
 
 //---------------------------------------------------------

--- a/libmscore/rendermidi.h
+++ b/libmscore/rendermidi.h
@@ -136,7 +136,8 @@ class MidiRenderer {
       };
 
 class Spanner;
-extern bool glissandoPitchOffsets(const Spanner* spanner, std::vector<int>* pitchOffsets);
+extern bool glissandoPitchOffsets(const Spanner* spanner, std::vector<int>& pitchOffsets);
+extern bool glissandoPitchOffsetsRef(const Spanner* spanner, std::vector<int>& pitchOffsets);
 
 } // namespace Ms
 

--- a/libmscore/rendermidi.h
+++ b/libmscore/rendermidi.h
@@ -135,6 +135,9 @@ class MidiRenderer {
       static const int ARTICULATION_CONV_FACTOR { 100000 };
       };
 
+class Spanner;
+extern bool glissandoPitchOffsets(const Spanner* spanner, std::vector<int>* pitchOffsets);
+
 } // namespace Ms
 
 #endif

--- a/libmscore/rendermidi.h
+++ b/libmscore/rendermidi.h
@@ -137,7 +137,6 @@ class MidiRenderer {
 
 class Spanner;
 extern bool glissandoPitchOffsets(const Spanner* spanner, std::vector<int>& pitchOffsets);
-extern bool glissandoPitchOffsetsRef(const Spanner* spanner, std::vector<int>& pitchOffsets);
 
 } // namespace Ms
 

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -163,7 +163,7 @@ add_library(mscoreapp STATIC
       analyse.h articulationprop.h
       bendcanvas.h breaksdialog.h
       chordview.h click.h clickableLabel.h continuouspanel.h downloadUtils.h
-      drumroll.h drumtools.h drumview.h editdrumset.h
+      drumroll.h drumtools.h drumview.h easeinoutcanvas.h editdrumset.h
       editinstrument.h editpitch.h editraster.h editstaff.h
       editstafftype.h editstringdata.h editstyle.h enableplayforwidget.h
       exampleview.h excerptsdialog.h exportdialog.h extension.h
@@ -193,7 +193,7 @@ add_library(mscoreapp STATIC
       recordbutton.h greendotbutton prefsdialog.h prefsdialog.cpp
       stringutils.h stringutils.cpp
       scoreview.cpp editharmony.cpp editfiguredbass.cpp events.cpp
-      editinstrument.cpp editstyle.cpp
+      editinstrument.cpp editstyle.cpp easeinoutcanvas.cpp
       clickableLabel.cpp
       icons.cpp
       instrdialog.cpp instrwidget.cpp

--- a/mscore/easeinoutcanvas.cpp
+++ b/mscore/easeinoutcanvas.cpp
@@ -1,0 +1,107 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2010-2019 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#include "easeinoutcanvas.h"
+#include "..\libmscore\easeInOut.h"
+#include "preferences.h"
+
+namespace Ms {
+
+//---------------------------------------------------------
+//   EaseInOutCanvas
+//---------------------------------------------------------
+
+EaseInOutCanvas::EaseInOutCanvas(QWidget* parent)
+   : QFrame(parent),
+     m_easeIn(0.0),
+     m_easeOut(0.0),
+     m_nEvents(11)
+      {
+      setFrameStyle(QFrame::NoFrame);
+      }
+
+//---------------------------------------------------------
+//   paintEvent
+//---------------------------------------------------------
+
+void EaseInOutCanvas::paintEvent(QPaintEvent* ev)
+      {
+      // not qreal here, even though elsewhere yes,
+      // because width and height return a number of pixels,
+      // hence integers.
+      const int w = width();
+      const int h = height();
+      const int border = 5;
+
+      const qreal graphWidth = static_cast<qreal>(w - 2 * border);
+      const qreal graphHeight = static_cast<qreal>(h - 2 * border);
+      const qreal nbEvents = static_cast<qreal>(m_nEvents);
+
+      // let half a column of margin around
+      const qreal leftPos = static_cast<qreal>(border);           // also left margin
+      const qreal topPos = leftPos;                               // also top margin
+      const qreal bottomPos = static_cast<qreal>(h - border);     // bottom end position of graph
+
+      EaseInOut eio(static_cast<qreal>(m_easeIn) / 100.0, static_cast<qreal>(m_easeOut) / 100.0);
+
+      QPainter painter(this);
+      painter.setRenderHint(QPainter::Antialiasing, preferences.getBool(PREF_UI_CANVAS_MISC_ANTIALIASEDDRAWING));
+
+      painter.fillRect(rect(), QApplication::palette().color(QPalette::Window).lighter());
+      QPen pen = painter.pen();
+      pen.setWidth(1);
+
+      QColor primaryLinesColor(preferences.isThemeDark() ? Qt::white : Qt::black);
+      QColor secondaryLinesColor(Qt::gray);
+
+      // draw time-warped vertical lines in lighter gray
+      pen.setColor(secondaryLinesColor);
+      painter.setPen(pen);
+      for (int i = 1; i < m_nEvents; ++i) {
+            qreal xPos = leftPos + eio.XfromY(static_cast<qreal>(i) / nbEvents) * graphWidth;
+            painter.drawLine(xPos, topPos, xPos, bottomPos);
+            }
+
+      // this lambda takes as input a pitch value, and determines where what are its x and y coordinates
+      auto getPosition = [this, graphWidth, graphHeight, leftPos, bottomPos] (const QPointF& p) -> QPointF {
+            return {leftPos + p.x() * graphWidth, bottomPos - p.y() * graphHeight };
+            };
+
+      pen = painter.pen();
+      pen.setWidth(2);
+      pen.setColor(Qt::red); // not theme dependant
+      painter.setPen(pen);
+      // draw line between points
+      QPointF lastPoint = getPosition({0.0, 0.0});
+      for (int i = 1; i <= 33; i++) {
+            QPointF currentPoint = getPosition(eio.Eval(static_cast<qreal>(i) / 33.0));
+            painter.drawLine(lastPoint, currentPoint);
+            lastPoint = currentPoint;
+            }
+
+      // draw the graph frame after the other lines to cover them
+      pen.setColor(primaryLinesColor);
+      pen.setWidth(1);
+      painter.setPen(pen);
+      painter.drawRect(border, border, w - 2 * border, h - 2 * border);
+
+      QFrame::paintEvent(ev);
+      }
+
+} // namespace Ms

--- a/mscore/easeinoutcanvas.cpp
+++ b/mscore/easeinoutcanvas.cpp
@@ -18,7 +18,7 @@
 //=============================================================================
 
 #include "easeinoutcanvas.h"
-#include "..\libmscore\easeInOut.h"
+#include "libmscore/easeInOut.h"
 #include "preferences.h"
 
 namespace Ms {

--- a/mscore/easeinoutcanvas.cpp
+++ b/mscore/easeinoutcanvas.cpp
@@ -92,7 +92,7 @@ void EaseInOutCanvas::paintEvent(QPaintEvent* ev)
             warpLineColor.setRgbF(0.914, 0.710, 0.588);
             borderLinesColor.setRgbF(0.016, 0.057, 0.093);
             pitchNameColor.setRgbF(0.310, 0.157, 0.066);
-      }
+            }
 
       // this lambda takes as input a pitch value, and determines where what are its x and y coordinates
       auto getPosition = [this, graphWidth, graphHeight, leftPos, bottomPos](const QPointF& p) -> QPointF {
@@ -150,7 +150,7 @@ void EaseInOutCanvas::paintEvent(QPaintEvent* ev)
             QPointF pos = { 4, topPos + fontHeight * 0.3 + (1.0 - (static_cast<qreal>(i) / pitchDelta)) * graphHeight };
             painter.drawText(pos, pitchName);
             curPitch++;
-      }
+            }
 
       if (m_events.size()) {
             // Not a portamento style glissando.
@@ -181,8 +181,8 @@ void EaseInOutCanvas::paintEvent(QPaintEvent* ev)
                   currPoint = getPosition(currPoint);
                   painter.drawLine(prevPoint, currPoint);
                   prevPoint = currPoint;
+                  }
             }
-      }
 
       // Draw the pitches level lines next so they cover the Bezier transfer curve.
       if (pitchPoints.size() > 1) {

--- a/mscore/easeinoutcanvas.cpp
+++ b/mscore/easeinoutcanvas.cpp
@@ -31,7 +31,8 @@ EaseInOutCanvas::EaseInOutCanvas(QWidget* parent)
    : QFrame(parent),
      m_easeIn(0.0),
      m_easeOut(0.0),
-     m_nEvents(11)
+     m_nEvents(25),
+     m_pitchDelta(0)
       {
       setFrameStyle(QFrame::NoFrame);
       }
@@ -47,16 +48,18 @@ void EaseInOutCanvas::paintEvent(QPaintEvent* ev)
       // hence integers.
       const int w = width();
       const int h = height();
-      const int border = 5;
+      const int border = 1;
 
       const qreal graphWidth = static_cast<qreal>(w - 2 * border);
       const qreal graphHeight = static_cast<qreal>(h - 2 * border);
       const qreal nbEvents = static_cast<qreal>(m_nEvents);
+      const qreal pitchDelta = static_cast<qreal>(m_pitchDelta);
 
       // let half a column of margin around
       const qreal leftPos = static_cast<qreal>(border);           // also left margin
       const qreal topPos = leftPos;                               // also top margin
       const qreal bottomPos = static_cast<qreal>(h - border);     // bottom end position of graph
+      const qreal rightPos = static_cast<qreal>(w - border);      // right end position of graph
 
       EaseInOut eio(static_cast<qreal>(m_easeIn) / 100.0, static_cast<qreal>(m_easeOut) / 100.0);
 
@@ -67,27 +70,71 @@ void EaseInOutCanvas::paintEvent(QPaintEvent* ev)
       QPen pen = painter.pen();
       pen.setWidth(1);
 
-      QColor primaryLinesColor(preferences.isThemeDark() ? Qt::white : Qt::black);
-      QColor secondaryLinesColor(Qt::gray);
+      QColor eventLinesColor(Qt::gray);
+      eventLinesColor.setAlphaF(0.5);
+      QColor pitchLinesColor(Qt::gray);
+      pitchLinesColor.setAlphaF(0.25);
+      QColor borderLinesColor, warpLineColor, pitchFillColor, pitchGraphColor;
+      if (preferences.isThemeDark()) {
+            pitchFillColor.setRgbF(0.078, 0.284, 0.463);
+            pitchGraphColor.setRgbF(0.125, 0.455, 0.741);
+            warpLineColor.setRgbF(0.574, 0.368, 0.255);
+            borderLinesColor.setRgbF(0.891, 0.932, 0.968);
+      }
+      else {
+            pitchFillColor.setRgbF(0.891, 0.932, 0.968);
+            pitchGraphColor.setRgbF(0.125, 0.455, 0.741);
+            warpLineColor.setRgbF(0.938, 0.691, 0.556);
+            borderLinesColor.setRgbF(0.016, 0.057, 0.093);
+      }
+
+      // this lambda takes as input a pitch value, and determines where what are its x and y coordinates
+      auto getPosition = [this, graphWidth, graphHeight, leftPos, bottomPos](const QPointF& p) -> QPointF {
+            return { leftPos + p.x() * graphWidth, bottomPos - p.y() * graphHeight };
+      };
+
+      // Draw the pitches staircase graph
+      if (m_events.size() > 1) {
+            pen.setWidth(3);
+            pen.setColor(pitchGraphColor);
+            painter.setPen(pen);
+            // draw line between points
+            qreal offset = m_events[m_events.size()-1] < 0 ? 1.0 : 0.0;
+            QPointF lastPoint = getPosition({0.0, offset + 0.0});
+            for (int i = 1; i < m_events.size(); i++) {
+                  qreal xPos = eio.XfromY(static_cast<qreal>(i) / nbEvents);
+                  qreal yPos = static_cast<qreal>(m_events[i]) / static_cast<qreal>(pitchDelta);
+                  QPointF currentPoint = getPosition({xPos, offset + yPos});
+                  painter.fillRect(lastPoint.x(), bottomPos, (currentPoint.x() - lastPoint.x()) + 1, lastPoint.y() - bottomPos, pitchFillColor);
+                  painter.drawLine(lastPoint, {currentPoint.x(), lastPoint.y()});
+                  lastPoint = currentPoint;
+            }
+            painter.fillRect(lastPoint.x(), bottomPos, (rightPos - lastPoint.x()) + 1, lastPoint.y() - bottomPos, pitchFillColor);
+            painter.drawLine(lastPoint, {rightPos, lastPoint.y()});
+      }
+
+      // draw half step horigontal lines in lighter gray
+      pen.setWidth(0);
+      pen.setColor(pitchLinesColor);
+      painter.setPen(pen);
+      for (int i = 1; i < m_pitchDelta; ++i) {
+            qreal yPos = topPos + (static_cast<qreal>(i) / pitchDelta) * graphHeight;
+            painter.drawLine(leftPos, yPos, rightPos, yPos);
+            }
 
       // draw time-warped vertical lines in lighter gray
-      pen.setColor(secondaryLinesColor);
+      pen.setWidth(0);
+      pen.setColor(eventLinesColor);
       painter.setPen(pen);
       for (int i = 1; i < m_nEvents; ++i) {
             qreal xPos = leftPos + eio.XfromY(static_cast<qreal>(i) / nbEvents) * graphWidth;
             painter.drawLine(xPos, topPos, xPos, bottomPos);
-            }
+      }
 
-      // this lambda takes as input a pitch value, and determines where what are its x and y coordinates
-      auto getPosition = [this, graphWidth, graphHeight, leftPos, bottomPos] (const QPointF& p) -> QPointF {
-            return {leftPos + p.x() * graphWidth, bottomPos - p.y() * graphHeight };
-            };
-
-      pen = painter.pen();
+      // Draw the Bezier transfer curve
       pen.setWidth(2);
-      pen.setColor(Qt::red); // not theme dependant
+      pen.setColor(warpLineColor);
       painter.setPen(pen);
-      // draw line between points
       QPointF lastPoint = getPosition({0.0, 0.0});
       for (int i = 1; i <= 33; i++) {
             QPointF currentPoint = getPosition(eio.Eval(static_cast<qreal>(i) / 33.0));
@@ -96,7 +143,7 @@ void EaseInOutCanvas::paintEvent(QPaintEvent* ev)
             }
 
       // draw the graph frame after the other lines to cover them
-      pen.setColor(primaryLinesColor);
+      pen.setColor(borderLinesColor);
       pen.setWidth(1);
       painter.setPen(pen);
       painter.drawRect(border, border, w - 2 * border, h - 2 * border);

--- a/mscore/easeinoutcanvas.h
+++ b/mscore/easeinoutcanvas.h
@@ -33,6 +33,7 @@ class EaseInOutCanvas : public QFrame {
       int m_easeOut;
       int m_nEvents;
       int m_pitchDelta;
+      int m_bottomPitch;
       std::vector<int> m_events;
 
       virtual void paintEvent(QPaintEvent*) override;
@@ -49,6 +50,8 @@ class EaseInOutCanvas : public QFrame {
       void setPitchDelta(int pitchDelta)              { m_pitchDelta = pitchDelta; }
       const std::vector<int>& Events() const          { return m_events; }
       void setEvents(const std::vector<int>& events)  { m_events = events; }
+      int bottomPitch() const                         { return m_bottomPitch; }
+      void setBottomPitch(int bottomPitch)            { m_bottomPitch = bottomPitch; }
 
    signals:
       void canvasChanged();

--- a/mscore/easeinoutcanvas.h
+++ b/mscore/easeinoutcanvas.h
@@ -31,7 +31,6 @@ class EaseInOutCanvas : public QFrame {
 
       int m_easeIn;
       int m_easeOut;
-      int m_nEvents;
       int m_pitchDelta;
       int m_bottomPitch;
       std::vector<int> m_events;
@@ -43,9 +42,6 @@ class EaseInOutCanvas : public QFrame {
 
       void setEaseInOut(const int easeIn, const int easeOut) { m_easeIn = easeIn; m_easeOut = easeOut; }
 
-      /// number of lines to draw vertically
-      int NbEvents() const                            { return m_nEvents;    }
-      void setNbEvents(int nEvents)                   { m_nEvents = nEvents; }
       int pitchDelta() const                          { return m_pitchDelta; }
       void setPitchDelta(int pitchDelta)              { m_pitchDelta = pitchDelta; }
       const std::vector<int>& Events() const          { return m_events; }

--- a/mscore/easeinoutcanvas.h
+++ b/mscore/easeinoutcanvas.h
@@ -1,0 +1,53 @@
+//=============================================================================
+//  MusE Score
+//  Linux Music Score Editor
+//
+//  Copyright (C) 2010 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef __EASEINOUTCANVAS_H__
+#define __EASEINOUTCANVAS_H__
+
+namespace Ms {
+
+//---------------------------------------------------------
+//   EaseInOutCanvas
+//---------------------------------------------------------
+
+class EaseInOutCanvas : public QFrame {
+      Q_OBJECT
+
+      int m_easeIn;
+      int m_easeOut;
+      int m_nEvents;
+
+      virtual void paintEvent(QPaintEvent*) override;
+
+   public:
+      EaseInOutCanvas(QWidget* parent = nullptr);
+
+      void setEaseInOut(const int easeIn, const int easeOut) { m_easeIn = easeIn; m_easeOut = easeOut; }
+
+      /// number of lines to draw vertically
+      int Events() const             { return m_nEvents;    }
+      void setEvents(int nEvents)    { m_nEvents = nEvents; }
+
+   signals:
+      void canvasChanged();
+      };
+
+} // namespace Ms
+#endif
+

--- a/mscore/easeinoutcanvas.h
+++ b/mscore/easeinoutcanvas.h
@@ -32,6 +32,8 @@ class EaseInOutCanvas : public QFrame {
       int m_easeIn;
       int m_easeOut;
       int m_nEvents;
+      int m_pitchDelta;
+      std::vector<int> m_events;
 
       virtual void paintEvent(QPaintEvent*) override;
 
@@ -41,8 +43,12 @@ class EaseInOutCanvas : public QFrame {
       void setEaseInOut(const int easeIn, const int easeOut) { m_easeIn = easeIn; m_easeOut = easeOut; }
 
       /// number of lines to draw vertically
-      int Events() const             { return m_nEvents;    }
-      void setEvents(int nEvents)    { m_nEvents = nEvents; }
+      int NbEvents() const                            { return m_nEvents;    }
+      void setNbEvents(int nEvents)                   { m_nEvents = nEvents; }
+      int pitchDelta() const                          { return m_pitchDelta; }
+      void setPitchDelta(int pitchDelta)              { m_pitchDelta = pitchDelta; }
+      const std::vector<int>& Events() const          { return m_events; }
+      void setEvents(const std::vector<int>& events)  { m_events = events; }
 
    signals:
       void canvasChanged();

--- a/mscore/inspector/inspectorGlissando.cpp
+++ b/mscore/inspector/inspectorGlissando.cpp
@@ -88,14 +88,14 @@ void InspectorGlissando::updateEvents() {
       GlissandoSegment* gs = inspector->element()->isGlissandoSegment() ? toGlissandoSegment(inspector->element()) : nullptr;
       std::vector<int> body;
       int nEvents = 25;
-      if (gs && glissandoPitchOffsets(gs->spanner(), body)) {
+      int pitchStart = toNote(gs->spanner()->startElement())->ppitch();
+      int pitchEnd = toNote(gs->spanner()->endElement())->ppitch();
+      if (gs && glissandoPitchOffsets(gs->spanner(), body))
             nEvents = body.size();
-            Note* noteStart = toNote(gs->spanner()->startElement());
-            Note* noteEnd = toNote(gs->spanner()->endElement());
-            g.easeInOutCanvas->setPitchDelta(std::abs(noteEnd->ppitch() - noteStart->ppitch()) + 1);
-      }
-      g.easeInOutCanvas->setEvents(body);
       g.easeInOutCanvas->setNbEvents(nEvents);
+      g.easeInOutCanvas->setBottomPitch(pitchEnd > pitchStart ? pitchStart : pitchEnd);
+      g.easeInOutCanvas->setPitchDelta(std::abs(pitchEnd - pitchStart) + 1);
+      g.easeInOutCanvas->setEvents(body);
 }
 
 }

--- a/mscore/inspector/inspectorGlissando.cpp
+++ b/mscore/inspector/inspectorGlissando.cpp
@@ -62,20 +62,7 @@ void InspectorGlissando::setElement()
       g.easeOutSlider->setSliderPosition(g.easeOutSpin->value());
       g.easeInOutCanvas->setEaseInOut(g.easeInSpin->value(), g.easeOutSpin->value());
 
-      GlissandoSegment* gs = inspector->element()->isGlissandoSegment() ? toGlissandoSegment(inspector->element()) : nullptr;
-      //Glissando* glissando = gs && gs->spanner()->isGlissando() ? toGlissando(gs->spanner()) : nullptr;
-      std::vector<int> body;
-      int nEvents = 25;
-      if (gs && glissandoPitchOffsets(gs->spanner(), &body))
-            nEvents = body.size();
-      //if (glissando && glissando->glissandoStyle() != GlissandoStyle::PORTAMENTO) {
-      //      Note* sn = toNote(glissando->startElement());
-      //      Note* en = toNote(glissando->endElement());
-      //      if (sn && en) {
-      //            nEvents = std::abs(sn->pitch() - en->pitch()) + 1;
-      //      }
-      //}
-      g.easeInOutCanvas->setEvents(nEvents);
+      updateEvents();
 }
 
 //---------------------------------------------------------
@@ -88,7 +75,7 @@ void InspectorGlissando::valueChanged(int n)
       if (iList[n].t == Pid::GLISS_EASEIN || iList[n].t == Pid::GLISS_EASEOUT)
             g.easeInOutCanvas->setEaseInOut(g.easeInSpin->value(), g.easeOutSpin->value());
       else if (iList[n].t == Pid::GLISS_STYLE)
-            updateNbEvents();
+            updateEvents();
       update();
 }
 
@@ -97,13 +84,18 @@ void InspectorGlissando::valueChanged(int n)
 //   For example, all the half notes, only the white notes, only the black notes, etc
 //---------------------------------------------------------
 
-void InspectorGlissando::updateNbEvents() {
+void InspectorGlissando::updateEvents() {
       GlissandoSegment* gs = inspector->element()->isGlissandoSegment() ? toGlissandoSegment(inspector->element()) : nullptr;
       std::vector<int> body;
       int nEvents = 25;
-      if (gs && glissandoPitchOffsets(gs->spanner(), &body))
+      if (gs && glissandoPitchOffsets(gs->spanner(), body)) {
             nEvents = body.size();
-      g.easeInOutCanvas->setEvents(nEvents);
+            Note* noteStart = toNote(gs->spanner()->startElement());
+            Note* noteEnd = toNote(gs->spanner()->endElement());
+            g.easeInOutCanvas->setPitchDelta(std::abs(noteEnd->ppitch() - noteStart->ppitch()) + 1);
+      }
+      g.easeInOutCanvas->setEvents(body);
+      g.easeInOutCanvas->setNbEvents(nEvents);
 }
 
 }

--- a/mscore/inspector/inspectorGlissando.cpp
+++ b/mscore/inspector/inspectorGlissando.cpp
@@ -42,7 +42,7 @@ InspectorGlissando::InspectorGlissando(QWidget* parent)
             { g.title, g.panel }
             };
       mapSignals(iiList, ppList);
-}
+      }
 
 //---------------------------------------------------------
 //   setElement
@@ -63,7 +63,7 @@ void InspectorGlissando::setElement()
       g.easeInOutCanvas->setEaseInOut(g.easeInSpin->value(), g.easeOutSpin->value());
 
       updateEvents();
-}
+      }
 
 //---------------------------------------------------------
 //   canvasChanged
@@ -77,7 +77,7 @@ void InspectorGlissando::valueChanged(int n)
       else if (iList[n].t == Pid::GLISS_STYLE)
             updateEvents();
       update();
-}
+      }
 
 //---------------------------------------------------------
 //   updateNbEvents computes the number of pitch events in the glissanso given the glissando style.
@@ -95,7 +95,7 @@ void InspectorGlissando::updateEvents() {
             g.easeInOutCanvas->setPitchDelta(pitchEnd - pitchStart);
             }
       g.easeInOutCanvas->setEvents(body);
-}
+      }
 
 }
 

--- a/mscore/inspector/inspectorGlissando.cpp
+++ b/mscore/inspector/inspectorGlissando.cpp
@@ -87,14 +87,13 @@ void InspectorGlissando::valueChanged(int n)
 void InspectorGlissando::updateEvents() {
       GlissandoSegment* gs = inspector->element()->isGlissandoSegment() ? toGlissandoSegment(inspector->element()) : nullptr;
       std::vector<int> body;
-      int nEvents = 25;
-      int pitchStart = toNote(gs->spanner()->startElement())->ppitch();
-      int pitchEnd = toNote(gs->spanner()->endElement())->ppitch();
-      if (gs && glissandoPitchOffsets(gs->spanner(), body))
-            nEvents = body.size();
-      g.easeInOutCanvas->setNbEvents(nEvents);
-      g.easeInOutCanvas->setBottomPitch(pitchEnd > pitchStart ? pitchStart : pitchEnd);
-      g.easeInOutCanvas->setPitchDelta(std::abs(pitchEnd - pitchStart) + 1);
+      if (gs) {
+            int pitchStart = toNote(gs->spanner()->startElement())->ppitch();
+            int pitchEnd = toNote(gs->spanner()->endElement())->ppitch();
+            glissandoPitchOffsets(gs->spanner(), body);
+            g.easeInOutCanvas->setBottomPitch(pitchEnd > pitchStart ? pitchStart : pitchEnd);
+            g.easeInOutCanvas->setPitchDelta(pitchEnd - pitchStart);
+            }
       g.easeInOutCanvas->setEvents(body);
 }
 

--- a/mscore/inspector/inspectorGlissando.h
+++ b/mscore/inspector/inspectorGlissando.h
@@ -30,10 +30,10 @@ class InspectorGlissando : public InspectorElementBase {
 
       void updateEvents();
 
-private slots:
+   private slots:
       void valueChanged(int);
 
-public:
+   public:
       InspectorGlissando(QWidget* parent);
       virtual void setElement() override;
       };

--- a/mscore/inspector/inspectorGlissando.h
+++ b/mscore/inspector/inspectorGlissando.h
@@ -28,7 +28,12 @@ class InspectorGlissando : public InspectorElementBase {
 
       Ui::InspectorGlissando g;
 
-   public:
+      void updateNbEvents();
+
+private slots:
+      void valueChanged(int);
+
+public:
       InspectorGlissando(QWidget* parent);
       virtual void setElement() override;
       };

--- a/mscore/inspector/inspectorGlissando.h
+++ b/mscore/inspector/inspectorGlissando.h
@@ -28,7 +28,7 @@ class InspectorGlissando : public InspectorElementBase {
 
       Ui::InspectorGlissando g;
 
-      void updateNbEvents();
+      void updateEvents();
 
 private slots:
       void valueChanged(int);

--- a/mscore/inspector/inspector_glissando.ui
+++ b/mscore/inspector/inspector_glissando.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>349</width>
-    <height>253</height>
+    <height>436</height>
    </rect>
   </property>
   <property name="accessibleName">
@@ -489,6 +489,22 @@
            </property>
           </widget>
          </item>
+         <item row="2" column="0" colspan="3">
+          <widget class="Ms::EaseInOutCanvas" name="easeInOutCanvas">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>180</height>
+            </size>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>
@@ -508,6 +524,12 @@
    <class>Ms::FontStyleSelect</class>
    <extends>QWidget</extends>
    <header>inspector/fontStyleSelect.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>Ms::EaseInOutCanvas</class>
+   <extends>QFrame</extends>
+   <header>easeinoutcanvas.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -530,12 +552,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>93</x>
-     <y>267</y>
+     <x>96</x>
+     <y>169</y>
     </hint>
     <hint type="destinationlabel">
-     <x>114</x>
-     <y>291</y>
+     <x>170</x>
+     <y>192</y>
     </hint>
    </hints>
   </connection>
@@ -546,12 +568,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>234</x>
-     <y>267</y>
+     <x>237</x>
+     <y>169</y>
     </hint>
     <hint type="destinationlabel">
-     <x>352</x>
-     <y>296</y>
+     <x>335</x>
+     <y>192</y>
     </hint>
    </hints>
   </connection>
@@ -562,12 +584,12 @@
    <slot>setVisible(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>45</x>
-     <y>156</y>
+     <x>48</x>
+     <y>64</y>
     </hint>
     <hint type="destinationlabel">
-     <x>41</x>
-     <y>168</y>
+     <x>44</x>
+     <y>149</y>
     </hint>
    </hints>
   </connection>
@@ -582,8 +604,8 @@
      <y>204</y>
     </hint>
     <hint type="destinationlabel">
-     <x>207</x>
-     <y>211</y>
+     <x>332</x>
+     <y>216</y>
     </hint>
    </hints>
   </connection>
@@ -598,8 +620,8 @@
      <y>231</y>
     </hint>
     <hint type="destinationlabel">
-     <x>208</x>
-     <y>234</y>
+     <x>332</x>
+     <y>241</y>
     </hint>
    </hints>
   </connection>
@@ -610,8 +632,8 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>272</x>
-     <y>205</y>
+     <x>332</x>
+     <y>216</y>
     </hint>
     <hint type="destinationlabel">
      <x>172</x>
@@ -626,12 +648,44 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>284</x>
-     <y>231</y>
+     <x>332</x>
+     <y>241</y>
     </hint>
     <hint type="destinationlabel">
      <x>181</x>
      <y>223</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>easeOutSlider</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>easeOutSpin</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>202</x>
+     <y>231</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>297</x>
+     <y>233</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>easeInSlider</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>easeInSpin</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>200</x>
+     <y>204</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>301</x>
+     <y>204</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
The added pitch warp graph is useful for previewing the effect of adjusting ease-in and ease-out sliders on the timing of pitch events in a glissando.

![Glissando graph](https://user-images.githubusercontent.com/20579591/100373632-11531b80-2fd9-11eb-9ed4-cb74760c3e41.PNG)

Given the start and end note of the glissando and the glissando style, the graph displays each of the glissando style pitch at their proper timing. The timing is warped according to the ease-in and ease-out values. A time warp transfer curve is displayed over the pitch graph and a note scale is displayed in the left side border.

The pitch graph is updated interactively as the ease-in and ease-out sliders are adjusted.

Note that because the first PR have not been merged, the diff currently shows all the changes including the changes that were already code reviewed in [PR #6868](https://github.com/musescore/MuseScore/pull/6868)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made