### PR TITLE
Fix #315237: Don't switch tab when opening a score when a modal is open

### DIFF
--- a/libmscore/musescoreCore.h
+++ b/libmscore/musescoreCore.h
@@ -42,7 +42,7 @@ class MuseScoreCore
 
       virtual int appendScore(MasterScore* s)               { scoreList.append(s); return 0;  }
       virtual void endCmd() {}
-      virtual Score* openScore(const QString& /*fn*/, bool /*switchTab*/, bool considerInCurrentSession = true) { Q_UNUSED(considerInCurrentSession); return 0;}
+      virtual Score* openScore(const QString& /*fn*/, bool /*switchTab*/, bool considerInCurrentSession = true, const QString& /*withFilename*/ = "") { Q_UNUSED(considerInCurrentSession); return 0;}
       QList<MasterScore*>& scores()                         { return scoreList; }
       virtual void updateInspector() {}
       };

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -395,7 +395,7 @@ void MuseScore::askAboutApplyingEdwinIfNeed(const QString& fileSuffix)
 //   openScore
 //---------------------------------------------------------
 
-Score* MuseScore::openScore(const QString& fn, bool switchTab, const bool considerInCurrentSession)
+Score* MuseScore::openScore(const QString& fn, bool switchTab, const bool considerInCurrentSession, const QString& name)
       {
       //
       // make sure we load a file only once
@@ -414,6 +414,10 @@ Score* MuseScore::openScore(const QString& fn, bool switchTab, const bool consid
 
       MasterScore* score = readScore(fn);
       if (score) {
+            if (!name.isEmpty())
+                  score->masterScore()->fileInfo()->setFile(name);
+                  // TODO: what if that path is no longer valid?
+            
             ScoreMigrator_3_6 migrator;
 
             migrator.registerHandler(new StyleDefaultsHandler());

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -404,7 +404,7 @@ Score* MuseScore::openScore(const QString& fn, bool switchTab, const bool consid
       QString path = fi.canonicalFilePath();
       for (Score* s : scoreList) {
             if (s->masterScore() && s->masterScore()->fileInfo()->canonicalFilePath() == path) {
-                  if (switchTab)
+                  if (switchTab && QApplication::activeModalWidget() == nullptr)
                         setCurrentScoreView(scoreList.indexOf(s->masterScore()));
                   return 0;
                   }
@@ -438,7 +438,7 @@ Score* MuseScore::openScore(const QString& fn, bool switchTab, const bool consid
 
             if (considerInCurrentSession) {
                   const int tabIdx = appendScore(score);
-                  if (switchTab)
+                  if (switchTab && QApplication::activeModalWidget() == nullptr)
                         setCurrentScoreView(tabIdx);
                   writeSessionFile(false);
                   }

--- a/mscore/migration/scoremigrationdialog.cpp
+++ b/mscore/migration/scoremigrationdialog.cpp
@@ -1,22 +1,20 @@
 #include "scoremigrationdialog.h"
 
-#include <QQuickItem>
-
 ScoreMigrationDialog::ScoreMigrationDialog(QQmlEngine* engine, Ms::Score* score)
-      : QQuickView(engine, nullptr), m_dialogModel(new ScoreMigrationDialogModel(score, this))
+      : QQuickWidget(engine, nullptr), m_dialogModel(new ScoreMigrationDialogModel(score, this))
       {
       setMinimumWidth(600);
       setMinimumHeight(m_dialogModel->isAutomaticPlacementAvailable() ? 570 : 548);
 
-      setFlags(Qt::Dialog);
+      setWindowFlags(Qt::Dialog);
+      setWindowModality(Qt::ApplicationModal);
 
-      setTitle(score->title());
+      setWindowTitle(score->title());
       setSource(QUrl(QStringLiteral("qrc:/qml/migration/ScoreMigrationDialog.qml")));
 
-      setModality(Qt::ApplicationModal);
-      setResizeMode(QQuickView::SizeRootObjectToView);
+      setResizeMode(SizeRootObjectToView);
 
-      connect(m_dialogModel, &ScoreMigrationDialogModel::closeRequested, this, &QQuickView::close);
+      connect(m_dialogModel, &ScoreMigrationDialogModel::closeRequested, this, &QQuickWidget::close);
 
       if (rootObject())
             rootObject()->setProperty("model", QVariant::fromValue(m_dialogModel));
@@ -24,6 +22,13 @@ ScoreMigrationDialog::ScoreMigrationDialog(QQmlEngine* engine, Ms::Score* score)
 
 void ScoreMigrationDialog::focusInEvent(QFocusEvent* event)
       {
-      QQuickView::focusInEvent(event);
+      QQuickWidget::focusInEvent(event);
+      rootObject()->forceActiveFocus();
+      }
+
+void ScoreMigrationDialog::showEvent(QShowEvent* event)
+      {
+      QQuickWidget::showEvent(event);
+      setFocus();
       rootObject()->forceActiveFocus();
       }

--- a/mscore/migration/scoremigrationdialog.h
+++ b/mscore/migration/scoremigrationdialog.h
@@ -1,12 +1,9 @@
 #ifndef SCOREMIGRATIONDIALOG_H
 #define SCOREMIGRATIONDIALOG_H
 
-#include <QQuickView>
-#include <QQmlEngine>
-
 #include "scoremigrationdialogmodel.h"
 
-class ScoreMigrationDialog : public QQuickView
+class ScoreMigrationDialog : public QQuickWidget
       {
       Q_OBJECT
 
@@ -14,6 +11,7 @@ class ScoreMigrationDialog : public QQuickView
       explicit ScoreMigrationDialog(QQmlEngine* engine, Ms::Score *score);
 
    private:
+      void showEvent(QShowEvent* event) override;
       void focusInEvent(QFocusEvent* event) override;
 
       ScoreMigrationDialogModel* m_dialogModel = nullptr;

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -3496,21 +3496,7 @@ static void loadScores(const QStringList& argv)
             else {
                   switch (preferences.sessionStart()) {
                         case SessionStart::LAST:
-                              {
-                              QSettings settings;
-                              int n = settings.value("scores", 0).toInt();
-                              int c = settings.value("currentScore", 0).toInt();
-                              for (int i = 0; i < n; ++i) {
-                                    QString s = settings.value(QString("score-%1").arg(i),"").toString();
-                                    MasterScore* score = mscore->readScore(s);
-                                    if (score) {
-                                          int view = mscore->appendScore(score);
-                                          if (i == c)
-                                                currentScoreView = view;
-                                          }
-                                    }
-                              }
-                              break;
+                              return; // Already managed by `restoreSession`
                         case SessionStart::EMPTY:
                               break;
                         case SessionStart::NEW:
@@ -5336,13 +5322,8 @@ bool MuseScore::restoreSession(bool always)
                                     else if (t == "dirty")
                                           /*int dirty =*/ e.readInt();
                                     else if (t == "path") {
-                                          Score* score = openScore(e.readElementText());
+                                          Score* score = openScore(e.readElementText(), false, true, name);
                                           if (score) {
-                                                if (!name.isEmpty()) {
-                                                      QFileInfo* fi = score->masterScore()->fileInfo();
-                                                      fi->setFile(name);
-                                                      // TODO: what if that path is no longer valid?
-                                                      }
                                                 if (cleanExit) {
                                                       // override if last session did a clean exit
                                                       created = false;
@@ -5393,7 +5374,7 @@ bool MuseScore::restoreSession(bool always)
                                           return false;
                                           }
                                     }
-                              (tab3 == 0 ? tab1 : tab2)->initScoreView(idx1, logicalZoomLevel, zoomIndex, x, y);
+                              (tab3 == 0 ? tab1 : tab2)->queueInitScoreView(idx1, logicalZoomLevel, zoomIndex, x, y);
                               }
                         else if (tag == "tab")
                               tab = e.readInt();

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -684,7 +684,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void loadFile(const QUrl&);
       QTemporaryFile* getTemporaryScoreFileCopy(const QFileInfo& info, const QString& baseNameTemplate);
       QNetworkAccessManager* networkManager();
-      virtual Score* openScore(const QString& fn, bool switchTab = true, const bool appendToExistingTabs = true) override;
+      virtual Score* openScore(const QString& fn, bool switchTab = true, const bool appendToExistingTabs = true, const QString& withFilename = "") override;
       bool hasToCheckForUpdate();
       bool hasToCheckForExtensionsUpdate();
       static bool unstable();

--- a/mscore/scoretab.cpp
+++ b/mscore/scoretab.cpp
@@ -332,6 +332,8 @@ void ScoreTab::setCurrent(int n)
             tab2->setVisible(false);
             }
       emit currentScoreViewChanged(v);
+
+      initScoreView(n);
       }
 
 //---------------------------------------------------------
@@ -555,26 +557,26 @@ void ScoreTab::removeTab(int idx, bool noCurrentChangedSignal)
 //   initScoreView
 //---------------------------------------------------------
 
-void ScoreTab::initScoreView(const int idx, const qreal logicalZoomLevel, const ZoomIndex zoomIndex, const qreal xoffset, const qreal yoffset)
+void ScoreTab::initScoreView(int idx)
       {
-      ScoreView* v = view(idx);
-      if (!v)  {
-            v = new ScoreView;
-            Score* sc = scoreList->value(idx);
-            if( sc != 0 )
-                  v->setScore(sc);
-            else {
-                  delete v;
-                  return;
+      auto it = scoreViewsToInit.find(idx);
+      if (it != scoreViewsToInit.end()) {
+            ScoreViewState s = it->second;
+            if (ScoreView* v = view(idx)) {
+                  v->setLogicalZoom(s.zoomIndex, s.logicalZoomLevel);
+                  v->setOffset(s.xOffset, s.yOffset);
                   }
-            QSplitter* vs = new QSplitter;
-            vs->setObjectName("score");
-            vs->setAccessibleName("");
-            vs->addWidget(v);
-            stack->addWidget(vs);
+            scoreViewsToInit.erase(it); // Init only one time
             }
-      v->setLogicalZoom(zoomIndex, logicalZoomLevel);
-      v->setOffset(xoffset, yoffset);
       }
-}
 
+//---------------------------------------------------------
+//   queueInitScoreView
+//---------------------------------------------------------
+
+void ScoreTab::queueInitScoreView(const int idx, const qreal logicalZoomLevel, const ZoomIndex zoomIndex, const qreal xoffset, const qreal yoffset)
+      {
+      scoreViewsToInit[idx] = ScoreViewState(logicalZoomLevel, zoomIndex, xoffset, yoffset);
+      }
+
+}

--- a/mscore/scoretab.h
+++ b/mscore/scoretab.h
@@ -26,6 +26,7 @@ class MuseScore;
 class ScoreView;
 class Score;
 enum class ZoomIndex : char;
+struct ScoreViewState;
 
 //---------------------------------------------------------
 //   TabScoreView
@@ -69,6 +70,7 @@ class ScoreTab : public QWidget {
       void clearTab2();
       TabScoreView* tabScoreView(int idx);
       const TabScoreView* tabScoreView(int idx) const;
+      std::map<int, ScoreViewState> scoreViewsToInit;
 
    signals:
       void currentScoreViewChanged(ScoreView*);
@@ -103,7 +105,8 @@ class ScoreTab : public QWidget {
       QSplitter* viewSplitter(int n) const;
       ScoreView* view() const { return view(currentIndex()); }
       bool contains(ScoreView*) const;
-      void initScoreView(int idx, qreal logicalZoomLevel, ZoomIndex zoomIndex, qreal xoffset, qreal yoffset);
+      void initScoreView(int idx);
+      void queueInitScoreView(int idx, qreal logicalZoomLevel, ZoomIndex zoomIndex, qreal xoffset, qreal yoffset);
       };
 
 

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -130,6 +130,26 @@ enum class ViewState {
       };
 
 //---------------------------------------------------------
+//   ScoreViewState
+//---------------------------------------------------------
+
+struct ScoreViewState {
+      qreal logicalZoomLevel = 1.0;
+      ZoomIndex zoomIndex = ZoomIndex::ZOOM_FREE;
+      qreal xOffset = 0.0;
+      qreal yOffset = 0.0;
+
+      ScoreViewState() {}
+      ScoreViewState(qreal zl, ZoomIndex zi, qreal x, qreal y)
+            {
+            logicalZoomLevel = zl;
+            zoomIndex = zi;
+            xOffset = x;
+            yOffset = y;
+            }
+};
+
+//---------------------------------------------------------
 //   ScoreView
 //---------------------------------------------------------
 

--- a/mscore/startcenter.cpp
+++ b/mscore/startcenter.cpp
@@ -124,8 +124,8 @@ void Startcenter::loadScore(QString s)
             newScore();
             }
       else {
-            mscore->openScore(s);
             close();
+            mscore->openScore(s);
             }
       }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/315237

- Don't switch tab when opening a score when a modal is open
- Make ScoreMigrationDialog QQuickWidget, so that it gets recognized by QApplication::activeModalWidget()
- (This caused an issue that the QML content wasn't focussed when the dialog was opened, which I fixed too.)

Result:
- When you open one score, it is appended to the tab bar, and its tab is activated
- The ScoreMigrationDialog for that score is shown
- When you open a second score, it is appended to the tab bar, but its tab is not activated, because a modal dialog is open (namely the ScoreMigrationDialog for score 1)
- When you close the dialog for score 1 and then switch to score 2 's tab, the ScoreMigrationDialog is shown for score 2.

(Maybe an even better solution would be to check not if there is *any* modal dialog open in the whole application, but to check whether there is a modal dialog *related to the current score* (i.e. when the style dialog is open, don't switch, but when the preferences dialog is open, do switch. But that's a bit of an edge case and IMHO not worth the complication.)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
