### PR TITLE
Fix #314435 - "Enable vertical adjustment of staves" does not undo

### DIFF
--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -1438,7 +1438,7 @@ void EditStyle::enableVerticalSpreadClicked(bool checked)
 
 void EditStyle::disableVerticalSpreadClicked(bool checked)
       {
-      cs->style().set(Sid::enableVerticalSpread, !checked);
+      cs->undo(new ChangeStyleVal(cs, Sid::enableVerticalSpread, !checked));
       enableVerticalSpread->setChecked(!checked);
       cs->setLayoutAll();
       }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/314435

Replace <code>cs->style().set(..)</code> by <code>cs->undo(new ChangeStyleVal..))</code>.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
