### PR TITLE
[MU4] Fix #313857: Fractional font sizes can't be input using the "Preferences" dialog

### DIFF
--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -34,7 +34,7 @@ void UiConfiguration::init()
     });
 
     settings()->valueChanged(FONT_SIZE_KEY).onReceive(nullptr, [this](const Val& val) {
-        m_currentFontSizeChannel.send(val.toInt());
+        m_currentFontSizeChannel.send(val.toDouble());
     });
 
     settings()->valueChanged(MUSICAL_FONT_FAMILY_KEY).onReceive(nullptr, [this](const Val& val) {
@@ -66,9 +66,9 @@ Channel<QString> UiConfiguration::fontFamilyChanged() const
     return m_currentFontFamilyChannel;
 }
 
-int UiConfiguration::fontSize() const
+qreal UiConfiguration::fontSize() const
 {
-    return settings()->value(FONT_SIZE_KEY).toInt();
+    return settings()->value(FONT_SIZE_KEY).toDouble();
 }
 
 Channel<int> UiConfiguration::fontSizeChanged() const

--- a/src/framework/ui/internal/uiconfiguration.h
+++ b/src/framework/ui/internal/uiconfiguration.h
@@ -39,7 +39,7 @@ public:
     QString fontFamily() const override;
     async::Channel<QString> fontFamilyChanged() const override;
 
-    int fontSize() const override;
+    qreal fontSize() const override;
     async::Channel<int> fontSizeChanged() const override;
 
     QString musicalFontFamily() const override;

--- a/src/framework/ui/iuiconfiguration.h
+++ b/src/framework/ui/iuiconfiguration.h
@@ -44,7 +44,7 @@ public:
     virtual QString fontFamily() const = 0;
     virtual async::Channel<QString> fontFamilyChanged() const = 0;
 
-    virtual int fontSize() const = 0;
+    virtual qreal fontSize() const = 0;
     virtual async::Channel<int> fontSizeChanged() const = 0;
 
     virtual QString musicalFontFamily() const = 0;

--- a/src/framework/ui/view/theme.cpp
+++ b/src/framework/ui/view/theme.cpp
@@ -215,7 +215,7 @@ QHash<int, QVariant> Theme::currentThemeProperites() const
 void Theme::initFont()
 {
     m_font.setFamily(configuration()->fontFamily());
-    m_font.setPixelSize(configuration()->fontSize());
+    m_font.setPointSizeF(configuration()->fontSize());
 
     configuration()->fontFamilyChanged().onReceive(this, [this](const QString& fontFamily) {
         m_font.setFamily(fontFamily);
@@ -223,8 +223,8 @@ void Theme::initFont()
         update();
     });
 
-    configuration()->fontSizeChanged().onReceive(this, [this](const int fontSize) {
-        m_font.setPixelSize(fontSize);
+    configuration()->fontSizeChanged().onReceive(this, [this](const float fontSize) {
+        m_font.setPointSizeF(fontSize);
 
         update();
     });
@@ -242,7 +242,7 @@ void Theme::initMusicalFont()
     });
 
     configuration()->musicalFontSizeChanged().onReceive(this, [this](const int fontSize) {
-        m_musicalFont.setPixelSize(fontSize);
+        m_musicalFont.setPointSizeF(fontSize);
 
         update();
     });

--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -56,7 +56,7 @@ public:
     virtual ValCh<int> currentZoom() const = 0;
     virtual void setCurrentZoom(int zoomPercentage) = 0;
 
-    virtual int fontSize() const = 0;
+    virtual qreal fontSize() const = 0;
 
     virtual io::path stylesDirPath() const = 0;
 

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -184,7 +184,7 @@ void NotationConfiguration::setCurrentZoom(int zoomPercentage)
     settings()->setValue(CURRENT_ZOOM, Val(zoomPercentage));
 }
 
-int NotationConfiguration::fontSize() const
+qreal NotationConfiguration::fontSize() const
 {
     return uiConfiguration()->fontSize();
 }

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -57,7 +57,7 @@ public:
     ValCh<int> currentZoom() const override;
     void setCurrentZoom(int zoomPercentage) override;
 
-    int fontSize() const override;
+    qreal fontSize() const override;
 
     io::path stylesDirPath() const override;
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/313857

This is the #7000 version for master, albeit pretty much untested, as the UI for preferences is... rather rough at the edges to put it very mildly