### PR TITLE
[MU3] Change cursor shape to Pointing Hand when hovering link in QML

### DIFF
--- a/mscore/qml/migration/TextLabel.qml
+++ b/mscore/qml/migration/TextLabel.qml
@@ -53,5 +53,11 @@ FocusableItem {
         onLinkActivated: {
             root.linkActivated()
         }
+
+        MouseArea {
+            anchors.fill: parent
+            cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : undefined
+            acceptedButtons: Qt.NoButton // Not actually accepting clicks, just changing the cursor
+        }
     }
 }


### PR DESCRIPTION
Change cursor shape to Pointing Hand when hovering link in QML
With specifically in mind the link to the 3.6 announcement video in the Score Migration Dialog.

<img width="711" alt="Schermafbeelding 2021-01-20 om 23 45 39" src="https://user-images.githubusercontent.com/48658420/105250327-db19be80-5b79-11eb-8ceb-a2456b73aa87.png">

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
