### PR TITLE
Fix #314828 Changing any property on a text line resets all styled properties to default

### DIFF
--- a/libmscore/textline.cpp
+++ b/libmscore/textline.cpp
@@ -333,7 +333,6 @@ void TextLine::undoChangeProperty(Pid id, const QVariant& v, PropertyFlags ps)
             MuseScoreCore::mscoreCore->updateInspector();
             return;
             }
-      initStyle();
       TextLineBase::undoChangeProperty(id, v, ps);
       }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/314828

Remove unnecessary <code>initStyle()</code> from <code>TextLine::undoChangeProperty()</code>.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
