### PR TITLE
[MU4] Stubs system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,8 @@ option(BUILD_TELEMETRY_MODULE "Build with telemetry module" ON)
 set(TELEMETRY_TRACK_ID "" CACHE STRING "Telemetry track id")
 set(CRASH_REPORT_URL "" CACHE STRING "URL where to send crash reports")
 
+option(BUILD_NETWORK_MODULE "Build network module" ON)
+
 option(SOUNDFONT3    "Ogg Vorbis compressed fonts"        ON)  # Enable Ogg Vorbis compressed fonts, requires Ogg & Vorbis
 option(DOWNLOAD_SOUNDFONT "Download the latest soundfont version as part of the build process" ON)
 

--- a/build/config.h.in
+++ b/build/config.h.in
@@ -43,6 +43,8 @@
 #cmakedefine BUILD_TELEMETRY_MODULE
 #define TELEMETRY_TRACK_ID "${TELEMETRY_TRACK_ID}"
 
+#cmakedefine BUILD_NETWORK_MODULE
+
 #cmakedefine WIN_SPARKLE_ENABLED
 #cmakedefine MAC_SPARKLE_ENABLED
 #cmakedefine OPENGL

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,9 @@ add_subdirectory(palette)
 add_subdirectory(inspector)
 add_subdirectory(instruments)
 
+# Stubs
+add_subdirectory(stubs)
+
 if (BUILD_UNIT_TESTS)
 #    add_subdirectory(notation/tests) no tests at moment
     add_subdirectory(userscores/tests)

--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -5,7 +5,11 @@ add_subdirectory(uicomponents)
 add_subdirectory(fonts)
 add_subdirectory(actions)
 add_subdirectory(shortcuts)
-add_subdirectory(network)
+
+if (BUILD_NETWORK_MODULE)
+    add_subdirectory(network)
+endif (BUILD_NETWORK_MODULE)
+
 add_subdirectory(system)
 add_subdirectory(audio)
 add_subdirectory(midi)

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -32,7 +32,13 @@
 #include "framework/actions/actionsmodule.h"
 #include "framework/shortcuts/shortcutsmodule.h"
 #include "framework/system/systemmodule.h"
+
+#ifdef BUILD_NETWORK_MODULE
 #include "framework/network/networkmodule.h"
+#else
+#include "stubs/framework/network/networkstubmodule.h"
+#endif
+
 #include "framework/audio/audiomodule.h"
 #include "framework/midi/midimodule.h"
 
@@ -98,7 +104,12 @@ int main(int argc, char** argv)
     app.addModule(new mu::ui::UiModule());
     app.addModule(new mu::uicomponents::UiComponentsModule());
     app.addModule(new mu::system::SystemModule());
+
+#ifdef BUILD_NETWORK_MODULE
     app.addModule(new mu::network::NetworkModule());
+#else
+    app.addModule(new mu::network::NetworkStubModule());
+#endif
 
     app.addModule(new mu::actions::ActionsModule());
     app.addModule(new mu::appshell::AppShellModule());

--- a/src/stubs/CMakeLists.txt
+++ b/src/stubs/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+add_subdirectory(framework)

--- a/src/stubs/framework/CMakeLists.txt
+++ b/src/stubs/framework/CMakeLists.txt
@@ -1,0 +1,4 @@
+
+if (NOT BUILD_NETWORK_MODULE)
+add_subdirectory(network)
+endif (NOT BUILD_NETWORK_MODULE)

--- a/src/stubs/framework/network/CMakeLists.txt
+++ b/src/stubs/framework/network/CMakeLists.txt
@@ -1,0 +1,31 @@
+#=============================================================================
+#  MuseScore
+#  Music Composition & Notation
+#
+#  Copyright (C) 2020 MuseScore BVBA and others
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#=============================================================================
+
+set(MODULE network)
+
+set(MODULE_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/networkstubmodule.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/networkstubmodule.h
+    ${CMAKE_CURRENT_LIST_DIR}/networkmanagercreatorstub.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/networkmanagercreatorstub.h
+    ${CMAKE_CURRENT_LIST_DIR}/networkmanagerstub.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/networkmanagerstub.h
+    )
+
+include(${PROJECT_SOURCE_DIR}/build/module.cmake)

--- a/src/stubs/framework/network/networkmanagercreatorstub.cpp
+++ b/src/stubs/framework/network/networkmanagercreatorstub.cpp
@@ -1,0 +1,28 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "networkmanagercreatorstub.h"
+
+#include "networkmanagerstub.h"
+
+using namespace mu::network;
+
+INetworkManagerPtr NetworkManagerCreatorStub::makeNetworkManager() const
+{
+    return std::make_shared<NetworkManagerStub>();
+}

--- a/src/stubs/framework/network/networkmanagercreatorstub.h
+++ b/src/stubs/framework/network/networkmanagercreatorstub.h
@@ -1,0 +1,32 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_NETWORK_NETWORKMANAGERCREATORSTUB_H
+#define MU_NETWORK_NETWORKMANAGERCREATORSTUB_H
+
+#include "network/inetworkmanagercreator.h"
+
+namespace mu::network {
+class NetworkManagerCreatorStub : public INetworkManagerCreator
+{
+public:
+    INetworkManagerPtr makeNetworkManager() const override;
+};
+}
+
+#endif // MU_NETWORK_NETWORKMANAGERCREATORSTUB_H

--- a/src/stubs/framework/network/networkmanagerstub.cpp
+++ b/src/stubs/framework/network/networkmanagerstub.cpp
@@ -1,0 +1,55 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "networkmanagerstub.h"
+
+using namespace mu::network;
+
+mu::Ret NetworkManagerStub::get(const QUrl&, mu::system::IODevice*)
+{
+    return make_ret(Ret::Code::NotSupported);
+}
+
+mu::Ret NetworkManagerStub::head(const QUrl&)
+{
+    return make_ret(Ret::Code::NotSupported);
+}
+
+mu::Ret NetworkManagerStub::post(const QUrl&, mu::system::IODevice*, mu::system::IODevice*)
+{
+    return make_ret(Ret::Code::NotSupported);
+}
+
+mu::Ret NetworkManagerStub::put(const QUrl&, mu::system::IODevice*, mu::system::IODevice*)
+{
+    return make_ret(Ret::Code::NotSupported);
+}
+
+mu::Ret NetworkManagerStub::del(const QUrl&, mu::system::IODevice*)
+{
+    return make_ret(Ret::Code::NotSupported);
+}
+
+mu::framework::ProgressChannel NetworkManagerStub::progressChannel() const
+{
+    return framework::ProgressChannel();
+}
+
+void NetworkManagerStub::abort()
+{
+}

--- a/src/stubs/framework/network/networkmanagerstub.h
+++ b/src/stubs/framework/network/networkmanagerstub.h
@@ -1,0 +1,40 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_NETWORK_NETWORKMANAGERSTUB_H
+#define MU_NETWORK_NETWORKMANAGERSTUB_H
+
+#include "network/inetworkmanager.h"
+
+namespace mu::network {
+class NetworkManagerStub : public INetworkManager
+{
+public:
+    Ret get(const QUrl&, system::IODevice*) override;
+    Ret head(const QUrl&) override;
+    Ret post(const QUrl&, system::IODevice*, system::IODevice*) override;
+    Ret put(const QUrl&, system::IODevice*, system::IODevice*) override;
+    Ret del(const QUrl&, system::IODevice*) override;
+
+    framework::ProgressChannel progressChannel() const override;
+
+    void abort() override;
+};
+}
+
+#endif // MU_NETWORK_NETWORKMANAGERSTUB_H

--- a/src/stubs/framework/network/networkstubmodule.cpp
+++ b/src/stubs/framework/network/networkstubmodule.cpp
@@ -1,0 +1,36 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "networkstubmodule.h"
+
+#include "modularity/ioc.h"
+
+#include "networkmanagercreatorstub.h"
+
+using namespace mu::network;
+using namespace mu::framework;
+
+std::string NetworkStubModule::moduleName() const
+{
+    return "network_stub";
+}
+
+void NetworkStubModule::registerExports()
+{
+    ioc()->registerExport<INetworkManagerCreator>(moduleName(), new NetworkManagerCreatorStub());
+}

--- a/src/stubs/framework/network/networkstubmodule.h
+++ b/src/stubs/framework/network/networkstubmodule.h
@@ -1,0 +1,33 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2020 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_NETWORK_NETWORKSTUBMODULE_H
+#define MU_NETWORK_NETWORKSTUBMODULE_H
+
+#include "modularity/imodulesetup.h"
+
+namespace mu::network {
+class NetworkStubModule : public framework::IModuleSetup
+{
+public:
+    std::string moduleName() const override;
+    void registerExports() override;
+};
+}
+
+#endif // MU_NETWORK_NETWORKSTUBMODULE_H


### PR DESCRIPTION
Some modules may be missing in the project. For example, someone doesn't need a network module.
If the developer decides to get rid of the module or just wants to save build time and not build a module that he does not need, then all the dependencies that are given outside the module will not be available.
Then other modules that use this dependency may crash because module dependency not exported. Then the developer will have to add another nullptr checker to all dependency uses. If not, then this is a potential place to crash, and the code just becomes ugly

We decided to add a stub module for each module, which will register stubs instead of implementation.
The stab module repeats the structure of the original module.

Example for network module:
Exports INetworkManagerCreator(see NetworkModule::registerExports()).

To work correctly without the network module (the exported interfaces and types must be in the path of the original module), we must do:
1. create a module along with the path corresponding to the location of the original module
src/framework/network -> src/stubs/framework/network
The standard CMakeLists.txt template, a simple NetworkStubModule class with an overridden registerExports method, in which we register a stub instead of a real class. The module name is better call as module_stub
2. create stubs for the exported interfaces
Stubs should be as simple as possible, ideally, they should return default values of each value
3. register the BUILD_NETWORK_MODULE compilation option in
/CMakeLists.txt
/build/config.h.in
4. replace the stub module in main.cpp with the original module if the module build option is disabled