### PR TITLE
Make maximum zoom limit bigger

### DIFF
--- a/mscore/globals.h
+++ b/mscore/globals.h
@@ -121,7 +121,7 @@ static constexpr qreal DPMM_DISPLAY    = DPI_DISPLAY / 25.4;
 static constexpr qreal PALETTE_SPATIUM = 1.764 * DPMM_DISPLAY;
 
 static constexpr qreal ZOOM_LEVEL_MIN     = 1.0 / 16.0; // 6.25%
-static constexpr qreal ZOOM_LEVEL_MAX     = 16.0;
+static constexpr qreal ZOOM_LEVEL_MAX     = 400;
 static constexpr int   ZOOM_PRECISION_MIN = 1;
 static constexpr int   ZOOM_PRECISION_MAX = 16;
 


### PR DESCRIPTION
Resolves: no issue in tracker

When taking precise screenshots, I am often discouraged by this max zoom level. Now the zoom limit is way higher. Not too high (>1000) because when it's too high the scoreview can become unresponsive.

a beautiful screenshot which can now be taken of a stem, a notehead and a ledger line:
![image](https://user-images.githubusercontent.com/35939574/101550122-c9d77280-397c-11eb-94bd-705e9c21553b.png)


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
