### PR TITLE
[MU3] Fixed init of colors

### DIFF
--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -301,13 +301,13 @@ void MScore::init()
             _globalShare = QString( INSTPREFIX "/share/" INSTALL_NAME);
 #endif
 
-      selectColor[0].setNamedColor("0065BF");   //blue
-      selectColor[1].setNamedColor("007F00");   //green
-      selectColor[2].setNamedColor("C53F00");   //orange
-      selectColor[3].setNamedColor("C31989");   //purple
+      selectColor[0].setNamedColor("#0065BF");   //blue
+      selectColor[1].setNamedColor("#007F00");   //green
+      selectColor[2].setNamedColor("#C53F00");   //orange
+      selectColor[3].setNamedColor("#C31989");   //purple
 
       defaultColor           = Qt::black;
-      dropColor              = QColor(0x1778db);
+      dropColor              = QColor("#1778db");
       defaultPlayDuration    = 300;      // ms
       warnPitchRange         = true;
       pedalEventsMinTicks    = 1;
@@ -317,9 +317,9 @@ void MScore::init()
 
       lastError           = "";
 
-      layoutBreakColor    = QColor(0xA0A0A4);
-      frameMarginColor    = QColor(0xA0A0A4);
-      bgColor.setNamedColor("dddddd");
+      layoutBreakColor    = QColor("#A0A0A4");
+      frameMarginColor    = QColor("#A0A0A4");
+      bgColor.setNamedColor("#dddddd");
 
       //
       //  initialize styles

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1268,7 +1268,7 @@ void Note::draw(QPainter* painter) const
                   if (i < in->minPitchP() || i > in->maxPitchP())
                         painter->setPen(selected() ? Qt::darkRed : Qt::red);
                   else if (i < in->minPitchA() || i > in->maxPitchA())
-                        painter->setPen(selected() ? QColor(0x565600) : Qt::darkYellow);
+                        painter->setPen(selected() ? QColor("#565600") : Qt::darkYellow);
                   }
             // draw blank notehead to avoid staff and ledger lines
             if (_cachedSymNull != SymId::noSym) {


### PR DESCRIPTION
- reverted changes that break init of colors
https://github.com/musescore/MuseScore/commit/fbe6949dfae5976626a466d804ba2729ee20b276

Some applications (musescorevideo) can use pure libmscore solution without mscore module. In this case, preferences are not available also (they fixed colors in MU3, see updateExternalValuesFromPreferences). As result, we get invalid colors in those applications