### PR TITLE
[MU4] Fix msvc_build.bat to work again

### DIFF
--- a/msvc_build.bat
+++ b/msvc_build.bat
@@ -180,7 +180,7 @@ IF /I "%1"=="clean" (
    if not exist "%INSTALL_FOLDER%\" mkdir "%INSTALL_FOLDER%"
 
 IF NOT "%MSCORE_STABLE_BUILD%" == "" (
-    IF NOT %CRASH_LOG_SERVER_URL% == "" (
+    IF NOT "%CRASH_LOG_SERVER_URL%" == "" (
         IF "%BUILD_FOR_WINSTORE%" == "OFF" (
             SET CRASH_REPORT_URL_OPT=-DCRASH_REPORT_URL=%CRASH_LOG_SERVER_URL% -DBUILD_CRASH_REPORTER=ON
         )


### PR DESCRIPTION
There's probably more work needed though, like making 'mscore' the default build target again and probably get rid of that `%CRASH_LOG_SERVER_URL%` section entirely.
But for now this change got me going again on master