### PR TITLE
Center Score in Score View when opening a score

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2596,15 +2596,13 @@ void MuseScore::reloadInstrumentTemplates()
       }
 
 //---------------------------------------------------------
-//   askResetOldScorePositions
+//   askMigrateScore
 //---------------------------------------------------------
 
-void MuseScore::askResetOldScorePositions(Score* score)
+void MuseScore::askMigrateScore(Score* score)
       {
       if (!preferences.getBool(PREF_MIGRATION_DO_NOT_ASK_ME_AGAIN) && score->mscVersion() < MSCVERSION) {
-
             ScoreMigrationDialog* migrationDialog = new ScoreMigrationDialog(mscore->getQmlUiEngine(), score);
-
             migrationDialog->show();
             }
       }
@@ -2766,7 +2764,7 @@ void MuseScore::setCurrentScoreView(ScoreView* view)
       MasterScore* master = cs->masterScore();
       if (!scoreWasShown[master]) {
             scoreWasShown[master] = true;
-            askResetOldScorePositions(master);
+            askMigrateScore(master);
             }
       }
 

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2656,6 +2656,10 @@ void MuseScore::setCurrentScoreView(ScoreView* view)
                   }
             cs = cv->score();
             cv->setFocusRect();
+            if (!cv->wasShown) {
+                  cv->wasShown = true;
+                  cv->pageTop();
+                  }
             }
       else
             cs = 0;
@@ -2666,7 +2670,7 @@ void MuseScore::setCurrentScoreView(ScoreView* view)
       if (cs)
             cs->masterScore()->setPlaybackScore(_playPartOnly ? cs : cs->masterScore());
 
-                  // set midi import panel
+      // set midi import panel
       QString fileName = cs ? cs->importedFilePath() : "";
       midiPanelOnSwitchToFile(fileName);
 

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -489,7 +489,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void createPlayPanel();
 
       ScoreTab* createScoreTab();
-      void askResetOldScorePositions(Score* score);
+      void askMigrateScore(Score* score);
 
       QString getUtmParameters(QString medium) const;
 

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -408,6 +408,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void setEditElement(Element*);
       void updateEditElement();
 
+      bool wasShown = false;
       bool noteEntryMode() const { return state == ViewState::NOTE_ENTRY; }
       bool editMode() const      { return state == ViewState::EDIT; }
       bool textEditMode() const  { return editMode() && editData.element && editData.element->isTextBase(); }


### PR DESCRIPTION
- Rename `askResetOldScorePositions` to `askMigrateScore`
  (quite unrelated, but I couldn't resist :) )

- Center score in ScoreView when opening a score (follow-up for PR #6983)
  Because it looks better. But don't center it always when switching to another tab, because it can be annoying if it scrolls back to the beginning every time you switch to another tab. 
  <img width="1689" alt="Schermafbeelding 2020-12-20 om 00 57 39" src="https://user-images.githubusercontent.com/48658420/102702052-5ed04a80-425e-11eb-9e46-5008e54aa45e.png">


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made