### PR TITLE
[MU3] Avoid deprecated assignment past the end of QString

### DIFF
--- a/libmscore/chordlist.cpp
+++ b/libmscore/chordlist.cpp
@@ -487,7 +487,7 @@ bool ParsedChord::parse(const QString& s, const ChordList* cl, bool syntaxOnly, 
 #endif
       int lastLeadingToken;
       int len = s.size();
-      int i, j;
+      int i;
       int thirdKey = 0, seventhKey = 0;
       bool susChord = false;
       QList<HDegree> hdl;
@@ -509,12 +509,12 @@ bool ParsedChord::parse(const QString& s, const ChordList* cl, bool syntaxOnly, 
 #endif
       lastLeadingToken = _tokenList.size();
       // get quality
-      for (j = 0, tok1 = "", tok1L = "", initial = ""; i < len; ++i, ++j) {
+      for (tok1 = "", tok1L = "", initial = ""; i < len; ++i) {
             // up to first (non-zero) digit, paren, or comma
             if (extensionDigits.contains(s[i]) || special.contains(s[i]))
                   break;
-            tok1[j] = s[i];
-            tok1L[j] = s[i].toLower();
+            tok1.push_back(s[i]);
+            tok1L.push_back(s[i].toLower());
             if (tok1L == "m" || major.contains(tok1L) || minor.contains(tok1L) || diminished.contains(tok1L) || augmented.contains(tok1L))
                   initial = tok1;
             }
@@ -617,10 +617,10 @@ bool ParsedChord::parse(const QString& s, const ChordList* cl, bool syntaxOnly, 
 #endif
       lastLeadingToken = _tokenList.size();
       // get extension - up to first non-digit other than comma or slash
-      for (j = 0, tok1 = ""; i < len; ++i, ++j) {
+      for (tok1 = ""; i < len; ++i) {
             if (!s[i].isDigit() && s[i] != ',' && s[i] != '/')
                   break;
-            tok1[j] = s[i];
+            tok1.push_back(s[i]);
             }
       _extension = tok1;
       if (_quality == "") {
@@ -789,11 +789,11 @@ bool ParsedChord::parse(const QString& s, const ChordList* cl, bool syntaxOnly, 
                   _xmlParens = "yes";
                   }
             // get first token - up to first digit, paren, or comma
-            for (j = 0, tok1 = "", tok1L = "", initial = ""; i < len; ++i, ++j) {
+            for (tok1 = "", tok1L = "", initial = ""; i < len; ++i) {
                   if (s[i].isDigit() || special.contains(s[i]))
                         break;
-                  tok1[j] = s[i];
-                  tok1L[j] = s[i].toLower();
+                  tok1.push_back(s[i]);
+                  tok1L.push_back(s[i].toLower());
                   if (mod2.contains(tok1L))
                         initial = tok1;
                   }
@@ -820,12 +820,12 @@ bool ParsedChord::parse(const QString& s, const ChordList* cl, bool syntaxOnly, 
             while (i < len && s[i] == ' ')
                   ++i;
             // get second token - a number <= 13
-            for (j = 0, tok2 = ""; i < len; ++i) {
+            for (tok2 = ""; i < len; ++i) {
                   if (!s[i].isDigit())
                         break;
-                  if (j == 1 && (tok2[0] != '1' || s[i] > '3'))
+                  if (tok2.size() == 1 && (tok2[0] != '1' || s[i] > '3'))
                         break;
-                  tok2[j++] = s[i];
+                  tok2.push_back(s[i]);
                   }
             tok2L = tok2.toLower();
             // re-attach "add"


### PR DESCRIPTION
https://doc.qt.io/qt-5/qstring.html#operator-5b-5d says this about
QCharRef QString::operator[](int position):

"Before Qt 5.14 it was possible to use this operator to access a
character at an out-of-bounds position in the string, and then assign
to such a position, causing the string to be automatically
resized. These behaviors are deprecated, and will be changed in a
future version of Qt."

Corresponding v4 PR: #7125

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made