### PR TITLE
[MU3] Corrects wrong <soloist> section in "Woodwind Ensemble".

### DIFF
--- a/share/instruments/orders.xml
+++ b/share/instruments/orders.xml
@@ -527,16 +527,7 @@
     </Order>
     <Order id="woodwind-ensemble">
         <name>Woodwind Ensemble</name>
-        <soloists>
-            <section id="woodwind" showSystemMarkings="true">
-                <family>flutes</family>
-                <family>oboes</family>
-                <family>clarinets</family>
-                <family>saxophones</family>
-                <family>bassoons</family>
-                <unsorted group="woodwinds"/>
-            </section>
-        </soloists>
+        <soloists/>
         <section id="woodwind" thinBrackets="false">
             <family>flutes</family>
             <family>oboes</family>


### PR DESCRIPTION
Instead of just a simple <code>\<soloists/\></code> tag, the tag had some content. This has been corrected.


- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
