### PR TITLE
Fix #315726: Applying key change to a selection causes crash if transposing instrument is involved.

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -686,7 +686,7 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
                                                 Interval v = staff->part()->instrument(tick1)->transpose();
                                                 if (!v.isZero()) {
                                                       Key k = okeysig->key();
-                                                      okeysig->setKey(transposeKey(k, v, okeysig->part()->preferSharpFlat()));
+                                                      okeysig->setKey(transposeKey(k, v, staff->part()->preferSharpFlat()));
                                                       }
                                                 }
                                           oelement = okeysig;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/315726.

The new KeySig element does not have a part yet, because it has not yet been added to the score.