### PR TITLE
[MU4] Fix #313771: Switching instruments from an instrument with tabulature in a linked staff to one that does not support tablature causes crash

### DIFF
--- a/libmscore/stringdata.cpp
+++ b/libmscore/stringdata.cpp
@@ -256,7 +256,7 @@ void StringData::fretChords(Chord* chord) const
 
     // check for any remaining fret conflict
     foreach (Note* note, sortedNotes) {
-        if (bUsed[note->string()] > 1) {
+        if (note->string() == -1 || bUsed[note->string()] > 1) {
             note->setFretConflict(true);
         }
     }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/313771

Version of #6973 (which got merged into 3.x meanwhile), but for master