### PR TITLE
[MU4] Added shared libs build on MinGW for debug mode

### DIFF
--- a/build/cmake/SetupBuildEnvironment.cmake
+++ b/build/cmake/SetupBuildEnvironment.cmake
@@ -43,7 +43,7 @@ elseif(CC_IS_MINGW)
     set(CMAKE_CXX_FLAGS_RELEASE "-O2")
 
     if (BUILD_IS_DEBUG)
-        #set(BUILD_SHARED_LIBS ON)
+        set(BUILD_SHARED_LIBS ON)
     endif(BUILD_IS_DEBUG)
 
     # -mno-ms-bitfields see #22048

--- a/src/cloud/internal/cloudmanager.cpp
+++ b/src/cloud/internal/cloudmanager.cpp
@@ -41,6 +41,14 @@ const QUrl ApiInfo::REGISTER_URL(ApiInfo::REGISTER_PAGE);
 const QUrl ApiInfo::LOGIN_URL(ApiInfo::LOGIN_PAGE);
 const QUrl ApiInfo::LOGIN_SUCCESS_URL(ApiInfo::LOGIN_SUCCESS_PAGE);
 
+const ApiInfo& ApiInfo::instance()
+{
+    if (!_instance) {
+        createInstance();
+    }
+    return *_instance;
+}
+
 //---------------------------------------------------------
 //   ApiInfo:apiInfoLocation
 //---------------------------------------------------------

--- a/src/cloud/internal/cloudmanager_p.h
+++ b/src/cloud/internal/cloudmanager_p.h
@@ -60,13 +60,7 @@ class ApiInfo
     static constexpr const char* DEFAULT_UPDATE_SCORE_INFO_PATH = "/score/manage/upload/update";
 
 public:
-    static const ApiInfo& instance()
-    {
-        if (!_instance) {
-            createInstance();
-        }
-        return *_instance;
-    }
+    static const ApiInfo& instance();
 
     static constexpr const char* API_HOST = "https://api.musescore.com/";
     static constexpr const char* API_ROOT = "/v2";

--- a/src/framework/global/modularity/modularity.cmake
+++ b/src/framework/global/modularity/modularity.cmake
@@ -1,6 +1,7 @@
 
 set (MODULARITY_SRC
     ${CMAKE_CURRENT_LIST_DIR}/imodulesetup.h
+    ${CMAKE_CURRENT_LIST_DIR}/modulesioc.cpp
     ${CMAKE_CURRENT_LIST_DIR}/modulesioc.h
     ${CMAKE_CURRENT_LIST_DIR}/imoduleexport.h
     ${CMAKE_CURRENT_LIST_DIR}/ioc.h

--- a/src/framework/global/modularity/modulesioc.cpp
+++ b/src/framework/global/modularity/modulesioc.cpp
@@ -2,7 +2,7 @@
 //  MuseScore
 //  Music Composition & Notation
 //
-//  Copyright (C) 2019 MuseScore BVBA and others
+//  Copyright (C) 2020 MuseScore BVBA and others
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2.
@@ -17,31 +17,12 @@
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
 
-#ifndef MODULESSETUP_H
-#define MODULESSETUP_H
+#include "modulesioc.h"
 
-#include <QList>
+using namespace mu::framework;
 
-#include "framework/global/modularity/imodulesetup.h"
-
-//---------------------------------------------------------
-//   ModulesSetup
-//---------------------------------------------------------
-
-class ModulesSetup
+ModulesIoC* ModulesIoC::instance()
 {
-public:
-    static ModulesSetup* instance();
-
-    void setup();
-    void deinit();
-
-private:
-    Q_DISABLE_COPY(ModulesSetup)
-
-    ModulesSetup();
-
-    QList<mu::framework::IModuleSetup*> m_modulesSetupList;
-};
-
-#endif // MODULESSETUP_H
+    static ModulesIoC p;
+    return &p;
+}

--- a/src/framework/global/modularity/modulesioc.h
+++ b/src/framework/global/modularity/modulesioc.h
@@ -33,11 +33,7 @@ class ModulesIoC
 {
 public:
 
-    static ModulesIoC* instance()
-    {
-        static ModulesIoC p;
-        return &p;
-    }
+    static ModulesIoC* instance();
 
     template<class I>
     void registerExportCreator(const std::string& module, IModuleExportCreator* c)

--- a/src/framework/global/settings.cpp
+++ b/src/framework/global/settings.cpp
@@ -27,6 +27,12 @@ using namespace mu;
 using namespace mu::framework;
 using namespace mu::async;
 
+Settings* Settings::instance()
+{
+    static Settings s;
+    return &s;
+}
+
 Settings::Settings()
 {
 #if defined(WIN_PORTABLE)

--- a/src/framework/global/settings.h
+++ b/src/framework/global/settings.h
@@ -36,11 +36,7 @@ namespace mu::framework {
 class Settings
 {
 public:
-    static Settings* instance()
-    {
-        static Settings s;
-        return &s;
-    }
+    static Settings* instance();
 
     struct Key
     {

--- a/src/framework/telemetry/internal/actioneventobserver.cpp
+++ b/src/framework/telemetry/internal/actioneventobserver.cpp
@@ -26,6 +26,12 @@
 
 using namespace mu::telemetry;
 
+ActionEventObserver* ActionEventObserver::instance()
+{
+    static ActionEventObserver s;
+    return &s;
+}
+
 ActionEventObserver::ActionEventObserver(QObject* parent)
     : QObject(parent)
 {

--- a/src/framework/telemetry/internal/actioneventobserver.h
+++ b/src/framework/telemetry/internal/actioneventobserver.h
@@ -35,11 +35,7 @@ class ActionEventObserver : public QObject
     INJECT(telemetry, ITelemetryService, telemetryService)
 
 public:
-    static ActionEventObserver* instance()
-    {
-        static ActionEventObserver s;
-        return &s;
-    }
+    static ActionEventObserver* instance();
 
     bool eventFilter(QObject* watched, QEvent* event) override;
 

--- a/src/libmscore/preferences.cpp
+++ b/src/libmscore/preferences.cpp
@@ -20,6 +20,12 @@
 
 using namespace Ms;
 
+ScorePreferences& ScorePreferences::instance()
+{
+    static ScorePreferences p;
+    return p;
+}
+
 QString ScorePreferences::backupDirPath() const
 {
     return m_backupDirPath;

--- a/src/libmscore/preferences.h
+++ b/src/libmscore/preferences.h
@@ -26,11 +26,7 @@ class ScorePreferences
 {
 public:
 
-    static ScorePreferences& instance()
-    {
-        static ScorePreferences p;
-        return p;
-    }
+    static ScorePreferences& instance();
 
     QString backupDirPath() const;
     void setBackupDirPath(const QString& path);

--- a/src/main/modulessetup.cpp
+++ b/src/main/modulessetup.cpp
@@ -61,6 +61,12 @@
 //! NOTE Separately to initialize logger and profiler as early as possible
 static mu::framework::GlobalModule globalModule;
 
+ModulesSetup* ModulesSetup::instance()
+{
+    static ModulesSetup s;
+    return &s;
+}
+
 ModulesSetup::ModulesSetup()
 {
     //! NOTE `telemetry` must be first, because it install crash handler.

--- a/thirdparty/deto_async/async/internal/queuedinvoker.cpp
+++ b/thirdparty/deto_async/async/internal/queuedinvoker.cpp
@@ -2,6 +2,12 @@
 
 using namespace deto::async;
 
+QueuedInvoker* QueuedInvoker::instance()
+{
+    static QueuedInvoker i;
+    return &i;
+}
+
 void QueuedInvoker::invoke(const std::thread::id& th, const Functor& f)
 {
     if (m_onMainThreadInvoke) {

--- a/thirdparty/deto_async/async/internal/queuedinvoker.h
+++ b/thirdparty/deto_async/async/internal/queuedinvoker.h
@@ -13,11 +13,7 @@ class QueuedInvoker
 {
 public:
 
-    static QueuedInvoker* instance()
-    {
-        static QueuedInvoker i;
-        return &i;
-    }
+    static QueuedInvoker* instance();
 
     using Functor = std::function<void ()>;
 

--- a/thirdparty/haw_logger/logger/logger.cpp
+++ b/thirdparty/haw_logger/logger/logger.cpp
@@ -271,6 +271,13 @@ LogLayout LogDest::layout() const
 }
 
 // Logger ---------------------------------
+
+Logger* Logger::instance()
+{
+    static Logger l;
+    return &l;
+}
+
 Logger::Logger()
 {
     setupDefault();

--- a/thirdparty/haw_logger/logger/logger.h
+++ b/thirdparty/haw_logger/logger/logger.h
@@ -132,11 +132,7 @@ class Logger
 {
 public:
 
-    static Logger* instance()
-    {
-        static Logger l;
-        return &l;
-    }
+    static Logger* instance();
 
     static const Type ERROR;
     static const Type WARN;

--- a/thirdparty/haw_profiler/src/profiler.cpp
+++ b/thirdparty/haw_profiler/src/profiler.cpp
@@ -13,6 +13,12 @@ Profiler::Options Profiler::m_options;
 
 constexpr int MAIN_THREAD_INDEX(0);
 
+Profiler* Profiler::instance()
+{
+    static Profiler p;
+    return &p;
+}
+
 Profiler::Profiler()
 {
     setup(Options(), new Printer());

--- a/thirdparty/haw_profiler/src/profiler.h
+++ b/thirdparty/haw_profiler/src/profiler.h
@@ -71,11 +71,7 @@ class Profiler
 {
 public:
 
-    static Profiler* instance()
-    {
-        static Profiler p;
-        return &p;
-    }
+    static Profiler* instance();
 
     struct Options {
         bool stepTimeEnabled{ true };


### PR DESCRIPTION
Problem - you change a little code and long waiting for the run app, because of a long time for linking.
MinGW has extremely long linking times.

To speed up linking and, accordingly, to speed up development cycles "change - run - check", 
you can make modules (libraries) shared.
In this case, only those libraries that depend on the changed code will be linking.
So, if you change the code in one module (and this is not `global` on which everything depends), 
then only this module will be linked, and not the entire application.
(If you changed the code in one module, and several are linking, then there is a dependency problem that should be fixed.)

P.S. I strongly recommend using MSVC instead of MinGW.
Despite the fact that shared libraries have not yet been made for MSVC, but even without this, compiles and linking much faster.
Now in the master, it is very easy to set up how MSVC works in QtCreator.


