### PR TITLE
[MU3] Fix #313195: enable the synalepha shortcut in lyrics edit mode

### DIFF
--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -458,7 +458,7 @@ bool TextBase::edit(EditData& ed)
                         }
                   }
             if (ctrlPressed && altPressed) {
-                  if (ed.key == Qt::Key_hyphen) {
+                  if (ed.key == Qt::Key_Minus) {
                         insertSym(ed, SymId::lyricsElision);
                         return true;
                         }

--- a/mscore/editlyrics.cpp
+++ b/mscore/editlyrics.cpp
@@ -66,6 +66,10 @@ bool ScoreView::editKeyLyrics()
 
             case Qt::Key_Minus:
                   if (editData.control(textEditing)) {
+                        if ((editData.modifiers & Qt::AltModifier) && editData.element->edit(editData)) {
+                              _score->update();
+                              break;
+                              }
                         // change into normal minus
                         editData.modifiers &= ~CONTROL_MODIFIER;
                         return false;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/313195

Having PR #6928 been merged for 3.6 Beta, I tried using the introduced shortcut and it failed.
I think that this PR solves that problem, because the needed key wasn't `Qt::Key_hyphen` but `Qt::Key_Minus`.
~~Although I yet don't know how to use cmake properly and get errors when trying to compile, I'll test the artifacts when they are generated.~~
~~This will conflict with #7099, so maybe a rebase will be needed (would that be done with `git checkout <my-branch-name>` and `git rebase 3.x`?).~~
editlyrics.cpp was also changed because, as it was, pressing ctrl ignored the commands from textedit.cpp

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
