### PR TITLE
Fix #313700: Allow to select text using mouse in Palettes search field

### DIFF
--- a/mscore/qml/palettes/PalettesWidgetHeader.qml
+++ b/mscore/qml/palettes/PalettesWidgetHeader.qml
@@ -59,6 +59,8 @@ Item {
                 Accessible.name = qsTr("Palette Search")
             }
 
+            selectByMouse: true
+
             Timer {
                 id: resultsTimer
                 interval: 500


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/313700

Allow the user to select text in the Palettes search field by double-clicking or dragging with the mouse. (Probably many users will expect this to work.)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
