### PR TITLE
[MU3] Solves a wrong placed system boundary box of the second system on a page

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1669,21 +1669,26 @@ static void distributeStaves(Page* page)
             if (vgd->sysStaff)
                   systems.insert(vgd->system);
             systemShift += vgd->actualAddedSpace();
-            if (prvSystem && (prvSystem != vgd->system)) {
+            if (prvSystem == vgd->system) {
+                  staffShift += vgd->actualAddedSpace();
+                  }
+            else {
                   vgd->system->rypos() += systemShift;
-                  prvSystem->setDistance(vgd->system->y() - prvSystem->y());
-                  prvSystem->setHeight(prvSystem->height() + staffShift);
+                  if (prvSystem) {
+                        prvSystem->setDistance(vgd->system->y() - prvSystem->y());
+                        prvSystem->setHeight(prvSystem->height() + staffShift);
+                        }
                   staffShift = 0.0;
                   }
-            else
-                  staffShift  += vgd->actualAddedSpace();
 
             if (vgd->sysStaff)
                   vgd->sysStaff->bbox().translate(0.0, staffShift);
+
             prvSystem = vgd->system;
             }
-      if (prvSystem)
+      if (prvSystem) {
             prvSystem->setHeight(prvSystem->height() + staffShift);
+            }
 
       for (System* system : systems) {
             system->setMeasureHeight(system->height());


### PR DESCRIPTION
Due to a bug the second system on a page got a wrong system boundary box, but only when the system had only single staff.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
