### PR TITLE
fix #316096, fix #305093: custom gliss text reverts to default "gliss"

### DIFF
--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -421,7 +421,7 @@ void Glissando::read(XmlReader& e)
             const QStringRef& tag = e.name();
             if (tag == "text") {
                   _showText = true;
-                  _text = e.readElementText();
+                  readProperty(e, Pid::GLISS_TEXT);
                   }
             else if (tag == "subtype")
                   _glissandoType = GlissandoType(e.readInt());


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/316096
Resolves: https://musescore.org/en/node/305093

Issue is that customized gliss text reverts back to the default "gliss".
In all 3.x versions, this happened after saving, reloading,
then making any style change.
In 3.6, this happens immediately on the save/reload.
Cause is that the property was never makred unstyled on read.
Fix is to change the plain setting of "_text" with
a call to readProperty() on Pid::GLISS_TEXT.