### PR TITLE
Fix shadow note ledger lines and stem length

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1608,6 +1608,24 @@ QPointF Element::symStemUpSE(SymId id) const
       }
 
 //---------------------------------------------------------
+//   symStemDownSW
+//---------------------------------------------------------
+
+QPointF Element::symStemDownSW(SymId id) const
+      {
+      return score()->scoreFont()->stemDownSW(id, magS());
+      }
+
+//---------------------------------------------------------
+//   symStemUpNW
+//---------------------------------------------------------
+
+QPointF Element::symStemUpNW(SymId id) const
+      {
+      return score()->scoreFont()->stemUpNW(id, magS());
+      }
+
+//---------------------------------------------------------
 //   symCutOutNE / symCutOutNW / symCutOutSE / symCutOutNW
 //---------------------------------------------------------
 

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -484,6 +484,8 @@ class Element : public ScoreElement {
       QRectF symBbox(const std::vector<SymId>&) const;
       QPointF symStemDownNW(SymId id) const;
       QPointF symStemUpSE(SymId id) const;
+      QPointF symStemDownSW(SymId id) const;
+      QPointF symStemUpNW(SymId id) const;
       QPointF symCutOutNE(SymId id) const;
       QPointF symCutOutNW(SymId id) const;
       QPointF symCutOutSE(SymId id) const;

--- a/libmscore/shadownote.cpp
+++ b/libmscore/shadownote.cpp
@@ -173,12 +173,13 @@ void ShadowNote::draw(QPainter* painter) const
             }
 
       qreal ms = spatium();
-      qreal x1 = noteheadWidth * .5 - (ms * mag());
-      qreal x2 = x1 + 2 * ms * mag();
+      qreal extraLen = score()->styleP(Sid::ledgerLineLength) * mag();
+      qreal x1 = -extraLen;
+      qreal x2 = noteheadWidth + extraLen;
       ms *= .5;
 
       lw = score()->styleP(Sid::ledgerLineWidth);
-      QPen penL(MScore::selectColor[_voice].lighter(SHADOW_NOTE_LIGHT), lw);
+      QPen penL(MScore::selectColor[_voice].lighter(SHADOW_NOTE_LIGHT), lw, Qt::SolidLine, Qt::FlatCap);
       painter->setPen(penL);
 
       if (_line < 100 && _line > -100 && !_rest) {

--- a/libmscore/sym.cpp
+++ b/libmscore/sym.cpp
@@ -6408,6 +6408,16 @@ void ScoreFont::load()
                         qreal y = ooo.value(j).toArray().at(1).toDouble();
                         sym->setStemUpSE(QPointF(4.0 * DPI_F * x, 4.0 * DPI_F * -y));
                         }
+                  else if (j == "stemDownSW") {
+                        qreal x = ooo.value(j).toArray().at(0).toDouble();
+                        qreal y = ooo.value(j).toArray().at(1).toDouble();
+                        sym->setStemDownSW(QPointF(4.0 * DPI_F * x, 4.0 * DPI_F * -y));
+                        }
+                  else if (j == "stemUpNW") {
+                        qreal x = ooo.value(j).toArray().at(0).toDouble();
+                        qreal y = ooo.value(j).toArray().at(1).toDouble();
+                        sym->setStemUpNW(QPointF(4.0 * DPI_F * x, 4.0 * DPI_F * -y));
+                        }
                   else if (j == "cutOutNE") {
                         qreal x = ooo.value(j).toArray().at(0).toDouble() * scale;
                         qreal y = ooo.value(j).toArray().at(1).toDouble() * scale;
@@ -6800,6 +6810,20 @@ QPointF ScoreFont::stemUpSE(SymId id, qreal mag) const
       if (useFallbackFont(id))
             return fallbackFont()->stemUpSE(id, mag);
       return sym(id).stemUpSE() * mag;
+      }
+
+QPointF ScoreFont::stemDownSW(SymId id, qreal mag) const
+      {
+      if (useFallbackFont(id))
+            return fallbackFont()->stemDownSW(id, mag);
+      return sym(id).stemDownSW() * mag;
+      }
+
+QPointF ScoreFont::stemUpNW(SymId id, qreal mag) const
+      {
+      if (useFallbackFont(id))
+            return fallbackFont()->stemUpNW(id, mag);
+      return sym(id).stemUpNW() * mag;
       }
 
 QPointF ScoreFont::cutOutNE(SymId id, qreal mag) const

--- a/libmscore/sym.h
+++ b/libmscore/sym.h
@@ -2898,6 +2898,8 @@ class Sym {
 
       QPointF _stemDownNW;
       QPointF _stemUpSE;
+      QPointF _stemDownSW;
+      QPointF _stemUpNW;
       QPointF _cutOutNE;
       QPointF _cutOutNW;
       QPointF _cutOutSE;
@@ -2928,6 +2930,10 @@ class Sym {
       void setStemDownNW(const QPointF& r)       { _stemDownNW = r;      }
       QPointF stemUpSE() const                   { return _stemUpSE;   }
       void setStemUpSE(const QPointF& r)         { _stemUpSE = r;      }
+      QPointF stemDownSW() const                 { return _stemDownSW; }
+      void setStemDownSW(const QPointF& r)       { _stemDownSW = r;    }
+      QPointF stemUpNW() const                   { return _stemUpNW;   }
+      void setStemUpNW(const QPointF& r)         { _stemUpNW = r;      }
       QPointF cutOutNE() const                   { return _cutOutNE; }
       void setCutOutNE(const QPointF& r)         { _cutOutNE = r;    }
       QPointF cutOutNW() const                   { return _cutOutNW; }
@@ -3056,6 +3062,8 @@ class ScoreFont {
       const QRectF bbox(const std::vector<SymId>& s, qreal mag) const;
       QPointF stemDownNW(SymId id, qreal mag) const;
       QPointF stemUpSE(SymId id, qreal mag) const;
+      QPointF stemDownSW(SymId id, qreal mag) const;
+      QPointF stemUpNW(SymId id, qreal mag) const;
       QPointF cutOutNE(SymId id, qreal mag) const;
       QPointF cutOutNW(SymId id, qreal mag) const;
       QPointF cutOutSE(SymId id, qreal mag) const;


### PR DESCRIPTION
Resolves: https://trello.com/c/uQ2x60xG/40-ghost-notes-have-stems-drawn-too-long

- The width for the ledger lines was calculated incorrectly, and they used square caps instead of flat ones.
    ![Shadow Note Ledger Lines before after](https://user-images.githubusercontent.com/48658420/101800848-04bce000-3b0e-11eb-9208-13428ab81421.jpg)

- The stem was drawn too long. 
    <img width="1321" alt="Shadow Note Stem Length before after" src="https://user-images.githubusercontent.com/48658420/101806054-ca564180-3b13-11eb-8999-ba7948900eff.png">


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
