### PR TITLE
Draw Ambitus with Flat Caps instead of Round Caps

### DIFF
--- a/libmscore/ambitus.cpp
+++ b/libmscore/ambitus.cpp
@@ -454,7 +454,7 @@ void Ambitus::draw(QPainter* p) const
       {
       qreal _spatium = spatium();
       qreal lw = lineWidth().val() * _spatium;
-      p->setPen(QPen(curColor(), lw, Qt::SolidLine, Qt::RoundCap));
+      p->setPen(QPen(curColor(), lw, Qt::SolidLine, Qt::FlatCap));
       drawSymbol(noteHead(), p, _topPos);
       drawSymbol(noteHead(), p, _bottomPos);
       if (_hasLine)
@@ -470,7 +470,7 @@ void Ambitus::draw(QPainter* p) const
             qreal stepTolerance = step * 0.1;
             qreal ledgerOffset = score()->styleS(Sid::ledgerLineLength).val() * _spatium;
             p->setPen(QPen(curColor(), score()->styleS(Sid::ledgerLineWidth).val() * _spatium,
-                        Qt::SolidLine, Qt::RoundCap) );
+                        Qt::SolidLine, Qt::FlatCap) );
             if (_topPos.y()-stepTolerance <= -step) {
                   qreal xMin = _topPos.x() - ledgerOffset;
                   qreal xMax = _topPos.x() + headWidth() + ledgerOffset;


### PR DESCRIPTION
Draw Ambitus with Flat Caps instead of Round Caps, to match normal ledger lines and stems.

<img width="373" alt="Schermafbeelding 2021-01-09 om 14 53 32" src="https://user-images.githubusercontent.com/48658420/104093418-af99f880-528a-11eb-9d92-8d39034823c9.png">

This is of course needed for the master branch too. Should I make a separate PR for that or can it be cherry-picked?

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
