### PR TITLE
Filter unused "customised" score orders.

### DIFF
--- a/libmscore/scoreOrder.cpp
+++ b/libmscore/scoreOrder.cpp
@@ -193,7 +193,7 @@ ScoreOrder* ScoreOrder::clone()
             }
       order->instrumentMap = instrumentMap;
       order->_groupMultiplier = _groupMultiplier;
-      order->_customised = true;
+      order->_customized = true;
       return order;
       }
 
@@ -207,7 +207,7 @@ void ScoreOrder::init()
       _soloists = nullptr;
       _unsorted = nullptr;
       _groupMultiplier = 1;
-      _customised = false;
+      _customized = false;
       if (!isCustom()) {
             for (auto ig : instrumentGroups)
                   _groupMultiplier += ig->instrumentTemplates.size();
@@ -381,7 +381,7 @@ void ScoreOrder::createUnsortedGroup()
 
 QString ScoreOrder::getId() const
       {
-      if (_customised)
+      if (_customized)
             return QString("%1-%2").arg(_id).arg(reinterpret_cast<quintptr>(this), 0, 16);
       else
             return _id;
@@ -402,7 +402,7 @@ QString ScoreOrder::getName() const
 
 QString ScoreOrder::getFullName() const
       {
-      if (_customised)
+      if (_customized)
             return QObject::tr("%1 (Customized)").arg(_name);
       else
             return getName();
@@ -418,22 +418,22 @@ bool ScoreOrder::isCustom() const
       }
 
 //---------------------------------------------------------
-//   isCustomised
+//   isCustomized
 //---------------------------------------------------------
 
-bool ScoreOrder::isCustomised() const
+bool ScoreOrder::isCustomized() const
       {
-      return _customised;
+      return _customized;
       }
 
 //---------------------------------------------------------
-//   setCustomised
+//   setCustomized
 //---------------------------------------------------------
 
-void ScoreOrder::setCustomised()
+void ScoreOrder::setCustomized()
       {
       if (!isCustom())
-            _customised = true;
+            _customized = true;
       }
 
 //---------------------------------------------------------
@@ -473,7 +473,7 @@ void ScoreOrder::read(XmlReader& e)
       {
       init();
       const QString id { "" };
-      _customised = e.intAttribute("customised");
+      _customized = e.intAttribute("customised");
       while (e.readNextStartElement()) {
             const QStringRef& tag(e.name());
             if (tag == "name")
@@ -504,7 +504,7 @@ void ScoreOrder::write(XmlWriter& xml) const
       if (isCustom())
             return;
 
-      xml.stag(QString("Order id=\"%1\" customised=\"%2\"").arg(_id).arg(_customised));
+      xml.stag(QString("Order id=\"%1\" customised=\"%2\"").arg(_id).arg(_customized));
       xml.tag("name", _name);
 
       QMapIterator<QString, InstrumentOverwrite> i(instrumentMap);
@@ -784,26 +784,26 @@ ScoreOrder* ScoreOrderList::getById(const QString& id)
 //      return nullptr if no matching ScoreOrder is found
 //---------------------------------------------------------
 
-ScoreOrder* ScoreOrderList::findByName(const QString& name, bool customised)
+ScoreOrder* ScoreOrderList::findByName(const QString& name, bool customized)
       {
-      ScoreOrder* customisedOrder { nullptr };
+      ScoreOrder* customizedOrder { nullptr };
       for (ScoreOrder* order : _orders) {
             if (order->getName() == name) {
-                  if (customised)
+                  if (customized)
                         {
-                        if (order->isCustomised())
+                        if (order->isCustomized())
                               return order;
                         }
                   else
                         {
-                        if (order->isCustomised())
-                              customisedOrder = order;
+                        if (order->isCustomized())
+                              customizedOrder = order;
                         else
                               return order;
                         }
                   }
             }
-      return customisedOrder;
+      return customizedOrder;
       }
 
 //---------------------------------------------------------
@@ -880,12 +880,12 @@ void ScoreOrderList::addScoreOrder(ScoreOrder* order)
       if (!order || _orders.contains(order))
             return;
 
-      if (!order->isCustomised()) {
+      if (!order->isCustomized()) {
             append(order);
             return;
             }
 
-      if (order->isCustomised()) {
+      if (order->isCustomized()) {
             for (int index { 0 }; index < _orders.size(); ++index) {
                   if (_orders[index]->getName() == order->getName()) {
                         _orders.insert(index+1, order);

--- a/libmscore/scoreOrder.h
+++ b/libmscore/scoreOrder.h
@@ -77,7 +77,7 @@ class ScoreOrder {
       ScoreGroup* _soloists;
       ScoreGroup* _unsorted;
       int _groupMultiplier;
-      bool _customised { false };
+      bool _customized { false };
 
    protected:
       QMap<QString, InstrumentOverwrite> instrumentMap;
@@ -107,8 +107,8 @@ class ScoreOrder {
       bool isCustom() const;
       void setOwner(Score *score);
       Score* getOwner() const;
-      bool isCustomised() const;
-      void setCustomised();
+      bool isCustomized() const;
+      void setCustomized();
 
       ScoreGroup* getGroup(const QString family, const QString instrumentGroup) const;
       ScoreGroup* getGroup(const QString instrumentId, bool soloist) const;
@@ -145,7 +145,7 @@ class ScoreOrderList {
 
       ScoreOrder* findById(const QString& orderId) const;
       ScoreOrder* getById(const QString& orderId);
-      ScoreOrder* findByName(const QString& orderName, bool customised=false);
+      ScoreOrder* findByName(const QString& orderName, bool customized=false);
       ScoreOrder* customScoreOrder() const;
       int getScoreOrderIndex(const ScoreOrder* order) const;
       QList<ScoreOrder*> searchScoreOrders(const QList<int>& indices) const;

--- a/mscore/instrwidget.h
+++ b/mscore/instrwidget.h
@@ -42,7 +42,7 @@ enum { PART_LIST_ITEM = QTreeWidgetItem::UserType, STAFF_LIST_ITEM };
 class ScoreOrderListModel : public QAbstractListModel {
    private:
       ScoreOrderList* _scoreOrders;
-      ScoreOrder* customisedOrder { nullptr };
+      ScoreOrder* _customizedOrder { nullptr };
 
    public:
       ScoreOrderListModel(ScoreOrderList* data, QObject* parent=nullptr);
@@ -51,7 +51,24 @@ class ScoreOrderListModel : public QAbstractListModel {
       QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
       void rebuildData();
 
-      void setCustomisedOrder(ScoreOrder* order);
+      void setCustomizedOrder(ScoreOrder* order);
+      };
+
+//---------------------------------------------------------
+//   ScoreOrderFilterProxyModel
+//---------------------------------------------------------
+
+class ScoreOrderFilterProxyModel : public QSortFilterProxyModel {
+   private:
+      ScoreOrderList* _scoreOrders;
+      ScoreOrder* _customizedOrder { nullptr };
+
+   public:
+      ScoreOrderFilterProxyModel(ScoreOrderList* data, QObject* parent=nullptr);
+      void setCustomizedOrder(ScoreOrder* order);
+
+   protected:
+      virtual bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
       };
 
 //---------------------------------------------------------
@@ -159,7 +176,7 @@ class InstrumentsWidget : public QWidget, public Ui::InstrumentsWidget {
       Q_OBJECT
 
       ScoreOrderListModel* _model;
-
+      ScoreOrderFilterProxyModel* _filter;
       int findPrvItem(PartListItem* pli, bool insert, int number=-1);
       QTreeWidgetItem* movePartItem(int oldPos, int newPos);
 


### PR DESCRIPTION
Resolves: https://trello.com/c/9n0YLhyS/90-two-orchestra-customised-options-in-the-ordering-dropdown

Adds a filter in the list of available score orders and passes a custumised score order for the score only.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
