### PR TITLE
AppImage: Don't attempt to bundle appimageupdatetool if it's not found

### DIFF
--- a/build/ci/linux/tools/make_appimage.sh
+++ b/build/ci/linux/tools/make_appimage.sh
@@ -196,6 +196,10 @@ done
 for name in "${extracted_appimages[@]}"; do
   symlink="$(which "${name}")"
   apprun="$(dirname "${symlink}")/$(readlink "${symlink}")"
+  if [[ ! -L "${symlink}" || ! -f "${apprun}" ]]; then
+    echo "$0: Warning: Unable to find AppImage for '${name}'. Will not bundle." >&2
+    continue
+  fi
   extracted_appdir_path="$(dirname "${apprun}")"
   extracted_appdir_name="$(basename "${extracted_appdir_path}")"
   cp -r "${extracted_appdir_path}" "${appdir}/"


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/314264
See also: https://github.com/AppImage/AppImageUpdate/issues/162

If appimageupdatetool was not found then the empty path was being resolved to the current directory, resulting in MuseScore's entire source directory getting bundled in the AppImage.