### PR TITLE
Mountain Dulcimer Updates

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -10624,15 +10624,15 @@ Aeolus organ synthesizer, currently disabled -->
                   <description>Standard Mountain Dulcimer</description>
                   <musicXMLid>pluck.dulcimer</musicXMLid>
                   <StringData>
-                        <frets>20</frets>
+                        <frets>28</frets>
                         <string>50</string>
                         <string>57</string>
                         <string>62</string>
                   </StringData>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>50-82</aPitchRange>
-                  <pPitchRange>50-82</pPitchRange>
+                  <aPitchRange>50-90</aPitchRange>
+                  <pPitchRange>50-90</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
                   <Channel>
                         <program value="25"/> <!--Acoustic Guitar (steel)-->
@@ -10655,15 +10655,15 @@ Aeolus organ synthesizer, currently disabled -->
                   <description>Baritone Mountain Dulcimer</description>
                   <musicXMLid>pluck.dulcimer</musicXMLid>
                   <StringData>
-                        <frets>20</frets>
+                        <frets>23</frets>
                         <string>45</string>
                         <string>52</string>
                         <string>57</string>
                   </StringData>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>45-77</aPitchRange>
-                  <pPitchRange>45-77</pPitchRange>
+                  <aPitchRange>45-80</aPitchRange>
+                  <pPitchRange>45-80</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
                   <Channel>
                         <program value="25"/> <!--Acoustic Guitar (steel)-->
@@ -10686,15 +10686,15 @@ Aeolus organ synthesizer, currently disabled -->
                   <description>Bass Mountain Dulcimer</description>
                   <musicXMLid>pluck.dulcimer</musicXMLid>
                   <StringData>
-                        <frets>20</frets>
+                        <frets>28</frets>
                         <string>38</string>
                         <string>45</string>
                         <string>50</string>
                   </StringData>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>38-70</aPitchRange>
-                  <pPitchRange>38-70</pPitchRange>
+                  <aPitchRange>38-78</aPitchRange>
+                  <pPitchRange>38-78</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
                   <Channel>
                         <program value="25"/> <!--Acoustic Guitar (steel)-->


### PR DESCRIPTION
Extended the fret and pitch ranges of the three Mountain Dulcimer instruments
to conform with what are now the common ranges for modern chromatic dulcimers.

Relates back to, as a refinement: https://musescore.org/en/node/153016

A luthier pointed out to me that today's chromatic mountain dulcimer builds routinely extend the fret and pitch range a bit further down the fretboard. So I am here proposing updates to the three Mountain Dulcimer instrument profiles in instruments.xml. 

This is my first pull request attempt, so please do point out any missteps I may have taken here. Also, it was unclear which branch I should go up against - the 3.x branch seems to be what the vast majority of pull requests are hitting so that is what I have used here.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
