### PR TITLE
fix systems jumping down page on every edit

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1588,6 +1588,8 @@ static void distributeStaves(Page* page)
                   transferCurlyBracket  = false;
                   }
             else {
+                  // reset staff and system heights
+                  system->restoreLayout2();
                   bool newSystem       { true };
                   bool addSpaceAroundNormalBracket { false };
                   bool addSpaceAroundCurlyBracket  { false };

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1588,8 +1588,6 @@ static void distributeStaves(Page* page)
                   transferCurlyBracket  = false;
                   }
             else {
-                  // reset staff and system heights
-                  system->restoreLayout2();
                   bool newSystem       { true };
                   bool addSpaceAroundNormalBracket { false };
                   bool addSpaceAroundCurlyBracket  { false };
@@ -4629,20 +4627,28 @@ void LayoutContext::collectPage()
       System* nextSystem = 0;
       int systemIdx = -1;
 
-      qreal y = page->systems().isEmpty() ? page->tm() : page->system(0)->y() + page->system(0)->height();
       // re-calculate positions for systems before current
       // (they may have been filled on previous layout)
       int pSystems = page->systems().size();
+      if (pSystems > 0)
+            page->system(0)->restoreLayout2();
+      qreal y = page->systems().isEmpty() ? page->tm() : page->system(0)->y() + page->system(0)->height();
       for (int i = 1; i < pSystems; ++i) {
             System* cs = page->system(i);
             System* ps = page->system(i - 1);
             qreal distance = ps->minDistance(cs);
             y += distance;
             cs->setPos(page->lm(), y);
+            cs->restoreLayout2();
             y += cs->height();
             }
 
       for (int k = 0;;++k) {
+
+            // we know we want this system;
+            // but it may have staff spread leftover from a previous layout
+            curSystem->restoreLayout2();
+
             //
             // calculate distance to previous system
             //

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -863,6 +863,8 @@ void System::layout2()
 
 void System::restoreLayout2()
       {
+      if (vbox())
+            return;
       for (SysStaff* s : _staves)
             s->restoreLayout();
 


### PR DESCRIPTION
A recent change improved much about the staff spreading algorithm,
and one important part of that was supposed to be
saving and restoring the default system height.
However, it seems somehow the restore never happened -
a new function restoreLayout2() is provided but never called.
The result is that in each edit, other systems on the page
would get taller, adding more and more space with each edit,
eventually pushing all other systems off the page entirely.

Comments in chat indicate the restoring of default system height
was meant to happen just before distributing staves,
so I have added a call to restoreLayout2()
at the top of the existing loop through systems
at the beginning of distributeStaves().

I do still see some layout shifts where system distance varies
as you enter notes into the last measure of a system
(and then back again as you enter notes into a measure
other than the first of the next system).
Somehow the algorithm computing the system spread
seems to sometimes get a wrong idea about how far to fill the page.
But this issue was probably there before my change here,
just masked because the ever-increasing system heights
were masking this.

The problem I am fixing here is the more important one for now,
as it was pushing systems right off the page,
so you'd end up with only one per page when three or four would fit.

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://musescore.org/en/cla)
- [ ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [ ] I made sure the code compiles on my machine
- [ ] I made sure there are no unnecessary changes in the code
- [ ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
