### PR TITLE
[MU3] Do not build with Qt 5.15

### DIFF
--- a/build/FindQt5.cmake
+++ b/build/FindQt5.cmake
@@ -36,6 +36,10 @@ if (WIN32)
       )
 endif(WIN32)
 
+find_package(Qt5Core 5.15.0 QUIET)
+if (Qt5Core_FOUND)
+    message(FATAL_ERROR "MuseScore 3 does not support Qt 5.15 and later (Palettes panel shows no palettes)")
+endif()
 find_package(Qt5Core ${QT_MIN_VERSION} REQUIRED)
 
 foreach(_component ${_components})


### PR DESCRIPTION
This notifies downstream packagers that even though MuseScore compiles with 5.15, it does not show palettes. Here is a screenshot of the build of the current 3.x branch (with release config, in an empty $HOME):

![ms3-qt5 15](https://user-images.githubusercontent.com/101514/102699656-4e0fdc80-423e-11eb-9809-d79c741d1de5.png)

This has affected NixPkgs that have switched the default Qt to 5.15 without noticing this issue for a while. If it were known that MuseScore does not work with Qt 5.15, they would have pinned it to Qt 5.14 sooner.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
