### PR TITLE
[MU4] fixed build with mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -675,6 +675,10 @@ if (MSVC)
    include_directories(${OGG_INCLUDE_DIR})
 endif (MSVC)
 
+if (MINGW)
+    include_directories(${SNDFILE_INCLUDE_DIR})
+endif(MINGW)
+
 if (USE_SYSTEM_FREETYPE)
       include_directories(${FREETYPE_INCLUDE_DIRS})
 else (USE_SYSTEM_FREETYPE)


### PR DESCRIPTION
I did not find where `include` was added earlier when compiling with MinGW. It looks like it was being added implicitly when setting up another dependency.
Added include explicitly.
The solution is temporary, in the process of tidying up in CMake projects, it will probably be changed.