### PR TITLE
fix #315529: crash on load of score with repeat

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2897,7 +2897,7 @@ bool Measure::isCutawayClef(int staffIdx) const
             etrack = strack + VOICES;
             }
       // find segment before EndBarLine
-      Segment* s;
+      Segment* s = nullptr;
       for (Segment* ls = last(); ls; ls = ls->prev()) {
             if (ls->segmentType() ==  SegmentType::EndBarLine) {
                   s = ls->prev();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/315529

Crash happens trying to find the last element before an end barline,
since in the case of start repeats, there may be no end barline.
Fix is to provide an initialization to the variable used.