### PR TITLE
Fix #287858 and Retranslate several dialogs on language switch

### DIFF
--- a/mscore/abstractdialog.cpp
+++ b/mscore/abstractdialog.cpp
@@ -26,11 +26,6 @@ AbstractDialog::AbstractDialog(QWidget * parent, Qt::WindowFlags f)
       {
       }
 
-AbstractDialog::~AbstractDialog()
-      {
-
-      }
-
 void AbstractDialog::changeEvent(QEvent *event)
       {
       QDialog::changeEvent(event);

--- a/mscore/abstractdialog.h
+++ b/mscore/abstractdialog.h
@@ -28,12 +28,10 @@ namespace Ms {
 
 class AbstractDialog : public QDialog
       {
-
-   Q_OBJECT
+      Q_OBJECT
 
    public:
       AbstractDialog(QWidget * parent = 0, Qt::WindowFlags f = {});
-      virtual ~AbstractDialog();
 
    protected:
       // change language event
@@ -42,7 +40,6 @@ class AbstractDialog : public QDialog
       // translate all strings
       virtual void retranslate() = 0;
       };
-
 }
 #endif
 

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -39,7 +39,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 EditStyle::EditStyle(Score* s, QWidget* parent)
-   : QDialog(parent), cs(s)
+   : AbstractDialog(parent), cs(s)
       {
       setObjectName("EditStyle");
       setupUi(this);
@@ -74,26 +74,6 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       QButtonGroup* fbStyle = new QButtonGroup(this);
       fbStyle->addButton(radioFBModern, 0);
       fbStyle->addButton(radioFBHistoric, 1);
-
-
-      const char* styles[] = {
-            QT_TRANSLATE_NOOP("EditStyleBase", "Continuous"),
-            QT_TRANSLATE_NOOP("EditStyleBase", "Dashed"),
-            QT_TRANSLATE_NOOP("EditStyleBase", "Dotted"),
-            QT_TRANSLATE_NOOP("EditStyleBase", "Dash-dotted"),
-            QT_TRANSLATE_NOOP("EditStyleBase", "Dash-dot-dotted")
-            };
-      int dta = 1;
-      voltaLineStyle->clear();
-      ottavaLineStyle->clear();
-      pedalLineStyle->clear();
-      for (const char* p : styles) {
-            QString trs = qApp->translate("EditStyleBase", p);
-            voltaLineStyle->addItem(trs, dta);
-            ottavaLineStyle->addItem(trs, dta);
-            pedalLineStyle->addItem(trs, dta);
-            ++dta;
-            }
 
       styleWidgets = {
       //   idx                --- showPercent      --- widget          --- resetButton
@@ -409,46 +389,6 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       { Sid::bendArrowWidth,    false, bendArrowWidth,    resetBendArrowWidth    },
       };
 
-      for (QComboBox* cb : std::vector<QComboBox*> {
-            lyricsPlacement, textLinePlacement, systemTextLinePlacement, hairpinPlacement, pedalLinePlacement,
-            trillLinePlacement, vibratoLinePlacement, dynamicsPlacement,
-            tempoTextPlacement, staffTextPlacement, rehearsalMarkPlacement,
-            measureNumberVPlacement, mmRestRangeVPlacement
-            }) {
-            cb->clear();
-            cb->addItem(tr("Above"), int(Placement::ABOVE));
-            cb->addItem(tr("Below"), int(Placement::BELOW));
-            }
-      for (QComboBox* cb : std::vector<QComboBox*> {
-           measureNumberHPlacement, mmRestRangeHPlacement
-           }) {
-            cb->clear();
-            cb->addItem(tr("Left"),   int(HPlacement::LEFT));
-            cb->addItem(tr("Center"), int(HPlacement::CENTER));
-            cb->addItem(tr("Right"),  int(HPlacement::RIGHT));
-            }
-
-      mmRestRangeBracketType->clear();
-      mmRestRangeBracketType->addItem(tr("None"),        int(MMRestRangeBracketType::NONE));
-      mmRestRangeBracketType->addItem(tr("Brackets"),    int(MMRestRangeBracketType::BRACKETS));
-      mmRestRangeBracketType->addItem(tr("Parentheses"), int(MMRestRangeBracketType::PARENTHESES));
-
-
-      autoplaceVerticalAlignRange->clear();
-      autoplaceVerticalAlignRange->addItem(tr("Segment"), int(VerticalAlignRange::SEGMENT));
-      autoplaceVerticalAlignRange->addItem(tr("Measure"), int(VerticalAlignRange::MEASURE));
-      autoplaceVerticalAlignRange->addItem(tr("System"),  int(VerticalAlignRange::SYSTEM));
-
-      tupletNumberType->clear();
-      tupletNumberType->addItem(tr("Number"), int(TupletNumberType::SHOW_NUMBER));
-      tupletNumberType->addItem(tr("Ratio"), int(TupletNumberType::SHOW_RELATION));
-      tupletNumberType->addItem(tr("None", "no tuplet number type"), int(TupletNumberType::NO_TEXT));
-
-      tupletBracketType->clear();
-      tupletBracketType->addItem(tr("Automatic"), int(TupletBracketType::AUTO_BRACKET));
-      tupletBracketType->addItem(tr("Bracket"), int(TupletBracketType::SHOW_BRACKET));
-      tupletBracketType->addItem(tr("None", "no tuplet bracket type"), int(TupletBracketType::SHOW_NO_BRACKET));
-
       pageList->setCurrentRow(0);
       accidentalsGroup->setVisible(false); // disable, not yet implemented
 
@@ -457,16 +397,6 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       for (auto i : ScoreFont::scoreFonts()) {
             musicalSymbolFont->addItem(i.name(), i.name());
             ++idx;
-            }
-
-      static const SymId ids[] = {
-            SymId::systemDivider, SymId::systemDividerLong, SymId::systemDividerExtraLong
-            };
-      for (SymId id : ids) {
-            const QString& un = Sym::id2userName(id);
-            const char* n  = Sym::id2name(id);
-            dividerLeftSym->addItem(un,  QVariant(QString(n)));
-            dividerRightSym->addItem(un, QVariant(QString(n)));
             }
 
       // figured bass init
@@ -478,90 +408,6 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
 
       // chord symbol init
       harmonyPlay->setChecked(true);
-
-      voicingSelectWidget->interpretBox->clear();
-      voicingSelectWidget->interpretBox->addItem(tr("Jazz"), int(0)); // two-item combobox for boolean style variant
-      voicingSelectWidget->interpretBox->addItem(tr("Literal"), int(1)); // true = literal
-
-      voicingSelectWidget->voicingBox->clear();
-      voicingSelectWidget->voicingBox->addItem(tr("Automatic"), int(Voicing::AUTO));
-      voicingSelectWidget->voicingBox->addItem(tr("Root Only"), int(Voicing::ROOT_ONLY));
-      voicingSelectWidget->voicingBox->addItem(tr("Close"), int(Voicing::CLOSE));
-      voicingSelectWidget->voicingBox->addItem(tr("Drop Two"), int(Voicing::DROP_2));
-      voicingSelectWidget->voicingBox->addItem(tr("Six Note"), int(Voicing::SIX_NOTE));
-      voicingSelectWidget->voicingBox->addItem(tr("Four Note"), int(Voicing::FOUR_NOTE));
-      voicingSelectWidget->voicingBox->addItem(tr("Three Note"), int(Voicing::THREE_NOTE));
-
-      voicingSelectWidget->durationBox->clear();
-      voicingSelectWidget->durationBox->addItem(tr("Until Next Chord Symbol"), int(HDuration::UNTIL_NEXT_CHORD_SYMBOL));
-      voicingSelectWidget->durationBox->addItem(tr("Until End of Measure"), int(HDuration::STOP_AT_MEASURE_END));
-      voicingSelectWidget->durationBox->addItem(tr("Chord/Rest Duration"), int(HDuration::SEGMENT_DURATION));
-
-      // keep in sync with implementation in Page::replaceTextMacros (page.cpp)
-      // jumping thru hoops here to make the job of translators easier, yet have a nice display
-      QString toolTipHeaderFooter
-            = QString("<html><head></head><body><p><b>")
-            + tr("Special symbols in header/footer")
-            + QString("</b></p>")
-            + QString("<table><tr><td>$p</td><td>-</td><td><i>")
-            + tr("Page number, except on first page")
-            + QString("</i></td></tr><tr><td>$N</td><td>-</td><td><i>")
-            + tr("Page number, if there is more than one page")
-            + QString("</i></td></tr><tr><td>$P</td><td>-</td><td><i>")
-            + tr("Page number, on all pages")
-            + QString("</i></td></tr><tr><td>$n</td><td>-</td><td><i>")
-            + tr("Number of pages")
-            + QString("</i></td></tr><tr><td>$f</td><td>-</td><td><i>")
-            + tr("File name")
-            + QString("</i></td></tr><tr><td>$F</td><td>-</td><td><i>")
-            + tr("File path+name")
-            + QString("</i></td></tr><tr><td>$i</td><td>-</td><td><i>")
-            + tr("Part name, except on first page")
-            + QString("</i></td></tr><tr><td>$I</td><td>-</td><td><i>")
-            + tr("Part name, on all pages")
-            + QString("</i></td></tr><tr><td>$d</td><td>-</td><td><i>")
-            + tr("Current date")
-            + QString("</i></td></tr><tr><td>$D</td><td>-</td><td><i>")
-            + tr("Creation date")
-            + QString("</i></td></tr><tr><td>$m</td><td>-</td><td><i>")
-            + tr("Last modification time")
-            + QString("</i></td></tr><tr><td>$M</td><td>-</td><td><i>")
-            + tr("Last modification date")
-            + QString("</i></td></tr><tr><td>$C</td><td>-</td><td><i>")
-            + tr("Copyright, on first page only")
-            + QString("</i></td></tr><tr><td>$c</td><td>-</td><td><i>")
-            + tr("Copyright, on all pages")
-            + QString("</i></td></tr><tr><td>$v</td><td>-</td><td><i>")
-            + tr("MuseScore version this score was last saved with")
-            + QString("</i></td></tr><tr><td>$r</td><td>-</td><td><i>")
-            + tr("MuseScore revision this score was last saved with")
-            + QString("</i></td></tr><tr><td>$$</td><td>-</td><td><i>")
-            + tr("The $ sign itself")
-            + QString("</i></td></tr><tr><td>$:tag:</td><td>-</td><td><i>")
-            + tr("Metadata tag, see below")
-            + QString("</i></td></tr></table><p>")
-            + tr("Available metadata tags and their current values")
-            + QString("<br />")
-            + tr("(in File > Score Properties…):")
-            + QString("</p><table>");
-      // show all tags for current score/part, see also Score::init()
-      if (!cs->isMaster()) {
-            QMapIterator<QString, QString> j(cs->masterScore()->metaTags());
-            while (j.hasNext()) {
-                  j.next();
-                  toolTipHeaderFooter += QString("<tr><td>%1</td><td>-</td><td>%2</td></tr>").arg(j.key()).arg(j.value());
-                  }
-            }
-      QMapIterator<QString, QString> i(cs->metaTags());
-      while (i.hasNext()) {
-            i.next();
-            toolTipHeaderFooter += QString("<tr><td>%1</td><td>-</td><td>%2</td></tr>").arg(i.key()).arg(i.value());
-            }
-      toolTipHeaderFooter += QString("</table></body></html>");
-      showHeader->setToolTip(toolTipHeaderFooter);
-      showHeader->setToolTipDuration(5000); // leaving the default value of -1 calculates the duration automatically and it takes too long
-      showFooter->setToolTip(toolTipHeaderFooter);
-      showFooter->setToolTipDuration(5000);
 
       connect(buttonBox,             SIGNAL(clicked(QAbstractButton*)), SLOT(buttonClicked(QAbstractButton*)));
       connect(enableVerticalSpread,  SIGNAL(toggled(bool)),             SLOT(enableVerticalSpreadClicked(bool)));
@@ -654,11 +500,6 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
             item->setData(Qt::UserRole, int(ss));
             textStyles->addItem(item);
             }
-
-      textStyleFrameType->clear();
-      textStyleFrameType->addItem(tr("None", "no frame for text"), int(FrameType::NO_FRAME));
-      textStyleFrameType->addItem(tr("Rectangle"), int(FrameType::SQUARE));
-      textStyleFrameType->addItem(tr("Circle"), int(FrameType::CIRCLE));
 
       resetTextStyleName->setIcon(*icons[int(Icons::reset_ICON)]);
       connect(resetTextStyleName, &QToolButton::clicked, [=](){ resetUserStyleName(); });
@@ -766,6 +607,8 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
 
       connect(textStyles, SIGNAL(currentRowChanged(int)), SLOT(textStyleChanged(int)));
       textStyles->setCurrentRow(0);
+
+      setTranslatedTexts();
 
       QRect scr = QGuiApplication::primaryScreen()->availableGeometry();
       QRect dlg = this->frameGeometry();
@@ -949,6 +792,182 @@ void EditStyle::gotoElement(Element* e)
             }
       }
 
+//---------------------------------------------------------
+//   retranslate
+//---------------------------------------------------------
+
+void EditStyle::retranslate()
+      {
+      retranslateUi(this);
+      setTranslatedTexts();
+      setValues();
+      }
+
+//---------------------------------------------------------
+//   setTranslatedTexts
+//---------------------------------------------------------
+
+void EditStyle::setTranslatedTexts()
+      {
+      const char* styles[] = {
+            QT_TRANSLATE_NOOP("EditStyleBase", "Continuous"),
+            QT_TRANSLATE_NOOP("EditStyleBase", "Dashed"),
+            QT_TRANSLATE_NOOP("EditStyleBase", "Dotted"),
+            QT_TRANSLATE_NOOP("EditStyleBase", "Dash-dotted"),
+            QT_TRANSLATE_NOOP("EditStyleBase", "Dash-dot-dotted")
+      };
+      int dta = 1;
+      voltaLineStyle->clear();
+      ottavaLineStyle->clear();
+      pedalLineStyle->clear();
+      for (const char* p : styles) {
+            QString trs = qApp->translate("EditStyleBase", p);
+            voltaLineStyle->addItem(trs, dta);
+            ottavaLineStyle->addItem(trs, dta);
+            pedalLineStyle->addItem(trs, dta);
+            ++dta;
+            }
+
+      for (QComboBox* cb : std::vector<QComboBox*> {
+            lyricsPlacement, textLinePlacement, systemTextLinePlacement, hairpinPlacement, pedalLinePlacement,
+            trillLinePlacement, vibratoLinePlacement, dynamicsPlacement,
+            tempoTextPlacement, staffTextPlacement, rehearsalMarkPlacement,
+            measureNumberVPlacement, mmRestRangeVPlacement
+            }) {
+            cb->clear();
+            cb->addItem(tr("Above"), int(Placement::ABOVE));
+            cb->addItem(tr("Below"), int(Placement::BELOW));
+            }
+      for (QComboBox* cb : std::vector<QComboBox*> {
+           measureNumberHPlacement, mmRestRangeHPlacement
+           }) {
+            cb->clear();
+            cb->addItem(tr("Left"),   int(HPlacement::LEFT));
+            cb->addItem(tr("Center"), int(HPlacement::CENTER));
+            cb->addItem(tr("Right"),  int(HPlacement::RIGHT));
+            }
+
+      mmRestRangeBracketType->clear();
+      mmRestRangeBracketType->addItem(tr("None"),        int(MMRestRangeBracketType::NONE));
+      mmRestRangeBracketType->addItem(tr("Brackets"),    int(MMRestRangeBracketType::BRACKETS));
+      mmRestRangeBracketType->addItem(tr("Parentheses"), int(MMRestRangeBracketType::PARENTHESES));
+
+      autoplaceVerticalAlignRange->clear();
+      autoplaceVerticalAlignRange->addItem(tr("Segment"), int(VerticalAlignRange::SEGMENT));
+      autoplaceVerticalAlignRange->addItem(tr("Measure"), int(VerticalAlignRange::MEASURE));
+      autoplaceVerticalAlignRange->addItem(tr("System"),  int(VerticalAlignRange::SYSTEM));
+
+      tupletNumberType->clear();
+      tupletNumberType->addItem(tr("Number"), int(TupletNumberType::SHOW_NUMBER));
+      tupletNumberType->addItem(tr("Ratio"),  int(TupletNumberType::SHOW_RELATION));
+      tupletNumberType->addItem(tr("None", "no tuplet number type"), int(TupletNumberType::NO_TEXT));
+
+      tupletBracketType->clear();
+      tupletBracketType->addItem(tr("Automatic"), int(TupletBracketType::AUTO_BRACKET));
+      tupletBracketType->addItem(tr("Bracket"),   int(TupletBracketType::SHOW_BRACKET));
+      tupletBracketType->addItem(tr("None", "no tuplet bracket type"), int(TupletBracketType::SHOW_NO_BRACKET));
+
+      static const SymId ids[] = {
+            SymId::systemDivider, SymId::systemDividerLong, SymId::systemDividerExtraLong
+            };
+      for (SymId id : ids) {
+            const QString& un = Sym::id2userName(id);
+            const char* n  = Sym::id2name(id);
+            dividerLeftSym->addItem(un,  QVariant(QString(n)));
+            dividerRightSym->addItem(un, QVariant(QString(n)));
+            }
+
+      voicingSelectWidget->interpretBox->clear();
+      voicingSelectWidget->interpretBox->addItem(tr("Jazz"), int(0)); // two-item combobox for boolean style variant
+      voicingSelectWidget->interpretBox->addItem(tr("Literal"), int(1)); // true = literal
+
+      voicingSelectWidget->voicingBox->clear();
+      voicingSelectWidget->voicingBox->addItem(tr("Automatic"), int(Voicing::AUTO));
+      voicingSelectWidget->voicingBox->addItem(tr("Root Only"), int(Voicing::ROOT_ONLY));
+      voicingSelectWidget->voicingBox->addItem(tr("Close"), int(Voicing::CLOSE));
+      voicingSelectWidget->voicingBox->addItem(tr("Drop Two"), int(Voicing::DROP_2));
+      voicingSelectWidget->voicingBox->addItem(tr("Six Note"), int(Voicing::SIX_NOTE));
+      voicingSelectWidget->voicingBox->addItem(tr("Four Note"), int(Voicing::FOUR_NOTE));
+      voicingSelectWidget->voicingBox->addItem(tr("Three Note"), int(Voicing::THREE_NOTE));
+
+      voicingSelectWidget->durationBox->clear();
+      voicingSelectWidget->durationBox->addItem(tr("Until Next Chord Symbol"), int(HDuration::UNTIL_NEXT_CHORD_SYMBOL));
+      voicingSelectWidget->durationBox->addItem(tr("Until End of Measure"), int(HDuration::STOP_AT_MEASURE_END));
+      voicingSelectWidget->durationBox->addItem(tr("Chord/Rest Duration"), int(HDuration::SEGMENT_DURATION));
+
+      // keep in sync with implementation in Page::replaceTextMacros (page.cpp)
+      // jumping thru hoops here to make the job of translators easier, yet have a nice display
+      QString toolTipHeaderFooter
+            = QString("<html><head></head><body><p><b>")
+            + tr("Special symbols in header/footer")
+            + QString("</b></p>")
+            + QString("<table><tr><td>$p</td><td>-</td><td><i>")
+            + tr("Page number, except on first page")
+            + QString("</i></td></tr><tr><td>$N</td><td>-</td><td><i>")
+            + tr("Page number, if there is more than one page")
+            + QString("</i></td></tr><tr><td>$P</td><td>-</td><td><i>")
+            + tr("Page number, on all pages")
+            + QString("</i></td></tr><tr><td>$n</td><td>-</td><td><i>")
+            + tr("Number of pages")
+            + QString("</i></td></tr><tr><td>$f</td><td>-</td><td><i>")
+            + tr("File name")
+            + QString("</i></td></tr><tr><td>$F</td><td>-</td><td><i>")
+            + tr("File path+name")
+            + QString("</i></td></tr><tr><td>$i</td><td>-</td><td><i>")
+            + tr("Part name, except on first page")
+            + QString("</i></td></tr><tr><td>$I</td><td>-</td><td><i>")
+            + tr("Part name, on all pages")
+            + QString("</i></td></tr><tr><td>$d</td><td>-</td><td><i>")
+            + tr("Current date")
+            + QString("</i></td></tr><tr><td>$D</td><td>-</td><td><i>")
+            + tr("Creation date")
+            + QString("</i></td></tr><tr><td>$m</td><td>-</td><td><i>")
+            + tr("Last modification time")
+            + QString("</i></td></tr><tr><td>$M</td><td>-</td><td><i>")
+            + tr("Last modification date")
+            + QString("</i></td></tr><tr><td>$C</td><td>-</td><td><i>")
+            + tr("Copyright, on first page only")
+            + QString("</i></td></tr><tr><td>$c</td><td>-</td><td><i>")
+            + tr("Copyright, on all pages")
+            + QString("</i></td></tr><tr><td>$v</td><td>-</td><td><i>")
+            + tr("MuseScore version this score was last saved with")
+            + QString("</i></td></tr><tr><td>$r</td><td>-</td><td><i>")
+            + tr("MuseScore revision this score was last saved with")
+            + QString("</i></td></tr><tr><td>$$</td><td>-</td><td><i>")
+            + tr("The $ sign itself")
+            + QString("</i></td></tr><tr><td>$:tag:</td><td>-</td><td><i>")
+            + tr("Metadata tag, see below")
+            + QString("</i></td></tr></table><p>")
+            + tr("Available metadata tags and their current values")
+            + QString("<br />")
+            + tr("(in File > Score Properties…):")
+            + QString("</p><table>");
+      // show all tags for current score/part, see also Score::init()
+      if (!cs->isMaster()) {
+            QMapIterator<QString, QString> j(cs->masterScore()->metaTags());
+            while (j.hasNext()) {
+                  j.next();
+                  toolTipHeaderFooter += QString("<tr><td>%1</td><td>-</td><td>%2</td></tr>").arg(j.key()).arg(j.value());
+                  }
+            }
+      QMapIterator<QString, QString> i(cs->metaTags());
+      while (i.hasNext()) {
+            i.next();
+            toolTipHeaderFooter += QString("<tr><td>%1</td><td>-</td><td>%2</td></tr>").arg(i.key()).arg(i.value());
+            }
+      toolTipHeaderFooter += QString("</table></body></html>");
+      showHeader->setToolTip(toolTipHeaderFooter);
+      showHeader->setToolTipDuration(5000); // leaving the default value of -1 calculates the duration automatically and it takes too long
+      showFooter->setToolTip(toolTipHeaderFooter);
+      showFooter->setToolTipDuration(5000);
+
+      textStyleFrameType->clear();
+      textStyleFrameType->addItem(tr("None", "no frame for text"), int(FrameType::NO_FRAME));
+      textStyleFrameType->addItem(tr("Rectangle"), int(FrameType::SQUARE));
+      textStyleFrameType->addItem(tr("Circle"), int(FrameType::CIRCLE));
+
+      buttonApplyToAllParts->setText(tr("Apply to all Parts"));
+      }
 //---------------------------------------------------------
 //   showEvent
 //---------------------------------------------------------

--- a/mscore/editstyle.h
+++ b/mscore/editstyle.h
@@ -21,6 +21,7 @@
 #define __EDITSTYLE_H__
 
 #include "ui_editstyle.h"
+#include "abstractdialog.h"
 #include "globals.h"
 #include "libmscore/mscore.h"
 #include "libmscore/style.h"
@@ -55,7 +56,7 @@ typedef QWidget* EditStyle::* EditStylePage;
 //   EditStyle
 //---------------------------------------------------------
 
-class EditStyle : public QDialog, private Ui::EditStyleBase {
+class EditStyle : public AbstractDialog, private Ui::EditStyleBase {
       Q_OBJECT
 
       Score* cs = nullptr;
@@ -66,6 +67,7 @@ class EditStyle : public QDialog, private Ui::EditStyleBase {
       bool hasShown = false;
       bool needResetStyle = false;
 
+      void setTranslatedTexts();
       virtual void showEvent(QShowEvent*);
       virtual void hideEvent(QHideEvent*);
       QVariant getValue(Sid idx);
@@ -105,6 +107,9 @@ class EditStyle : public QDialog, private Ui::EditStyleBase {
       void editUserStyleName();
       void endEditUserStyleName();
       void resetUserStyleName();
+
+   protected:
+      virtual void retranslate();
 
    public:
       EditStyle(Score*, QWidget*);

--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -45,7 +45,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 InstrumentsDialog::InstrumentsDialog(QWidget* parent)
-   : QDialog(parent)
+   : AbstractDialog(parent)
       {
       setObjectName("Instruments");
       setupUi(this);
@@ -65,6 +65,15 @@ InstrumentsDialog::InstrumentsDialog(QWidget* parent)
 void InstrumentsDialog::init()
       {
       instrumentsWidget->init();
+      }
+
+//---------------------------------------------------------
+//   retranslate
+//---------------------------------------------------------
+
+void InstrumentsDialog::retranslate()
+      {
+      retranslateUi(this);
       }
 
 //---------------------------------------------------------

--- a/mscore/instrdialog.h
+++ b/mscore/instrdialog.h
@@ -14,6 +14,7 @@
 #define __INSTRDIALOG_H__
 
 #include "ui_instrdialog.h"
+#include "abstractdialog.h"
 
 namespace Ms {
 
@@ -23,7 +24,7 @@ class Score;
 //   InstrumentsDialog
 //---------------------------------------------------------
 
-class InstrumentsDialog : public QDialog, public Ui::InstrumentsDialog {
+class InstrumentsDialog : public AbstractDialog, public Ui::InstrumentsDialog {
       Q_OBJECT
 
       void readSettings();
@@ -33,6 +34,9 @@ class InstrumentsDialog : public QDialog, public Ui::InstrumentsDialog {
       void buttonBoxClicked(QAbstractButton*);
       void on_saveButton_clicked();
       void on_loadButton_clicked();
+      
+   protected:
+      virtual void retranslate();
 
    public:
       InstrumentsDialog(QWidget* parent = 0);

--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -513,6 +513,26 @@ InstrumentsWidget::InstrumentsWidget(QWidget* parent)
       }
 
 //---------------------------------------------------------
+//   changeEvent
+//---------------------------------------------------------
+
+void InstrumentsWidget::changeEvent(QEvent* event)
+      {
+      QWidget::changeEvent(event);
+      if (event->type() == QEvent::LanguageChange)
+            retranslate();
+      }
+
+//---------------------------------------------------------
+//   retranslate
+//---------------------------------------------------------
+
+void InstrumentsWidget::retranslate()
+      {
+      retranslateUi(this);
+      }
+
+//---------------------------------------------------------
 //   populateGenreCombo
 //---------------------------------------------------------
 

--- a/mscore/instrwidget.h
+++ b/mscore/instrwidget.h
@@ -180,6 +180,10 @@ class InstrumentsWidget : public QWidget, public Ui::InstrumentsWidget {
       void filterInstrumentsByGenre(QTreeWidget *, QString);
       void sortInstruments();
       void updateScoreOrder();
+      
+   protected:
+      virtual void changeEvent(QEvent*);
+      void retranslate();
 
    public slots:
       void buildTemplateList();

--- a/mscore/mixer/mixer.cpp
+++ b/mscore/mixer/mixer.cpp
@@ -228,6 +228,8 @@ void Mixer::retranslate(bool firstTime)
       {
       setWindowTitle(qApp->translate("Mixer", "Mixer"));
       if (!firstTime) {
+            retranslateUi(this);
+            mixerDetails->retranslateUi(mixerDetails);
             for (int i = 0; i < trackAreaLayout->count(); i++) {
                   PartEdit* p = getPartAtIndex(i);
                   if (p) p->retranslateUi(p);

--- a/mscore/texttools.cpp
+++ b/mscore/texttools.cpp
@@ -55,54 +55,49 @@ TextTools::TextTools(QWidget* parent)
    : QDockWidget(parent)
       {
       setObjectName("text-tools");
-      setWindowTitle(tr("Text Tools"));
       setAllowedAreas(Qt::DockWidgetAreas(Qt::TopDockWidgetArea | Qt::BottomDockWidgetArea));
       setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
 
       text = nullptr;
       cursor = nullptr;
 
-      QToolBar* tb = new QToolBar(tr("Text Edit"));
-      tb->setIconSize(QSize(preferences.getInt(PREF_UI_THEME_ICONWIDTH) * guiScaling, preferences.getInt(PREF_UI_THEME_ICONHEIGHT) * guiScaling));
+      toolbar = new QToolBar(tr("Text Edit"));
+      toolbar->setIconSize(QSize(preferences.getInt(PREF_UI_THEME_ICONWIDTH) * guiScaling,
+                                 preferences.getInt(PREF_UI_THEME_ICONHEIGHT) * guiScaling));
 
       showKeyboard = getAction("show-keys");
       showKeyboard->setCheckable(true);
-      tb->addAction(showKeyboard);
+      toolbar->addAction(showKeyboard);
 
-      typefaceBold = tb->addAction(*icons[int(Icons::textBold_ICON)], "");
-      typefaceBold->setToolTip(tr("Bold"));
+      typefaceBold = toolbar->addAction(*icons[int(Icons::textBold_ICON)], "");
       typefaceBold->setCheckable(true);
 
-      typefaceItalic = tb->addAction(*icons[int(Icons::textItalic_ICON)], "");
-      typefaceItalic->setToolTip(tr("Italic"));
+      typefaceItalic = toolbar->addAction(*icons[int(Icons::textItalic_ICON)], "");
       typefaceItalic->setCheckable(true);
 
-      typefaceUnderline = tb->addAction(*icons[int(Icons::textUnderline_ICON)], "");
-      typefaceUnderline->setToolTip(tr("Underline"));
+      typefaceUnderline = toolbar->addAction(*icons[int(Icons::textUnderline_ICON)], "");
       typefaceUnderline->setCheckable(true);
 
-      tb->addSeparator();
+      toolbar->addSeparator();
 
-      typefaceSubscript   = tb->addAction(*icons[int(Icons::textSub_ICON)], "");
-      typefaceSubscript->setToolTip(tr("Subscript"));
+      typefaceSubscript = toolbar->addAction(*icons[int(Icons::textSub_ICON)], "");
       typefaceSubscript->setCheckable(true);
 
-      typefaceSuperscript = tb->addAction(*icons[int(Icons::textSuper_ICON)], "");
-      typefaceSuperscript->setToolTip(tr("Superscript"));
+      typefaceSuperscript = toolbar->addAction(*icons[int(Icons::textSuper_ICON)], "");
       typefaceSuperscript->setCheckable(true);
 
-      tb->addSeparator();
+      toolbar->addSeparator();
 
       typefaceFamily = new QFontComboBox(this);
       typefaceFamily->setEditable(false);
-      tb->addWidget(typefaceFamily);
+      toolbar->addWidget(typefaceFamily);
 
       typefaceSize = new QDoubleSpinBox(this);
       typefaceSize->setFocusPolicy(Qt::ClickFocus);
       typefaceSize->setMinimum(1);
-      tb->addWidget(typefaceSize);
+      toolbar->addWidget(typefaceSize);
 
-      setWidget(tb);
+      setWidget(toolbar);
       QWidget* w = new QWidget(this);
       setTitleBarWidget(w);
       titleBarWidget()->hide();
@@ -115,6 +110,33 @@ TextTools::TextTools(QWidget* parent)
       connect(typefaceSubscript,   SIGNAL(triggered(bool)), SLOT(subscriptClicked(bool)));
       connect(typefaceSuperscript, SIGNAL(triggered(bool)), SLOT(superscriptClicked(bool)));
       connect(showKeyboard,        SIGNAL(toggled(bool)),   SLOT(showKeyboardClicked(bool)));
+      
+      retranslate();
+      }
+
+//---------------------------------------------------------
+//   retranslate
+//---------------------------------------------------------
+
+void TextTools::retranslate()
+      {
+      setWindowTitle(tr("Text Tools"));
+      toolbar->setWindowTitle(tr("Text Edit"));
+      typefaceBold->setToolTip(tr("Bold"));
+      typefaceItalic->setToolTip(tr("Italic"));
+      typefaceSubscript->setToolTip(tr("Subscript"));
+      typefaceSuperscript->setToolTip(tr("Superscript"));
+      }
+
+//---------------------------------------------------------
+//   changeEvent
+//---------------------------------------------------------
+
+void TextTools::changeEvent(QEvent* event)
+      {
+      QDockWidget::changeEvent(event);
+      if (event->type() == QEvent::LanguageChange)
+            retranslate();
       }
 
 //---------------------------------------------------------
@@ -341,4 +363,3 @@ void TextTools::showKeyboardClicked(bool val)
             }
       }
 }
-

--- a/mscore/texttools.h
+++ b/mscore/texttools.h
@@ -30,6 +30,7 @@ class TextTools : public QDockWidget {
       TextBase* text;
       TextCursor* cursor;
 
+      QToolBar* toolbar;
       QDoubleSpinBox* typefaceSize;
       QFontComboBox* typefaceFamily;
       QAction* typefaceBold;
@@ -52,6 +53,10 @@ class TextTools : public QDockWidget {
       void subscriptClicked(bool);
       void superscriptClicked(bool);
       void showKeyboardClicked(bool);
+      
+   protected:
+      void changeEvent(QEvent*);
+      void retranslate();
 
    public:
       TextTools(QWidget* parent = 0);

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -93,6 +93,17 @@ void TDockWidget::closeEvent(QCloseEvent* event)
       }
 
 //---------------------------------------------------------
+//   changeEvent
+//---------------------------------------------------------
+
+void TDockWidget::changeEvent(QEvent* event)
+      {
+      QDockWidget::changeEvent(event);
+      if (event->type() == QEvent::LanguageChange)
+            setWindowTitle(tr("Timeline"));
+      }
+
+//---------------------------------------------------------
 //   TRowLabels
 //---------------------------------------------------------
 
@@ -2425,6 +2436,34 @@ void Timeline::showEvent(QShowEvent* evt)
       QGraphicsView::showEvent(evt);
       if (!evt->spontaneous())
             setScore(_score);
+      }
+
+//---------------------------------------------------------
+//   changeEvent
+//---------------------------------------------------------
+
+void Timeline::changeEvent(QEvent* event)
+      {
+      QGraphicsView::changeEvent(event);
+      if (event->type() == QEvent::LanguageChange) {
+            _metas.clear();
+            std::tuple<QString, void (Timeline::*)(Segment*, int*, int), bool> t1(tr("Tempo"), &Ms::Timeline::tempoMeta, true);
+            std::tuple<QString, void (Timeline::*)(Segment*, int*, int), bool> t2(tr("Time Signature"), &Ms::Timeline::timeMeta, true);
+            std::tuple<QString, void (Timeline::*)(Segment*, int*, int), bool> t3(tr("Rehearsal Mark"), &Ms::Timeline::rehearsalMeta, true);
+            std::tuple<QString, void (Timeline::*)(Segment*, int*, int), bool> t4(tr("Key Signature"), &Ms::Timeline::keyMeta, true);
+            std::tuple<QString, void (Timeline::*)(Segment*, int*, int), bool> t5(tr("Barlines"), &Ms::Timeline::barlineMeta, true);
+            std::tuple<QString, void (Timeline::*)(Segment*, int*, int), bool> t6(tr("Jumps and Markers"), &Ms::Timeline::jumpMarkerMeta, true);
+            std::tuple<QString, void (Timeline::*)(Segment*, int*, int), bool> t7(tr("Measures"), &Ms::Timeline::measureMeta, true);
+            _metas.push_back(t1);
+            _metas.push_back(t2);
+            _metas.push_back(t3);
+            _metas.push_back(t4);
+            _metas.push_back(t5);
+            _metas.push_back(t6);
+            _metas.push_back(t7);
+
+            updateGridFull();
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/timeline.h
+++ b/mscore/timeline.h
@@ -43,6 +43,7 @@ class TDockWidget : public QDockWidget {
       QSplitter* _grid;
 
       virtual void closeEvent(QCloseEvent* event);
+      virtual void changeEvent(QEvent*);
 
    signals:
       void closed(bool);
@@ -198,6 +199,7 @@ class Timeline : public QGraphicsView {
       virtual void wheelEvent(QWheelEvent *event);
       virtual void leaveEvent(QEvent*);
       void showEvent(QShowEvent*) override;
+      virtual void changeEvent(QEvent*);
 
       unsigned correctMetaRow(unsigned row);
       int correctStave(int stave);

--- a/mscore/toolbarEditor.cpp
+++ b/mscore/toolbarEditor.cpp
@@ -41,7 +41,7 @@ void MuseScore::showToolbarEditor()
 //---------------------------------------------------------
 
 ToolbarEditor::ToolbarEditor(QWidget* parent)
-   : QDialog(parent)
+   : AbstractDialog(parent)
       {
       setObjectName("ToolbarEditor");
       setupUi(this);
@@ -76,6 +76,9 @@ ToolbarEditor::ToolbarEditor(QWidget* parent)
 
 void ToolbarEditor::init()
       {
+      for (int i = 0; i < toolbarList->count(); i++)
+            toolbarList->item(i)->setText(qApp->translate("toolbar", toolbars[i]));
+
       QString name = WorkspacesManager::currentWorkspace()->name();
       bool writable = !WorkspacesManager::currentWorkspace()->readOnly();
       if (!writable) {
@@ -92,6 +95,16 @@ void ToolbarEditor::init()
       new_toolbars->at(1) = mscore->fileOperationEntries();
       new_toolbars->at(2) = mscore->playbackControlEntries();
       toolbarChanged(toolbarList->currentRow());  // populate lists
+      }
+
+//---------------------------------------------------------
+//   retranslate
+//---------------------------------------------------------
+
+void ToolbarEditor::retranslate()
+      {
+      retranslateUi(this);
+      init();
       }
 
 //---------------------------------------------------------
@@ -122,14 +135,16 @@ void ToolbarEditor::populateLists(const std::list<const char*>& all, std::list<c
       availableList->clear();
       for (auto i : *current) {
             QAction* a = getAction(i);
-            QListWidgetItem* item;
-            QString actionName = QString(i);
+            QListWidgetItem* item = nullptr;
+            QString id = QString(i);
             if (a)
-                  item = new QListWidgetItem(a->icon(), actionName);
-            else if (actionName.isEmpty())
+                  // Remove '&', because text contains '&' signs for mnemonics,
+                  // but in a QListWidgetItem, you get the '&' instead of the mnemonic.
+                  item = new QListWidgetItem(a->icon(), a->text().remove('&'));
+            else if (id.isEmpty())
                   item = new QListWidgetItem(tr("Separator"));
             else
-                  item = new QListWidgetItem(actionName);
+                  item = new QListWidgetItem(id);
             item->setData(Qt::UserRole, QVariant::fromValue((void*)i));
             actionList->addItem(item);
             }
@@ -143,13 +158,13 @@ void ToolbarEditor::populateLists(const std::list<const char*>& all, std::list<c
                   }
             if (!found) {
                   QAction* a = getAction(i);
-                  QListWidgetItem* item = 0;
-                  QString actionName = QString(i);
+                  QListWidgetItem* item = nullptr;
+                  QString id = QString(i);
                   if (a)
-                        item = new QListWidgetItem(a->icon(), actionName);
-                  else if (!actionName.isEmpty())
-                        item = new QListWidgetItem(QString(i));
-				  if (item) {
+                        item = new QListWidgetItem(a->icon(), a->text().remove('&'));
+                  else if (!id.isEmpty())
+                        item = new QListWidgetItem(id);
+                  if (item) {
                         item->setData(Qt::UserRole, QVariant::fromValue((void*)i));
                         availableList->addItem(item);
                         }
@@ -161,10 +176,10 @@ void ToolbarEditor::populateLists(const std::list<const char*>& all, std::list<c
       }
 
 //---------------------------------------------------------
-//   isSpacer
+//   isSeparator
 //---------------------------------------------------------
 
-bool ToolbarEditor::isSpacer(QListWidgetItem* item) const
+bool ToolbarEditor::isSeparator(QListWidgetItem* item) const
       {
       return !*(const char*)(item->data(Qt::UserRole).value<void*>());
       }
@@ -180,7 +195,7 @@ void ToolbarEditor::addAction()
             return;
       QListWidgetItem* item = availableList->item(cr);
 
-      if (isSpacer(item)) {
+      if (isSeparator(item)) {
             QListWidgetItem* nitem = new QListWidgetItem(item->text());
             nitem->setData(Qt::UserRole, QVariant::fromValue((void*)""));
             item = nitem;
@@ -205,7 +220,7 @@ void ToolbarEditor::removeAction()
       if (cr == -1)
             return;
       QListWidgetItem* item = actionList->takeItem(cr);
-      if (!isSpacer(item))
+      if (!isSeparator(item))
             availableList->addItem(item);
       updateNewToolbar(toolbarList->currentRow());
       }

--- a/mscore/toolbarEditor.h
+++ b/mscore/toolbarEditor.h
@@ -14,6 +14,7 @@
 #define __TOOLBAREDITOR_H__
 
 #include "ui_toolbarEditor.h"
+#include "abstractdialog.h"
 
 namespace Ms {
 
@@ -21,16 +22,17 @@ namespace Ms {
 //   ToolbarEditor
 //---------------------------------------------------------
 
-class ToolbarEditor : public QDialog, public Ui::ToolbarEditor {
+class ToolbarEditor : public AbstractDialog, public Ui::ToolbarEditor {
       Q_OBJECT
 
       std::vector<std::list<const char*>*> *new_toolbars;
       void updateNewToolbar(int toolbar_to_update);
 
       void populateLists(const std::list<const char*>&, std::list<const char*>*);
-      bool isSpacer(QListWidgetItem*) const;
+      bool isSeparator(QListWidgetItem*) const;
 
       virtual void hideEvent(QHideEvent*);
+      
    private slots:
       void toolbarChanged(int);
       void addAction();
@@ -38,6 +40,9 @@ class ToolbarEditor : public QDialog, public Ui::ToolbarEditor {
       void upAction();
       void downAction();
       void accepted();
+      
+   protected:
+      virtual void retranslate();
 
    public:
       ToolbarEditor(QWidget* parent = 0);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/287858

- Retranslate Style Dialog on language switch
- Retranslate Instruments Dialog on language switch
- Fix #287858: Make the Edit Toolbars Dialog fully (re)translatable
- Retranslate Text Tools on language switch
- Retranslate Timeline on language switch
- Retranslate Mixer on language switch

---

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
