### PR TITLE
[MU4] Fix #314696: Ties end at wrong note

### DIFF
--- a/src/libmscore/read206.cpp
+++ b/src/libmscore/read206.cpp
@@ -1336,7 +1336,16 @@ bool readNoteProperties206(Note* note, XmlReader& e)
     const QStringRef& tag(e.name());
 
     if (tag == "pitch") {
-        note->setPitch(e.readInt());
+        int pitch = e.readInt();
+        Tie* tie = note->tieBack();
+        if (tie) {
+            int startPitch = tie->startNote()->pitch();
+            if (pitch != startPitch) {
+                qDebug("Changing pitch from %d to %d to match pitch of note at start of tie.", pitch, startPitch);
+                pitch = startPitch;
+            }
+        }
+        note->setPitch(pitch);
     } else if (tag == "tpc") {
         const int tpc = e.readInt();
         note->setTpc1(tpc);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/314696.

When reading the properties of a tied note from a 2.x score, check to see if the specified pitch matches the pitch of the note at the beginning of the tie. If the pitches do not match, then print a debug message to the console, and set the pitch of the new note to match the pitch of the starting note.