### PR TITLE
fix #315841: indent can cause measures to not fit on system

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3784,7 +3784,7 @@ System* Score::collectSystem(LayoutContext& lc)
                   Measure* m = toMeasure(lc.curMeasure);
                   if (firstMeasure) {
                         layoutSystemMinWidth = minWidth;
-                        system->layoutSystem(minWidth);
+                        system->layoutSystem(minWidth, lc.firstSystem, lc.firstSystemIndent);
                         minWidth += system->leftMargin();
                         if (m->repeatStart()) {
                               Segment* s = m->findSegmentR(SegmentType::StartRepeatBarLine, Fraction(0,1));

--- a/vtest/accidental-12.mscx
+++ b/vtest/accidental-12.mscx
@@ -26,6 +26,7 @@
       <harmonyFretDist>0.5</harmonyFretDist>
       <harmonyPlay>0</harmonyPlay>
       <showMeasureNumber>0</showMeasureNumber>
+      <enableIndentationOnFirstSystem>0</enableIndentationOnFirstSystem>
       <showFooter>0</showFooter>
       <defaultFramePadding>0.5</defaultFramePadding>
       <defaultFrameWidth>0.2</defaultFrameWidth>
@@ -104,13 +105,14 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument>
+      <Instrument id="piano">
         <shortName>Pno.</shortName>
         <trackName>Piano</trackName>
         <minPitchP>21</minPitchP>
         <maxPitchP>108</maxPitchP>
         <minPitchA>21</minPitchA>
         <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>70</gateTime>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/315841

The first system indent setting does it what it says,
but it doens't actually add the space until *after*
we've collected the measures to fit on the system.
This can result in one too many measures being added to the system
(actually could be more than one if you have a crazy big indent).
The result is the measures will overflow into the margin.

This commit fixes the issue by accounting for the indent
on the first layout of the system when laying out its first measure.
This is the same time we allocate space for the instrument names,
so it makes sense to handle indent here as well.
In fact, that already happens on the subsequent system layout
that happens *after* measures are collected.
There is even code to do a "max" betwene indent and instrument names.
So it seems natural to incorporate the indent during that first layout.