### PR TITLE
[MU3] Improve migration dialog texts

### DIFF
--- a/mscore/qml/migration/ScoreMigrationDialog.qml
+++ b/mscore/qml/migration/ScoreMigrationDialog.qml
@@ -85,7 +85,7 @@ FocusScope {
 
                 CheckBoxControl {
                     checked: root.model ? root.model.isLelandAllowed : false
-                    text: qsTr("Our new professional notation font")
+                    text: qsTr("Our new professional notation font, Leland")
 
                     onToggled: {
                         root.model.isLelandAllowed = checked
@@ -94,7 +94,7 @@ FocusScope {
 
                 CheckBoxControl {
                     checked: root.model ? root.model.isEdwinAllowed : false
-                    text: qsTr("Our improved text font")
+                    text: qsTr("Our improved text font, Edwin")
 
                     onToggled: {
                         root.model.isEdwinAllowed = checked
@@ -121,7 +121,7 @@ FocusScope {
                     horizontalAlignment: Qt.AlignLeft
 
                     text: root.model ? qsTr("Since this file was created in MuseScore %1, some layout changes may occur.").arg(root.model.creationAppVersion)
-                                     : ""
+                                     : qsTr("(unknown)")
                 }
 
                 TextLabel {
@@ -133,7 +133,7 @@ FocusScope {
                     color: globalStyle.buttonText
                     horizontalAlignment: Qt.AlignLeft
 
-                    text: qsTr("<a href=\"https://youtu.be/qLR40BGNy68\">Watch our release video to learn more</a>")
+                    text: "<a href=\"https://youtu.be/qLR40BGNy68\">%1</a>".arg(qsTr("Watch our release video to learn more"))
 
                     onLinkActivated: {
                         if (root.model) {


### PR DESCRIPTION
*  mentioning the names of the new fonts, Leland and Edwin (maybe better non-translatable? "Edwin" is (part of) a translatable string elsewhere, Leland is not though)
*  showing "(unknown)" rather than an empty string, if the MuseScore version is that, unknown
*  translating just the message itself, not the URL and the HTML tags, having the URL there opens the door for malicious translations and redirecting to an entirely different site (having the URL in an editable text file still is not good, it'd better be compiled in, non-editable)