### PR TITLE
[MU4] Implement -o file converter command line option

### DIFF
--- a/src/appshell/appshell.cpp
+++ b/src/appshell/appshell.cpp
@@ -208,9 +208,14 @@ int AppShell::processConverter(const CommandLineController::ConverterTask& task)
 {
     Ret ret;
     if (task.isBatchMode) {
-        ret = converter()->batchConvert(task.batchJobFile);
+        ret = converter()->batchConvert(task.inputFile);
         if (!ret) {
             LOGE() << "failed batch convert, error: " << ret.toString();
+        }
+    } else {
+        ret = converter()->fileConvert(task.inputFile, task.outputFile);
+        if (!ret) {
+            LOGE() << "failed file convert, error: " << ret.toString();
         }
     }
 

--- a/src/appshell/commandlinecontroller.h
+++ b/src/appshell/commandlinecontroller.h
@@ -38,8 +38,8 @@ public:
 
     struct ConverterTask {
         bool isBatchMode = false;
-        QString batchJobFile;
-        QString exportFile;
+        QString inputFile;
+        QString outputFile;
     };
 
     void parse(const QStringList& args);

--- a/src/converter/iconvertercontroller.h
+++ b/src/converter/iconvertercontroller.h
@@ -30,6 +30,7 @@ class IConverterController : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IConverterController() = default;
 
+    virtual Ret fileConvert(const io::path& in, const io::path& out) = 0;
     virtual Ret batchConvert(const io::path& batchJobFile) = 0;
 };
 }

--- a/src/converter/internal/convertercontroller.cpp
+++ b/src/converter/internal/convertercontroller.cpp
@@ -40,7 +40,7 @@ mu::Ret ConverterController::batchConvert(const io::path& batchJobFile)
 
     Ret ret = make_ret(Ret::Code::Ok);
     for (const Job& job : batchJob.val) {
-        ret = convert(job.in, job.out);
+        ret = fileConvert(job.in, job.out);
         if (!ret) {
             LOGE() << "failed convert, err: " << ret.toString() << ", in: " << job.in << ", out: " << job.out;
             break;
@@ -50,7 +50,7 @@ mu::Ret ConverterController::batchConvert(const io::path& batchJobFile)
     return ret;
 }
 
-mu::Ret ConverterController::convert(const io::path& in, const io::path& out)
+mu::Ret ConverterController::fileConvert(const io::path& in, const io::path& out)
 {
     TRACEFUNC;
     LOGI() << "in: " << in << ", out: " << out;

--- a/src/converter/internal/convertercontroller.h
+++ b/src/converter/internal/convertercontroller.h
@@ -38,6 +38,7 @@ class ConverterController : public IConverterController
 public:
     ConverterController() = default;
 
+    Ret fileConvert(const io::path& in, const io::path& out) override;
     Ret batchConvert(const io::path& batchJobFile) override;
 
 private:
@@ -50,8 +51,6 @@ private:
     using BatchJob = std::list<Job>;
 
     RetVal<BatchJob> parseBatchJob(const io::path& batchJobFile) const;
-
-    Ret convert(const io::path& in, const io::path& out);
 };
 }
 


### PR DESCRIPTION
Implement `-o` file converter command line option. 

A disadvantage of this way, is that `CommandLineController::ConverterTask` and `ConverterController::Job` are now very similar. Maybe even _so_ similar, that we want to use only one. That might need an improvement.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
