### PR TITLE
Fix #315627 - Musescore 3.6 crashes when opening large orchestration created in Musescore 3.4.2

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2908,8 +2908,10 @@ bool Measure::isCutawayClef(int staffIdx) const
             return false;
       for (int track = strack; track < etrack; ++track) {
             Element* e = s->element(track);
-            if (e && e->isClef() && (nextMeasure()->system() == system() || toClef(e)->showCourtesy()))
-                return true;
+            if (!e || !e->isClef())
+                  continue;
+            if ((nextMeasure() && (nextMeasure()->system() == system())) || toClef(e)->showCourtesy())
+                  return true;
             }            
       return false;
       }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/315627

Solve a crash in case <code>nextMeasure()</code> returns a <code>nullptr</code> instead of a pointer to a measure.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
