### PR TITLE
Temporarily disable Save to Cloud option for Beta release

### DIFF
--- a/mscore/cloud/uploadscoredialog.cpp
+++ b/mscore/cloud/uploadscoredialog.cpp
@@ -28,6 +28,10 @@ namespace Ms {
 
 void MuseScore::showUploadScoreDialog()
       {
+      if (MuseScore::unstable()) {
+            QMessageBox::warning(this, tr("Save online"), tr("Saving scores online is disabled in this unstable prerelease version of MuseScore."));
+            return;
+      }
       if (!currentScore())
             return;
       if (!currentScore()->sanityCheck(QString())) {

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -3347,6 +3347,10 @@ static void parseSourceUrl(const QString& sourceUrl, int& uid, int& nid)
 
 bool MuseScore::saveOnline(const QStringList& inFilePaths)
       {
+      if (MuseScore::unstable()) {
+            qCritical() << qUtf8Printable(tr("Error: Saving scores online is disabled in this unstable prerelease version of MuseScore."));
+            return false;
+      }
       if (!_loginManager->syncGetUser()) {
             return false;
             }


### PR DESCRIPTION
Resolves: https://trello.com/c/TiatpJIG/57-disable-save-to-cloud-option-for-beta-release

> We need to prevent users trying to upload scores, since the version on MuseScore.com will still be using 3.5.2.
> It doesn't make sense to update the MuseScore.com version until we are satisfied that 3.6 is stable.

(I hope this is the desired way to do this. Obviously it should be reverted again, at some point.)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
