### PR TITLE
[MU3] Spacer issue

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1595,7 +1595,6 @@ static void distributeStaves(Page* page)
                   int endCurlyBracket  { -1   };
                   int staffNr { -1 };
                   for (SysStaff* sysStaff : *system->staves()) {
-                        sysStaff->restoreLayout();
                         Staff* staff { score->staff(++staffNr)};
                         addSpaceAroundNormalBracket |= endNormalBracket == staffNr;
                         addSpaceAroundCurlyBracket  |= endCurlyBracket == staffNr;
@@ -1662,10 +1661,8 @@ static void distributeStaves(Page* page)
             if (almostZero(smallest) || almostZero(nextSmallest))
                   break;
 
-            if ((nextSmallest - smallest) * vgdl.sumStretchFactor() > spaceLeft) {
+            if ((nextSmallest - smallest) * vgdl.sumStretchFactor() > spaceLeft)
                   nextSmallest = smallest + spaceLeft/vgdl.sumStretchFactor();
-                  std::cout << "           nextSmallest = " << nextSmallest << std::endl;
-                  }
 
             qreal addedSpace { 0.0 };
             VerticalGapDataList modified;
@@ -4680,6 +4677,7 @@ void LayoutContext::collectPage()
 
             y += distance;
             curSystem->setPos(page->lm(), y);
+            curSystem->restoreLayout2();
             page->appendSystem(curSystem);
             y += curSystem->height();
 

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -863,6 +863,9 @@ void System::layout2()
 
 void System::restoreLayout2()
       {
+      if (vbox())
+            return;
+
       for (SysStaff* s : _staves)
             s->restoreLayout();
 


### PR DESCRIPTION
Restore original system layout data earlier so <code>collectPage()</code> is using the correct information.
This solves a very strange and sometimes unpredictable behavior of spacers in combination with vertical staves adjustment.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
