### PR TITLE
fix #279403: Disable autoplace on drag for hairpins and slurties.

### DIFF
--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -413,6 +413,16 @@ std::unique_ptr<ElementGroup> HairpinSegment::getDragGroup(std::function<bool(co
       }
 
 //---------------------------------------------------------
+//   startDrag
+//---------------------------------------------------------
+
+void HairpinSegment::startDrag(EditData& ed)
+      {
+      TextLineBaseSegment::startDrag(ed);
+      setAutoplace(false);
+      }
+
+//---------------------------------------------------------
 //   startEditDrag
 //---------------------------------------------------------
 

--- a/libmscore/hairpin.h
+++ b/libmscore/hairpin.h
@@ -43,6 +43,7 @@ class HairpinSegment final : public TextLineBaseSegment {
       QPointF circledTip;
       qreal   circledTipRadius;
 
+      void startDrag(EditData&) override;
       void startEditDrag(EditData&) override;
       void editDrag(EditData&) override;
 

--- a/libmscore/slurtie.cpp
+++ b/libmscore/slurtie.cpp
@@ -128,6 +128,16 @@ std::vector<QPointF> SlurTieSegment::gripsPositions(const EditData&) const
       }
 
 //---------------------------------------------------------
+//   startDrag
+//---------------------------------------------------------
+
+void SlurTieSegment::startDrag(EditData& ed)
+      {
+      SpannerSegment::startDrag(ed);
+      setAutoplace(false);
+      }
+
+//---------------------------------------------------------
 //   startEditDrag
 //---------------------------------------------------------
 

--- a/libmscore/slurtie.h
+++ b/libmscore/slurtie.h
@@ -94,6 +94,7 @@ class SlurTieSegment : public SpannerSegment {
       virtual void spatiumChanged(qreal, qreal) override;
       SlurTie* slurTie() const { return (SlurTie*)spanner(); }
 
+      virtual void startDrag(EditData& ed) override;
       virtual void startEditDrag(EditData& ed) override;
       virtual void endEditDrag(EditData& ed) override;
       virtual void editDrag(EditData&) override;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/279403

fix #279403: Disable autoplace on drag for hairpins and slurties.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made

NOTES:
* The edited files do not follow the code guidelines (6 indent spaces); the changes retain this indent spacing.
* Test TBD.
