### PR TITLE
[MU3] Use instrumentId in instrument-famiy override instead of old trackName.

### DIFF
--- a/libmscore/scoreOrder.cpp
+++ b/libmscore/scoreOrder.cpp
@@ -353,8 +353,8 @@ QString ScoreOrder::getFamilyName(const InstrumentTemplate* instrTemplate, bool 
             return QString("<unsorted>");
       if (soloist)
            return QString("<soloists>");
-      else if (instrumentMap.contains(instrTemplate->trackName.toLower()))
-            return instrumentMap[instrTemplate->trackName.toLower()].id;
+      else if (instrumentMap.contains(instrTemplate->id))
+            return instrumentMap[instrTemplate->id].id;
       else if (instrTemplate->family)
             return instrTemplate->family->id;
       else


### PR DESCRIPTION
Solves a bug in using local family definition, the local definition was never used.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
