### PR TITLE
Fix #314149: Order of buttons in ScoreMigrationDialog platform specific

### DIFF
--- a/mscore/qml.qrc
+++ b/mscore/qml.qrc
@@ -1,13 +1,24 @@
 <RCC>
     <qresource prefix="/">
+        <file>qml/migration/CheckBoxControl.qml</file>
+        <file>qml/migration/placeholder.png</file>
+        <file>qml/migration/ScoreMigrationDialog.qml</file>
+        <file>qml/migration/StyledDialogButtonBox.qml</file>
+        <file>qml/migration/Tick_Icon.png</file>
         <file>qml/palettes/MoreElementsPopup.qml</file>
-        <file>qml/palettes/PaletteBackground.qml</file>
         <file>qml/palettes/Palette.qml</file>
+        <file>qml/palettes/PaletteBackground.qml</file>
         <file>qml/palettes/PalettesListPopup.qml</file>
-        <file>qml/palettes/PalettesWidgetHeader.qml</file>
         <file>qml/palettes/PalettesWidget.qml</file>
+        <file>qml/palettes/PalettesWidgetHeader.qml</file>
         <file>qml/palettes/PaletteTree.qml</file>
         <file>qml/palettes/PlaceholderManager.qml</file>
+        <file>qml/palettes/icons/ArrowDown.svg</file>
+        <file>qml/palettes/icons/ArrowRight.svg</file>
+        <file>qml/palettes/icons/CloseButton.svg</file>
+        <file>qml/palettes/icons/MagnifyingGlass.svg</file>
+        <file>qml/palettes/icons/ThreeDotMenu.svg</file>
+        <file>qml/palettes/icons/TrashCan.svg</file>
         <file>qml/palettes/StyledButton.qml</file>
         <file>qml/palettes/StyledCheckBox.qml</file>
         <file>qml/palettes/StyledIcon.qml</file>
@@ -15,15 +26,5 @@
         <file>qml/palettes/StyledToolButton.qml</file>
         <file>qml/palettes/TreePaletteHeader.qml</file>
         <file>qml/palettes/utils.js</file>
-        <file>qml/palettes/icons/ArrowDown.svg</file>
-        <file>qml/palettes/icons/ArrowRight.svg</file>
-        <file>qml/migration/ScoreMigrationDialog.qml</file>
-        <file>qml/migration/CheckBoxControl.qml</file>
-        <file>qml/migration/Tick_Icon.png</file>
-        <file>qml/migration/placeholder.png</file>
-        <file>qml/palettes/icons/CloseButton.svg</file>
-        <file>qml/palettes/icons/MagnifyingGlass.svg</file>
-        <file>qml/palettes/icons/ThreeDotMenu.svg</file>
-        <file>qml/palettes/icons/TrashCan.svg</file>
     </qresource>
 </RCC>

--- a/mscore/qml/migration/ScoreMigrationDialog.qml
+++ b/mscore/qml/migration/ScoreMigrationDialog.qml
@@ -157,44 +157,23 @@ FocusScope {
             }
         }
 
-        RowLayout {
-            Layout.maximumWidth: parent.width / 2
+        StyledDialogButtonBox {
+            Layout.preferredWidth: parent.width / 2
             Layout.alignment: Qt.AlignRight
-            Layout.leftMargin: 12
 
-            spacing: 4
+            onRejected: if (root.model) root.model.ignore()
+            onAccepted: if (root.model) root.model.apply()
 
             StyledButton {
-                id: ignoreButton
-                Layout.fillWidth: true
-                Layout.preferredWidth: parent.width / 2
                 text: qsTr("Keep old style")
-
+                DialogButtonBox.buttonRole: DialogButtonBox.RejectRole
                 focus: true
-
-                onClicked: {
-                    if (!root.model) {
-                        return
-                    }
-
-                    root.model.ignore()
-                }
             }
 
             StyledButton {
-                Layout.fillWidth: true
-                Layout.preferredWidth: parent.width / 2
                 text: qsTr("Apply new style")
-
+                DialogButtonBox.buttonRole: DialogButtonBox.AcceptRole
                 enabled: root.model ? root.model.isApplyingAvailable : false
-
-                onPressed: {
-                    if (!root.model) {
-                        return
-                    }
-
-                    root.model.apply()
-                }
             }
         }
     }

--- a/mscore/qml/migration/StyledDialogButtonBox.qml
+++ b/mscore/qml/migration/StyledDialogButtonBox.qml
@@ -1,0 +1,28 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+
+DialogButtonBox {
+    spacing: 6
+    implicitHeight: 24
+    background: null
+    padding: 0
+}


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/314149 = https://trello.com/c/FAckEYaZ/60-buttons-are-backwards-on-apply-new-styles-dialog-on-windows-see-https-musescoreorg-en-node-314149

On some platforms, among which Windows, the order of the buttons in the Score Migration Dialog was not like usually on those platforms. This is (should be) solved by using QML's DialogButtonBox, which automatically takes the platform into account.

Ironically, I'm on macOS, and can't test it on Windows. Maybe I can do that tomorrow, but if somebody else would have time to try it, that would be great!

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
