### PR TITLE
fix #315861: don't show clef changes on hidden staves

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2884,7 +2884,10 @@ bool Measure::isEmpty(int staffIdx) const
 
 bool Measure::isCutawayClef(int staffIdx) const
       {
-      if (!isEmpty(staffIdx))
+      if (!score()->staff(staffIdx) || !_mstaves[staffIdx])
+            return false;
+      bool empty = (score()->staff(staffIdx)->cutaway() && isEmpty(staffIdx)) || !_mstaves[staffIdx]->visible();
+      if (!empty)
             return false;
       int strack;
       int etrack;

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -1165,7 +1165,7 @@ void Segment::scanElements(void* data, void (*func)(void*, Element*), bool all)
       {
       for (int track = 0; track < score()->nstaves() * VOICES; ++track) {
             int staffIdx = track/VOICES;
-            if (!all && !(score()->staff(staffIdx)->show())) {
+            if (!all && !(score()->staff(staffIdx)->show() && system() && !system()->staves()->empty() && system()->staff(staffIdx)->show())) {
                   track += VOICES - 1;
                   continue;
                   }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/315861

Issue is that a clef change at the end of a system
on a staff that is hidden
will still generate the clef and it will be displayed
on the top staff of the score.

The issue stems from the new isCutawayClef() function
returning true in many places where it does not need to.
Most importantly to this issue,
it's returning true for the hidden staff,
We could check for staff visibility everything this function is called,
but just checking within the function seems simpler.

Hoewever, in my simple test case added to the issue,
cutaway staves were not even invovled.
It seems this function should not be doing any of the things it does
*unless* it's a cutaway staff.
Checking for that, as well as staff visibility,
at the start of this function should help protect
against regressions that might otherwise appear
if this function doens't do what makes sense in the usual case.