### PR TITLE
Palettes search refinements

### DIFF
--- a/mscore/qml/palettes/PalettesWidgetHeader.qml
+++ b/mscore/qml/palettes/PalettesWidgetHeader.qml
@@ -44,6 +44,15 @@ Item {
         searchTextField.selectAll()
     }
 
+    function stopPaletteSearch() {
+        searchTextField.clear()
+        searchTextFieldShown = false
+        if (paletteTree.currentTreeItem)
+            paletteTree.currentTreeItem.forceActiveFocus()
+        else
+            startSearchButton.forceActiveFocus()
+    }
+
     function showPaletteOptionsMenu() {
         paletteOptionsMenu.x = paletteOptionsButton.x + paletteOptionsButton.width - paletteOptionsMenu.width;
         paletteOptionsMenu.y = paletteOptionsButton.y;
@@ -105,6 +114,7 @@ Item {
             id: searchTextField
             visible: searchTextFieldShown
             Layout.fillWidth: true
+            rightPadding: stopSearchButton.width + 6
 
             placeholderText: qsTr("Search")
             font: globalStyle.font
@@ -134,6 +144,7 @@ Item {
 
             Keys.onDownPressed: paletteTree.focusFirstItem();
             Keys.onUpPressed: paletteTree.focusLastItem();
+            Keys.onEscapePressed: stopPaletteSearch();
 
             StyledToolButton {
                 id: stopSearchButton
@@ -145,11 +156,7 @@ Item {
                 }
                 width: height
                 flat: true
-                onClicked: {
-                    searchTextField.clear()
-                    searchTextFieldShown = false
-                    paletteTree.currentTreeItem.forceActiveFocus()
-                }
+                onClicked: stopPaletteSearch()
 
                 padding: 5
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/pull/6944#issuecomment-744561464

- Add padding to text field to avoid collision from search text with stop search button;
- Pressing the Escape key from the search field will now do the same as the stop search button.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
