### PR TITLE
[MU3] Fix #314935 - Adding instruments on top of others whose parts have be…

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2668,12 +2668,6 @@ void Score::sortStaves(QList<int>& dst)
                   trackMap.insert(idx * VOICES + itrack, track++);
             }
       _staves = dl;
-      for (Excerpt* e : excerpts()) {
-            QMultiMap<int, int> oldTracks = e->tracks();
-            e->tracks().clear();
-            for (QMap<int, int>::iterator it = oldTracks.begin(); it != oldTracks.end(); ++it)
-                  e->tracks().insert(trackMap[it.key()], it.value());
-            }
 
       for (Measure* m = firstMeasure(); m; m = m->nextMeasure()) {
             m->sortStaves(dst);
@@ -2694,6 +2688,25 @@ void Score::sortStaves(QList<int>& dst)
                   }
             }
       setLayoutAll();
+      }
+
+//---------------------------------------------------------
+//   mapExcerptTracks
+//---------------------------------------------------------
+
+void Score::mapExcerptTracks(QList<int> &dst)
+      {
+      for (Excerpt* e : excerpts()) {
+            QMultiMap<int, int> tr = e->tracks();
+            QMultiMap<int, int> tracks;
+            for (QMap<int, int>::iterator it = tr.begin(); it != tr.end(); ++it) {
+                  int prvStaffIdx = it.key() / VOICES;
+                  int curStaffIdx = dst.indexOf(prvStaffIdx);
+                  int offset = (curStaffIdx - prvStaffIdx) * VOICES;
+                  tracks.insert(it.key() + offset, it.value());
+                  }
+            e->tracks() = tracks;
+            }
       }
 
 //---------------------------------------------------------

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -791,6 +791,7 @@ class Score : public QObject, public ScoreElement {
       void appendPart(const InstrumentTemplate*);
       void updateStaffIndex();
       void sortStaves(QList<int>& dst);
+      void mapExcerptTracks(QList<int>& l);
 
       bool showInvisible() const       { return _showInvisible; }
       bool showUnprintable() const     { return _showUnprintable; }

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1092,6 +1092,37 @@ void SortStaves::undo(EditData*)
       }
 
 //---------------------------------------------------------
+//   MapExcerptTracks
+//---------------------------------------------------------
+
+MapExcerptTracks::MapExcerptTracks(Score* s, QList<int> l)
+      {
+      score = s;
+
+      /*
+       *    In list l [x] represents the previous index of the staffIdx x.
+       *    If the a staff x is a newly added staff, l[x] = -1.
+       *    For the "undo" all staves which value -1 are *not* remapped since
+       *    it is assumed this staves are removed later.
+       */
+      for (int i = 0; i < l.size(); ++i) {
+            if (l[i] >= 0)
+                  rlist.insert(l[i], i);
+            }
+      list = l;
+      }
+
+void MapExcerptTracks::redo(EditData*)
+      {
+      score->mapExcerptTracks(list);
+      }
+
+void MapExcerptTracks::undo(EditData*)
+      {
+      score->mapExcerptTracks(rlist);
+      }
+
+//---------------------------------------------------------
 //   ChangePitch
 //---------------------------------------------------------
 

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -355,6 +355,22 @@ class SortStaves : public UndoCommand {
       };
 
 //---------------------------------------------------------
+//   MapExcerptTracks
+//---------------------------------------------------------
+
+class MapExcerptTracks : public UndoCommand {
+      Score* score;
+      QList<int> list;
+      QList<int> rlist;
+
+   public:
+      MapExcerptTracks(Score*, QList<int>);
+      virtual void undo(EditData*) override;
+      virtual void redo(EditData*) override;
+      UNDO_NAME("MapExcerptTracks")
+      };
+
+//---------------------------------------------------------
 //   ChangePitch
 //---------------------------------------------------------
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/314935

When adding/removing or changing the order of staves, for all <code>Excerpts</code> the track mapping between <code>Excerpt</code> and <code>masterScore</code> must be updated but the original implementation had some flaws.
- 1 The rebuild of the mapping was incomplete
- 2 The rebuild of the mapping was in <code>MuseScore::editInstrList()</code> which also adds/removes staves. However this adding/removing was done via the "undo" mechanism, the rebuild if the mapping was't.

PR #7029 moved the rebuild of the mapping inside the "undo" class <code>SortStaves()</code> which used when the order of the staves was changed.

This PR moves the rebuild of the mapping into a nwe "undo" class <code>MapExcerptTracks()</code> and inside <code>MuseScore::editInstrList()</code> a new instance of the class is created and added to the undo stack. As a result, the mapping will always adapted to the new staff order.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
