### PR TITLE
[MU4] Fix #314235: Size, Font and Style for glissando text get lost on save

### DIFF
--- a/src/libmscore/glissando.cpp
+++ b/src/libmscore/glissando.cpp
@@ -377,6 +377,9 @@ void Glissando::write(XmlWriter& xml) const
     for (auto id : { Pid::GLISS_TYPE, Pid::PLAY, Pid::GLISSANDO_STYLE }) {
         writeProperty(xml, id);
     }
+    for (const StyledProperty& spp : *styledProperties()) {
+        writeProperty(xml, spp.pid);
+    }
 
     SLine::writeProperties(xml);
     xml.etag();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/314235

This is the #7059 counterpart for master