### PR TITLE
[MU4] Add option to open popup upwards

### DIFF
--- a/src/appshell/qml/DevTools/DevToolsMenu.qml
+++ b/src/appshell/qml/DevTools/DevToolsMenu.qml
@@ -1,27 +1,33 @@
-import QtQuick 2.7
-import QtQuick.Controls 2.2
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
-Rectangle {
+import MuseScore.Ui 1.0
+import MuseScore.UiComponents 1.0
 
-    id: root
+RadioButtonGroup {
+    id: radioButtonList
 
-    property var model: null
+    orientation: ListView.Vertical
+    spacing: 0
 
     signal selected(string name)
 
-    Column {
-        anchors.fill: parent
+    currentIndex: 0
 
-        Repeater {
-            model: root.model
-            delegate: ItemDelegate {
-                height: 56
-                anchors.left: parent.left
-                anchors.right: parent.right
+    delegate: GradientTabButton {
+        id: radioButtonDelegate
 
-                text: modelData.title
-                onClicked: root.selected(modelData.name)
-            }
+        width: parent.width
+
+        ButtonGroup.group: radioButtonList.radioButtonGroup
+        orientation: Qt.Horizontal
+        checked: index === radioButtonList.currentIndex
+
+        title: modelData["title"]
+
+        onToggled: {
+            radioButtonList.currentIndex = index
+            radioButtonList.selected(modelData["name"])
         }
     }
 }

--- a/src/appshell/qml/DevTools/DevToolsPage.qml
+++ b/src/appshell/qml/DevTools/DevToolsPage.qml
@@ -1,13 +1,14 @@
-import QtQuick 2.7
-import MuseScore.Ui 1.0
+import QtQuick 2.15
+
 import MuseScore.Dock 1.0
+import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
 
+import "./Gallery"
 import "./Interactive"
+import "./NotationDialogs"
 import "./Telemetry"
 import "./Audio"
-import "./Gallery"
-import "./NotationDialogs"
 import "./VST"
 import "./Plugins"
 
@@ -21,27 +22,36 @@ DockPage {
             id: resourcesPanel
             objectName: "devtoolsPanel"
 
-            width: 200
+            width: 292
+            minimumWidth: 76
+
             color: ui.theme.backgroundPrimaryColor
 
-            DevToolsMenu {
+            Rectangle {
+                anchors.fill: parent
+                color: ui.theme.backgroundPrimaryColor
 
-                model: [
-                    { "name": "gallery", "title": "UI Gallery" },
-                    { "name": "interactive", "title": "Interactive" },
-                    { "name": "mu3dialogs", "title": "MU3Dialogs" },
-                    { "name": "telemetry", "title": "Telemetry" },
-                    { "name": "audio", "title": "Audio" },
-                    { "name": "synth", "title": "Synth" },
-                    { "name": "midiports", "title": "Midi ports" },
-                    { "name": "vst", "title": "VST" },
-                    { "name": "plugins", "title": "Plugins" }
-                ]
+                DevToolsMenu {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
 
-                onSelected: {
-                    devtoolsCentral.load(name)
+                    model: [
+                        { "name": "gallery", "title": "UI Gallery" },
+                        { "name": "interactive", "title": "Interactive" },
+                        { "name": "mu3dialogs", "title": "MU3Dialogs" },
+                        { "name": "telemetry", "title": "Telemetry" },
+                        { "name": "audio", "title": "Audio" },
+                        { "name": "synth", "title": "Synth" },
+                        { "name": "midiports", "title": "Midi ports" },
+                        { "name": "vst", "title": "VST" },
+                        { "name": "plugins", "title": "Plugins" }
+                    ]
+
+                    onSelected: {
+                        devtoolsCentral.load(name)
+                    }
                 }
-
             }
         }
     ]
@@ -50,7 +60,7 @@ DockPage {
         id: devtoolsCentral
         objectName: "devtoolsCentral"
 
-        property var currentComp: interactiveComp
+        property var currentComp: galleryComp
 
         function load(name) {
             console.info("loadCentral: " + name)
@@ -68,7 +78,6 @@ DockPage {
         }
 
         Rectangle {
-
             Loader {
                 id: centralLoader
                 anchors.fill: parent
@@ -78,8 +87,18 @@ DockPage {
     }
 
     Component {
+        id: galleryComp
+        GeneralComponentsGallery {}
+    }
+
+    Component {
         id: interactiveComp
         InteractiveTests {}
+    }
+
+    Component {
+        id: notationDialogs
+        MU3Dialogs {}
     }
 
     Component {
@@ -89,7 +108,7 @@ DockPage {
         }
     }
 
-    Component{
+    Component {
         id: audioComp
         AudioEngineTests {}
     }
@@ -105,22 +124,11 @@ DockPage {
     }
 
     Component {
-        id: notationDialogs
-        MU3Dialogs {}
-    }
-
-    Component {
         id: vstComponent
         //safe if VST is not available
         Loader {
             source: "qrc:/qml/DevTools/VST/VSTTests.qml"
         }
-    }
-
-    Component {
-        id: galleryComp
-
-        GeneralComponentsGallery {}
     }
 
     Component {

--- a/src/appshell/qml/DevTools/Gallery/GeneralComponentsGallery.qml
+++ b/src/appshell/qml/DevTools/Gallery/GeneralComponentsGallery.qml
@@ -106,32 +106,61 @@ Rectangle {
     Component {
         id: popupSample
 
-        Item {
-            width: root.width
-            height: 40
+        Column {
+            spacing: 12
 
             FlatButton {
-                id: popupButton
+                id: popupDownButton
 
-                text: "Click to show popup"
+                text: "Click to show popup downward"
 
                 onClicked: {
-                    if (popup.opened) {
-                        popup.close()
-                        return
+                    if (popupDown.opened) {
+                        popupDown.close()
+                    } else {
+                        popupDown.open()
                     }
-
-                    popup.open()
                 }
             }
 
             StyledPopup {
-                id: popup
+                id: popupDown
 
                 width: 200
                 height: 200
 
-                y: popupButton.y + popupButton.height
+                anchorItem: popupDownButton
+
+                StyledTextLabel {
+                    text: "Hello, World!"
+
+                    anchors.centerIn: parent
+                }
+            }
+
+            FlatButton {
+                id: popupUpButton
+
+                text: "Click to show popup upward"
+
+                onClicked: {
+                    if (popupUp.opened) {
+                        popupUp.close()
+                    } else {
+                        popupUp.open()
+                    }
+                }
+            }
+
+            StyledPopup {
+                id: popupUp
+
+                width: 200
+                height: 200
+
+                anchorItem: popupUpButton
+
+                opensUpward: true
 
                 StyledTextLabel {
                     text: "Hello, World!"

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledPopup.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledPopup.qml
@@ -28,16 +28,22 @@ Popup {
     property color borderColor: ui.theme.strokeColor
     property color fillColor: ui.theme.backgroundPrimaryColor
     property bool isOpened: false
+    property bool opensUpward: false
 
     property var arrowX: width / 2
     property alias arrowHeight: arrow.height
 
     readonly property int borderWidth: 1
 
-    topPadding: bottomPadding + arrow.height
-    bottomPadding: 12
-    leftPadding: bottomPadding
-    rightPadding: bottomPadding
+    property Item anchorItem: null
+
+    y: opensUpward ? anchorItem.y - height : anchorItem.y + anchorItem.height
+
+    property var popupPadding: 12
+    topPadding: opensUpward ? popupPadding : popupPadding + arrowHeight
+    bottomPadding: opensUpward ? popupPadding + arrowHeight : popupPadding
+    leftPadding: popupPadding
+    rightPadding: popupPadding
 
     onOpened: { isOpened = true }
     onClosed: { isOpened = false }
@@ -63,6 +69,8 @@ Popup {
 
             Canvas {
                 id: arrow
+                anchors.top: opensUpward ? undefined : parent.top
+                anchors.bottom: opensUpward ? parent.bottom : undefined
                 z: 1
                 height: 12
                 width: 22
@@ -73,11 +81,18 @@ Popup {
                     ctx.lineWidth = 2;
                     ctx.fillStyle = fillColor;
                     ctx.strokeStyle = borderColor;
-
                     ctx.beginPath();
-                    ctx.moveTo(0, height);
-                    ctx.lineTo(width / 2, 1);
-                    ctx.lineTo(width, height);
+
+                    if (opensUpward) {
+                        ctx.moveTo(0, 0);
+                        ctx.lineTo(width / 2, height - 1);
+                        ctx.lineTo(width, 0);
+                    } else {
+                        ctx.moveTo(0, height);
+                        ctx.lineTo(width / 2, 1);
+                        ctx.lineTo(width, height);
+                    }
+
                     ctx.stroke();
                     ctx.fill();
                 }
@@ -88,9 +103,10 @@ Popup {
                 border { width: root.borderWidth; color: root.borderColor }
 
                 anchors {
-                    top: arrow.bottom
-                    topMargin: -1
-                    bottom: parent.bottom
+                    top: opensUpward ? parent.top : arrow.bottom
+                    topMargin: opensUpward ? 0 : -1
+                    bottom: opensUpward ? arrow.top : parent.bottom
+                    bottomMargin: opensUpward ? -1 : 0
                     left: parent.left
                     right: parent.right
                 }


### PR DESCRIPTION
- DevTools tab improvements: 
  - Select "UI Gallery" when you first open DevTools tab (it is the topmost tab, but the "Interactive" tab would be selected)
  - Same nice-looking sidebar as in home tab (not strictly necessary, but still nice)

- Option to open popup upwards
  <img width="777" alt="Schermafbeelding 2021-01-20 om 23 41 48" src="https://user-images.githubusercontent.com/48658420/105249867-136ccd00-5b79-11eb-90bd-231dcaa35823.png">
  Might be needed for example if we want a popup in the status bar. 
  (I would like to implement a zoom popup in the status bar, but the popup won't grow higher than the status bar, which makes it useless. Like this: 
  <img width="469" alt="Schermafbeelding 2021-01-20 om 23 38 32" src="https://user-images.githubusercontent.com/48658420/105249574-9e00fc80-5b78-11eb-96ba-9d33d21c3f68.png">



<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
