### PR TITLE
[MU3] Remove outdated <tremoloPlacement> property from style files

### DIFF
--- a/share/styles/legacy-style-defaults-v1.mss
+++ b/share/styles/legacy-style-defaults-v1.mss
@@ -412,7 +412,6 @@
     <tremoloBoxHeight>0.65</tremoloBoxHeight>
     <tremoloLineWidth>0.5</tremoloLineWidth>
     <tremoloDistance>0.8</tremoloDistance>
-    <tremoloPlacement>0</tremoloPlacement>
     <tremoloStrokeStyle>0</tremoloStrokeStyle>
     <linearStretch>1.5</linearStretch>
     <crossMeasureValues>0</crossMeasureValues>

--- a/share/styles/legacy-style-defaults-v2.mss
+++ b/share/styles/legacy-style-defaults-v2.mss
@@ -412,7 +412,6 @@
     <tremoloBoxHeight>0.65</tremoloBoxHeight>
     <tremoloLineWidth>0.5</tremoloLineWidth>
     <tremoloDistance>0.8</tremoloDistance>
-    <tremoloPlacement>0</tremoloPlacement>
     <tremoloStrokeStyle>0</tremoloStrokeStyle>
     <linearStretch>1.5</linearStretch>
     <crossMeasureValues>0</crossMeasureValues>

--- a/share/styles/legacy-style-defaults-v3.mss
+++ b/share/styles/legacy-style-defaults-v3.mss
@@ -411,7 +411,6 @@
     <tremoloBoxHeight>0.65</tremoloBoxHeight>
     <tremoloLineWidth>0.5</tremoloLineWidth>
     <tremoloDistance>0.8</tremoloDistance>
-    <tremoloPlacement>0</tremoloPlacement>
     <tremoloStrokeStyle>0</tremoloStrokeStyle>
     <linearStretch>1.5</linearStretch>
     <crossMeasureValues>0</crossMeasureValues>


### PR DESCRIPTION
Remove outdated <tremoloPlacement> property from style files.
This property was deleted, but it was still in the style files, which caused output like 
```
libmscore/xmlreader.cpp:Ms::XmlReader::unknown: tag in <:/styles/legacy-style-defaults-v3.mss> line 414 col 22: tremoloPlacement
```

I think it is not likely that removing them will cause any problems. But still the question remains how they got into those style files. They might be generated before the property was removed, but I still doubt about that. 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
