### PR TITLE
Fix stem length of notes with mirrored notehead

### DIFF
--- a/libmscore/stem.cpp
+++ b/libmscore/stem.cpp
@@ -107,7 +107,10 @@ void Stem::layout()
             else {                              // non-TAB
                   // move stem start to note attach point
                   Note* n  = up() ? chord()->downNote() : chord()->upNote();
-                  y1      += (up() ? n->stemUpSE().y() : n->stemDownNW().y());
+                  if ((up() && !n->mirror()) || (!up() && n->mirror()))
+                        y1 += n->stemUpSE().y();
+                  else
+                        y1 += n->stemDownNW().y();
                   rypos() = n->rypos();
                   }
             }


### PR DESCRIPTION
Resolves: https://trello.com/c/EpRJtt7w/51-square-caps-adds-gap-between-stem-and-notehead-when-notehead-is-reversed

Fixed by cleverly reading the anchor points for noteheads. (In contrast to what was suggested in the Trello issue, this was not related to replacing the round caps by flat ones, but became only more visible.)

Before: 
<img width="200" alt="Mirrored Noteheads before" src="https://trello-attachments.s3.amazonaws.com/5fae87b15d0e7a223218efbd/5fc9d6adeb79e018f9666c69/7398f37436bf199d07b08717c28ef488/image.png">
After:
![Mirrored Noteheads after](https://user-images.githubusercontent.com/48658420/101529687-30ff2200-3991-11eb-97d0-6c3a967e0051.png)
The issue with the ledger line being too long for that last note already existed in 3.5.2. I might solve that in another PR. 

A (still pretty theoretical) use case for 'mirrored noteheads' could be, when one doesn't like how the notes are oriented in a chord. Or, when one wants to show on an educational worksheet: "This is wrong". 
<img width="488" alt="Mirrored Noteheads Use Case" src="https://user-images.githubusercontent.com/48658420/101544243-9fe67600-39a5-11eb-8a97-7599496ed8d0.png">

---

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
