### PR TITLE
Fix #314910: Cutaway courtesy clefs in 3.6 don't show before time sig…

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2879,7 +2879,7 @@ bool Measure::isEmpty(int staffIdx) const
 //---------------------------------------------------------
 //   isCutawayClef
 ///    Check for empty measure with only
-///    a Courtesy Clef before the End Bar Line
+///    a Courtesy Clef before End Bar Line
 //---------------------------------------------------------
 
 bool Measure::isCutawayClef(int staffIdx) const
@@ -2896,7 +2896,14 @@ bool Measure::isCutawayClef(int staffIdx) const
             strack = staffIdx * VOICES;
             etrack = strack + VOICES;
             }
-      Segment* s = last()->prev();
+      // find segment before EndBarLine
+      Segment* s;
+      for (Segment* ls = last(); ls; ls = ls->prev()) {
+            if (ls->segmentType() ==  SegmentType::EndBarLine) {
+                  s = ls->prev();
+                  break;
+                  }
+            }
       if (!s)
             return false;
       for (int track = strack; track < etrack; ++track) {


### PR DESCRIPTION
…natures

Resolves: *https://musescore.org/en/node/315014*

*Fixes cutaway courtesy clefs not showing when the EndBarLine segment is not the last segment in the measure. (This happens when there is a time signature or a key signature in next measure, generating timesig/keysig Courtesy segments)*

This is an improvement to functionality introduced in PR #6461.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [NA] I created the test (mtest, vtest, script test) to verify the changes I made
