### PR TITLE
[MU4] Fix (MSCV) compiler warnings related to UNITY build

### DIFF
--- a/src/appshell/dockwindow/dockwindow.cpp
+++ b/src/appshell/dockwindow/dockwindow.cpp
@@ -169,10 +169,10 @@ void DockWindow::hidePage(DockPage* page)
         widgetsToHide << sw.widget;
     }
 
-    static QWidget* dummy = new QWidget();
+    static QWidget* sDummy = new QWidget();
     for (QWidget* w : widgetsToHide) {
         w->hide();
-        w->setParent(dummy);
+        w->setParent(sDummy);
     }
 
     m_window->update();

--- a/src/importexport/internal/braille/exportbraille.cpp
+++ b/src/importexport/internal/braille/exportbraille.cpp
@@ -1569,8 +1569,8 @@ QString ExportBraille::brailleChord(Chord* chord)
     }
 
     QString articulationsBraille = QString();
-    for (Articulation* articulation : chord->articulations()) {
-        articulationsBraille += brailleArticulation(articulation);
+    for (Articulation* artic : chord->articulations()) {
+        articulationsBraille += brailleArticulation(artic);
     }
 
     std::vector<Slur*> chordSlurs = slurs(chord);
@@ -1978,9 +1978,9 @@ QString ExportBraille::brailleTremolo(Chord* chord)
     return QString();
 }
 
-QString ExportBraille::brailleArticulation(Articulation* articulation)
+QString ExportBraille::brailleArticulation(Articulation* artic)
 {
-    switch (articulation->symId()) {
+    switch (artic->symId()) {
     case SymId::articAccentAbove:
     case SymId::articAccentBelow:
         return BRAILLE_ARTIC_ACCENT;

--- a/thirdparty/haw_profiler/src/profiler.cpp
+++ b/thirdparty/haw_profiler/src/profiler.cpp
@@ -260,22 +260,22 @@ bool Profiler::save_file(const std::string& path, const std::string& content)
 
 std::string FuncMarker::formatSig(const std::string& sig)
 {
-    static const std::string Colon("::");
-    static const std::string Space(" ");
-    static const std::string ArgBegin("(");
+    static const std::string Coln("::");
+    static const std::string Spc(" ");
+    static const std::string ArgBeg("(");
 
-    std::size_t endFunc = sig.find_first_of(ArgBegin);
+    std::size_t endFunc = sig.find_first_of(ArgBeg);
     if (endFunc == std::string::npos) {
         return sig;
     }
 
-    std::size_t beginFunc = sig.find_last_of(Colon, endFunc);
+    std::size_t beginFunc = sig.find_last_of(Coln, endFunc);
     if (beginFunc == std::string::npos) {
         return sig;
     }
 
-    std::size_t beginClassColon = sig.find_last_of(Colon, beginFunc - 2);
-    std::size_t beginClassSpace = sig.find_last_of(Space, beginFunc - 2);
+    std::size_t beginClassColon = sig.find_last_of(Coln, beginFunc - 2);
+    std::size_t beginClassSpace = sig.find_last_of(Spc, beginFunc - 2);
 
     std::size_t beginClass = std::string::npos;
     if (beginClassColon == std::string::npos) {
@@ -414,7 +414,7 @@ static std::string formatDouble(double val, size_t prec)
 
 void Profiler::Printer::printStep(const std::string& tag, double beginMs, double stepMs, const std::string& info)
 {
-    static const std::string COLON(" : ");
+    static const std::string COLN(" : ");
     static const std::string SEP("/");
     static const std::string MS(" ms: ");
 
@@ -423,7 +423,7 @@ void Profiler::Printer::printStep(const std::string& tag, double beginMs, double
 
     str
     .append(tag)
-    .append(COLON)
+    .append(COLN)
     .append(formatDouble(beginMs, 3))
     .append(SEP)
     .append(formatDouble(stepMs, 3))


### PR DESCRIPTION
There's 1 more (being reported twice) reg. unreachable code at https://github.com/musescore/MuseScore/blob/bfd75feec3e4da1b8c01cc0fd0aa81350ed42710/src/plugins/api/scoreelement.h#L154
Not sure whether it is related to UNITY build, nor how to fix it