### PR TITLE
[MU3] Fix #314246: Some dialogs (under MacOS) have the Cancel and OK buttons reversed, right to left.

### DIFF
--- a/avsomr/ret.cpp
+++ b/avsomr/ret.cpp
@@ -108,7 +108,7 @@ QString Ret::text(Code c)
       {
       switch (c) {
             case Undefined:         return "Undefined error";
-            case Ok:                return QObject::tr("Ok");
+            case Ok:                return QObject::tr("OK");
                   // common
             case UnknownError:      return QObject::tr("Unknown error");
             case FailedReadFile:    return QObject::tr("Failed reading file");

--- a/mscore/insertmeasuresdialog.ui
+++ b/mscore/insertmeasuresdialog.ui
@@ -102,16 +102,9 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="okButton">
-       <property name="text">
-        <string>OK</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="cancelButton">
-       <property name="text">
-        <string>Cancel</string>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
        </property>
       </widget>
      </item>
@@ -120,38 +113,5 @@
   </layout>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>okButton</sender>
-   <signal>clicked()</signal>
-   <receiver>InsertMeasuresDialogBase</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>278</x>
-     <y>253</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>96</x>
-     <y>254</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>cancelButton</sender>
-   <signal>clicked()</signal>
-   <receiver>InsertMeasuresDialogBase</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>369</x>
-     <y>253</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>179</x>
-     <y>282</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -51,7 +51,7 @@ InstrumentsDialog::InstrumentsDialog(QWidget* parent)
       setupUi(this);
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
       QAction* a = getAction("instruments");
-      connect(a, SIGNAL(triggered()), SLOT(reject()));
+      connect(buttonBox, SIGNAL(clicked(QAbstractButton*)), SLOT(buttonBoxClicked(QAbstractButton*)));
       addAction(a);
       saveButton->setVisible(false);
       loadButton->setVisible(false);
@@ -65,6 +65,23 @@ InstrumentsDialog::InstrumentsDialog(QWidget* parent)
 void InstrumentsDialog::init()
       {
       instrumentsWidget->init();
+      }
+
+//---------------------------------------------------------
+//   buttonBoxClicked
+//---------------------------------------------------------
+
+void InstrumentsDialog::buttonBoxClicked(QAbstractButton* button)
+      {
+      switch (buttonBox->buttonRole(button)) {
+            case QDialogButtonBox::AcceptRole:
+                  accept();
+                  // fall through
+            case QDialogButtonBox::RejectRole:
+                  close();
+            default:
+                  break;
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/instrdialog.h
+++ b/mscore/instrdialog.h
@@ -27,9 +27,10 @@ class InstrumentsDialog : public QDialog, public Ui::InstrumentsDialog {
       Q_OBJECT
 
       void readSettings();
+      virtual void accept();
 
    private slots:
-      virtual void accept();
+      void buttonBoxClicked(QAbstractButton*);
       void on_saveButton_clicked();
       void on_loadButton_clicked();
 

--- a/mscore/instrdialog.ui
+++ b/mscore/instrdialog.ui
@@ -69,22 +69,9 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="okButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>OK</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="cancelButton">
-       <property name="text">
-        <string>Cancel</string>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
        </property>
       </widget>
      </item>
@@ -103,42 +90,7 @@
  <tabstops>
   <tabstop>loadButton</tabstop>
   <tabstop>saveButton</tabstop>
-  <tabstop>okButton</tabstop>
-  <tabstop>cancelButton</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>okButton</sender>
-   <signal>clicked()</signal>
-   <receiver>InstrumentsDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>278</x>
-     <y>253</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>96</x>
-     <y>254</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>cancelButton</sender>
-   <signal>clicked()</signal>
-   <receiver>InstrumentsDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>369</x>
-     <y>253</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>179</x>
-     <y>282</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/mscore/measuresdialog.ui
+++ b/mscore/measuresdialog.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ui version="4.0" >
+<ui version="4.0">
  <class>MeasuresDialogBase</class>
  <widget class="QDialog" name="MeasuresDialogBase">
   <property name="geometry">
@@ -102,16 +102,9 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="okButton">
-       <property name="text">
-        <string>OK</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="cancelButton">
-       <property name="text" >
-        <string>Cancel</string>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
        </property>
       </widget>
      </item>
@@ -120,38 +113,5 @@
   </layout>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>okButton</sender>
-   <signal>clicked()</signal>
-   <receiver>MeasuresDialogBase</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>278</x>
-     <y>253</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>96</x>
-     <y>254</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>cancelButton</sender>
-   <signal>clicked()</signal>
-   <receiver>MeasuresDialogBase</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>369</x>
-     <y>253</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>179</x>
-     <y>282</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/mscore/metaedit.cpp
+++ b/mscore/metaedit.cpp
@@ -71,7 +71,8 @@ MetaEditDialog::MetaEditDialog(Score* score, QWidget* parent)
       scrollAreaLayout->setColumnStretch(1, 1); // The 'value' column should be expanding
 
       connect(newButton,  &QPushButton::clicked, this, &MetaEditDialog::newClicked);
-      connect(saveButton, &QPushButton::clicked, this, &MetaEditDialog::save);
+      connect(buttonBox, SIGNAL(clicked(QAbstractButton*)), SLOT(buttonBoxClicked(QAbstractButton*)));
+      buttonBox->button(QDialogButtonBox::Save)->setEnabled(m_dirty);
       if (!QFileInfo::exists(score->importedFilePath()))
             revealButton->setEnabled(false);
 
@@ -177,7 +178,7 @@ void MetaEditDialog::setDirty(const bool dirty)
       if (dirty == m_dirty)
             return;
 
-      saveButton->setEnabled(dirty);
+      buttonBox->button(QDialogButtonBox::Save)->setEnabled(dirty);
       setWindowTitle(tr("Score properties: %1%2").arg(m_score->title()).arg((dirty ? "*" : "")));
 
       m_dirty = dirty;
@@ -193,6 +194,26 @@ void MetaEditDialog::openFileLocation()
       if (!OpenFileLocation::openFileLocation(filePath->text()))
             QMessageBox::warning(this, tr("Open Containing Folder Error"),
                                        tr("Could not open containing folder"));
+      }
+
+//---------------------------------------------------------
+//   buttonBoxClicked
+//---------------------------------------------------------
+
+void MetaEditDialog::buttonBoxClicked(QAbstractButton* button)
+      {
+      switch (buttonBox->buttonRole(button)) {
+            case QDialogButtonBox::ApplyRole:
+                  save();
+                  break;
+            case QDialogButtonBox::AcceptRole:
+                  accept();
+                  // fall through
+            case QDialogButtonBox::RejectRole:
+                  close();
+            default:
+                  break;
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/metaedit.h
+++ b/mscore/metaedit.h
@@ -51,10 +51,13 @@ class MetaEditDialog : public QDialog, public Ui::MetaEditDialog {
       void newClicked();
       void setDirty(const bool dirty = true);
       void openFileLocation();
+      virtual void accept();
+
+   private slots:
+      void buttonBoxClicked(QAbstractButton*);
 
    public:
       MetaEditDialog(Score* score, QWidget* parent = nullptr);
-      virtual void accept();
       };
 
 

--- a/mscore/metaedit.ui
+++ b/mscore/metaedit.ui
@@ -186,8 +186,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>660</width>
-        <height>295</height>
+        <width>662</width>
+        <height>299</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="scrollAreaLayout">
@@ -233,32 +233,9 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="okButton">
-       <property name="text">
-        <string>Ok</string>
-       </property>
-       <property name="default">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="cancelButton">
-       <property name="text">
-        <string>Cancel</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="saveButton">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="cursor">
-        <cursorShape>PointingHandCursor</cursorShape>
-       </property>
-       <property name="text">
-        <string>Save</string>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::Save</set>
        </property>
       </widget>
      </item>
@@ -268,43 +245,7 @@
  </widget>
  <tabstops>
   <tabstop>newButton</tabstop>
-  <tabstop>saveButton</tabstop>
-  <tabstop>okButton</tabstop>
-  <tabstop>cancelButton</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>okButton</sender>
-   <signal>clicked()</signal>
-   <receiver>MetaEditDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>499</x>
-     <y>395</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>435</x>
-     <y>389</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>cancelButton</sender>
-   <signal>clicked()</signal>
-   <receiver>MetaEditDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>585</x>
-     <y>395</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>546</x>
-     <y>405</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/mscore/musescoredialogs.cpp
+++ b/mscore/musescoredialogs.cpp
@@ -37,6 +37,24 @@ InsertMeasuresDialog::InsertMeasuresDialog(QWidget* parent)
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
       setModal(true);
       insmeasures->selectAll();
+      connect(buttonBox, SIGNAL(clicked(QAbstractButton*)), SLOT(buttonBoxClicked(QAbstractButton*)));
+      }
+
+//---------------------------------------------------------
+//   buttonBoxClicked
+//---------------------------------------------------------
+
+void InsertMeasuresDialog::buttonBoxClicked(QAbstractButton* button)
+      {
+      switch (buttonBox->buttonRole(button)) {
+            case QDialogButtonBox::AcceptRole:
+                  accept();
+                  // fall through
+            case QDialogButtonBox::RejectRole:
+                  close();
+            default:
+                  break;
+            }
       }
 
 //---------------------------------------------------------
@@ -72,6 +90,24 @@ MeasuresDialog::MeasuresDialog(QWidget* parent)
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
       setModal(true);
       measures->selectAll();
+      connect(buttonBox, SIGNAL(clicked(QAbstractButton*)), SLOT(buttonBoxClicked(QAbstractButton*)));
+      }
+
+//---------------------------------------------------------
+//   buttonBoxClicked
+//---------------------------------------------------------
+
+void MeasuresDialog::buttonBoxClicked(QAbstractButton* button)
+      {
+      switch (buttonBox->buttonRole(button)) {
+            case QDialogButtonBox::AcceptRole:
+                  accept();
+                  // fall through
+            case QDialogButtonBox::RejectRole:
+                  close();
+            default:
+                  break;
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/musescoredialogs.h
+++ b/mscore/musescoredialogs.h
@@ -61,9 +61,10 @@ class InsertMeasuresDialog : public QDialog, public Ui::InsertMeasuresDialogBase
       Q_OBJECT
 
       void hideEvent(QHideEvent*) override;
+      void accept() override;
 
    private slots:
-      void accept() override;
+      void buttonBoxClicked(QAbstractButton*);
 
    public:
       InsertMeasuresDialog(QWidget* parent = 0);
@@ -76,8 +77,10 @@ class InsertMeasuresDialog : public QDialog, public Ui::InsertMeasuresDialogBase
 class MeasuresDialog : public QDialog, public Ui::MeasuresDialogBase {
       Q_OBJECT
 
-   private slots:
       void accept() override;
+
+   private slots:
+      void buttonBoxClicked(QAbstractButton*);
 
    public:
       MeasuresDialog(QWidget* parent = 0);

--- a/mscore/pagesettings.cpp
+++ b/mscore/pagesettings.cpp
@@ -56,9 +56,8 @@ PageSettings::PageSettings(QWidget* parent)
 
       connect(mmButton,             SIGNAL(clicked()),            SLOT(mmClicked()));
       connect(inchButton,           SIGNAL(clicked()),            SLOT(inchClicked()));
-      connect(buttonApply,          SIGNAL(clicked()),            SLOT(apply()));
+      connect(buttonBox,            SIGNAL(clicked(QAbstractButton*)), SLOT(buttonBoxClicked(QAbstractButton*)));
       connect(buttonApplyToAllParts,SIGNAL(clicked()),            SLOT(applyToAllParts()));
-      connect(buttonOk,             SIGNAL(clicked()),            SLOT(ok()));
       connect(portraitButton,       SIGNAL(clicked()),            SLOT(orientationClicked()));
       connect(landscapeButton,      SIGNAL(clicked()),            SLOT(orientationClicked()));
       connect(twosided,             SIGNAL(toggled(bool)),        SLOT(twosidedToggled(bool)));
@@ -278,6 +277,26 @@ void PageSettings::twosidedToggled(bool flag)
       }
 
 //---------------------------------------------------------
+//   buttonBoxClicked
+//---------------------------------------------------------
+
+void PageSettings::buttonBoxClicked(QAbstractButton* button)
+      {
+      switch (buttonBox->buttonRole(button)) {
+            case QDialogButtonBox::ApplyRole:
+                  PageSettings::apply();
+                  break;
+            case QDialogButtonBox::AcceptRole:
+                  PageSettings::apply();
+                  // fall through
+            case QDialogButtonBox::RejectRole:
+                  close();
+            default:
+                  break;
+            }
+      }
+
+//---------------------------------------------------------
 //   apply
 //---------------------------------------------------------
 
@@ -330,25 +349,6 @@ void PageSettings::applyToAllParts()
       _changeFlag = false;
       }
 
-//---------------------------------------------------------
-//   ok
-//---------------------------------------------------------
-
-void PageSettings::ok()
-      {
-      apply();
-      done(0);
-      }
-
-//---------------------------------------------------------
-//   done
-//---------------------------------------------------------
-
-void PageSettings::done(int val)
-      {
-      cs->setLayoutAll();     // HACK
-      QDialog::done(val);
-      }
 
 //---------------------------------------------------------
 //   pageFormatSelected

--- a/mscore/pagesettings.h
+++ b/mscore/pagesettings.h
@@ -43,16 +43,15 @@ class PageSettings : public AbstractDialog, private Ui::PageSettingsBase {
       void blockSignals(bool);
       void applyToScore(Score*);
       void setMarginsMax(double);
+      void apply();
 
    private slots:
       void mmClicked();
       void inchClicked();
       void pageFormatSelected(int);
 
-      void apply();
       void applyToAllParts();
-      void ok();
-      void done(int val);
+      void buttonBoxClicked(QAbstractButton*);
 
       void twosidedToggled(bool);
       void otmChanged(double val);

--- a/mscore/pagesettings.ui
+++ b/mscore/pagesettings.ui
@@ -268,26 +268,9 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="buttonApply">
-       <property name="text">
-        <string>Apply</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="buttonOk">
-       <property name="text">
-        <string>OK</string>
-       </property>
-       <property name="default">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="buttonCancel">
-       <property name="text">
-        <string>Cancel</string>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
        </property>
       </widget>
      </item>
@@ -512,43 +495,7 @@
   <tabstop>evenPageBottomMargin</tabstop>
   <tabstop>pageOffsetEntry</tabstop>
   <tabstop>buttonApplyToAllParts</tabstop>
-  <tabstop>buttonApply</tabstop>
-  <tabstop>buttonOk</tabstop>
-  <tabstop>buttonCancel</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonOk</sender>
-   <signal>clicked()</signal>
-   <receiver>PageSettingsBase</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>278</x>
-     <y>253</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>96</x>
-     <y>254</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonCancel</sender>
-   <signal>clicked()</signal>
-   <receiver>PageSettingsBase</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>369</x>
-     <y>253</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>179</x>
-     <y>282</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>


### PR DESCRIPTION
Resolves (so far only partly): https://musescore.org/en/node/314246

* Fix the Format > Page settings dialog
* Add > Measures > Insert measure dialog
* Add > Measures > Append measures dialog
* Edit > Instruments dialog
* File > Score properties
* Change "Ok" to "OK" for the currently disabled AVSOMR / Import PDF dialog.

Not sure yet which parts might be needed for master too