### PR TITLE
fix #315363 : Workaround for bad on-screen rendering of emboldened fo…

### DIFF
--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1501,8 +1501,12 @@ void Harmony::draw(QPainter* painter) const
       for (const TextSegment* ts : textList) {
             QFont f(ts->font);
             f.setPointSizeF(f.pointSizeF() * MScore::pixelRatio);
+#ifndef Q_OS_MACOS
+            TextBase::drawTextWorkaround(painter, f, ts->pos(), ts->text);
+#else
             painter->setFont(f);
             painter->drawText(ts->pos(), ts->text);
+#endif
             }
       }
 

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -751,6 +751,19 @@ void TextFragment::draw(QPainter* p, const TextBase* t) const
       QFont f(font(t));
       f.setPointSizeF(f.pointSizeF() * MScore::pixelRatio);
 #ifndef Q_OS_MACOS
+      TextBase::drawTextWorkaround(p, f, pos, text);
+#else
+      p->setFont(f);
+      p->drawText(pos, text);
+#endif
+      }
+
+//---------------------------------------------------------
+//   drawTextWorkaround
+//---------------------------------------------------------
+
+void TextBase::drawTextWorkaround(QPainter* p, QFont& f, const QPointF pos, const QString text)
+      {
       qreal mm = p->worldTransform().m11();
       if (!(MScore::pdfPrinting) && (mm < 1.0) && f.bold() && !(f.underline())) {
             // workaround for https://musescore.org/en/node/284218
@@ -819,10 +832,6 @@ void TextFragment::draw(QPainter* p, const TextBase* t) const
             p->setFont(f);
             p->drawText(pos, text);
             }
-#else
-      p->setFont(f);
-      p->drawText(pos, text);
-#endif
       }
 
 //---------------------------------------------------------

--- a/libmscore/textbase.h
+++ b/libmscore/textbase.h
@@ -282,6 +282,7 @@ class TextBase : public Element {
 
       virtual void draw(QPainter*) const override;
       virtual void drawEditMode(QPainter* p, EditData& ed) override;
+      static void drawTextWorkaround(QPainter* p, QFont& f, const QPointF pos, const QString text);
 
       static QString plainToXmlText(const QString& s) { return s.toHtmlEscaped(); }
       void setPlainText(const QString& t) { setXmlText(plainToXmlText(t)); }


### PR DESCRIPTION
…nt for harmony elements

Resolves: https://musescore.org/en/node/315363

The problem is the same as https://musescore.org/en/node/284218 and this PR implements the same workaround also for harmony (chord) elements. See PR https://github.com/musescore/MuseScore/pull/5794

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
