### PR TITLE
[MU3] Use "Custom" as default score order for old scores.

### DIFF
--- a/libmscore/scoreOrder.cpp
+++ b/libmscore/scoreOrder.cpp
@@ -807,6 +807,20 @@ ScoreOrder* ScoreOrderList::findByName(const QString& name, bool customised)
       }
 
 //---------------------------------------------------------
+//   customScoreOrder
+//      return Custom ScoreOrder
+//---------------------------------------------------------
+
+ScoreOrder* ScoreOrderList::customScoreOrder() const
+      {
+      for (ScoreOrder* so : _orders) {
+            if (so->isCustom())
+                  return so;
+            }
+      return nullptr; // should never happen, there is always a custom score order.
+      }
+
+//---------------------------------------------------------
 //   searchScoreOrder
 //      return the index of the ScoreOrder or 0 (= Custom)
 //      if the order is not found.

--- a/libmscore/scoreOrder.h
+++ b/libmscore/scoreOrder.h
@@ -146,6 +146,7 @@ class ScoreOrderList {
       ScoreOrder* findById(const QString& orderId) const;
       ScoreOrder* getById(const QString& orderId);
       ScoreOrder* findByName(const QString& orderName, bool customised=false);
+      ScoreOrder* customScoreOrder() const;
       int getScoreOrderIndex(const ScoreOrder* order) const;
       QList<ScoreOrder*> searchScoreOrders(const QList<int>& indices) const;
       QList<ScoreOrder*> searchScoreOrders(const Score* score) const;

--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -245,7 +245,8 @@ void MuseScore::editInstrList()
       instrList->init();
       MasterScore* masterScore = cs->masterScore();
       instrList->genPartList(masterScore);
-      instrList->setScoreOrder(masterScore->scoreOrder());
+      ScoreOrder* order = masterScore->scoreOrder();
+      instrList->setScoreOrder(order ? order : scoreOrders.customScoreOrder());
       masterScore->startCmd();
       masterScore->deselectAll();
       int rv = instrList->exec();


### PR DESCRIPTION
Use <code>Custom</code> score order in the <code>Edit Instruments</code> form if the score has no score order defined.

Resolves: https://trello.com/c/hYmA8fOs/44-when-opening-an-old-score-the-instruments-ordering-dropdown-should-be-defaulted-to-custom

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
