### PR TITLE
Fix #313896 Portamento playdown not working

### DIFF
--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -268,7 +268,7 @@ static void playNote(EventMap* events, const Note* note, int channel, int pitch,
                         Note* nextNote = toNote(spanner->endElement());
                         double pitchDelta = (static_cast<double>(nextNote->pitch()) - pitch) * 50.0;
                         double timeDelta = static_cast<double>(offTime - onTime);
-                        double timeStep = timeDelta / pitchDelta * 20.0;
+                        double timeStep = std::abs(timeDelta / pitchDelta * 20.0);
                         double t = 0.0;
                         QList<int> onTimes;
                         EaseInOut easeInOut(static_cast<qreal>(glissando->easeIn()) / 100.0,


### PR DESCRIPTION
Resolves: [Glissando down playback not working when set to "Portamento"](https://musescore.org/en/node/313896)

Portamento style glissando going from a higher note to a lower note did not play like a portamento but played the two begin and end note.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
