### PR TITLE
Fix #316025 - Fixed spacers do not function with vertical justification enabled

### DIFF
--- a/libmscore/layout.h
+++ b/libmscore/layout.h
@@ -41,7 +41,7 @@ class VerticalGapData {
       SysStaff* sysStaff { nullptr };
       Staff*    staff    { nullptr };
 
-      VerticalGapData(bool first, System* sys, Staff* st, SysStaff* sst, qreal y);
+      VerticalGapData(bool first, System* sys, Staff* st, SysStaff* sst, const Spacer* spacer, qreal y);
 
       void addSpaceBetweenSections();
       void addSpaceAroundVBox(bool above);

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -1403,7 +1403,7 @@ qreal System::minDistance(System* s2) const
             }
 
       dist = qMax(dist, score()->staff(firstStaff)->userDist());
-      fixedDownDistance = false;
+      fixedSpacer = nullptr;
 
       for (MeasureBase* mb1 : ml) {
             if (mb1->isMeasure()) {
@@ -1411,8 +1411,8 @@ qreal System::minDistance(System* s2) const
                   Spacer* sp = m->vspacerDown(lastStaff);
                   if (sp) {
                         if (sp->spacerType() == SpacerType::FIXED) {
+                              fixedSpacer = sp;
                               dist = sp->gap();
-                              fixedDownDistance = true;
                               break;
                               }
                         else
@@ -1420,7 +1420,7 @@ qreal System::minDistance(System* s2) const
                         }
                   }
             }
-      if (!fixedDownDistance) {
+      if (!getFixedSpacer()) {
             for (MeasureBase* mb2 : s2->ml) {
                   if (mb2->isMeasure()) {
                         Measure* m = toMeasure(mb2);

--- a/libmscore/system.h
+++ b/libmscore/system.h
@@ -95,10 +95,10 @@ class System final : public Element {
       QList<Bracket*> _brackets;
       QList<SpannerSegment*> _spannerSegments;
 
-      qreal _leftMargin              { 0.0   };     ///< left margin for instrument name, brackets etc.
-      mutable bool fixedDownDistance { false };
-      qreal _distance                { 0.0   };     // temp. variable used during layout
-      qreal _systemHeight            { 0.0   };
+      qreal _leftMargin           { 0.0     };     ///< left margin for instrument name, brackets etc.
+      mutable Spacer* fixedSpacer { nullptr };
+      qreal _distance             { 0.0     };     // temp. variable used during layout
+      qreal _systemHeight         { 0.0     };
 
       int firstVisibleSysStaff() const;
       int lastVisibleSysStaff() const;
@@ -191,7 +191,7 @@ public:
       qreal firstNoteRestSegmentX(bool leading = false);
 
       void moveBracket(int staffIdx, int srcCol, int dstCol);
-      bool hasFixedDownDistance() const { return fixedDownDistance; }
+      Spacer* getFixedSpacer() const { return fixedSpacer; }
       int firstVisibleStaff() const;
       int nextVisibleStaff(int) const;
       qreal distance() const { return _distance; }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/316025

When a system contains a fixed spacer, the gap above that system will become a gap with a fixed gap and no extra space will be added to this gap.
To implement this, <code>System::minDistance()</code> will now, instead of just saving the fixed distance, save the fixed spacer instead. <code>distributeStaves()</code> will use this to find out whether a system has a fixed spacer or not.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
