### PR TITLE
[MU3] add transpose function to pluginAPI::score

### DIFF
--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -15,6 +15,7 @@
 
 #include "config.h"
 #include "style.h"
+#include "types.h"
 
 namespace Ms {
 
@@ -119,22 +120,6 @@ enum class BracketType : signed char {
 
 enum class PlaceText : char {
       AUTO, ABOVE, BELOW, LEFT
-      };
-
-//---------------------------------------------------------
-//   TransposeDirection
-//---------------------------------------------------------
-
-enum class TransposeDirection : char {
-      UP, DOWN, CLOSEST
-      };
-
-//---------------------------------------------------------
-//   TransposeMode
-//---------------------------------------------------------
-
-enum class TransposeMode : char {
-      TO_KEY, BY_INTERVAL, DIATONICALLY
       };
 
 //---------------------------------------------------------

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -639,7 +639,7 @@ class Score : public QObject, public ScoreElement {
       bool transpose(Note* n, Interval, bool useSharpsFlats);
       void transposeKeys(int staffStart, int staffEnd, const Fraction& tickStart, const Fraction& tickEnd, const Interval&, bool useInstrument = false, bool flip = false);
       bool transpose(TransposeMode mode, TransposeDirection, Key transposeKey, int transposeInterval,
-      bool trKeys, bool transposeChordNames, bool useDoubleSharpsFlats);
+                     bool trKeys, bool transposeChordNames, bool useDoubleSharpsFlats);
 
       bool appendMeasuresFromScore(Score* score, const Fraction& startTick, const Fraction& endTick);
       bool appendScore(Score*, bool addPageBreak = false, bool addSectionBreak = true);
@@ -1486,4 +1486,3 @@ Q_DECLARE_OPERATORS_FOR_FLAGS(LayoutFlags);
 
 
 #endif
-

--- a/libmscore/types.h
+++ b/libmscore/types.h
@@ -604,6 +604,18 @@ enum class PlayEventType : char {
       ///.\}
       };
 
+enum class TransposeDirection : char {
+      ///.\{
+      UP, DOWN, CLOSEST
+      ///.\}
+      };
+
+enum class TransposeMode : char {
+      ///.\{
+      TO_KEY, BY_INTERVAL, DIATONICALLY
+      ///.\}
+      };
+
 //---------------------------------------------------------
 //   Tuplets
 //---------------------------------------------------------
@@ -625,6 +637,8 @@ Q_ENUM_NS(NoteType);
 Q_ENUM_NS(PlayEventType);
 Q_ENUM_NS(AccidentalType);
 Q_ENUM_NS(HarmonyType);
+Q_ENUM_NS(TransposeDirection);
+Q_ENUM_NS(TransposeMode);
 #endif
 
 //hack: to force the build system to run moc on this file

--- a/mscore/plugin/api/qmlpluginapi.cpp
+++ b/mscore/plugin/api/qmlpluginapi.cpp
@@ -53,6 +53,9 @@ Enum* PluginAPI::segmentTypeEnum = nullptr;
 Enum* PluginAPI::spannerAnchorEnum = nullptr;
 Enum* PluginAPI::symIdEnum = nullptr;
 Enum* PluginAPI::harmonyTypeEnum = nullptr;
+Enum* PluginAPI::transposeModeEnum = nullptr;
+Enum* PluginAPI::transposeDirectionEnum = nullptr;
+Enum* PluginAPI::keyEnum = nullptr;
 
 //---------------------------------------------------------
 //   PluginAPI

--- a/mscore/plugin/api/qmlpluginapi.h
+++ b/mscore/plugin/api/qmlpluginapi.h
@@ -167,6 +167,21 @@ class PluginAPI : public Ms::QmlPlugin {
       /// \since MuseScore 3.6
       DECLARE_API_ENUM( HarmonyType,      harmonyTypeEnum,        Ms::HarmonyType           )
 
+      /// Contains Ms::TransposeMode enumeration values.
+      /// Possible values: `TO_KEY`, `BY_INTERVAL`, `DIATONICALLY`
+      /// \since MuseScore 3.6
+      DECLARE_API_ENUM( TransposeMode,    transposeModeEnum,      Ms::TransposeMode         )
+      /// Contains Ms::TransposeDirection enumeration values.
+      /// Possible values: `UP`, `DOWN`, `CLOSEST`
+      /// \since MuseScore 3.6
+      DECLARE_API_ENUM( TransposeDirection, transposeDirectionEnum, Ms::TransposeDirection  )
+      /// Contains Ms::Key enumeration values.
+      ///  Possible values: `C_B`, `G_B`, `D_B`, `A_B`, `E_B`, `B_B`, `F`,
+      ///                   `C`, `G`, `D`, `A`, `E`, `B`, `F_S`, `C_S`,
+      /// \since MuseScore 3.6
+      DECLARE_API_ENUM( Key, keyEnum, Ms::Key  )
+
+
       QFile logFile;
 
    signals:

--- a/mscore/plugin/api/score.cpp
+++ b/mscore/plugin/api/score.cpp
@@ -216,5 +216,12 @@ void Score::startCmd()
             score()->startCmd();
             }
       }
+
+
+void Score::transpose(Ms::PluginAPI::TransposeMode mode, Ms::PluginAPI::TransposeDirection direction, Ms::PluginAPI::Key trKey,
+                      int transposeInterval, bool transposeKeySignatures, bool transposeChordNames, bool useDoubleSharpsFlats)
+      {
+      score()->transpose(mode, direction, trKey, transposeInterval, transposeKeySignatures, transposeChordNames, useDoubleSharpsFlats);
+      }
 }
 }

--- a/mscore/plugin/api/score.h
+++ b/mscore/plugin/api/score.h
@@ -227,6 +227,19 @@ class Score : public Ms::PluginAPI::ScoreElement {
        */
       Q_INVOKABLE void createPlayEvents() { score()->createPlayEvents(); }
 
+      /**
+       * Transpose the score (or the selection).
+       * \since 3.6
+       */
+      Q_INVOKABLE void transpose(Ms::PluginAPI::TransposeMode mode,
+                                 Ms::PluginAPI::TransposeDirection direction,
+                                 Ms::PluginAPI::Key trKey,
+                                 int transposeInterval,
+                                 bool transposeKeySignatures,
+                                 bool transposeChordNames,
+                                 bool useDoubleSharpsFlats);
+
+
       /// \cond MS_INTERNAL
       QString mscoreVersion() { return score()->mscoreVersion(); }
       QString mscoreRevision() { return QString::number(score()->mscoreRevision(), /* base */ 16); }


### PR DESCRIPTION
Resolves: No issue in tracker

Adds ability to transpose a score from plugin.

NOTE: I still cannot build Musescore on my PC, so I will test the generated artifacts when the CI outputs them.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
