### PR TITLE
fix #292387 : [MusicXML] Drumset of MusicXML sounds pitch

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -473,13 +473,17 @@ static Instrument createInstrument(const MusicXMLInstrument& mxmlInstr, const In
 //   updatePartWithInstrument
 //---------------------------------------------------------
 
-static void updatePartWithInstrument(Part* const part, const MusicXMLInstrument& mxmlInstr, const Interval interval)
+static void updatePartWithInstrument(Part* const part, const MusicXMLInstrument& mxmlInstr, const Interval interval, const bool hasDrumset = false)
       {
-      const Instrument instr = createInstrument(mxmlInstr, interval);
+      Instrument instr = createInstrument(mxmlInstr, interval);
+      if (hasDrumset)
+            instr.channel(0)->setBank(128);
       part->setInstrument(instr);
-      if (mxmlInstr.midiChannel >= 0) part->setMidiChannel(mxmlInstr.midiChannel, mxmlInstr.midiPort);
+      if (mxmlInstr.midiChannel >= 0)
+            part->setMidiChannel(mxmlInstr.midiChannel, mxmlInstr.midiPort);
       // note: setMidiProgram() does more than simply setting the MIDI program
-      if (mxmlInstr.midiProgram >= 0) part->setMidiProgram(mxmlInstr.midiProgram);
+      if (mxmlInstr.midiProgram >= 0)
+            part->setMidiProgram(mxmlInstr.midiProgram);
       }
 
 //---------------------------------------------------------
@@ -546,7 +550,7 @@ static void setPartInstruments(MxmlLogger* logger, const QXmlStreamReader* const
             // do not create multiple instruments for a drum part
             //qDebug("hasDrumset");
             MusicXMLInstrument mxmlInstr = instruments.first();
-            updatePartWithInstrument(part, mxmlInstr, {});
+            updatePartWithInstrument(part, mxmlInstr, {}, true);
             return;
             }
 

--- a/importexport/musicxml/musicxmlsupport.h
+++ b/importexport/musicxml/musicxmlsupport.h
@@ -150,7 +150,7 @@ struct MusicXMLInstrument {
             notehead(NoteHead::Group::HEAD_INVALID), line(0), stemDirection(Direction::AUTO) {}
       MusicXMLInstrument(QString s)
             : unpitched(-1), name(s), midiChannel(-1), midiPort(-1), midiProgram(-1), midiVolume(100), midiPan(63),
-            notehead(NoteHead::Group::HEAD_INVALID), line(0), stemDirection(Direction::AUTO) {}
+            notehead(NoteHead::Group::HEAD_NORMAL), line(0), stemDirection(Direction::AUTO) {}
       /*
       MusicXMLInstrument(int p, QString s, NoteHead::Group nh, int l, Direction d)
             : unpitched(p), name(s), midiChannel(-1), midiPort(-1), midiProgram(-1), midiVolume(100), midiPan(63),


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/292387

This PR sets the channel bank to 128 before setting the first instrument, which is then added to the masterScore midiMapping (and the channel is cloned to midiMapping articulation channel).
Bank 128 is thus set for both the masterChannel and the articulation channel inside midiMapping

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
