### PR TITLE
Fix #313960 Portamento starts on wrong pitch

### DIFF
--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -276,7 +276,7 @@ static void playNote(EventMap* events, const Note* note, int channel, int pitch,
                         easeInOut.timeList(static_cast<int>((timeDelta + timeStep * 0.5) / timeStep), int(timeDelta), &onTimes);
                         double nTimes = static_cast<double>(onTimes.size() - 1);
                         for (double time : onTimes) {
-                              int p = int(pitch + (t / nTimes) * pitchDelta);
+                              int p = int((t / nTimes) * pitchDelta);
                               int timeStamp = std::min(onTime + int(time), offTime - 1);
                               int midiPitch = (p * 16384) / 1200 + 8192;
                               NPlayEvent evb(ME_PITCHBEND, channel, midiPitch % 128, midiPitch / 128);


### PR DESCRIPTION
Resolves: [Portamento style glissando starts on wrong note](https://musescore.org/en/node/313960)

Portamento style glissando start pitch was offset by twice the start note

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
