### PR TITLE
[MU3] Fix printing user errors in musescore.cpp

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2001,7 +2001,8 @@ MuseScore::MuseScore()
             const bool loadSuccess = _loginManager->load();
 
             if (cliSaveOnline && !loadSuccess) {
-                  qFatal(qUtf8Printable(tr("No login credentials stored. Please sign in via the GUI.")));
+                  fprintf(stderr, "%s\n", qPrintable(tr("No login credentials stored. Please sign in via the GUI.")));
+                  ::exit(EXIT_FAILURE);
                   }
             }
 
@@ -7768,7 +7769,8 @@ MuseScoreApplication::CommandLineParseResult MuseScoreApplication::parseCommandL
             MScore::noGui = true;
 
             if (parser.positionalArguments().isEmpty()) {
-                  qFatal("Must specify at least one score to save online.");
+                  fprintf(stderr, "%s\n", qPrintable(tr("Must specify at least one score to save online.")));
+                  ::exit(EXIT_FAILURE);
             }
       }
 
@@ -7822,8 +7824,10 @@ MuseScoreApplication::CommandLineParseResult MuseScoreApplication::parseCommandL
             diffMode = true;
             }
       if (parser.isSet("run-test-script")) {
-            if (rawDiffMode || diffMode)
-                  qFatal("incompatible options");
+            if (rawDiffMode || diffMode) {
+                  fprintf(stderr, "%s\n", qPrintable(tr("--run-test-script is incompatible with --diff and --raw-diff")));
+                  ::exit(EXIT_FAILURE);
+                  }
             MScore::noGui = true;
             scriptTestMode = true;
             }
@@ -7853,11 +7857,15 @@ MuseScoreApplication::CommandLineParseResult MuseScoreApplication::parseCommandL
                         }
             }
       if (rawDiffMode || diffMode) {
-            if (argv.size() != 2)
-                  qFatal("Only two scores are needed for performing a comparison");
+            if (argv.size() != 2) {
+                  fprintf(stderr, "%s\n", qPrintable(tr("Only two scores are needed for performing a comparison")));
+                  ::exit(EXIT_FAILURE);
+                  }
             }
-      if (scriptTestMode && argv.empty())
-            qFatal("Please specify scripts to execute");
+      if (scriptTestMode && argv.empty()) {
+            fprintf(stderr, "%s\n", qPrintable(tr("Please specify scripts to execute")));
+            ::exit(EXIT_FAILURE);
+            }
 
       parseResult.argv = argv;
       return parseResult;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/pull/6914#discussion_r546256995

v3.6_public_beta fails to build with Nixpkgs because by default it enables `-Wformat -Wformat-security -Werror=format-security`, which does not accept `qFatal(qUtf8Printable(tr("…")))`. This fixes it by replacing qFatal with fprintf. (See also commit description.)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
