### PR TITLE
[MU3] Fix #316071: Display sym smufl name in symbols palette, use available translations there too

### DIFF
--- a/mscore/symboldialog.cpp
+++ b/mscore/symboldialog.cpp
@@ -57,7 +57,7 @@ void SymbolDialog::createSymbols()
                || Sym::id2userName(id).contains(search->text(), Qt::CaseInsensitive)) {
                   Symbol* s = new Symbol(gscore);
                   s->setSym(SymId(id), f);
-                  sp->append(s, Sym::id2userName(SymId(id)));
+                  sp->append(s, qApp->translate("symUserNames", Sym::id2userName(SymId(id)).toUtf8()) + " \"<sym>" + Sym::id2name(SymId(id)) + "</sym>\"");
                   }
             }
       }


### PR DESCRIPTION
Shows the SMuFL Id in addition to the descriptive text for the symbol.
Additionaly shows the **translated** description, if one exists. We do this for the 'normal' palettes already, not so for the symbols palette, this should get fixed (and does by this PR)

Resolves: https://musescore.org/en/node/316071

A more complete, but also more involved one is in #7308, it fully contains this one here