### PR TITLE
fix #290356: Allow copy-pasting of the LetRing, PalmMute and Vibrato elements.

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -534,6 +534,9 @@ void Score::readAddConnector(ConnectorInfoReader* info, bool pasteMode)
             case ElementType::TRILL:
             case ElementType::TEXTLINE:
             case ElementType::VOLTA:
+            case ElementType::PALM_MUTE:
+            case ElementType::LET_RING:
+            case ElementType::VIBRATO:
                   {
                   Spanner* sp = toSpanner(info->connector());
                   const Location& l = info->location();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/290356

This code converts HairPin, LetRing, PalmMute and Vibrato to spanners, to utilize **setTick()** and **setTrack2()** methods. This prepares the ground to be used for any line element.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
