### PR TITLE
Fix #315553 - MuseScore 3.6 Symphony Orchestra Template Violin Errors

### DIFF
--- a/share/templates/08-Orchestral/02-Symphony_Orchestra.mscx
+++ b/share/templates/08-Orchestral/02-Symphony_Orchestra.mscx
@@ -1339,11 +1339,13 @@
           <name>stdNormal</name>
           </StaffType>
         <bracket type="0" span="5" col="0"/>
+        <bracket type="2" span="2" col="1"/>
+        <barLineSpan>1</barLineSpan>
         </Staff>
-      <trackName>Violins 2</trackName>
+      <trackName>Violins 1</trackName>
       <Instrument id="strings">
-        <longName>Violins 2</longName>
-        <shortName>Vlns. 2</shortName>
+        <longName>Violins 1</longName>
+        <shortName>Vlns. 1</shortName>
         <trackName>Violins</trackName>
         <minPitchP>55</minPitchP>
         <maxPitchP>103</maxPitchP>
@@ -1411,10 +1413,10 @@
           </StaffType>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <trackName>Violins 1</trackName>
+      <trackName>Violins 2</trackName>
       <Instrument id="violins">
-        <longName>Violins 1</longName>
-        <shortName>Vlns. 1</shortName>
+        <longName>Violins 2</longName>
+        <shortName>Vlns. 2</shortName>
         <trackName>Violins</trackName>
         <minPitchP>55</minPitchP>
         <maxPitchP>103</maxPitchP>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/315553

Correct the order of Violins 1 and 2.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
