### PR TITLE
[Mu3]: Fix #315002: Prevent potential crash

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1477,7 +1477,7 @@ qreal Chord::minAbsStemLength() const
 
       // two-note tremolo
       else {
-            if (_tremolo->chord1()->up() == _tremolo->chord2()->up()) {
+            if (_tremolo->chord2() && _tremolo->chord1()->up() == _tremolo->chord2()->up()) {
                   const qreal tremoloMinHeight = _tremolo->minHeight() * spatium();
                   return tremoloMinHeight + beamLvl * beamDist + 2 * td * spatium();
                   }


### PR DESCRIPTION
Partly resolves: https://musescore.org/en/node/315002 (forum topic) and https://musescore.org/en/node/315067 (issue tracker)

In the sample score from that forum post MuseScore crashes on (one of the 2) two-note tremolos that for some strange reason (_swapping notes with keyboard shortcut_) had no 2nd chord.
This PR just checks whether a 2nd chord exists before checking whether it is stem up or down.

A real fix would either prevent that swapping of notes on a 2-note tremolo or, even better, just make it work.

@Howard-C ?