### PR TITLE
Add ability to get path to a score from plugins

### DIFF
--- a/mscore/plugin/api/score.h
+++ b/mscore/plugin/api/score.h
@@ -117,6 +117,14 @@ class Score : public Ms::PluginAPI::ScoreElement {
        */
       Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::Staff> staves    READ staves)
 
+      /**
+       * Returns the path to the file from which the score was imported, or empty.
+       * \warning If the score hasn't been saved yet, this will return an empty string.
+       * \since MuseScore 3.6
+       */
+      Q_PROPERTY(QString path READ path)
+
+
    public:
       /// \cond MS_INTERNAL
       Score(Ms::Score* s = nullptr, Ownership o = Ownership::SCORE)
@@ -136,6 +144,7 @@ class Score : public Ms::PluginAPI::ScoreElement {
       QString title() { return score()->metaTag("workTitle"); }
       Ms::PluginAPI::Selection* selection() { return selectionWrap(&score()->selection()); }
       MStyle* style() { return wrap(&score()->style(), score()); }
+      QString path() { return score()->importedFilePath(); }
 
       int pageNumberOffset() const { return score()->pageNumberOffset(); }
       void setPageNumberOffset(int offset) { score()->undoChangePageNumberOffset(offset); }


### PR DESCRIPTION
Resolves: no issue in tracker I know of but a forum discussion: https://musescore.org/en/node/314074

When for example saving a copy of a score, one might want to know where the file was initially read from.

~NOTE: I still cannot build on my PC, so I'll test the artifacts when they get generated.~
UPDATE: I have tested the artifacts and everything to worked.

will need a master counterpart

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
