### PR TITLE
Fix #311039: Let fretboard diagrams include open strings with multipl…

### DIFF
--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -897,23 +897,21 @@ void FretDiagram::setDot(int string, int fret, bool add /*= false*/, FretDotType
                   _dots[string].clear();
 
             _dots[string].push_back(FretItem::Dot(fret, dtype));
-            setMarker(string, FretMarkerType::NONE);
+            if (!add)
+                  setMarker(string, FretMarkerType::NONE);
             }
       }
 
 //---------------------------------------------------------
 //   setMarker
-//    Remove any dots and barres if the marker is being set to anything other than none.
+//    Removal of dots and barres if "Multiple dots" is inactive
+//    is handled in FretCanvas::mousePressEvent()
 //---------------------------------------------------------
 
 void FretDiagram::setMarker(int string, FretMarkerType mtype)
       {
       if (string >= 0 && string < _strings) {
             _markers[string] = FretItem::Marker(mtype);
-            if (mtype != FretMarkerType::NONE) {
-                  removeDot(string);
-                  removeBarres(string);
-                  }
             }
       }
 

--- a/mscore/fretcanvas.cpp
+++ b/mscore/fretcanvas.cpp
@@ -247,10 +247,15 @@ void FretCanvas::mousePressEvent(QMouseEvent* ev)
       if (fret < 0 || fret > _frets || string < 0 || string >= _strings)
             return;
 
+      bool haveShift = (ev->modifiers() & Qt::ShiftModifier) || _barreMode;
+      bool haveCtrl  = (ev->modifiers() & Qt::ControlModifier) || _multidotMode;
+
       diagram->score()->startCmd();
 
       // Click above the fret diagram, so change the open/closed string marker
       if (fret == 0) {
+            if (!haveCtrl)
+                  diagram->undoSetFretDot(string, 0);
             switch (diagram->marker(string).mtype) {
                   case FretMarkerType::CIRCLE:
                         diagram->undoSetFretMarker(string, FretMarkerType::CROSS);
@@ -260,7 +265,6 @@ void FretCanvas::mousePressEvent(QMouseEvent* ev)
                         break;
                   case FretMarkerType::NONE:
                   default:
-                        diagram->undoSetFretDot(string, 0);
                         diagram->undoSetFretMarker(string, FretMarkerType::CIRCLE);
                         break;
                   }
@@ -268,8 +272,6 @@ void FretCanvas::mousePressEvent(QMouseEvent* ev)
       // Otherwise, the click is on the fretboard itself
       else {
             FretItem::Dot thisDot = diagram->dot(string, fret)[0];
-            bool haveShift = (ev->modifiers() & Qt::ShiftModifier) || _barreMode;
-            bool haveCtrl  = (ev->modifiers() & Qt::ControlModifier) || _multidotMode;
 
             // Click on an existing dot
             if (thisDot.exists() && !haveShift)


### PR DESCRIPTION
…e dots

Resolves: https://musescore.org/en/node/311039

![MultiDottingMarkers](https://user-images.githubusercontent.com/7139517/100949866-0cea9f00-34c0-11eb-9912-66648a89da31.gif)

Allows for X and O markings of Fretboard Diagrams to be coincident with dot markers.
Clearing related to 0-fret markers now has been re-arranged so that it only occurs when Multiple Dots is unchecked (or the CTRL-modifier is inactive). This ought to help some users have more control over the fretboard diagrams. Any extra testing much appreciated. 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
