### PR TITLE
fix #315638: wrong key signature on reset styles with concert pitch

### DIFF
--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -1152,7 +1152,10 @@ void EditStyle::on_resetStylesButton_clicked()
 
 void EditStyle::resetStyle(Score* score)
 {
-    score->style().resetAllStyles(score, pageStyles());
+      auto ignoreStyles = pageStyles();
+      ignoreStyles.insert(Sid::concertPitch);
+      ignoreStyles.insert(Sid::createMultiMeasureRests);
+      score->style().resetAllStyles(score, ignoreStyles);
 }
 
 void EditStyle::applyToAllParts()


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/315638

This is not a new regression, but the reset styles command
was undiscovered by most users prior to 3.6,
when it was moved to the style dialog and promoted
as the way to convert old scores to the new style defaults.
The original issue was that the reset of concert pitch
back to the default (off) didn't update key signatures.
But I suggest, people don't really think of this as a style anyhow,
and we already treat it specially by giving it a toolbar button,
managing it specially when generating parts, etc.
And there is potentially information lost on toggling concert pitch
(enharmonic spelling adjustments, etc).

So this commit doesn't actually attempt to fix the key signatures.
Instead, it simply adds concert pitch to the list of styles to ignore
when doing the reset.
This will better match user expectations and lessen the risk of damage.
For similar reasons, I am adding multimeasure rests to the ignore list.
It also is managed specially by MuseScore already,
so doing so again here is actually quite consistent
and I think very much in line with user expectations.
Especially when thinking about parts where it was enabled automatically
and the user might not even know how to re-enable them after reset.