### PR TITLE
fix #315781: measure number offset changes on reload

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -146,7 +146,7 @@ qreal Element::spatium() const
 
 bool Element::offsetIsSpatiumDependent() const
       {
-      return sizeIsSpatiumDependent() || (parent() && !parent()->isBox());
+      return sizeIsSpatiumDependent() || (_flags & ElementFlag::ON_STAFF);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/315781

Measure numbers were formerly scaled with spatium, but now they are not.
The offset should still be in sp rather than mm,
so a new fucntionoffsetIsSpatiumDependent() was introduced,
analogous to sizeIsSpatiumDependent(), to allow measure numbers
to have size not scale with spatium but keep the scaling of offset.
However, the function depended on checking the parent of the element,
on the idea that measure numebrs are attached to measures,
whereas other non-spatium-dependent elements like title text are not.
Unfortunately, during score read, parent is not set yet,
so this check was failing.

Instead, this commit checks the ON_STAFF element flag,
which really tells us the same basic thing.
So, for measure numbers, ON_STAFF is true,
so even though sizeIsSpatiumDependent is false,
offsetIsSpatiumDependent will return true.
For title text and other elements for which sizeIsSPatiumDependent,
ON_STAFF is false, so the offset will continue to not scale.
This is the correct solution going forward as well
should any other elements need to have size and offset scaling
managed differently.