### PR TITLE
update pre-3.6 style defaults for bracketed accidentals and column alignment

### DIFF
--- a/share/styles/Pre-3.6-defaults.mss
+++ b/share/styles/Pre-3.6-defaults.mss
@@ -1100,6 +1100,8 @@
     <figuredBassMinDistance>0.5</figuredBassMinDistance>
     <tupletMinDistance>0.5</tupletMinDistance>
     <autoplaceEnabled>1</autoplaceEnabled>
+    <bracketedAccidentalPadding>0</bracketedAccidentalPadding>
+    <alignAccidentalsLeft>true</alignAccidentalsLeft>
     <Spatium>1.76389</Spatium>
     </Style>
   </museScore>


### PR DESCRIPTION
Resolves: No issue in tracker

with the accidental padding PR I added 2 style values which modified the layout of older scores. In order for them to not be applied by default, the pre-3.6 default values had to be updated.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
