### PR TITLE
[MU4] Text editing fix

### DIFF
--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -27,10 +27,11 @@ using namespace mu::notation;
 using namespace mu::actions;
 
 static constexpr int INVALID_BOX_INDEX = -1;
+static const ActionName ESCAPE_ACTION_NAME = "escape";
 
 void NotationActionController::init()
 {
-    dispatcher()->reg(this, "escape", this, &NotationActionController::resetState);
+    dispatcher()->reg(this, ESCAPE_ACTION_NAME, this, &NotationActionController::resetState);
 
     dispatcher()->reg(this, "note-input", [this]() { toggleNoteInputMethod(NoteInputMethod::STEPTIME); });
     dispatcher()->reg(this, "note-input-rhythm", [this]() { toggleNoteInputMethod(NoteInputMethod::RHYTHM); });
@@ -203,9 +204,13 @@ void NotationActionController::init()
     }
 }
 
-bool NotationActionController::canReceiveAction(const actions::ActionName&) const
+bool NotationActionController::canReceiveAction(const actions::ActionName& actionName) const
 {
-    return !isTextEditting();
+    if (isTextEditting()) {
+        return actionName == ESCAPE_ACTION_NAME;
+    }
+
+    return true;
 }
 
 INotationPtr NotationActionController::currentNotation() const

--- a/src/notation/internal/notationactioncontroller.h
+++ b/src/notation/internal/notationactioncontroller.h
@@ -39,7 +39,7 @@ public:
     void init();
 
 private:
-    bool canReceiveAction(const actions::ActionName& action) const override;
+    bool canReceiveAction(const actions::ActionName& actionName) const override;
 
     INotationPtr currentNotation() const;
     INotationInteractionPtr currentNotationInteraction() const;

--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -121,7 +121,9 @@ void NotationPaintView::onCurrentNotationChanged()
     });
 
     interaction->textEditingStarted().onNotify(this, [this]() {
-        emit textEdittingStarted();
+        if (!hasActiveFocus()) {
+            emit textEdittingStarted();
+        }
     });
 
     update();
@@ -334,7 +336,7 @@ void NotationPaintView::keyReleaseEvent(QKeyEvent* event)
     if (!isInited()) {
         return;
     }
-    m_inputController->keyPressEvent(event);
+    m_inputController->keyReleaseEvent(event);
 }
 
 void NotationPaintView::dragEnterEvent(QDragEnterEvent* ev)

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -305,7 +305,7 @@ void NotationViewInputController::hoverMoveEvent(QHoverEvent* ev)
     }
 }
 
-void NotationViewInputController::keyPressEvent(QKeyEvent* event)
+void NotationViewInputController::keyReleaseEvent(QKeyEvent* event)
 {
     if (m_view->notationInteraction()->isTextEditingStarted()) {
         m_view->notationInteraction()->editText(event);

--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -71,7 +71,7 @@ public:
     void mouseReleaseEvent(QMouseEvent*);
     void mouseDoubleClickEvent(QMouseEvent* ev);
     void hoverMoveEvent(QHoverEvent* ev);
-    void keyPressEvent(QKeyEvent* event);
+    void keyReleaseEvent(QKeyEvent* event);
 
     void dragEnterEvent(QDragEnterEvent* ev);
     void dragLeaveEvent(QDragLeaveEvent* ev);


### PR DESCRIPTION
- If notation view is in focus then not needed setting focus
- End editing text by ESC