### PR TITLE
[MU4] Fix #314696: Ties end at wrong note

### DIFF
--- a/src/libmscore/read206.cpp
+++ b/src/libmscore/read206.cpp
@@ -2334,6 +2334,25 @@ static void convertDoubleArticulations(Chord* chord, XmlReader& e)
 }
 
 //---------------------------------------------------------
+//   fixTies
+//---------------------------------------------------------
+
+static void fixTies(Chord* chord)
+{
+    std::vector<Note*> notes;
+    for (Note* note : chord->notes()) {
+        Tie* tie = note->tieBack();
+        if (tie && tie->startNote()->pitch() != note->pitch()) {
+            notes.push_back(tie->startNote());
+        }
+    }
+    for (Note* note : notes) {
+        Note* endNote = chord->findNote(note->pitch());
+        note->tieFor()->setEndNote(endNote);
+    }
+}
+
+//---------------------------------------------------------
 //   readChord
 //---------------------------------------------------------
 
@@ -2370,6 +2389,7 @@ static void readChord(Chord* chord, XmlReader& e)
         }
     }
     convertDoubleArticulations(chord, e);
+    fixTies(chord);
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/314696.

Counterpart to #7190, which has been merged into 3.x. There is no earlier fix to revert, since it was never merged into master.