### PR TITLE
[MU3] Update track mapping in excerpts when order of staves is changed.

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2653,6 +2653,8 @@ void Score::sortStaves(QList<int>& dst)
       _parts.clear();
       Part* curPart = 0;
       QList<Staff*> dl;
+      QMap<int, int> trackMap;
+      int track = 0;
       foreach (int idx, dst) {
             Staff* staff = _staves[idx];
             if (staff->part() != curPart) {
@@ -2662,8 +2664,16 @@ void Score::sortStaves(QList<int>& dst)
                   }
             curPart->staves()->push_back(staff);
             dl.push_back(staff);
+            for (int itrack = 0; itrack < VOICES; ++itrack)
+                  trackMap.insert(idx * VOICES + itrack, track++);
             }
       _staves = dl;
+      for (Excerpt* e : excerpts()) {
+            QMultiMap<int, int> oldTracks = e->tracks();
+            e->tracks().clear();
+            for (QMap<int, int>::iterator it = oldTracks.begin(); it != oldTracks.end(); ++it)
+                  e->tracks().insert(trackMap[it.key()], it.value());
+            }
 
       for (Measure* m = firstMeasure(); m; m = m->nextMeasure()) {
             m->sortStaves(dst);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/313664

When (re-)sorting staves after changing the order of instruments, the track mapping in the excerpts wasn't updated. Since linking elements are based on this track mapping, the linking was not possible (or wrong),
With this PR, 

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
