### PR TITLE
Implement PlatformTheme and macOS Dark Mode improvements

### DIFF
--- a/src/framework/ui/CMakeLists.txt
+++ b/src/framework/ui/CMakeLists.txt
@@ -22,6 +22,27 @@ set(MODULE ui)
 set(MODULE_QRC ui.qrc)
 set(MODULE_QML_IMPORT ${CMAKE_CURRENT_LIST_DIR}/qml)
 
+include(GetPlatformInfo)
+if (OS_IS_MAC)
+    set(PLATFORM_THEME_SRC
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosplatformtheme.mm
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosplatformtheme.h
+    )
+    # Don't mix C++ and Objective-C++ in Unity Build
+    set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosplatformtheme.mm
+                                PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+
+    if (NOT (CC_IS_CLANG AND CMAKE_GENERATOR STREQUAL "Xcode"))
+        set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosplatformtheme.mm
+                                    PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+    endif()
+else()
+    set(PLATFORM_THEME_SRC
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/stub/stubplatformtheme.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/stub/stubplatformtheme.h
+    )
+endif()
+
 set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/uimodule.cpp
     ${CMAKE_CURRENT_LIST_DIR}/uimodule.h
@@ -33,6 +54,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/uitypes.h
     ${CMAKE_CURRENT_LIST_DIR}/imainwindow.h
     ${CMAKE_CURRENT_LIST_DIR}/itheme.h
+    ${CMAKE_CURRENT_LIST_DIR}/iplatformtheme.h
 
     ${CMAKE_CURRENT_LIST_DIR}/internal/interactiveuriregister.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/interactiveuriregister.h
@@ -40,6 +62,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/uiengine.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/uiconfiguration.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/uiconfiguration.h
+    ${PLATFORM_THEME_SRC}
 
     ${CMAKE_CURRENT_LIST_DIR}/view/interactiveprovider.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/interactiveprovider.h

--- a/src/framework/ui/internal/platform/macos/macosplatformtheme.h
+++ b/src/framework/ui/internal/platform/macos/macosplatformtheme.h
@@ -1,0 +1,44 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2021 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef MU_FRAMEWORK_MACOSPLATFORMTHEME_H
+#define MU_FRAMEWORK_MACOSPLATFORMTHEME_H
+
+#include "ui/iplatformtheme.h"
+
+namespace mu::framework {
+class MacOSPlatformTheme : public IPlatformTheme
+{
+public:
+    MacOSPlatformTheme();
+    ~MacOSPlatformTheme();
+
+    bool isFollowSystemThemeAvailable() const override;
+
+    bool isDarkMode() const override;
+    async::Channel<bool> darkModeSwitched() const override;
+
+    void setAppThemeDark(bool) override;
+
+private:
+    async::Channel<bool> m_darkModeSwitched;
+};
+}
+
+#endif // MU_FRAMEWORK_MACOSPLATFORMTHEME_H

--- a/src/framework/ui/internal/platform/macos/macosplatformtheme.mm
+++ b/src/framework/ui/internal/platform/macos/macosplatformtheme.mm
@@ -1,0 +1,63 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2021 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#include "macosplatformtheme.h"
+
+#include <Cocoa/Cocoa.h>
+
+using namespace mu::framework;
+using namespace mu::async;
+
+id<NSObject> darkModeObserverToken;
+
+MacOSPlatformTheme::MacOSPlatformTheme()
+{
+    NSDistributedNotificationCenter* n = [NSDistributedNotificationCenter defaultCenter];
+    darkModeObserverToken = [n addObserverForName:@"AppleInterfaceThemeChangedNotification"
+                                           object:nil
+                                            queue:nil
+                                       usingBlock:^(NSNotification*) { m_darkModeSwitched.send(isDarkMode()); }];
+}
+
+MacOSPlatformTheme::~MacOSPlatformTheme()
+{
+    NSDistributedNotificationCenter* n = [NSDistributedNotificationCenter defaultCenter];
+    [n removeObserver:darkModeObserverToken];
+}
+
+bool MacOSPlatformTheme::isFollowSystemThemeAvailable() const
+{
+    return true;
+}
+
+bool MacOSPlatformTheme::isDarkMode() const
+{
+    NSString* systemMode = [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];
+    return ([systemMode isEqualToString:@"Dark"]);
+}
+
+Channel<bool> MacOSPlatformTheme::darkModeSwitched() const
+{
+    return m_darkModeSwitched;
+}
+
+void MacOSPlatformTheme::setAppThemeDark(bool dark)
+{
+    [NSApp setAppearance:[NSAppearance appearanceNamed:dark ? NSAppearanceNameDarkAqua : NSAppearanceNameAqua]];
+}

--- a/src/framework/ui/internal/platform/stub/stubplatformtheme.cpp
+++ b/src/framework/ui/internal/platform/stub/stubplatformtheme.cpp
@@ -1,0 +1,42 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2021 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#include "stubplatformtheme.h"
+
+using namespace mu::framework;
+using namespace mu::async;
+
+bool StubPlatformTheme::isFollowSystemThemeAvailable() const
+{
+    return false;
+}
+
+bool StubPlatformTheme::isDarkMode() const
+{
+    return false;
+}
+
+Channel<bool> StubPlatformTheme::darkModeSwitched() const
+{
+    return m_darkModeSwitched;
+}
+
+void StubPlatformTheme::setAppThemeDark(bool)
+{
+}

--- a/src/framework/ui/internal/platform/stub/stubplatformtheme.h
+++ b/src/framework/ui/internal/platform/stub/stubplatformtheme.h
@@ -1,0 +1,43 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2021 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef MU_FRAMEWORK_STUBPLATFORMTHEME_H
+#define MU_FRAMEWORK_STUBPLATFORMTHEME_H
+
+#include "ui/iplatformtheme.h"
+
+namespace mu::framework {
+class StubPlatformTheme : public IPlatformTheme
+{
+public:
+    StubPlatformTheme() = default;
+    ~StubPlatformTheme() = default;
+
+    bool isFollowSystemThemeAvailable() const override;
+
+    bool isDarkMode() const override;
+    async::Channel<bool> darkModeSwitched() const override;
+
+    void setAppThemeDark(bool) override;
+private:
+    async::Channel<bool> m_darkModeSwitched;
+};
+}
+
+#endif // MU_FRAMEWORK_STUBPLATFORMTHEME_H

--- a/src/framework/ui/internal/uiconfiguration.h
+++ b/src/framework/ui/internal/uiconfiguration.h
@@ -22,6 +22,7 @@
 
 #include "iuiconfiguration.h"
 #include "imainwindow.h"
+#include "iplatformtheme.h"
 
 #include "modularity/ioc.h"
 
@@ -29,12 +30,15 @@ namespace mu::framework {
 class UiConfiguration : public IUiConfiguration
 {
     INJECT(framework, IMainWindow, mainWindow)
+    INJECT(framework, IPlatformTheme, platformTheme)
 
 public:
     void init();
 
-    ThemeType themeType() const override;
-    async::Channel<ThemeType> themeTypeChanged() const override;
+    ThemeType preferredThemeType() const override;
+    async::Channel<ThemeType> preferredThemeTypeChanged() const override;
+    ThemeType actualThemeType() const override;
+    async::Channel<ThemeType> actualThemeTypeChanged() const override;
 
     std::string fontFamily() const override;
     int fontSize(FontSizeType type) const override;
@@ -54,7 +58,8 @@ public:
     void setPhysicalDotsPerInch(std::optional<float> dpi) override;
 
 private:
-    async::Channel<ThemeType> m_currentThemeTypeChannel;
+    async::Channel<ThemeType> m_currentPreferredThemeTypeChannel;
+    async::Channel<ThemeType> m_currentActualThemeTypeChannel;
 
     async::Notification m_fontChanged;
     async::Notification m_musicalFontChanged;

--- a/src/framework/ui/iplatformtheme.h
+++ b/src/framework/ui/iplatformtheme.h
@@ -1,0 +1,43 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2021 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef MU_FRAMEWORK_IPLATFORMTHEME_H
+#define MU_FRAMEWORK_IPLATFORMTHEME_H
+
+#include "modularity/imoduleexport.h"
+#include "async/channel.h"
+
+namespace mu::framework {
+class IPlatformTheme : MODULE_EXPORT_INTERFACE
+{
+    INTERFACE_ID(IPlatformTheme)
+
+public:
+    virtual ~IPlatformTheme() = default;
+
+    virtual bool isFollowSystemThemeAvailable() const = 0;
+
+    virtual bool isDarkMode() const = 0;
+    virtual async::Channel<bool> darkModeSwitched() const = 0;
+
+    virtual void setAppThemeDark(bool) = 0;
+};
+}
+
+#endif // MU_FRAMEWORK_IPLATFORMTHEME_H

--- a/src/framework/ui/iuiconfiguration.h
+++ b/src/framework/ui/iuiconfiguration.h
@@ -37,11 +37,14 @@ public:
 
     enum class ThemeType {
         DARK_THEME = 0,
-        LIGHT_THEME
+        LIGHT_THEME,
+        FOLLOW_SYSTEM_THEME
     };
 
-    virtual ThemeType themeType() const = 0;
-    virtual async::Channel<ThemeType> themeTypeChanged() const = 0;
+    virtual ThemeType preferredThemeType() const = 0;
+    virtual async::Channel<ThemeType> preferredThemeTypeChanged() const = 0;
+    virtual ThemeType actualThemeType() const = 0;
+    virtual async::Channel<ThemeType> actualThemeTypeChanged() const = 0;
 
     enum class FontSizeType {
         BODY,

--- a/src/framework/ui/uimodule.cpp
+++ b/src/framework/ui/uimodule.cpp
@@ -7,6 +7,13 @@
 #include "internal/uiengine.h"
 #include "internal/uiconfiguration.h"
 #include "internal/interactiveuriregister.h"
+
+#ifdef Q_OS_MAC
+#include "internal/platform/macos/macosplatformtheme.h"
+#else
+#include "internal/platform/stub/stubplatformtheme.h"
+#endif
+
 #include "view/qmltooltip.h"
 #include "view/iconcodes.h"
 #include "view/musicalsymbolcodes.h"
@@ -36,6 +43,12 @@ void UiModule::registerExports()
     ioc()->registerExportNoDelete<ITheme>(moduleName(), UiEngine::instance()->theme());
     ioc()->registerExport<IInteractiveProvider>(moduleName(), UiEngine::instance()->interactiveProvider());
     ioc()->registerExport<IInteractiveUriRegister>(moduleName(), new InteractiveUriRegister());
+
+#ifdef Q_OS_MAC
+    ioc()->registerExport<IPlatformTheme>(moduleName(), new MacOSPlatformTheme());
+#else
+    ioc()->registerExport<IPlatformTheme>(moduleName(), new StubPlatformTheme());
+#endif
 }
 
 void UiModule::resolveImports()

--- a/src/framework/ui/view/theme.cpp
+++ b/src/framework/ui/view/theme.cpp
@@ -108,7 +108,7 @@ Theme::Theme(QObject* parent)
 
 void Theme::init()
 {
-    configuration()->themeTypeChanged().onReceive(this, [this](const IUiConfiguration::ThemeType) {
+    configuration()->actualThemeTypeChanged().onReceive(this, [this](const IUiConfiguration::ThemeType) {
         update();
     });
 
@@ -128,47 +128,47 @@ void Theme::update()
 
 QColor Theme::backgroundPrimaryColor() const
 {
-    return currentThemeProperites().value(BACKGROUND_PRIMARY_COLOR).toString();
+    return currentThemeProperties().value(BACKGROUND_PRIMARY_COLOR).toString();
 }
 
 QColor Theme::backgroundSecondaryColor() const
 {
-    return currentThemeProperites().value(BACKGROUND_SECONDARY_COLOR).toString();
+    return currentThemeProperties().value(BACKGROUND_SECONDARY_COLOR).toString();
 }
 
 QColor Theme::popupBackgroundColor() const
 {
-    return currentThemeProperites().value(POPUP_BACKGROUND_COLOR).toString();
+    return currentThemeProperties().value(POPUP_BACKGROUND_COLOR).toString();
 }
 
 QColor Theme::textFieldColor() const
 {
-    return currentThemeProperites().value(TEXT_FIELD_COLOR).toString();
+    return currentThemeProperties().value(TEXT_FIELD_COLOR).toString();
 }
 
 QColor Theme::accentColor() const
 {
-    return currentThemeProperites().value(ACCENT_COLOR).toString();
+    return currentThemeProperties().value(ACCENT_COLOR).toString();
 }
 
 QColor Theme::strokeColor() const
 {
-    return currentThemeProperites().value(STROKE_COLOR).toString();
+    return currentThemeProperties().value(STROKE_COLOR).toString();
 }
 
 QColor Theme::buttonColor() const
 {
-    return currentThemeProperites().value(BUTTON_COLOR).toString();
+    return currentThemeProperties().value(BUTTON_COLOR).toString();
 }
 
 QColor Theme::fontPrimaryColor() const
 {
-    return currentThemeProperites().value(FONT_PRIMARY_COLOR).toString();
+    return currentThemeProperties().value(FONT_PRIMARY_COLOR).toString();
 }
 
 QColor Theme::fontSecondaryColor() const
 {
-    return currentThemeProperites().value(FONT_SECONDARY_COLOR).toString();
+    return currentThemeProperties().value(FONT_SECONDARY_COLOR).toString();
 }
 
 QFont Theme::bodyFont() const
@@ -228,37 +228,37 @@ QFont Theme::musicalFont() const
 
 qreal Theme::accentOpacityNormal() const
 {
-    return currentThemeProperites().value(ACCENT_OPACITY_NORMAL).toReal();
+    return currentThemeProperties().value(ACCENT_OPACITY_NORMAL).toReal();
 }
 
 qreal Theme::accentOpacityHover() const
 {
-    return currentThemeProperites().value(ACCENT_OPACITY_HOVER).toReal();
+    return currentThemeProperties().value(ACCENT_OPACITY_HOVER).toReal();
 }
 
 qreal Theme::accentOpacityHit() const
 {
-    return currentThemeProperites().value(ACCENT_OPACITY_HIT).toReal();
+    return currentThemeProperties().value(ACCENT_OPACITY_HIT).toReal();
 }
 
 qreal Theme::buttonOpacityNormal() const
 {
-    return currentThemeProperites().value(BUTTON_OPACITY_NORMAL).toReal();
+    return currentThemeProperties().value(BUTTON_OPACITY_NORMAL).toReal();
 }
 
 qreal Theme::buttonOpacityHover() const
 {
-    return currentThemeProperites().value(BUTTON_OPACITY_HOVER).toReal();
+    return currentThemeProperties().value(BUTTON_OPACITY_HOVER).toReal();
 }
 
 qreal Theme::buttonOpacityHit() const
 {
-    return currentThemeProperites().value(BUTTON_OPACITY_HIT).toReal();
+    return currentThemeProperties().value(BUTTON_OPACITY_HIT).toReal();
 }
 
 qreal Theme::itemOpacityDisabled() const
 {
-    return currentThemeProperites().value(ITEM_OPACITY_DISABLED).toReal();
+    return currentThemeProperties().value(ITEM_OPACITY_DISABLED).toReal();
 }
 
 mu::async::Notification Theme::themeChanged() const
@@ -266,9 +266,9 @@ mu::async::Notification Theme::themeChanged() const
     return m_themeChanged;
 }
 
-QHash<int, QVariant> Theme::currentThemeProperites() const
+QHash<int, QVariant> Theme::currentThemeProperties() const
 {
-    if (configuration()->themeType() == IUiConfiguration::ThemeType::DARK_THEME) {
+    if (configuration()->actualThemeType() == IUiConfiguration::ThemeType::DARK_THEME) {
         return DARK_THEME;
     }
 
@@ -362,6 +362,8 @@ void Theme::setupWidgetTheme()
     palette.setColor(QPalette::PlaceholderText, fontPrimaryColor());
 
     QApplication::setPalette(palette);
+
+    platformTheme()->setAppThemeDark(configuration()->actualThemeType() == IUiConfiguration::ThemeType::DARK_THEME);
 }
 
 void Theme::notifyAboutThemeChanged()

--- a/src/framework/ui/view/theme.h
+++ b/src/framework/ui/view/theme.h
@@ -25,6 +25,7 @@
 #include "modularity/ioc.h"
 #include "ui/iuiconfiguration.h"
 #include "ui/itheme.h"
+#include "ui/iplatformtheme.h"
 #include "async/asyncable.h"
 
 namespace mu::framework {
@@ -33,6 +34,7 @@ class Theme : public QObject, public ITheme, public async::Asyncable
     Q_OBJECT
 
     INJECT(ui, IUiConfiguration, configuration)
+    INJECT(ui, IPlatformTheme, platformTheme)
 
     Q_PROPERTY(QColor backgroundPrimaryColor READ backgroundPrimaryColor NOTIFY dataChanged)
     Q_PROPERTY(QColor backgroundSecondaryColor READ backgroundSecondaryColor NOTIFY dataChanged)
@@ -112,7 +114,7 @@ signals:
     void dataChanged();
 
 private:
-    QHash<int, QVariant> currentThemeProperites() const;
+    QHash<int, QVariant> currentThemeProperties() const;
 
     void initUiFonts();
     void initIconsFont();

--- a/src/inspector/view/widgets/gridcanvas.cpp
+++ b/src/inspector/view/widgets/gridcanvas.cpp
@@ -159,7 +159,7 @@ void GridCanvas::paint(QPainter* painter)
     QPen pen = painter->pen();
     pen.setWidth(1);
 
-    QColor primaryLinesColor(uiConfig()->themeType() == IUiConfiguration::ThemeType::DARK_THEME ? Qt::white : Qt::black);
+    QColor primaryLinesColor(uiConfig()->actualThemeType() == IUiConfiguration::ThemeType::DARK_THEME ? Qt::white : Qt::black);
     QColor secondaryLinesColor(Qt::gray);
     // draw vertical lines
     for (int i = 0; i < m_columns; ++i) {


### PR DESCRIPTION
Replaces PR #7206

Through PlatformTheme, we can now:
- Check whether the current platform has a Dark Mode that we can follow;
- Check whether that Dark Mode is currently enabled;
- Get notifications when the platform's Dark Mode is switched, so that MuseScore can switch along;
- Set the 'appearance' of the app; on macOS that includes the style of the window title bar, light or dark. This is used to make the window title bar color follow MuseScore's theme.

The platform-specific code is entirely 'hidden' behind `IPlatformTheme`, so that there are as little platform checks as possible. 
For platforms other than macOS, there is no real implementation (yet), but with this structure, it will be very easy to add that if we want.

https://user-images.githubusercontent.com/48658420/103769733-1fa74500-5025-11eb-9713-38c9cfe8f5b9.mov

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
