### PR TITLE
[MU4] MScore init refactor

### DIFF
--- a/src/framework/fonts/CMakeLists.txt
+++ b/src/framework/fonts/CMakeLists.txt
@@ -37,6 +37,8 @@ set(MODULE_QRC
 set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/fontsmodule.cpp
     ${CMAKE_CURRENT_LIST_DIR}/fontsmodule.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/fontscontroller.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/fontscontroller.h
     )
 
 set(MODULE_USE_UNITY_NONE ON)

--- a/src/framework/fonts/fontsmodule.cpp
+++ b/src/framework/fonts/fontsmodule.cpp
@@ -21,7 +21,11 @@
 #include <QtGlobal>
 #include "modularity/ioc.h"
 
+#include "internal/fontscontroller.h"
+
 using namespace mu::fonts;
+
+static FontsController* m_fontsController = nullptr;
 
 static void init_fonts_qrc()
 {
@@ -51,4 +55,10 @@ void FontsModule::registerResources()
 
 void FontsModule::registerExports()
 {
+    m_fontsController = new FontsController();
+}
+
+void FontsModule::onInit(const mu::framework::IApplication::RunMode&)
+{
+    m_fontsController->init();
 }

--- a/src/framework/fonts/internal/fontscontroller.cpp
+++ b/src/framework/fonts/internal/fontscontroller.cpp
@@ -1,0 +1,70 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "fontscontroller.h"
+
+#include <QFontDatabase>
+
+#include "log.h"
+
+using namespace mu::fonts;
+
+constexpr int INVALID_LOAD_FONTS_CODE = -1;
+
+void FontsController::init()
+{
+    loadInternalFonts();
+}
+
+void FontsController::loadInternalFonts()
+{
+    // Do not load application specific fonts
+    // for MAC, they are in Resources/fonts
+#if defined(Q_OS_MAC) || defined(Q_OS_IOS)
+    return;
+#endif
+
+    static const QStringList fonts = {
+        ":/fonts/musejazz/MuseJazzText.otf",
+        ":/fonts/campania/Campania.otf",
+        ":/fonts/FreeSans.ttf",
+        ":/fonts/firasans/FiraSansRegular.ttf",
+        ":/fonts/firasans/FiraSansSemiBold.ttf",
+        ":/fonts/FreeSerif.ttf",
+        ":/fonts/FreeSerifBold.ttf",
+        ":/fonts/FreeSerifItalic.ttf",
+        ":/fonts/FreeSerifBoldItalic.ttf",
+        ":/fonts/mscoreTab.ttf",
+        ":/fonts/mscore-BC.ttf",
+        ":/fonts/bravura/BravuraText.otf",
+        ":/fonts/gootville/GootvilleText.otf",
+        ":/fonts/mscore/MScoreText.ttf",
+        ":/fonts/mscore/MusescoreIcon.ttf",
+        ":/fonts/leland/Leland.otf",
+        ":/fonts/petaluma/PetalumaText.otf",
+        ":/fonts/petaluma/PetalumaScript.otf",
+    };
+
+    for (const QString& font: fonts) {
+        int loadStatusCode = QFontDatabase::addApplicationFont(font);
+        if (loadStatusCode == INVALID_LOAD_FONTS_CODE) {
+            LOGE() << "Fatal error: cannot load internal font " << font;
+            QCoreApplication::exit(loadStatusCode);
+        }
+    }
+}

--- a/src/framework/fonts/internal/fontscontroller.h
+++ b/src/framework/fonts/internal/fontscontroller.h
@@ -16,23 +16,20 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#ifndef MU_FONTS_FONTSMODULE_H
-#define MU_FONTS_FONTSMODULE_H
+#ifndef MU_FONTS_FONTSCONTROLLER_H
+#define MU_FONTS_FONTSCONTROLLER_H
 
-#include "modularity/imodulesetup.h"
+#include "modularity/imoduleexport.h"
 
 namespace mu::fonts {
-class FontsModule : public framework::IModuleSetup
+class FontsController
 {
 public:
+    void init();
 
-    std::string moduleName() const override;
-
-    void registerResources() override;
-    void registerExports() override;
-
-    void onInit(const framework::IApplication::RunMode&) override;
+private:
+    void loadInternalFonts();
 };
 }
 
-#endif // MU_FONTS_FONTSMODULE_H
+#endif // MU_FONTS_FONTSCONTROLLER_H

--- a/src/libmscore/mscore.cpp
+++ b/src/libmscore/mscore.cpp
@@ -384,48 +384,6 @@ void MScore::init()
         }
     }
 
-    //
-    //  load internal fonts
-    //
-    //
-    // do not load application specific fonts
-    // for MAC, they are in Resources/fonts
-    //
-#if !defined(Q_OS_MAC) && !defined(Q_OS_IOS)
-    static const char* fonts[] = {
-        ":/fonts/musejazz/MuseJazzText.otf",
-        ":/fonts/campania/Campania.otf",
-        ":/fonts/FreeSans.ttf",
-        ":/fonts/firasans/FiraSansRegular.ttf",
-        ":/fonts/firasans/FiraSansSemiBold.ttf",
-        ":/fonts/FreeSerif.ttf",
-        ":/fonts/FreeSerifBold.ttf",
-        ":/fonts/FreeSerifItalic.ttf",
-        ":/fonts/FreeSerifBoldItalic.ttf",
-        ":/fonts/mscoreTab.ttf",
-        ":/fonts/mscore-BC.ttf",
-        ":/fonts/bravura/BravuraText.otf",
-        ":/fonts/gootville/GootvilleText.otf",
-        ":/fonts/mscore/MScoreText.ttf",
-        ":/fonts/mscore/MusescoreIcon.ttf",
-        ":/fonts/leland/Leland.otf",
-        ":/fonts/petaluma/PetalumaText.otf",
-        ":/fonts/petaluma/PetalumaScript.otf",
-    };
-
-    for (unsigned i = 0; i < sizeof(fonts) / sizeof(*fonts); ++i) {
-        QString str(fonts[i]);
-        if (-1 == QFontDatabase::addApplicationFont(str)) {
-            if (!MScore::testMode) {
-                qDebug("Mscore: fatal error: cannot load internal font <%s>", qPrintable(str));
-            }
-            if (!MScore::debugMode && !MScore::testMode) {
-                exit(-1);
-            }
-        }
-    }
-
-#endif
     initScoreFonts();
     StaffType::initStaffTypes();
     initDrumset();

--- a/src/libmscore/mscore.cpp
+++ b/src/libmscore/mscore.cpp
@@ -264,47 +264,6 @@ void MScore::init()
         return;
     }
 
-    if (!QMetaType::registerConverter<Spatium, double>(&Spatium::toDouble)) {
-        qFatal("registerConverter Spatium::toDouble failed");
-    }
-    if (!QMetaType::registerConverter<double, Spatium>(&doubleToSpatium)) {
-        qFatal("registerConverter doubleToSpatium failed");
-    }
-//      if (!QMetaType::registerComparators<Spatium>())
-//            qFatal("registerComparators for Spatium failed");
-
-#ifdef SCRIPT_INTERFACE
-    qRegisterMetaType<Note::ValueType>("ValueType");
-
-    qRegisterMetaType<MScore::DirectionH>("DirectionH");
-    qRegisterMetaType<Spanner::Anchor>("Anchor");
-    qRegisterMetaType<NoteHead::Group>("NoteHeadGroup");
-    qRegisterMetaType<NoteHead::Type>("NoteHeadType");
-    qRegisterMetaType<SegmentType>("SegmentType");
-    qRegisterMetaType<FiguredBassItem::Modifier>("Modifier");
-    qRegisterMetaType<FiguredBassItem::Parenthesis>("Parenthesis");
-    qRegisterMetaType<FiguredBassItem::ContLine>("ContLine");
-    qRegisterMetaType<Volta::Type>("VoltaType");
-    qRegisterMetaType<OttavaType>("OttavaType");
-    qRegisterMetaType<Trill::Type>("TrillType");
-    qRegisterMetaType<Dynamic::Range>("DynamicRange");
-    qRegisterMetaType<Jump::Type>("JumpType");
-    qRegisterMetaType<Marker::Type>("MarkerType");
-    qRegisterMetaType<Beam::Mode>("BeamMode");
-    qRegisterMetaType<HairpinType>("HairpinType");
-    qRegisterMetaType<Lyrics::Syllabic>("Syllabic");
-    qRegisterMetaType<LayoutBreak::Type>("LayoutBreakType");
-
-    //classed enumerations
-//      qRegisterMetaType<MSQE_StyledPropertyListIdx::E>("StyledPropertyListIdx");
-//      qRegisterMetaType<MSQE_BarLineType::E>("BarLineType");
-#endif
-    qRegisterMetaType<Fraction>("Fraction");
-
-    if (!QMetaType::registerConverter<Fraction, QString>(&Fraction::toString)) {
-        qFatal("registerConverter Fraction::toString failed");
-    }
-
 #ifdef Q_OS_WIN
     QDir dir(QCoreApplication::applicationDirPath() + QString("/../" INSTALL_NAME));
     _globalShare = dir.absolutePath() + "/";
@@ -394,6 +353,50 @@ void MScore::init()
 #endif
 
     initDone = true;
+}
+
+void MScore::registerUiTypes()
+{
+    if (!QMetaType::registerConverter<Spatium, double>(&Spatium::toDouble)) {
+        qFatal("registerConverter Spatium::toDouble failed");
+    }
+    if (!QMetaType::registerConverter<double, Spatium>(&doubleToSpatium)) {
+        qFatal("registerConverter doubleToSpatium failed");
+    }
+//      if (!QMetaType::registerComparators<Spatium>())
+//            qFatal("registerComparators for Spatium failed");
+
+#ifdef SCRIPT_INTERFACE
+    qRegisterMetaType<Note::ValueType>("ValueType");
+
+    qRegisterMetaType<MScore::DirectionH>("DirectionH");
+    qRegisterMetaType<Spanner::Anchor>("Anchor");
+    qRegisterMetaType<NoteHead::Group>("NoteHeadGroup");
+    qRegisterMetaType<NoteHead::Type>("NoteHeadType");
+    qRegisterMetaType<SegmentType>("SegmentType");
+    qRegisterMetaType<FiguredBassItem::Modifier>("Modifier");
+    qRegisterMetaType<FiguredBassItem::Parenthesis>("Parenthesis");
+    qRegisterMetaType<FiguredBassItem::ContLine>("ContLine");
+    qRegisterMetaType<Volta::Type>("VoltaType");
+    qRegisterMetaType<OttavaType>("OttavaType");
+    qRegisterMetaType<Trill::Type>("TrillType");
+    qRegisterMetaType<Dynamic::Range>("DynamicRange");
+    qRegisterMetaType<Jump::Type>("JumpType");
+    qRegisterMetaType<Marker::Type>("MarkerType");
+    qRegisterMetaType<Beam::Mode>("BeamMode");
+    qRegisterMetaType<HairpinType>("HairpinType");
+    qRegisterMetaType<Lyrics::Syllabic>("Syllabic");
+    qRegisterMetaType<LayoutBreak::Type>("LayoutBreakType");
+
+    //classed enumerations
+//      qRegisterMetaType<MSQE_StyledPropertyListIdx::E>("StyledPropertyListIdx");
+//      qRegisterMetaType<MSQE_BarLineType::E>("BarLineType");
+#endif
+    qRegisterMetaType<Fraction>("Fraction");
+
+    if (!QMetaType::registerConverter<Fraction, QString>(&Fraction::toString)) {
+        qFatal("registerConverter Fraction::toString failed");
+    }
 }
 
 //---------------------------------------------------------

--- a/src/libmscore/mscore.h
+++ b/src/libmscore/mscore.h
@@ -320,6 +320,7 @@ public:
     static std::vector<MScoreError> errorList;
 
     static void init();
+    static void registerUiTypes();
 
     static const MStyle& baseStyle() { return _baseStyle; }
     static MStyle& defaultStyle() { return _defaultStyle; }

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -94,9 +94,9 @@ int main(int argc, char** argv)
 #ifdef BUILD_TELEMETRY_MODULE
     app.addModule(new mu::telemetry::TelemetrySetup());
 #endif
+    app.addModule(new mu::fonts::FontsModule());
     app.addModule(new mu::framework::UiModule());
     app.addModule(new mu::framework::UiComponentsModule());
-    app.addModule(new mu::fonts::FontsModule());
     app.addModule(new mu::framework::SystemModule());
     app.addModule(new mu::framework::NetworkModule());
 

--- a/src/notation/notationmodule.cpp
+++ b/src/notation/notationmodule.cpp
@@ -91,8 +91,6 @@ void NotationModule::registerExports()
     readers->reg({ "mscz", "mscx" }, std::make_shared<MsczNotationReader>());
     framework::ioc()->registerExport<INotationReadersRegister>(moduleName(), readers);
     framework::ioc()->registerExport<INotationWritersRegister>(moduleName(), std::make_shared<NotationWritersRegister>());
-
-    Notation::init();
 }
 
 void NotationModule::resolveImports()
@@ -168,6 +166,8 @@ void NotationModule::registerUiTypes()
     qRegisterMetaType<SelectDialog>("SelectDialog");
 
     framework::ioc()->resolve<framework::IUiEngine>(moduleName())->addSourceImportPath(notation_QML_IMPORT);
+
+    Ms::MScore::registerUiTypes();
 }
 
 void NotationModule::onInit(const IApplication::RunMode&)
@@ -175,4 +175,6 @@ void NotationModule::onInit(const IApplication::RunMode&)
     s_configuration->init();
     s_actionController->init();
     s_midiInputController->init();
+
+    Notation::init();
 }


### PR DESCRIPTION
- registering qml types(additional static method in MScore, which I call from NotationModule::registerUiTypes)
- loading fonts(in FontsModule::onInit)

MScore::init is called from Notation::init in the init of notation module, previously was called in registerExports