### PR TITLE
[MU3] Labeling solo parts

### DIFF
--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -1230,6 +1230,7 @@ void InstrumentsWidget::createInstruments(Score* cs)
             const InstrumentTemplate* t = ((PartListItem*)item)->it;
             part = new Part(cs);
             part->initFromInstrTemplate(t);
+            part->setSoloist(pli->isSoloist());
 
             pli->part = part;
             QTreeWidgetItem* ci = 0;


### PR DESCRIPTION
Resolves: https://trello.com/c/piTSKoq2/28-solo-instrument-names-should-end-in-solo-eg-flute-solo-soprano-solo

Solves two issues in two different commits:
1) When creating a new score, <code>Soloists</code> wasn't store in the part.
2) New instrument numbering, renumbers instruments and soloists independently.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
