### PR TITLE
Fix #313771: Switching instruments from an instrument with tabulature in a linked staff to one that does not support tablature causes crash

### DIFF
--- a/libmscore/stringdata.cpp
+++ b/libmscore/stringdata.cpp
@@ -244,8 +244,8 @@ void StringData::fretChords(Chord * chord) const
             }
 
       // check for any remaining fret conflict
-      foreach(Note * note, sortedNotes)
-            if (bUsed[note->string()] > 1)
+      for (Note* note : sortedNotes)
+            if (note->string() == -1 || bUsed[note->string()] > 1)
                   note->setFretConflict(true);
 
       bFretting = false;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/313771