### PR TITLE
[MU3] Enable Ctrl+Shift+# to add a sharp for some more non-US keyboards

### DIFF
--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -423,6 +423,8 @@ bool TextBase::edit(EditData& ed)
                         case Qt::Key_NumberSign: // e.g. QWERTY (US)
                         case Qt::Key_AsciiTilde: // e.g. QWERTY (GB)
                         case Qt::Key_Apostrophe: // e.g. QWERTZ (DE)
+                        case Qt::Key_periodcentered: // e.g. QWERTY (ES)
+                        case Qt::Key_3: // e.g. AZERTY (FR, BE)
                               s = "\u266f"; // Unicode sharp
                               break;
                         case Qt::Key_H:


### PR DESCRIPTION
like Spanish QWERTZ, Belgian and French AZERTY. Follow up for #7093 

Resolves: https://musescore.org/en/node/314375 (forum topic)

Ctrl+Shift+3 (for AZERTY) is also the shortcut for switching to voice 3, but there should not be a collision, as this one here is only used in text edit mode, while the other is not. @jeetee , please test ;-)
@Asmatzaile please test your Spanish QWERTZY too...

