### PR TITLE
[MU4] Fix -Wdeprecated-copy warnings

### DIFF
--- a/framework/global/io/path.cpp
+++ b/framework/global/io/path.cpp
@@ -25,11 +25,6 @@
 
 using namespace mu::io;
 
-path::path(const path& p)
-    : m_path(p.m_path)
-{
-}
-
 path::path(const QString& s)
     : m_path(s.toUtf8())
 {

--- a/framework/global/io/path.h
+++ b/framework/global/io/path.h
@@ -28,7 +28,7 @@ struct path;
 using paths = std::vector<path>;
 struct path {
     path() = default;
-    path(const path& p);
+    path(const path&) = default;
     path(const QString& s);
     path(const std::string& s);
     path(const char* s);

--- a/libmscore/key.cpp
+++ b/libmscore/key.cpp
@@ -21,19 +21,6 @@
 
 namespace Ms {
 //---------------------------------------------------------
-//   KeySigEvent
-//---------------------------------------------------------
-
-KeySigEvent::KeySigEvent(const KeySigEvent& k)
-{
-    _key        = k._key;
-    _mode       = k._mode;
-    _custom     = k._custom;
-    _keySymbols = k._keySymbols;
-    _forInstrumentChange = k._forInstrumentChange;
-}
-
-//---------------------------------------------------------
 //   enforceLimits - ensure _key
 //   is within acceptable limits (-7 .. +7).
 //   see KeySig::layout()

--- a/libmscore/key.h
+++ b/libmscore/key.h
@@ -103,7 +103,7 @@ class KeySigEvent
 
 public:
     KeySigEvent() {}
-    KeySigEvent(const KeySigEvent&);
+    KeySigEvent(const KeySigEvent&) = default;
 
     bool operator==(const KeySigEvent& e) const;
     bool operator!=(const KeySigEvent& e) const { return !(*this == e); }

--- a/libmscore/sig.cpp
+++ b/libmscore/sig.cpp
@@ -408,17 +408,6 @@ void TimeSigMap::read(XmlReader& e, int fileDivision)
 }
 
 //---------------------------------------------------------
-//   SigEvent
-//---------------------------------------------------------
-
-SigEvent::SigEvent(const SigEvent& e)
-{
-    _timesig = e._timesig;
-    _nominal = e._nominal;
-    _bar     = e._bar;
-}
-
-//---------------------------------------------------------
 //   SigEvent::write
 //---------------------------------------------------------
 

--- a/libmscore/sig.h
+++ b/libmscore/sig.h
@@ -47,8 +47,7 @@ public:
         : Fraction(n, d) {}
     TimeSigFrac(const Fraction& f)
         : TimeSigFrac(f.numerator(), f.denominator()) {}
-    TimeSigFrac(const TimeSigFrac& f)
-        : TimeSigFrac(f.numerator(), f.denominator()) {}
+    TimeSigFrac(const TimeSigFrac&) = default;
 
     // isCompound? Note: 3/8, 3/16, ... are NOT considered compound.
     bool isCompound() const { return numerator() > 3 /*&& denominator() >= 8*/ && numerator() % 3 == 0; }
@@ -115,7 +114,7 @@ public:
         : _timesig(s), _nominal(s), _bar(bar) {}
     SigEvent(const Fraction& s, const Fraction& ss, int bar = 0)
         : _timesig(s), _nominal(ss), _bar(bar) {}
-    SigEvent(const SigEvent& e);
+    SigEvent(const SigEvent&) = default;
 
     bool operator==(const SigEvent& e) const;
     bool valid() const { return _timesig.isValid(); }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/313872

Replaced some copy constructors with the defualt copy constructor, for the most part this appears okay, except for the change with event.cpp/event.h which I'm very unsure about whether or not it works. It compiles on my machine and doesn't appear to introduce any new bugs, so I guess we'll see what Travis CI thinks.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
