### PR TITLE
[MU3] Set window not modified when last score is closed

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2669,6 +2669,9 @@ void MuseScore::setCurrentScoreView(ScoreView* view)
       else
             cs = 0;
 
+      updateWindowTitle(cs);
+      setWindowModified(cs ? cs->dirty() : false);
+
       if (ScriptRecorder* rec = getScriptRecorder())
             rec->recordCurrentScoreChange();
 
@@ -2703,7 +2706,6 @@ void MuseScore::setCurrentScoreView(ScoreView* view)
             }
 #endif
       if (!cs) {
-            setWindowTitle(MUSESCORE_NAME_VERSION);
             if (_navigator && _navigator->widget()) {
                   navigator()->setScoreView(cv);
                   }
@@ -2749,16 +2751,10 @@ void MuseScore::setCurrentScoreView(ScoreView* view)
       getAction("fotomode")->setChecked(cv->fotoMode());
       getAction("join-measures")->setEnabled(cs->masterScore()->excerpts().size() == 0);
       getAction("split-measure")->setEnabled(cs->masterScore()->excerpts().size() == 0);
+      getAction("concert-pitch")->setChecked(cs->styleB(Sid::concertPitch));
       updateUndoRedo();
 
       setZoom(cv->zoomIndex(), cv->logicalZoomLevel());
-
-      updateWindowTitle(cs);
-      setWindowModified(cs->dirty());
-
-      QAction* a = getAction("concert-pitch");
-      a->setChecked(cs->styleB(Sid::concertPitch));
-
       setPos(cs->inputPos());
       //showMessage(cs->filePath(), 2000);
       if (_navigator && _navigator->widget()) {
@@ -6952,20 +6948,24 @@ void MuseScore::restoreGeometry(QWidget *const qw)
 
 void MuseScore::updateWindowTitle(Score* score)
       {
-#ifdef Q_OS_MAC
-      if (!cs->isMaster())
-            setWindowTitle(cs->masterScore()->title() + "-" + cs->title());
+      if (!score) {
+            setWindowTitle(MUSESCORE_NAME_VERSION);
+            setWindowFilePath(QString());
+            return;
+            }
+      QString scoreTitle;
+      if (score->isMaster())
+            scoreTitle = score->title();
       else
-            setWindowTitle(cs->title());
+            scoreTitle = score->masterScore()->title() + "-" + score->title();
+#ifdef Q_OS_MAC
+      setWindowTitle(scoreTitle);
       if (score->masterScore()->created())
             setWindowFilePath(QString());
       else
             setWindowFilePath(score->masterScore()->fileInfo()->absoluteFilePath());
 #else
-      if (!cs->isMaster())
-            setWindowTitle(MUSESCORE_NAME_VERSION ": " + cs->masterScore()->title() + "-" + cs->title() + "[*]");
-      else
-            setWindowTitle(MUSESCORE_NAME_VERSION ": " + score->title() + "[*]");
+      setWindowTitle(MUSESCORE_NAME_VERSION ": " + scoreTitle + "[*]");
 #endif
       }
 


### PR DESCRIPTION
I noticed that when the last score is closed, the window is still marked as modified and the window file path is not set to an empty string. Both issues are fixed with this PR.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
