### PR TITLE
Fix #284796: Incomplete voice in local time signature leads to corruption upon import

### DIFF
--- a/libmscore/check.cpp
+++ b/libmscore/check.cpp
@@ -388,7 +388,7 @@ void Measure::checkMeasure(int staffIdx)
             if (f > expectedPos) {
                   // don't fill empty voices
                   if (expectedPos.isNotZero())
-                        fillGap(expectedPos, ticks() - expectedPos, track, stretch);
+                        fillGap(expectedPos, f - expectedPos, track, stretch);
                   }
             else if (f < expectedPos)
                   qDebug("measure overrun %6d, %d > %d, track %d", tick().ticks(), expectedPos.ticks(), f.ticks(), track);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/284796.

Part of the process for verifying the internal integrity of a measure is to create gap rests when any of the voices in the measure are incomplete. The duration of the gap rest was incorrectly determined based on the length of the measure in terms of the global time signature, which caused a problem in the presence of a local time signature.