### PR TITLE
[MU3] Fix #314235: Size, Font and Style for glissando text get lost on save

### DIFF
--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -394,6 +394,8 @@ void Glissando::write(XmlWriter& xml) const
 
       for (auto id : { Pid::GLISS_TYPE, Pid::PLAY, Pid::GLISS_STYLE, Pid::GLISS_EASEIN, Pid::GLISS_EASEOUT })
             writeProperty(xml, id);
+      for (const StyledProperty& spp : *styledProperties())
+            writeProperty(xml, spp.pid);
 
       SLine::writeProperties(xml);
       xml.etag();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/314235

Similar fix is most probably needed for master too.