### PR TITLE
[MU3] Allow beaming across crotchet rests.

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -1740,7 +1740,7 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
                   for (; i < n; ++i) {
                         ChordRest* c = crl[i];
                         ChordRest* p = i ? crl[i - 1] : 0;
-                        int l = c->durationType().hooks() - 1;
+                        int l = c->isChord() ? c->durationType().hooks() - 1 : beamLevel;
 
                         Mode bm = Groups::endBeam(c, p);
                         b32 = (beamLevel >= 1) && (bm == Mode::BEGIN32);

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2575,8 +2575,7 @@ void Score::createBeams(LayoutContext& lc, Measure* measure)
                                     if (!beamNoContinue(prevCR->beamMode())
                                         && !pm->lineBreak() && !pm->pageBreak() && !pm->sectionBreak()
                                         && lc.prevMeasure
-                                        && prevCR->durationType().type() >= TDuration::DurationType::V_EIGHTH
-                                        && prevCR->durationType().type() <= TDuration::DurationType::V_1024TH) {
+                                        && !(prevCR->isChord() && prevCR->durationType().type() <= TDuration::DurationType::V_QUARTER)) {
                                           beam = prevCR->beam();
                                           //a1 = beam ? beam->elements().front() : prevCR;
                                           a1 = beam ? nullptr : prevCR; // when beam is found, a1 is no longer required.
@@ -2638,7 +2637,7 @@ void Score::createBeams(LayoutContext& lc, Measure* measure)
                   if (cr->durationType().hooks() > 0 && cr->crossMeasure() == CrossMeasure::SECOND)
                         bm = Beam::Mode::NONE;
 
-                  if ((cr->durationType().type() <= TDuration::DurationType::V_QUARTER) || (bm == Beam::Mode::NONE)) {
+                  if ((cr->isChord() && cr->durationType().type() <= TDuration::DurationType::V_QUARTER) || (bm == Beam::Mode::NONE)) {
                         bool removeBeam = true;
                         if (beam) {
                               beam->layout1();


### PR DESCRIPTION
Currently it is possible to create beams across rests that are less than a quarter note in duration by setting the beaming property of the rest to "Beam middle". This change allows us to honor the beaming properties of all rests, no matter the duration. See https://musescore.org/en/node/315677.