### PR TITLE
[MU3] Activate "Orchestra" in "New Instruments" form if no order is defined.

### DIFF
--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -1411,6 +1411,7 @@ void InstrumentsWidget::setMakeSoloistButtonText()
 void InstrumentsWidget::setScoreOrder(ScoreOrder* order)
       {
       scoreOrderComboBox->setCurrentIndex(scoreOrders.getScoreOrderIndex(order));
+      sortInstruments();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
When the <code>Edit Instruments</code> form is opened for a score not having a score order, order <code>Orchestra</code> is shown but is now also selected/activated.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
