### PR TITLE
Fix #313926: Correct focus-in problem when a dialog box is open

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4023,7 +4023,6 @@ bool MuseScoreApplication::event(QEvent* event)
 void MuseScore::focusScoreView()
       {
       if (currentScoreView()) {
-            currentScoreView()->activateWindow();
             currentScoreView()->setFocus();
             }
       else

--- a/mscore/qmldockwidget.cpp
+++ b/mscore/qmldockwidget.cpp
@@ -22,6 +22,7 @@
 #include "musescore.h"
 #include "preferences.h"
 #include "qml/nativemenu.h"
+#include "scoreview.h"
 
 #include <QQmlContext>
 
@@ -146,6 +147,7 @@ void MsQuickView::keyPressEvent(QKeyEvent* evt)
             return;
 
       if (evt->key() == Qt::Key_Escape && evt->modifiers() == Qt::NoModifier) {
+            mscore->currentScoreView()->activateWindow();
             mscore->focusScoreView();
             evt->accept();
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/313926 (bug-fix)

**Explanation**:
MS steals the focus here as mentioned in the issue. This is due to a clash between the code found in 
`MuseScore::onFocusWindowChanged(QWindow* w)` 
mixed with a recent change (from #6802) with `MuseScore::focusScoreView `to allow for the QML dock widget for palettes to float and honor [`escape key functionality`] to bring score back into focus. Apparently `onFocusWindowChanged` is making a dummy widget and calling focus on it, and that focus was switching focus to the main application if a dialog box was open, even when accessing OS/WindowManager-level windows. 

Instead of attempting to change the `onFocusWindowChanged` code (what seems like a hack based upon QML dock window limitations?), I made sure that the activation only occurs when specifically triggering Escape from within the Palette QMLwidget and all seems well.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
