### PR TITLE
[MU3] Fix #286153: Check box "Show MIDI controls in mixer" in Preferences/Score page has no effect

### DIFF
--- a/mscore/mixer/mixer.cpp
+++ b/mscore/mixer/mixer.cpp
@@ -76,7 +76,7 @@ char userRangeToReverb(double v) { return (char)qBound(0, static_cast<int>(v / 1
 
 Mixer::Mixer(QWidget* parent)
     : QDockWidget(qApp->translate("Mixer", "Mixer"), parent),
-      showDetails(true),
+      showDetails(preferences.getBool(PREF_IO_MIDI_SHOWCONTROLSINMIXER)),
       trackHolder(nullptr)
       {
 
@@ -452,8 +452,9 @@ void Mixer::updateTracks()
 //   midiPrefsChanged
 //---------------------------------------------------------
 
-void Mixer::midiPrefsChanged(bool)
+void Mixer::midiPrefsChanged(bool showMidiControls)
       {
+      showDetailsToggled(showMidiControls);
       updateTracks();
       }
 
@@ -503,6 +504,7 @@ void MuseScore::showMixer(bool visible)
 
       if (mixer == 0) {
             mixer = new Mixer(this);
+            mixer->showDetailsToggled(preferences.getBool(PREF_IO_MIDI_SHOWCONTROLSINMIXER));
             mscore->stackUnder(mixer);
             if (synthControl)
                   connect(synthControl, SIGNAL(soundFontChanged()), mixer, SLOT(updateTrack()));


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/286153