### PR TITLE
update/fix mtest after PR 7001

### DIFF
--- a/mtest/musicxml/io/testSystemBrackets3_ref.mscx
+++ b/mtest/musicxml/io/testSystemBrackets3_ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <Spatium>1.74978</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>


### PR DESCRIPTION
An mtest had been added to PR #7001 before the recent spatium change, but the PR was not merged until afterwards.  Thus, the ref file was not updated.  This updates the spatium value in the mtest ref.