### PR TITLE
[MU3] Fixes for the Style and Preferences dialogs

### DIFF
--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -10057,7 +10057,7 @@
             </widget>
            </item>
            <item row="0" column="0" colspan="4">
-            <widget class="QGroupBox" name="groupBox_25">
+            <widget class="QGroupBox" name="harmonyAppearance">
              <property name="title">
               <string>Appearance</string>
              </property>
@@ -10116,83 +10116,6 @@
                  <cstring>extensionAdjust</cstring>
                 </property>
                </widget>
-              </item>
-              <item row="0" column="0" colspan="6">
-               <layout class="QHBoxLayout" name="horizontalLayout_7">
-                <item>
-                 <widget class="QLabel" name="label_147">
-                  <property name="text">
-                   <string>Style:</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QRadioButton" name="chordsStandard">
-                  <property name="text">
-                   <string>Standard</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QRadioButton" name="chordsJazz">
-                  <property name="text">
-                   <string>Jazz</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QRadioButton" name="chordsCustom">
-                  <property name="text">
-                   <string>Custom</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLineEdit" name="chordDescriptionFile"/>
-                </item>
-                <item>
-                 <widget class="QWidget" name="chordDescriptionGroup" native="true">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <layout class="QGridLayout" name="chordDescriptionLayout">
-                   <property name="leftMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>0</number>
-                   </property>
-                   <item row="0" column="1">
-                    <widget class="QToolButton" name="chordDescriptionFileButton">
-                     <property name="text">
-                      <string notr="true"/>
-                     </property>
-                     <property name="icon">
-                      <iconset resource="musescore.qrc">
-                       <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="2">
-                    <widget class="QCheckBox" name="chordsXmlFile">
-                     <property name="text">
-                      <string>Load XML</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-               </layout>
               </item>
               <item row="1" column="0">
                <widget class="QLabel" name="labelExtensionMag">
@@ -10321,79 +10244,158 @@
                 </layout>
                </widget>
               </item>
-              <item row="3" column="0" colspan="5">
-               <layout class="QHBoxLayout" name="horizontalLayout_6">
-                <item>
-                 <widget class="QLabel" name="label_148">
-                  <property name="text">
-                   <string>Spelling:</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QRadioButton" name="useStandardNoteNames">
-                  <property name="toolTip">
-                   <string notr="true">A, B♭, B, C, C♯, …</string>
-                  </property>
-                  <property name="text">
-                   <string>Standard</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QRadioButton" name="useGermanNoteNames">
-                  <property name="toolTip">
-                   <string notr="true">A, B♭, H, C, C♯, …</string>
-                  </property>
-                  <property name="text">
-                   <string>German</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QRadioButton" name="useFullGermanNoteNames">
-                  <property name="toolTip">
-                   <string notr="true">A, B, H, C, Cis, …</string>
-                  </property>
-                  <property name="text">
-                   <string>Full German</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QRadioButton" name="useSolfeggioNoteNames">
-                  <property name="toolTip">
-                   <string notr="true">Do, Do♯, Re♭, Re, …</string>
-                  </property>
-                  <property name="text">
-                   <string>Solfeggio</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QRadioButton" name="useFrenchNoteNames">
-                  <property name="toolTip">
-                   <string notr="true">Do, Do♯, Ré♭, Ré, …</string>
-                  </property>
-                  <property name="text">
-                   <string>French</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer_12">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-               </layout>
+              <item row="3" column="0" colspan="6">
+               <widget class="QGroupBox" name="harmonySpelling">
+                <property name="title">
+                 <string>Spelling</string>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_6">
+                 <item>
+                  <widget class="QRadioButton" name="useStandardNoteNames">
+                   <property name="toolTip">
+                    <string notr="true">A, B♭, B, C, C♯, …</string>
+                   </property>
+                   <property name="text">
+                    <string>Standard</string>
+                   </property>
+                   <property name="checked">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRadioButton" name="useGermanNoteNames">
+                   <property name="toolTip">
+                    <string notr="true">A, B♭, H, C, C♯, …</string>
+                   </property>
+                   <property name="text">
+                    <string>German</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRadioButton" name="useFullGermanNoteNames">
+                   <property name="toolTip">
+                    <string notr="true">A, B, H, C, Cis, …</string>
+                   </property>
+                   <property name="text">
+                    <string>Full German</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRadioButton" name="useSolfeggioNoteNames">
+                   <property name="toolTip">
+                    <string notr="true">Do, Do♯, Re♭, Re, …</string>
+                   </property>
+                   <property name="text">
+                    <string>Solfeggio</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRadioButton" name="useFrenchNoteNames">
+                   <property name="toolTip">
+                    <string notr="true">Do, Do♯, Ré♭, Ré, …</string>
+                   </property>
+                   <property name="text">
+                    <string>French</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_12">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item row="0" column="0" colspan="6">
+               <widget class="QGroupBox" name="harmonyStyle">
+                <property name="title">
+                 <string>Style</string>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_7">
+                 <item>
+                  <widget class="QRadioButton" name="chordsStandard">
+                   <property name="text">
+                    <string>Standard</string>
+                   </property>
+                   <property name="checked">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRadioButton" name="chordsJazz">
+                   <property name="text">
+                    <string>Jazz</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRadioButton" name="chordsCustom">
+                   <property name="text">
+                    <string>Custom</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLineEdit" name="chordDescriptionFile"/>
+                 </item>
+                 <item>
+                  <widget class="QWidget" name="chordDescriptionGroup" native="true">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <layout class="QGridLayout" name="chordDescriptionLayout">
+                    <property name="leftMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="topMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="rightMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="bottomMargin">
+                     <number>0</number>
+                    </property>
+                    <item row="0" column="1">
+                     <widget class="QToolButton" name="chordDescriptionFileButton">
+                      <property name="text">
+                       <string notr="true"/>
+                      </property>
+                      <property name="icon">
+                       <iconset resource="musescore.qrc">
+                        <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="2">
+                     <widget class="QCheckBox" name="chordsXmlFile">
+                      <property name="text">
+                       <string>Load XML</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
               </item>
              </layout>
             </widget>
@@ -10419,7 +10421,7 @@
             </spacer>
            </item>
            <item row="1" column="0" rowspan="3" colspan="2">
-            <widget class="QGroupBox" name="groupBox_24">
+            <widget class="QGroupBox" name="harmonyPositioning">
              <property name="title">
               <string>Positioning</string>
              </property>

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -11558,6 +11558,11 @@
   <tabstop>minEmptyMeasures</tabstop>
   <tabstop>minMeasureWidth</tabstop>
   <tabstop>resetMinMMRestWidth</tabstop>
+  <tabstop>mmRestNumberPos</tabstop>
+  <tabstop>resetMMRestNumberPos</tabstop>
+  <tabstop>enableIndentationOnFirstSystem</tabstop>
+  <tabstop>indentationValue</tabstop>
+  <tabstop>resetFirstSystemIndentation</tabstop>
   <tabstop>hideEmptyStaves</tabstop>
   <tabstop>dontHideStavesInFirstSystem</tabstop>
   <tabstop>alwaysShowBrackets</tabstop>
@@ -11571,14 +11576,43 @@
   <tabstop>resetAutoplaceVerticalAlignRange</tabstop>
   <tabstop>minVerticalDistance</tabstop>
   <tabstop>resetMinVerticalDistance</tabstop>
+  <tabstop>staffUpperBorder</tabstop>
+  <tabstop>resetStaffUpperBorder</tabstop>
+  <tabstop>staffLowerBorder</tabstop>
+  <tabstop>resetStaffLowerBorder</tabstop>
+  <tabstop>enableVerticalSpread</tabstop>
+  <tabstop>staffDistance</tabstop>
+  <tabstop>resetStaffDistance</tabstop>
+  <tabstop>akkoladeDistance</tabstop>
+  <tabstop>resetAkkoladeDistance</tabstop>
+  <tabstop>minSystemDistance</tabstop>
+  <tabstop>resetMinSystemDistance</tabstop>
+  <tabstop>maxSystemDistance</tabstop>
+  <tabstop>resetMaxSystemDistance</tabstop>
+  <tabstop>spreadSystem</tabstop>
+  <tabstop>resetSpreadSystem</tabstop>
+  <tabstop>maxSystemSpread</tabstop>
+  <tabstop>resetMaxSystemSpread</tabstop>
+  <tabstop>spreadSquareBracket</tabstop>
+  <tabstop>resetSpreadSquareBracket</tabstop>
+  <tabstop>minStaffSpread</tabstop>
+  <tabstop>resetMinStaffSpread</tabstop>
+  <tabstop>maxStaffSpread</tabstop>
+  <tabstop>resetMaxStaffSpread</tabstop>
+  <tabstop>spreadCurlyBracket</tabstop>
+  <tabstop>resetSpreadCurlyBracket</tabstop>
+  <tabstop>maxAkkoladeDistance</tabstop>
+  <tabstop>resetMaxAkkoladeDistance</tabstop>
+  <tabstop>systemFrameDistance</tabstop>
+  <tabstop>resetSystemFrameDistance</tabstop>
+  <tabstop>frameSystemDistance</tabstop>
+  <tabstop>resetFrameSystemDistance</tabstop>
+  <tabstop>lastSystemFillThreshold</tabstop>
+  <tabstop>resetLastSystemFillThreshold</tabstop>
   <tabstop>genClef</tabstop>
   <tabstop>genKeysig</tabstop>
   <tabstop>genCourtesyClef</tabstop>
   <tabstop>genCourtesyTimesig</tabstop>
-  <tabstop>genCourtesyKeysig</tabstop>
-  <tabstop>genClef</tabstop>
-  <tabstop>genKeysig</tabstop>
-  <tabstop>genCourtesyClef</tabstop>
   <tabstop>genCourtesyKeysig</tabstop>
   <tabstop>smallStaffSize</tabstop>
   <tabstop>resetSmallStaffSize</tabstop>
@@ -11608,15 +11642,15 @@
   <tabstop>evenFooterR</tabstop>
   <tabstop>showMeasureNumber</tabstop>
   <tabstop>showFirstMeasureNumber</tabstop>
-  <tabstop>showAllStavesMeasureNumber</tabstop>
-  <tabstop>showEverySystemMeasureNumber</tabstop>
-  <tabstop>showIntervalMeasureNumber</tabstop>
-  <tabstop>intervalMeasureNumber</tabstop>
   <tabstop>measureNumberVPlacement</tabstop>
   <tabstop>resetMeasureNumberVPlacement</tabstop>
+  <tabstop>showAllStavesMeasureNumber</tabstop>
   <tabstop>measureNumberHPlacement</tabstop>
   <tabstop>resetMeasureNumberHPlacement</tabstop>
+  <tabstop>showEverySystemMeasureNumber</tabstop>
   <tabstop>resetMeasureNumberPosAbove</tabstop>
+  <tabstop>showIntervalMeasureNumber</tabstop>
+  <tabstop>intervalMeasureNumber</tabstop>
   <tabstop>resetMeasureNumberPosBelow</tabstop>
   <tabstop>bracketWidth</tabstop>
   <tabstop>akkoladeWidth</tabstop>
@@ -11884,13 +11918,18 @@
   <tabstop>radioFBBottom</tabstop>
   <tabstop>radioFBModern</tabstop>
   <tabstop>radioFBHistoric</tabstop>
+  <tabstop>chordsStandard</tabstop>
+  <tabstop>chordsJazz</tabstop>
+  <tabstop>chordsCustom</tabstop>
+  <tabstop>chordDescriptionFile</tabstop>
   <tabstop>chordDescriptionFileButton</tabstop>
+  <tabstop>chordsXmlFile</tabstop>
   <tabstop>extensionMag</tabstop>
   <tabstop>resetExtensionMag</tabstop>
-  <tabstop>extensionAdjust</tabstop>
-  <tabstop>resetExtensionAdjust</tabstop>
   <tabstop>modifierMag</tabstop>
   <tabstop>resetModifierMag</tabstop>
+  <tabstop>extensionAdjust</tabstop>
+  <tabstop>resetExtensionAdjust</tabstop>
   <tabstop>modifierAdjust</tabstop>
   <tabstop>resetModifierAdjust</tabstop>
   <tabstop>useStandardNoteNames</tabstop>
@@ -11898,9 +11937,18 @@
   <tabstop>useFullGermanNoteNames</tabstop>
   <tabstop>useSolfeggioNoteNames</tabstop>
   <tabstop>useFrenchNoteNames</tabstop>
+  <tabstop>automaticCapitalization</tabstop>
   <tabstop>lowerCaseMinorChords</tabstop>
   <tabstop>lowerCaseBassNotes</tabstop>
   <tabstop>allCapsNoteNames</tabstop>
+  <tabstop>harmonyFretDist</tabstop>
+  <tabstop>minHarmonyDistance</tabstop>
+  <tabstop>maxHarmonyBarDistance</tabstop>
+  <tabstop>maxChordShiftAbove</tabstop>
+  <tabstop>resetMaxChordShiftAbove</tabstop>
+  <tabstop>resetMaxChordShiftBelow</tabstop>
+  <tabstop>harmonyPlay</tabstop>
+  <tabstop>capoPosition</tabstop>
   <tabstop>fretY</tabstop>
   <tabstop>fretMag</tabstop>
   <tabstop>fretNumMag</tabstop>
@@ -11910,6 +11958,10 @@
   <tabstop>fretDotSize</tabstop>
   <tabstop>fretStringSpacing</tabstop>
   <tabstop>fretFretSpacing</tabstop>
+  <tabstop>maxFretShiftAbove</tabstop>
+  <tabstop>resetMaxFretShiftAbove</tabstop>
+  <tabstop>maxFretShiftBelow</tabstop>
+  <tabstop>resetMaxFretShiftBelow</tabstop>
   <tabstop>textStyles</tabstop>
   <tabstop>styleName</tabstop>
   <tabstop>resetTextStyleName</tabstop>
@@ -11923,11 +11975,14 @@
   <tabstop>resetTextStyleSpatiumDependent</tabstop>
   <tabstop>resetTextStyleFontStyle</tabstop>
   <tabstop>resetTextStyleAlign</tabstop>
+  <tabstop>textStyleColor</tabstop>
   <tabstop>resetTextStyleColor</tabstop>
   <tabstop>resetTextStyleOffset</tabstop>
   <tabstop>textStyleFrameType</tabstop>
   <tabstop>resetTextStyleFrameType</tabstop>
+  <tabstop>textStyleFrameForeground</tabstop>
   <tabstop>resetTextStyleFrameForeground</tabstop>
+  <tabstop>textStyleFrameBackground</tabstop>
   <tabstop>resetTextStyleFrameBackground</tabstop>
   <tabstop>textStyleFrameBorder</tabstop>
   <tabstop>resetTextStyleFrameBorder</tabstop>
@@ -11935,10 +11990,8 @@
   <tabstop>resetTextStyleFramePadding</tabstop>
   <tabstop>textStyleFrameBorderRadius</tabstop>
   <tabstop>resetTextStyleFrameBorderRadius</tabstop>
+  <tabstop>maxChordShiftBelow</tabstop>
   <tabstop>buttonTogglePagelist</tabstop>
-  <tabstop>textStyleFrameForeground</tabstop>
-  <tabstop>textStyleFrameBackground</tabstop>
-  <tabstop>textStyleColor</tabstop>
  </tabstops>
  <resources>
   <include location="musescore.qrc"/>

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>912</width>
-    <height>692</height>
+    <width>910</width>
+    <height>660</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -3457,64 +3457,7 @@
            </item>
            <item row="0" column="0">
             <layout class="QGridLayout" name="gridLayout_99">
-             <item row="13" column="1">
-              <widget class="QDoubleSpinBox" name="keyTimesigDistance">
-               <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.010000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="12" column="1">
-              <widget class="QDoubleSpinBox" name="clefTimesigDistance">
-               <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.010000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="11" column="1">
-              <widget class="QDoubleSpinBox" name="clefKeyDistance">
-               <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.010000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="11" column="0">
-              <widget class="QLabel" name="label_94">
-               <property name="text">
-                <string>Clef to key distance:</string>
-               </property>
-               <property name="buddy">
-                <cstring>clefKeyDistance</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="17" column="2">
-              <widget class="QToolButton" name="resetStaffLineWidth">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Staff line thickness' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="16" column="2">
+             <item row="20" column="2">
               <widget class="QToolButton" name="resetMultiMeasureRestMargin">
                <property name="toolTip">
                 <string>Reset to default</string>
@@ -3531,13 +3474,33 @@
                </property>
               </widget>
              </item>
-             <item row="9" column="2">
-              <widget class="QToolButton" name="resetClefKeyRightMargin">
+             <item row="3" column="0">
+              <widget class="QLabel" name="label_102">
+               <property name="text">
+                <string>Barline to accidental distance:</string>
+               </property>
+               <property name="buddy">
+                <cstring>barAccidentalDistance</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="0">
+              <widget class="QLabel" name="label_18">
+               <property name="text">
+                <string>Clef left margin:</string>
+               </property>
+               <property name="buddy">
+                <cstring>clefLeftMargin</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="6">
+              <widget class="QToolButton" name="resetNoteBarDistance">
                <property name="toolTip">
                 <string>Reset to default</string>
                </property>
                <property name="accessibleName">
-                <string>Reset 'Clef/Key right margin' value</string>
+                <string>Reset 'Note to barline distance' value</string>
                </property>
                <property name="text">
                 <string notr="true"/>
@@ -3548,17 +3511,7 @@
                </property>
               </widget>
              </item>
-             <item row="13" column="0">
-              <widget class="QLabel" name="label_109">
-               <property name="text">
-                <string>Key to time signature distance:</string>
-               </property>
-               <property name="buddy">
-                <cstring>keyTimesigDistance</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="8" column="2">
+             <item row="12" column="2">
               <widget class="QToolButton" name="resetTimesigLeftMargin">
                <property name="toolTip">
                 <string>Reset to default</string>
@@ -3572,6 +3525,197 @@
                <property name="icon">
                 <iconset resource="musescore.qrc">
                  <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="8" column="1">
+              <widget class="QDoubleSpinBox" name="clefKeyDistance">
+               <property name="suffix">
+                <string extracomment="spatium unit">sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.010000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="6">
+              <widget class="QToolButton" name="resetClefBarlineDistance">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Clef to barline distance' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="12" column="0">
+              <widget class="QLabel" name="label_20">
+               <property name="text">
+                <string>Time signature left margin:</string>
+               </property>
+               <property name="buddy">
+                <cstring>timesigLeftMargin</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="2">
+              <widget class="QToolButton" name="resetMinMeasureWidth">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Minimum measure width' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_12">
+               <property name="text">
+                <string>Note left margin:</string>
+               </property>
+               <property name="buddy">
+                <cstring>barNoteDistance</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="19" column="6">
+              <widget class="QToolButton" name="resetSystemHeaderTimeSigDistance">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'System header with time signature distance' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="10" column="1">
+              <widget class="QDoubleSpinBox" name="keysigLeftMargin">
+               <property name="suffix">
+                <string>sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QDoubleSpinBox" name="barGraceDistance">
+               <property name="suffix">
+                <string>sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="20" column="1">
+              <widget class="QDoubleSpinBox" name="multiMeasureRestMargin">
+               <property name="suffix">
+                <string>sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="19" column="5">
+              <widget class="QDoubleSpinBox" name="systemHeaderTimeSigDistance">
+               <property name="suffix">
+                <string extracomment="spatium unit">sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="12" column="1">
+              <widget class="QDoubleSpinBox" name="timesigLeftMargin">
+               <property name="suffix">
+                <string>sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="12" column="5">
+              <widget class="QDoubleSpinBox" name="timesigBarlineDistance">
+               <property name="suffix">
+                <string>sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="9" column="2">
+              <widget class="QToolButton" name="resetClefTimesigDistance">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Clef to time signature distance' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="21" column="1">
+              <widget class="QDoubleSpinBox" name="staffLineWidth">
+               <property name="suffix">
+                <string extracomment="spatium unit">sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="21" column="0">
+              <widget class="QLabel" name="label">
+               <property name="text">
+                <string>Staff line thickness:</string>
+               </property>
+               <property name="wordWrap">
+                <bool>false</bool>
+               </property>
+               <property name="buddy">
+                <cstring>staffLineWidth</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="4">
+              <widget class="QLabel" name="label_13">
+               <property name="text">
+                <string>Note to barline distance:</string>
+               </property>
+               <property name="buddy">
+                <cstring>noteBarDistance</cstring>
                </property>
               </widget>
              </item>
@@ -3592,173 +3736,18 @@
                </property>
               </widget>
              </item>
-             <item row="5" column="2">
-              <widget class="QToolButton" name="resetMinNoteDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Minimum note distance' value</string>
-               </property>
+             <item row="9" column="0">
+              <widget class="QLabel" name="label_108">
                <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="2">
-              <widget class="QToolButton" name="resetNoteBarDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Note to barline distance' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="14" column="2">
-              <widget class="QToolButton" name="resetKeyBarlineDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Key to barline distance' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="12" column="2">
-              <widget class="QToolButton" name="resetClefTimesigDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Clef to time signature distance' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="14" column="1">
-              <widget class="QDoubleSpinBox" name="keyBarlineDistance">
-               <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.010000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="11" column="2">
-              <widget class="QToolButton" name="resetClefKeyDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Clef to key distance' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="13" column="2">
-              <widget class="QToolButton" name="resetKeyTimesigDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Key to time signature distance' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="15" column="0">
-              <widget class="QLabel" name="label_111">
-               <property name="text">
-                <string>System header distance:</string>
+                <string>Clef to time signature distance:</string>
                </property>
                <property name="buddy">
-                <cstring>systemHeaderDistance</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="14" column="0">
-              <widget class="QLabel" name="label_110">
-               <property name="text">
-                <string>Key to barline distance:</string>
-               </property>
-               <property name="buddy">
-                <cstring>keyBarlineDistance</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="15" column="2">
-              <widget class="QToolButton" name="resetSystemHeaderDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'System header distance' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="15" column="1">
-              <widget class="QDoubleSpinBox" name="systemHeaderDistance">
-               <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
+                <cstring>clefTimesigDistance</cstring>
                </property>
               </widget>
              </item>
              <item row="0" column="5">
               <widget class="QDoubleSpinBox" name="measureSpacing">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
                <property name="decimals">
                 <number>3</number>
                </property>
@@ -3770,122 +3759,43 @@
                </property>
               </widget>
              </item>
-             <item row="12" column="0">
-              <widget class="QLabel" name="label_108">
-               <property name="text">
-                <string>Clef to time signature distance:</string>
+             <item row="9" column="1">
+              <widget class="QDoubleSpinBox" name="clefTimesigDistance">
+               <property name="suffix">
+                <string extracomment="spatium unit">sp</string>
                </property>
-               <property name="buddy">
-                <cstring>clefTimesigDistance</cstring>
+               <property name="singleStep">
+                <double>0.010000000000000</double>
                </property>
               </widget>
              </item>
-             <item row="9" column="1">
-              <widget class="QDoubleSpinBox" name="clefKeyRightMargin">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
+             <item row="6" column="4">
+              <widget class="QLabel" name="label_53">
+               <property name="text">
+                <string>Clef to barline distance:</string>
                </property>
+               <property name="buddy">
+                <cstring>clefBarlineDistance</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="5">
+              <widget class="QDoubleSpinBox" name="noteBarDistance">
                <property name="suffix">
                 <string>sp</string>
                </property>
                <property name="singleStep">
-                <double>0.050000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_89">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Minimum measure width:</string>
-               </property>
-               <property name="buddy">
-                <cstring>minMeasureWidth_2</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="2">
-              <widget class="QToolButton" name="resetBarAccidentalDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Barline to accidental distance' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                <double>0.100000000000000</double>
                </property>
               </widget>
              </item>
              <item row="10" column="2">
-              <widget class="QToolButton" name="resetClefBarlineDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Clef to barline distance' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="7" column="2">
               <widget class="QToolButton" name="resetKeysigLeftMargin">
                <property name="toolTip">
                 <string>Reset to default</string>
                </property>
                <property name="accessibleName">
                 <string>Reset 'Key signature left margin' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="label_61">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Barline to grace note distance:</string>
-               </property>
-               <property name="buddy">
-                <cstring>barGraceDistance</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="2">
-              <widget class="QToolButton" name="resetMinMeasureWidth">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Minimum measure width' value</string>
                </property>
                <property name="text">
                 <string notr="true"/>
@@ -3913,45 +3823,278 @@
                </property>
               </widget>
              </item>
-             <item row="2" column="1">
-              <widget class="QDoubleSpinBox" name="barGraceDistance">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
+             <item row="8" column="0">
+              <widget class="QLabel" name="label_94">
+               <property name="text">
+                <string>Clef to key distance:</string>
                </property>
-               <property name="suffix">
-                <string>sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
+               <property name="buddy">
+                <cstring>clefKeyDistance</cstring>
                </property>
               </widget>
              </item>
-             <item row="16" column="1">
-              <widget class="QDoubleSpinBox" name="multiMeasureRestMargin">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
+             <item row="12" column="4">
+              <widget class="QLabel" name="label_113">
+               <property name="text">
+                <string>Time signature to barline distance:</string>
                </property>
-               <property name="suffix">
-                <string>sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
+               <property name="buddy">
+                <cstring>timesigBarlineDistance</cstring>
                </property>
               </widget>
              </item>
-             <item row="16" column="0">
+             <item row="20" column="0">
               <widget class="QLabel" name="label_103">
                <property name="text">
                 <string>Multimeasure rest margin:</string>
                </property>
                <property name="buddy">
                 <cstring>multiMeasureRestMargin</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="12" column="6">
+              <widget class="QToolButton" name="resetTimesigBarlineDistance">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Time signature to barline distance' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QDoubleSpinBox" name="barAccidentalDistance">
+               <property name="suffix">
+                <string>sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_89">
+               <property name="text">
+                <string>Minimum measure width:</string>
+               </property>
+               <property name="buddy">
+                <cstring>minMeasureWidth_2</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="4">
+              <widget class="QLabel" name="label_11">
+               <property name="text">
+                <string>Spacing (1=tight):</string>
+               </property>
+               <property name="buddy">
+                <cstring>measureSpacing</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="19" column="4">
+              <widget class="QLabel" name="label_112">
+               <property name="text">
+                <string>System header with time signature distance:</string>
+               </property>
+               <property name="buddy">
+                <cstring>systemHeaderTimeSigDistance</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="19" column="0">
+              <widget class="QLabel" name="label_111">
+               <property name="text">
+                <string>System header distance:</string>
+               </property>
+               <property name="buddy">
+                <cstring>systemHeaderDistance</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="10" column="5">
+              <widget class="QDoubleSpinBox" name="keyBarlineDistance">
+               <property name="suffix">
+                <string extracomment="spatium unit">sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.010000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="19" column="1">
+              <widget class="QDoubleSpinBox" name="systemHeaderDistance">
+               <property name="suffix">
+                <string extracomment="spatium unit">sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="2">
+              <widget class="QToolButton" name="resetMinNoteDistance">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Minimum note distance' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="1">
+              <widget class="QDoubleSpinBox" name="clefLeftMargin">
+               <property name="suffix">
+                <string>sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="10" column="6">
+              <widget class="QToolButton" name="resetKeyBarlineDistance">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Key to barline distance' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QDoubleSpinBox" name="barNoteDistance">
+               <property name="suffix">
+                <string>sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="10" column="4">
+              <widget class="QLabel" name="label_110">
+               <property name="text">
+                <string>Key to barline distance:</string>
+               </property>
+               <property name="buddy">
+                <cstring>keyBarlineDistance</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="7" column="0">
+              <widget class="QLabel" name="label_21">
+               <property name="text">
+                <string>Clef/Key right margin:</string>
+               </property>
+               <property name="textFormat">
+                <enum>Qt::PlainText</enum>
+               </property>
+               <property name="buddy">
+                <cstring>clefKeyRightMargin</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="21" column="2">
+              <widget class="QToolButton" name="resetStaffLineWidth">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Staff line thickness' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QDoubleSpinBox" name="minMeasureWidth_2">
+               <property name="suffix">
+                <string extracomment="spatium unit">sp</string>
+               </property>
+               <property name="minimum">
+                <double>2.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="7" column="2">
+              <widget class="QToolButton" name="resetClefKeyRightMargin">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Clef/Key right margin' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="5">
+              <widget class="QDoubleSpinBox" name="clefBarlineDistance">
+               <property name="suffix">
+                <string extracomment="spatium unit">sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.010000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="7" column="1">
+              <widget class="QDoubleSpinBox" name="clefKeyRightMargin">
+               <property name="suffix">
+                <string>sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.050000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="8" column="2">
+              <widget class="QToolButton" name="resetClefKeyDistance">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Clef to key distance' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
                </property>
               </widget>
              </item>
@@ -3972,327 +4115,20 @@
                </property>
               </widget>
              </item>
-             <item row="3" column="1">
-              <widget class="QDoubleSpinBox" name="barAccidentalDistance">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
+             <item row="3" column="2">
+              <widget class="QToolButton" name="resetBarAccidentalDistance">
+               <property name="toolTip">
+                <string>Reset to default</string>
                </property>
-               <property name="suffix">
-                <string>sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="17" column="1">
-              <widget class="QDoubleSpinBox" name="staffLineWidth">
-               <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0">
-              <widget class="QLabel" name="label_102">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
+               <property name="accessibleName">
+                <string>Reset 'Barline to accidental distance' value</string>
                </property>
                <property name="text">
-                <string>Barline to accidental distance:</string>
+                <string notr="true"/>
                </property>
-               <property name="buddy">
-                <cstring>barAccidentalDistance</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="17" column="0">
-              <widget class="QLabel" name="label">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Staff line thickness:</string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-               <property name="buddy">
-                <cstring>staffLineWidth</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="10" column="1">
-              <widget class="QDoubleSpinBox" name="clefBarlineDistance">
-               <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.010000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="10" column="0">
-              <widget class="QLabel" name="label_53">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Clef to barline distance:</string>
-               </property>
-               <property name="buddy">
-                <cstring>clefBarlineDistance</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="9" column="0">
-              <widget class="QLabel" name="label_21">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Clef/Key right margin:</string>
-               </property>
-               <property name="textFormat">
-                <enum>Qt::PlainText</enum>
-               </property>
-               <property name="buddy">
-                <cstring>clefKeyRightMargin</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="8" column="1">
-              <widget class="QDoubleSpinBox" name="timesigLeftMargin">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="suffix">
-                <string>sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QDoubleSpinBox" name="barNoteDistance">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="suffix">
-                <string>sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="1">
-              <widget class="QDoubleSpinBox" name="noteBarDistance">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="suffix">
-                <string>sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="8" column="0">
-              <widget class="QLabel" name="label_20">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Time signature left margin:</string>
-               </property>
-               <property name="buddy">
-                <cstring>timesigLeftMargin</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="7" column="0">
-              <widget class="QLabel" name="label_19">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Key signature left margin:</string>
-               </property>
-               <property name="buddy">
-                <cstring>keysigLeftMargin</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="label_12">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Note left margin:</string>
-               </property>
-               <property name="buddy">
-                <cstring>barNoteDistance</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="0">
-              <widget class="QLabel" name="label_13">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Note to barline distance:</string>
-               </property>
-               <property name="buddy">
-                <cstring>noteBarDistance</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="7" column="1">
-              <widget class="QDoubleSpinBox" name="keysigLeftMargin">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="suffix">
-                <string>sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="5" column="1">
-              <widget class="QDoubleSpinBox" name="minNoteDistance">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="suffix">
-                <string>sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="6" column="1">
-              <widget class="QDoubleSpinBox" name="clefLeftMargin">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="suffix">
-                <string>sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="5" column="0">
-              <widget class="QLabel" name="label_14">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Minimum note distance:</string>
-               </property>
-               <property name="buddy">
-                <cstring>minNoteDistance</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QDoubleSpinBox" name="minMeasureWidth_2">
-               <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
-               </property>
-               <property name="minimum">
-                <double>2.000000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="6" column="0">
-              <widget class="QLabel" name="label_18">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Clef left margin:</string>
-               </property>
-               <property name="buddy">
-                <cstring>clefLeftMargin</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="4">
-              <widget class="QLabel" name="label_11">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Spacing (1=tight):</string>
-               </property>
-               <property name="buddy">
-                <cstring>measureSpacing</cstring>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
                </property>
               </widget>
              </item>
@@ -4313,16 +4149,23 @@
                </property>
               </widget>
              </item>
-             <item row="15" column="4">
-              <widget class="QLabel" name="label_112">
+             <item row="2" column="0">
+              <widget class="QLabel" name="label_61">
                <property name="text">
-                <string>System header with time signature distance:</string>
-               </property>
-               <property name="indent">
-                <number>-1</number>
+                <string>Barline to grace note distance:</string>
                </property>
                <property name="buddy">
-                <cstring>systemHeaderTimeSigDistance</cstring>
+                <cstring>barGraceDistance</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="10" column="0">
+              <widget class="QLabel" name="label_19">
+               <property name="text">
+                <string>Key signature left margin:</string>
+               </property>
+               <property name="buddy">
+                <cstring>keysigLeftMargin</cstring>
                </property>
               </widget>
              </item>
@@ -4342,13 +4185,13 @@
                </property>
               </spacer>
              </item>
-             <item row="15" column="6">
-              <widget class="QToolButton" name="resetSystemHeaderTimeSigDistance">
+             <item row="19" column="2">
+              <widget class="QToolButton" name="resetSystemHeaderDistance">
                <property name="toolTip">
                 <string>Reset to default</string>
                </property>
                <property name="accessibleName">
-                <string>Reset 'System header with time signature distance' value</string>
+                <string>Reset 'System header distance' value</string>
                </property>
                <property name="text">
                 <string notr="true"/>
@@ -4359,62 +4202,60 @@
                </property>
               </widget>
              </item>
-             <item row="8" column="4">
-              <widget class="QLabel" name="label_113">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Time signature to barline distance:</string>
-               </property>
-               <property name="buddy">
-                <cstring>timesigBarlineDistance</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="15" column="5">
-              <widget class="QDoubleSpinBox" name="systemHeaderTimeSigDistance">
-               <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="8" column="6">
-              <widget class="QToolButton" name="resetTimesigBarlineDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Time signature to barline distance' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="8" column="5">
-              <widget class="QDoubleSpinBox" name="timesigBarlineDistance">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
+             <item row="5" column="1">
+              <widget class="QDoubleSpinBox" name="minNoteDistance">
                <property name="suffix">
                 <string>sp</string>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="0">
+              <widget class="QLabel" name="label_14">
+               <property name="text">
+                <string>Minimum note distance:</string>
+               </property>
+               <property name="buddy">
+                <cstring>minNoteDistance</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="11" column="0">
+              <widget class="QLabel" name="label_109">
+               <property name="text">
+                <string>Key to time signature distance:</string>
+               </property>
+               <property name="buddy">
+                <cstring>keyTimesigDistance</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="11" column="1">
+              <widget class="QDoubleSpinBox" name="keyTimesigDistance">
+               <property name="suffix">
+                <string extracomment="spatium unit">sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.010000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="11" column="2">
+              <widget class="QToolButton" name="resetKeyTimesigDistance">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Key to time signature distance' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
                </property>
               </widget>
              </item>
@@ -5219,8 +5060,8 @@
           <property name="title">
            <string>Tuplets</string>
           </property>
-          <layout class="QVBoxLayout" name="verticalLayout_38">
-           <item>
+          <layout class="QGridLayout" name="gridLayout_48">
+           <item row="0" column="0">
             <widget class="QGroupBox" name="verticalDistance">
              <property name="title">
               <string>Vertical Distance from Notes</string>
@@ -5402,7 +5243,7 @@
              </layout>
             </widget>
            </item>
-           <item>
+           <item row="0" column="1">
             <widget class="QGroupBox" name="groupBox_26">
              <property name="title">
               <string>Horizontal Distance from Notes</string>
@@ -5626,7 +5467,7 @@
              </layout>
             </widget>
            </item>
-           <item>
+           <item row="2" column="0" colspan="2">
             <widget class="QGroupBox" name="groupBox_19">
              <property name="title">
               <string>Brackets</string>
@@ -5749,7 +5590,7 @@
              </layout>
             </widget>
            </item>
-           <item>
+           <item row="3" column="0" colspan="2">
             <widget class="QGroupBox" name="groupBox_30">
              <property name="title">
               <string>Properties</string>
@@ -11520,6 +11361,12 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>Awl::ColorLabel</class>
+   <extends>QPushButton</extends>
+   <header>awl/colorlabel.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>Ms::OffsetSelect</class>
    <extends>QWidget</extends>
    <header>inspector/offsetSelect.h</header>
@@ -11529,12 +11376,6 @@
    <class>Ms::FontStyleSelect</class>
    <extends>QWidget</extends>
    <header>inspector/fontStyleSelect.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>Awl::ColorLabel</class>
-   <extends>QPushButton</extends>
-   <header>awl/colorlabel.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -11678,34 +11519,34 @@
   <tabstop>resetMeasureSpacing</tabstop>
   <tabstop>barNoteDistance</tabstop>
   <tabstop>resetBarNoteDistance</tabstop>
+  <tabstop>noteBarDistance</tabstop>
+  <tabstop>resetNoteBarDistance</tabstop>
   <tabstop>barGraceDistance</tabstop>
   <tabstop>resetBarGraceDistance</tabstop>
   <tabstop>barAccidentalDistance</tabstop>
   <tabstop>resetBarAccidentalDistance</tabstop>
-  <tabstop>noteBarDistance</tabstop>
-  <tabstop>resetNoteBarDistance</tabstop>
   <tabstop>minNoteDistance</tabstop>
   <tabstop>resetMinNoteDistance</tabstop>
   <tabstop>clefLeftMargin</tabstop>
   <tabstop>resetClefLeftMargin</tabstop>
-  <tabstop>keysigLeftMargin</tabstop>
-  <tabstop>resetKeysigLeftMargin</tabstop>
-  <tabstop>timesigLeftMargin</tabstop>
-  <tabstop>resetTimesigLeftMargin</tabstop>
-  <tabstop>timesigBarlineDistance</tabstop>
-  <tabstop>resetTimesigBarlineDistance</tabstop>
-  <tabstop>clefKeyRightMargin</tabstop>
-  <tabstop>resetClefKeyRightMargin</tabstop>
   <tabstop>clefBarlineDistance</tabstop>
   <tabstop>resetClefBarlineDistance</tabstop>
+  <tabstop>clefKeyRightMargin</tabstop>
+  <tabstop>resetClefKeyRightMargin</tabstop>
   <tabstop>clefKeyDistance</tabstop>
   <tabstop>resetClefKeyDistance</tabstop>
   <tabstop>clefTimesigDistance</tabstop>
   <tabstop>resetClefTimesigDistance</tabstop>
-  <tabstop>keyTimesigDistance</tabstop>
-  <tabstop>resetKeyTimesigDistance</tabstop>
+  <tabstop>keysigLeftMargin</tabstop>
+  <tabstop>resetKeysigLeftMargin</tabstop>
   <tabstop>keyBarlineDistance</tabstop>
   <tabstop>resetKeyBarlineDistance</tabstop>
+  <tabstop>keyTimesigDistance</tabstop>
+  <tabstop>resetKeyTimesigDistance</tabstop>
+  <tabstop>timesigLeftMargin</tabstop>
+  <tabstop>resetTimesigLeftMargin</tabstop>
+  <tabstop>timesigBarlineDistance</tabstop>
+  <tabstop>resetTimesigBarlineDistance</tabstop>
   <tabstop>systemHeaderDistance</tabstop>
   <tabstop>resetSystemHeaderDistance</tabstop>
   <tabstop>systemHeaderTimeSigDistance</tabstop>
@@ -11948,6 +11789,7 @@
   <tabstop>maxHarmonyBarDistance</tabstop>
   <tabstop>maxChordShiftAbove</tabstop>
   <tabstop>resetMaxChordShiftAbove</tabstop>
+  <tabstop>maxChordShiftBelow</tabstop>
   <tabstop>resetMaxChordShiftBelow</tabstop>
   <tabstop>harmonyPlay</tabstop>
   <tabstop>capoPosition</tabstop>
@@ -11992,7 +11834,6 @@
   <tabstop>resetTextStyleFramePadding</tabstop>
   <tabstop>textStyleFrameBorderRadius</tabstop>
   <tabstop>resetTextStyleFrameBorderRadius</tabstop>
-  <tabstop>maxChordShiftBelow</tabstop>
   <tabstop>buttonTogglePagelist</tabstop>
  </tabstops>
  <resources>

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>834</width>
-    <height>739</height>
+    <width>702</width>
+    <height>599</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -54,8 +54,8 @@
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>131</width>
-         <height>31</height>
+         <width>0</width>
+         <height>0</height>
         </size>
        </property>
       </spacer>
@@ -570,8 +570,8 @@
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
-              <height>20</height>
+              <width>0</width>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -586,8 +586,8 @@
          </property>
          <property name="sizeHint" stdset="0">
           <size>
-           <width>20</width>
-           <height>40</height>
+           <width>0</width>
+           <height>0</height>
           </size>
          </property>
         </spacer>
@@ -761,8 +761,8 @@
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
-              <height>20</height>
+              <width>0</width>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -795,10 +795,7 @@
       <attribute name="title">
        <string>Canvas</string>
       </attribute>
-      <layout class="QVBoxLayout">
-       <property name="spacing">
-        <number>6</number>
-       </property>
+      <layout class="QGridLayout" name="gridLayout1">
        <property name="leftMargin">
         <number>9</number>
        </property>
@@ -811,7 +808,20 @@
        <property name="bottomMargin">
         <number>9</number>
        </property>
-       <item>
+       <item row="3" column="0">
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="0">
         <widget class="QGroupBox" name="groupBox_2">
          <property name="accessibleName">
           <string>Background</string>
@@ -930,7 +940,7 @@
          </layout>
         </widget>
        </item>
-       <item>
+       <item row="1" column="0">
         <widget class="QGroupBox" name="groupBox_3">
          <property name="accessibleName">
           <string>Paper</string>
@@ -1056,12 +1066,70 @@
          </layout>
         </widget>
        </item>
-       <item>
+       <item row="1" column="1">
+        <widget class="QGroupBox" name="groupBox_11">
+         <property name="title">
+          <string>Scroll Pages</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_12">
+          <item row="0" column="1">
+           <widget class="QRadioButton" name="pageHorizontal">
+            <property name="text">
+             <string>Horizontally</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QRadioButton" name="pageVertical">
+            <property name="text">
+             <string>Vertically</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <spacer name="horizontalSpacer_22">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="2" column="1">
+           <widget class="QCheckBox" name="limitScrollArea">
+            <property name="toolTip">
+             <string>Limit the scroll area to the edges of the score</string>
+            </property>
+            <property name="whatsThis">
+             <string>If this is checked, scrolling will stop at the edge of the score.</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>If this is checked, scrolling will stop at the edge of the score.</string>
+            </property>
+            <property name="text">
+             <string>Limit scroll area to page borders</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="0" column="1">
         <widget class="QGroupBox" name="groupBox_7">
          <property name="title">
           <string>Zoom</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout3">
+         <layout class="QGridLayout" name="gridLayout31">
           <item row="0" column="2">
            <widget class="QSpinBox" name="zoomDefaultLevel">
             <property name="enabled">
@@ -1207,8 +1275,8 @@
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>487</width>
-              <height>20</height>
+              <width>0</width>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -1216,52 +1284,7 @@
          </layout>
         </widget>
        </item>
-       <item>
-        <widget class="QGroupBox" name="groupBox_11">
-         <property name="title">
-          <string>Scroll Pages</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_12">
-          <item row="0" column="0">
-           <widget class="QRadioButton" name="pageHorizontal">
-            <property name="text">
-             <string>Horizontally</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QRadioButton" name="pageVertical">
-            <property name="text">
-             <string>Vertically</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QCheckBox" name="limitScrollArea">
-            <property name="toolTip">
-             <string>Limit the scroll area to the edges of the score</string>
-            </property>
-            <property name="whatsThis">
-             <string>If this is checked, scrolling will stop at the edge of the score.</string>
-            </property>
-            <property name="accessibleDescription">
-             <string>If this is checked, scrolling will stop at the edge of the score.</string>
-            </property>
-            <property name="text">
-             <string>Limit scroll area to page borders</string>
-            </property>
-            <property name="checked">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
+       <item row="2" column="0" colspan="2">
         <widget class="QGroupBox" name="groupBox_4">
          <property name="title">
           <string>Miscellaneous</string>
@@ -1283,6 +1306,13 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_24">
+            <property name="text">
+             <string>Proximity for selecting elements:</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="1">
            <widget class="QSpinBox" name="proximity">
             <property name="accessibleName">
@@ -1299,41 +1329,21 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="2" colspan="2">
-           <spacer>
+          <item row="1" column="2">
+           <spacer name="horizontalSpacer_5">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>201</width>
+              <width>40</width>
               <height>20</height>
              </size>
             </property>
            </spacer>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_24">
-            <property name="text">
-             <string>Proximity for selecting elements:</string>
-            </property>
-           </widget>
-          </item>
          </layout>
         </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
        </item>
       </layout>
      </widget>
@@ -1401,8 +1411,8 @@
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
-              <height>20</height>
+              <width>0</width>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -1432,8 +1442,8 @@
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
-              <height>20</height>
+              <width>0</width>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -1622,8 +1632,8 @@
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
-              <height>20</height>
+              <width>0</width>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -2103,8 +2113,8 @@
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
-              <height>20</height>
+              <width>0</width>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -2116,8 +2126,8 @@
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
-              <height>20</height>
+              <width>0</width>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -2129,8 +2139,8 @@
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
-              <height>20</height>
+              <width>0</width>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -2533,8 +2543,8 @@
          </property>
          <property name="sizeHint" stdset="0">
           <size>
-           <width>20</width>
-           <height>40</height>
+           <width>0</width>
+           <height>0</height>
           </size>
          </property>
         </spacer>
@@ -2818,8 +2828,8 @@
          </property>
          <property name="sizeHint" stdset="0">
           <size>
-           <width>20</width>
-           <height>40</height>
+           <width>0</width>
+           <height>0</height>
           </size>
          </property>
         </spacer>
@@ -2884,8 +2894,8 @@
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
-              <height>20</height>
+              <width>0</width>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -3133,8 +3143,8 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
-              <height>20</height>
+              <width>0</width>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -3249,8 +3259,8 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
-              <height>20</height>
+              <width>0</width>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -3332,8 +3342,8 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>324</width>
-              <height>20</height>
+              <width>0</width>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -3377,8 +3387,8 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
-              <height>20</height>
+              <width>0</width>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -3393,8 +3403,8 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
          </property>
          <property name="sizeHint" stdset="0">
           <size>
-           <width>20</width>
-           <height>40</height>
+           <width>0</width>
+           <height>0</height>
           </size>
          </property>
         </spacer>
@@ -3560,12 +3570,6 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
        </item>
        <item>
         <widget class="QGroupBox" name="MIDI">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>100</height>
-          </size>
-         </property>
          <property name="accessibleName">
           <string notr="true">MIDI</string>
          </property>
@@ -3645,8 +3649,8 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>525</width>
-              <height>20</height>
+              <width>0</width>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -3691,8 +3695,8 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
-              <height>20</height>
+              <width>0</width>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -3723,8 +3727,8 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
          </property>
          <property name="sizeHint" stdset="0">
           <size>
-           <width>20</width>
-           <height>40</height>
+           <width>0</width>
+           <height>0</height>
           </size>
          </property>
         </spacer>
@@ -3746,8 +3750,8 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
          </property>
          <property name="sizeHint" stdset="0">
           <size>
-           <width>20</width>
-           <height>40</height>
+           <width>0</width>
+           <height>0</height>
           </size>
          </property>
         </spacer>
@@ -3782,8 +3786,8 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
-              <height>20</height>
+              <width>0</width>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -3933,8 +3937,8 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
-              <height>20</height>
+              <width>0</width>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -4087,8 +4091,8 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
-              <height>20</height>
+              <width>0</width>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -4263,8 +4267,8 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
            </property>
            <property name="sizeHint" stdset="0">
             <size>
-             <width>40</width>
-             <height>20</height>
+             <width>0</width>
+             <height>0</height>
             </size>
            </property>
           </spacer>
@@ -4300,36 +4304,6 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
           <string>Automatic Update Check</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_6">
-          <item row="4" column="0">
-           <spacer name="verticalSpacer_5">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="2" column="0">
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
-            <item>
-             <spacer name="horizontalSpacer_5">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
           <item row="0" column="0">
            <widget class="QCheckBox" name="checkUpdateStartup">
             <property name="text">
@@ -4343,6 +4317,19 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
              <string>Check for new version of MuseScore extensions</string>
             </property>
            </widget>
+          </item>
+          <item row="3" column="0">
+           <spacer name="verticalSpacer_5">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>
@@ -4397,8 +4384,8 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
              </property>
              <property name="sizeHint" stdset="0">
               <size>
-               <width>40</width>
-               <height>20</height>
+               <width>0</width>
+               <height>0</height>
               </size>
              </property>
             </spacer>

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>702</width>
-    <height>599</height>
+    <height>486</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -1354,8 +1354,8 @@
       <attribute name="title">
        <string>Note Input</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_4">
-       <item>
+      <layout class="QGridLayout" name="gridLayout5">
+       <item row="0" column="0">
         <widget class="QGroupBox" name="groupBox_13">
          <property name="title">
           <string>Note Input</string>
@@ -1420,7 +1420,20 @@
          </layout>
         </widget>
        </item>
-       <item>
+       <item row="3" column="0">
+        <spacer>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="1">
         <widget class="QGroupBox" name="playNotes">
          <property name="mouseTracking">
           <bool>true</bool>
@@ -1447,13 +1460,6 @@
              </size>
             </property>
            </spacer>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_37">
-            <property name="text">
-             <string>Default duration:</string>
-            </property>
-           </widget>
           </item>
           <item row="1" column="0">
            <widget class="QCheckBox" name="playChordOnAddNote">
@@ -1494,10 +1500,17 @@
             </property>
            </widget>
           </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_37">
+            <property name="text">
+             <string>Default duration:</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
-       <item>
+       <item row="2" column="0" colspan="2">
         <widget class="QGroupBox" name="rcGroup">
          <property name="toolTip">
           <string>Enable MIDI remote control</string>
@@ -2536,19 +2549,6 @@
          </layout>
         </widget>
        </item>
-       <item>
-        <spacer>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="tabScore">
@@ -3418,8 +3418,86 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
       <attribute name="title">
        <string>Import</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_10">
-       <item>
+      <layout class="QGridLayout" name="gridLayout_16">
+       <item row="5" column="0">
+        <widget class="QGroupBox" name="resetElementPositions">
+         <property name="toolTip">
+          <string>Reset element positions when importing scores from older MuseScore versions.</string>
+         </property>
+         <property name="title">
+          <string>Reset Element Positions</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_7">
+          <item>
+           <widget class="QRadioButton" name="resetElementPositionsAlwaysAsk">
+            <property name="text">
+             <string>Always ask</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="resetElementPositionsYes">
+            <property name="text">
+             <string>Yes</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="resetElementPositionsNo">
+            <property name="text">
+             <string>No</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_21">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QGroupBox" name="MusicXML">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="accessibleName">
+          <string notr="true">MusicXML</string>
+         </property>
+         <property name="title">
+          <string notr="true">MusicXML</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_13">
+          <item>
+           <widget class="QCheckBox" name="importLayout">
+            <property name="text">
+             <string>Import layout</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="importBreaks">
+            <property name="text">
+             <string>Import system and page breaks</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="0" column="0">
         <widget class="QGroupBox" name="styleUsedForImport">
          <property name="title">
           <string>Style Used for Import</string>
@@ -3473,102 +3551,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
          </layout>
         </widget>
        </item>
-       <item>
-        <widget class="QGroupBox" name="characterSetUsedWhenImportingBinaryFiles">
-         <property name="title">
-          <string>Character Set Used When Importing Binary Files</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_12">
-          <item>
-           <layout class="QFormLayout" name="formLayout">
-            <item row="2" column="0">
-             <widget class="QLabel" name="label_49">
-              <property name="text">
-               <string>Overture import character set:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QComboBox" name="importCharsetListOve">
-              <property name="accessibleName">
-               <string>Overture import character set</string>
-              </property>
-              <property name="accessibleDescription">
-               <string>Choose Overture import character set</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_23">
-              <property name="text">
-               <string>Guitar Pro import character set:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QComboBox" name="importCharsetListGP">
-              <property name="accessibleName">
-               <string>Guitar Pro import character set</string>
-              </property>
-              <property name="accessibleDescription">
-               <string>Choose Guitar Pro import character set</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="MusicXML">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="accessibleName">
-          <string notr="true">MusicXML</string>
-         </property>
-         <property name="title">
-          <string notr="true">MusicXML</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_13">
-          <item>
-           <widget class="QCheckBox" name="importLayout">
-            <property name="text">
-             <string>Import layout</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="importBreaks">
-            <property name="text">
-             <string>Import system and page breaks</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="groupBox_omr">
-         <property name="title">
-          <string>OMR</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_omr">
-          <item row="0" column="0">
-           <widget class="QCheckBox" name="useLocalAvsOmr">
-            <property name="text">
-             <string>Use local OMR engine</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
+       <item row="2" column="1">
         <widget class="QGroupBox" name="MIDI">
          <property name="accessibleName">
           <string notr="true">MIDI</string>
@@ -3658,53 +3641,67 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
          </layout>
         </widget>
        </item>
-       <item>
-        <widget class="QGroupBox" name="resetElementPositions">
-         <property name="toolTip">
-          <string>Reset element positions when importing scores from older MuseScore versions.</string>
+       <item row="7" column="0">
+        <spacer>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="1">
+        <widget class="QGroupBox" name="characterSetUsedWhenImportingBinaryFiles">
          <property name="title">
-          <string>Reset Element Positions</string>
+          <string>Character Set Used When Importing Binary Files</string>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_7">
+         <layout class="QVBoxLayout" name="verticalLayout_12">
           <item>
-           <widget class="QRadioButton" name="resetElementPositionsAlwaysAsk">
-            <property name="text">
-             <string>Always ask</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="resetElementPositionsYes">
-            <property name="text">
-             <string>Yes</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="resetElementPositionsNo">
-            <property name="text">
-             <string>No</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_21">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-           </spacer>
+           <layout class="QFormLayout" name="formLayout">
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_49">
+              <property name="text">
+               <string>Overture import character set:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QComboBox" name="importCharsetListOve">
+              <property name="accessibleName">
+               <string>Overture import character set</string>
+              </property>
+              <property name="accessibleDescription">
+               <string>Choose Overture import character set</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QComboBox" name="importCharsetListGP">
+              <property name="accessibleName">
+               <string>Guitar Pro import character set</string>
+              </property>
+              <property name="accessibleDescription">
+               <string>Choose Guitar Pro import character set</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_23">
+              <property name="text">
+               <string>Guitar Pro import character set:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>
        </item>
-       <item>
+       <item row="5" column="1">
         <widget class="QGroupBox" name="groupBox_scoreMigration">
          <property name="title">
           <string>Score improvements</string>
@@ -3720,18 +3717,21 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
          </layout>
         </widget>
        </item>
-       <item>
-        <spacer>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
+       <item row="6" column="0" colspan="2">
+        <widget class="QGroupBox" name="groupBox_omr">
+         <property name="title">
+          <string>OMR</string>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-        </spacer>
+         <layout class="QGridLayout" name="gridLayout_omr">
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="useLocalAvsOmr">
+            <property name="text">
+             <string>Use local OMR engine</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -4460,7 +4460,6 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>fontFamily</tabstop>
   <tabstop>fontSize</tabstop>
   <tabstop>autoSave</tabstop>
-  <tabstop>autoSaveTime</tabstop>
   <tabstop>oscServer</tabstop>
   <tabstop>oscPort</tabstop>
   <tabstop>bgColorButton</tabstop>
@@ -4533,6 +4532,10 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>instrumentList1Button</tabstop>
   <tabstop>instrumentList2</tabstop>
   <tabstop>instrumentList2Button</tabstop>
+  <tabstop>scoreOrderList1</tabstop>
+  <tabstop>scoreOrderList1Button</tabstop>
+  <tabstop>scoreOrderList2</tabstop>
+  <tabstop>scoreOrderList2Button</tabstop>
   <tabstop>defaultStyle</tabstop>
   <tabstop>defaultStyleButton</tabstop>
   <tabstop>partStyle</tabstop>
@@ -4565,11 +4568,12 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>importCharsetListOve</tabstop>
   <tabstop>importLayout</tabstop>
   <tabstop>importBreaks</tabstop>
-  <tabstop>useLocalAvsOmr</tabstop>
   <tabstop>shortestNote</tabstop>
   <tabstop>resetElementPositionsAlwaysAsk</tabstop>
   <tabstop>resetElementPositionsYes</tabstop>
   <tabstop>resetElementPositionsNo</tabstop>
+  <tabstop>scoreMigrationEnabled</tabstop>
+  <tabstop>useLocalAvsOmr</tabstop>
   <tabstop>pngResolution</tabstop>
   <tabstop>pngTransparent</tabstop>
   <tabstop>exportPdfDpi</tabstop>
@@ -4596,6 +4600,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>advancedSearch</tabstop>
   <tabstop>resetToDefault</tabstop>
   <tabstop>buttonBox</tabstop>
+  <tabstop>autoSaveTime</tabstop>
  </tabstops>
  <resources>
   <include location="musescore.qrc"/>


### PR DESCRIPTION
* Fix tab order in Edit Style dialog
* Fix [#312195](https://musescore.org/en/node/312195): Style dialog loses setting of chord symbol radio buttons (replaces and improves @MarcSabatella's PR #6954)
* Fix [#306644](https://musescore.org/en/node/306644): Preferences window doesn't match on a 15'' Laptop screen and height isn't resizeable
* Reducing hight of Preferences dialog further by using grid layouts for the Note Input and Import tabs.
   Also fixing the tab order.
* Reducing height of the Edit Style dialog by reorganizing the Measure part of the dialog.
   Limiting factor now being the the top entry, the Score settings