### PR TITLE
Fix #313886: Streamline user experience regarding Export

### DIFF
--- a/libmscore/musescoreCore.h
+++ b/libmscore/musescoreCore.h
@@ -17,6 +17,7 @@ namespace Ms {
 
 class MasterScore;
 class Score;
+enum class SaveReplacePolicy;
 
 //---------------------------------------------------------
 //   class MuseScoreCore
@@ -34,7 +35,7 @@ class MuseScoreCore
       Score* currentScore() const        { return cs;     }
       void setCurrentScore(Score* score) { cs = score;    }
 
-      virtual bool saveAs(Score*, bool /*saveCopy*/, const QString& /*path*/, const QString& /*ext*/) { return false; }
+      virtual bool saveAs(Score*, bool /*saveCopy*/, const QString& /*path*/, const QString& /*ext*/, SaveReplacePolicy* /*replacePolicy*/ = nullptr) { return false; }
       virtual void closeScore(Score*) {}
       virtual void cmd(QAction* /*a*/) {}
       virtual void setCurrentView(int /*tabIdx*/, int /*idx*/) {}
@@ -46,7 +47,5 @@ class MuseScoreCore
       virtual void updateInspector() {}
       };
 
-
 } // namespace Ms
 #endif
-

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -157,6 +157,16 @@ struct LanguageItem {
       };
 
 //---------------------------------------------------------
+//   SaveReplacePolicy
+//---------------------------------------------------------
+
+enum class SaveReplacePolicy {
+      NO_CHOICE,
+      SKIP_ALL,
+      REPLACE_ALL
+      };
+
+//---------------------------------------------------------
 //   MuseScoreApplication (mac only)
 //---------------------------------------------------------
 
@@ -686,7 +696,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QList<LanguageItem>& languages() { return _languages; }
 
       QStringList getOpenScoreNames(const QString& filter, const QString& title, bool singleFile = false);
-      QString getSaveScoreName(const QString& title, QString& name, const QString& filter, bool folder = false);
+      QString getSaveScoreName(const QString& title, QString& name, const QString& filter, bool folder = false, bool askOverwrite = true);
       QString getStyleFilename(bool open, const QString& title = QString());
       QString getFotoFilename(QString& filter, QString *selectedFilter);
       QString getChordStyleFilename(bool open);
@@ -696,6 +706,8 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QString getPluginFilename(bool open);
       QString getPaletteFilename(bool open, const QString& name = "");
       QString getWallpaper(const QString& caption);
+      
+      int askOverwriteAll(QString&);
 
       bool hRaster() const { return hRasterAction->isChecked(); }
       bool vRaster() const { return vRasterAction->isChecked(); }
@@ -719,7 +731,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void endCmd(bool undoRedo);
       void endCmd() override { endCmd(false); };
       void printFile();
-      virtual bool saveAs(Score*, bool saveCopy, const QString& path, const QString& ext);
+      virtual bool saveAs(Score*, bool saveCopy, const QString& path, const QString& ext, SaveReplacePolicy* replacePolicy = nullptr);
       QString saveFilename(QString fn);
       bool savePdf(const QString& saveName);
       bool savePdf(Score* cs, const QString& saveName);
@@ -739,10 +751,10 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       bool canSaveMp3();
       bool saveMp3(Score*, const QString& name);
       bool saveMp3(Score*, QIODevice*, bool& wasCanceled);
-      bool saveSvg(Score*, const QString& name, const NotesColors& notesColors = NotesColors());
+      bool saveSvg(Score*, const QString& name, const NotesColors& notesColors = NotesColors(), SaveReplacePolicy* replacePolicy = nullptr);
       bool saveSvg(Score*, QIODevice*, int pageNum = 0, bool drawPageBackground = false, const NotesColors& notesColors = NotesColors());
+      bool savePng(Score*, const QString& name, SaveReplacePolicy* replacePolicy = nullptr);
       bool savePng(Score*, QIODevice*, int pageNum = 0, bool drawPageBackground = false);
-      bool savePng(Score*, const QString& name);
       bool saveMidi(Score*, const QString& name);
       bool saveMidi(Score*, QIODevice*);
       bool savePositions(Score*, const QString& name, bool segments);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/313886

- Smarter suggestions for filenames.
- If only one file will be created during export, the filename will be exactly as the user types in the SaveDialog, so therefore, we can have the SaveDialog responsible for asking whether the user wants to replace any existing files.
- Otherwise, we will ask the user ourselves.
- If the user has clicked "Skip all" or "Replace all", that choice will be synced between the ExportDialog and savePng and saveSvg (by having them use a pointer to the same SaveReplacePolicy), so that the user won't be asked again the same question.
 - Removed the "Export was successful" message (was redundant).

There is a known issue in Qt/macOS: it seems since macOS 10.15, the `DontConfirmOverwrite` option is ignored with `QFileDialog::getSaveFileName`. This annoying in cases like when a file "Somefile.pdf" exists, and the user is exporting multiple scores and types "Somefile.pdf" in the QFileDialog. macOS thinks that the file "Somefile.pdf" will be overwritten, so it gives a false alarm to the user; in fact, files like "Somefile - Full Score.pdf" and "Somefile - Violin 1.pdf" are created, and "Somefile.pdf" will be untouched. 
In the case that "Somefile - Full Score.pdf" already exists, MuseScore will still ask whether it should be overwritten. So there is completely no risk of data loss, only the user is confused with a false warning by macOS. We can't do much about that, and it only occurs in quite specific circumstances, so I think it's not a huge problem for us.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
