### PR TITLE
[MU3] Improvement vertical staves adjustment

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1563,6 +1563,7 @@ static void distributeStaves(Page* page)
                   int endCurlyBracket  { - 1 };
                   int staffNr { -1 };
                   for (SysStaff* sysStaff : *system->staves()) {
+                        sysStaff->restoreLayout();
                         Staff* staff { score->staff(++staffNr)};
                         addSpaceAroundNormalBracket |= endNormalBracket == staffNr;
                         addSpaceAroundCurlyBracket  |= endCurlyBracket == staffNr;
@@ -4626,7 +4627,7 @@ void LayoutContext::collectPage()
             //  check for page break or if next system will fit on page
             //
             bool collected = false;
-            if (rangeDone && !score->enableVerticalSpread()) {
+            if (rangeDone) {
                   // take next system unchanged
                   if (systemIdx > 0) {
                         nextSystem = score->systems().value(systemIdx++);
@@ -4881,11 +4882,6 @@ void Score::doLayoutRange(const Fraction& st, const Fraction& et)
             }
       if (!layoutAll && m->system()) {
             System* system  = m->system();
-            if (enableVerticalSpread()) {
-                  system = system->page()->systems().first();
-                  lc.endTick = system->page()->systems().last()->endTick();
-                  }
-
             int systemIndex = _systems.indexOf(system);
             lc.page         = system->page();
             lc.curPage      = pageIdx(lc.page);

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1543,24 +1543,25 @@ static void distributeStaves(Page* page)
       qreal prevYBottom { page->tm() };
       qreal yBottom     { 0.0        };
       bool  vbox        { false      };
+      bool transferNormalBracket { false };
+      bool transferCurlyBracket  { false };
       for (System* system : page->systems()) {
             if (system->vbox()) {
-                  VerticalGapData* vgd = new VerticalGapData(system, nullptr, nullptr, prevYBottom);
+                  VerticalGapData* vgd = new VerticalGapData(!ngaps++, system, nullptr, nullptr, prevYBottom);
                   vgd->addSpaceAroundVBox(true);
                   prevYBottom = system->y();
                   yBottom     = system->y() + system->height();
                   vbox        = true;
-                  if (ngaps++)
-                        vgdl.append(vgd);
-                  else
-                        delete vgd;
+                  vgdl.append(vgd);
+                  transferNormalBracket = false;
+                  transferCurlyBracket  = false;
                   }
             else {
-                  bool newSystem          { true };
+                  bool newSystem       { true };
                   bool addSpaceAroundNormalBracket { false };
                   bool addSpaceAroundCurlyBracket  { false };
-                  int endNormalBracket { - 1 };
-                  int endCurlyBracket  { - 1 };
+                  int endNormalBracket { -1   };
+                  int endCurlyBracket  { -1   };
                   int staffNr { -1 };
                   for (SysStaff* sysStaff : *system->staves()) {
                         sysStaff->restoreLayout();
@@ -1581,19 +1582,21 @@ static void distributeStaves(Page* page)
                         if (!sysStaff->show())
                               continue;
 
-                        VerticalGapData* vgd = new VerticalGapData(system, staff, sysStaff, prevYBottom);
+                        VerticalGapData* vgd = new VerticalGapData(!ngaps++, system, staff, sysStaff, prevYBottom);
 
                         if (newSystem) {
                               vgd->addSpaceBetweenSections();
                               newSystem = false;
                               }
-                        if (addSpaceAroundNormalBracket) {
+                        if (addSpaceAroundNormalBracket || transferNormalBracket) {
                               vgd->addSpaceAroundNormalBracket();
                               addSpaceAroundNormalBracket = false;
+                              transferNormalBracket = false;
                               }
-                        if (addSpaceAroundCurlyBracket) {
+                        if (addSpaceAroundCurlyBracket || transferCurlyBracket) {
                               vgd->addSpaceAroundCurlyBracket();
                               addSpaceAroundCurlyBracket = false;
+                              transferCurlyBracket = false;
                               }
                         else if (staffNr < endCurlyBracket) {
                               vgd->insideCurlyBracket();
@@ -1606,11 +1609,10 @@ static void distributeStaves(Page* page)
 
                         prevYBottom = system->y() + sysStaff->y() + sysStaff->bbox().height();
                         yBottom     = system->y() + sysStaff->y() + sysStaff->skyline().south().max();
-                        if (ngaps++)
-                              vgdl.append(vgd);
-                        else
-                              delete vgd;
+                        vgdl.append(vgd);
                         }
+                  transferNormalBracket = endNormalBracket >= 0;
+                  transferCurlyBracket  = endCurlyBracket >= 0;
                   }
             }
       --ngaps;
@@ -1620,7 +1622,7 @@ static void distributeStaves(Page* page)
             return;
 
       // Try to make the gaps equal, taking the spread factors and maximum spacing into account.
-      static const int maxPasses { 10 };   // Saveguard to prevent endless loops.
+      static const int maxPasses { 20 };   // Saveguard to prevent endless loops.
       int pass { 0 };
       while (!almostZero(spaceLeft) && (ngaps > 0) && (++pass < maxPasses)) {
             ngaps = 0;
@@ -1641,16 +1643,18 @@ static void distributeStaves(Page* page)
                         modified.append(vgd);
                         ++ngaps;
                         }
+                  if ((spaceLeft - addedSpace) <= 0.0)
+                        break;
                   }
             if ((spaceLeft - addedSpace) <= 0.0)
                   {
-                  qreal step = (spaceLeft - addedSpace) / modified.sumStretchFactor();
-                  for (VerticalGapData* vgd : modified) {
-                        vgd->addSpacing(step);
-                        addedSpace += step * vgd->factor();
-                        }
+                  for (VerticalGapData* vgd : modified)
+                        vgd->undoLastAddSpacing();
+                  ngaps = 0;
                   }
-            spaceLeft -= addedSpace;
+            else {
+                  spaceLeft -= addedSpace;
+                  }
             }
 
       // If there is still space left, distribute the space of the staves.
@@ -5025,11 +5029,17 @@ LayoutContext::~LayoutContext()
 //   VerticalStretchData
 //---------------------------------------------------------
 
-VerticalGapData::VerticalGapData(System *sys, Staff *st, SysStaff *sst, qreal y)
-      : system(sys), sysStaff(sst), staff(st)
+VerticalGapData::VerticalGapData(bool first, System *sys, Staff *st, SysStaff *sst, qreal y)
+      : _fixedHeight(first), system(sys), sysStaff(sst), staff(st)
       {
-      _spacing = system->y() + (sysStaff ? sysStaff->y() : 0.0) - y;
-      _maxActualSpacing = system->score()->styleP(Sid::maxStaffSpread);
+      if (_fixedHeight) {
+            _normalisedSpacing = system->score()->styleP(Sid::staffUpperBorder);
+            _maxActualSpacing = _normalisedSpacing;
+            }
+      else {
+            _normalisedSpacing = system->y() + (sysStaff ? sysStaff->y() : 0.0) - y;
+            _maxActualSpacing = system->score()->styleP(Sid::maxStaffSpread);
+            }
       }
 
 //---------------------------------------------------------
@@ -5038,8 +5048,10 @@ VerticalGapData::VerticalGapData(System *sys, Staff *st, SysStaff *sst, qreal y)
 
 void VerticalGapData::updateFactor(qreal factor)
       {
+      if (_fixedHeight)
+            return;
       qreal f = qMax(factor, _factor);
-      _spacing *= _factor / f;
+      _normalisedSpacing *= _factor / f;
       _factor = f;
       }
 
@@ -5050,7 +5062,8 @@ void VerticalGapData::updateFactor(qreal factor)
 void VerticalGapData::addSpaceBetweenSections()
       {
       updateFactor(system->score()->styleD(Sid::spreadSystem));
-      _maxActualSpacing = system->score()->styleP(Sid::maxSystemSpread);
+      if (!_fixedHeight)
+            _maxActualSpacing = qMax(_maxActualSpacing, system->score()->styleP(Sid::maxSystemSpread));
       }
 
 //---------------------------------------------------------
@@ -5060,9 +5073,10 @@ void VerticalGapData::addSpaceBetweenSections()
 void VerticalGapData::addSpaceAroundVBox(bool above)
       {
       _fixedHeight = true;
-      updateFactor(1.0);
+      _factor = 1.0;
       const Score* score { system->score() };
-      _spacing = above ? score->styleP(Sid::frameSystemDistance) : score->styleP(Sid::systemFrameDistance);
+      _normalisedSpacing = above ? score->styleP(Sid::frameSystemDistance) : score->styleP(Sid::systemFrameDistance);
+      _maxActualSpacing = _normalisedSpacing;
       }
 
 //---------------------------------------------------------
@@ -5108,7 +5122,7 @@ qreal VerticalGapData::factor() const
 
 qreal VerticalGapData::spacing() const
       {
-      return _spacing + _addedSpace;
+      return _normalisedSpacing + _addedNormalisedSpace;
       }
 
 //---------------------------------------------------------
@@ -5117,7 +5131,7 @@ qreal VerticalGapData::spacing() const
 
 qreal VerticalGapData::actualAddedSpace() const
       {
-      return _addedSpace * factor();
+      return _addedNormalisedSpace * factor();
       }
 
 //---------------------------------------------------------
@@ -5128,17 +5142,37 @@ qreal VerticalGapData::addSpacing(qreal step)
       {
       if (_fixedHeight)
             return 0.0;
-      if ((_spacing >= _maxActualSpacing)) {
-            _spacing = _maxActualSpacing;
+      if ((_normalisedSpacing >= _maxActualSpacing)) {
+            _normalisedSpacing = _maxActualSpacing;
             step = 0.0;
             }
       else {
-            qreal newSpacing { _spacing + _addedSpace + step };
+            qreal newSpacing { _normalisedSpacing + _addedNormalisedSpace + step };
             if ((newSpacing >= _maxActualSpacing))
-                  step = _maxActualSpacing - _spacing - _addedSpace;
+                  step = _maxActualSpacing - _normalisedSpacing - _addedNormalisedSpace;
             }
-      _addedSpace += step;
+      _addedNormalisedSpace += step;
+      _lastStep = step;
       return step;
+      }
+
+//---------------------------------------------------------
+//   isFixedHeight
+//---------------------------------------------------------
+
+bool VerticalGapData::isFixedHeight() const
+      {
+      return _fixedHeight;
+      }
+
+//---------------------------------------------------------
+//   undoLastAddSpacing
+//---------------------------------------------------------
+
+void VerticalGapData::undoLastAddSpacing()
+      {
+      _addedNormalisedSpace -= _lastStep;
+      _lastStep = 0.0;
       }
 
 //---------------------------------------------------------
@@ -5170,7 +5204,6 @@ qreal VerticalGapDataList::sumStretchFactor() const
       {
       qreal sum { 0.0 };
       for (VerticalGapData* vsd : *this)
-//            if (vsd->canAddSpace())
                   sum += vsd->factor();
       return sum;
       }
@@ -5183,12 +5216,14 @@ qreal VerticalGapDataList::smallest(qreal limit) const
       {
       VerticalGapData* vdp { nullptr };
       for (VerticalGapData* vgd : *this) {
-//            if ((limit >= 0.0) && (qCeil(limit) == qCeil(vgd->normalisedSpacing())))
+            if (vgd->isFixedHeight())
+                  continue;
             if ((qCeil(limit) == qCeil(vgd->spacing())))
                   continue;
-            if (!vdp ||  (vgd->spacing() <  vdp->spacing()))
+            if (!vdp || (vgd->spacing() <  vdp->spacing()))
                   vdp = vgd;
             }
       return vdp ? vdp->spacing() : 0.0;
       }
+
 }

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1626,10 +1626,15 @@ static void distributeStaves(Page* page)
       int pass { 0 };
       while (!almostZero(spaceLeft) && (ngaps > 0) && (++pass < maxPasses)) {
             ngaps = 0;
-            const qreal smallest     { vgdl.smallest()         };
-            const qreal nextSmallest { vgdl.smallest(smallest) };
+            qreal smallest     { vgdl.smallest()         };
+            qreal nextSmallest { vgdl.smallest(smallest) };
             if (almostZero(smallest) || almostZero(nextSmallest))
                   break;
+
+            if ((nextSmallest - smallest) * vgdl.sumStretchFactor() > spaceLeft) {
+                  nextSmallest = smallest + spaceLeft/vgdl.sumStretchFactor();
+                  std::cout << "           nextSmallest = " << nextSmallest << std::endl;
+                  }
 
             qreal addedSpace { 0.0 };
             VerticalGapDataList modified;
@@ -1637,6 +1642,8 @@ static void distributeStaves(Page* page)
                   if (!almostZero(vgd->spacing() - smallest))
                         continue;
                   qreal step { nextSmallest - vgd->spacing() };
+                  if (step < 0.0)
+                        continue;
                   step = vgd->addSpacing(step);
                   if (!almostZero(step)) {
                         addedSpace += step * vgd->factor();
@@ -5204,7 +5211,7 @@ qreal VerticalGapDataList::sumStretchFactor() const
       {
       qreal sum { 0.0 };
       for (VerticalGapData* vsd : *this)
-                  sum += vsd->factor();
+            sum += vsd->factor();
       return sum;
       }
 

--- a/libmscore/layout.h
+++ b/libmscore/layout.h
@@ -27,20 +27,21 @@ class Page;
 
 class VerticalGapData {
    private:
-      bool      _fixedHeight      { false   };
-      qreal     _factor           { 1.0     };
-      qreal     _spacing          { 0.0     };
-      qreal     _maxActualSpacing { 0.0     };
-      qreal     _addedSpace       { 0.0     };
-      qreal     _fillSpacing      { 0.0     };
+      bool  _fixedHeight          { false };
+      qreal _factor               { 1.0   };
+      qreal _normalisedSpacing    { 0.0   };
+      qreal _maxActualSpacing     { 0.0   };
+      qreal _addedNormalisedSpace { 0.0   };
+      qreal _fillSpacing          { 0.0   };
+      qreal _lastStep             { 0.0   };
+      void  updateFactor(qreal factor);
 
-      void     updateFactor(qreal factor);
    public:
-      System*   system          { nullptr };
-      SysStaff* sysStaff        { nullptr };
-      Staff*    staff           { nullptr };
+      System*   system   { nullptr };
+      SysStaff* sysStaff { nullptr };
+      Staff*    staff    { nullptr };
 
-      VerticalGapData(System* sys, Staff* st, SysStaff* sst, qreal y);
+      VerticalGapData(bool first, System* sys, Staff* st, SysStaff* sst, qreal y);
 
       void addSpaceBetweenSections();
       void addSpaceAroundVBox(bool above);
@@ -53,6 +54,8 @@ class VerticalGapData {
       qreal actualAddedSpace() const;
 
       qreal addSpacing(qreal step);
+      bool isFixedHeight() const;
+      void undoLastAddSpacing();
       qreal addFillSpacing(qreal step, qreal maxFill);
       };
 

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -58,6 +58,26 @@ SysStaff::~SysStaff()
       }
 
 //---------------------------------------------------------
+//   saveLayout
+//---------------------------------------------------------
+
+void SysStaff::saveLayout()
+      {
+      _height =  bbox().height();
+      _yPos = bbox().y();
+      }
+
+//---------------------------------------------------------
+//   saveLayout
+//---------------------------------------------------------
+
+void SysStaff::restoreLayout()
+      {
+      bbox().setY(_yPos);
+      bbox().setHeight(_height);
+      }
+
+//---------------------------------------------------------
 //   System
 //---------------------------------------------------------
 
@@ -674,6 +694,7 @@ void System::layout2()
 //                  ss->setYOff(staff->lines(0) == 1 ? _spatium * staff->mag(0) : 0.0);
                   ss->setYOff(yOffset);
                   ss->bbox().setRect(_leftMargin, y - yOffset, width() - _leftMargin, h);
+                  ss->saveLayout();
                   break;
                   }
 
@@ -791,13 +812,14 @@ void System::layout2()
 //            ss->setYOff(staff->lines(0) == 1 ? _spatium * staff->mag(0) : 0.0);
             ss->setYOff(yOffset);
             ss->bbox().setRect(_leftMargin, y - yOffset, width() - _leftMargin, h);
+            ss->saveLayout();
             y += dist;
             }
 
-      qreal systemHeight = staff(visibleStaves.back().first)->bbox().bottom();
-      setHeight(systemHeight);
+      _systemHeight = staff(visibleStaves.back().first)->bbox().bottom();
+      setHeight(_systemHeight);
 
-      setMeasureHeight(systemHeight);
+      setMeasureHeight(_systemHeight);
 
       //---------------------------------------------------
       //  layout brackets vertical position
@@ -833,6 +855,19 @@ void System::layout2()
                   }
             }
 
+      }
+
+//---------------------------------------------------------
+//   restoreLayout2
+//---------------------------------------------------------
+
+void System::restoreLayout2()
+      {
+      for (SysStaff* s : _staves)
+            s->restoreLayout();
+
+      setHeight(_systemHeight);
+      setMeasureHeight(_systemHeight);
       }
 
 //---------------------------------------------------------

--- a/libmscore/system.h
+++ b/libmscore/system.h
@@ -47,7 +47,9 @@ class BarLine;
 class SysStaff {
       QRectF _bbox;                 // Bbox of StaffLines.
       Skyline _skyline;
-      qreal _yOff { 0    };         // offset of top staff line within bbox
+      qreal _yOff   { 0.0 };        // offset of top staff line within bbox
+      qreal _yPos   { 0.0 };        // y position of bbox after System::layout2
+      qreal _height { 0.0 };        // height of bbox after System::layout2
       qreal _continuousDist { -1.0 }; // distance for continuous mode
       bool _show  { true };         // derived from Staff or false if empty
                                     // staff is hidden
@@ -61,6 +63,9 @@ class SysStaff {
       qreal y() const               { return _bbox.y() + _yOff; }
       void setYOff(qreal offset)    { _yOff = offset; }
       qreal yOffset() const         { return _yOff; }
+
+      void saveLayout();
+      void restoreLayout();
 
       qreal continuousDist() const      { return _continuousDist;  }
       void setContinuousDist(qreal val) { _continuousDist = val;   }
@@ -93,6 +98,7 @@ class System final : public Element {
       qreal _leftMargin              { 0.0   };     ///< left margin for instrument name, brackets etc.
       mutable bool fixedDownDistance { false };
       qreal _distance                { 0.0   };     // temp. variable used during layout
+      qreal _systemHeight            { 0.0   };
 
       int firstVisibleSysStaff() const;
       int lastVisibleSysStaff() const;
@@ -130,6 +136,7 @@ public:
       void addBrackets(Measure* measure);
 
       void layout2();                     ///< Called after Measure layout.
+      void restoreLayout2();
       void clear();                       ///< Clear measure list.
 
       QRectF bboxStaff(int staff) const      { return _staves[staff]->bbox(); }


### PR DESCRIPTION
Corrects five issues:
1) Handle the gap above the first staff as fixed gap with a fixed <code>staffUpperBorder</code> spacing.
2) Transfer of extra bracket/brace space to gap between systems. This ensures the gap between staves always use the greatest factor.
3) Prevent adding extra space in phase 2 (make gaps between staves as equal as possible) to first staves only. Now, if the space is left, phase 2 stops and leave it to phase 3 (divide remaining evenly (wih taking the factors into account) over all gaps.
4) When a page was edited, all following pages were laid out again, causing a performance issue on large scores.
5) An optimisation in the second phase of the vertical staves adjustment prevent adding extra space to gaps which don't needed.

Resolves: https://trello.com/c/lAsD7xUf/59-distorted-spacing-between-topmost-pair-of-staves-on-some-pages

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
