### PR TITLE
[MU3] Fix #314696: Ties end at wrong note

### DIFF
--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -1054,18 +1054,8 @@ bool readNoteProperties206(Note* note, XmlReader& e)
       {
       const QStringRef& tag(e.name());
 
-      if (tag == "pitch") {
-            int pitch = e.readInt();
-            Tie* tie = note->tieBack();
-            if (tie) {
-                  int startPitch = tie->startNote()->pitch();
-                  if (pitch != startPitch) {
-                        qDebug("readNoteProperties206: Changing pitch from %d to %d to match pitch of note at start of tie.", pitch, startPitch);
-                        pitch = startPitch;
-                        }
-                  }
-            note->setPitch(pitch);
-            }
+      if (tag == "pitch")
+            note->setPitch(e.readInt());
       else if (tag == "tpc") {
             const int tpc = e.readInt();
             note->setTpc1(tpc);

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -2068,6 +2068,25 @@ static void convertDoubleArticulations(Chord* chord, XmlReader& e)
       }
 
 //---------------------------------------------------------
+//   fixTies
+//---------------------------------------------------------
+
+static void fixTies(Chord* chord)
+      {
+      std::vector<Note*> notes;
+      for (Note* note : chord->notes()) {
+            Tie* tie = note->tieBack();
+            if (tie && tie->startNote()->pitch() != note->pitch()) {
+                  notes.push_back(tie->startNote());
+                  }
+            }
+      for (Note* note : notes) {
+            Note* endNote = chord->findNote(note->pitch());
+            note->tieFor()->setEndNote(endNote);
+            }
+      }
+
+//---------------------------------------------------------
 //   readChord
 //---------------------------------------------------------
 
@@ -2106,6 +2125,7 @@ static void readChord(Chord* chord, XmlReader& e)
                   e.unknown();
             }
       convertDoubleArticulations(chord, e);
+      fixTies(chord);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/314696.

Reverts and replaces #7155.

Ties from 2.x scores may import incorrectly due to an error in the way the spanner ids were written to the file. To correct this, check all ties ending at notes in the chord just read. If the starting pitch does not match the ending pitch, then find the correct note in the chord at which to end the tie.