### PR TITLE
[MU3] Harp and braces

### DIFF
--- a/libmscore/scoreOrder.cpp
+++ b/libmscore/scoreOrder.cpp
@@ -626,8 +626,6 @@ void ScoreOrder::setBracketsAndBarlines(Score* score)
                               thnBracketSpan  = 0;
                               }
                         }
-                  if (sg->thinBracket && !blockThinBracket && !staffIdx)
-                        thnBracketSpan += part->nstaves();
 
                   if (ii.instrTemplate->nstaves() > 1)
                         {
@@ -641,6 +639,8 @@ void ScoreOrder::setBracketsAndBarlines(Score* score)
                         }
                   else
                         {
+                        if (sg->thinBracket && !staffIdx)
+                              thnBracketSpan += part->nstaves();
                         if (prvStaff)
                               prvStaff->undoChangeProperty(Pid::STAFF_BARLINE_SPAN, (sg->barLineSpan && (!prvScoreGroup || (sg->section() == prvScoreGroup->section()))));
                         prvStaff = staff;

--- a/share/instruments/orders.xml
+++ b/share/instruments/orders.xml
@@ -5,6 +5,9 @@
         <instrument id="timpani">
             <family id="timpani">Timpani</family>
         </instrument>
+        <instrument id="harp">
+            <family id="harps">Harps</family>
+        </instrument>
         <section id="woodwind" showSystemMarkings="true">
             <family>flutes</family>
             <family>oboes</family>
@@ -31,6 +34,7 @@
             <family>other-percussion</family>
         </section>
         <family>keyboards</family>
+        <family>harps</family>
         <family>organs</family>
         <family>synths</family>
         <section id="plucked-strings">


### PR DESCRIPTION
Resolves: https://trello.com/c/iVfSQodt/15-harp-has-all-the-brackets

Solves a bug preventing generating square braces for an instrument having multiple staves.
Next moved the harp to a dedicated family for the <code>Orchestra</code> score order.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
