### PR TITLE
fix #315147: two-note tremolos display incorrectly when the stave has custom scale

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1446,8 +1446,8 @@ qreal Chord::minAbsStemLength() const
       if (!_tremolo)
             return 0.0;
 
-      const qreal sw = score()->styleS(Sid::tremoloStrokeWidth).val() * mag();
-      const qreal td = score()->styleS(Sid::tremoloDistance).val() * mag();
+      const qreal sw = score()->styleS(Sid::tremoloStrokeWidth).val() * chordMag();
+      const qreal td = score()->styleS(Sid::tremoloDistance).val() * chordMag();
       int beamLvl = beams();
       const qreal beamDist = beam() ? beam()->beamDist() : (sw * spatium());
 
@@ -2957,18 +2957,27 @@ void Chord::removeMarkings(bool keepTremolo)
       }
 
 //---------------------------------------------------------
+//   chordMag
+//---------------------------------------------------------
+
+qreal Chord::chordMag() const
+      {
+      qreal m = 1.0;
+      if (small())
+            m *= score()->styleD(Sid::smallNoteMag);
+      if (_noteType != NoteType::NORMAL)
+            m *= score()->styleD(Sid::graceNoteMag);
+      return m;
+      }
+
+//---------------------------------------------------------
 //   mag
 //---------------------------------------------------------
 
 qreal Chord::mag() const
       {
       const Staff* st = staff();
-      qreal m = st ? st->mag(this) : 1.0;
-      if (small())
-            m *= score()->styleD(Sid::smallNoteMag);
-      if (_noteType != NoteType::NORMAL)
-            m *= score()->styleD(Sid::graceNoteMag);
-      return m;
+      return (st ? st->mag(this) : 1.0) * chordMag();
       }
 
 //---------------------------------------------------------

--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -98,6 +98,7 @@ class Chord final : public ChordRest {
 
       void setScore(Score* s) override;
       ElementType type() const override   { return ElementType::CHORD; }
+      qreal chordMag() const;
       qreal mag() const override;
 
       void write(XmlWriter& xml) const override;

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2805,7 +2805,7 @@ void layoutDrumsetChord(Chord* c, const Drumset* drumset, const StaffType* st, q
 
 std::pair<qreal, qreal> extendedStemLenWithTwoNoteTremolo(Tremolo* tremolo, qreal stemLen1, qreal stemLen2)
       {
-      const qreal spatium = tremolo->score()->spatium();
+      const qreal spatium = tremolo->spatium();
       Chord* c1 = tremolo->chord1();
       Chord* c2 = tremolo->chord2();
       Stem*  s1 = c1->stem();

--- a/libmscore/tremolo.h
+++ b/libmscore/tremolo.h
@@ -72,6 +72,7 @@ class Tremolo final : public Element {
 
       qreal minHeight() const;
 
+      qreal chordMag() const;
       qreal mag() const override;
       void draw(QPainter*) const override;
       void layout() override;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/315147.

The issue is caused by the stave scale multiplied twice: once in `spatium()` and once in `mag()`. To avoid this, I created a function `chordMag()` for chords (and also for tremolos which calls the one for chords) which doesn't multiply stave scale, and used that instead of `mag()` for tremolo calculations.