### PR TITLE
Don't discard events with positive velocity (Note On) during an export

### DIFF
--- a/mscore/exportaudio.cpp
+++ b/mscore/exportaudio.cpp
@@ -156,7 +156,7 @@ bool MuseScore::saveAudio(Score* score, QIODevice *device, std::function<bool(fl
                         playTime  += n;
                         frames    -= n;
                         const NPlayEvent& e = playPos->second;
-                        if (!e.discard() && e.isChannelEvent()) {
+                        if (!(!e.velo() && e.discard()) && e.isChannelEvent()) {
                               int channelIdx = e.channel();
                               const Channel* c = score->masterScore()->midiMapping(channelIdx)->articulation();
                               if (!c->mute()) {

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7282,7 +7282,7 @@ bool MuseScore::saveMp3(Score* score, QIODevice* device, bool& wasCanceled)
                               frames    -= n;
                               }
                         const NPlayEvent& e = playPos->second;
-                        if (!e.discard() && e.isChannelEvent()) {
+                        if (!(!e.velo() && e.discard()) && e.isChannelEvent()) {
                               int channelIdx = e.channel();
                               Channel* c = score->masterScore()->midiMapping(channelIdx)->articulation();
                               if (!c->mute()) {


### PR DESCRIPTION
Resolves: 
https://musescore.com/groups/improving-musescore-com/discuss/5084153
https://musescore.com/groups/improving-musescore-com/discuss/5083064

Fix a discarding of repeated events when they should be refired.