### PR TITLE
Fix #269740: Retranslate when current language is updated

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -224,7 +224,6 @@ static bool scoresOnCommandline { false };
 
 static QList<QTranslator*> translatorList;
 
-QString localeName;
 bool useFactorySettings = false;
 bool deletePreferences = false;
 QString styleName;
@@ -343,6 +342,17 @@ QString getSharePath()
       return QString( INSTPREFIX "/share/" INSTALL_NAME);
 #endif
 #endif
+      }
+
+//---------------------------------------------------------
+//   localeName
+//---------------------------------------------------------
+
+QString localeName()
+      {
+      if (useFactorySettings)
+            return "system";
+      return preferences.getString(PREF_UI_APP_LANGUAGE);
       }
 
 //---------------------------------------------------------
@@ -2249,12 +2259,10 @@ void MuseScore::startAutoSave()
 
 QString MuseScore::getLocaleISOCode() const
       {
-      QString lang;
-      if (localeName.toLower() == "system")
-            lang = QLocale::system().name();
-      else
-            lang = localeName;
-      return lang;
+      QString l = localeName();
+      if (l.toLower() == "system")
+            return QLocale::system().name();
+      return l;
       }
 
 //---------------------------------------------------------
@@ -7987,8 +7995,10 @@ void MuseScore::init(QStringList& argv)
       if (MScore::debugMode)
             qDebug("global share: <%s>", qPrintable(mscoreGlobalShare));
 
-      // set translator before Shortcut are initialized to get translations for all shortcuts
-      // can not use preferences to retrieve these values as it needs to be initialized after translator is set
+      // Set translator before Shortcuts are initialized to get translations for all shortcuts.
+      // Cannot use `preferences` or `localeName()` (which uses `preferences`) to retrieve
+      // these values, as `preferences` needs to be initialized after translator is set.
+      QString localeName;
       if (useFactorySettings)
             localeName = "system";
       else {

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -125,6 +125,8 @@ static const int PROJECT_LIST_LEN = 6;
 extern const char* voiceActions[];
 extern bool mscoreFirstStart;
 
+QString localeName();
+
 using NotesColors = QHash<int /* noteIndex */, QColor>;
 
 //---------------------------------------------------------

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -1703,7 +1703,7 @@ void PreferenceDialog::selectExtensionsDirectory()
 
 void PreferenceDialog::updateTranslationClicked()
       {
-      ResourceManager r(0);
+      ResourceManager r(this);
       r.selectLanguagesTab();
       r.exec();
       }

--- a/mscore/resourceManager.h
+++ b/mscore/resourceManager.h
@@ -29,6 +29,8 @@ class ResourceManager : public QDialog, public Ui::Resource
       bool verifyFile(QString path, QString hash);
       bool verifyLanguageFile(QString filename, QString hash);
       
+      QPushButton* currentLanguageButton = nullptr;
+      
    public:
       explicit ResourceManager(QWidget *parent = 0);
       void selectLanguagesTab();


### PR DESCRIPTION
Previously, when you updated the current language using the Resource Manager, you would only be able to see the updated strings after restarting MuseScore. This was, because the condition to determine whether the *current* language had been updated was wrong, so the `retranslate` function would not be called. Now, the condition is correct, and the function is correctly called.
I also renamed some variables to make the code clearer to understand, and I fixed a problem with the variable `localeName` not being updated on a language switch, which caused that the wrong language appeared at the top of the list in the Resource Manager, and might have caused other problems too.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
