### PR TITLE
[MU3] Solve sorting bug which  reverse the sorting order for every sort.

### DIFF
--- a/mscore/instrwidget.h
+++ b/mscore/instrwidget.h
@@ -160,7 +160,7 @@ class InstrumentsWidget : public QWidget, public Ui::InstrumentsWidget {
 
       ScoreOrderListModel* _model;
 
-      int findPrvItem(PartListItem* pli, int number=0);
+      int findPrvItem(PartListItem* pli, bool insert, int number=-1);
       QTreeWidgetItem* movePartItem(int oldPos, int newPos);
 
    private slots:


### PR DESCRIPTION
Resolves: https://trello.com/c/NOiUjych/45-opening-edit-instruments-form-changes-position-of-instruments

When opening the <code>Edit Instruments</code> form a sort of instruments is triggered but due to a bug, the order of all similar instruments was reversed. 

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
