### PR TITLE
Fix #315599 - MuseScore 3.6 crashes when rearranging instrument positions and changing Ordering

### DIFF
--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -94,15 +94,6 @@ void ScoreOrderListModel::rebuildData()
       }
 
 //---------------------------------------------------------
-//   setCustomizedOrder
-//---------------------------------------------------------
-
-void ScoreOrderListModel::setCustomizedOrder(ScoreOrder* order)
-      {
-      _customizedOrder = (order && order->isCustomized()) ? order : nullptr;
-      }
-
-//---------------------------------------------------------
 //   ScoreOrderFilterProxyModel
 //---------------------------------------------------------
 ScoreOrderFilterProxyModel::ScoreOrderFilterProxyModel(ScoreOrderList* data, QObject* parent)
@@ -118,6 +109,7 @@ ScoreOrderFilterProxyModel::ScoreOrderFilterProxyModel(ScoreOrderList* data, QOb
 void ScoreOrderFilterProxyModel::setCustomizedOrder(ScoreOrder* order)
       {
       _customizedOrder = (order && order->isCustomized()) ? order : nullptr;
+      invalidateFilter();
       }
 
 //---------------------------------------------------------
@@ -1239,8 +1231,8 @@ void InstrumentsWidget::updateScoreOrder()
                   if (!custom) {
                         custom = order->clone();
                         scoreOrders.addScoreOrder(custom);
-                        _filter->setCustomizedOrder(custom);
                         }
+                  _filter->setCustomizedOrder(custom);
                   setScoreOrder(custom);
                   }
             }

--- a/mscore/instrwidget.h
+++ b/mscore/instrwidget.h
@@ -42,7 +42,6 @@ enum { PART_LIST_ITEM = QTreeWidgetItem::UserType, STAFF_LIST_ITEM };
 class ScoreOrderListModel : public QAbstractListModel {
    private:
       ScoreOrderList* _scoreOrders;
-      ScoreOrder* _customizedOrder { nullptr };
 
    public:
       ScoreOrderListModel(ScoreOrderList* data, QObject* parent=nullptr);
@@ -50,8 +49,6 @@ class ScoreOrderListModel : public QAbstractListModel {
       int rowCount(const QModelIndex& parent = QModelIndex()) const;
       QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
       void rebuildData();
-
-      void setCustomizedOrder(ScoreOrder* order);
       };
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/315599

Add the customized score order always to the filter if the new order is a customized order.
Also the never used method <code>ScoreOrderListModel::setCustomizedOrder()</code> removed.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
