### PR TITLE
Fixes for Edit Style Dialog

### DIFF
--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -1007,12 +1007,10 @@ void EditStyle::buttonClicked(QAbstractButton* b)
       {
       switch (buttonBox->standardButton(b)) {
             case QDialogButtonBox::Ok:
-                  done(1);
-                  cs->endCmd();
+                  accept();
                   break;
             case QDialogButtonBox::Cancel:
-                  done(0);
-                  cs->endCmd(true);
+                  reject();
                   break;
             case QDialogButtonBox::NoButton:
             default:
@@ -1020,6 +1018,26 @@ void EditStyle::buttonClicked(QAbstractButton* b)
                         applyToAllParts();
                   break;
             }
+      }
+
+//---------------------------------------------------------
+//   accept
+//---------------------------------------------------------
+
+void EditStyle::accept()
+      {
+      cs->endCmd();
+      QDialog::accept();
+      }
+
+//---------------------------------------------------------
+//   reject
+//---------------------------------------------------------
+
+void EditStyle::reject()
+      {
+      cs->endCmd(true);
+      QDialog::reject();
       }
 
 //---------------------------------------------------------

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -45,10 +45,7 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       setupUi(this);
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
       buttonApplyToAllParts = buttonBox->addButton(tr("Apply to all Parts"), QDialogButtonBox::ApplyRole);
-      //buttonApplyToAllParts->setEnabled(!cs->isMaster()); // set in showEvent() now
       buttonTogglePagelist->setIcon(QIcon(*icons[int(Icons::goNext_ICON)]));
-      // Allow user to scroll/zoom score while selecting style options:
-      setModal(false);
 
       // create button groups for every set of radio button widgets
       // use this group widgets in list styleWidgets
@@ -665,7 +662,11 @@ void MuseScore::showStyleDialog(Element* e)
             _styleDlg->activateWindow();
             }
       else
-            _styleDlg->show();
+            // use `_styleDlg->show();` to show non-modally to allow
+            // user to scroll/zoom score while selecting style options;
+            // however, that must be properly implemented, otherwise it
+            // will cause problems.
+            _styleDlg->exec();
       }
 
 //---------------------------------------------------------

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -786,10 +786,9 @@ bool EditStyle::elementHasPage(Element* e)
 
 void EditStyle::gotoElement(Element* e)
       {
-      if (auto pagePointer = pageForElement(e)) {
+      if (auto pagePointer = pageForElement(e))
             if (QWidget* page = this->*pagePointer)
-                  pageStack->setCurrentWidget(page);
-            }
+                  setPage(pageStack->indexOf(page));
       }
 
 //---------------------------------------------------------
@@ -1570,7 +1569,8 @@ void EditStyle::systemMinDistanceValueChanged(double val)
 
 void EditStyle::setPage(int row)
       {
-      pageList->setCurrentRow(row);
+      if (row >= 0)
+            pageList->setCurrentRow(row);
       }
 
 //---------------------------------------------------------

--- a/mscore/editstyle.h
+++ b/mscore/editstyle.h
@@ -119,6 +119,10 @@ class EditStyle : public AbstractDialog, private Ui::EditStyleBase {
       void gotoElement(Element* e);
       void gotoHeaderFooterPage();
       static bool elementHasPage(Element* e);
+      
+   public slots:
+      void accept();
+      void reject();
       };
 
 


### PR DESCRIPTION
- **Resolves: https://trello.com/c/DE9tYdOL/97-style-dialog-shows-wrong-tab-in-left-column-upon-opening**
  Fix left column of Edit Style Dialog being not up-to-date
  When you right-clicked an item and chose 'Style…', the Style Dialog would show the correct page, but the left page still showed the first row selected. That is now fixed.

- **Resolves: https://trello.com/c/trG7Eihi/96-wrong-behavior-of-cancel-and-esc-in-style-dialog = https://musescore.org/en/node/315054**
  Fix #315054: Fix behavior of Esc key in Style Dialog

- **Temporarily resolves: https://trello.com/c/tFasP1lX/95-style-dialog-does-not-update-when-score-is-changed-shows-wrong-settings = https://musescore.org/en/node/315050**
  Temporary fix #315050: Show Edit Style Dialog modally, to prevent problems
  Actually reverts PR #6845, because getting this to work properly would require quite a lot of refactoring. 

---

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
