### PR TITLE
[MU3] Update height of last system when adjusting distance between staves

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1682,6 +1682,9 @@ static void distributeStaves(Page* page)
                   vgd->sysStaff->bbox().translate(0.0, staffShift);
             prvSystem = vgd->system;
             }
+      if (prvSystem)
+            prvSystem->setHeight(prvSystem->height() + staffShift);
+
       for (System* system : systems) {
             system->setMeasureHeight(system->height());
             system->layoutBracketsVertical();


### PR DESCRIPTION
Vertical staves justification didn't update the height of the last system. As a result, spanning barlines by dragging a barline to the nest staff was not possible because it was limited to the, not updated, height of the system.

Resolves: https://trello.com/c/vGvlxlFY/47-not-possible-to-drag-barlines-to-next-staff

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
