### PR TITLE
fix #312029: don't scale fingering with note size

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2102,8 +2102,8 @@ void Note::layout2()
       for (Element* e : _el) {
             if (!score()->tagIsValid(e->tag()))
                   continue;
-            e->setMag(mag());
             if (e->isSymbol()) {
+                  e->setMag(mag());
                   qreal w = headWidth();
                   Symbol* sym = toSymbol(e);
                   e->layout();
@@ -2120,6 +2120,7 @@ void Note::layout2()
                         }
                   }
             else if (e->isFingering()) {
+                  // don't set mag; fingerings should not scale with note
                   Fingering* f = toFingering(e);
                   if (f->propertyFlags(Pid::PLACEMENT) == PropertyFlags::STYLED)
                         f->setPlacement(f->calculatePlacement());
@@ -2129,6 +2130,7 @@ void Note::layout2()
                         f->layout();
                   }
             else {
+                  e->setMag(mag());
                   e->layout();
                   }
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/312029

A recent change to text layout for the sake of scale tuplet numbers
caused fingerings to start scaling with note size.
On one hand this might seem desirable, in practice it seems not.
After discussion on Telegram, it was decided to keep fingerings
full size when making notes small.

The original change - to have text layout respect
the text element's own "mag" setting - is good.
The fix here is to prevent changes to note sizes
from affecting the fingering "mag".