### PR TITLE
 Fix #86376, fix #313736: Additions to F2 Special Characters > Common Symbols

### DIFF
--- a/mscore/textpalette.cpp
+++ b/mscore/textpalette.cpp
@@ -635,7 +635,7 @@ int commonTextSymbols[] = {
       0x00c9,    // &Eacute;
       0x00ca,    // &Ecirc;
       0x00cb,    // &Euml;
-      0x00cc,    // %Igrave;
+      0x00cc,    // &Igrave;
       0x00cd,    // &Iacute;
       0x00ce,    // &Icirc;
       0x00cf,    // &Iuml
@@ -729,9 +729,33 @@ int commonTextSymbols[] = {
       0x215D,    // &frac58; ?
       0x215E,    // &frac78; ?
 
-      // 0x203F,    // curved ligature to connect two syllables
+      //0x203F,    // undertie
       0x035c,    // curved ligature to connect two syllables
-      0x0361     // curved ligature (top)
+      //0x2040,    // character tie
+      0x0361,    // curved ligature (top)
+
+      0x2013,    // &endash
+      0x2014,    // &emdash
+      0x2018,    // &rsquo;
+      0x2019,    // &lsquo;
+      0x201C,    // &ldquo;
+      0x201D,    // &rdquo;
+      0x2020,    // &dagger;
+      0x2021,    // &Dagger;
+      0x2022,    // &bull;
+      0x2026,    // &mldr;
+      0x00A7,    // &sect;
+      0x00B0,    // &deg;
+      0x00B1,    // &pm;
+      0x00B9,    // &sup1;
+      0x00B2,    // &sup2;
+      0x00B3,    // &sup3;
+
+      0x0024,    // &dollar;
+      0x20Ac,    // &euro;
+      0x00A2,    // &cent;
+      0x00A3,    // &pound;
+      0x00A5,    // &yen;
       };
 
 void TextPalette::populateCommon()


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/86376 and https://musescore.org/en/node/313736
On top add the most common currency symbols, $, €, ¢, £ and ¥

Except for indenting changes this should apply to master also.