### PR TITLE
[MU3] Solve brace scaling issues

### DIFF
--- a/libmscore/bracket.cpp
+++ b/libmscore/bracket.cpp
@@ -116,8 +116,11 @@ void Bracket::setStaffSpan(int a, int b)
          score()->styleSt(Sid::MusicalSymbolFont) != "Emmentaler" && score()->styleSt(Sid::MusicalSymbolFont) != "Gonville")
             {
             int v = _lastStaff - _firstStaff + 1;
+            if (score()->styleSt(Sid::MusicalSymbolFont) == "Leland")
+                  v = qMin(4, v);
             // total default height of a system of n staves / height of a 5 line staff
-            _magx = v + ((v - 1) * score()->styleS(Sid::akkoladeDistance).val() / 4.0);
+            qreal dist = score()->enableVerticalSpread() ? score()->styleS(Sid::maxAkkoladeDistance).val() : score()->styleS(Sid::akkoladeDistance).val();
+            _magx = v + ((v - 1) * dist / 4.0);
             if (v == 1)
                   _braceSymbol = SymId::braceSmall;
             else if (v <= 2)
@@ -245,7 +248,7 @@ void Bracket::draw(QPainter* painter) const
                         qreal mag      = h / (100 * magS());
                         painter->setPen(curColor());
                         painter->save();
-                        painter->scale(mag, mag);
+                        painter->scale(_magx, mag);
                         drawSymbol(_braceSymbol, painter, QPointF(0, 100 * magS()));
                         painter->restore();
                         }

--- a/mscore/palette/palettetree.cpp
+++ b/mscore/palette/palettetree.cpp
@@ -880,7 +880,7 @@ std::function<void (PaletteCell*)> PalettePanel::cellHandlerByPaletteType(const 
                   Bracket* bracket = toBracket(cellPtr->element.get());
 
                   if (bracket->bracketType() == BracketType::BRACE) {
-                        bracket->setBraceSymbol(SymId::braceSmall);
+                        bracket->setStaffSpan(0, 1);
                         cellPtr->mag = 1.2;
                         }
                   };


### PR DESCRIPTION
Resolves: https://trello.com/c/knmrYs5s/35-braces-are-too-thick
Resolves: https://trello.com/c/VFE5Ivxj/69-when-resizing-grand-staff-brace-scales-on-the-x-and-y-it-should-only-scale-on-the-y

Use the correct width scaling for braces to prevent a width scaling which includes extra added space between staves enclosed by the brace.

To make sure the palette contains the right symbol, <code>Bracket::setStaffSpan()</code> is used to define the brace symbol and width scaling used in the palette instead setting the symbol using <code>Bracket::setBraceSymbol()</code> which does set the correct symbol but does not set the correct scaling.
Also, the calculation of the scaling includes the correct <code>akkoladeDistance>/code>/<code>maxAkkoladeDistance</code>.


- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
