### PR TITLE
[MU3] Enable Ctrl+Shift+# to add a sharp for some non-US keyboards

### DIFF
--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -420,7 +420,9 @@ bool TextBase::edit(EditData& ed)
                         case Qt::Key_B:
                               s = "\u266d"; // Unicode flat
                               break;
-                        case Qt::Key_NumberSign:
+                        case Qt::Key_NumberSign: // e.g. QWERTY (US)
+                        case Qt::Key_AsciiTilde: // e.g. QWERTY (GB)
+                        case Qt::Key_Apostrophe: // e.g. QWERTZ (DE)
                               s = "\u266f"; // Unicode sharp
                               break;
                         case Qt::Key_H:


### PR DESCRIPTION
This should enable the Ctrl+Shift+# shortcut to enter a sharp symbol into text on some non-US keyboards like the British QWERTY (as thankfully tested and confirmed to work by @oktophonie) and German QWERTZ (verified by myself :-)).