### PR TITLE
[MU3] Move soloist section in Orchestra

### DIFF
--- a/share/instruments/orders.xml
+++ b/share/instruments/orders.xml
@@ -36,10 +36,10 @@
         <section id="plucked-strings">
             <family>plucked-strings</family>
         </section>
+        <soloists/>
         <section id="voices" barLineSpan="false">
             <family>voices</family>
         </section>
-        <soloists/>
         <section id="strings" showSystemMarkings="true">
             <family>orchestral-strings</family>
         </section>


### PR DESCRIPTION
Move soloist section in <code>Orchestra</code> above choir to make sure vocal soloists are always above the choir.

In case a score has both vocal and instrumental soloists, the instrumental soloist is at the wrong place and should moved manually to the right position in the score.

The intention is to come with a flexible definition of soloist locations in a future version.

Resolves: https://trello.com/c/3Oa4SG5R/27-solo-singers-should-go-above-all-other-singers-in-orchestral-ordering

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
