### PR TITLE
[MU3] Make AutoSize default for new scores but disable it for older scores.

### DIFF
--- a/libmscore/box.cpp
+++ b/libmscore/box.cpp
@@ -224,6 +224,8 @@ void Box::read(XmlReader& e)
       _boxHeight       = Spatium(0);     // override default set in constructor
       _boxWidth        = Spatium(0);
       MeasureBase::read(e);
+      if (score()->mscVersion() < 302)
+            _isAutoSizeEnabled = false; // disable auto-size for older scores by default.
       }
 
 //---------------------------------------------------------
@@ -357,7 +359,7 @@ QVariant Box::getProperty(Pid propertyId) const
             case Pid::BOTTOM_MARGIN:
                   return _bottomMargin;
             case Pid::BOX_AUTOSIZE:
-                  return _isAutoSizeEnabled;
+                  return (score()->mscVersion() >= 302) ? _isAutoSizeEnabled : false;
             default:
                   return MeasureBase::getProperty(propertyId);
             }
@@ -427,7 +429,7 @@ QVariant Box::propertyDefault(Pid id) const
             case Pid::BOTTOM_MARGIN:
                   return 0.0;
             case Pid::BOX_AUTOSIZE:
-                  return false;
+                  return true;
             default:
                   return MeasureBase::propertyDefault(id);
             }
@@ -741,7 +743,6 @@ VBox::VBox(Score* score)
       initElementStyle(&boxStyle);
       setBoxHeight(Spatium(10.0));
       setLineBreak(true);
-      setAutoSizeEnabled(score->mscVersion() >= 302); // enable auto-size feature only for newest scores by default
       }
 
 qreal VBox::minHeight() const

--- a/libmscore/box.h
+++ b/libmscore/box.h
@@ -41,7 +41,7 @@ class Box : public MeasureBase {
       qreal _rightMargin            { 0.0   };       // inner margins in metric mm
       qreal _topMargin              { 0.0   };
       qreal _bottomMargin           { 0.0   };
-      bool _isAutoSizeEnabled       { false };
+      bool _isAutoSizeEnabled       { true  };
       bool editMode                 { false };
 
    public:

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -2270,6 +2270,7 @@ static void readBox(XmlReader& e, Box* b)
       b->setBottomMargin(0.0);
       b->setBoxHeight(Spatium(0));     // override default set in constructor
       b->setBoxWidth(Spatium(0));
+      b->setAutoSizeEnabled(false);
 
       while (e.readNextStartElement()) {
             const QStringRef& tag(e.name());

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -3467,6 +3467,7 @@ static void readBox(Box* b, XmlReader& e)
       b->setBottomMargin(0.0);
       b->setTopGap(0.0);
       b->setBottomGap(0.0);
+      b->setAutoSizeEnabled(false);
       b->setPropertyFlags(Pid::TOP_GAP, PropertyFlags::UNSTYLED);
       b->setPropertyFlags(Pid::BOTTOM_GAP, PropertyFlags::UNSTYLED);
 

--- a/mtest/biab/chords-ref.mscx
+++ b/mtest/biab/chords-ref.mscx
@@ -39,7 +39,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Chord Test1</text>

--- a/mtest/capella/io/test1.cap-ref.mscx
+++ b/mtest/capella/io/test1.cap-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>4</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/capella/io/test1.capx-ref.mscx
+++ b/mtest/capella/io/test1.capx-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>14</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/capella/io/test2.cap-ref.mscx
+++ b/mtest/capella/io/test2.cap-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>4</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/capella/io/test2.capx-ref.mscx
+++ b/mtest/capella/io/test2.capx-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>14</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/capella/io/test3.cap-ref.mscx
+++ b/mtest/capella/io/test3.cap-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>4</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/capella/io/test3.capx-ref.mscx
+++ b/mtest/capella/io/test3.capx-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>14</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/capella/io/test4.cap-ref.mscx
+++ b/mtest/capella/io/test4.cap-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>4</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/capella/io/test4.capx-ref.mscx
+++ b/mtest/capella/io/test4.capx-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>14</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/capella/io/test5.cap-ref.mscx
+++ b/mtest/capella/io/test5.cap-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>4</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/capella/io/test5.capx-ref.mscx
+++ b/mtest/capella/io/test5.capx-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>14</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/capella/io/test6.cap-ref.mscx
+++ b/mtest/capella/io/test6.cap-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>4</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/capella/io/test6.capx-ref.mscx
+++ b/mtest/capella/io/test6.capx-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>14</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/capella/io/test7.cap-ref.mscx
+++ b/mtest/capella/io/test7.cap-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>4</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/capella/io/test7.capx-ref.mscx
+++ b/mtest/capella/io/test7.capx-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>14</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <LayoutBreak>

--- a/mtest/capella/io/test8.cap-ref.mscx
+++ b/mtest/capella/io/test8.cap-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>4</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/capella/io/testBarline.capx-ref.mscx
+++ b/mtest/capella/io/testBarline.capx-ref.mscx
@@ -46,7 +46,6 @@
     <Staff id="1">
       <VBox>
         <height>5</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure len="4/4">
         <voice>

--- a/mtest/capella/io/testEmptyStaff1.capx-ref.mscx
+++ b/mtest/capella/io/testEmptyStaff1.capx-ref.mscx
@@ -59,7 +59,6 @@
     <Staff id="1">
       <VBox>
         <height>14</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <LayoutBreak>

--- a/mtest/capella/io/testEmptyStaff2.capx-ref.mscx
+++ b/mtest/capella/io/testEmptyStaff2.capx-ref.mscx
@@ -59,7 +59,6 @@
     <Staff id="1">
       <VBox>
         <height>14</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <LayoutBreak>

--- a/mtest/capella/io/testPianoG4G5.capx-ref.mscx
+++ b/mtest/capella/io/testPianoG4G5.capx-ref.mscx
@@ -59,7 +59,6 @@
     <Staff id="1">
       <VBox>
         <height>14</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <LayoutBreak>

--- a/mtest/capella/io/testScaleC4C5.capx-ref.mscx
+++ b/mtest/capella/io/testScaleC4C5.capx-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>14</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/capella/io/testSlurTie.capx-ref.mscx
+++ b/mtest/capella/io/testSlurTie.capx-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>14</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <LayoutBreak>

--- a/mtest/capella/io/testText1.capx-ref.mscx
+++ b/mtest/capella/io/testText1.capx-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>14</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure len="2/4">
         <voice>

--- a/mtest/capella/io/testTuplet1.capx-ref.mscx
+++ b/mtest/capella/io/testTuplet1.capx-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>14</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/capella/io/testTuplet2.cap-ref.mscx
+++ b/mtest/capella/io/testTuplet2.cap-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>4</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <LayoutBreak>

--- a/mtest/capella/io/testTuplet2.capx-ref.mscx
+++ b/mtest/capella/io/testTuplet2.capx-ref.mscx
@@ -45,7 +45,6 @@
     <Staff id="1">
       <VBox>
         <height>4</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <LayoutBreak>

--- a/mtest/capella/io/testVolta1.capx-ref.mscx
+++ b/mtest/capella/io/testVolta1.capx-ref.mscx
@@ -47,7 +47,6 @@
     <Staff id="1">
       <VBox>
         <height>14</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/guitarpro/UncompletedMeasure.gpx-ref.mscx
+++ b/mtest/guitarpro/UncompletedMeasure.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -268,7 +267,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/accent.gp-ref.mscx
+++ b/mtest/guitarpro/accent.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -199,7 +198,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/accent.gpx-ref.mscx
+++ b/mtest/guitarpro/accent.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -297,7 +296,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/arpeggio.gp-ref.mscx
+++ b/mtest/guitarpro/arpeggio.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -213,7 +212,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/arpeggio.gpx-ref.mscx
+++ b/mtest/guitarpro/arpeggio.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -311,7 +310,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/artificial-harmonic.gp-ref.mscx
+++ b/mtest/guitarpro/artificial-harmonic.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -243,7 +242,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/artificial-harmonic.gpx-ref.mscx
+++ b/mtest/guitarpro/artificial-harmonic.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -440,7 +439,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/basic-bend.gp-ref.mscx
+++ b/mtest/guitarpro/basic-bend.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -202,7 +201,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/basic-bend.gp5-ref.mscx
+++ b/mtest/guitarpro/basic-bend.gp5-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -180,7 +179,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/basic-bend.gpx-ref.mscx
+++ b/mtest/guitarpro/basic-bend.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -299,7 +298,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/brush.gp-ref.mscx
+++ b/mtest/guitarpro/brush.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -213,7 +212,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/brush.gp4-ref.mscx
+++ b/mtest/guitarpro/brush.gp4-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -215,7 +214,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/brush.gp5-ref.mscx
+++ b/mtest/guitarpro/brush.gp5-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -210,7 +209,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/brush.gpx-ref.mscx
+++ b/mtest/guitarpro/brush.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -311,7 +310,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/capo-fret.gp3-ref.mscx
+++ b/mtest/guitarpro/capo-fret.gp3-ref.mscx
@@ -55,7 +55,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -221,7 +220,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/capo-fret.gp4-ref.mscx
+++ b/mtest/guitarpro/capo-fret.gp4-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -221,7 +220,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/capo-fret.gp5-ref.mscx
+++ b/mtest/guitarpro/capo-fret.gp5-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -221,7 +220,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/clefs.gp-ref.mscx
+++ b/mtest/guitarpro/clefs.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -280,7 +279,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/clefs.gpx-ref.mscx
+++ b/mtest/guitarpro/clefs.gpx-ref.mscx
@@ -90,7 +90,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -317,7 +316,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/copyright.gp-ref.mscx
+++ b/mtest/guitarpro/copyright.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -176,7 +175,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/copyright.gp3-ref.mscx
+++ b/mtest/guitarpro/copyright.gp3-ref.mscx
@@ -55,7 +55,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -168,7 +167,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/copyright.gp4-ref.mscx
+++ b/mtest/guitarpro/copyright.gp4-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -178,7 +177,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/copyright.gp5-ref.mscx
+++ b/mtest/guitarpro/copyright.gp5-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -168,7 +167,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/copyright.gpx-ref.mscx
+++ b/mtest/guitarpro/copyright.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -293,7 +292,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/crescendo-diminuendo.gp-ref.mscx
+++ b/mtest/guitarpro/crescendo-diminuendo.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -257,7 +256,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/crescendo-diminuendo.gpx-ref.mscx
+++ b/mtest/guitarpro/crescendo-diminuendo.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -355,7 +354,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/dead-note.gp-ref.mscx
+++ b/mtest/guitarpro/dead-note.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -197,7 +196,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/dead-note.gpx-ref.mscx
+++ b/mtest/guitarpro/dead-note.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -295,7 +294,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/dotted-gliss.gp-ref.mscx
+++ b/mtest/guitarpro/dotted-gliss.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -237,7 +236,6 @@ Innuendo</text>
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/dotted-gliss.gp3-ref.mscx
+++ b/mtest/guitarpro/dotted-gliss.gp3-ref.mscx
@@ -55,7 +55,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -239,7 +238,6 @@ Innuendo</text>
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/dotted-gliss.gpx-ref.mscx
+++ b/mtest/guitarpro/dotted-gliss.gpx-ref.mscx
@@ -103,7 +103,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -337,7 +336,6 @@ Innuendo</text>
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/dotted-tuplets.gp-ref.mscx
+++ b/mtest/guitarpro/dotted-tuplets.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -257,7 +256,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/dotted-tuplets.gp5-ref.mscx
+++ b/mtest/guitarpro/dotted-tuplets.gp5-ref.mscx
@@ -55,7 +55,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -238,7 +237,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/dotted-tuplets.gpx-ref.mscx
+++ b/mtest/guitarpro/dotted-tuplets.gpx-ref.mscx
@@ -103,7 +103,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -357,7 +356,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/double-bar.gp-ref.mscx
+++ b/mtest/guitarpro/double-bar.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -225,7 +224,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/double-bar.gpx-ref.mscx
+++ b/mtest/guitarpro/double-bar.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -323,7 +322,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/dynamic.gp-ref.mscx
+++ b/mtest/guitarpro/dynamic.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -314,7 +313,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/dynamic.gp5-ref.mscx
+++ b/mtest/guitarpro/dynamic.gp5-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -280,7 +279,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/dynamic.gpx-ref.mscx
+++ b/mtest/guitarpro/dynamic.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -412,7 +411,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/fade-in.gp-ref.mscx
+++ b/mtest/guitarpro/fade-in.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -179,7 +178,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/fade-in.gp4-ref.mscx
+++ b/mtest/guitarpro/fade-in.gp4-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -181,7 +180,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/fade-in.gp5-ref.mscx
+++ b/mtest/guitarpro/fade-in.gp5-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -194,7 +193,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/fade-in.gpx-ref.mscx
+++ b/mtest/guitarpro/fade-in.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -295,7 +294,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/fingering.gp-ref.mscx
+++ b/mtest/guitarpro/fingering.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -340,7 +339,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/fingering.gp4-ref.mscx
+++ b/mtest/guitarpro/fingering.gp4-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -331,7 +330,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/fingering.gp5-ref.mscx
+++ b/mtest/guitarpro/fingering.gp5-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -331,7 +330,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/fingering.gpx-ref.mscx
+++ b/mtest/guitarpro/fingering.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -438,7 +437,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/free-time.gp-ref.mscx
+++ b/mtest/guitarpro/free-time.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -231,7 +230,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/free-time.gpx-ref.mscx
+++ b/mtest/guitarpro/free-time.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -329,7 +328,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/ghost_note.gp3-ref.mscx
+++ b/mtest/guitarpro/ghost_note.gp3-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -261,7 +260,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/grace.gp5-ref.mscx
+++ b/mtest/guitarpro/grace.gp5-ref.mscx
@@ -55,7 +55,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -368,7 +367,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/heavy-accent.gp-ref.mscx
+++ b/mtest/guitarpro/heavy-accent.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -196,7 +195,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/heavy-accent.gp5-ref.mscx
+++ b/mtest/guitarpro/heavy-accent.gp5-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -175,7 +174,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/heavy-accent.gpx-ref.mscx
+++ b/mtest/guitarpro/heavy-accent.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -294,7 +293,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/high-pitch.gp-ref.mscx
+++ b/mtest/guitarpro/high-pitch.gp-ref.mscx
@@ -51,7 +51,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -324,7 +323,6 @@ Puki Kuki</text>
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/high-pitch.gp3-ref.mscx
+++ b/mtest/guitarpro/high-pitch.gp3-ref.mscx
@@ -54,7 +54,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -326,7 +325,6 @@ Puki Kuki</text>
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/high-pitch.gpx-ref.mscx
+++ b/mtest/guitarpro/high-pitch.gpx-ref.mscx
@@ -111,7 +111,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -438,7 +437,6 @@ Puki Kuki</text>
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/keysig.gp-ref.mscx
+++ b/mtest/guitarpro/keysig.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -1989,7 +1988,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/keysig.gp4-ref.mscx
+++ b/mtest/guitarpro/keysig.gp4-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -1991,7 +1990,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/keysig.gp5-ref.mscx
+++ b/mtest/guitarpro/keysig.gp5-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -1991,7 +1990,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/keysig.gpx-ref.mscx
+++ b/mtest/guitarpro/keysig.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -2087,7 +2086,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/let-ring.gp-ref.mscx
+++ b/mtest/guitarpro/let-ring.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -212,7 +211,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/let-ring.gp4-ref.mscx
+++ b/mtest/guitarpro/let-ring.gp4-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -214,7 +213,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/let-ring.gp5-ref.mscx
+++ b/mtest/guitarpro/let-ring.gp5-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -209,7 +208,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/let-ring.gpx-ref.mscx
+++ b/mtest/guitarpro/let-ring.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -310,7 +309,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/mordents.gp-ref.mscx
+++ b/mtest/guitarpro/mordents.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -203,7 +202,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/mordents.gpx-ref.mscx
+++ b/mtest/guitarpro/mordents.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -301,7 +300,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/multivoices.gp-ref.mscx
+++ b/mtest/guitarpro/multivoices.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -371,7 +370,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/multivoices.gpx-ref.mscx
+++ b/mtest/guitarpro/multivoices.gpx-ref.mscx
@@ -104,7 +104,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -475,7 +474,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/ottava1.gp-ref.mscx
+++ b/mtest/guitarpro/ottava1.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -351,7 +350,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/ottava1.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava1.gpx-ref.mscx
@@ -104,7 +104,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -455,7 +454,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/ottava2.gp-ref.mscx
+++ b/mtest/guitarpro/ottava2.gp-ref.mscx
@@ -82,7 +82,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -484,7 +483,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -882,7 +880,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/guitarpro/ottava2.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava2.gpx-ref.mscx
@@ -179,7 +179,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -633,7 +632,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1080,7 +1078,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/guitarpro/ottava3.gp-ref.mscx
+++ b/mtest/guitarpro/ottava3.gp-ref.mscx
@@ -82,7 +82,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -248,7 +247,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -402,7 +400,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/guitarpro/ottava3.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava3.gpx-ref.mscx
@@ -179,7 +179,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -397,7 +396,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -600,7 +598,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/guitarpro/ottava4.gp-ref.mscx
+++ b/mtest/guitarpro/ottava4.gp-ref.mscx
@@ -82,7 +82,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -518,7 +517,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -916,7 +914,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/guitarpro/ottava4.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava4.gpx-ref.mscx
@@ -179,7 +179,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -667,7 +666,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1114,7 +1112,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/guitarpro/ottava5.gp-ref.mscx
+++ b/mtest/guitarpro/ottava5.gp-ref.mscx
@@ -82,7 +82,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -347,7 +346,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -561,7 +559,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/guitarpro/ottava5.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava5.gpx-ref.mscx
@@ -179,7 +179,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -496,7 +495,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -759,7 +757,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/guitarpro/palm-mute.gp-ref.mscx
+++ b/mtest/guitarpro/palm-mute.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -212,7 +211,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/palm-mute.gp4-ref.mscx
+++ b/mtest/guitarpro/palm-mute.gp4-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -214,7 +213,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/palm-mute.gp5-ref.mscx
+++ b/mtest/guitarpro/palm-mute.gp5-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -209,7 +208,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/palm-mute.gpx-ref.mscx
+++ b/mtest/guitarpro/palm-mute.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -310,7 +309,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/pick-up-down.gp-ref.mscx
+++ b/mtest/guitarpro/pick-up-down.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -203,7 +202,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/pick-up-down.gp4-ref.mscx
+++ b/mtest/guitarpro/pick-up-down.gp4-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -205,7 +204,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/pick-up-down.gp5-ref.mscx
+++ b/mtest/guitarpro/pick-up-down.gp5-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -200,7 +199,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/pick-up-down.gpx-ref.mscx
+++ b/mtest/guitarpro/pick-up-down.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -301,7 +300,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/repeated-bars.gp-ref.mscx
+++ b/mtest/guitarpro/repeated-bars.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -204,7 +203,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/repeated-bars.gpx-ref.mscx
+++ b/mtest/guitarpro/repeated-bars.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -302,7 +301,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/repeats.gp-ref.mscx
+++ b/mtest/guitarpro/repeats.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -223,7 +222,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/repeats.gpx-ref.mscx
+++ b/mtest/guitarpro/repeats.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -321,7 +320,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/rest-centered.gp-ref.mscx
+++ b/mtest/guitarpro/rest-centered.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -180,7 +179,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/rest-centered.gp4-ref.mscx
+++ b/mtest/guitarpro/rest-centered.gp4-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -182,7 +181,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/rest-centered.gp5-ref.mscx
+++ b/mtest/guitarpro/rest-centered.gp5-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -182,7 +181,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/rest-centered.gpx-ref.mscx
+++ b/mtest/guitarpro/rest-centered.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -278,7 +277,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/sforzato.gp-ref.mscx
+++ b/mtest/guitarpro/sforzato.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -187,7 +186,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/sforzato.gp4-ref.mscx
+++ b/mtest/guitarpro/sforzato.gp4-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -189,7 +188,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/sforzato.gpx-ref.mscx
+++ b/mtest/guitarpro/sforzato.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -285,7 +284,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/shift-slide.gp4-ref.mscx
+++ b/mtest/guitarpro/shift-slide.gp4-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -208,7 +207,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/slide-in-above.gp4-ref.mscx
+++ b/mtest/guitarpro/slide-in-above.gp4-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -217,7 +216,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/slur-notes-effect-mask.gp5-ref.mscx
+++ b/mtest/guitarpro/slur-notes-effect-mask.gp5-ref.mscx
@@ -51,7 +51,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -363,7 +362,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/slur.gp-ref.mscx
+++ b/mtest/guitarpro/slur.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -234,7 +233,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/slur.gp4-ref.mscx
+++ b/mtest/guitarpro/slur.gp4-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -200,7 +199,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/slur.gpx-ref.mscx
+++ b/mtest/guitarpro/slur.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -315,7 +314,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/slur_hammer_slur.gp-ref.mscx
+++ b/mtest/guitarpro/slur_hammer_slur.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -238,7 +237,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/slur_hammer_slur.gpx-ref.mscx
+++ b/mtest/guitarpro/slur_hammer_slur.gpx-ref.mscx
@@ -104,7 +104,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -342,7 +341,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/slur_over_3_measures.gp-ref.mscx
+++ b/mtest/guitarpro/slur_over_3_measures.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -275,7 +274,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/slur_over_3_measures.gpx-ref.mscx
+++ b/mtest/guitarpro/slur_over_3_measures.gpx-ref.mscx
@@ -104,7 +104,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -379,7 +378,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/slur_slur_hammer.gp-ref.mscx
+++ b/mtest/guitarpro/slur_slur_hammer.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -270,7 +269,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/slur_slur_hammer.gpx-ref.mscx
+++ b/mtest/guitarpro/slur_slur_hammer.gpx-ref.mscx
@@ -104,7 +104,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -374,7 +373,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/slur_voices.gp-ref.mscx
+++ b/mtest/guitarpro/slur_voices.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -866,7 +865,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/slur_voices.gpx-ref.mscx
+++ b/mtest/guitarpro/slur_voices.gpx-ref.mscx
@@ -104,7 +104,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -970,7 +969,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/tap-slap-pop.gp-ref.mscx
+++ b/mtest/guitarpro/tap-slap-pop.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -200,7 +199,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/tap-slap-pop.gp5-ref.mscx
+++ b/mtest/guitarpro/tap-slap-pop.gp5-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -197,7 +196,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/tap-slap-pop.gpx-ref.mscx
+++ b/mtest/guitarpro/tap-slap-pop.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -298,7 +297,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/tempo.gp-ref.mscx
+++ b/mtest/guitarpro/tempo.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -305,7 +304,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/tempo.gp3-ref.mscx
+++ b/mtest/guitarpro/tempo.gp3-ref.mscx
@@ -55,7 +55,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -302,7 +301,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/tempo.gp4-ref.mscx
+++ b/mtest/guitarpro/tempo.gp4-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -307,7 +306,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/tempo.gp5-ref.mscx
+++ b/mtest/guitarpro/tempo.gp5-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -302,7 +301,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/tempo.gpx-ref.mscx
+++ b/mtest/guitarpro/tempo.gpx-ref.mscx
@@ -104,7 +104,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -409,7 +408,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/testIrrTuplet.gp-ref.mscx
+++ b/mtest/guitarpro/testIrrTuplet.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -231,7 +230,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/testIrrTuplet.gp4-ref.mscx
+++ b/mtest/guitarpro/testIrrTuplet.gp4-ref.mscx
@@ -55,7 +55,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -255,7 +254,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/testIrrTuplet.gpx-ref.mscx
+++ b/mtest/guitarpro/testIrrTuplet.gpx-ref.mscx
@@ -103,7 +103,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -331,7 +330,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/text.gp-ref.mscx
+++ b/mtest/guitarpro/text.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -199,7 +198,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/text.gpx-ref.mscx
+++ b/mtest/guitarpro/text.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -297,7 +296,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/tremolos.gp-ref.mscx
+++ b/mtest/guitarpro/tremolos.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -207,7 +206,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/tremolos.gp5-ref.mscx
+++ b/mtest/guitarpro/tremolos.gp5-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -186,7 +185,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/tremolos.gpx-ref.mscx
+++ b/mtest/guitarpro/tremolos.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -305,7 +304,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/trill.gp-ref.mscx
+++ b/mtest/guitarpro/trill.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -205,7 +204,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/trill.gp4-ref.mscx
+++ b/mtest/guitarpro/trill.gp4-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -180,7 +179,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/trill.gpx-ref.mscx
+++ b/mtest/guitarpro/trill.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -303,7 +302,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/tuplets.gpx-ref.mscx
+++ b/mtest/guitarpro/tuplets.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -648,7 +647,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/tuplets2.gpx-ref.mscx
+++ b/mtest/guitarpro/tuplets2.gpx-ref.mscx
@@ -104,7 +104,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -848,7 +847,6 @@ solo concert</text>
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/turn.gp-ref.mscx
+++ b/mtest/guitarpro/turn.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -203,7 +202,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/turn.gpx-ref.mscx
+++ b/mtest/guitarpro/turn.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -301,7 +300,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/vibrato.gp-ref.mscx
+++ b/mtest/guitarpro/vibrato.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -327,7 +326,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/vibrato.gp5-ref.mscx
+++ b/mtest/guitarpro/vibrato.gp5-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -247,7 +246,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/vibrato.gpx-ref.mscx
+++ b/mtest/guitarpro/vibrato.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -425,7 +424,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/volta.gp3-ref.mscx
+++ b/mtest/guitarpro/volta.gp3-ref.mscx
@@ -55,7 +55,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -942,7 +941,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/volta.gp4-ref.mscx
+++ b/mtest/guitarpro/volta.gp4-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -783,7 +782,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/volta.gp5-ref.mscx
+++ b/mtest/guitarpro/volta.gp5-ref.mscx
@@ -53,7 +53,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -1283,7 +1282,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/volume-swell.gp-ref.mscx
+++ b/mtest/guitarpro/volume-swell.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -197,7 +196,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/volume-swell.gpx-ref.mscx
+++ b/mtest/guitarpro/volume-swell.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -295,7 +294,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/wah.gp-ref.mscx
+++ b/mtest/guitarpro/wah.gp-ref.mscx
@@ -52,7 +52,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -203,7 +202,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/guitarpro/wah.gpx-ref.mscx
+++ b/mtest/guitarpro/wah.gpx-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -301,7 +300,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/libmscore/beam/Beam-2.mscx
+++ b/mtest/libmscore/beam/Beam-2.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>bt</text>

--- a/mtest/libmscore/beam/Beam-23.mscx
+++ b/mtest/libmscore/beam/Beam-23.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Beam-Test</text>

--- a/mtest/libmscore/beam/Beam-A.mscx
+++ b/mtest/libmscore/beam/Beam-A.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Subtitle</style>
           <text>Slant + Stem len</text>

--- a/mtest/libmscore/beam/Beam-B.mscx
+++ b/mtest/libmscore/beam/Beam-B.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Subtitle</style>
           <text>Slant + Stem len</text>

--- a/mtest/libmscore/beam/Beam-C.mscx
+++ b/mtest/libmscore/beam/Beam-C.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Subtitle</style>
           <text>Slant + Stem len</text>

--- a/mtest/libmscore/beam/Beam-CrossM2.mscx
+++ b/mtest/libmscore/beam/Beam-CrossM2.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Subtitle</style>
           <text>Quarter note</text>

--- a/mtest/libmscore/beam/Beam-CrossM3.mscx
+++ b/mtest/libmscore/beam/Beam-CrossM3.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Subtitle</style>
           <text>Quarter note</text>

--- a/mtest/libmscore/beam/Beam-CrossM4.mscx
+++ b/mtest/libmscore/beam/Beam-CrossM4.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Subtitle</style>
           <text>Quarter note</text>

--- a/mtest/libmscore/beam/Beam-D.mscx
+++ b/mtest/libmscore/beam/Beam-D.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Subtitle</style>
           <text>Slant + Stem len</text>

--- a/mtest/libmscore/beam/Beam-E.mscx
+++ b/mtest/libmscore/beam/Beam-E.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Subtitle</style>
           <text>Slant + Stem len</text>

--- a/mtest/libmscore/beam/Beam-F.mscx
+++ b/mtest/libmscore/beam/Beam-F.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Subtitle</style>
           <text>Slant + Stem len</text>

--- a/mtest/libmscore/beam/Beam-G.mscx
+++ b/mtest/libmscore/beam/Beam-G.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Subtitle</style>
           <text>Slant + Stem len</text>

--- a/mtest/libmscore/beam/Beam-S0.mscx
+++ b/mtest/libmscore/beam/Beam-S0.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Beam-Test</text>

--- a/mtest/libmscore/beam/Beam-dir.mscx
+++ b/mtest/libmscore/beam/Beam-dir.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Beam-Test</text>

--- a/mtest/libmscore/box/undoRemoveVBox2-ref.mscx
+++ b/mtest/libmscore/box/undoRemoveVBox2-ref.mscx
@@ -86,7 +86,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>VBox</text>

--- a/mtest/libmscore/chordsymbol/add-part-ref.mscx
+++ b/mtest/libmscore/chordsymbol/add-part-ref.mscx
@@ -169,7 +169,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           </VBox>
         <Measure>
           <voice>

--- a/mtest/libmscore/chordsymbol/no-system-ref.mscx
+++ b/mtest/libmscore/chordsymbol/no-system-ref.mscx
@@ -102,7 +102,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -251,7 +250,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -367,7 +365,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/chordsymbol/realize-concert-pitch-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-concert-pitch-ref.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/libmscore/chordsymbol/realize-duration-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-duration-ref.mscx
@@ -92,7 +92,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/libmscore/chordsymbol/realize-jazz-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-jazz-ref.mscx
@@ -100,7 +100,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/libmscore/chordsymbol/realize-transpose-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-transpose-ref.mscx
@@ -76,7 +76,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/libmscore/chordsymbol/realize-triplet-ref.mscx
+++ b/mtest/libmscore/chordsymbol/realize-triplet-ref.mscx
@@ -92,7 +92,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/libmscore/chordsymbol/transpose-part-ref.mscx
+++ b/mtest/libmscore/chordsymbol/transpose-part-ref.mscx
@@ -76,7 +76,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -190,7 +189,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/libmscore/chordsymbol/transpose-ref.mscx
+++ b/mtest/libmscore/chordsymbol/transpose-ref.mscx
@@ -76,7 +76,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         </VBox>
       <Measure>
         <voice>

--- a/mtest/libmscore/clef/clef-2-ref.mscx
+++ b/mtest/libmscore/clef/clef-2-ref.mscx
@@ -76,7 +76,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>ClefTimeSig</text>

--- a/mtest/libmscore/compat114/clefs-ref.mscx
+++ b/mtest/libmscore/compat114/clefs-ref.mscx
@@ -88,6 +88,7 @@
         <rightMargin>5</rightMargin>
         <topMargin>5</topMargin>
         <bottomMargin>5</bottomMargin>
+        <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>
           <text><font face="Times New Roman"/>Clefs</text>

--- a/mtest/libmscore/compat114/fingering-ref.mscx
+++ b/mtest/libmscore/compat114/fingering-ref.mscx
@@ -97,6 +97,7 @@
         <rightMargin>5</rightMargin>
         <topMargin>5</topMargin>
         <bottomMargin>5</bottomMargin>
+        <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>
           <text><font face="Times New Roman"/>fing</text>

--- a/mtest/libmscore/compat114/hairpin-ref.mscx
+++ b/mtest/libmscore/compat114/hairpin-ref.mscx
@@ -93,6 +93,7 @@
         <rightMargin>5</rightMargin>
         <topMargin>5</topMargin>
         <bottomMargin>5</bottomMargin>
+        <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>
           <text><font face="Times New Roman"/>Hairpin</text>

--- a/mtest/libmscore/compat114/hor_frame_and_mmrest-ref.mscx
+++ b/mtest/libmscore/compat114/hor_frame_and_mmrest-ref.mscx
@@ -88,6 +88,7 @@
         <rightMargin>5</rightMargin>
         <topMargin>5</topMargin>
         <bottomMargin>5</bottomMargin>
+        <boxAutoSize>0</boxAutoSize>
         </HBox>
       <Measure>
         <voice>

--- a/mtest/libmscore/compat114/keysig-ref.mscx
+++ b/mtest/libmscore/compat114/keysig-ref.mscx
@@ -88,6 +88,7 @@
         <rightMargin>5</rightMargin>
         <topMargin>5</topMargin>
         <bottomMargin>5</bottomMargin>
+        <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>
           <text><font face="Times New Roman"/>keysig</text>

--- a/mtest/libmscore/compat114/notes-ref.mscx
+++ b/mtest/libmscore/compat114/notes-ref.mscx
@@ -88,6 +88,7 @@
         <rightMargin>5</rightMargin>
         <topMargin>5</topMargin>
         <bottomMargin>5</bottomMargin>
+        <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>
           <text><font face="Times New Roman"/>notes</text>

--- a/mtest/libmscore/compat114/text_scaling-ref.mscx
+++ b/mtest/libmscore/compat114/text_scaling-ref.mscx
@@ -93,6 +93,7 @@
         <rightMargin>5</rightMargin>
         <topMargin>5</topMargin>
         <bottomMargin>5</bottomMargin>
+        <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>
           <text><font face="Times New Roman"/>Title</text>

--- a/mtest/libmscore/compat114/textstyles-ref.mscx
+++ b/mtest/libmscore/compat114/textstyles-ref.mscx
@@ -1672,6 +1672,7 @@
         <rightMargin>5</rightMargin>
         <topMargin>5</topMargin>
         <bottomMargin>5</bottomMargin>
+        <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>
           <text><font size="28"/><font face="MuseJazz"/><b>Title</b></text>

--- a/mtest/libmscore/compat114/title-ref.mscx
+++ b/mtest/libmscore/compat114/title-ref.mscx
@@ -93,6 +93,7 @@
         <rightMargin>5</rightMargin>
         <topMargin>5</topMargin>
         <bottomMargin>5</bottomMargin>
+        <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>
           <text><font face="Times New Roman"/>title</text>

--- a/mtest/libmscore/compat114/tuplets-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets-ref.mscx
@@ -86,6 +86,7 @@
         <rightMargin>5</rightMargin>
         <topMargin>5</topMargin>
         <bottomMargin>5</bottomMargin>
+        <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>
           <text><font face="Times New Roman"/>Tuplets</text>

--- a/mtest/libmscore/compat114/tuplets_1-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets_1-ref.mscx
@@ -86,6 +86,7 @@
         <rightMargin>5</rightMargin>
         <topMargin>5</topMargin>
         <bottomMargin>5</bottomMargin>
+        <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>
           <text><font face="Times New Roman"/>Tuplet 1.3 file</text>

--- a/mtest/libmscore/compat114/tuplets_2-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets_2-ref.mscx
@@ -86,6 +86,7 @@
         <rightMargin>5</rightMargin>
         <topMargin>5</topMargin>
         <bottomMargin>5</bottomMargin>
+        <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>
           <text><font face="Times New Roman"/>Tuplet 1.3 file</text>

--- a/mtest/libmscore/compat206/articulations-double-ref.mscx
+++ b/mtest/libmscore/compat206/articulations-double-ref.mscx
@@ -107,6 +107,7 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
+        <boxAutoSize>0</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -1845,6 +1846,7 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
+          <boxAutoSize>0</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/libmscore/compat206/articulations-ref.mscx
+++ b/mtest/libmscore/compat206/articulations-ref.mscx
@@ -126,6 +126,7 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
+        <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Articulations</text>

--- a/mtest/libmscore/compat206/barlines-ref.mscx
+++ b/mtest/libmscore/compat206/barlines-ref.mscx
@@ -479,6 +479,7 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
+        <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>barlines</text>

--- a/mtest/libmscore/compat206/clefs-ref.mscx
+++ b/mtest/libmscore/compat206/clefs-ref.mscx
@@ -125,6 +125,7 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
+        <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>clefs</text>

--- a/mtest/libmscore/compat206/frame_text2-ref.mscx
+++ b/mtest/libmscore/compat206/frame_text2-ref.mscx
@@ -250,6 +250,7 @@
         <height>25.5926</height>
         <bottomGap>0</bottomGap>
         <topMargin>3</topMargin>
+        <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Frame</style>
           <text>îèéààéà</text>
@@ -264,6 +265,7 @@
         <height>47.762</height>
         <topGap>10</topGap>
         <bottomGap>0</bottomGap>
+        <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Frame</style>
           <text>êêàééééç*éô</text>

--- a/mtest/libmscore/compat206/hairpin-ref.mscx
+++ b/mtest/libmscore/compat206/hairpin-ref.mscx
@@ -135,6 +135,7 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
+        <boxAutoSize>0</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -720,6 +721,7 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
+          <boxAutoSize>0</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/libmscore/compat206/lidemptytext-ref.mscx
+++ b/mtest/libmscore/compat206/lidemptytext-ref.mscx
@@ -187,6 +187,7 @@
       <VBox>
         <height>8</height>
         <bottomGap>13</bottomGap>
+        <boxAutoSize>0</boxAutoSize>
         </VBox>
       <Measure>
         <stretch>0.9</stretch>
@@ -359,6 +360,7 @@
         <VBox>
           <height>8</height>
           <bottomGap>13</bottomGap>
+          <boxAutoSize>0</boxAutoSize>
           <Text>
             <style>Instrument Name (Part)</style>
             <text>Bass</text>

--- a/mtest/libmscore/compat206/tuplets-ref.mscx
+++ b/mtest/libmscore/compat206/tuplets-ref.mscx
@@ -125,6 +125,7 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
+        <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Tuplets</text>

--- a/mtest/libmscore/compat206/userstylesparts-ref.mscx
+++ b/mtest/libmscore/compat206/userstylesparts-ref.mscx
@@ -284,6 +284,7 @@
     <Staff id="1">
       <VBox>
         <height>36.9323</height>
+        <boxAutoSize>0</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -561,6 +562,7 @@
       <Staff id="1">
         <VBox>
           <height>36.9323</height>
+          <boxAutoSize>0</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -799,6 +801,7 @@
       <Staff id="1">
         <VBox>
           <height>36.9323</height>
+          <boxAutoSize>0</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>
@@ -1061,6 +1064,7 @@
       <Staff id="1">
         <VBox>
           <height>36.9323</height>
+          <boxAutoSize>0</boxAutoSize>
           <linked>
             <location>
               <staves>-2</staves>

--- a/mtest/libmscore/copypaste/copypaste01-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste01-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/copypaste/copypaste02-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste02-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/copypaste/copypaste03-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste03-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/copypaste/copypaste04-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste04-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/copypaste/copypaste05-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste05-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/copypaste/copypaste06-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste06-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/copypaste/copypaste08-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste08-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/copypaste/copypaste09-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste09-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/copypaste/copypaste10-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste10-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/copypaste/copypaste11-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste11-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/copypaste/copypaste12-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste12-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/copypaste/copypaste13-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste13-ref.mscx
@@ -74,7 +74,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>voice-paste1</text>

--- a/mtest/libmscore/copypaste/copypaste14-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste14-ref.mscx
@@ -74,7 +74,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>voice-paste</text>

--- a/mtest/libmscore/copypaste/copypaste15-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste15-ref.mscx
@@ -74,7 +74,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>voice-paste</text>

--- a/mtest/libmscore/copypaste/copypaste16-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste16-ref.mscx
@@ -74,7 +74,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>voice-paste</text>

--- a/mtest/libmscore/copypaste/copypaste17-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste17-ref.mscx
@@ -74,7 +74,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>voice-paste</text>

--- a/mtest/libmscore/copypaste/copypaste18-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste18-ref.mscx
@@ -74,7 +74,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>voice-paste</text>

--- a/mtest/libmscore/copypaste/copypaste19-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste19-ref.mscx
@@ -61,7 +61,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/copypaste/copypaste20-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste20-ref.mscx
@@ -74,7 +74,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>voice-paste</text>

--- a/mtest/libmscore/copypaste/copypaste21-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste21-ref.mscx
@@ -74,7 +74,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>voice-paste</text>

--- a/mtest/libmscore/copypaste/copypaste22-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste22-ref.mscx
@@ -64,7 +64,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/copypaste/copypaste25-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste25-ref.mscx
@@ -78,7 +78,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/copypaste/copypaste50-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste50-ref.mscx
@@ -92,7 +92,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/copypaste/copypaste_tremolo-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste_tremolo-ref.mscx
@@ -74,7 +74,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>voice-paste</text>

--- a/mtest/libmscore/copypastesymbollist/copypastesymbollist-articulation-rest-ref.mscx
+++ b/mtest/libmscore/copypastesymbollist/copypastesymbollist-articulation-rest-ref.mscx
@@ -74,7 +74,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>copypastesymbollist-articulation-rest</text>

--- a/mtest/libmscore/copypastesymbollist/copypastesymbollist-range-01-ref.mscx
+++ b/mtest/libmscore/copypastesymbollist/copypastesymbollist-range-01-ref.mscx
@@ -123,7 +123,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>tst_copy_symbol_list</text>

--- a/mtest/libmscore/copypastesymbollist/copypastesymbollist-range-ref.mscx
+++ b/mtest/libmscore/copypastesymbollist/copypastesymbollist-range-ref.mscx
@@ -123,7 +123,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>tst_copy_symbol_list</text>

--- a/mtest/libmscore/exchangevoices/undoChangeVoice01-ref.mscx
+++ b/mtest/libmscore/exchangevoices/undoChangeVoice01-ref.mscx
@@ -75,7 +75,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -622,7 +621,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/libmscore/exchangevoices/undoChangeVoice02-ref.mscx
+++ b/mtest/libmscore/exchangevoices/undoChangeVoice02-ref.mscx
@@ -75,7 +75,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -603,7 +602,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/libmscore/implode_explode/implode1-ref.mscx
+++ b/mtest/libmscore/implode_explode/implode1-ref.mscx
@@ -245,7 +245,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>implode1</text>

--- a/mtest/libmscore/implode_explode/implode1.mscx
+++ b/mtest/libmscore/implode_explode/implode1.mscx
@@ -245,7 +245,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>implode1</text>

--- a/mtest/libmscore/instrumentchange/add-ref.mscx
+++ b/mtest/libmscore/instrumentchange/add-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Instrument Change</text>

--- a/mtest/libmscore/instrumentchange/change-ref.mscx
+++ b/mtest/libmscore/instrumentchange/change-ref.mscx
@@ -97,7 +97,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Instrument Change</text>

--- a/mtest/libmscore/instrumentchange/copy-ref.mscx
+++ b/mtest/libmscore/instrumentchange/copy-ref.mscx
@@ -97,7 +97,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Instrument Change</text>

--- a/mtest/libmscore/instrumentchange/delete-ref.mscx
+++ b/mtest/libmscore/instrumentchange/delete-ref.mscx
@@ -101,7 +101,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Instrument Change</text>

--- a/mtest/libmscore/instrumentchange/mixer-ref.mscx
+++ b/mtest/libmscore/instrumentchange/mixer-ref.mscx
@@ -97,7 +97,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Instrument Change</text>

--- a/mtest/libmscore/join/join01-ref.mscx
+++ b/mtest/libmscore/join/join01-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/join/join02-ref.mscx
+++ b/mtest/libmscore/join/join02-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/join/join03-ref.mscx
+++ b/mtest/libmscore/join/join03-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/join/join04-ref.mscx
+++ b/mtest/libmscore/join/join04-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/join/join05-ref.mscx
+++ b/mtest/libmscore/join/join05-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/join/join06-ref.mscx
+++ b/mtest/libmscore/join/join06-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/join/join07-ref.mscx
+++ b/mtest/libmscore/join/join07-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/measure/measure-1-ref.mscx
+++ b/mtest/libmscore/measure/measure-1-ref.mscx
@@ -102,7 +102,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>
@@ -387,7 +386,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <Text>
             <style>Title</style>
             <text>Test</text>
@@ -636,7 +634,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <Text>
             <style>Title</style>
             <text>Test</text>

--- a/mtest/libmscore/measure/measure-2-ref.mscx
+++ b/mtest/libmscore/measure/measure-2-ref.mscx
@@ -102,7 +102,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>
@@ -384,7 +383,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <Text>
             <style>Title</style>
             <text>Test</text>
@@ -629,7 +627,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <Text>
             <style>Title</style>
             <text>Test</text>

--- a/mtest/libmscore/measure/measure-3-ref.mscx
+++ b/mtest/libmscore/measure/measure-3-ref.mscx
@@ -102,7 +102,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>
@@ -387,7 +386,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <Text>
             <style>Title</style>
             <text>Test</text>
@@ -636,7 +634,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <Text>
             <style>Title</style>
             <text>Test</text>

--- a/mtest/libmscore/measure/mmrest-ref.mscx
+++ b/mtest/libmscore/measure/mmrest-ref.mscx
@@ -85,7 +85,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Title</text>

--- a/mtest/libmscore/measure/undoDelInitialVBox_269919-ref.mscx
+++ b/mtest/libmscore/measure/undoDelInitialVBox_269919-ref.mscx
@@ -84,7 +84,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Title</text>

--- a/mtest/libmscore/note/notelimits-ref.mscx
+++ b/mtest/libmscore/note/notelimits-ref.mscx
@@ -75,7 +75,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Title</text>

--- a/mtest/libmscore/parts/part-54346-parts.mscx
+++ b/mtest/libmscore/parts/part-54346-parts.mscx
@@ -132,7 +132,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -341,7 +340,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -517,7 +515,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-54346.mscx
+++ b/mtest/libmscore/parts/part-54346.mscx
@@ -132,7 +132,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/parts/part-all-appendmeasures.mscx
+++ b/mtest/libmscore/parts/part-all-appendmeasures.mscx
@@ -103,7 +103,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -1128,7 +1127,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1850,7 +1848,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-all-parts.mscx
+++ b/mtest/libmscore/parts/part-all-parts.mscx
@@ -103,7 +103,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -1110,7 +1109,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1822,7 +1820,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-all-uappendmeasures.mscx
+++ b/mtest/libmscore/parts/part-all-uappendmeasures.mscx
@@ -103,7 +103,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -1110,7 +1109,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1822,7 +1820,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-all-uinsertmeasures.mscx
+++ b/mtest/libmscore/parts/part-all-uinsertmeasures.mscx
@@ -103,7 +103,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -1110,7 +1109,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1822,7 +1820,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-all.mscx
+++ b/mtest/libmscore/parts/part-all.mscx
@@ -103,7 +103,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>testpart2</text>

--- a/mtest/libmscore/parts/part-breath-add.mscx
+++ b/mtest/libmscore/parts/part-breath-add.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -820,7 +819,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1273,7 +1271,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-breath-del.mscx
+++ b/mtest/libmscore/parts/part-breath-del.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -816,7 +815,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1264,7 +1262,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-breath-parts.mscx
+++ b/mtest/libmscore/parts/part-breath-parts.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -829,7 +828,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1288,7 +1286,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-breath-uadd.mscx
+++ b/mtest/libmscore/parts/part-breath-uadd.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -816,7 +815,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1264,7 +1262,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-breath-udel.mscx
+++ b/mtest/libmscore/parts/part-breath-udel.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -820,7 +819,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1273,7 +1271,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-breath-uradd.mscx
+++ b/mtest/libmscore/parts/part-breath-uradd.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -820,7 +819,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1273,7 +1271,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-breath-urdel.mscx
+++ b/mtest/libmscore/parts/part-breath-urdel.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -816,7 +815,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1264,7 +1262,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-breath.mscx
+++ b/mtest/libmscore/parts/part-breath.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>test-part</text>

--- a/mtest/libmscore/parts/part-chordline-add.mscx
+++ b/mtest/libmscore/parts/part-chordline-add.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -820,7 +819,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1273,7 +1271,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-chordline-del.mscx
+++ b/mtest/libmscore/parts/part-chordline-del.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -811,7 +810,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1253,7 +1251,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-chordline-parts.mscx
+++ b/mtest/libmscore/parts/part-chordline-parts.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -815,7 +814,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1262,7 +1260,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-chordline-uadd.mscx
+++ b/mtest/libmscore/parts/part-chordline-uadd.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -816,7 +815,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1264,7 +1262,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-chordline-udel.mscx
+++ b/mtest/libmscore/parts/part-chordline-udel.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -815,7 +814,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1262,7 +1260,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-chordline-uradd.mscx
+++ b/mtest/libmscore/parts/part-chordline-uradd.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -820,7 +819,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1273,7 +1271,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-chordline-urdel.mscx
+++ b/mtest/libmscore/parts/part-chordline-urdel.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -811,7 +810,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1253,7 +1251,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-chordline.mscx
+++ b/mtest/libmscore/parts/part-chordline.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>testpart1</text>

--- a/mtest/libmscore/parts/part-empty-parts.mscx
+++ b/mtest/libmscore/parts/part-empty-parts.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -816,7 +815,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1264,7 +1262,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-empty.mscx
+++ b/mtest/libmscore/parts/part-empty.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>testpart1</text>

--- a/mtest/libmscore/parts/part-fingering-add.mscx
+++ b/mtest/libmscore/parts/part-fingering-add.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -820,7 +819,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1273,7 +1271,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-fingering-del.mscx
+++ b/mtest/libmscore/parts/part-fingering-del.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -821,7 +820,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1275,7 +1273,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-fingering-parts.mscx
+++ b/mtest/libmscore/parts/part-fingering-parts.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -826,7 +825,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1286,7 +1284,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-fingering-uadd.mscx
+++ b/mtest/libmscore/parts/part-fingering-uadd.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -816,7 +815,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1264,7 +1262,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-fingering-udel.mscx
+++ b/mtest/libmscore/parts/part-fingering-udel.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -826,7 +825,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1286,7 +1284,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-fingering-uradd.mscx
+++ b/mtest/libmscore/parts/part-fingering-uradd.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -820,7 +819,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1273,7 +1271,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-fingering-urdel.mscx
+++ b/mtest/libmscore/parts/part-fingering-urdel.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -821,7 +820,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1275,7 +1273,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-fingering.mscx
+++ b/mtest/libmscore/parts/part-fingering.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>test-part</text>

--- a/mtest/libmscore/parts/part-stemless-parts.mscx
+++ b/mtest/libmscore/parts/part-stemless-parts.mscx
@@ -154,7 +154,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -561,7 +560,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -850,7 +848,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-stemless.mscx
+++ b/mtest/libmscore/parts/part-stemless.mscx
@@ -154,7 +154,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Stemless</text>

--- a/mtest/libmscore/parts/part-symbol-add.mscx
+++ b/mtest/libmscore/parts/part-symbol-add.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -820,7 +819,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1273,7 +1271,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-symbol-del.mscx
+++ b/mtest/libmscore/parts/part-symbol-del.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -816,7 +815,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1264,7 +1262,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-symbol-parts.mscx
+++ b/mtest/libmscore/parts/part-symbol-parts.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -820,7 +819,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1273,7 +1271,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-symbol-uadd.mscx
+++ b/mtest/libmscore/parts/part-symbol-uadd.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -816,7 +815,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1264,7 +1262,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-symbol-udel.mscx
+++ b/mtest/libmscore/parts/part-symbol-udel.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -820,7 +819,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1273,7 +1271,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-symbol-uradd.mscx
+++ b/mtest/libmscore/parts/part-symbol-uradd.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -820,7 +819,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1273,7 +1271,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-symbol-urdel.mscx
+++ b/mtest/libmscore/parts/part-symbol-urdel.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -816,7 +815,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1264,7 +1262,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/parts/part-symbol.mscx
+++ b/mtest/libmscore/parts/part-symbol.mscx
@@ -95,7 +95,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>testpart1</text>

--- a/mtest/libmscore/parts/voices-ref.mscx
+++ b/mtest/libmscore/parts/voices-ref.mscx
@@ -146,7 +146,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -1139,7 +1138,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>
@@ -1988,7 +1986,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-2</staves>
@@ -2530,7 +2527,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-2</staves>

--- a/mtest/libmscore/readwriteundoreset/barlines.mscx
+++ b/mtest/libmscore/readwriteundoreset/barlines.mscx
@@ -80,7 +80,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>barlines</text>

--- a/mtest/libmscore/readwriteundoreset/mmrestBarlineTextLinks-disable-mmrest-ref.mscx
+++ b/mtest/libmscore/readwriteundoreset/mmrestBarlineTextLinks-disable-mmrest-ref.mscx
@@ -89,7 +89,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>mmrest text links (see issue #296426)</text>

--- a/mtest/libmscore/readwriteundoreset/mmrestBarlineTextLinks-recreate-mmrest-ref.mscx
+++ b/mtest/libmscore/readwriteundoreset/mmrestBarlineTextLinks-recreate-mmrest-ref.mscx
@@ -90,7 +90,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>mmrest text links (see issue #296426)</text>

--- a/mtest/libmscore/readwriteundoreset/mmrestBarlineTextLinks.mscx
+++ b/mtest/libmscore/readwriteundoreset/mmrestBarlineTextLinks.mscx
@@ -90,7 +90,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>mmrest text links (see issue #296426)</text>

--- a/mtest/libmscore/readwriteundoreset/slurs.mscx
+++ b/mtest/libmscore/readwriteundoreset/slurs.mscx
@@ -83,7 +83,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>slurs</text>

--- a/mtest/libmscore/rhythmicGrouping/groupConflicts-ref.mscx
+++ b/mtest/libmscore/rhythmicGrouping/groupConflicts-ref.mscx
@@ -125,7 +125,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Grouping conflicts</text>

--- a/mtest/libmscore/rhythmicGrouping/groupSubbeats-ref.mscx
+++ b/mtest/libmscore/rhythmicGrouping/groupSubbeats-ref.mscx
@@ -75,7 +75,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Subbeat Groupings</text>

--- a/mtest/libmscore/rhythmicGrouping/groupVoices-ref.mscx
+++ b/mtest/libmscore/rhythmicGrouping/groupVoices-ref.mscx
@@ -74,7 +74,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Grouping with multiple voices</text>

--- a/mtest/libmscore/selectionrangedelete/selectionrangedelete03-ref.mscx
+++ b/mtest/libmscore/selectionrangedelete/selectionrangedelete03-ref.mscx
@@ -74,7 +74,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>selection-range-delete</text>

--- a/mtest/libmscore/selectionrangedelete/selectionrangedelete04-ref.mscx
+++ b/mtest/libmscore/selectionrangedelete/selectionrangedelete04-ref.mscx
@@ -74,7 +74,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>selection-range-delete</text>

--- a/mtest/libmscore/selectionrangedelete/selectionrangedelete05-ref.mscx
+++ b/mtest/libmscore/selectionrangedelete/selectionrangedelete05-ref.mscx
@@ -77,7 +77,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>delete-skip-annotations</text>

--- a/mtest/libmscore/spanners/glissando-cloning02-ref.mscx
+++ b/mtest/libmscore/spanners/glissando-cloning02-ref.mscx
@@ -74,7 +74,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -204,7 +203,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/libmscore/spanners/glissando-cloning04-ref.mscx
+++ b/mtest/libmscore/spanners/glissando-cloning04-ref.mscx
@@ -74,7 +74,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -200,7 +199,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/libmscore/spanners/glissando-cloning05-ref.mscx
+++ b/mtest/libmscore/spanners/glissando-cloning05-ref.mscx
@@ -87,7 +87,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -322,7 +321,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/libmscore/split/split01-ref.mscx
+++ b/mtest/libmscore/split/split01-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/split/split02-ref.mscx
+++ b/mtest/libmscore/split/split02-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/split/split03-ref.mscx
+++ b/mtest/libmscore/split/split03-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/split/split04-ref.mscx
+++ b/mtest/libmscore/split/split04-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/split/split05-ref.mscx
+++ b/mtest/libmscore/split/split05-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/split/split06-ref.mscx
+++ b/mtest/libmscore/split/split06-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/split/split07-ref.mscx
+++ b/mtest/libmscore/split/split07-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/split/split08-ref.mscx
+++ b/mtest/libmscore/split/split08-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/split/split295207-ref.mscx
+++ b/mtest/libmscore/split/split295207-ref.mscx
@@ -58,7 +58,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/splitstaff/splitstaff01-ref.mscx
+++ b/mtest/libmscore/splitstaff/splitstaff01-ref.mscx
@@ -67,7 +67,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test</text>

--- a/mtest/libmscore/timesig/timesig-02-ref.mscx
+++ b/mtest/libmscore/timesig/timesig-02-ref.mscx
@@ -66,7 +66,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Test invalid shortening of time signature</text>

--- a/mtest/libmscore/timesig/timesig-04-ref.mscx
+++ b/mtest/libmscore/timesig/timesig-04-ref.mscx
@@ -73,7 +73,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>timesig</text>

--- a/mtest/libmscore/timesig/timesig-06-ref.mscx
+++ b/mtest/libmscore/timesig/timesig-06-ref.mscx
@@ -64,7 +64,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Timesig change with tremolo</text>

--- a/mtest/libmscore/timesig/timesig-07-ref.mscx
+++ b/mtest/libmscore/timesig/timesig-07-ref.mscx
@@ -64,7 +64,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Timesig change with tremolo</text>

--- a/mtest/libmscore/timesig/timesig01-ref.mscx
+++ b/mtest/libmscore/timesig/timesig01-ref.mscx
@@ -61,7 +61,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>timesig1</text>

--- a/mtest/libmscore/tools/undoResequencePart01-ref.mscx
+++ b/mtest/libmscore/tools/undoResequencePart01-ref.mscx
@@ -75,7 +75,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -368,7 +367,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/libmscore/tools/undoResequencePart02-ref.mscx
+++ b/mtest/libmscore/tools/undoResequencePart02-ref.mscx
@@ -75,7 +75,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         </VBox>
       <Measure>
@@ -368,7 +367,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             </linked>
           <Text>

--- a/mtest/libmscore/tuplet/nestedTuplets_addStaff-ref.mscx
+++ b/mtest/libmscore/tuplet/nestedTuplets_addStaff-ref.mscx
@@ -91,7 +91,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Title</text>

--- a/mtest/libmscore/unrollrepeats/clef-key-ts-ref.mscx
+++ b/mtest/libmscore/unrollrepeats/clef-key-ts-ref.mscx
@@ -140,7 +140,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <linkedMain/>
         <Text>
           <linkedMain/>
@@ -1415,7 +1414,6 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
-          <boxAutoSize>1</boxAutoSize>
           <linked>
             <location>
               <staves>-1</staves>

--- a/mtest/libmscore/unrollrepeats/pickup-measure-ref.mscx
+++ b/mtest/libmscore/unrollrepeats/pickup-measure-ref.mscx
@@ -77,7 +77,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>pickup measure repeat test</text>

--- a/mtest/scripting/testTextStyle-ref.mscx
+++ b/mtest/scripting/testTextStyle-ref.mscx
@@ -84,7 +84,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Title</text>

--- a/mtest/scripting/testTextStyle.mscx
+++ b/mtest/scripting/testTextStyle.mscx
@@ -84,7 +84,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <boxAutoSize>1</boxAutoSize>
         <Text>
           <style>Title</style>
           <text>Title</text>


### PR DESCRIPTION
Resolves: https://trello.com/c/11WgLsL1/23-disabling-vertical-frame-enable-auto-size-is-not-saved-in-score-file

In the <code>VBox::VBox()</code> constructor, the variable <code>_isAutoSizeEnabled</code> was always set to <code>true</code> for score with a version number >= 3.02. However, the default for that property is <code>false</code>. So, when this option was switched of, the property has the default value and isn't written into the score file. Next, when reading the file, there no such property but if the score version was >= 3.02, the property was set to <code>true</code> again.

This is solved by setting the default of <code>_isAutoSizeEnabled</code> to <code>true</code>. But when reading an score < 3.02, this property in set to <code>false</code> after reading the properties in <code>Box::read()</code>. Also, <code>Box::getProperty()</code> will always return <code>false</code> for older scores.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
