### PR TITLE
[MU3] Fix #315106: Show 2 decimals for Tempo in Play Panel

### DIFF
--- a/mscore/playpanel.cpp
+++ b/mscore/playpanel.cpp
@@ -244,8 +244,7 @@ double PlayPanel::speed() const
 
 void PlayPanel::setTempo(double val)
       {
-      int tempo = lrint(val * 60.0);
-      tempoLabel->setText(tr("Tempo\n%1 BPM").arg(tempo, 3, 10, QLatin1Char(' ')));
+      tempoLabel->setText(tr("Tempo\n%1 BPM").arg(val * 60, 6, 'f', 2, QLatin1Char(' ')));
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/315106