### PR TITLE
[MU4] Audio. Step 4. Fixed using mixer from different threads

### DIFF
--- a/src/framework/audio/CMakeLists.txt
+++ b/src/framework/audio/CMakeLists.txt
@@ -93,6 +93,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/equaliser.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/audiothread.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/audiothread.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/audiosanitizer.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/audiosanitizer.h
     ${CMAKE_CURRENT_LIST_DIR}/devtools/audioenginedevtools.cpp
     ${CMAKE_CURRENT_LIST_DIR}/devtools/audioenginedevtools.h
 

--- a/src/framework/audio/devtools/audioenginedevtools.cpp
+++ b/src/framework/audio/devtools/audioenginedevtools.cpp
@@ -30,7 +30,7 @@ using namespace mu::midi;
 AudioEngineDevTools::AudioEngineDevTools(QObject* parent)
     : QObject(parent)
 {
-    audioEngine()->driver()->availableOutputDevicesChanged().onNotify(this, [this]() {
+    audioDriver()->availableOutputDevicesChanged().onNotify(this, [this]() {
         emit devicesChanged();
     });
 
@@ -224,7 +224,7 @@ float AudioEngineDevTools::time() const
 QVariantList AudioEngineDevTools::devices() const
 {
     QVariantList list;
-    auto devices = audioEngine()->driver()->availableOutputDevices();
+    auto devices = audioDriver()->availableOutputDevices();
     for (auto&& device : devices) {
         list.push_back(QString::fromStdString(device));
     }
@@ -233,12 +233,12 @@ QVariantList AudioEngineDevTools::devices() const
 
 QString AudioEngineDevTools::device() const
 {
-    return QString::fromStdString(audioEngine()->driver()->outputDevice());
+    return QString::fromStdString(audioDriver()->outputDevice());
 }
 
 void AudioEngineDevTools::selectDevice(QString name)
 {
-    audioEngine()->driver()->selectOutputDevice(name.toStdString());
+    audioDriver()->selectOutputDevice(name.toStdString());
 }
 
 void AudioEngineDevTools::makeArpeggio()

--- a/src/framework/audio/devtools/audioenginedevtools.h
+++ b/src/framework/audio/devtools/audioenginedevtools.h
@@ -37,7 +37,7 @@ class AudioEngineDevTools : public QObject, public async::Asyncable
 {
     Q_OBJECT
     INJECT(audio, IAudioEngine, audioEngine)
-    //INJECT(audio, IAudioDriver, audioDriver)
+    INJECT(audio, IAudioDriver, audioDriver)
     INJECT(audio, context::IGlobalContext, globalContext)
     INJECT(audio, audio::ISequencer, sequencer)
     INJECT(audio, framework::IInteractive, interactive)

--- a/src/framework/audio/iaudiodriver.h
+++ b/src/framework/audio/iaudiodriver.h
@@ -24,11 +24,15 @@
 #include <vector>
 #include <functional>
 #include <memory>
+
+#include "modularity/imoduleexport.h"
 #include "async/notification.h"
 
 namespace mu::audio {
-class IAudioDriver
+class IAudioDriver : MODULE_EXPORT_INTERFACE
 {
+    INTERFACE_ID(IAudioDriver)
+
 public:
     virtual ~IAudioDriver() = default;
 

--- a/src/framework/audio/iaudioengine.h
+++ b/src/framework/audio/iaudioengine.h
@@ -39,8 +39,6 @@ class IAudioEngine : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IAudioEngine() = default;
 
-    virtual Ret init(IAudioDriverPtr, uint16_t bufferSize) = 0;
-    virtual void deinit() = 0;
     virtual bool isInited() const = 0;
     virtual async::Channel<bool> initChanged() const = 0;
     virtual unsigned int sampleRate() const = 0;
@@ -49,9 +47,6 @@ public:
     virtual IMixerPtr mixer() const = 0;
     virtual IAudioBufferPtr buffer() const = 0;
     virtual void setBuffer(IAudioBufferPtr) = 0;
-    virtual IAudioDriverPtr driver() const = 0;
-    virtual void resumeDriver() = 0;
-    virtual void suspendDriver() = 0;
 };
 }
 #endif // MU_AUDIO_IAUDIOENGINE_H

--- a/src/framework/audio/internal/audiobuffer.h
+++ b/src/framework/audio/internal/audiobuffer.h
@@ -42,14 +42,15 @@ public:
     void setMinSampleLag(unsigned int lag) override;
 
 private:
+
     unsigned int sampleLag() const;
     void fillup();
 
+    std::recursive_mutex m_mutex; //! TODO get rid *recursive*
     unsigned int m_streamsPerSample = 0;
     unsigned int m_minSampleLag = FILL_SAMPLES;
-    std::atomic<unsigned int> m_writeIndex = 0;
-    std::atomic<unsigned int> m_readIndex = 0;
-    std::mutex m_dataMutex;
+    unsigned int m_writeIndex = 0;
+    unsigned int m_readIndex = 0;
     std::vector<float> m_data = {};
     std::shared_ptr<IAudioSource> m_source = nullptr;
 };

--- a/src/framework/audio/internal/audioengine.h
+++ b/src/framework/audio/internal/audioengine.h
@@ -25,27 +25,28 @@
 
 #include "iaudioengine.h"
 #include "modularity/ioc.h"
-#include "iaudiodriver.h"
 
 #include "ret.h"
 #include "retval.h"
-#include "invoker.h"
 
 #include "mixer.h"
 #include "audiobuffer.h"
 #include "internal/sequencer.h"
 #include "async/asyncable.h"
-#include "internal/audiothread.h"
+#include "midi/isynthesizersregister.h"
 
 namespace mu::audio {
 class AudioEngine : public IAudioEngine, public async::Asyncable
 {
+    INJECT(audio, midi::ISynthesizersRegister, synthesizersRegister)
 public:
-    AudioEngine();
     ~AudioEngine();
 
-    Ret init(IAudioDriverPtr driver, uint16_t bufferSize) override;
-    void deinit() override;
+    static AudioEngine* instance();
+
+    Ret init(int sampleRate, uint16_t readBufferSize);
+    void deinit();
+
     bool isInited() const override;
     async::Channel<bool> initChanged() const override;
     unsigned int sampleRate() const override;
@@ -54,14 +55,14 @@ public:
     std::shared_ptr<ISequencer> sequencer() const override;
     IAudioBufferPtr buffer() const override;
     void setBuffer(IAudioBufferPtr buffer) override;
-    IAudioDriverPtr driver() const override;
-    void resumeDriver() override;
-    void suspendDriver() override;
 
 private:
+
+    AudioEngine();
+
     bool m_inited = false;
-    IAudioDriver::Spec m_format;
     mu::async::Channel<bool> m_initChanged;
+    unsigned int m_sampleRate = 0;
     std::shared_ptr<Sequencer> m_sequencer = nullptr;
     std::shared_ptr<IAudioDriver> m_driver = nullptr;
     std::shared_ptr<Mixer> m_mixer = nullptr;

--- a/src/framework/audio/internal/audiosanitizer.cpp
+++ b/src/framework/audio/internal/audiosanitizer.cpp
@@ -16,39 +16,20 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#ifndef MU_AUDIO_RPCCONTROLLER_H
-#define MU_AUDIO_RPCCONTROLLER_H
+#include "audiosanitizer.h"
 
-#include <functional>
+#include <thread>
 
-#include "modularity/ioc.h"
-#include "irpcchannel.h"
-#include "../audioengine.h"
+using namespace mu::audio;
 
-namespace mu::audio::rpc {
-class RpcController : public async::Asyncable
+static std::thread::id s_as_workerThreadID;
+
+void AudioSanitizer::setupWorkerThread()
 {
-    INJECT(audio, IRpcChannel, rpcChannel)
-
-public:
-    RpcController() = default;
-
-    void init();
-
-private:
-
-    using Call = std::function<void (const Args& args)>;
-    using Calls = std::map<Method, Call>;
-
-    AudioEngine* audioEngine() const;
-    ISequencerPtr sequencer() const;
-
-    void bindMethod(Calls& calls, const Method& method, const Call& call);
-    void doCall(const Calls& calls, const Msg& msg);
-
-    void audioEngineHandle(const Msg& msg);
-    void sequencerHandle(const Msg& msg);
-};
+    s_as_workerThreadID = std::this_thread::get_id();
 }
 
-#endif // MU_AUDIO_RPCCONTROLLER_H
+bool AudioSanitizer::isWorkerThread()
+{
+    return std::this_thread::get_id() == s_as_workerThreadID;
+}

--- a/src/framework/audio/internal/audiosanitizer.h
+++ b/src/framework/audio/internal/audiosanitizer.h
@@ -2,7 +2,7 @@
 //  MuseScore
 //  Music Composition & Notation
 //
-//  Copyright (C) 2020 MuseScore BVBA and others
+//  Copyright (C) 2021 MuseScore BVBA and others
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2.
@@ -16,29 +16,23 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#ifndef MU_MIDI_SYNTHESIZERSREGISTER_H
-#define MU_MIDI_SYNTHESIZERSREGISTER_H
+#ifndef MU_AUDIO_AUDIOSANITIZER_H
+#define MU_AUDIO_AUDIOSANITIZER_H
 
-#include <map>
-#include "../isynthesizersregister.h"
+//! NOTE This is dev tools
 
-namespace mu::midi {
-class SynthesizersRegister : public ISynthesizersRegister
+#include <cassert>
+
+namespace mu::audio {
+class AudioSanitizer
 {
 public:
 
-    void registerSynthesizer(const SynthName& name, std::shared_ptr<ISynthesizer> s) override;
-    std::shared_ptr<ISynthesizer> synthesizer(const SynthName& name) const override;
-    std::vector<std::shared_ptr<ISynthesizer> > synthesizers() const override;
-
-    void setDefaultSynthesizer(const SynthName& name) override;
-    std::shared_ptr<ISynthesizer> defaultSynthesizer() const override;
-
-private:
-
-    std::map<std::string, std::shared_ptr<ISynthesizer> > m_synths;
-    SynthName m_defaultName;
+    static void setupWorkerThread();
+    static bool isWorkerThread();
 };
 }
 
-#endif // MU_MIDI_SYNTHESIZERSREGISTER_H
+#define ONLY_AUDIO_WORKER_THREAD assert(mu::audio::AudioSanitizer::isWorkerThread())
+
+#endif // MU_AUDIO_AUDIOSANITIZER_H

--- a/src/framework/audio/internal/audiothread.cpp
+++ b/src/framework/audio/internal/audiothread.cpp
@@ -41,8 +41,10 @@ AudioThread::~AudioThread()
     }
 }
 
-void AudioThread::run()
+void AudioThread::run(const OnStart& onStart)
 {
+    m_onStart = onStart;
+
 #ifndef Q_OS_WASM
     m_running = true;
     m_thread = std::make_shared<std::thread>([this]() {
@@ -81,6 +83,10 @@ void AudioThread::loopBody()
 void AudioThread::main()
 {
     mu::runtime::setThreadName("audio_worker");
+
+    if (m_onStart) {
+        m_onStart();
+    }
 
     m_channel->setupWorkerThread();
     m_controller->init();

--- a/src/framework/audio/internal/audiothread.h
+++ b/src/framework/audio/internal/audiothread.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <thread>
 #include <atomic>
+#include <functional>
 
 #include "iaudiobuffer.h"
 #include "modularity/ioc.h"
@@ -36,7 +37,9 @@ public:
     AudioThread();
     ~AudioThread();
 
-    void run();
+    using OnStart = std::function<void ()>;
+
+    void run(const OnStart& onStart = nullptr);
     void stop();
 
     void setAudioBuffer(std::shared_ptr<IAudioBuffer> buffer);
@@ -49,6 +52,7 @@ public:
 private:
     void main();
 
+    OnStart m_onStart;
     rpc::QueuedRpcChannelPtr m_channel;
     std::shared_ptr<rpc::RpcController> m_controller;
     std::shared_ptr<IAudioBuffer> m_buffer = nullptr;

--- a/src/framework/audio/internal/midiplayer.cpp
+++ b/src/framework/audio/internal/midiplayer.cpp
@@ -183,7 +183,10 @@ void MIDIPlayer::forwardTime(unsigned long miliseconds)
 
     sendEvents(prevTicks, toTick);
 
-    m_onTickPlayed.send(m_playTick);
+    if (m_lastSentTick != m_playTick) {
+        m_lastSentTick = m_playTick;
+        m_onTickPlayed.send(m_playTick);
+    }
 
     m_prevMSec = m_curMSec;
     checkPosition();

--- a/src/framework/audio/internal/midiplayer.h
+++ b/src/framework/audio/internal/midiplayer.h
@@ -133,6 +133,7 @@ private:
         std::vector<float> buf;
     };
     std::vector<SynthState> m_synthStates = {};
+    midi::tick_t m_lastSentTick = -1;
     async::Channel<midi::tick_t> m_onTickPlayed;
 };
 }

--- a/src/framework/audio/internal/mixer.h
+++ b/src/framework/audio/internal/mixer.h
@@ -74,7 +74,6 @@ private:
     float m_masterLevel = 1.f;
     std::map<ChannelID, std::shared_ptr<MixerChannel> > m_inputList = {};
     std::map<unsigned int, std::shared_ptr<IAudioInsert> > m_insertList = {};
-    std::mutex m_mutex;
     std::shared_ptr<Clock> m_clock;
 };
 }

--- a/src/framework/audio/internal/rpc/rpctypes.h
+++ b/src/framework/audio/internal/rpc/rpctypes.h
@@ -26,7 +26,8 @@
 namespace mu::audio::rpc {
 enum class TargetName {
     Undefined = 0,
-    Sequencer = 1
+    AudioEngine = 1,
+    Sequencer = 2,
 };
 
 struct Target {

--- a/src/framework/audio/internal/samplerateconvertor.h
+++ b/src/framework/audio/internal/samplerateconvertor.h
@@ -16,8 +16,8 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
-#ifndef MU_AUDIO_SRC_H
-#define MU_AUDIO_SRC_H
+#ifndef MU_AUDIO_SAMPLERATECONVERTOR_H
+#define MU_AUDIO_SAMPLERATECONVERTOR_H
 
 #include <vector>
 #include <deque>
@@ -73,4 +73,4 @@ private:
 };
 }
 
-#endif // MU_AUDIO_SRC_H
+#endif // MU_AUDIO_SAMPLERATECONVERTOR_H

--- a/src/framework/audio/internal/sequencer.cpp
+++ b/src/framework/audio/internal/sequencer.cpp
@@ -149,9 +149,10 @@ void Sequencer::timeUpdate()
     }
 
     bool willcontinue = false;
-    for (auto& track : m_tracks) {
-        track.second->forwardTime(m_clock->timeInMiliSeconds());
-        willcontinue |= track.second->isRunning();
+    for (auto& val : m_tracks) {
+        Track& track = val.second;
+        track->forwardTime(m_clock->timeInMiliSeconds());
+        willcontinue |= track->isRunning();
     }
     m_positionChanged.notify();
     if (!willcontinue) {

--- a/src/framework/midi/internal/synthesizersregister.cpp
+++ b/src/framework/midi/internal/synthesizersregister.cpp
@@ -23,7 +23,6 @@ using namespace mu::midi;
 void SynthesizersRegister::registerSynthesizer(const SynthName& name, std::shared_ptr<ISynthesizer> s)
 {
     m_synths[name] = s;
-    audioEngine()->startSynthesizer(s);
 }
 
 std::shared_ptr<ISynthesizer> SynthesizersRegister::synthesizer(const SynthName& name) const

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -56,6 +56,7 @@ void PlaybackController::init()
 
     case STEPPED:
         sequencer()->midiTickPlayed(MIDI_TRACK).onReceive(this, [this](midi::tick_t tick) {
+            LOGI() << "midiTickPlayed tick: " << tick;
             m_tickPlayed.send(tick);
         });
         break;


### PR DESCRIPTION
```
We have three layers
        ------------------------
        Main (main thread) - public client interface
            see registerExports
        ------------------------
        Worker (worker thread) - generate and mix audio data
            * AudioEngine
            * Sequencer
            * Players
            * Synthesizers
            * Audio decode (.ogg ...)
            * Mixer
        ------------------------
        Driver (driver thread) - request audio data to play
        ------------------------

        All layers work in separate threads.
        We need to make sure that each part of the system works only in its thread and,
        ideally, there is no access to the same object from different threads,
        in order to avoid problems associated with access data thread safety.

        Objects from different layers (threads) must interact only through:
            * Rpc (remote call procedure) channel - controls and pass midi data
            * AudioBuffer - pass audio data from worker to driver for play

        AudioEngine is in the worker and operates only with the buffer,
        in fact, it knows nothing about the data consumer, about the audio driver.
```

original block scheme from https://github.com/musescore/MuseScore/pull/6848
![image](https://user-images.githubusercontent.com/3818029/105385414-ffc67280-5c1b-11eb-9c3d-67d8bd4244a5.png)


I noticed that in the mixer, some methods have mutex, but in others is no mutex, and it is not obvious why (for me).
According to the architecture, the mixer should work in the audio worker thread 
I added a check on the thread in which the methods are called, found that the methods are called from different threads.
This PR corrects this.