### PR TITLE
(3.x) Fix MinGW parens code warnings (follow up PR #6461)

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -388,14 +388,23 @@ int nextVisibleSpannedStaff(const BarLine* bl)
       int nstaves = score->nstaves();
       int staffIdx = bl->staffIdx();
       Segment* segment = bl->segment();
-      Measure* nm = bl->measure()->nextMeasure();
       for (int i = staffIdx + 1; i < nstaves; ++i) {
             Staff* s = score->staff(i);
-            if (s->part()->show() && (bl->measure()->visible(i) ||        // span bar line if measure is visible
-                 (segment && segment->isEndBarLineType() &&               // or if this is a measure's End Bar Line and...
-                   ((nm ? nm->visible(i) : false) && (nm ? nm->system() == bl->measure()->system() : false)    // ...next measure is visible in system
-                   || bl->measure()->isCutawayClef(i)))))                                                     // ...or measure has Courtesy Clef
-                  return i;
+            if (s->part()->show()) {
+                  // span/show bar line if this measure is visible 
+                  if (bl->measure()->visible(i))
+                        return i;
+                  // or if this is an endBarLine and:
+                  if (segment && segment->isEndBarLineType()) {
+                        // ...this measure contains a (cutaway) courtesy clef only
+                        if (bl->measure()->isCutawayClef(i))
+                              return i;
+                        // ...or next measure is both visible and in the same system
+                        Measure* nm = bl->measure()->nextMeasure();
+                        if ((nm ? nm->visible(i) : false) && (nm ? nm->system() == bl->measure()->system() : false))
+                              return i;
+                        }
+                  }
             BarLine* nbl = toBarLine(segment->element(i * VOICES));
             if (!nbl || !nbl->spanStaff())
                   break;


### PR DESCRIPTION
FOLLOW UP to PR #6461 
Resolves warning about recommended parenthesis in the code while building with MinGW.
`(warning: suggest parentheses around '&&' within '||')`

*Cleaned up code and improved formatting in barline.cpp at 392-398*


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [N] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N] I created the test (mtest, vtest, script test) to verify the changes I made
