### PR TITLE
fix #315067: swapping notes in a two-note tremolo causes corrupt tremolo (and crash)

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -2174,6 +2174,14 @@ void SwapCR::flip(EditData*)
       Segment* s2 = cr2->segment();
       int track = cr1->track();
 
+      if (cr1->isChord() && cr2->isChord() && (toChord(cr1)->tremolo() == toChord(cr2)->tremolo())) {
+            Tremolo* t = toChord(cr1)->tremolo();
+            Chord* c1 = t->chord1();
+            Chord* c2 = t->chord2();
+            t->setParent(toChord(c2));
+            t->setChords(toChord(c2), toChord(c1));
+            }
+
       Element* cr = s1->element(track);
       s1->setElement(track, s2->element(track));
       s2->setElement(track, cr);

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -5278,8 +5278,15 @@ void ScoreView::cmdMoveCR(bool left)
                               break;
                         }
                   ChordRest* cr2 = left ? prevChordRest(cr1) : nextChordRest(cr1);
-                  if (cr2 && cr1->measure() == cr2->measure() && !cr1->tuplet() && !cr2->tuplet()
-                      && cr1->durationType() == cr2->durationType() && cr1->ticks() == cr2->ticks()) {
+                  // ensures cr1 is the left chord, useful in SwapCR::flip()
+                  if (left)
+                        std::swap(cr1, cr2);
+                  if (cr1 && cr2 && cr1->measure() == cr2->measure() && !cr1->tuplet() && !cr2->tuplet()
+                     && cr1->durationType() == cr2->durationType() && cr1->ticks() == cr2->ticks()
+                     // if two chords belong to different two-note tremolos, abort
+                     && !(cr1->isChord() && toChord(cr1)->tremolo() && toChord(cr1)->tremolo()->twoNotes()
+                        && cr2->isChord() && toChord(cr2)->tremolo() && toChord(cr2)->tremolo()->twoNotes()
+                        && toChord(cr1)->tremolo() != toChord(cr2)->tremolo())) {
                         if (!cmdActive) {
                               _score->startCmd();
                               cmdActive = true;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/315067

This is because the two-note tremolo has not been properly updated and still thinks it is the child of the now second chord (with `chord1()` being the now second chord and `chord2()` being the now first chord). Properly updating these fixes the issue. Meanwhile, if the two chords belong to different two-note tremolos, the swap is disabled, because there's no way of determining the expected behaviour.