### PR TITLE
fix measure number colliding with brackets

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -110,7 +110,7 @@ namespace Ms {
 
 void Element::spatiumChanged(qreal oldValue, qreal newValue)
       {
-      if (sizeIsSpatiumDependent())
+      if (offsetIsSpatiumDependent())
             _offset *= (newValue / oldValue);
       }
 
@@ -121,7 +121,7 @@ void Element::spatiumChanged(qreal oldValue, qreal newValue)
 
 void Element::localSpatiumChanged(qreal oldValue, qreal newValue)
       {
-      if (sizeIsSpatiumDependent())
+      if (offsetIsSpatiumDependent())
             _offset *= (newValue / oldValue);
       }
 
@@ -138,6 +138,15 @@ qreal Element::spatium() const
             Staff* s = staff();
             return s ? s->spatium(this) : score()->spatium();
             }
+      }
+
+//---------------------------------------------------------
+//   offsetIsSpatiumDependent
+//---------------------------------------------------------
+
+bool Element::offsetIsSpatiumDependent() const
+      {
+      return sizeIsSpatiumDependent() || (parent() && !parent()->isBox());
       }
 
 //---------------------------------------------------------

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -223,6 +223,7 @@ class Element : public ScoreElement {
 
       virtual bool sizeIsSpatiumDependent() const override { return !flag(ElementFlag::SIZE_SPATIUM_DEPENDENT); }
       void setSizeIsSpatiumDependent(bool v)  { setFlag(ElementFlag::SIZE_SPATIUM_DEPENDENT, !v); }
+      virtual bool offsetIsSpatiumDependent() const override;
 
       Placement placement() const             { return Placement(!flag(ElementFlag::PLACE_ABOVE));  }
       void setPlacement(Placement val)        { setFlag(ElementFlag::PLACE_ABOVE, !bool(val)); }

--- a/libmscore/scoreElement.cpp
+++ b/libmscore/scoreElement.cpp
@@ -370,7 +370,7 @@ void ScoreElement::readProperty(XmlReader& e, Pid id)
                   v = v.toPointF() * score()->spatium();
                   break;
             case P_TYPE::POINT_SP_MM:
-                  if (sizeIsSpatiumDependent())
+                  if (offsetIsSpatiumDependent())
                         v = v.toPointF() * score()->spatium();
                   else
                         v = v.toPointF() * DPMM;
@@ -448,7 +448,7 @@ void ScoreElement::writeProperty(XmlWriter& xml, Pid pid) const
                   if ((qAbs(p1.x() - p2.x()) < 0.0001) && (qAbs(p1.y() - p2.y()) < 0.0001))
                         return;
                   }
-            qreal q = sizeIsSpatiumDependent() ? score()->spatium() : DPMM;
+            qreal q = offsetIsSpatiumDependent() ? score()->spatium() : DPMM;
             p = QVariant(p1/q);
             d = QVariant();
             }
@@ -883,7 +883,7 @@ QVariant ScoreElement::styleValue(Pid pid, Sid sid) const
                   }
             case P_TYPE::POINT_SP_MM: {
                   QPointF val = score()->styleV(sid).toPointF();
-                  if (sizeIsSpatiumDependent()) {
+                  if (offsetIsSpatiumDependent()) {
                         val *= score()->spatium();
                         if (isElement()) {
                               const Element* e = toElement(this);

--- a/libmscore/scoreElement.h
+++ b/libmscore/scoreElement.h
@@ -203,6 +203,7 @@ class ScoreElement {
       virtual void resetProperty(Pid id);
       QVariant propertyDefault(Pid pid, Tid tid) const;
       virtual bool sizeIsSpatiumDependent() const { return true; }
+      virtual bool offsetIsSpatiumDependent() const { return true; }
 
       virtual void reset();                     // reset all properties & position to default
 

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -105,7 +105,7 @@ void SpannerSegment::setSystem(System* s)
 void SpannerSegment::spatiumChanged(qreal ov, qreal nv) 
       {
       Element::spatiumChanged(ov, nv);
-      if (sizeIsSpatiumDependent())
+      if (offsetIsSpatiumDependent())
             _offset2 *= (nv / ov);
       }
 

--- a/mscore/inspector/inspectorBase.cpp
+++ b/mscore/inspector/inspectorBase.cpp
@@ -98,7 +98,7 @@ QVariant InspectorBase::getValue(const InspectorItem& ii) const
                   break;
             case P_TYPE::POINT_SP_MM: {
                   Element* e = inspector->element();
-                  if (e->sizeIsSpatiumDependent())
+                  if (e->offsetIsSpatiumDependent())
                         v = v.toPointF() * e->score()->spatium();
                   else
                         v = v.toPointF() * DPMM;
@@ -158,7 +158,7 @@ void InspectorBase::setValue(const InspectorItem& ii, QVariant val)
                   break;
             case P_TYPE::POINT_SP_MM: {
                   Element* e = inspector->element();
-                  if (e->sizeIsSpatiumDependent())
+                  if (e->offsetIsSpatiumDependent())
                         val = val.toPointF() / e->score()->spatium();
                   else
                         val = val.toPointF() / DPMM;
@@ -494,7 +494,7 @@ void InspectorBase::setStyleClicked(int i)
       else if (t == P_TYPE::POINT_SP)
             val = val.toPointF() / score->spatium();
       else if (t == P_TYPE::POINT_SP_MM) {
-            if (e->sizeIsSpatiumDependent())
+            if (e->offsetIsSpatiumDependent())
                   val = val.toPointF() / score->spatium();
             else
                   val = val.toPointF() / DPMM;

--- a/mscore/inspector/inspectorElementBase.cpp
+++ b/mscore/inspector/inspectorElementBase.cpp
@@ -45,7 +45,7 @@ InspectorElementBase::InspectorElementBase(QWidget* parent)
 void InspectorElementBase::setElement()
       {
       InspectorBase::setElement();
-      if (inspector->element()->sizeIsSpatiumDependent())
+      if (inspector->element()->offsetIsSpatiumDependent())
             e.offset->setSuffix("sp");
       else
             e.offset->setSuffix("mm");


### PR DESCRIPTION
When we changed measure numbers to not scale with staff size,
this caused the offset to not scalke either,
and this in turn causes the units to be interpreted as mm not sp.
The old default value of -2 is good for sp, but too small in mm.

A bandaid fix would be to increase the default value,
but the approach taken here is I think better.
The idea is that converting the offset units to mm
only makes sense for elements like titles that are placed in frames,
as opposed to elements lime measure numbers that are on staff.

So I have introduced a new function offsetIsSpatiumDependent(),
and I use it instead of sizeIsSpatiumDependent() in the relevant places.
The offset is considered spatium dependent if the size is,
*or* if the object is not attached to a frame.
There might be a better way to make the determination,
but this gets the job done.