### PR TITLE
[MU3] Center score when switching LayoutMode

### DIFF
--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -1235,9 +1235,7 @@ void PreferenceDialog::applyPageVertical()
                   ss->doLayout();
             }
       if (cv)
-            cv->setOffset(0.0, 0.0);
-      if (mscore->currentScoreView())
-            mscore->currentScoreView()->setOffset(0.0, 0.0);
+            cv->pageTop();
       mscore->scorePageLayoutChanged();
       mscore->update();
       }

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3577,10 +3577,46 @@ void ScoreView::screenPrev()
 
 void ScoreView::pageTop()
       {
-      if (score()->layoutMode() == LayoutMode::LINE)
-            setOffset(thinPadding, 0.0);
-      else
-            setOffset(thinPadding, thinPadding);
+      switch (score()->layoutMode()) {
+            case LayoutMode::PAGE:
+                  {
+                  qreal dx = thinPadding, dy = thinPadding;
+                  Page* firstPage = score()->pages().front();
+                  Page* lastPage  = score()->pages().back();
+                  if (firstPage && lastPage) {
+                        QPointF offsetPt(xoffset(), yoffset());
+                        QRectF firstPageRect(firstPage->pos().x() * physicalZoomLevel(),
+                                             firstPage->pos().y() * physicalZoomLevel(),
+                                             firstPage->width() * physicalZoomLevel(),
+                                             firstPage->height() * physicalZoomLevel());
+                        QRectF lastPageRect(lastPage->pos().x() * physicalZoomLevel(),
+                                            lastPage->pos().y() * physicalZoomLevel(),
+                                            lastPage->width() * physicalZoomLevel(),
+                                            lastPage->height() * physicalZoomLevel());
+                        QRectF pagesRect = firstPageRect.united(lastPageRect);
+                        dx = qMax(thinPadding, (width() - pagesRect.width()) / 2);
+                        dy = qMax(thinPadding, (height() - pagesRect.height()) / 2);
+                        }
+                  setOffset(dx, dy);
+                  break;
+                  }
+            case LayoutMode::LINE:
+                  setOffset(thinPadding, 0.0);
+                  break;
+            case LayoutMode::SYSTEM:
+                  {
+                  qreal dx = thinPadding, dy = thinPadding;
+                  Page* page = score()->pages().front();
+                  if (page) {
+                        dx = qMax(thinPadding, (width() - page->width() * physicalZoomLevel()) / 2);
+                        }
+                  setOffset(dx, dy);
+                  break;
+                  }
+            default:
+                  setOffset(thinPadding, thinPadding);
+                  break;
+      }
       update();
       }
 


### PR DESCRIPTION
In Page view and Single Page view:
If the width of the entire score is smaller than the width of the Score View, then the score will be centered horizontally; otherwise, the score will be left-aligned, with some padding.

In Page view, the same goes for height / vertical alignment. 

Small width, large height:
<img width="1696" alt="Small width, large height" src="https://user-images.githubusercontent.com/48658420/100726658-85206a00-33c5-11eb-97aa-67625c0c5316.png">

Large width and height:
<img width="1696" alt="Schermafbeelding 2020-12-01 om 11 14 25" src="https://user-images.githubusercontent.com/48658420/100727345-61a9ef00-33c6-11eb-8afb-37e0a20b03c5.png">

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
