### PR TITLE
[MU3] Fix #314655: Avoid spaces and more when exporting files

### DIFF
--- a/mscore/exportdialog.cpp
+++ b/mscore/exportdialog.cpp
@@ -446,10 +446,10 @@ void ExportDialog::accept()
       QString name = QString("%1/%2").arg(saveDirectory, cs->masterScore()->fileInfo()->completeBaseName());
       if (oneScore) {
             Score* score = scores.first();
-            name.append(QString(" - %1").arg(score->isMaster() ? tr("Full Score") : score->title()));
+            name.append(QString("%1").arg(score->isMaster() ? "" : "-" + score->title()));
             }
       else if (singlePDF)
-            name.append(QString(" - %1").arg(containsMasterScore ? tr("Score and Parts") : tr("Parts")));
+            name.append(QString("-%1").arg(containsMasterScore ? tr("Score_and_Parts") : tr("Parts")));
 
 #ifdef Q_OS_WIN
       if (QOperatingSystemVersion::current() > QOperatingSystemVersion(QOperatingSystemVersion::Windows, 5, 1))    // XP
@@ -485,10 +485,10 @@ void ExportDialog::accept()
             SaveReplacePolicy replacePolicy = SaveReplacePolicy::NO_CHOICE;
 
             for (Score* score : scores) {
-                  QString definitiveFilename = QString("%1/%2 - %3.%4")
+                  QString definitiveFilename = QString("%1/%2%3.%4")
                         .arg(fileinfo.absolutePath(),
                              fileinfo.completeBaseName(),
-                             score->isMaster() ? tr("Full Score") : score->title(),
+                             score->isMaster() ? "" : "-" + score->title(),
                              suffix);
                   if (saveFormat != "png" && saveFormat != "svg" && QFileInfo(definitiveFilename).exists()) {
                         // Png and Svg export functions change the filename, so they
@@ -519,8 +519,8 @@ void ExportDialog::accept()
                         success = false;
                   }
             }
-      if (success)
-            QMessageBox::information(this, tr("Export"), tr("Export was successful."));
+      //if (success)
+      //      QMessageBox::information(this, tr("Export"), tr("Export was successful."));
       }
 
 //---------------------------------------------------------

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -2791,7 +2791,7 @@ bool MuseScore::saveSvg(Score* score, const QString& name, const NotesColors& no
             QString fileName(name);
             if (fileName.endsWith(".svg"))
                   fileName = fileName.left(fileName.size() - 4);
-            fileName += QString(" - %1.svg").arg(pageNumber+1, padding, 10, QLatin1Char('0'));
+            fileName += QString("-%1.svg").arg(pageNumber+1, padding, 10, QLatin1Char('0'));
             if (!converterMode && QFileInfo(fileName).exists()) {
                   switch (_replacePolicy) {
                         case SaveReplacePolicy::NO_CHOICE:


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/314655

Also avoids that "Success" dialog, which is an annoying extra click with no value IHMO