### PR TITLE
fix #309333: crash hiding palettes

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6009,14 +6009,10 @@ void MuseScore::cmd(QAction* a)
             }
       if (cmdn == "toggle-palette") {
             showPalette(a->isChecked());
-            if (a->isChecked()) {
-                  lastFocusWidget = QApplication::focusWidget();
+            if (a->isChecked())
                   paletteWidget->activateSearchBox();
-                  }
-            else {
-                  if (lastFocusWidget)
-                        lastFocusWidget->setFocus();
-                  }
+            else if (cv)
+                  cv->setFocus();
             return;
             }
       if (cmdn == "palette-search") {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/309333

Crash happens on trying to set the focus upon closing the palette,
we try to restore the previous focused widget.
But it may no longer be valid.

Changed to return focus to the score view if possible,
otherwise let Qt worry about it.
