### PR TITLE
[MU4] Fixed two crashes

### DIFF
--- a/.github/workflows/ci_vtests.yml
+++ b/.github/workflows/ci_vtests.yml
@@ -2,9 +2,9 @@ name: CI_vtests
 
 on:
   # Temporary off
-  # pull_request:
-  #   branches:
-  #   - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   run_vtests:

--- a/.github/workflows/ci_vtests.yml
+++ b/.github/workflows/ci_vtests.yml
@@ -2,9 +2,9 @@ name: CI_vtests
 
 on:
   # Temporary off
-  pull_request:
-    branches:
-    - master
+  # pull_request:
+  #   branches:
+  #   - master
 
 jobs:
   run_vtests:

--- a/src/converter/internal/convertercontroller.cpp
+++ b/src/converter/internal/convertercontroller.cpp
@@ -52,6 +52,7 @@ mu::Ret ConverterController::batchConvert(const io::path& batchJobFile)
 
 mu::Ret ConverterController::convert(const io::path& in, const io::path& out)
 {
+    LOGI() << "in: " << in;
     auto notation = notationCreator()->newMasterNotation();
     IF_ASSERT_FAILED(notation) {
         return make_ret(Err::UnknownError);
@@ -110,7 +111,10 @@ mu::RetVal<ConverterController::BatchJob> ConverterController::parseBatchJob(con
         Job job;
         job.in = obj["in"].toString();
         job.out = obj["out"].toString();
-        rv.val.push_back(std::move(job));
+
+        if (!job.in.empty() && !job.out.empty()) {
+            rv.val.push_back(std::move(job));
+        }
     }
 
     rv.ret = make_ret(Ret::Code::Ok);

--- a/src/libmscore/measure.cpp
+++ b/src/libmscore/measure.cpp
@@ -3341,7 +3341,7 @@ MeasureRepeat* Measure::measureRepeatElement(int staffIdx) const
     if (!m) {
         return nullptr;
     }
-    while (m->isMeasureRepeatGroup(staffIdx)) {
+    while (m && m->isMeasureRepeatGroup(staffIdx)) {
         int strack = staff2track(staffIdx);
         int etrack = staff2track(staffIdx + 1);
         for (int track = strack; track < etrack; ++track) {

--- a/src/libmscore/trill.cpp
+++ b/src/libmscore/trill.cpp
@@ -269,6 +269,16 @@ Trill::Trill(Score* s)
     initElementStyle(&trillStyle);
 }
 
+Trill::Trill(const Trill& t)
+    : SLine(t.score())
+{
+    _trillType = t._trillType;
+    _accidental = t._accidental ? t._accidental->clone() : nullptr;
+    _ornamentStyle = t._ornamentStyle;
+    _playArticulation = t._playArticulation;
+    initElementStyle(&trillStyle);
+}
+
 Trill::~Trill()
 {
     delete _accidental;

--- a/src/libmscore/trill.h
+++ b/src/libmscore/trill.h
@@ -78,6 +78,7 @@ private:
 
 public:
     Trill(Score* s);
+    Trill(const Trill& t);
     ~Trill();
 
     // Score Tree functions


### PR DESCRIPTION
I tried to enable vtest and catch two crashes 

1. First simple - no check null element
2. Second more difficult - double free (double delete) 

The reason is that the default copy constructor was used for Trill when implementing the clone method, which copied the _accidental pointer, respectively, when deleting Trills, the same _accidental was deleted twice.