### PR TITLE
[MU3] Don't show empty Inspector

### DIFF
--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -320,14 +320,19 @@ void Inspector::update(Score* s)
                         case ElementType::LAYOUT_BREAK:
                               if (toLayoutBreak(element())->layoutBreakType() == LayoutBreak::Type::SECTION)
                                     ie = new InspectorSectionBreak(this);
+#if 0 // currently empty and such not needed
                               else
                                     ie = new InspectorBreak(this);
+#endif
                               break;
                         case ElementType::BEND:
                               ie = new InspectorBend(this);
                               break;
                         case ElementType::TREMOLO:
-                              ie = new InspectorTremolo(this);
+                              if (toTremolo(element())->customStyleApplicable())
+                                    ie = new InspectorTremolo(this);
+                              else
+                                    ie = new InspectorElement(this);
                               break;
                         case ElementType::TREMOLOBAR:
                               ie = new InspectorTremoloBar(this);
@@ -1062,6 +1067,7 @@ InspectorTremolo::InspectorTremolo(QWidget* parent)
       mapSignals(iiList, ppList);
       }
 
+#if 0 // not needed currently
 //---------------------------------------------------------
 //   setElement
 //---------------------------------------------------------
@@ -1078,6 +1084,7 @@ void InspectorTremolo::setElement()
                   }
             }
       }
+#endif
 
 //---------------------------------------------------------
 //   InspectorClef

--- a/mscore/inspector/inspector.h
+++ b/mscore/inspector/inspector.h
@@ -327,7 +327,9 @@ class InspectorTremolo : public InspectorElementBase {
 
    public:
       InspectorTremolo(QWidget* parent);
+#if 0 // not needed currently
       virtual void setElement() override;
+#endif
       };
 
 //---------------------------------------------------------


### PR DESCRIPTION
for tremolos between notes if on tablature or not on half notes.
Also disable Inspector for system- and page breaks.

Resolves: issue discussed in the developers' chat on Telegram.