### PR TITLE
[MU3] Disabled check max Qt version for Windows

### DIFF
--- a/build/FindQt5.cmake
+++ b/build/FindQt5.cmake
@@ -36,10 +36,14 @@ if (WIN32)
       )
 endif(WIN32)
 
-#find_package(Qt5Core 5.15.0 QUIET)
-#if (Qt5Core_FOUND)
-#    message(FATAL_ERROR "MuseScore 3 does not support Qt 5.15 and later (Palettes panel shows no palettes)")
-#endif()
+# For Windows, because of these lines, for some unknown reason, the build of the .msi package fails.
+if(NOT ${CMAKE_HOST_SYSTEM_NAME} MATCHES "Windows")
+    find_package(Qt5Core 5.15.0 QUIET)
+    if (Qt5Core_FOUND)
+        message(FATAL_ERROR "MuseScore 3 does not support Qt 5.15: 5.15.0 shows empty palettes panel, 5.15.1 and later crash when opening pre-3.6 scores due to QTBUG-77337")
+    endif()
+endif()
+
 find_package(Qt5Core ${QT_MIN_VERSION} REQUIRED)
 
 foreach(_component ${_components})


### PR DESCRIPTION
Disable check max Qt version for Windows

For some unknown reason, this check fails to build the .msi package.
https://github.com/musescore/MuseScore/runs/1622651464?check_suite_focus=true
```
CMake Error at build/FindQt5.cmake:43 (find_package):
  By not providing "FindQt5Core.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Qt5Core", but
  CMake did not find one.
```
