### PR TITLE
fix #315963: Add Flügelhorns to instruments/orders.xml

### DIFF
--- a/share/instruments/orders.xml
+++ b/share/instruments/orders.xml
@@ -14,6 +14,7 @@
             <family>horns</family>
             <family>trumpets</family>
             <family>cornets</family>
+            <family>flugelhorns</family>
             <family>trombones</family>
             <family>tubas</family>
         </section>
@@ -53,7 +54,7 @@
         <family>organs</family>
         <unsorted/>
     </Order>
-        <Order id="marching-band">
+    <Order id="marching-band">
         <name>Marching Band</name>
         <instrument id="mellophone">
             <family id="horns">Horns</family>
@@ -78,6 +79,7 @@
         <section id="brass">
             <family>cornets</family>
             <family>trumpets</family>
+            <family>flugelhorns</family>
             <family>horns</family>
             <family>trombones</family>
             <family>baritone-horns</family>
@@ -120,6 +122,7 @@
         </section>
         <section id="trumpets" thinBrackets="false">
             <family>trumpets</family>
+            <family>flugelhorns</family>
         </section>
         <section id="trombones" thinBrackets="false">
             <family>trombones</family>
@@ -156,6 +159,7 @@
         <family>voices</family>
         <family>flutes</family>
         <family>clarinets</family>
+        <family>flugelhorns</family>
         <family>trumpets</family>
         <family>saxophones</family>
         <family>trombones</family>
@@ -203,6 +207,7 @@
         <section id="brass">
             <family>cornets</family>
             <family>trumpets</family>
+            <family>flugelhorns</family>
             <family>horns</family>
             <family>trombones</family>
             <family>baritone-horns</family>
@@ -271,6 +276,7 @@
         <section id="brass" thinBrackets="false">
             <family>trumpets</family>
             <family>cornets</family>
+            <family>flugelhorns</family>
             <family>horns</family>
             <family>trombones</family>
             <family>tubas</family>

--- a/share/templates/03-Chamber_Music/05-Brass_Quartet.mscx
+++ b/share/templates/03-Chamber_Music/05-Brass_Quartet.mscx
@@ -40,6 +40,7 @@
       <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
         <family>trumpets</family>
         <family>cornets</family>
+        <family>flugelhorns</family>
         <family>horns</family>
         <family>trombones</family>
         <family>tubas</family>

--- a/share/templates/03-Chamber_Music/06-Brass_Quintet.mscx
+++ b/share/templates/03-Chamber_Music/06-Brass_Quintet.mscx
@@ -87,6 +87,7 @@
       <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
         <family>trumpets</family>
         <family>cornets</family>
+        <family>flugelhorns</family>
         <family>horns</family>
         <family>trombones</family>
         <family>tubas</family>

--- a/share/templates/07-Band_and_Percussion/01-Concert_Band.mscx
+++ b/share/templates/07-Band_and_Percussion/01-Concert_Band.mscx
@@ -102,6 +102,7 @@
       <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
         <family>cornets</family>
         <family>trumpets</family>
+        <family>flugelhorns</family>
         <family>horns</family>
         <family>trombones</family>
         <family>baritone-horns</family>

--- a/share/templates/07-Band_and_Percussion/02-Small_Concert_Band.mscx
+++ b/share/templates/07-Band_and_Percussion/02-Small_Concert_Band.mscx
@@ -95,6 +95,7 @@
         <family>horns</family>
         <family>cornets</family>
         <family>trumpets</family>
+        <family>flugelhorns</family>
         <family>trombones</family>
         <family>baritone-horns</family>
         <family>euphoniums</family>

--- a/share/templates/07-Band_and_Percussion/04-Marching_Band.mscx
+++ b/share/templates/07-Band_and_Percussion/04-Marching_Band.mscx
@@ -112,6 +112,7 @@
       <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
         <family>cornets</family>
         <family>trumpets</family>
+        <family>flugelhorns</family>
         <family>horns</family>
         <family>trombones</family>
         <family>baritone-horns</family>

--- a/share/templates/07-Band_and_Percussion/09-European_Concert_Band.mscx
+++ b/share/templates/07-Band_and_Percussion/09-European_Concert_Band.mscx
@@ -105,6 +105,7 @@
       <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
         <family>cornets</family>
         <family>trumpets</family>
+        <family>flugelhorns</family>
         <family>horns</family>
         <family>trombones</family>
         <family>baritone-horns</family>

--- a/share/templates/08-Orchestral/01-Classical_Orchestra.mscx
+++ b/share/templates/08-Orchestral/01-Classical_Orchestra.mscx
@@ -65,6 +65,7 @@
         <family>horns</family>
         <family>trumpets</family>
         <family>cornets</family>
+        <family>flugelhorns</family>
         <family>trombones</family>
         <family>tubas</family>
         </section>

--- a/share/templates/08-Orchestral/02-Symphony_Orchestra.mscx
+++ b/share/templates/08-Orchestral/02-Symphony_Orchestra.mscx
@@ -94,6 +94,7 @@
         <family>horns</family>
         <family>trumpets</family>
         <family>cornets</family>
+        <family>flugelhorns</family>
         <family>trombones</family>
         <family>tubas</family>
         </section>

--- a/share/templates/08-Orchestral/03-String_Orchestra.mscx
+++ b/share/templates/08-Orchestral/03-String_Orchestra.mscx
@@ -54,6 +54,7 @@
         <family>horns</family>
         <family>trumpets</family>
         <family>cornets</family>
+        <family>flugelhorns</family>
         <family>trombones</family>
         <family>tubas</family>
         </section>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/315963

Add Flügelhorns as discussed in the issue to concert bands, orchestral and big bands, jazz combos and brass ensembles.

I also added a whitespace fix.

---

No code changes, so no compilation needed. I verified by loading the modified file into my settings.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
