### PR TITLE
[MU4] remove MIDI2.0 UMP deprecated methods

### DIFF
--- a/build/cmake/SetupCompileWarnings.cmake
+++ b/build/cmake/SetupCompileWarnings.cmake
@@ -75,22 +75,3 @@ function(target_no_warning TARGET WNAME)
     endif()
 
 endfunction()
-
-# Temporary solution
-# Pavel added the `deprecated` attribute to the old midi event, hoping that the use of deprecated methods will be quickly removed.
-# But! This is not yet true, the methods are used.
-# Displaying warnings is very annoying for all developers.
-# Pavel insists on keep these warnings.
-# So we will keep them only for Pavel until he removes the use of obsolete methods.
-find_program(GIT_EXECUTABLE git PATHS ENV PATH)
-if (GIT_EXECUTABLE)
-    execute_process(
-        COMMAND "${GIT_EXECUTABLE}" config --get user.email
-        OUTPUT_VARIABLE git_email
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-    if (git_email STREQUAL "p.smokotnin@gmail.com")
-        add_definitions(-DSHOW_MIDI_EVENT_DEPRECATED_WARNING)
-    endif()
-
-endif (GIT_EXECUTABLE)

--- a/src/framework/midi/internal/fluidsynth.cpp
+++ b/src/framework/midi/internal/fluidsynth.cpp
@@ -230,28 +230,32 @@ bool FluidSynth::handleEvent(const Event& e)
     }
 
     int ret = FLUID_OK;
-    switch (e.type()) {
-    case EventType::ME_NOTEON: {
-        ret = fluid_synth_noteon(m_fluid->synth, e.channel(), e.note(), e.velocity());
+    int channel = 0;
+    if (e.isChannelVoice()) {
+        channel = e.channel() + e.group() * 16;
+    }
+    switch (e.opcode()) {
+    case Event::Opcode::NoteOn: {
+        ret = fluid_synth_noteon(m_fluid->synth, channel, e.note(), e.velocity());
     } break;
-    case EventType::ME_NOTEOFF: {
-        ret = fluid_synth_noteoff(m_fluid->synth, e.channel(), e.note());
+    case Event::Opcode::NoteOff: {
+        ret = fluid_synth_noteoff(m_fluid->synth, channel, e.note());
     } break;
-    case EventType::ME_CONTROLLER: {
+    case Event::Opcode::ControlChange: {
         if (e.index() == CntrType::CTRL_PROGRAM) {
-            ret = fluid_synth_program_change(m_fluid->synth, e.channel(), e.data());
+            ret = fluid_synth_program_change(m_fluid->synth, channel, e.data());
         } else {
-            ret = fluid_synth_cc(m_fluid->synth, e.channel(), e.index(), e.data());
+            ret = fluid_synth_cc(m_fluid->synth, channel, e.index(), e.data());
         }
     } break;
-    case EventType::ME_PROGRAM: {
-        fluid_synth_program_change(m_fluid->synth, e.channel(), e.program());
+    case Event::Opcode::ProgramChange: {
+        fluid_synth_program_change(m_fluid->synth, channel, e.program());
     } break;
-    case EventType::ME_PITCHBEND: {
-        ret = fluid_synth_pitch_bend(m_fluid->synth, e.channel(), e.data());
+    case Event::Opcode::PitchBend: {
+        ret = fluid_synth_pitch_bend(m_fluid->synth, channel, e.data());
     } break;
     default: {
-        LOGW() << "not supported event type: " << static_cast<int>(e.type());
+        LOGW() << "not supported event opcode: " << e.opcodeString();
         ret = FLUID_FAILED;
     }
     }

--- a/src/framework/midi/internal/midiportdatasender.cpp
+++ b/src/framework/midi/internal/midiportdatasender.cpp
@@ -40,8 +40,6 @@ void MidiPortDataSender::onChunkReceived(const Chunk& chunk)
 
 bool MidiPortDataSender::sendEvents(tick_t fromTick, tick_t toTick)
 {
-    static const std::set<EventType> SKIP_EVENTS = { EventType::ME_EOT, EventType::ME_TICK1, EventType::ME_TICK2 };
-
     //! NOTE Here we need to set up a callback to receive data in the same thread as reading,
     //! and accordingly, then the mutex is not needed
     if (m_stream->isStreamingAllowed && !m_isStreamConnected) {
@@ -82,7 +80,7 @@ bool MidiPortDataSender::sendEvents(tick_t fromTick, tick_t toTick)
 
         const Event& event = pos->second;
 
-        if (SKIP_EVENTS.find(event.type()) == SKIP_EVENTS.end()) {
+        if (event) {
             midiOutPort()->sendEvent(event);
         }
 

--- a/src/framework/midi/internal/platform/lin/alsamidioutport.cpp
+++ b/src/framework/midi/internal/platform/lin/alsamidioutport.cpp
@@ -176,20 +176,20 @@ mu::Ret AlsaMidiOutPort::sendEvent(const Event& e)
     snd_seq_ev_set_source(&seqev, 0);
     snd_seq_ev_set_dest(&seqev, SND_SEQ_ADDRESS_SUBSCRIBERS, 0);
 
-    switch (e.type()) {
-    case EventType::ME_NOTEON:
+    switch (e.opcode()) {
+    case Event::Opcode::NoteOn:
         snd_seq_ev_set_noteon(&seqev, e.channel(), e.note(), e.velocity());
         break;
-    case EventType::ME_NOTEOFF:
+    case Event::Opcode::NoteOff:
         snd_seq_ev_set_noteoff(&seqev, e.channel(), e.note(), e.velocity());
         break;
-    case EventType::ME_PROGRAM:
+    case Event::Opcode::ProgramChange:
         snd_seq_ev_set_pgmchange(&seqev, e.channel(), e.program());
         break;
-    case EventType::ME_CONTROLLER:
+    case Event::Opcode::ControlChange:
         snd_seq_ev_set_controller(&seqev, e.channel(), e.index(), e.data());
         break;
-    case EventType::ME_PITCHBEND:
+    case Event::Opcode::PitchBend:
         snd_seq_ev_set_pitchbend(&seqev, e.channel(), e.data() - 8192);
         break;
     default:

--- a/src/framework/midi/internal/sequencer.cpp
+++ b/src/framework/midi/internal/sequencer.cpp
@@ -195,8 +195,6 @@ std::shared_ptr<ISynthesizer> Sequencer::synth(channel_t ch) const
 
 bool Sequencer::sendEvents(tick_t fromTick, tick_t toTick)
 {
-    static const std::set<EventType> SKIP_EVENTS = { EventType::ME_TICK1, EventType::ME_TICK2, EventType::ME_EOT };
-
     std::lock_guard<std::mutex> lock(m_dataMutex);
 
     m_isPlayTickSet = false;
@@ -239,7 +237,7 @@ bool Sequencer::sendEvents(tick_t fromTick, tick_t toTick)
         }
 
         ChanState& chState = m_chanStates[event.channel()];
-        if (chState.muted || SKIP_EVENTS.find(event.type()) != SKIP_EVENTS.end()) {
+        if (chState.muted || !event) {
             // noop
         } else {
             auto s = synth(event.channel());

--- a/src/framework/midi/internal/zerberussynth.cpp
+++ b/src/framework/midi/internal/zerberussynth.cpp
@@ -134,27 +134,31 @@ bool ZerberusSynth::handleEvent(const Event& e)
         return false;
     }
 
-    int ret = true;
-    switch (e.type()) {
-    case EventType::ME_NOTEON: {
-        ret = m_zerb->noteOn(e.channel(), e.note(), e.velocity());
+    bool ret = true;
+    int channel = 0;
+    if (e.isChannelVoice()) {
+        channel = e.channel() + e.group() * 16;
+    }
+    switch (e.opcode()) {
+    case Event::Opcode::NoteOn: {
+        ret = m_zerb->noteOn(channel, e.note(), e.velocity());
     } break;
-    case EventType::ME_NOTEOFF: {
-        ret = m_zerb->noteOff(e.channel(), e.note());
+    case Event::Opcode::NoteOff: {
+        ret = m_zerb->noteOff(channel, e.note());
     } break;
-    case EventType::ME_CONTROLLER: {
-        ret = m_zerb->controller(e.channel(), e.index(), e.data());
+    case Event::Opcode::ControlChange: {
+        ret = m_zerb->controller(channel, e.index(), e.data());
     } break;
-    case EventType::ME_PROGRAM: {
+    case Event::Opcode::ProgramChange: {
         ret = false;
         NOT_IMPLEMENTED;
     } break;
-    case EventType::ME_PITCHBEND: {
+    case Event::Opcode::PitchBend: {
         ret = false;
         NOT_IMPLEMENTED;
     } break;
     default: {
-        NOT_SUPPORTED << " event type: " << static_cast<int>(e.type());
+        NOT_SUPPORTED << "not supported event opcode: " << e.opcodeString();
         ret = false;
     }
     }

--- a/src/instruments/internal/instrumentsreader.cpp
+++ b/src/instruments/internal/instrumentsreader.cpp
@@ -342,13 +342,16 @@ MidiAction InstrumentsReader::readMidiAction(Ms::XmlReader& reader) const
 
     while (reader.readNextStartElement()) {
         if (reader.name() == "program") {
-            Event event(0 /*TODO*/, EventType::ME_CONTROLLER, CntrType::CTRL_PROGRAM,
-                        reader.attributes().value("value").toInt());
+            Event event(Event::Opcode::ProgramChange, Event::MessageType::ChannelVoice10);
+            event.setChannel(0);//TODO
+            event.setProgram(reader.attributes().value("value").toInt());
             action.events.push_back(event);
             reader.skipCurrentElement();
         } else if (reader.name() == "controller") {
-            Event event(0 /*TODO*/, EventType::ME_CONTROLLER, reader.attributes().value("ctrl").toInt(),
-                        reader.attributes().value("value").toInt());
+            Event event(Event::Opcode::ControlChange, Event::MessageType::ChannelVoice10);
+            event.setChannel(0);//TODO
+            event.setIndex(reader.attributes().value("ctrl").toInt());
+            event.setData(reader.attributes().value("value").toInt());
             action.events.push_back(event);
             reader.skipCurrentElement();
         } else if (reader.name() == "descr") {

--- a/src/notation/internal/instrumentsconverter.cpp
+++ b/src/notation/internal/instrumentsconverter.cpp
@@ -110,12 +110,11 @@ QList<Ms::NamedEventList> InstrumentsConverter::convertMidiActions(const MidiAct
         event.descr = action.description;
 
         for (const midi::Event& midiEvent: action.events) {
-            Ms::MidiCoreEvent midiCoreEvent;
-            midiCoreEvent.setType(static_cast<uchar>(midiEvent.type()));
-            midiCoreEvent.setChannel(midiCoreEvent.channel());
-            //!FIXME
-            //midiCoreEvent.setData(midiEvent.a, midiEvent.b);
-            event.events.push_back(midiCoreEvent);
+            auto midi10Events = midiEvent.toMIDI10();
+            for (const auto& midi10Event : midi10Events) {
+                Ms::MidiCoreEvent midiCoreEvent = midi10Event.toMSEvent();
+                event.events.push_back(midiCoreEvent);
+            }
         }
     }
 
@@ -132,12 +131,7 @@ MidiActionList InstrumentsConverter::convertMidiActions(const QList<Ms::NamedEve
         action.description = coreAction.descr;
 
         for (const Ms::MidiCoreEvent& midiCoreEvent: coreAction.events) {
-            midi::Event midiEvent(midiCoreEvent.channel(),
-                                  static_cast<midi::EventType>(midiCoreEvent.type()),
-                                  midiCoreEvent.dataA(),
-                                  midiCoreEvent.dataB()
-                                  );
-
+            midi::Event midiEvent(midiCoreEvent);
             action.events.push_back(midiEvent);
         }
     }

--- a/src/notation/internal/notationmidiinput.cpp
+++ b/src/notation/internal/notationmidiinput.cpp
@@ -44,7 +44,7 @@ void NotationMidiInput::onMidiEventReceived(const midi::Event& e)
 {
     LOGI() << e.to_string();
 
-    if (e.type() == midi::EventType::ME_NOTEON || e.type() == midi::EventType::ME_NOTEOFF) {
+    if (e.opcode() == midi::Event::Opcode::NoteOn || e.opcode() == midi::Event::Opcode::NoteOff) {
         onNoteReceived(e);
     }
 }
@@ -64,7 +64,7 @@ void NotationMidiInput::onNoteReceived(const midi::Event& e)
         return inputEv.pitch == val.pitch;
     });
 
-    if (e.type() == midi::EventType::ME_NOTEOFF || e.velocity() == 0) {
+    if (e.opcode() == midi::Event::Opcode::NoteOff || e.velocity() == 0) {
         return;
     }
 

--- a/src/notation/internal/notationplayback.cpp
+++ b/src/notation/internal/notationplayback.cpp
@@ -127,12 +127,12 @@ void NotationPlayback::makeInitEvents(std::vector<midi::Event>& events, const Ms
     Ms::MasterScore* masterScore = score->masterScore();
     for (const Ms::MidiMapping& mm : masterScore->midiMapping()) {
         const Ms::Channel* channel = mm.articulation();
-        for (const Ms::MidiCoreEvent& mse : channel->initList()) {
+        for (Ms::MidiCoreEvent mse : channel->initList()) {
             if (mse.type() == Ms::ME_INVALID) {
                 continue;
             }
-
-            midi::Event e(channel->channel(), static_cast<midi::EventType>(mse.type()), mse.dataA(), mse.dataB());
+            mse.setChannel(channel->channel());
+            midi::Event e(mse);
             events.push_back(std::move(e));
         }
     }
@@ -233,13 +233,7 @@ void NotationPlayback::makeChunk(midi::Chunk& chunk, tick_t fromTick) const
         if (SKIP_EVENTS.find(etype) != SKIP_EVENTS.end()) {
             continue;
         }
-        midi::Event e
-        {
-            static_cast<channel_t>(ev.channel()),
-            etype,
-            static_cast<uint8_t>(ev.dataA()),
-            static_cast<uint8_t>(ev.dataB())
-        };
+        midi::Event e(ev);
         chunk.events.insert({ tick, std::move(e) });
     }
 }


### PR DESCRIPTION
- Added constructor for midi::Event from Ms::MidiCoreEvent
- Add convertor from MIDI 1.0 Channel Voice to Ms::MidiCoreEvent
- Remove deprecated methods
- Fix an assert if notation playback needs more than 16 channels
