### PR TITLE
Improvements to line dragging behavior

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -2099,9 +2099,9 @@ QVector<QLineF> Element::genericDragAnchorLines() const
       if (parent()->isSegment()) {
             System* system = toSegment(parent())->measure()->system();
             const int stIdx = staffIdx();
-            yp = system->staffCanvasYpage(stIdx);
+            yp = system ? system->staffCanvasYpage(stIdx) : 0.0;
             if (placement() == Placement::BELOW)
-                  yp += system->staff(stIdx)->bbox().height();
+                  yp += system ? system->staff(stIdx)->bbox().height() : 0.0;
             //adjust anchor Y positions to staffType offset
             if (staff())
                 yp += staff()->staffTypeForElement(this)->yoffset().val()* spatium();
@@ -2191,7 +2191,10 @@ void Element::endEditDrag(EditData& ed)
       if (eed) {
             for (const PropertyData &pd : qAsConst(eed->propertyData)) {
                   setPropertyFlags(pd.id, pd.f); // reset initial property flags state
-                  if (score()->undoPropertyChanged(this, pd.id, pd.data))
+                  PropertyFlags f = pd.f;
+                  if (f == PropertyFlags::STYLED)
+                        f = PropertyFlags::UNSTYLED;
+                  if (score()->undoPropertyChanged(this, pd.id, pd.data, f))
                         changed = true;
                   }
             eed->propertyData.clear();

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3723,6 +3723,8 @@ static void processLines(System* system, std::vector<Spanner*> lines, bool align
                         }
                   }
             for (SpannerSegment* ss : segments) {
+                  if (!ss->isStyled(Pid::OFFSET))
+                        continue;
                   const qreal staffY = y[ss->staffIdx()];
                   if (staffY > minY)
                         ss->rypos() = staffY;
@@ -4555,7 +4557,8 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
 
                   for (int i = 0; i < idx; ++i) {
                         SpannerSegment* ss = voltaSegments[i];
-                        ss->rypos() = y;
+                        if (ss->autoplace() && ss->isStyled(Pid::OFFSET))
+                              ss->rypos() = y;
                         if (ss->addToSkyline())
                               system->staff(staffIdx)->skyline().add(ss->shape().translated(ss->pos()));
                         }

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -534,6 +534,10 @@ void LineSegment::rebaseAnchors(EditData& ed, Grip grip)
       {
       if (line()->anchor() != Spanner::Anchor::SEGMENT)
             return;
+      // don't change anchors on keyboard adjustment or if Ctrl is pressed
+      // (Ctrl+Left/Right is handled elsewhere!)
+      if (ed.key == Qt::Key_Left || ed.key == Qt::Key_Right || ed.modifiers & Qt::ControlModifier)
+            return;
 
       switch (grip) {
             case Grip::START:

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -612,7 +612,7 @@ void Score::dragPosition(const QPointF& p, int* rst, Segment** seg, qreal spacin
       {
       const System* preferredSystem = (*seg) ? (*seg)->system() : nullptr;
       Measure* m = searchMeasure(p, preferredSystem, spacingFactor);
-      if (m == 0)
+      if (m == 0 || m->isMMRest())
             return;
 
       System* s = m->system();

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -493,6 +493,7 @@ void ScoreView::mousePressEvent(QMouseEvent* ev)
       editData.pos       = editData.startMove;
       editData.buttons   = ev->buttons();
       editData.modifiers = qApp->keyboardModifiers();
+      editData.key       = 0;
 
       bool gripFound = false;
       if (hasEditGrips() && ev->button() == Qt::LeftButton) {


### PR DESCRIPTION
This PR contains a number of separate but related improvements to line dragging functionality.  It addresses some long-standing bugs (the behavior where aligned pedal lines can jump wildly on drag has been around since 3.1, and the problem where reset does not restore the offset to styled status has been around since 3.0), as well as some more recent regressions (the inability to manually adjust end handles without being forced into an anchor change was new with 3.5).

The commits here are mostly separate and could standalone for cherry-picking if need be.  However, the fix to the wild jumps of dragged pedal lines does rely in part on the fix to the styling of the offset property.  And they are all related to dragging behavior and are bested tested together.

Here are the direct links to the issues fixed (also found within the individual commit messages):

1) https://musescore.org/en/node/314854
2) https://trello.com/c/QRquMj6w/84-pedal-markings-seem-broken-when-trying-to-move-them-vertically
3) https://musescore.org/en/node/313721
4) https://musescore.org/en/node/309368