### PR TITLE
fix #313704: crash generating parts with text/hbo/vbox

### DIFF
--- a/libmscore/measurebase.cpp
+++ b/libmscore/measurebase.cpp
@@ -337,7 +337,7 @@ void MeasureBase::triggerLayout() const
       const MeasureBase* mb = top();
       // avoid triggering layout before getting added to a score
       if (mb->prev() || mb->next())
-            score()->setLayout(mb->tick(), -1, this);
+            score()->setLayout(mb->tick(), -1, mb);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/313704

Crash happens if you have a text within an hbox within a vbox,
and then you create parts.
The crash appears to happen because while cloning the hbox,
(so within the copy constructor), we call triggerLlayout,
but the hbox isn't fully constructed.
It's actually more complex than that -
it turns out we are within the MeasureBase constructor
and as far as the compiler knows that's the object type -
it doesn't realize we actually are trying to construct an HBox.
Probably there is some more clever C++-ism to solve this.
But, my solution here is not so esteric.

In MeasureBase::triggerLayout(), we are already checking top()
to get the top-level measure base so we can check
that it has been added to the measurebase list for the score.
In this case, that is the Vbox containing the HBox.
And luckily, that seems to be fully constructed -
or at least, constructed enough that we don't crash.

So the fix is simply to send "mb" instead of "this"
as the third parameter to Score::setLayout()
from withing MeasureBase::triggerLayout().

It's totally safe and seems to fix the problem.
I can't swear that means I totally understand all the intricacies
or guarantee there aren't other problems lurking.
But I'm pretty sure this improves the situation.