### PR TITLE
[MU3] Fix typo (this score just doesn't exist, with that name)

### DIFF
--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -322,7 +322,7 @@ void NewWizardTemplatePage::buildTemplatesList()
       QDir dir(mscoreGlobalShare + "/templates");
       QFileInfoList fil = dir.entryInfoList(QDir::NoDotAndDotDot | QDir::Readable | QDir::Dirs | QDir::Files, QDir::Name);
       if(fil.isEmpty()){
-          fil.append(QFileInfo(QFile(":data/Empty_Score.mscz")));
+          fil.append(QFileInfo(QFile(":data/Empty_Score.mscx")));
           }
 
       QDir myTemplatesDir(preferences.getString(PREF_APP_PATHS_MYTEMPLATES));


### PR DESCRIPTION
Seems to have been forgotten to change here when the templates changed from mscz to mscx, quite a wile ago.
No idea why it apparently hadn't failed since, or if it has, why nobody noticed?

As far as I can tell this doesn't seem to apply to master, only to 3.x