### PR TITLE
[MU3] Fix #314551: Duplicate check of identical expression

### DIFF
--- a/importexport/midiimport/importmidi_voice.cpp
+++ b/importexport/midiimport/importmidi_voice.cpp
@@ -61,7 +61,7 @@ bool areNotesSortedByOffTimeInAscOrder(
 bool areNotesSortedByOffTimeInAscOrder(const QList<MidiNote>& notes)
       {
       for (int i = 0; i != (int)notes.size() - 1; ++i) {
-            if (notes[i].offTime > notes[i].offTime)
+            if (notes[i].offTime > notes[i + 1].offTime)
                   return false;
             }
       return true;


### PR DESCRIPTION
Apparently a long time bug, introduced 6 years ago in f4067835

Resolves: https://musescore.org/en/node/314551

@trig-ger : please review...

Needed for master too, there the same code is at
https://github.com/musescore/MuseScore/blob/854faa2c654cfaae07b252a945ba764d75b92e6f/src/importexport/internal/midiimport/importmidi_voice.cpp#L63
See #7135