### PR TITLE
[MU4] Added macOS module and implement two dark mode improvements

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,10 @@ if (BUILD_UNIT_TESTS)
     add_subdirectory(libmscore/tests)
 endif(BUILD_UNIT_TESTS)
 
+if (OS_IS_MAC)
+    add_subdirectory(macos)
+endif()
+
 if (OS_IS_WASM)
     add_subdirectory(wasmtest)
 endif()

--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -27,8 +27,15 @@ void UiConfiguration::init()
     settings()->setDefaultValue(UI_MUSICAL_FONT_SIZE_KEY, Val(12));
 
     settings()->valueChanged(UI_THEME_TYPE_KEY).onReceive(nullptr, [this](const Val& val) {
-        m_currentThemeTypeChannel.send(static_cast<ThemeType>(val.toInt()));
+        m_currentPreferredThemeTypeChannel.send(static_cast<ThemeType>(val.toInt()));
+        m_currentActualThemeTypeChannel.send(actualThemeType());
     });
+
+#ifdef Q_OS_MAC
+    macos()->systemDarkModeSwitched().onReceive(nullptr, [this](const bool) {
+        m_currentActualThemeTypeChannel.send(actualThemeType());
+    });
+#endif
 
     settings()->valueChanged(UI_FONT_FAMILY_KEY).onReceive(nullptr, [this](const Val&) {
         m_fontChanged.notify();
@@ -52,14 +59,32 @@ void UiConfiguration::init()
     });
 }
 
-ThemeType UiConfiguration::themeType() const
+ThemeType UiConfiguration::preferredThemeType() const
 {
     return static_cast<ThemeType>(settings()->value(UI_THEME_TYPE_KEY).toInt());
 }
 
-Channel<ThemeType> UiConfiguration::themeTypeChanged() const
+Channel<ThemeType> UiConfiguration::preferredThemeTypeChanged() const
 {
-    return m_currentThemeTypeChannel;
+    return m_currentPreferredThemeTypeChannel;
+}
+
+ThemeType UiConfiguration::actualThemeType() const
+{
+    switch (preferredThemeType()) {
+    case IUiConfiguration::ThemeType::LIGHT_THEME:
+    case IUiConfiguration::ThemeType::DARK_THEME:
+        return preferredThemeType();
+#ifdef Q_OS_MAC
+    case IUiConfiguration::ThemeType::FOLLOW_SYSTEM_THEME:
+        return macos()->isSystemDarkModeOn() ? IUiConfiguration::ThemeType::DARK_THEME : IUiConfiguration::ThemeType::LIGHT_THEME;
+#endif
+    }
+}
+
+Channel<ThemeType> UiConfiguration::actualThemeTypeChanged() const
+{
+    return m_currentActualThemeTypeChannel;
 }
 
 std::string UiConfiguration::fontFamily() const

--- a/src/framework/ui/internal/uiconfiguration.h
+++ b/src/framework/ui/internal/uiconfiguration.h
@@ -22,6 +22,9 @@
 
 #include "iuiconfiguration.h"
 #include "imainwindow.h"
+#ifdef Q_OS_MAC
+#include "macos/imacos.h"
+#endif
 
 #include "modularity/ioc.h"
 
@@ -29,12 +32,17 @@ namespace mu::framework {
 class UiConfiguration : public IUiConfiguration
 {
     INJECT(framework, IMainWindow, mainWindow)
+#ifdef Q_OS_MAC
+    INJECT(framework, macos::IMacOS, macos)
+#endif
 
 public:
     void init();
 
-    ThemeType themeType() const override;
-    async::Channel<ThemeType> themeTypeChanged() const override;
+    ThemeType preferredThemeType() const override;
+    async::Channel<ThemeType> preferredThemeTypeChanged() const override;
+    ThemeType actualThemeType() const override;
+    async::Channel<ThemeType> actualThemeTypeChanged() const override;
 
     std::string fontFamily() const override;
     int fontSize(FontSizeType type) const override;
@@ -54,7 +62,8 @@ public:
     void setPhysicalDotsPerInch(std::optional<float> dpi) override;
 
 private:
-    async::Channel<ThemeType> m_currentThemeTypeChannel;
+    async::Channel<ThemeType> m_currentPreferredThemeTypeChannel;
+    async::Channel<ThemeType> m_currentActualThemeTypeChannel;
 
     async::Notification m_fontChanged;
     async::Notification m_musicalFontChanged;

--- a/src/framework/ui/iuiconfiguration.h
+++ b/src/framework/ui/iuiconfiguration.h
@@ -37,11 +37,16 @@ public:
 
     enum class ThemeType {
         DARK_THEME = 0,
-        LIGHT_THEME
+        LIGHT_THEME,
+#ifdef Q_OS_MAC
+        FOLLOW_SYSTEM_THEME
+#endif
     };
 
-    virtual ThemeType themeType() const = 0;
-    virtual async::Channel<ThemeType> themeTypeChanged() const = 0;
+    virtual ThemeType preferredThemeType() const = 0;
+    virtual async::Channel<ThemeType> preferredThemeTypeChanged() const = 0;
+    virtual ThemeType actualThemeType() const = 0;
+    virtual async::Channel<ThemeType> actualThemeTypeChanged() const = 0;
 
     enum class FontSizeType {
         BODY,

--- a/src/framework/ui/view/theme.cpp
+++ b/src/framework/ui/view/theme.cpp
@@ -108,7 +108,7 @@ Theme::Theme(QObject* parent)
 
 void Theme::init()
 {
-    configuration()->themeTypeChanged().onReceive(this, [this](const IUiConfiguration::ThemeType) {
+    configuration()->actualThemeTypeChanged().onReceive(this, [this](const IUiConfiguration::ThemeType) {
         update();
     });
 
@@ -128,47 +128,47 @@ void Theme::update()
 
 QColor Theme::backgroundPrimaryColor() const
 {
-    return currentThemeProperites().value(BACKGROUND_PRIMARY_COLOR).toString();
+    return currentThemeProperties().value(BACKGROUND_PRIMARY_COLOR).toString();
 }
 
 QColor Theme::backgroundSecondaryColor() const
 {
-    return currentThemeProperites().value(BACKGROUND_SECONDARY_COLOR).toString();
+    return currentThemeProperties().value(BACKGROUND_SECONDARY_COLOR).toString();
 }
 
 QColor Theme::popupBackgroundColor() const
 {
-    return currentThemeProperites().value(POPUP_BACKGROUND_COLOR).toString();
+    return currentThemeProperties().value(POPUP_BACKGROUND_COLOR).toString();
 }
 
 QColor Theme::textFieldColor() const
 {
-    return currentThemeProperites().value(TEXT_FIELD_COLOR).toString();
+    return currentThemeProperties().value(TEXT_FIELD_COLOR).toString();
 }
 
 QColor Theme::accentColor() const
 {
-    return currentThemeProperites().value(ACCENT_COLOR).toString();
+    return currentThemeProperties().value(ACCENT_COLOR).toString();
 }
 
 QColor Theme::strokeColor() const
 {
-    return currentThemeProperites().value(STROKE_COLOR).toString();
+    return currentThemeProperties().value(STROKE_COLOR).toString();
 }
 
 QColor Theme::buttonColor() const
 {
-    return currentThemeProperites().value(BUTTON_COLOR).toString();
+    return currentThemeProperties().value(BUTTON_COLOR).toString();
 }
 
 QColor Theme::fontPrimaryColor() const
 {
-    return currentThemeProperites().value(FONT_PRIMARY_COLOR).toString();
+    return currentThemeProperties().value(FONT_PRIMARY_COLOR).toString();
 }
 
 QColor Theme::fontSecondaryColor() const
 {
-    return currentThemeProperites().value(FONT_SECONDARY_COLOR).toString();
+    return currentThemeProperties().value(FONT_SECONDARY_COLOR).toString();
 }
 
 QFont Theme::bodyFont() const
@@ -228,37 +228,37 @@ QFont Theme::musicalFont() const
 
 qreal Theme::accentOpacityNormal() const
 {
-    return currentThemeProperites().value(ACCENT_OPACITY_NORMAL).toReal();
+    return currentThemeProperties().value(ACCENT_OPACITY_NORMAL).toReal();
 }
 
 qreal Theme::accentOpacityHover() const
 {
-    return currentThemeProperites().value(ACCENT_OPACITY_HOVER).toReal();
+    return currentThemeProperties().value(ACCENT_OPACITY_HOVER).toReal();
 }
 
 qreal Theme::accentOpacityHit() const
 {
-    return currentThemeProperites().value(ACCENT_OPACITY_HIT).toReal();
+    return currentThemeProperties().value(ACCENT_OPACITY_HIT).toReal();
 }
 
 qreal Theme::buttonOpacityNormal() const
 {
-    return currentThemeProperites().value(BUTTON_OPACITY_NORMAL).toReal();
+    return currentThemeProperties().value(BUTTON_OPACITY_NORMAL).toReal();
 }
 
 qreal Theme::buttonOpacityHover() const
 {
-    return currentThemeProperites().value(BUTTON_OPACITY_HOVER).toReal();
+    return currentThemeProperties().value(BUTTON_OPACITY_HOVER).toReal();
 }
 
 qreal Theme::buttonOpacityHit() const
 {
-    return currentThemeProperites().value(BUTTON_OPACITY_HIT).toReal();
+    return currentThemeProperties().value(BUTTON_OPACITY_HIT).toReal();
 }
 
 qreal Theme::itemOpacityDisabled() const
 {
-    return currentThemeProperites().value(ITEM_OPACITY_DISABLED).toReal();
+    return currentThemeProperties().value(ITEM_OPACITY_DISABLED).toReal();
 }
 
 mu::async::Notification Theme::themeChanged() const
@@ -266,9 +266,9 @@ mu::async::Notification Theme::themeChanged() const
     return m_themeChanged;
 }
 
-QHash<int, QVariant> Theme::currentThemeProperites() const
+QHash<int, QVariant> Theme::currentThemeProperties() const
 {
-    if (configuration()->themeType() == IUiConfiguration::ThemeType::DARK_THEME) {
+    if (configuration()->actualThemeType() == IUiConfiguration::ThemeType::DARK_THEME) {
         return DARK_THEME;
     }
 
@@ -362,6 +362,10 @@ void Theme::setupWidgetTheme()
     palette.setColor(QPalette::PlaceholderText, fontPrimaryColor());
 
     QApplication::setPalette(palette);
+
+#ifdef Q_OS_MAC
+    macos()->setAppAppearanceDark(configuration()->actualThemeType() == IUiConfiguration::ThemeType::DARK_THEME);
+#endif
 }
 
 void Theme::notifyAboutThemeChanged()

--- a/src/framework/ui/view/theme.h
+++ b/src/framework/ui/view/theme.h
@@ -26,6 +26,9 @@
 #include "ui/iuiconfiguration.h"
 #include "ui/itheme.h"
 #include "async/asyncable.h"
+#ifdef Q_OS_MAC
+#include "macos/imacos.h"
+#endif
 
 namespace mu::framework {
 class Theme : public QObject, public ITheme, public async::Asyncable
@@ -33,6 +36,9 @@ class Theme : public QObject, public ITheme, public async::Asyncable
     Q_OBJECT
 
     INJECT(ui, IUiConfiguration, configuration)
+#ifdef Q_OS_MAC
+    INJECT(ui, macos::IMacOS, macos)
+#endif
 
     Q_PROPERTY(QColor backgroundPrimaryColor READ backgroundPrimaryColor NOTIFY dataChanged)
     Q_PROPERTY(QColor backgroundSecondaryColor READ backgroundSecondaryColor NOTIFY dataChanged)
@@ -112,7 +118,7 @@ signals:
     void dataChanged();
 
 private:
-    QHash<int, QVariant> currentThemeProperites() const;
+    QHash<int, QVariant> currentThemeProperties() const;
 
     void initUiFonts();
     void initIconsFont();

--- a/src/inspector/view/widgets/gridcanvas.cpp
+++ b/src/inspector/view/widgets/gridcanvas.cpp
@@ -159,7 +159,7 @@ void GridCanvas::paint(QPainter* painter)
     QPen pen = painter->pen();
     pen.setWidth(1);
 
-    QColor primaryLinesColor(uiConfig()->themeType() == IUiConfiguration::ThemeType::DARK_THEME ? Qt::white : Qt::black);
+    QColor primaryLinesColor(uiConfig()->actualThemeType() == IUiConfiguration::ThemeType::DARK_THEME ? Qt::white : Qt::black);
     QColor secondaryLinesColor(Qt::gray);
     // draw vertical lines
     for (int i = 0; i < m_columns; ++i) {

--- a/src/macos/CMakeLists.txt
+++ b/src/macos/CMakeLists.txt
@@ -1,0 +1,38 @@
+#=============================================================================
+#  MuseScore
+#  Music Composition & Notation
+#
+#  Copyright (C) 2021 MuseScore BVBA and others
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#=============================================================================
+
+if(OS_IS_MAC)
+
+    set(MODULE macos)
+
+    set(MODULE_SRC
+        ${CMAKE_CURRENT_LIST_DIR}/macosmodule.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/macosmodule.h
+        ${CMAKE_CURRENT_LIST_DIR}/imacos.h
+        ${CMAKE_CURRENT_LIST_DIR}/internal/macos.mm
+        ${CMAKE_CURRENT_LIST_DIR}/internal/macos.h
+        )
+
+    set(MODULE_USE_UNITY_NONE ON) # doesn't work due to Objective-C++ code
+    # TODO: control that Cmake puts the C++ code and the Objective-C++ code in
+    # separate unities (and compile one as Objective-C++), so that it will work.
+
+    include(${PROJECT_SOURCE_DIR}/build/module.cmake)
+
+endif()

--- a/src/macos/imacos.h
+++ b/src/macos/imacos.h
@@ -1,0 +1,44 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2021 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_MACOS_IMACOS_H
+#define MU_MACOS_IMACOS_H
+
+#include "modularity/imoduleexport.h"
+#include "async/channel.h"
+
+namespace mu::macos {
+class IMacOS : MODULE_EXPORT_INTERFACE
+{
+    INTERFACE_ID(IMacOS)
+public:
+    virtual ~IMacOS() = default;
+
+    virtual void* observeDistributedNotifications(std::string, std::function<void()>) const = 0;
+
+    virtual void stopObservingDistributedNotificationsForName(std::string) = 0;
+    virtual void stopObservingDistributedNotificationsForToken(void*) = 0;
+    virtual void stopObservingDistributedAllNotifications() = 0;
+
+    virtual bool isSystemDarkModeOn() const = 0;
+    virtual async::Channel<bool> systemDarkModeSwitched() const = 0;
+    virtual void setAppAppearanceDark(bool) = 0;
+};
+}
+
+#endif // MU_MACOS_IMACOS_H

--- a/src/macos/internal/macos.h
+++ b/src/macos/internal/macos.h
@@ -1,0 +1,47 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_MACOS_MACOS_H
+#define MU_MACOS_MACOS_H
+
+#include "imacos.h"
+
+namespace mu::macos {
+class MacOS : public IMacOS
+{
+public:
+    MacOS() = default;
+
+    void init();
+
+    void* observeDistributedNotifications(std::string, std::function<void()>) const override;
+
+    void stopObservingDistributedNotificationsForName(std::string) override;
+    void stopObservingDistributedNotificationsForToken(void*) override;
+    void stopObservingDistributedAllNotifications() override;
+
+    bool isSystemDarkModeOn() const override;
+    async::Channel<bool> systemDarkModeSwitched() const override;
+    void setAppAppearanceDark(bool) override;
+
+private:
+    async::Channel<bool> m_systemDarkModeSwitched;
+};
+}
+
+#endif // MU_MACOS_MACOS_H

--- a/src/macos/internal/macos.mm
+++ b/src/macos/internal/macos.mm
@@ -1,0 +1,91 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "macos.h"
+
+#include "log.h"
+
+#include <Cocoa/Cocoa.h>
+
+using namespace mu::macos;
+using namespace mu::async;
+
+using ObserverToken = id<NSObject>;
+
+std::map<std::string, std::list<ObserverToken>> observerTokens;
+
+void MacOS::init() {
+    observeDistributedNotifications("AppleInterfaceThemeChangedNotification", [this]() {
+        m_systemDarkModeSwitched.send(isSystemDarkModeOn());
+    });
+}
+
+// Returns a pointer to the observer token
+void* MacOS::observeDistributedNotifications(std::string name, std::function<void()> f) const {
+    NSString* nsName = [NSString stringWithUTF8String:name.c_str()];
+    NSDistributedNotificationCenter* n = [NSDistributedNotificationCenter defaultCenter];
+    ObserverToken token = [n addObserverForName:nsName object:nil queue:nil usingBlock:^(NSNotification*) { f(); }];
+    observerTokens[name].push_back(token);
+    LOGI() << "Observing notifications for name \"" << name << "\"";
+    return (void*)token;
+}
+
+void MacOS::stopObservingDistributedNotificationsForName(std::string name) {
+    NSString* nsName = [NSString stringWithUTF8String:name.c_str()];
+    NSDistributedNotificationCenter* n = [NSDistributedNotificationCenter defaultCenter];
+    for (auto token : observerTokens[name]) {
+        [n removeObserver:token name:nsName object:nil];
+    }
+    observerTokens.erase(name);
+    LOGI() << "Stopped observing notifications for name \"" << name << "\"";
+}
+
+void MacOS::stopObservingDistributedNotificationsForToken(void* vToken) {
+    auto token = (ObserverToken)vToken;
+    NSDistributedNotificationCenter* n = [NSDistributedNotificationCenter defaultCenter];
+    [n removeObserver:token];
+    for (auto& [name, tokens] : observerTokens) {
+        tokens.remove(token);
+    }
+}
+
+void MacOS::stopObservingDistributedAllNotifications() {
+    NSDistributedNotificationCenter* n = [NSDistributedNotificationCenter defaultCenter];
+    for (auto const& [name, tokens] : observerTokens) {
+        NSString* nsName = [NSString stringWithUTF8String:name.c_str()];
+        for (auto token : tokens) {
+            [n removeObserver:token name:nsName object:nil];
+        }
+        LOGI() << "Stopped observing notifications for name \"" << name << "\"";
+    }
+    observerTokens.clear();
+}
+
+bool MacOS::isSystemDarkModeOn() const {
+    NSString* systemMode = [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];
+    return ([systemMode isEqualToString:@"Dark"]);
+}
+
+Channel<bool> MacOS::systemDarkModeSwitched() const
+{
+    return m_systemDarkModeSwitched;
+}
+
+void MacOS::setAppAppearanceDark(bool flag) {
+    [NSApp setAppearance:[NSAppearance appearanceNamed:flag ? NSAppearanceNameDarkAqua : NSAppearanceNameAqua]];
+}

--- a/src/macos/macosmodule.cpp
+++ b/src/macos/macosmodule.cpp
@@ -1,0 +1,53 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2021 MuseScore BVBA
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "macosmodule.h"
+
+#include "modularity/ioc.h"
+#include "internal/macos.h"
+
+#include "log.h"
+
+using namespace mu::macos;
+using namespace mu::framework;
+
+static std::shared_ptr<MacOS> s_macos = std::make_shared<MacOS>();
+
+std::string MacosModule::moduleName() const
+{
+    return "macos";
+}
+
+void MacosModule::registerExports()
+{
+    framework::ioc()->registerExport<IMacOS>(moduleName(), s_macos);
+}
+
+void MacosModule::onInit(const framework::IApplication::RunMode& mode)
+{
+    if (IApplication::RunMode::Converter == mode) {
+        return;
+    }
+
+    s_macos->init();
+}
+
+void MacosModule::onDeinit()
+{
+    s_macos->stopObservingDistributedAllNotifications();
+}

--- a/src/macos/macosmodule.h
+++ b/src/macos/macosmodule.h
@@ -1,0 +1,37 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2021 MuseScore BVBA
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_MACOS_MACOS_MODULE_H
+#define MU_MACOS_MACOS_MODULE_H
+
+#include "modularity/imodulesetup.h"
+
+namespace mu {
+namespace macos {
+class MacosModule : public framework::IModuleSetup
+{
+public:
+    std::string moduleName() const override;
+    void registerExports() override;
+    void onInit(const framework::IApplication::RunMode& mode) override;
+    void onDeinit() override;
+};
+}
+}
+
+#endif // MU_MACOS_MACOS_MODULE_H

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -169,6 +169,10 @@ if (NOT CC_IS_EMSCRIPTEN)
     list(APPEND LINK_LIB plugins)
 endif()
 
+if (OS_IS_MAC)
+    list(APPEND LINK_LIB macos)
+endif()
+
 if (BUILD_VST)
     set(LINK_LIB ${LINK_LIB} vst)
 endif(BUILD_VST)

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -72,6 +72,10 @@
 #include "wasmtest/wasmtestmodule.h"
 #endif
 
+#ifdef Q_OS_MAC
+#include "macos/macosmodule.h"
+#endif
+
 #if (defined (_MSCVER) || defined (_MSC_VER))
 #include <vector>
 #include <algorithm>
@@ -131,6 +135,10 @@ int main(int argc, char** argv)
     app.addModule(new mu::languages::LanguagesModule());
 #else
     app.addModule(new mu::wasmtest::WasmTestModule());
+#endif
+
+#ifdef Q_OS_MAC
+    app.addModule(new mu::macos::MacosModule());
 #endif
 
 #if (defined (_MSCVER) || defined (_MSC_VER))


### PR DESCRIPTION
In this PR, I add a 'macOS' module for Mac-specific things. This way, other systems will be affected by it as little as possible. 
@igorkorsukov I would be interested to hear your opinion about this approach!

This makes it possible to:
- observe system notifications;
- set the appearance of the app (= the window title bars) to light or dark.

And of course more things can be added in the future. 

For now, I used this to make the following possible:
- Make the appearance of the window title bars follow MuseScore's theme
- Give the user the possibility to let MuseScore switch it's theme along with the system's theme. That seems a controversial subject: I am personally a great fan of this, but Tantacrul didn't really like it. Anyway, every user can choose what they like. I think it would be good to ask users which theme they want when they launch MuseScore for the first time.

https://user-images.githubusercontent.com/48658420/103769733-1fa74500-5025-11eb-9713-38c9cfe8f5b9.mov

(I also fixed a typo in theme.cpp: currentThemeProperites -> currentThemeProperties)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
