### PR TITLE
[MU3] Don't disable Qt 5.15 for 3.x

### DIFF
--- a/build/FindQt5.cmake
+++ b/build/FindQt5.cmake
@@ -36,14 +36,6 @@ if (WIN32)
       )
 endif(WIN32)
 
-# For Windows, because of these lines, for some unknown reason, the build of the .msi package fails.
-if(NOT ${CMAKE_HOST_SYSTEM_NAME} MATCHES "Windows")
-    find_package(Qt5Core 5.15.0 QUIET)
-    if (Qt5Core_FOUND)
-        message(FATAL_ERROR "MuseScore 3 does not support Qt 5.15: 5.15.0 shows empty palettes panel, 5.15.1 and later crash when opening pre-3.6 scores due to QTBUG-77337")
-    endif()
-endif()
-
 find_package(Qt5Core ${QT_MIN_VERSION} REQUIRED)
 
 foreach(_component ${_components})


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/315557 (forum topic)

Disabling Qt 5.15 seems no longer needed (not with 5.15.2 at least), it doesn't crash any longer on Linux nor on Windows (where that disabling hadn't worked anyhow).