### PR TITLE
[MU4] Convert some enums to enum classes

### DIFF
--- a/src/framework/midi/internal/midiconfiguration.cpp
+++ b/src/framework/midi/internal/midiconfiguration.cpp
@@ -57,12 +57,12 @@ const SynthesizerState& MidiConfiguration::defaultSynthesizerState() const
     if (state.isNull()) {
         SynthesizerState::Group gf;
         gf.name = "Fluid";
-        gf.vals.push_back(SynthesizerState::Val(SynthesizerState::SoundFontID, DEFAULT_FLUID_SOUNDFONT));
+        gf.vals.push_back(SynthesizerState::Val(SynthesizerState::ValID::SoundFontID, DEFAULT_FLUID_SOUNDFONT));
         state.groups.insert({ gf.name, std::move(gf) });
 
         SynthesizerState::Group gz;
         gz.name = "Zerberus";
-        gz.vals.push_back(SynthesizerState::Val(SynthesizerState::SoundFontID, DEFAULT_ZERBERUS_SOUNDFONT));
+        gz.vals.push_back(SynthesizerState::Val(SynthesizerState::ValID::SoundFontID, DEFAULT_ZERBERUS_SOUNDFONT));
         state.groups.insert({ gz.name, std::move(gz) });
     }
 

--- a/src/framework/midi/internal/soundfontsprovider.cpp
+++ b/src/framework/midi/internal/soundfontsprovider.cpp
@@ -41,7 +41,7 @@ std::vector<io::path> SoundFontsProvider::soundFontPathsForSynth(const SynthName
 
     std::vector<std::string> fontNames;
     for (const SynthesizerState::Val& val : g.vals) {
-        if (val.id == SynthesizerState::SoundFontID) {
+        if (val.id == SynthesizerState::ValID::SoundFontID) {
             fontNames.push_back(val.val);
         }
     }

--- a/src/framework/midi/miditypes.h
+++ b/src/framework/midi/miditypes.h
@@ -55,13 +55,13 @@ enum class SoundFontFormat {
 using SoundFontFormats = std::set<SoundFontFormat>;
 
 struct SynthesizerState {
-    enum ValID {
+    enum class ValID {
         UndefinedID = -1,
         SoundFontID = 0,
     };
 
     struct Val {
-        ValID id = UndefinedID;
+        ValID id = ValID::UndefinedID;
         std::string val;
         Val() = default;
         Val(ValID id, const std::string& val)

--- a/src/framework/midi/view/synthssettingsmodel.cpp
+++ b/src/framework/midi/view/synthssettingsmodel.cpp
@@ -60,7 +60,7 @@ QStringList SynthsSettingsModel::selectedSoundFonts(const QString& synth) const
 
     QStringList list;
     for (const SynthesizerState::Val& val : g.vals) {
-        if (val.id == SynthesizerState::SoundFontID) {
+        if (val.id == SynthesizerState::ValID::SoundFontID) {
             list << QString::fromStdString(val.val);
         }
     }
@@ -148,7 +148,7 @@ void SynthsSettingsModel::addSoundFont(int avalableIndex_, const QString& synth)
         return;
     }
 
-    g.vals.push_back(SynthesizerState::Val(SynthesizerState::SoundFontID, name));
+    g.vals.push_back(SynthesizerState::Val(SynthesizerState::ValID::SoundFontID, name));
 
     emit selectedChanged(synth);
 }

--- a/src/framework/midi_old/event.cpp
+++ b/src/framework/midi_old/event.cpp
@@ -57,7 +57,7 @@ Event::Event(int t)
     _duration        = 0;
     _tpc             = 0;
     _voice           = 0;
-    _edata            = 0;
+    _edata           = 0;
     _len             = 0;
     _metaType        = 0;
     _note            = 0;

--- a/src/importexport/internal/midiimport/importmidi_chord.h
+++ b/src/importexport/internal/midiimport/importmidi_chord.h
@@ -13,8 +13,8 @@ class TimeSigMap;
 class MidiNote
 {
 public:
-    int pitch;
-    int velo;
+    int pitch = 0;
+    int velo = 0;
     ReducedFraction offTime;
     Tie* tie = nullptr;
     bool staccato = false;

--- a/src/inspector/internal/services/elementrepositoryservice.cpp
+++ b/src/inspector/internal/services/elementrepositoryservice.cpp
@@ -260,7 +260,7 @@ QList<Ms::Element*> ElementRepositoryService::findSectionBreaks() const
     for (Ms::Element* element : m_elementList) {
         if (element && element->type() == Ms::ElementType::LAYOUT_BREAK) {
             const Ms::LayoutBreak* layoutBreak = Ms::toLayoutBreak(element);
-            if (layoutBreak->layoutBreakType() != Ms::LayoutBreak::SECTION) {
+            if (layoutBreak->layoutBreakType() != Ms::LayoutBreak::Type::SECTION) {
                 continue;
             }
 

--- a/src/inspector/models/abstractinspectormodel.cpp
+++ b/src/inspector/models/abstractinspectormodel.cpp
@@ -92,12 +92,12 @@ AbstractInspectorModel::InspectorSectionType AbstractInspectorModel::sectionType
     const Ms::ElementType elementType)
 {
     if (NOTATION_ELEMENT_TYPES.contains(elementType)) {
-        return SECTION_NOTATION;
+        return InspectorSectionType::SECTION_NOTATION;
     } else if (TEXT_ELEMENT_TYPES.contains(elementType)) {
-        return SECTION_TEXT;
+        return InspectorSectionType::SECTION_TEXT;
     }
 
-    return SECTION_UNDEFINED;
+    return InspectorSectionType::SECTION_UNDEFINED;
 }
 
 bool AbstractInspectorModel::isEmpty() const
@@ -109,12 +109,12 @@ QList<Ms::ElementType> AbstractInspectorModel::supportedElementTypesBySectionTyp
     const AbstractInspectorModel::InspectorSectionType sectionType)
 {
     switch (sectionType) {
-    case SECTION_GENERAL:
+    case InspectorSectionType::SECTION_GENERAL:
         return { Ms::ElementType::MAXTYPE };
-    case SECTION_NOTATION: {
+    case InspectorSectionType::SECTION_NOTATION: {
         return NOTATION_ELEMENT_TYPES;
     }
-    case SECTION_TEXT: {
+    case InspectorSectionType::SECTION_TEXT: {
         return TEXT_ELEMENT_TYPES;
     }
     default:

--- a/src/inspector/models/abstractinspectormodel.h
+++ b/src/inspector/models/abstractinspectormodel.h
@@ -38,7 +38,7 @@ public:
         SECTION_SCORE_APPEARANCE
     };
 
-    enum InspectorModelType {
+    enum class InspectorModelType {
         TYPE_UNDEFINED = -1,
         TYPE_NOTE,
         TYPE_BEAM,
@@ -141,7 +141,7 @@ private:
 
     QString m_title;
     InspectorSectionType m_sectionType = InspectorSectionType::SECTION_UNDEFINED;
-    InspectorModelType m_modelType = TYPE_UNDEFINED;
+    InspectorModelType m_modelType = InspectorModelType::TYPE_UNDEFINED;
     bool m_isEmpty = false;
 };
 

--- a/src/inspector/models/abstractinspectormodel.h
+++ b/src/inspector/models/abstractinspectormodel.h
@@ -29,7 +29,7 @@ class AbstractInspectorModel : public QObject
     Q_ENUMS(InspectorModelType)
 
 public:
-    enum InspectorSectionType {
+    enum class InspectorSectionType {
         SECTION_UNDEFINED = -1,
         SECTION_GENERAL,
         SECTION_TEXT,
@@ -140,7 +140,7 @@ private:
     Ms::Sid styleIdByPropertyId(const Ms::Pid pid) const;
 
     QString m_title;
-    InspectorSectionType m_sectionType = SECTION_UNDEFINED;
+    InspectorSectionType m_sectionType = InspectorSectionType::SECTION_UNDEFINED;
     InspectorModelType m_modelType = TYPE_UNDEFINED;
     bool m_isEmpty = false;
 };

--- a/src/inspector/models/abstractinspectorproxymodel.cpp
+++ b/src/inspector/models/abstractinspectorproxymodel.cpp
@@ -7,7 +7,7 @@ AbstractInspectorProxyModel::AbstractInspectorProxyModel(QObject* parent)
 
 QObject* AbstractInspectorProxyModel::modelByType(const InspectorModelType type)
 {
-    return m_modelsHash.value(type);
+    return m_modelsHash.value(static_cast<int>(type));
 }
 
 void AbstractInspectorProxyModel::requestResetToDefaults()
@@ -38,5 +38,5 @@ void AbstractInspectorProxyModel::addModel(AbstractInspectorModel* model)
         setIsEmpty(!hasAcceptableElements());
     });
 
-    m_modelsHash.insert(model->modelType(), model);
+    m_modelsHash.insert(static_cast<int>(model->modelType()), model);
 }

--- a/src/inspector/models/general/generalsettingsmodel.cpp
+++ b/src/inspector/models/general/generalsettingsmodel.cpp
@@ -6,7 +6,7 @@ GeneralSettingsModel::GeneralSettingsModel(QObject* parent, IElementRepositorySe
     createProperties();
 
     setTitle(tr("General"));
-    setSectionType(SECTION_GENERAL);
+    setSectionType(InspectorSectionType::SECTION_GENERAL);
     setPlaybackProxyModel(new PlaybackProxyModel(this, repository));
     setAppearanceSettingsModel(new AppearanceSettingsModel(this, repository));
 }

--- a/src/inspector/models/inspectorlistmodel.cpp
+++ b/src/inspector/models/inspectorlistmodel.cpp
@@ -21,7 +21,7 @@ InspectorListModel::InspectorListModel(QObject* parent)
 
 void InspectorListModel::buildModelsForSelectedElements(const QSet<Ms::ElementType>& selectedElementSet)
 {
-    static QList<AbstractInspectorModel::InspectorSectionType> persistentSectionList = { AbstractInspectorModel::SECTION_GENERAL };
+    static QList<AbstractInspectorModel::InspectorSectionType> persistentSectionList = { AbstractInspectorModel::InspectorSectionType::SECTION_GENERAL };
 
     removeUnusedModels(selectedElementSet, persistentSectionList);
 
@@ -38,8 +38,8 @@ void InspectorListModel::buildModelsForSelectedElements(const QSet<Ms::ElementTy
 
 void InspectorListModel::buildModelsForEmptySelection(const QSet<Ms::ElementType>& selectedElementSet)
 {
-    static QList<AbstractInspectorModel::InspectorSectionType> persistentSectionList = { AbstractInspectorModel::SECTION_SCORE_DISPLAY,
-                                                                                         AbstractInspectorModel::SECTION_SCORE_APPEARANCE
+    static QList<AbstractInspectorModel::InspectorSectionType> persistentSectionList = { AbstractInspectorModel::InspectorSectionType::SECTION_SCORE_DISPLAY,
+                                                                                         AbstractInspectorModel::InspectorSectionType::SECTION_SCORE_APPEARANCE
     };
 
     removeUnusedModels(selectedElementSet, persistentSectionList);
@@ -108,19 +108,19 @@ void InspectorListModel::createModelsBySectionType(const QList<AbstractInspector
         beginInsertRows(QModelIndex(), rowCount(), rowCount());
 
         switch (modelType) {
-        case SectionType::SECTION_GENERAL:
+        case AbstractInspectorModel::InspectorSectionType::SECTION_GENERAL:
             m_modelList << new GeneralSettingsModel(this, m_repository);
             break;
-        case SectionType::SECTION_TEXT:
+        case AbstractInspectorModel::InspectorSectionType::SECTION_TEXT:
             m_modelList << new TextSettingsModel(this, m_repository);
             break;
-        case SectionType::SECTION_NOTATION:
+        case AbstractInspectorModel::InspectorSectionType::SECTION_NOTATION:
             m_modelList << new NotationSettingsProxyModel(this, m_repository);
             break;
-        case AbstractInspectorModel::SECTION_SCORE_DISPLAY:
+        case AbstractInspectorModel::InspectorSectionType::SECTION_SCORE_DISPLAY:
             m_modelList << new ScoreSettingsModel(this, m_repository);
             break;
-        case AbstractInspectorModel::SECTION_SCORE_APPEARANCE:
+        case AbstractInspectorModel::InspectorSectionType::SECTION_SCORE_APPEARANCE:
             m_modelList << new ScoreAppearanceSettingsModel(this, m_repository);
             break;
         default:

--- a/src/inspector/models/notation/accidentals/accidentalsettingsmodel.cpp
+++ b/src/inspector/models/notation/accidentals/accidentalsettingsmodel.cpp
@@ -3,7 +3,7 @@
 AccidentalSettingsModel::AccidentalSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_ACCIDENTAL);
+    setModelType(InspectorModelType::TYPE_ACCIDENTAL);
     setTitle(tr("Accidental"));
     createProperties();
 }

--- a/src/inspector/models/notation/ambituses/ambitussettingsmodel.cpp
+++ b/src/inspector/models/notation/ambituses/ambitussettingsmodel.cpp
@@ -5,7 +5,7 @@
 AmbitusSettingsModel::AmbitusSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_AMBITUS);
+    setModelType(InspectorModelType::TYPE_AMBITUS);
     setTitle(tr("Ambitus"));
     createProperties();
 

--- a/src/inspector/models/notation/articulations/articulationsettingsmodel.cpp
+++ b/src/inspector/models/notation/articulations/articulationsettingsmodel.cpp
@@ -6,7 +6,7 @@
 ArticulationSettingsModel::ArticulationSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_ARTICULATION);
+    setModelType(InspectorModelType::TYPE_ARTICULATION);
     setTitle(tr("Articulation"));
     createProperties();
 }

--- a/src/inspector/models/notation/barlines/barlinesettingsmodel.cpp
+++ b/src/inspector/models/notation/barlines/barlinesettingsmodel.cpp
@@ -5,7 +5,7 @@
 BarlineSettingsModel::BarlineSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_BARLINE);
+    setModelType(InspectorModelType::TYPE_BARLINE);
     setTitle(tr("Barline"));
     createProperties();
 }

--- a/src/inspector/models/notation/bends/bendsettingsmodel.cpp
+++ b/src/inspector/models/notation/bends/bendsettingsmodel.cpp
@@ -6,7 +6,7 @@
 BendSettingsModel::BendSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_BEND);
+    setModelType(InspectorModelType::TYPE_BEND);
     setTitle(tr("Bend"));
     createProperties();
 }

--- a/src/inspector/models/notation/brackets/bracesettingsmodel.cpp
+++ b/src/inspector/models/notation/brackets/bracesettingsmodel.cpp
@@ -6,7 +6,7 @@
 BraceSettingsModel::BraceSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_BRACE);
+    setModelType(InspectorModelType::TYPE_BRACE);
     setTitle(tr("Brace"));
     createProperties();
 }

--- a/src/inspector/models/notation/brackets/bracketsettingsmodel.cpp
+++ b/src/inspector/models/notation/brackets/bracketsettingsmodel.cpp
@@ -6,7 +6,7 @@
 BracketSettingsModel::BracketSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_BRACKET);
+    setModelType(InspectorModelType::TYPE_BRACKET);
     setTitle(tr("Bracket"));
     createProperties();
 }

--- a/src/inspector/models/notation/chordsymbols/chordsymbolsettingsmodel.cpp
+++ b/src/inspector/models/notation/chordsymbols/chordsymbolsettingsmodel.cpp
@@ -3,7 +3,7 @@
 ChordSymbolSettingsModel::ChordSymbolSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_CHORD_SYMBOL);
+    setModelType(InspectorModelType::TYPE_CHORD_SYMBOL);
     setTitle(tr("Chord symbol"));
     createProperties();
 }

--- a/src/inspector/models/notation/clefs/clefsettingsmodel.cpp
+++ b/src/inspector/models/notation/clefs/clefsettingsmodel.cpp
@@ -3,7 +3,7 @@
 ClefSettingsModel::ClefSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_CLEF);
+    setModelType(InspectorModelType::TYPE_CLEF);
     setTitle(tr("Clef"));
     createProperties();
 }

--- a/src/inspector/models/notation/crescendos/crescendosettingsmodel.cpp
+++ b/src/inspector/models/notation/crescendos/crescendosettingsmodel.cpp
@@ -7,7 +7,7 @@
 CrescendoSettingsModel::CrescendoSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_CRESCENDO);
+    setModelType(InspectorModelType::TYPE_CRESCENDO);
     setTitle(tr("Crescendo"));
     createProperties();
 }

--- a/src/inspector/models/notation/fermatas/fermatasettingsmodel.cpp
+++ b/src/inspector/models/notation/fermatas/fermatasettingsmodel.cpp
@@ -3,7 +3,7 @@
 FermataSettingsModel::FermataSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_FERMATA);
+    setModelType(InspectorModelType::TYPE_FERMATA);
     setTitle(tr("Fermata"));
     createProperties();
 }

--- a/src/inspector/models/notation/frames/horizontalframesettingsmodel.cpp
+++ b/src/inspector/models/notation/frames/horizontalframesettingsmodel.cpp
@@ -5,7 +5,7 @@
 HorizontalFrameSettingsModel::HorizontalFrameSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_HORIZONTAL_FRAME);
+    setModelType(InspectorModelType::TYPE_HORIZONTAL_FRAME);
     setTitle(tr("Horizontal frame"));
     createProperties();
 }

--- a/src/inspector/models/notation/frames/textframesettingsmodel.cpp
+++ b/src/inspector/models/notation/frames/textframesettingsmodel.cpp
@@ -3,7 +3,7 @@
 TextFrameSettingsModel::TextFrameSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_TEXT_FRAME);
+    setModelType(InspectorModelType::TYPE_TEXT_FRAME);
     setTitle(tr("Text frame"));
     createProperties();
 }

--- a/src/inspector/models/notation/frames/verticalframesettingsmodel.cpp
+++ b/src/inspector/models/notation/frames/verticalframesettingsmodel.cpp
@@ -5,7 +5,7 @@
 VerticalFrameSettingsModel::VerticalFrameSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_VERTICAL_FRAME);
+    setModelType(InspectorModelType::TYPE_VERTICAL_FRAME);
     setTitle(tr("Vertical frame"));
     createProperties();
 }

--- a/src/inspector/models/notation/fretdiagrams/fretdiagramsettingsmodel.cpp
+++ b/src/inspector/models/notation/fretdiagrams/fretdiagramsettingsmodel.cpp
@@ -5,7 +5,7 @@
 FretDiagramSettingsModel::FretDiagramSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_FRET_DIAGRAM);
+    setModelType(InspectorModelType::TYPE_FRET_DIAGRAM);
     setTitle(tr("Fretboard Diagram"));
     createProperties();
 }

--- a/src/inspector/models/notation/glissandos/glissandosettingsmodel.cpp
+++ b/src/inspector/models/notation/glissandos/glissandosettingsmodel.cpp
@@ -3,7 +3,7 @@
 GlissandoSettingsModel::GlissandoSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_GLISSANDO);
+    setModelType(InspectorModelType::TYPE_GLISSANDO);
     setTitle(tr("Glissando"));
     createProperties();
 }

--- a/src/inspector/models/notation/hairpins/hairpinsettingsmodel.cpp
+++ b/src/inspector/models/notation/hairpins/hairpinsettingsmodel.cpp
@@ -9,7 +9,7 @@
 HairpinSettingsModel::HairpinSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_HAIRPIN);
+    setModelType(InspectorModelType::TYPE_HAIRPIN);
     setTitle(tr("Hairpin"));
     createProperties();
 }

--- a/src/inspector/models/notation/images/imagesettingsmodel.cpp
+++ b/src/inspector/models/notation/images/imagesettingsmodel.cpp
@@ -7,7 +7,7 @@
 ImageSettingsModel::ImageSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_IMAGE);
+    setModelType(InspectorModelType::TYPE_IMAGE);
     setTitle(tr("Image"));
     createProperties();
 }

--- a/src/inspector/models/notation/jumps/jumpsettingsmodel.cpp
+++ b/src/inspector/models/notation/jumps/jumpsettingsmodel.cpp
@@ -3,7 +3,7 @@
 JumpSettingsModel::JumpSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_JUMP);
+    setModelType(InspectorModelType::TYPE_JUMP);
     setTitle(tr("Jump"));
     createProperties();
 }

--- a/src/inspector/models/notation/keysignatures/keysignaturesettingsmodel.cpp
+++ b/src/inspector/models/notation/keysignatures/keysignaturesettingsmodel.cpp
@@ -3,7 +3,7 @@
 KeySignatureSettingsModel::KeySignatureSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_KEYSIGNATURE);
+    setModelType(InspectorModelType::TYPE_KEYSIGNATURE);
     setTitle(tr("Key signature"));
     createProperties();
 }

--- a/src/inspector/models/notation/markers/markersettingsmodel.cpp
+++ b/src/inspector/models/notation/markers/markersettingsmodel.cpp
@@ -3,7 +3,7 @@
 MarkerSettingsModel::MarkerSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_MARKER);
+    setModelType(InspectorModelType::TYPE_MARKER);
     setTitle(tr("Marker"));
     createProperties();
 }

--- a/src/inspector/models/notation/measurerepeats/measurerepeatsettingsmodel.cpp
+++ b/src/inspector/models/notation/measurerepeats/measurerepeatsettingsmodel.cpp
@@ -3,7 +3,7 @@
 MeasureRepeatSettingsModel::MeasureRepeatSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_MEASURE_REPEAT);
+    setModelType(InspectorModelType::TYPE_MEASURE_REPEAT);
     setTitle(tr("Measure repeat"));
     createProperties();
 }

--- a/src/inspector/models/notation/mmrests/mmrestsettingsmodel.cpp
+++ b/src/inspector/models/notation/mmrests/mmrestsettingsmodel.cpp
@@ -3,7 +3,7 @@
 MMRestSettingsModel::MMRestSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_MMREST);
+    setModelType(InspectorModelType::TYPE_MMREST);
     setTitle(tr("Multimeasure rest"));
     createProperties();
 }

--- a/src/inspector/models/notation/notationsettingsproxymodel.cpp
+++ b/src/inspector/models/notation/notationsettingsproxymodel.cpp
@@ -38,7 +38,7 @@
 NotationSettingsProxyModel::NotationSettingsProxyModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorProxyModel(parent)
 {
-    setSectionType(SECTION_NOTATION);
+    setSectionType(InspectorSectionType::SECTION_NOTATION);
     setTitle(QStringLiteral("Notation"));
 
     addModel(new NoteSettingsProxyModel(this, repository));

--- a/src/inspector/models/notation/notes/beams/beamsettingsmodel.cpp
+++ b/src/inspector/models/notation/notes/beams/beamsettingsmodel.cpp
@@ -5,7 +5,7 @@
 BeamSettingsModel::BeamSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_BEAM);
+    setModelType(InspectorModelType::TYPE_BEAM);
     setTitle(tr("Beam"));
     setBeamModesModel(new BeamModesModel(this, repository));
 

--- a/src/inspector/models/notation/notes/hooks/hooksettingsmodel.cpp
+++ b/src/inspector/models/notation/notes/hooks/hooksettingsmodel.cpp
@@ -5,7 +5,7 @@
 HookSettingsModel::HookSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_HOOK);
+    setModelType(InspectorModelType::TYPE_HOOK);
     setTitle(tr("Flag")); // internally called "Hook", but "Flag" in SMuFL, so here externally too
 
     createProperties();

--- a/src/inspector/models/notation/notes/noteheads/noteheadsettingsmodel.cpp
+++ b/src/inspector/models/notation/notes/noteheads/noteheadsettingsmodel.cpp
@@ -7,7 +7,7 @@ NoteheadSettingsModel::NoteheadSettingsModel(QObject* parent, IElementRepository
     : AbstractInspectorModel(parent, repository)
 {
     setTitle(tr("Head"));
-    setModelType(TYPE_NOTEHEAD);
+    setModelType(InspectorModelType::TYPE_NOTEHEAD);
 
     createProperties();
 

--- a/src/inspector/models/notation/notes/notesettingsproxymodel.cpp
+++ b/src/inspector/models/notation/notes/notesettingsproxymodel.cpp
@@ -8,7 +8,7 @@
 NoteSettingsProxyModel::NoteSettingsProxyModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorProxyModel(parent)
 {
-    setSectionType(SECTION_NOTATION);
+    setSectionType(InspectorSectionType::SECTION_NOTATION);
     setModelType(TYPE_NOTE);
     setTitle(tr("Note"));
 

--- a/src/inspector/models/notation/notes/notesettingsproxymodel.cpp
+++ b/src/inspector/models/notation/notes/notesettingsproxymodel.cpp
@@ -9,7 +9,7 @@ NoteSettingsProxyModel::NoteSettingsProxyModel(QObject* parent, IElementReposito
     : AbstractInspectorProxyModel(parent)
 {
     setSectionType(InspectorSectionType::SECTION_NOTATION);
-    setModelType(TYPE_NOTE);
+    setModelType(InspectorModelType::TYPE_NOTE);
     setTitle(tr("Note"));
 
     addModel(new StemSettingsModel(this, repository));

--- a/src/inspector/models/notation/notes/stems/stemsettingsmodel.cpp
+++ b/src/inspector/models/notation/notes/stems/stemsettingsmodel.cpp
@@ -6,7 +6,7 @@
 StemSettingsModel::StemSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_STEM);
+    setModelType(InspectorModelType::TYPE_STEM);
     setTitle(tr("Stem"));
 
     createProperties();

--- a/src/inspector/models/notation/ornaments/ornamentsettingsmodel.cpp
+++ b/src/inspector/models/notation/ornaments/ornamentsettingsmodel.cpp
@@ -6,7 +6,7 @@
 OrnamentSettingsModel::OrnamentSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_ORNAMENT);
+    setModelType(InspectorModelType::TYPE_ORNAMENT);
     setTitle(tr("Ornament"));
     createProperties();
 }

--- a/src/inspector/models/notation/pedals/pedalsettingsmodel.cpp
+++ b/src/inspector/models/notation/pedals/pedalsettingsmodel.cpp
@@ -5,7 +5,7 @@
 PedalSettingsModel::PedalSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_PEDAL);
+    setModelType(InspectorModelType::TYPE_PEDAL);
     setTitle(tr("Pedal"));
     createProperties();
 }

--- a/src/inspector/models/notation/sectionbreaks/sectionbreaksettingsmodel.cpp
+++ b/src/inspector/models/notation/sectionbreaks/sectionbreaksettingsmodel.cpp
@@ -5,7 +5,7 @@
 SectionBreakSettingsModel::SectionBreakSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_SECTIONBREAK);
+    setModelType(InspectorModelType::TYPE_SECTIONBREAK);
     setTitle(tr("Section Break"));
     createProperties();
 }

--- a/src/inspector/models/notation/spacers/spacersettingsmodel.cpp
+++ b/src/inspector/models/notation/spacers/spacersettingsmodel.cpp
@@ -5,7 +5,7 @@
 SpacerSettingsModel::SpacerSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_SPACER);
+    setModelType(InspectorModelType::TYPE_SPACER);
     setTitle(tr("Spacer"));
     createProperties();
 }

--- a/src/inspector/models/notation/staffs/staffsettingsmodel.cpp
+++ b/src/inspector/models/notation/staffs/staffsettingsmodel.cpp
@@ -3,7 +3,7 @@
 StaffSettingsModel::StaffSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_STAFF);
+    setModelType(InspectorModelType::TYPE_STAFF);
     setTitle(tr("Staff"));
     createProperties();
 }

--- a/src/inspector/models/notation/stafftype/stafftypesettingsmodel.cpp
+++ b/src/inspector/models/notation/stafftype/stafftypesettingsmodel.cpp
@@ -5,7 +5,7 @@
 StaffTypeSettingsModel::StaffTypeSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_STAFF_TYPE_CHANGES);
+    setModelType(InspectorModelType::TYPE_STAFF_TYPE_CHANGES);
     setTitle(tr("Staff type changes"));
     createProperties();
 }

--- a/src/inspector/models/notation/tempos/temposettingsmodel.cpp
+++ b/src/inspector/models/notation/tempos/temposettingsmodel.cpp
@@ -5,7 +5,7 @@
 TempoSettingsModel::TempoSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_TEMPO);
+    setModelType(InspectorModelType::TYPE_TEMPO);
     setTitle(tr("Tempo"));
     createProperties();
 }

--- a/src/inspector/models/notation/timesignatures/timesignaturesettingsmodel.cpp
+++ b/src/inspector/models/notation/timesignatures/timesignaturesettingsmodel.cpp
@@ -7,7 +7,7 @@
 TimeSignatureSettingsModel::TimeSignatureSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_TIME_SIGNATURE);
+    setModelType(InspectorModelType::TYPE_TIME_SIGNATURE);
     setTitle(tr("Time signature"));
     createProperties();
 }

--- a/src/inspector/models/notation/tremolobars/tremolobarsettingsmodel.cpp
+++ b/src/inspector/models/notation/tremolobars/tremolobarsettingsmodel.cpp
@@ -6,7 +6,7 @@
 TremoloBarSettingsModel::TremoloBarSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_TREMOLOBAR);
+    setModelType(InspectorModelType::TYPE_TREMOLOBAR);
     setTitle(tr("Tremolo bar"));
     createProperties();
 }

--- a/src/inspector/models/notation/tremolos/tremolosettingsmodel.cpp
+++ b/src/inspector/models/notation/tremolos/tremolosettingsmodel.cpp
@@ -5,7 +5,7 @@
 TremoloSettingsModel::TremoloSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(TYPE_TREMOLO);
+    setModelType(InspectorModelType::TYPE_TREMOLO);
     setTitle(tr("Tremolos"));
     createProperties();
 }

--- a/src/inspector/models/score/scoreappearancesettingsmodel.cpp
+++ b/src/inspector/models/score/scoreappearancesettingsmodel.cpp
@@ -9,7 +9,7 @@
 ScoreAppearanceSettingsModel::ScoreAppearanceSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setSectionType(SECTION_SCORE_APPEARANCE);
+    setSectionType(InspectorSectionType::SECTION_SCORE_APPEARANCE);
     setTitle(tr("Score appearance"));
     createProperties();
 }

--- a/src/inspector/models/score/scoredisplaysettingsmodel.cpp
+++ b/src/inspector/models/score/scoredisplaysettingsmodel.cpp
@@ -3,7 +3,7 @@
 ScoreSettingsModel::ScoreSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setSectionType(SECTION_SCORE_DISPLAY);
+    setSectionType(InspectorSectionType::SECTION_SCORE_DISPLAY);
     setTitle(tr("Show"));
     createProperties();
 }

--- a/src/inspector/models/text/textsettingsmodel.cpp
+++ b/src/inspector/models/text/textsettingsmodel.cpp
@@ -9,7 +9,7 @@
 TextSettingsModel::TextSettingsModel(QObject* parent, IElementRepositoryService* repository)
     : AbstractInspectorModel(parent, repository)
 {
-    setSectionType(SECTION_TEXT);
+    setSectionType(InspectorSectionType::SECTION_TEXT);
     setTitle(tr("Text"));
     createProperties();
 

--- a/src/instruments/view/instrumenttreeitem.cpp
+++ b/src/instruments/view/instrumenttreeitem.cpp
@@ -67,12 +67,12 @@ void InstrumentTreeItem::moveChildren(const int sourceRow, const int count, Abst
     }
 
     int destinationRowLast = destinationRow;
-    INotationParts::InsertMode moveMode = INotationParts::Before;
+    INotationParts::InsertMode moveMode = INotationParts::InsertMode::Before;
 
     // exclude the control item
     if (destinationRow == destinationParent->childCount() - 1) {
         destinationRowLast = destinationRow - 1;
-        moveMode = INotationParts::After;
+        moveMode = INotationParts::InsertMode::After;
     }
 
     auto staff = dynamic_cast<const StaffTreeItem*>(destinationParent->childAtRow(destinationRowLast));

--- a/src/instruments/view/parttreeitem.cpp
+++ b/src/instruments/view/parttreeitem.cpp
@@ -67,12 +67,12 @@ void PartTreeItem::moveChildren(const int sourceRow, const int count, AbstractIn
     }
 
     int destinationRowLast = destinationRow;
-    INotationParts::InsertMode moveMode = INotationParts::Before;
+    INotationParts::InsertMode moveMode = INotationParts::InsertMode::Before;
 
     // exclude the control item
     if (destinationRow == destinationParent->childCount() - 1) {
         destinationRowLast = destinationRow - 1;
-        moveMode = INotationParts::After;
+        moveMode = INotationParts::InsertMode::After;
     }
 
     AbstractInstrumentPanelTreeItem* destinationStaffItem = destinationParent->childAtRow(destinationRowLast);

--- a/src/instruments/view/roottreeitem.cpp
+++ b/src/instruments/view/roottreeitem.cpp
@@ -36,11 +36,11 @@ void RootTreeItem::moveChildren(const int sourceRow, const int count, AbstractIn
     }
 
     int destinationRow_ = destinationRow;
-    INotationParts::InsertMode moveMode = INotationParts::Before;
+    INotationParts::InsertMode moveMode = INotationParts::InsertMode::Before;
 
     if (destinationRow_ == destinationParent->childCount()) {
         destinationRow_--;
-        moveMode = INotationParts::After;
+        moveMode = INotationParts::InsertMode::After;
     }
 
     const AbstractInstrumentPanelTreeItem* destinationPartItem = destinationParent->childAtRow(destinationRow_);

--- a/src/libmscore/barline.cpp
+++ b/src/libmscore/barline.cpp
@@ -158,7 +158,7 @@ static void undoChangeBarLineType(BarLine* bl, BarLineType barType, bool allStav
         Measure* m2 = m->isMMRest() ? m->mmRestFirst() : m;
         for (int staffIdx = 0; staffIdx < m2->score()->nstaves(); ++staffIdx) {
             if (m2->isMeasureRepeatGroupWithPrevM(staffIdx)) {
-                MScore::setError(CANNOT_SPLIT_MEASURE_REPEAT);
+                MScore::setError(MsError::CANNOT_SPLIT_MEASURE_REPEAT);
                 return;
             }
         }
@@ -174,7 +174,7 @@ static void undoChangeBarLineType(BarLine* bl, BarLineType barType, bool allStav
         Measure* m2 = m->isMMRest() ? m->mmRestLast() : m;
         for (int staffIdx = 0; staffIdx < m2->score()->nstaves(); ++staffIdx) {
             if (m2->isMeasureRepeatGroupWithNextM(staffIdx)) {
-                MScore::setError(CANNOT_SPLIT_MEASURE_REPEAT);
+                MScore::setError(MsError::CANNOT_SPLIT_MEASURE_REPEAT);
                 return;
             }
         }
@@ -190,7 +190,7 @@ static void undoChangeBarLineType(BarLine* bl, BarLineType barType, bool allStav
         Measure* m2 = m->isMMRest() ? m->mmRestLast() : m;
         for (int staffIdx = 0; staffIdx < m2->score()->nstaves(); ++staffIdx) {
             if (m2->isMeasureRepeatGroupWithNextM(staffIdx)) {
-                MScore::setError(CANNOT_SPLIT_MEASURE_REPEAT);
+                MScore::setError(MsError::CANNOT_SPLIT_MEASURE_REPEAT);
                 return;
             }
         }

--- a/src/libmscore/cmd.cpp
+++ b/src/libmscore/cmd.cpp
@@ -268,7 +268,7 @@ void Score::endCmd(const bool isCmdFromInspector, bool rollback)
         update();
         return;
     }
-    if (readOnly() || MScore::_error != MS_NO_ERROR) {
+    if (readOnly() || MScore::_error != MsError::MS_NO_ERROR) {
         rollback = true;
     }
 
@@ -2900,7 +2900,7 @@ bool Score::makeMeasureRepeatGroup(Measure* firstMeasure, int numMeasures, int s
     Measure* measure = firstMeasure;
     for (int i = 1; i <= numMeasures; ++i) {
         if (!measure || measure->ticks() != firstMeasure->ticks()) {
-            MScore::setError(INSUFFICIENT_MEASURES);
+            MScore::setError(MsError::INSUFFICIENT_MEASURES);
             return false;
         }
         measures.push_back(measure);

--- a/src/libmscore/edit.cpp
+++ b/src/libmscore/edit.cpp
@@ -78,7 +78,7 @@ Note* Score::getSelectedNote()
     if (el && el->isNote()) {
         return toNote(el);
     }
-    MScore::setError(NO_NOTE_SELECTED);
+    MScore::setError(MsError::NO_NOTE_SELECTED);
     return 0;
 }
 
@@ -98,7 +98,7 @@ ChordRest* Score::getSelectedChordRest() const
             return toChord(el);
         }
     }
-    MScore::setError(NO_NOTE_REST_SELECTED);
+    MScore::setError(MsError::NO_NOTE_REST_SELECTED);
     return 0;
 }
 
@@ -125,7 +125,7 @@ void Score::getSelectedChordRest2(ChordRest** cr1, ChordRest** cr2) const
         }
     }
     if (*cr1 == 0) {
-        MScore::setError(NO_NOTE_REST_SELECTED);
+        MScore::setError(MsError::NO_NOTE_REST_SELECTED);
     }
     if (*cr1 == *cr2) {
         *cr2 = 0;
@@ -1013,7 +1013,7 @@ bool Score::rewriteMeasures(Measure* fm, const Fraction& ns, int staffIdx)
 
     // disable local time sig modifications in linked staves
     if (staffIdx != -1 && excerpts().size() > 0) {
-        MScore::setError(CANNOT_CHANGE_LOCAL_TIMESIG);
+        MScore::setError(MsError::CANNOT_CHANGE_LOCAL_TIMESIG);
         return false;
     }
 
@@ -1030,7 +1030,7 @@ bool Score::rewriteMeasures(Measure* fm, const Fraction& ns, int staffIdx)
 
             if (!rewriteMeasures(fm1, lm, ns, staffIdx)) {
                 if (staffIdx >= 0) {
-                    MScore::setError(CANNOT_CHANGE_LOCAL_TIMESIG);
+                    MScore::setError(MsError::CANNOT_CHANGE_LOCAL_TIMESIG);
                     // restore measure rests that were prematurely modified
                     Fraction fr(staff(staffIdx)->timeSig(fm->tick())->sig());
                     for (Measure* m = fm1; m; m = m->nextMeasure()) {
@@ -1046,7 +1046,7 @@ bool Score::rewriteMeasures(Measure* fm, const Fraction& ns, int staffIdx)
                     // (if we are rewriting all staves, but one has a local time signature)
                     // TODO: detect error conditions better, have clearer error messages
                     // and perform necessary fixups
-                    MScore::setError(TUPLET_CROSSES_BAR);
+                    MScore::setError(MsError::TUPLET_CROSSES_BAR);
                 }
                 for (Measure* m = fm1; m; m = m->nextMeasure()) {
                     if (m->first(SegmentType::TimeSig)) {
@@ -1339,7 +1339,7 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
 void Score::cmdRemoveTimeSig(TimeSig* ts)
 {
     if (ts->isLocal() && excerpts().size() > 0) {
-        MScore::setError(CANNOT_CHANGE_LOCAL_TIMESIG);
+        MScore::setError(MsError::CANNOT_CHANGE_LOCAL_TIMESIG);
         return;
     }
 
@@ -2020,7 +2020,7 @@ void Score::cmdFlip()
 {
     const QList<Element*>& el = selection().elements();
     if (el.empty()) {
-        MScore::setError(NO_FLIPPABLE_SELECTED);
+        MScore::setError(MsError::NO_FLIPPABLE_SELECTED);
         return;
     }
 
@@ -3283,7 +3283,7 @@ Lyrics* Score::addLyrics()
 {
     Element* el = selection().element();
     if (el == 0 || (!el->isNote() && !el->isLyrics() && !el->isRest())) {
-        MScore::setError(NO_LYRICS_SELECTED);
+        MScore::setError(MsError::NO_LYRICS_SELECTED);
         return 0;
     }
     ChordRest* cr;
@@ -3441,7 +3441,7 @@ void Score::colorItem(Element* element)
 void Score::cmdExchangeVoice(int s, int d)
 {
     if (!selection().isRange()) {
-        MScore::setError(NO_STAFF_SELECTED);
+        MScore::setError(MsError::NO_STAFF_SELECTED);
         return;
     }
     Fraction t1 = selection().tickStart();
@@ -3605,7 +3605,7 @@ void Score::insertMeasure(ElementType type, MeasureBase* measure, bool createEmp
             }
             for (int staffIdx = 0; staffIdx < nstaves(); ++staffIdx) {
                 if (toMeasure(measure)->isMeasureRepeatGroupWithPrevM(staffIdx)) {
-                    MScore::setError(CANNOT_SPLIT_MEASURE_REPEAT);
+                    MScore::setError(MsError::CANNOT_SPLIT_MEASURE_REPEAT);
                     return;
                 }
             }
@@ -3883,7 +3883,7 @@ bool Score::checkTimeDelete(Segment* startSegment, Segment* endSegment)
             || (endMeasure->isMeasureRepeatGroup(staffIdx) && !endsAtEndOfMeasure)
             || startMeasure->isMeasureRepeatGroupWithPrevM(staffIdx)
             || endMeasure->isMeasureRepeatGroupWithNextM(staffIdx)) {
-            MScore::setError(CANNOT_REMOVE_TIME_MEASURE_REPEAT);
+            MScore::setError(MsError::CANNOT_REMOVE_TIME_MEASURE_REPEAT);
             return false;
         }
     }
@@ -3922,7 +3922,7 @@ bool Score::checkTimeDelete(Segment* startSegment, Segment* endSegment)
         etick = endTick;
     }
     if (!canDeleteTime) {
-        MScore::setError(CANNOT_REMOVE_TIME_TUPLET);
+        MScore::setError(MsError::CANNOT_REMOVE_TIME_TUPLET);
         return false;
     }
     return true;

--- a/src/libmscore/figuredbass.cpp
+++ b/src/libmscore/figuredbass.cpp
@@ -1878,7 +1878,7 @@ FiguredBass* Score::addFiguredBass()
 {
     Element* el = selection().element();
     if (!el || (!(el->isNote()) && !(el->isRest()) && !(el->isFiguredBass()))) {
-        MScore::setError(NO_NOTE_FIGUREDBASS_SELECTED);
+        MScore::setError(MsError::NO_NOTE_FIGUREDBASS_SELECTED);
         return 0;
     }
 

--- a/src/libmscore/joinMeasure.cpp
+++ b/src/libmscore/joinMeasure.cpp
@@ -30,7 +30,7 @@ void Score::cmdJoinMeasure(Measure* m1, Measure* m2)
 
     for (int staffIdx = 0; staffIdx < nstaves(); ++staffIdx) {
         if (m1->isMeasureRepeatGroupWithPrevM(staffIdx) || m2->isMeasureRepeatGroupWithNextM(staffIdx)) {
-            MScore::setError(CANNOT_SPLIT_MEASURE_REPEAT);
+            MScore::setError(MsError::CANNOT_SPLIT_MEASURE_REPEAT);
             return;
         }
     }

--- a/src/libmscore/layout.h
+++ b/src/libmscore/layout.h
@@ -39,8 +39,8 @@ struct LayoutContext {
     System* prevSystem       { 0 };       // used during page layout
     System* curSystem        { 0 };
 
-    MeasureBase* systemOldMeasure;
-    MeasureBase* pageOldMeasure;
+    MeasureBase* systemOldMeasure { 0 };
+    MeasureBase* pageOldMeasure   { 0 };
     bool rangeDone           { false };
 
     MeasureBase* prevMeasure { 0 };

--- a/src/libmscore/layoutbreak.h
+++ b/src/libmscore/layoutbreak.h
@@ -29,7 +29,7 @@ class LayoutBreak final : public Element
 {
     Q_GADGET
 public:
-    enum Type {
+    enum class Type {
         ///.\{
         PAGE, LINE, SECTION, NOBREAK
         ///\}
@@ -72,10 +72,10 @@ public:
     bool startWithMeasureOne() const { return _startWithMeasureOne; }
     void setStartWithMeasureOne(bool v) { _startWithMeasureOne = v; }
 
-    bool isPageBreak() const { return _layoutBreakType == PAGE; }
-    bool isLineBreak() const { return _layoutBreakType == LINE; }
-    bool isSectionBreak() const { return _layoutBreakType == SECTION; }
-    bool isNoBreak() const { return _layoutBreakType == NOBREAK; }
+    bool isPageBreak() const { return _layoutBreakType == Type::PAGE; }
+    bool isLineBreak() const { return _layoutBreakType == Type::LINE; }
+    bool isSectionBreak() const { return _layoutBreakType == Type::SECTION; }
+    bool isNoBreak() const { return _layoutBreakType == Type::NOBREAK; }
 
     QVariant getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const QVariant&) override;

--- a/src/libmscore/measure.cpp
+++ b/src/libmscore/measure.cpp
@@ -1527,7 +1527,7 @@ Element* Measure::drop(EditData& data)
         LayoutBreak* b = toLayoutBreak(e);
         Measure* measure = isMMRest() ? mmRestLast() : this;
         switch (b->layoutBreakType()) {
-        case  LayoutBreak::PAGE:
+        case  LayoutBreak::Type::PAGE:
             if (measure->pageBreak()) {
                 delete b;
                 b = 0;
@@ -1535,7 +1535,7 @@ Element* Measure::drop(EditData& data)
                 measure->setLineBreak(false);
             }
             break;
-        case  LayoutBreak::LINE:
+        case  LayoutBreak::Type::LINE:
             if (measure->lineBreak()) {
                 delete b;
                 b = 0;
@@ -1543,7 +1543,7 @@ Element* Measure::drop(EditData& data)
                 measure->setPageBreak(false);
             }
             break;
-        case  LayoutBreak::SECTION:
+        case  LayoutBreak::Type::SECTION:
             if (measure->sectionBreak()) {
                 delete b;
                 b = 0;
@@ -1551,7 +1551,7 @@ Element* Measure::drop(EditData& data)
                 measure->setLineBreak(false);
             }
             break;
-        case LayoutBreak::NOBREAK:
+        case LayoutBreak::Type::NOBREAK:
             if (measure->noBreak()) {
                 delete b;
                 b = 0;

--- a/src/libmscore/measure.cpp
+++ b/src/libmscore/measure.cpp
@@ -1625,7 +1625,7 @@ Element* Measure::drop(EditData& data)
             Measure* m2 = isMMRest() ? mmRestFirst() : this;
             for (int stIdx = 0; stIdx < score()->nstaves(); ++stIdx) {
                 if (m2->isMeasureRepeatGroupWithPrevM(stIdx)) {
-                    MScore::setError(CANNOT_SPLIT_MEASURE_REPEAT);
+                    MScore::setError(MsError::CANNOT_SPLIT_MEASURE_REPEAT);
                     return nullptr;
                 }
             }
@@ -1639,7 +1639,7 @@ Element* Measure::drop(EditData& data)
             Measure* m2 = isMMRest() ? mmRestLast() : this;
             for (int stIdx = 0; stIdx < score()->nstaves(); ++stIdx) {
                 if (m2->isMeasureRepeatGroupWithNextM(stIdx)) {
-                    MScore::setError(CANNOT_SPLIT_MEASURE_REPEAT);
+                    MScore::setError(MsError::CANNOT_SPLIT_MEASURE_REPEAT);
                     return nullptr;
                 }
             }
@@ -1653,7 +1653,7 @@ Element* Measure::drop(EditData& data)
             Measure* m2 = isMMRest() ? mmRestLast() : this;
             for (int stIdx = 0; stIdx < score()->nstaves(); ++stIdx) {
                 if (m2->isMeasureRepeatGroupWithNextM(stIdx)) {
-                    MScore::setError(CANNOT_SPLIT_MEASURE_REPEAT);
+                    MScore::setError(MsError::CANNOT_SPLIT_MEASURE_REPEAT);
                     return nullptr;
                 }
             }

--- a/src/libmscore/measure.h
+++ b/src/libmscore/measure.h
@@ -343,7 +343,7 @@ private:
                                 // 0 if this is the start of am mmrest (m_mmRest != 0)
                                 // < 0 if this measure is covered by an mmrest
 
-    int m_playbackCount;        // temp. value used in RepeatList
+    int m_playbackCount { 0 };  // temp. value used in RepeatList
                                 // counts how many times this measure was already played
 
     int m_repeatCount;          ///< end repeat marker and repeat count

--- a/src/libmscore/measurebase.cpp
+++ b/src/libmscore/measurebase.cpp
@@ -102,25 +102,25 @@ void MeasureBase::add(Element* e)
     if (e->isLayoutBreak()) {
         LayoutBreak* b = toLayoutBreak(e);
         switch (b->layoutBreakType()) {
-        case LayoutBreak::PAGE:
+        case LayoutBreak::Type::PAGE:
             setPageBreak(true);
             setLineBreak(false);
             setNoBreak(false);
             break;
-        case LayoutBreak::LINE:
+        case LayoutBreak::Type::LINE:
             setPageBreak(false);
             setLineBreak(true);
             setSectionBreak(false);
             setNoBreak(false);
             break;
-        case LayoutBreak::SECTION:
+        case LayoutBreak::Type::SECTION:
             setLineBreak(false);
             setSectionBreak(true);
             setNoBreak(false);
             //does not work with repeats: score()->tempomap()->setPause(endTick(), b->pause());
             triggerLayoutAll();
             break;
-        case LayoutBreak::NOBREAK:
+        case LayoutBreak::Type:: NOBREAK:
             setPageBreak(false);
             setLineBreak(false);
             setSectionBreak(false);
@@ -146,18 +146,18 @@ void MeasureBase::remove(Element* el)
     if (el->isLayoutBreak()) {
         LayoutBreak* lb = toLayoutBreak(el);
         switch (lb->layoutBreakType()) {
-        case LayoutBreak::PAGE:
+        case LayoutBreak::Type::PAGE:
             setPageBreak(false);
             break;
-        case LayoutBreak::LINE:
+        case LayoutBreak::Type::LINE:
             setLineBreak(false);
             break;
-        case LayoutBreak::SECTION:
+        case LayoutBreak::Type::SECTION:
             setSectionBreak(false);
             score()->setPause(endTick(), 0);
             triggerLayoutAll();
             break;
-        case LayoutBreak::NOBREAK:
+        case LayoutBreak::Type::NOBREAK:
             setNoBreak(false);
             break;
         }
@@ -417,13 +417,13 @@ QVariant MeasureBase::propertyDefault(Pid propertyId) const
 void MeasureBase::undoSetBreak(bool v, LayoutBreak::Type type)
 {
     switch (type) {
-    case LayoutBreak::LINE:
+    case LayoutBreak::Type::LINE:
         if (lineBreak() == v) {
             return;
         }
         setLineBreak(v);
         break;
-    case LayoutBreak::PAGE:
+    case LayoutBreak::Type::PAGE:
         if (pageBreak() == v) {
             return;
         }
@@ -432,7 +432,7 @@ void MeasureBase::undoSetBreak(bool v, LayoutBreak::Type type)
         }
         setPageBreak(v);
         break;
-    case LayoutBreak::SECTION:
+    case LayoutBreak::Type::SECTION:
         if (sectionBreak() == v) {
             return;
         }
@@ -441,7 +441,7 @@ void MeasureBase::undoSetBreak(bool v, LayoutBreak::Type type)
         }
         setSectionBreak(v);
         break;
-    case LayoutBreak::NOBREAK:
+    case LayoutBreak::Type::NOBREAK:
         if (noBreak() == v) {
             return;
         }
@@ -476,22 +476,22 @@ void MeasureBase::cleanupLayoutBreaks(bool undo)
     for (Element* e : el()) {
         if (e->isLayoutBreak()) {
             switch (toLayoutBreak(e)->layoutBreakType()) {
-            case LayoutBreak::LINE:
+            case LayoutBreak::Type::LINE:
                 if (!lineBreak()) {
                     toDelete.push_back(e);
                 }
                 break;
-            case LayoutBreak::PAGE:
+            case LayoutBreak::Type::PAGE:
                 if (!pageBreak()) {
                     toDelete.push_back(e);
                 }
                 break;
-            case LayoutBreak::SECTION:
+            case LayoutBreak::Type::SECTION:
                 if (!sectionBreak()) {
                     toDelete.push_back(e);
                 }
                 break;
-            case LayoutBreak::NOBREAK:
+            case LayoutBreak::Type::NOBREAK:
                 if (!noBreak()) {
                     toDelete.push_back(e);
                 }
@@ -561,22 +561,22 @@ bool MeasureBase::readProperties(XmlReader& e)
         lb->read(e);
         bool doAdd = true;
         switch (lb->layoutBreakType()) {
-        case LayoutBreak::LINE:
+        case LayoutBreak::Type::LINE:
             if (lineBreak()) {
                 doAdd = false;
             }
             break;
-        case LayoutBreak::PAGE:
+        case LayoutBreak::Type::PAGE:
             if (pageBreak()) {
                 doAdd = false;
             }
             break;
-        case LayoutBreak::SECTION:
+        case LayoutBreak::Type::SECTION:
             if (sectionBreak()) {
                 doAdd = false;
             }
             break;
-        case LayoutBreak::NOBREAK:
+        case LayoutBreak::Type::NOBREAK:
             if (noBreak()) {
                 doAdd = false;
             }

--- a/src/libmscore/measurebase.h
+++ b/src/libmscore/measurebase.h
@@ -114,10 +114,10 @@ public:
     LayoutBreak* sectionBreakElement() const;
 
     void undoSetBreak(bool v, LayoutBreak::Type type);
-    void undoSetLineBreak(bool v) { undoSetBreak(v, LayoutBreak::LINE); }
-    void undoSetPageBreak(bool v) { undoSetBreak(v, LayoutBreak::PAGE); }
-    void undoSetSectionBreak(bool v) { undoSetBreak(v, LayoutBreak::SECTION); }
-    void undoSetNoBreak(bool v) { undoSetBreak(v, LayoutBreak::NOBREAK); }
+    void undoSetLineBreak(bool v) { undoSetBreak(v, LayoutBreak::Type::LINE); }
+    void undoSetPageBreak(bool v) { undoSetBreak(v, LayoutBreak::Type::PAGE); }
+    void undoSetSectionBreak(bool v) { undoSetBreak(v, LayoutBreak::Type::SECTION); }
+    void undoSetNoBreak(bool v) { undoSetBreak(v, LayoutBreak::Type::NOBREAK); }
 
     virtual void moveTicks(const Fraction& diff) { setTick(tick() + diff); }
 

--- a/src/libmscore/mscore.cpp
+++ b/src/libmscore/mscore.cpp
@@ -128,52 +128,52 @@ extern void initScoreFonts();
 extern QString mscoreGlobalShare;
 
 std::vector<MScoreError> MScore::errorList {
-    { MS_NO_ERROR,                     0,    0 },
+    { MsError::MS_NO_ERROR,                     0,    0 },
 
-    { NO_NOTE_SELECTED,                "s1", QT_TRANSLATE_NOOP("error",
+    { MsError::NO_NOTE_SELECTED,                "s1", QT_TRANSLATE_NOOP("error",
                                                                "No note selected:\nPlease select a note and retry") },
-    { NO_CHORD_REST_SELECTED,          "s2", QT_TRANSLATE_NOOP("error",
+    { MsError::NO_CHORD_REST_SELECTED,          "s2", QT_TRANSLATE_NOOP("error",
                                                                "No chord/rest selected:\nPlease select a chord or rest and retry") },
-    { NO_LYRICS_SELECTED,              "s3", QT_TRANSLATE_NOOP("error",
+    { MsError::NO_LYRICS_SELECTED,              "s3", QT_TRANSLATE_NOOP("error",
                                                                "No note or lyrics selected:\nPlease select a note or lyrics and retry") },
-    { NO_NOTE_REST_SELECTED,           "s4", QT_TRANSLATE_NOOP("error",
+    { MsError::NO_NOTE_REST_SELECTED,           "s4", QT_TRANSLATE_NOOP("error",
                                                                "No note or rest selected:\nPlease select a note or rest and retry") },
-    { NO_FLIPPABLE_SELECTED,           "s5", QT_TRANSLATE_NOOP("error",
+    { MsError::NO_FLIPPABLE_SELECTED,           "s5", QT_TRANSLATE_NOOP("error",
                                                                "No flippable element selected:\nPlease select an element that can be flipped and retry") },
-    { NO_STAFF_SELECTED,               "s6", QT_TRANSLATE_NOOP("error",
+    { MsError::NO_STAFF_SELECTED,               "s6", QT_TRANSLATE_NOOP("error",
                                                                "No staff selected:\nPlease select one or more staves and retry") },
-    { NO_NOTE_FIGUREDBASS_SELECTED,    "s7", QT_TRANSLATE_NOOP("error",
+    { MsError::NO_NOTE_FIGUREDBASS_SELECTED,    "s7", QT_TRANSLATE_NOOP("error",
                                                                "No note or figured bass selected:\nPlease select a note or figured bass and retry") },
 
-    { CANNOT_INSERT_TUPLET,            "t1", QT_TRANSLATE_NOOP("error", "Cannot insert chord/rest in tuplet") },
-    { CANNOT_SPLIT_TUPLET,             "t2", QT_TRANSLATE_NOOP("error", "Cannot split tuplet") },
+    { MsError::CANNOT_INSERT_TUPLET,            "t1", QT_TRANSLATE_NOOP("error", "Cannot insert chord/rest in tuplet") },
+    { MsError::CANNOT_SPLIT_TUPLET,             "t2", QT_TRANSLATE_NOOP("error", "Cannot split tuplet") },
 
-    { CANNOT_SPLIT_MEASURE_FIRST_BEAT, "m1", QT_TRANSLATE_NOOP("error",
+    { MsError::CANNOT_SPLIT_MEASURE_FIRST_BEAT, "m1", QT_TRANSLATE_NOOP("error",
                                                                "Cannot split measure here:\n"
                                                                "First beat of measure") },
-    { CANNOT_SPLIT_MEASURE_TUPLET,     "m2", QT_TRANSLATE_NOOP("error",
+    { MsError::CANNOT_SPLIT_MEASURE_TUPLET,     "m2", QT_TRANSLATE_NOOP("error",
                                                                "Cannot split measure here:\n" "Cannot split tuplet") },
-    { INSUFFICIENT_MEASURES,           "m3", QT_TRANSLATE_NOOP("error",
+    { MsError::INSUFFICIENT_MEASURES,           "m3", QT_TRANSLATE_NOOP("error",
                                                                "Measure repeat cannot be added here:\nInsufficient or unequal measures") },
-    { CANNOT_SPLIT_MEASURE_REPEAT,     "m4", QT_TRANSLATE_NOOP("error", "Cannot split measure repeat") },
+    { MsError::CANNOT_SPLIT_MEASURE_REPEAT,     "m4", QT_TRANSLATE_NOOP("error", "Cannot split measure repeat") },
 
-    { CANNOT_REMOVE_TIME_TUPLET,       "d1", QT_TRANSLATE_NOOP("error",
+    { MsError::CANNOT_REMOVE_TIME_TUPLET,       "d1", QT_TRANSLATE_NOOP("error",
                                                                "Cannot remove time from tuplet:\nPlease select the complete tuplet and retry") },
-    { CANNOT_REMOVE_TIME_MEASURE_REPEAT, "d2", QT_TRANSLATE_NOOP("error",
+    { MsError::CANNOT_REMOVE_TIME_MEASURE_REPEAT, "d2", QT_TRANSLATE_NOOP("error",
                                                                  "Cannot remove time from measure repeat:\nPlease select the complete measure repeat and retry") },
 
-    { NO_DEST,                         "p1", QT_TRANSLATE_NOOP("error", "No destination to paste") },
-    { DEST_TUPLET,                     "p2", QT_TRANSLATE_NOOP("error", "Cannot paste into tuplet") },
-    { TUPLET_CROSSES_BAR,              "p3", QT_TRANSLATE_NOOP("error", "Tuplet cannot cross barlines") },
-    { DEST_LOCAL_TIME_SIGNATURE,       "p4", QT_TRANSLATE_NOOP("error", "Cannot paste in local time signature") },
-    { DEST_TREMOLO,                    "p5", QT_TRANSLATE_NOOP("error", "Cannot paste in tremolo") },
-    { NO_MIME,                         "p6", QT_TRANSLATE_NOOP("error", "Nothing to paste") },
-    { DEST_NO_CR,                      "p7", QT_TRANSLATE_NOOP("error", "Destination is not a chord or rest") },
-    { CANNOT_CHANGE_LOCAL_TIMESIG,     "l1", QT_TRANSLATE_NOOP("error",
+    { MsError::NO_DEST,                         "p1", QT_TRANSLATE_NOOP("error", "No destination to paste") },
+    { MsError::DEST_TUPLET,                     "p2", QT_TRANSLATE_NOOP("error", "Cannot paste into tuplet") },
+    { MsError::TUPLET_CROSSES_BAR,              "p3", QT_TRANSLATE_NOOP("error", "Tuplet cannot cross barlines") },
+    { MsError::DEST_LOCAL_TIME_SIGNATURE,       "p4", QT_TRANSLATE_NOOP("error", "Cannot paste in local time signature") },
+    { MsError::DEST_TREMOLO,                    "p5", QT_TRANSLATE_NOOP("error", "Cannot paste in tremolo") },
+    { MsError::NO_MIME,                         "p6", QT_TRANSLATE_NOOP("error", "Nothing to paste") },
+    { MsError::DEST_NO_CR,                      "p7", QT_TRANSLATE_NOOP("error", "Destination is not a chord or rest") },
+    { MsError::CANNOT_CHANGE_LOCAL_TIMESIG,     "l1", QT_TRANSLATE_NOOP("error",
                                                                "Cannot change local time signature:\nMeasure is not empty") },
 };
 
-MsError MScore::_error { MS_NO_ERROR };
+MsError MScore::_error { MsError::MS_NO_ERROR };
 
 //---------------------------------------------------------
 //   Direction

--- a/src/libmscore/mscore.h
+++ b/src/libmscore/mscore.h
@@ -237,7 +237,7 @@ enum class IconType : signed char {
 //   MScoreError
 //---------------------------------------------------------
 
-enum MsError {
+enum class MsError {
     MS_NO_ERROR,
     NO_NOTE_SELECTED,
     NO_CHORD_REST_SELECTED,

--- a/src/libmscore/noteentry.cpp
+++ b/src/libmscore/noteentry.cpp
@@ -618,7 +618,7 @@ void Score::insertChord(const Position& pos)
     }
     Segment* seg = pos.segment;
     if (seg->splitsTuplet()) {
-        MScore::setError(CANNOT_INSERT_TUPLET);
+        MScore::setError(MsError::CANNOT_INSERT_TUPLET);
         return;
     }
     if (_is.insertMode()) {

--- a/src/libmscore/paste.cpp
+++ b/src/libmscore/paste.cpp
@@ -180,7 +180,7 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff, Fraction scale)
                     Fraction tick = doScale ? (e.tick() - dstTick) * scale + dstTick : e.tick();
                     // no paste into local time signature
                     if (staff(dstStaffIdx)->isLocalTimeSignature(tick)) {
-                        MScore::setError(DEST_LOCAL_TIME_SIGNATURE);
+                        MScore::setError(MsError::DEST_LOCAL_TIME_SIGNATURE);
                         if (oldTuplet && oldTuplet->elements().empty()) {
                             delete oldTuplet;
                         }
@@ -202,7 +202,7 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff, Fraction scale)
                         if (oldTuplet && oldTuplet->elements().empty()) {
                             delete oldTuplet;
                         }
-                        MScore::setError(TUPLET_CROSSES_BAR);
+                        MScore::setError(MsError::TUPLET_CROSSES_BAR);
                         return false;
                     }
                     if (oldTuplet) {
@@ -234,7 +234,7 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff, Fraction scale)
                     Fraction tick = doScale ? (e.tick() - dstTick) * scale + dstTick : e.tick();
                     // no paste into local time signature
                     if (staff(dstStaffIdx)->isLocalTimeSignature(tick)) {
-                        MScore::setError(DEST_LOCAL_TIME_SIGNATURE);
+                        MScore::setError(MsError::DEST_LOCAL_TIME_SIGNATURE);
                         return false;
                     }
                     if (tick2measure(tick)->isMeasureRepeatGroup(dstStaffIdx)) {
@@ -275,7 +275,7 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff, Fraction scale)
                                 Fraction ticks = cr->actualTicks();
                                 Fraction rticks = m->endTick() - tick;
                                 if (rticks < ticks || (rticks != ticks && rticks < ticks * 2)) {
-                                    MScore::setError(DEST_TREMOLO);
+                                    MScore::setError(MsError::DEST_TREMOLO);
                                     return false;
                                 }
                             }
@@ -1022,7 +1022,7 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view, Fraction scale)
 {
     if (ms == 0) {
         qDebug("no application mime data");
-        MScore::setError(NO_MIME);
+        MScore::setError(MsError::NO_MIME);
         return;
     }
     if ((_selection.isSingle() || _selection.isList()) && ms->hasFormat(mimeSymbolFormat)) {
@@ -1093,7 +1093,7 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view, Fraction scale)
             Element* e = _selection.element();
             if (!e->isNote() && !e->isChordRest()) {
                 qDebug("cannot paste to %s", e->name());
-                MScore::setError(DEST_NO_CR);
+                MScore::setError(MsError::DEST_NO_CR);
                 return;
             }
             if (e->isNote()) {
@@ -1102,10 +1102,10 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view, Fraction scale)
             cr  = toChordRest(e);
         }
         if (cr == 0) {
-            MScore::setError(NO_DEST);
+            MScore::setError(MsError::NO_DEST);
             return;
         } else if (cr->tuplet() && cr->tick() != cr->topTuplet()->tick()) {
-            MScore::setError(DEST_TUPLET);
+            MScore::setError(MsError::DEST_TUPLET);
             return;
         } else {
             QByteArray data(ms->data(mimeStaffListFormat));
@@ -1126,7 +1126,7 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view, Fraction scale)
             Element* e = _selection.element();
             if (!e->isNote() && !e->isRest() && !e->isChord()) {
                 qDebug("cannot paste to %s", e->name());
-                MScore::setError(DEST_NO_CR);
+                MScore::setError(MsError::DEST_NO_CR);
                 return;
             }
             if (e->isNote()) {
@@ -1135,7 +1135,7 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view, Fraction scale)
             cr  = toChordRest(e);
         }
         if (cr == 0) {
-            MScore::setError(NO_DEST);
+            MScore::setError(MsError::NO_DEST);
             return;
         } else {
             QByteArray data(ms->data(mimeSymbolListFormat));

--- a/src/libmscore/property.cpp
+++ b/src/libmscore/property.cpp
@@ -760,16 +760,16 @@ QVariant propertyFromString(Pid id, QString value)
     break;
     case P_TYPE::LAYOUT_BREAK: {
         if (value == "line") {
-            return QVariant(int(LayoutBreak::LINE));
+            return QVariant(int(LayoutBreak::Type::LINE));
         }
         if (value == "page") {
-            return QVariant(int(LayoutBreak::PAGE));
+            return QVariant(int(LayoutBreak::Type::PAGE));
         }
         if (value == "section") {
-            return QVariant(int(LayoutBreak::SECTION));
+            return QVariant(int(LayoutBreak::Type::SECTION));
         }
         if (value == "nobreak") {
-            return QVariant(int(LayoutBreak::NOBREAK));
+            return QVariant(int(LayoutBreak::Type::NOBREAK));
         }
         qDebug("getProperty: invalid P_TYPE::LAYOUT_BREAK: <%s>", qPrintable(value));
     }
@@ -1060,13 +1060,13 @@ QString propertyToString(Pid id, QVariant value, bool mscx)
         break;
     case P_TYPE::LAYOUT_BREAK:
         switch (LayoutBreak::Type(value.toInt())) {
-        case LayoutBreak::LINE:
+        case LayoutBreak::Type::LINE:
             return "line";
-        case LayoutBreak::PAGE:
+        case LayoutBreak::Type::PAGE:
             return "page";
-        case LayoutBreak::SECTION:
+        case LayoutBreak::Type::SECTION:
             return "section";
-        case LayoutBreak::NOBREAK:
+        case LayoutBreak::Type::NOBREAK:
             return "nobreak";
         }
         break;

--- a/src/libmscore/range.cpp
+++ b/src/libmscore/range.cpp
@@ -488,7 +488,7 @@ bool TrackList::write(Score* score, const Fraction& tick) const
             if (duration > remains && e->isTuplet()) {
                 // experimental: allow tuplet split in the middle
                 if (duration != remains * 2) {
-                    MScore::setError(CANNOT_SPLIT_TUPLET);
+                    MScore::setError(MsError::CANNOT_SPLIT_TUPLET);
                     return false;
                 }
             }

--- a/src/libmscore/splitMeasure.cpp
+++ b/src/libmscore/splitMeasure.cpp
@@ -41,17 +41,17 @@ void Score::cmdSplitMeasure(ChordRest* cr)
 void Score::splitMeasure(Segment* segment)
 {
     if (segment->rtick().isZero()) {
-        MScore::setError(CANNOT_SPLIT_MEASURE_FIRST_BEAT);
+        MScore::setError(MsError::CANNOT_SPLIT_MEASURE_FIRST_BEAT);
         return;
     }
     if (segment->splitsTuplet()) {
-        MScore::setError(CANNOT_SPLIT_MEASURE_TUPLET);
+        MScore::setError(MsError::CANNOT_SPLIT_MEASURE_TUPLET);
         return;
     }
     Measure* measure = segment->measure();
     for (int staffIdx = 0; staffIdx < nstaves(); ++staffIdx) {
         if (measure->isMeasureRepeatGroup(staffIdx)) {
-            MScore::setError(CANNOT_SPLIT_MEASURE_REPEAT);
+            MScore::setError(MsError::CANNOT_SPLIT_MEASURE_REPEAT);
             return;
         }
     }

--- a/src/libmscore/systemdivider.cpp
+++ b/src/libmscore/systemdivider.cpp
@@ -48,7 +48,7 @@ void SystemDivider::layout()
     SymId sid;
     ScoreFont* sf = score()->scoreFont();
 
-    if (_dividerType == SystemDivider::LEFT) {
+    if (_dividerType == SystemDivider::Type::LEFT) {
         sid = Sym::name2id(score()->styleSt(Sid::dividerLeftSym));
     } else {
         sid = Sym::name2id(score()->styleSt(Sid::dividerRightSym));
@@ -64,7 +64,7 @@ void SystemDivider::layout()
 void SystemDivider::setDividerType(SystemDivider::Type v)
 {
     _dividerType = v;
-    if (v == SystemDivider::LEFT) {
+    if (v == SystemDivider::Type::LEFT) {
         setOffset(QPointF(score()->styleD(Sid::dividerLeftX), score()->styleD(Sid::dividerLeftY)));
     } else {
         setOffset(QPointF(score()->styleD(Sid::dividerRightX), score()->styleD(Sid::dividerRightY)));

--- a/src/libmscore/systemdivider.h
+++ b/src/libmscore/systemdivider.h
@@ -24,7 +24,7 @@ namespace Ms {
 class SystemDivider final : public Symbol
 {
 public:
-    enum Type {
+    enum class Type {
         LEFT, RIGHT
     };
 

--- a/src/notation/inotationparts.h
+++ b/src/notation/inotationparts.h
@@ -63,15 +63,15 @@ public:
     virtual void removeInstruments(const IDList& instrumentsIds, const ID& fromPartId) = 0;
     virtual void removeStaves(const IDList& stavesIds) = 0;
 
-    enum InsertMode {
+    enum class InsertMode {
         Before,
         After
     };
 
-    virtual void moveParts(const IDList& sourcePartsIds, const ID& destinationPartId, InsertMode mode = Before) = 0;
+    virtual void moveParts(const IDList& sourcePartsIds, const ID& destinationPartId, InsertMode mode = InsertMode::Before) = 0;
     virtual void moveInstruments(const IDList& sourceInstrumentsIds, const ID& sourcePartId, const ID& destinationPartId,
-                                 const ID& destinationInstrumentId, InsertMode mode = Before) = 0;
-    virtual void moveStaves(const IDList& sourceStavesIds, const ID& destinationStaffId, InsertMode mode = Before) = 0;
+                                 const ID& destinationInstrumentId, InsertMode mode = InsertMode::Before) = 0;
+    virtual void moveStaves(const IDList& sourceStavesIds, const ID& destinationStaffId, InsertMode mode = InsertMode::Before) = 0;
 
     virtual void appendDoublingInstrument(const instruments::Instrument& instrument, const ID& destinationPartId) = 0;
     virtual void appendStaff(const ID& destinationPartId) = 0;

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -386,7 +386,7 @@ void NotationParts::doMovePart(const ID& sourcePartId, const ID& destinationPart
     score()->undoRemovePart(part);
 
     int toPartIndex = score()->parts().indexOf(destinationPart);
-    int newPartIndex = mode == Before ? toPartIndex : toPartIndex + 1;
+    int newPartIndex = mode == InsertMode::Before ? toPartIndex : toPartIndex + 1;
     score()->parts().insert(newPartIndex, part);
 
     auto instruments = *part->instruments();
@@ -983,7 +983,7 @@ void NotationParts::doInsertInstruments(const QMap<Ms::Fraction, Ms::Instrument*
         }
     }
 
-    int newInstrumentIndex = (mode == Before ? destinationIndex : destinationIndex + 1);
+    int newInstrumentIndex = (mode == InsertMode::Before ? destinationIndex : destinationIndex + 1);
 
     for (Ms::Instrument* instrument: instruments.values()) {
         partInstruments.insert(newInstrumentIndex++, new Ms::Instrument(*instrument));
@@ -1051,7 +1051,7 @@ void NotationParts::moveStaves(const IDList& sourceStavesIds, const ID& destinat
 
     std::vector<Staff*> staves = this->staves(sourceStavesIds);
     Part* destinationPart = destinationStaff->part();
-    int destinationStaffIndex = (mode == Before ? destinationStaff->idx() : destinationStaff->idx() + 1);
+    int destinationStaffIndex = (mode == InsertMode::Before ? destinationStaff->idx() : destinationStaff->idx() + 1);
     destinationStaffIndex -= score()->staffIdx(destinationPart); // NOTE: convert to local part's staff index
 
     startEdit();

--- a/src/notation/internal/notationparts.h
+++ b/src/notation/internal/notationparts.h
@@ -60,10 +60,10 @@ public:
     void removeInstruments(const IDList& instrumentsIds, const ID& fromPartId) override;
     void removeStaves(const IDList& stavesIds) override;
 
-    void moveParts(const IDList& sourcePartsIds, const ID& destinationPartId, InsertMode mode = Before) override;
+    void moveParts(const IDList& sourcePartsIds, const ID& destinationPartId, InsertMode mode = InsertMode::Before) override;
     void moveInstruments(const IDList& sourceInstrumentIds, const ID& sourcePartId, const ID& destinationPartId,
-                         const ID& destinationInstrumentId, InsertMode mode = Before) override;
-    void moveStaves(const IDList& sourceStavesIds, const ID& destinationStaffId, InsertMode mode = Before) override;
+                         const ID& destinationInstrumentId, InsertMode mode = InsertMode::Before) override;
+    void moveStaves(const IDList& sourceStavesIds, const ID& destinationStaffId, InsertMode mode = InsertMode::Before) override;
 
     void appendDoublingInstrument(const instruments::Instrument& instrument, const ID& destinationPartId) override;
     void appendStaff(const ID& destinationPartId) override;
@@ -117,7 +117,7 @@ private:
 
     void updatePartTitles();
 
-    void doMovePart(const ID& sourcePartId, const ID& destinationPartId, InsertMode mode = Before);
+    void doMovePart(const ID& sourcePartId, const ID& destinationPartId, InsertMode mode = InsertMode::Before);
     void doMoveStaves(const std::vector<Staff*>& staves, int destinationStaffIndex, Part* destinationPart = nullptr);
     void doSetStaffVisible(Staff* staff, bool visible);
     void doSetStaffVoiceVisible(Staff* staff, int voiceIndex, bool visible);
@@ -164,7 +164,7 @@ private:
 
     QMap<Ms::Fraction, Ms::Instrument*> instruments(const Part* fromPart, const IDList& filterInstrumentsIds = IDList()) const;
     void doInsertInstruments(const QMap<Ms::Fraction, Ms::Instrument*>& instruments, const ID& destinationPartId,
-                             const ID& destinationInstrumentId, InsertMode mode = Before);
+                             const ID& destinationInstrumentId, InsertMode mode = InsertMode::Before);
 
     IGetScore* m_getScore = nullptr;
     INotationUndoStackPtr m_undoStack;


### PR DESCRIPTION
Fixes a bunch of MSVC IntelliSense warnings

* `INotationParts::InsertMode`
* `LayoutBreak::Type`
* `AbstractInspectorModel::InspectorSectionType`
* `AbstractInspectorProxyModel::InspectorModelType`
* `SystemDivider::Type`
* `Ms:MsError`
* `mu::midi::SynthesizerState::ValID`

ToDo:

* `Ms::EventType`, being deprecated this might not be worth the effort though? For sure it'd be getting pretty ugly...

In the passing initialize some member variables that MSVC  was complaing about

Not changing, as these are in third party code:

* `deto::async::Channel::Type`
* `haw::Logger::Level`
* Lots from Qt