### PR TITLE
[MU3] Fix AppImage nightly autoupdates and build scripts

### DIFF
--- a/build/ci/linux/package.sh
+++ b/build/ci/linux/package.sh
@@ -15,13 +15,17 @@ INSTALL_DIR="$(cat $BUILD_DIR/PREFIX.txt)" # MuseScore was installed here
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --build_mode) BUILD_MODE="$2"; shift ;;
+        -v|--version) BUILD_VERSION="$2"; shift ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
 done
 
 if [ -z "$BUILD_MODE" ]; then BUILD_MODE=$(cat $ARTIFACTS_DIR/env/build_mode.env); fi
+if [ -z "$BUILD_VERSION" ]; then BUILD_VERSION=$(cat $ARTIFACTS_DIR/env/build_version.env); fi
+
 if [ -z "$BUILD_MODE" ]; then echo "error: not set BUILD_MODE"; exit 1; fi
+if [ -z "$BUILD_VERSION" ]; then echo "error: not set BUILD_VERSION"; exit 1; fi
 
 PACKTYPE=appimage
 if [ "$BUILD_MODE" == "devel_build" ]; then PACKTYPE=appimage; fi
@@ -29,7 +33,11 @@ if [ "$BUILD_MODE" == "nightly_build" ]; then PACKTYPE=appimage; fi
 if [ "$BUILD_MODE" == "testing_build" ]; then PACKTYPE=appimage; fi
 if [ "$BUILD_MODE" == "stable_build" ]; then PACKTYPE=appimage; fi
 
+MAJOR_VERSION="${BUILD_VERSION%%.*}"
+
 echo "BUILD_MODE: $BUILD_MODE"
+echo "BUILD_VERSION: $BUILD_VERSION"
+echo "MAJOR_VERSION: $MAJOR_VERSION"
 echo "PACKTYPE: $PACKTYPE"
 echo "INSTALL_DIR: $INSTALL_DIR"
 
@@ -40,7 +48,7 @@ if [ "$BUILD_MODE" == "nightly_build" ]; then
   ARTIFACT_NAME=MuseScoreNightly-${BUILD_DATETIME}-${BUILD_BRANCH}-${BUILD_REVISION}-x86_64
 else
   BUILD_VERSION=$(cat $ARTIFACTS_DIR/env/build_version.env)
-  ARTIFACT_NAME=MuseScore-${BUILD_VERSION}-x86_64  
+  ARTIFACT_NAME=MuseScore-${BUILD_VERSION}-x86_64
 fi
 
 if [ "$PACKTYPE" == "7z" ]; then
@@ -55,21 +63,20 @@ if [ "$PACKTYPE" == "appimage" ]; then
     # https://github.com/AppImage/AppImageSpec/blob/master/draft.md#update-information
     case "${BUILD_MODE}" in
     "stable_build")  export UPDATE_INFORMATION="gh-releases-zsync|musescore|MuseScore|latest|MuseScore-*x86_64.AppImage.zsync";;
-    "nightly_build") export UPDATE_INFORMATION="zsync|https://ftp.osuosl.org/pub/musescore-nightlies/linux/3x/nightly/MuseScoreNightly-latest-x86_64.AppImage.zsync";;
+    "nightly_build") export UPDATE_INFORMATION="zsync|https://ftp.osuosl.org/pub/musescore-nightlies/linux/${MAJOR_VERSION}x/nightly/MuseScoreNightly-latest-x86_64.AppImage.zsync";;
     *) unset UPDATE_INFORMATION;; # disable updates for other build modes
     esac
 
-    bash ./build/ci/linux/tools/make_appimage.sh $INSTALL_DIR
-    APPIMAGE_FILE="$(ls $BUILD_DIR/*.AppImage)"
-    mv $APPIMAGE_FILE $ARTIFACTS_DIR/$ARTIFACT_NAME.AppImage
+    bash ./build/ci/linux/tools/make_appimage.sh "${INSTALL_DIR}" "${ARTIFACT_NAME}.AppImage"
+    mv "${BUILD_DIR}/${ARTIFACT_NAME}.AppImage" "${ARTIFACTS_DIR}/"
     bash ./build/ci/tools/make_artifact_name_env.sh $ARTIFACT_NAME.AppImage
 
     if [ -v UPDATE_INFORMATION ]; then
-        ZSYNC_FILE="$(ls $BUILD_DIR/*.AppImage.zsync)" # data for delta updates
-        mv $ZSYNC_FILE $ARTIFACTS_DIR/$ARTIFACT_NAME.AppImage.zsync
+        # zsync file contains data for automatic delta updates
+        mv "${BUILD_DIR}/${ARTIFACT_NAME}.AppImage.zsync" "${ARTIFACTS_DIR}/"
     fi
-fi 
+fi
 
 df -h .
 
-echo "Package has finished!" 
+echo "Package has finished!"

--- a/build/ci/linux/tools/make_appimage.sh
+++ b/build/ci/linux/tools/make_appimage.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
-INSTALL_DIR=$1
+INSTALL_DIR="$1" # MuseScore was installed here
+APPIMAGE_NAME="$2" # name for AppImage file (created outside $INSTALL_DIR)
+
 if [ -z "$INSTALL_DIR" ]; then echo "error: not set INSTALL_DIR"; exit 1; fi
+if [ -z "$APPIMAGE_NAME" ]; then echo "error: not set APPIMAGE_NAME"; exit 1; fi
 
 ##########################################################################
 # INSTALL APPIMAGETOOL AND LINUXDEPLOY
@@ -211,7 +214,7 @@ done
 # TURN APPDIR INTO AN APPIMAGE
 ##########################################################################
 
-appimage="${appdir%.AppDir}.AppImage" # name to use for AppImage file
+appimage="${APPIMAGE_NAME}" # name to use for AppImage file
 
 appimagetool_args=( # array
   # none


### PR DESCRIPTION
@igorkorsukov, I tried updating with [AppImageUpdate](https://github.com/AppImage/AppImageUpdate/releases) but it didn't work so I downloaded the latest zsync file and examined it:

```
$ wget https://ftp.osuosl.org/pub/musescore-nightlies/linux/3x/nightly/MuseScoreNightly-latest-x86_64.AppImage.zsync
$ head MuseScoreNightly-latest-x86_64.AppImage.zsync
zsync: 0.6.2
Filename: MuseScore-x86_64.AppImage
MTime: Sun, 29 Nov 2020 04:34:26 +0000
Blocksize: 4096
Length: 154656744
Hash-Lengths: 2,2,5
URL: MuseScore-x86_64.AppImage
SHA-1: 915cc5b7410607ecc2fc43631861ba184fabc24d

[start of binary data...]
```

Notice that `MuseScore-x86_64.AppImage` (default AppImage name) was hardcoded as both Filename and (relative) URL at the time the zsync was created. When we subsequently renamed the AppImage file to `MuseScore-[build_info]-x86_64.AppImage` the link would stop working. I have now updated the script so that the AppImage is created with its final name, so the zsync metadata should be valid.

Other improvements:

- Substituted `3x` string for a variable in $UPDATE_INFORMATION so the scripts can be safely copied to the master branch.

- Latest "AppImage" symlink was being created for [Windows](https://ftp.osuosl.org/pub/musescore-nightlies/windows/3x/nightly/?C=M;O=D) and [macOS](https://ftp.osuosl.org/pub/musescore-nightlies/macos/3x/nightly/?C=M;O=D) as well as Linux. The symlink might be useful so I kept it, but the file extension is now `.7z` or `.dmg` on those platforms.
