### PR TITLE
[MU4] Note input stabilization

### DIFF
--- a/src/framework/actions/actiontypes.h
+++ b/src/framework/actions/actiontypes.h
@@ -31,6 +31,7 @@
 namespace mu {
 namespace actions {
 using ActionName = std::string;
+using ActionNameList = std::vector<ActionName>;
 
 inline static ActionName namefromQString(const QString& s)
 {

--- a/src/libmscore/chord.cpp
+++ b/src/libmscore/chord.cpp
@@ -2997,11 +2997,11 @@ void Chord::updateArticulations(const std::set<SymId>& newArticulationIds, Artic
         score()->undoRemoveElement(articulation);
     }
 
-    std::set<SymId> articulationIds = splitArticulations(currentArticulationIds);
-    articulationIds = flipArticulations(articulationIds, Placement::ABOVE);
+    std::set<SymId> articulationIds = flipArticulations(currentArticulationIds, Placement::ABOVE);
+    articulationIds = splitArticulations(articulationIds);
 
-    std::set<SymId> _newArticulationIds = splitArticulations(newArticulationIds);
-    _newArticulationIds = flipArticulations(_newArticulationIds, Placement::ABOVE);
+    std::set<SymId> _newArticulationIds = flipArticulations(newArticulationIds, Placement::ABOVE);
+    _newArticulationIds = splitArticulations(_newArticulationIds);
 
     for (const SymId& articulationId: _newArticulationIds) {
         articulationIds = Ms::updateArticulations(articulationIds, articulationId, updateMode);
@@ -3967,6 +3967,16 @@ void Chord::layoutArticulations3(Slur* slur)
             }
         }
     }
+}
+
+std::set<SymId> Chord::articulationSymbolIds() const
+{
+    std::set<SymId> result;
+    for (const Articulation* articulation: _articulations) {
+        result.insert(articulation->symId());
+    }
+
+    return result;
 }
 
 //---------------------------------------------------------

--- a/src/libmscore/chord.h
+++ b/src/libmscore/chord.h
@@ -215,6 +215,7 @@ public:
 
     QVector<Articulation*>& articulations() { return _articulations; }
     const QVector<Articulation*>& articulations() const { return _articulations; }
+    std::set<SymId> articulationSymbolIds() const;
     Articulation* hasArticulation(const Articulation*);
     bool hasSingleArticulation() const { return _articulations.size() == 1; }
 

--- a/src/libmscore/input.cpp
+++ b/src/libmscore/input.cpp
@@ -144,6 +144,8 @@ void InputState::update(Selection& selection)
                 for (Articulation* articulation: n->chord()->articulations()) {
                     articulationsIds.insert(articulation->symId());
                 }
+
+                articulationsIds = Ms::splitArticulations(articulationsIds);
                 articulationsIds = Ms::flipArticulations(articulationsIds, Ms::Placement::ABOVE);
                 for (const SymId& articulationSymbolId: articulationsIds) {
                     if (std::find(articulationSymbolIds.begin(), articulationSymbolIds.end(),

--- a/src/notation/internal/notationactions.cpp
+++ b/src/notation/internal/notationactions.cpp
@@ -583,16 +583,11 @@ const ActionList NotationActions::m_noteInputActions = {
            ShortcutContext::NotationActive,
            IconCode::Code::FOOT_PEDAL
            ),
-//    Action("note-input-timewise", // TODO Insert (shifts notation to the right)
-//           QT_TRANSLATE_NOOP("action", "Re-pitch existing notes "),
-//           ShortcutContext::NotationActive,
-//           IconCode::Code::NOTE_TO_RIGHT
-//           ),
-//    Action("note-input-repitch", // TODO Insert (extends measure)
-//           QT_TRANSLATE_NOOP("action", "Re-pitch existing notes "),
-//           ShortcutContext::NotationActive,
-//           IconCode::Code::NOTE_PLUS
-//           ),
+    Action("note-input-timewise",
+           QT_TRANSLATE_NOOP("action", "Insert"),
+           ShortcutContext::NotationActive,
+           IconCode::Code::NOTE_PLUS
+           ),
     Action("note-longa",
            QT_TRANSLATE_NOOP("action", "Longo"),
            ShortcutContext::NotationActive,
@@ -683,15 +678,15 @@ const ActionList NotationActions::m_noteInputActions = {
            ShortcutContext::NotationActive,
            IconCode::Code::REST
            ),
-    Action("flat2",
-           QT_TRANSLATE_NOOP("action", "Double flat"),
-           ShortcutContext::NotationActive,
-           IconCode::Code::FLAT_DOUBLE
-           ),
     Action("flat",
            QT_TRANSLATE_NOOP("action", "Flat"),
            ShortcutContext::NotationActive,
            IconCode::Code::FLAT
+           ),
+    Action("flat2",
+           QT_TRANSLATE_NOOP("action", "Double flat"),
+           ShortcutContext::NotationActive,
+           IconCode::Code::FLAT_DOUBLE
            ),
     Action("nat",
            QT_TRANSLATE_NOOP("action", "Natural"),

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -865,7 +865,7 @@ bool NotationInteraction::drop(const QPointF& pos, Qt::KeyboardModifiers modifie
     return accepted;
 }
 
-void NotationInteraction::selectInstrument(Ms::InstrumentChange *instrumentChange)
+void NotationInteraction::selectInstrument(Ms::InstrumentChange* instrumentChange)
 {
     if (!instrumentChange) {
         return;
@@ -1340,7 +1340,7 @@ bool NotationInteraction::notesHaveActiculation(const std::vector<Note*>& notes,
     for (Note* note: notes) {
         Chord* chord = note->chord();
 
-        std::set<SymId> chordArticulations = chord->articulationSymbolIds();
+        std::set<SymbolId> chordArticulations = chord->articulationSymbolIds();
         chordArticulations = Ms::flipArticulations(chordArticulations, Ms::Placement::ABOVE);
         chordArticulations = Ms::splitArticulations(chordArticulations);
 
@@ -2025,9 +2025,8 @@ void NotationInteraction::changeSelectedNotesArticulation(SymbolId articulationS
     std::vector<Ms::Note*> notes = score()->selection().noteList();
 
     auto updateMode = notesHaveActiculation(notes, articulationSymbolId)
-                      ? ArticulationsUpdateMode::Remove : ArticulationsUpdateMode::Insert;
+                      ? Ms::ArticulationsUpdateMode::Remove : Ms::ArticulationsUpdateMode::Insert;
 
-    startEdit();
     std::set<Chord*> chords;
     for (Note* note: notes) {
         Chord* chord = note->chord();
@@ -2036,6 +2035,7 @@ void NotationInteraction::changeSelectedNotesArticulation(SymbolId articulationS
         }
     }
 
+    startEdit();
     for (Chord* chord: chords) {
         chord->updateArticulations({ articulationSymbolId }, updateMode);
     }

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -169,6 +169,7 @@ private:
     void doAddSlur(const Ms::Slur* slurTemplate = nullptr);
 
     bool scoreHasMeasure() const;
+    bool notesHaveActiculation(const std::vector<Note*>& notes, SymbolId articulationSymbolId) const;
 
     bool needEndTextEditing(const std::vector<Element*>& newSelectedElements) const;
 

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -39,11 +39,9 @@ NotationNoteInput::NotationNoteInput(const IGetScore* getScore, INotationInterac
     m_scoreCallbacks = new ScoreCallbacks();
 
     m_interaction->selectionChanged().onNotify(this, [this]() {
-        updateInputState();
-    });
-
-    m_undoStack->stackChanged().onNotify(this, [this]() {
-        updateInputState();
+        if (!isNoteInputMode()) {
+            updateInputState();
+        }
     });
 }
 
@@ -220,7 +218,8 @@ void NotationNoteInput::setArticulation(SymbolId articulationSymbolId)
 {
     Ms::InputState& inputState = score()->inputState();
 
-    std::set<SymbolId> articulations = Ms::updateArticulations(inputState.articulationIds(), articulationSymbolId);
+    std::set<SymbolId> articulations = Ms::updateArticulations(
+        inputState.articulationIds(), articulationSymbolId, Ms::ArticulationsUpdateMode::Remove);
     inputState.setArticulationIds(articulations);
 
     notifyAboutStateChanged();

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -41,6 +41,10 @@ NotationNoteInput::NotationNoteInput(const IGetScore* getScore, INotationInterac
     m_interaction->selectionChanged().onNotify(this, [this]() {
         updateInputState();
     });
+
+    m_undoStack->stackChanged().onNotify(this, [this]() {
+        updateInputState();
+    });
 }
 
 NotationNoteInput::~NotationNoteInput()
@@ -245,16 +249,16 @@ void NotationNoteInput::putTuplet(const TupletOptions& options)
 {
     Ms::InputState& inputState = score()->inputState();
 
-    m_undoStack->prepareChanges();
+    startEdit();
     score()->expandVoice();
     Ms::ChordRest* chordRest = inputState.cr();
     if (chordRest) {
         score()->changeCRlen(chordRest, inputState.duration());
         score()->addTuplet(chordRest, options.ratio, options.numberType, options.bracketType);
     }
-    m_undoStack->commitChanges();
+    apply();
 
-    m_stateChanged.notify();
+    notifyAboutStateChanged();
 }
 
 QRectF NotationNoteInput::cursorRect() const

--- a/src/notation/qml/MuseScore/NotationScene/NoteInputBarCustomiseDialog.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NoteInputBarCustomiseDialog.qml
@@ -12,7 +12,7 @@ QmlDialog {
     id: root
 
     width: 280
-    height: 825
+    height: 600
 
     modal: true
 
@@ -138,7 +138,7 @@ QmlDialog {
 
                 delegate: Item {
                     width: parent ? parent.width : 0
-                    height: 48
+                    height: 38
 
                     Loader {
                         property var delegateType: Boolean(itemRole) ? itemRole.type : NoteInputBarItem.UNDEFINED

--- a/src/notation/qml/MuseScore/NotationScene/internal/NoteInputBarActionDelegate.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/NoteInputBarActionDelegate.qml
@@ -21,13 +21,16 @@ Item {
 
         spacing: 16
 
-        CheckBox {
+        FlatButton {
             Layout.alignment: Qt.AlignLeft
 
-            checked: Boolean(itemRole) ? itemRole.checked : false
+            normalStateColor: "transparent"
+            pressedStateColor: ui.theme.accentColor
+
+            icon: Boolean(itemRole) && itemRole.checked ? IconCode.VISIBILITY_ON : IconCode.VISIBILITY_OFF
 
             onClicked: {
-                itemRole.checked = !checked
+                itemRole.checked = !itemRole.checked
             }
         }
 

--- a/src/notation/view/noteinputbarcustomisemodel.h
+++ b/src/notation/view/noteinputbarcustomisemodel.h
@@ -101,11 +101,11 @@ private:
     AbstractNoteInputBarItem* makeItem(const actions::Action& action, bool checked);
     AbstractNoteInputBarItem* makeSeparatorItem() const;
 
-    std::vector<std::string> customizedActions() const;
-    std::vector<std::string> defaultActions() const;
-    std::vector<std::string> currentActions() const;
+    actions::ActionNameList customizedActions() const;
+    actions::ActionNameList defaultActions() const;
+    actions::ActionNameList currentActions() const;
 
-    std::vector<std::string> currentWorkspaceActions() const;
+    actions::ActionNameList currentWorkspaceActions() const;
 
     bool actionFromNoteInputModes(const actions::ActionName& actionName) const;
 

--- a/src/notation/view/noteinputbarmodel.cpp
+++ b/src/notation/view/noteinputbarmodel.cpp
@@ -28,7 +28,7 @@ using namespace mu::workspace;
 using namespace mu::framework;
 
 static const std::string TOOLBAR_TAG("Toolbar");
-static const std::string NOTE_INPUT_TOOLBAR_NAME("noteInput");
+static const std::string TOOLBAR_NAME("noteInput");
 
 static const std::string ADD_ACTION_NAME("add");
 static const std::string ADD_ACTION_TITLE("Add");
@@ -108,7 +108,7 @@ void NoteInputBarModel::load()
         });
 
         workspace.val->dataChanged().onReceive(this, [this](const AbstractDataPtr data) {
-            if (data->name == NOTE_INPUT_TOOLBAR_NAME) {
+            if (data->name == TOOLBAR_NAME) {
                 load();
             }
         });
@@ -527,10 +527,10 @@ std::vector<std::string> NoteInputBarModel::currentWorkspaceActions() const
         return {};
     }
 
-    AbstractDataPtr abstractData = workspace.val->data(WorkspaceTag::Toolbar, NOTE_INPUT_TOOLBAR_NAME);
+    AbstractDataPtr abstractData = workspace.val->data(WorkspaceTag::Toolbar, TOOLBAR_NAME);
     ToolbarDataPtr toolbarData = std::dynamic_pointer_cast<ToolbarData>(abstractData);
     if (!toolbarData) {
-        LOGE() << "Failed to get data of actions for " << NOTE_INPUT_TOOLBAR_NAME;
+        LOGE() << "Failed to get data of actions for " << TOOLBAR_NAME;
         return {};
     }
 

--- a/src/notation/view/noteinputbarmodel.cpp
+++ b/src/notation/view/noteinputbarmodel.cpp
@@ -160,6 +160,10 @@ void NoteInputBarModel::onNotationChanged()
         interaction()->selectionChanged().onNotify(this, [this]() {
             updateState();
         });
+
+        undoStack()->stackChanged().onNotify(this, [this]() {
+            updateState();
+        });
     }
 
     updateState();
@@ -572,6 +576,11 @@ INotationInteractionPtr NoteInputBarModel::interaction() const
 INotationSelectionPtr NoteInputBarModel::selection() const
 {
     return interaction() ? interaction()->selection() : nullptr;
+}
+
+INotationUndoStackPtr NoteInputBarModel::undoStack() const
+{
+    return notation() ? notation()->undoStack() : nullptr;
 }
 
 INotationNoteInputPtr NoteInputBarModel::noteInput() const

--- a/src/notation/view/noteinputbarmodel.h
+++ b/src/notation/view/noteinputbarmodel.h
@@ -106,6 +106,8 @@ private:
     INotationNoteInputPtr noteInput() const;
     INotationInteractionPtr interaction() const;
     INotationSelectionPtr selection() const;
+    INotationUndoStackPtr undoStack() const;
+
     int resolveCurrentVoiceIndex() const;
     std::set<SymbolId> resolveCurrentArticulations() const;
     bool resolveRestSelected() const;


### PR DESCRIPTION
- Updating note input state after undoing stack change
- Changed checkboxes to eyes
- Fixed articulations
- Fixed the formation of the list of toolbar items when first open the customization dialog