### PR TITLE
[MU3] fix #314665: don't force "long" slurs above the staff

### DIFF
--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -1049,11 +1049,13 @@ SpannerSegment* Slur::layoutSystem(System* system)
                         _up = !(startCR()->up());
 
                         Measure* m1 = startCR()->measure();
+#if 0
+                        // the following code was in place until 3.6,
+                        // to force "long" slurs (duration > one measure) above
+                        // but it's much too aggressive - one measure isn't necessarily long
                         if ((endCR()->tick() - startCR()->tick()) > m1->ticks()) // long slurs are always above
                               _up = true;
-                        else
-                              _up = !startCR()->up();
-
+#endif
                         if (c1 && c2 && isDirectionMixture(c1, c2) && !c1->isGrace()) {
                               // slurs go above if start and end note have different stem directions,
                               // but grace notes are exceptions


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/314665

NOTE: I am confident the code itself is good,
not as confident we want to make this change for 3.6,
at least not without adding more compatibility handling.
But I wanted to make this available for testing and discussion.

We have code to force "long" slurs above the staff,
which isn't a terrible idea, but we're way too heavy-handed about it.
Anything more than one measure in duration is considered long.

Since this determination is best made subjectively by the user,
the code here removes this check.
However, it will doubtless have an efrect on existing scores.
In most cases, a good one, as slurs that were erroneously forced up
will now be where they really belong, below the staff.
In some cases, though - especially truly long slurs
like ones extending for most of the system -
it could cause too much extra space below the staff.

Ultimately we could consider adding a style setting to control this.
And having the default different for older versus newer scores.