### PR TITLE
[MU4] Enable Ctrl+Shift+# to add a sharp for some non-US keyboards, add Synalepha shortcut

### DIFF
--- a/src/libmscore/textedit.cpp
+++ b/src/libmscore/textedit.cpp
@@ -448,7 +448,11 @@ bool TextBase::edit(EditData& ed)
             case Qt::Key_B:
                 s = "\u266d";               // Unicode flat
                 break;
-            case Qt::Key_NumberSign:
+            case Qt::Key_NumberSign: // e.g. QWERTY (US)
+            case Qt::Key_AsciiTilde: // e.g. QWERTY (GB)
+            case Qt::Key_Apostrophe: // e.g. QWERTZ (DE)
+            case Qt::Key_periodcentered: // e.g. QWERTY (ES)
+            case Qt::Key_3: // e.g. AZERTY (FR, BE)
                 s = "\u266f";               // Unicode sharp
                 break;
             case Qt::Key_H:

--- a/src/libmscore/textedit.cpp
+++ b/src/libmscore/textedit.cpp
@@ -244,6 +244,7 @@ bool TextBase::edit(EditData& ed)
     QString s         = ed.s;
     bool ctrlPressed  = ed.modifiers & Qt::ControlModifier;
     bool shiftPressed = ed.modifiers & Qt::ShiftModifier;
+    bool altPressed = ed.modifiers & Qt::AltModifier;
 
     QTextCursor::MoveMode mm = shiftPressed ? QTextCursor::KeepAnchor : QTextCursor::MoveAnchor;
 
@@ -485,6 +486,12 @@ bool TextBase::edit(EditData& ed)
                 // so Shift+Ctrl+Z works
                 insertSym(ed, SymId::dynamicZ);
                 return true;
+            }
+            if (ctrlPressed && altPressed) {
+                if (ed.key == Qt::Key_Minus) {
+                    insertSym(ed, SymId::lyricsElision);
+                    return true;
+                }
             }
         }
     }


### PR DESCRIPTION
* Enable Ctrl+Shift+# to add a sharp for some non-US keyboards like German QWERTY, British and Spanish QWERTZ, Belgian and French AZERTY
* Fix #313195: Add Synalepha shortcut (so far only in 'normal text edit mode, but not for Lyrics, watch this space...)

Resolves: https://musescore.org/en/node/314375 (forum topic) and https://musescore.org/en/node/313195

This is for master what #6928, #7093. #7099, #7105 are for 3.x