### PR TITLE
[MU4] SMuFL Symbol Anchors, ledger lines, flag placing, Shadow Note refactoring

### DIFF
--- a/src/libmscore/ambitus.cpp
+++ b/src/libmscore/ambitus.cpp
@@ -476,25 +476,25 @@ void Ambitus::draw(QPainter* p) const
 
     // draw ledger lines (if not in a palette)
     if (segment() && track() > -1) {
-        Fraction tick          = segment()->tick();
-        Staff* stf        = score()->staff(staffIdx());
-        qreal lineDist    = stf->lineDistance(tick);
-        int numOfLines    = stf->lines(tick);
-        qreal step        = lineDist * _spatium;
-        qreal stepTolerance = step * 0.1;
-        qreal ledgerOffset = score()->styleS(Sid::ledgerLineLength).val() * 0.5 * _spatium;
-        p->setPen(QPen(curColor(), score()->styleS(Sid::ledgerLineWidth).val() * _spatium,
-                       Qt::SolidLine, Qt::FlatCap));
+        Fraction tick  = segment()->tick();
+        Staff* staff   = score()->staff(staffIdx());
+        qreal lineDist = staff->lineDistance(tick);
+        int numOfLines = staff->lines(tick);
+        qreal step     = lineDist * _spatium;
+        qreal stepTolerance    = step * 0.1;
+        qreal ledgerLineLength = score()->styleS(Sid::ledgerLineLength).val() * _spatium;
+        qreal ledgerLineWidth  = score()->styleS(Sid::ledgerLineWidth).val() * _spatium;
+        p->setPen(QPen(curColor(), ledgerLineWidth, Qt::SolidLine, Qt::FlatCap));
         if (_topPos.y() - stepTolerance <= -step) {
-            qreal xMin = _topPos.x() - ledgerOffset;
-            qreal xMax = _topPos.x() + headWidth() + ledgerOffset;
+            qreal xMin = _topPos.x() - ledgerLineLength;
+            qreal xMax = _topPos.x() + headWidth() + ledgerLineLength;
             for (qreal y = -step; y >= _topPos.y() - stepTolerance; y -= step) {
                 p->drawLine(QPointF(xMin, y), QPointF(xMax, y));
             }
         }
         if (_bottomPos.y() + stepTolerance >= numOfLines * step) {
-            qreal xMin = _bottomPos.x() - ledgerOffset;
-            qreal xMax = _bottomPos.x() + headWidth() + ledgerOffset;
+            qreal xMin = _bottomPos.x() - ledgerLineLength;
+            qreal xMax = _bottomPos.x() + headWidth() + ledgerLineLength;
             for (qreal y = numOfLines * step; y <= _bottomPos.y() + stepTolerance; y += step) {
                 p->drawLine(QPointF(xMin, y), QPointF(xMax, y));
             }

--- a/src/libmscore/beam.cpp
+++ b/src/libmscore/beam.cpp
@@ -461,9 +461,9 @@ void Beam::layout1()
 
         _cross = minMove < maxMove;
         if (minMove == 1 && maxMove == 1) {
-            setTrack(staffIdx * VOICES + voice());
+            setStaffIdx(staffIdx);
         } else if (c1) {
-            setTrack(c1->staffIdx() * VOICES + voice());
+            setStaffIdx(c1->staffIdx());
         }
 
         // int idx = (_direction == Direction::AUTO || _direction == Direction::DOWN) ? 0 : 1;

--- a/src/libmscore/chord.cpp
+++ b/src/libmscore/chord.cpp
@@ -762,8 +762,8 @@ void Chord::addLedgerLines()
         return;
     }
 
-    // the extra length of a ledger line with respect to notehead (half of it on each side)
-    qreal extraLen = score()->styleP(Sid::ledgerLineLength) * mag * 0.5;
+    // the extra length of a ledger line to be added on each side of the notehead
+    qreal extraLen = score()->styleP(Sid::ledgerLineLength) * mag;
     qreal hw;
     qreal minX, maxX;                           // note extrema in raster units
     int minLine, maxLine;

--- a/src/libmscore/chord.cpp
+++ b/src/libmscore/chord.cpp
@@ -1293,59 +1293,6 @@ void Chord::setScore(Score* s)
 }
 
 //-----------------------------------------------------------------------------
-//   hookAdjustment
-//    Adjustment to the length of the stem in order to accommodate hooks
-//    This function replaces this bit of code:
-//      switch (hookIdx) {
-//            case 3: normalStemLen += small() ? .5  : 0.75; break; //32nd notes
-//            case 4: normalStemLen += small() ? 1.0 : 1.5;  break; //64th notes
-//            case 5: normalStemLen += small() ? 1.5 : 2.25; break; //128th notes
-//            }
-//    which was not sufficient for two reasons:
-//      1. It only lengthened the stem for 3, 4, or 5 hooks.
-//      2. It was too general to produce good results for all combinations of factors.
-//    This provides a way to take a number of factors into account. Further tweaking may be in order.
-//-----------------------------------------------------------------------------
-
-qreal hookAdjustment(QString font, int hooks, bool up, bool small)
-{
-    bool fallback = MScore::useFallbackFont && (hooks > 5);
-
-    if (font == "Emmentaler" && !fallback) {
-        if (up) {
-            if (hooks > 2) {
-                return (hooks - 2) * (small ? .75 : 1);
-            }
-        } else {
-            if (hooks == 3) {
-                return small ? .75 : 1;
-            } else if (hooks > 3) {
-                return (hooks - 2) * (small ? .5 : .75);
-            }
-        }
-    } else if (font == "Gonville" && !fallback) {
-        if (up) {
-            if (hooks > 2) {
-                return (hooks - 2) * (small ? .5 : .75);
-            }
-        } else {
-            if (hooks > 1) {
-                return (hooks - 1) * (small ? .5 : .75);
-            }
-        }
-    } else if (font == "MuseJazz") {
-        if (hooks > 2) {
-            return (hooks - 2) * (small ? .75 : 1);
-        }
-    } else {
-        if (hooks > 2) {
-            return (hooks - 2) * (small ? .5 : .75);
-        }
-    }
-    return 0;
-}
-
-//-----------------------------------------------------------------------------
 //   defaultStemLength
 ///   Get the default stem length for this chord
 //-----------------------------------------------------------------------------
@@ -1399,7 +1346,6 @@ qreal Chord::defaultStemLength() const
     }
 
     qreal normalStemLen = small() ? 2.5 : 3.5;
-    normalStemLen += hookAdjustment(score()->styleSt(Sid::MusicalSymbolFont), hookIdx, up(), small());
     if (hookIdx && tab == 0) {
         if (up() && durationType().dots()) {
             //
@@ -1627,13 +1573,7 @@ void Chord::layoutStem()
 #if 0
                     _hook->layout();
                     QPointF p(_stem->hookPos());
-                    if (up()) {
-                        p.ry() -= _hook->bbox().top();
-                        p.rx() -= _stem->width();
-                    } else {
-                        p.ry() -= _hook->bbox().bottom();
-                        p.rx() -= _stem->width();
-                    }
+                    p.rx() -= _stem->width();
                     _hook->setPos(p);
 #endif
                 }
@@ -1650,13 +1590,7 @@ void Chord::layoutStem()
         if (_hook) {
             _hook->layout();
             QPointF p(_stem->hookPos());
-            if (up()) {
-                p.ry() -= _hook->bbox().top();
-                p.rx() -= _stem->width();
-            } else {
-                p.ry() -= _hook->bbox().bottom();
-                p.rx() -= _stem->width();
-            }
+            p.rx() -= _stem->width();
             _hook->setPos(p);
         }
         if (_stemSlash) {
@@ -2366,13 +2300,7 @@ void Chord::layoutTablature()
                 }
 
                 QPointF p(_stem->hookPos());
-                if (up()) {
-                    p.ry() -= _hook->bbox().top();
-                    p.rx() -= _stem->width();
-                } else {
-                    p.ry() -= _hook->bbox().bottom();
-                    p.rx() -= _stem->width();
-                }
+                p.rx() -= _stem->width();
                 _hook->setPos(p);
             }
         }

--- a/src/libmscore/chordrest.cpp
+++ b/src/libmscore/chordrest.cpp
@@ -542,7 +542,7 @@ Element* ChordRest::drop(EditData& data)
     case ElementType::REHEARSAL_MARK:
     {
         e->setParent(segment());
-        e->setTrack((track() / VOICES) * VOICES);
+        e->setTrack(trackZeroVoice(track()));
         if (e->isRehearsalMark()) {
             RehearsalMark* r = toRehearsalMark(e);
             if (fromPalette) {
@@ -560,7 +560,7 @@ Element* ChordRest::drop(EditData& data)
         } else {
             InstrumentChange* ic = toInstrumentChange(e);
             ic->setParent(segment());
-            ic->setTrack((track() / VOICES) * VOICES);
+            ic->setTrack(trackZeroVoice(track()));
             Instrument* instr = ic->instrument();
             Instrument* prevInstr = part()->instrument(tick());
             if (instr && instr->isDifferentInstrument(*prevInstr)) {
@@ -574,7 +574,7 @@ Element* ChordRest::drop(EditData& data)
         bool bNew;
         FiguredBass* fb = toFiguredBass(e);
         fb->setParent(segment());
-        fb->setTrack((track() / VOICES) * VOICES);
+        fb->setTrack(trackZeroVoice(track()));
         fb->setTicks(ticks());
         fb->setOnNote(true);
         FiguredBass::addFiguredBassToSegment(segment(), fb->track(), fb->ticks(), &bNew);

--- a/src/libmscore/cmd.cpp
+++ b/src/libmscore/cmd.cpp
@@ -4160,7 +4160,7 @@ void Score::cmdAddPitch(const EditData& ed, int note, bool addFlag, bool insert)
             return;
         }
         is.setDrumNote(pitch);
-        is.setTrack((is.track() / VOICES) * VOICES + voice);
+        is.setTrack(trackZeroVoice(is.track()) + voice);
         octave = pitch / 12;
         if (is.segment()) {
             Segment* seg = is.segment();
@@ -4204,7 +4204,7 @@ void Score::cmdAddPitch(const EditData& ed, int note, bool addFlag, bool insert)
                             break;
                         }
                     } else if (seg->isClefType() || seg->isHeaderClefType()) {
-                        Element* p = seg->element((is.track() / VOICES) * VOICES);              // clef on voice 1
+                        Element* p = seg->element(trackZeroVoice(is.track()));              // clef on voice 1
                         if (p && p->isClef()) {
                             Clef* clef = toClef(p);
                             // check if it's an actual change or just a courtesy

--- a/src/libmscore/edit.cpp
+++ b/src/libmscore/edit.cpp
@@ -5513,7 +5513,7 @@ void Score::undoAddElement(Element* element)
                     }
                     nsp->setTrack2(tl2.at(it));
                 } else if (!element->isSlur()) {
-                    nsp->setTrack(ntrack & ~3);
+                    nsp->setTrack(trackZeroVoice(ntrack));
                 }
 #endif
 

--- a/src/libmscore/element.cpp
+++ b/src/libmscore/element.cpp
@@ -283,7 +283,7 @@ Staff* Element::staff() const
         return 0;
     }
 
-    return score()->staff(_track >> 2);
+    return score()->staff(staffIdx());
 }
 
 //---------------------------------------------------------
@@ -770,7 +770,7 @@ bool Element::readProperties(XmlReader& e)
     } else if (tag == "pos") {           // obsolete
         readProperty(e, Pid::OFFSET);
     } else if (tag == "voice") {
-        setTrack((_track / VOICES) * VOICES + e.readInt());
+        setVoice(e.readInt());
     } else if (tag == "tag") {
         QString val(e.readElementText());
         for (int i = 1; i < MAX_TAGS; i++) {

--- a/src/libmscore/element.cpp
+++ b/src/libmscore/element.cpp
@@ -1685,45 +1685,12 @@ QRectF Element::symBbox(const std::vector<SymId>& s) const
 }
 
 //---------------------------------------------------------
-//   symStemDownNW
+//   symSmuflAnchor
 //---------------------------------------------------------
 
-QPointF Element::symStemDownNW(SymId id) const
+QPointF Element::symSmuflAnchor(SymId symId, SmuflAnchorId anchorId) const
 {
-    return score()->scoreFont()->stemDownNW(id, magS());
-}
-
-//---------------------------------------------------------
-//   symStemUpSE
-//---------------------------------------------------------
-
-QPointF Element::symStemUpSE(SymId id) const
-{
-    return score()->scoreFont()->stemUpSE(id, magS());
-}
-
-//---------------------------------------------------------
-//   symCutOutNE / symCutOutNW / symCutOutSE / symCutOutNW
-//---------------------------------------------------------
-
-QPointF Element::symCutOutNE(SymId id) const
-{
-    return score()->scoreFont()->cutOutNE(id, magS());
-}
-
-QPointF Element::symCutOutNW(SymId id) const
-{
-    return score()->scoreFont()->cutOutNW(id, magS());
-}
-
-QPointF Element::symCutOutSE(SymId id) const
-{
-    return score()->scoreFont()->cutOutSE(id, magS());
-}
-
-QPointF Element::symCutOutSW(SymId id) const
-{
-    return score()->scoreFont()->cutOutSW(id, magS());
+    return score()->scoreFont()->smuflAnchor(symId, anchorId, magS());
 }
 
 //---------------------------------------------------------

--- a/src/libmscore/element.h
+++ b/src/libmscore/element.h
@@ -382,11 +382,11 @@ public:
     int z() const;
     void setZ(int val) { _z = val; }
 
-    int staffIdx() const { return _track >> 2; }
-    void setStaffIdx(int val) { _track = val << 2 | voice(); }
+    int staffIdx() const { return _track / VOICES; }
+    void setStaffIdx(int val) { _track = val * VOICES + voice(); }
     virtual int vStaffIdx() const { return staffIdx(); }
-    int voice() const { return _track & 3; }
-    void setVoice(int v) { _track = (_track & ~3) | v; }
+    int voice() const { return _track % VOICES; }
+    void setVoice(int v) { _track = (_track / VOICES) * VOICES + v; }
     Staff* staff() const;
     const StaffType* staffType() const;
     bool onTabStaff() const;

--- a/src/libmscore/element.h
+++ b/src/libmscore/element.h
@@ -383,9 +383,10 @@ public:
     void setZ(int val) { _z = val; }
 
     int staffIdx() const { return _track >> 2; }
+    void setStaffIdx(int val) { _track = val << 2 | voice(); }
     virtual int vStaffIdx() const { return staffIdx(); }
     int voice() const { return _track & 3; }
-    void setVoice(int v) { _track = (_track / VOICES) * VOICES + v; }
+    void setVoice(int v) { _track = (_track & ~3) | v; }
     Staff* staff() const;
     const StaffType* staffType() const;
     bool onTabStaff() const;

--- a/src/libmscore/element.h
+++ b/src/libmscore/element.h
@@ -511,12 +511,7 @@ public:
     qreal symWidth(const std::vector<SymId>&) const;
     QRectF symBbox(SymId id) const;
     QRectF symBbox(const std::vector<SymId>&) const;
-    QPointF symStemDownNW(SymId id) const;
-    QPointF symStemUpSE(SymId id) const;
-    QPointF symCutOutNE(SymId id) const;
-    QPointF symCutOutNW(SymId id) const;
-    QPointF symCutOutSE(SymId id) const;
-    QPointF symCutOutSW(SymId id) const;
+    QPointF symSmuflAnchor(SymId symId, SmuflAnchorId anchorId) const;
     qreal symAdvance(SymId id) const;
     bool symIsValid(SymId id) const;
 

--- a/src/libmscore/excerpt.cpp
+++ b/src/libmscore/excerpt.cpp
@@ -610,11 +610,11 @@ void Excerpt::cloneStaves(Score* oscore, Score* score, const QList<int>& sourceS
 
                     for (int track : qAsConst(t)) {
                         //Clone KeySig TimeSig and Clefs if voice 1 of source staff is not mapped to a track
-                        Element* oef = oseg->element(srcTrack & ~3);
+                        Element* oef = oseg->element(trackZeroVoice(srcTrack));
                         if (oef && !oef->generated() && (oef->isTimeSig() || oef->isKeySig())
                             && !(trackList.size() == (score->excerpt()->nstaves() * VOICES))) {
                             Element* ne = oef->linkedClone();
-                            ne->setTrack(track & ~3);
+                            ne->setTrack(trackZeroVoice(track));
                             ne->setScore(score);
                             ns = nm->getSegment(oseg->segmentType(), oseg->tick());
                             ns->add(ne);

--- a/src/libmscore/hook.cpp
+++ b/src/libmscore/hook.cpp
@@ -103,6 +103,7 @@ void Hook::draw(QPainter* painter) const
     if (chord() && chord()->crossMeasure() == CrossMeasure::SECOND) {
         return;
     }
-    Symbol::draw(painter);
+    painter->setPen(curColor());
+    drawSymbol(_sym, painter);
 }
 }

--- a/src/libmscore/input.h
+++ b/src/libmscore/input.h
@@ -84,6 +84,7 @@ public:
     void setDrumNote(int v) { _drumNote = v; }
 
     int voice() const { return _track == -1 ? 0 : (_track % VOICES); }
+    void setVoice(int v) { setTrack((_track & ~3) | v); }
     int track() const { return _track; }
     void setTrack(int v) { _prevTrack = _track; _track = v; }
     int prevTrack() const { return _prevTrack; }

--- a/src/libmscore/input.h
+++ b/src/libmscore/input.h
@@ -84,7 +84,7 @@ public:
     void setDrumNote(int v) { _drumNote = v; }
 
     int voice() const { return _track == -1 ? 0 : (_track % VOICES); }
-    void setVoice(int v) { setTrack((_track & ~3) | v); }
+    void setVoice(int v) { setTrack((_track / VOICES) * VOICES + v); }
     int track() const { return _track; }
     void setTrack(int v) { _prevTrack = _track; _track = v; }
     int prevTrack() const { return _prevTrack; }

--- a/src/libmscore/layout.cpp
+++ b/src/libmscore/layout.cpp
@@ -882,8 +882,8 @@ void Score::layoutChords3(std::vector<Note*>& notes, const Staff* staff, Segment
                 acel.width  = ac->width();
                 QPointF bboxNE = ac->symBbox(ac->symbol()).topRight();
                 QPointF bboxSW = ac->symBbox(ac->symbol()).bottomLeft();
-                QPointF cutOutNE = ac->symCutOutNE(ac->symbol());
-                QPointF cutOutSW = ac->symCutOutSW(ac->symbol());
+                QPointF cutOutNE = ac->symSmuflAnchor(ac->symbol(), SmuflAnchorId::cutOutNE);
+                QPointF cutOutSW = ac->symSmuflAnchor(ac->symbol(), SmuflAnchorId::cutOutSW);
                 if (!cutOutNE.isNull()) {
                     acel.ascent     = cutOutNE.y() - bboxNE.y();
                     acel.rightClear = bboxNE.x() - cutOutNE.x();

--- a/src/libmscore/mscore.h
+++ b/src/libmscore/mscore.h
@@ -72,10 +72,10 @@ enum class HairpinType : signed char;
 #define VOICES 4
 #endif
 
-inline int staff2track(int staffIdx) { return staffIdx << 2; }
-inline int track2staff(int voice) { return voice >> 2; }
-inline int track2voice(int track) { return track & 3; }
-inline int trackZeroVoice(int track) { return track & ~3; }
+inline int staff2track(int staffIdx) { return staffIdx * VOICES; }
+inline int track2staff(int track) { return track / VOICES; }
+inline int track2voice(int track) { return track % VOICES; }
+inline int trackZeroVoice(int track) { return (track / VOICES) * VOICES; }
 
 static const int MAX_TAGS = 32;
 

--- a/src/libmscore/note.cpp
+++ b/src/libmscore/note.cpp
@@ -1135,7 +1135,7 @@ qreal Note::tabHeadHeight(const StaffType* tab) const
 
 QPointF Note::stemDownNW() const
 {
-    return symStemDownNW(noteHead());
+    return symSmuflAnchor(noteHead(), SmuflAnchorId::stemDownNW);
 }
 
 //---------------------------------------------------------
@@ -1144,7 +1144,7 @@ QPointF Note::stemDownNW() const
 
 QPointF Note::stemUpSE() const
 {
-    return symStemUpSE(noteHead());
+    return symSmuflAnchor(noteHead(), SmuflAnchorId::stemUpSE);
 }
 
 //---------------------------------------------------------

--- a/src/libmscore/paste.cpp
+++ b/src/libmscore/paste.cpp
@@ -393,8 +393,7 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff, Fraction scale)
                     // be sure to paste the element in the destination track;
                     // setting track needs to be repeated, as it might have been overwritten by el->read()
                     // preserve *voice* from source, though
-                    el->setTrack((e.track() / VOICES) * VOICES + el->voice());
-
+                    el->setStaffIdx(e.track() / VOICES);
                     undoAddElement(el);
                 } else if (tag == "Clef") {
                     Clef* clef = new Clef(this);

--- a/src/libmscore/shadownote.cpp
+++ b/src/libmscore/shadownote.cpp
@@ -168,7 +168,7 @@ void ShadowNote::draw(QPainter* painter) const
     if (flag != SymId::noSym) {
         QPointF pos;
         pos.rx() = up == 1 ? (noteheadWidth - (lw / 2)) : lw / 2;
-        qreal yOffset = up == 1 ? symStemUpSE(_notehead).y() * magS() : symStemDownNW(_notehead).y() * magS();
+        qreal yOffset = symSmuflAnchor(_notehead, up == 1 ? SmuflAnchorId::stemUpSE : SmuflAnchorId::stemDownNW).y() * magS();
         if (flag != SymId::lastSym) {
             qreal flagHeight
                 = (_duration.type() < TDuration::DurationType::V_256TH) ? symHeight(flag) : symHeight(flag) / 2;

--- a/src/libmscore/shadownote.h
+++ b/src/libmscore/shadownote.h
@@ -15,6 +15,7 @@
 
 #include "element.h"
 #include "durationtype.h"
+#include "staff.h"
 
 class QPointF;
 class QRectF;
@@ -30,14 +31,14 @@ namespace Ms {
 
 class ShadowNote final : public Element
 {
-    int _line;
-    SymId _notehead;
-    TDuration _duration;
-    int _voice;
-    bool _rest;
+    Fraction m_tick;
+    int m_lineIndex;
+    SymId m_noteheadSymbol;
+    TDuration m_duration;
+    bool m_isRest;
 
-    qreal _segmentSkylineTopY = 0;
-    qreal _segmentSkylineBottomY = 0;
+    qreal m_segmentSkylineTopY = 0;
+    qreal m_segmentSkylineBottomY = 0;
 
 public:
     ShadowNote(Score*);
@@ -45,23 +46,26 @@ public:
     ShadowNote* clone() const override { return new ShadowNote(*this); }
     ElementType type() const override { return ElementType::SHADOW_NOTE; }
 
+    bool isValid() const;
+
+    Fraction tick() const override { return m_tick; }
+    void setTick(Fraction t) { m_tick = t; }
+
+    int lineIndex() const { return m_lineIndex; }
+    void setLineIndex(int n) { m_lineIndex = n; }
+
+    void setState(SymId noteSymbol, TDuration duration, bool isRest, qreal segmentSkylineTopY, qreal segmentSkylineBottomY);
+
     void layout() override;
-    int line() const { return _line; }
-    void setLine(int n) { _line = n; }
 
     void draw(QPainter*) const override;
     void drawArticulations(QPainter* painter) const;
-    void drawMarcatto(QPainter* painter, const SymId& articulation, QRectF& boundRect) const;
+    void drawMarcato(QPainter* painter, const SymId& articulation, QRectF& boundRect) const;
     void drawArticulation(QPainter* painter, const SymId& articulation, QRectF& boundRect) const;
 
-    void setState(SymId noteSymbol, int voice, TDuration duration, bool rest = false, qreal segmentSkylineTopY = 0,
-                  qreal segmentSkylineBottomY = 0);
-
-    SymId getNoteFlag() const;
     bool computeUp() const;
-
-    SymId notehead() const { return _notehead; }
-    bool isValid() const;
+    SymId noteheadSymbol() const { return m_noteheadSymbol; }
+    SymId getNoteFlag() const;
 };
-}     // namespace Ms
+} // namespace Ms
 #endif

--- a/src/libmscore/stem.cpp
+++ b/src/libmscore/stem.cpp
@@ -115,8 +115,12 @@ void Stem::layout()
             // in other TAB types, no correction
         } else {                                // non-TAB
             // move stem start to note attach point
-            Note* n  = up() ? chord()->downNote() : chord()->upNote();
-            y1      += (up() ? n->stemUpSE().y() : n->stemDownNW().y());
+            Note* n = up() ? chord()->downNote() : chord()->upNote();
+            if ((up() && !n->mirror()) || (!up() && n->mirror())) {
+                y1 += n->stemUpSE().y();
+            } else {
+                y1 += n->stemDownNW().y();
+            }
             rypos() = n->rypos();
         }
     }

--- a/src/libmscore/stem.cpp
+++ b/src/libmscore/stem.cpp
@@ -169,7 +169,7 @@ void Stem::draw(QPainter* painter) const
     const StaffType* stt = st ? st->staffType(chord()->tick()) : 0;
     bool useTab          = stt && stt->isTabStaff();
 
-    painter->setPen(QPen(curColor(), lineWidthMag(), Qt::SolidLine, Qt::RoundCap));
+    painter->setPen(QPen(curColor(), lineWidthMag(), Qt::SolidLine, Qt::FlatCap));
     painter->drawLine(line);
 
     if (!useTab) {

--- a/src/libmscore/style.cpp
+++ b/src/libmscore/style.cpp
@@ -192,7 +192,7 @@ static const StyleType styleTypes[] {
     { Sid::fourMeasureRepeatShowExtenders, "fourMeasureRepeatShowExtenders", QVariant(false) },
     { Sid::staffLineWidth,          "staffLineWidth",          Spatium(0.08) },       // 0.09375
     { Sid::ledgerLineWidth,         "ledgerLineWidth",         Spatium(0.16) },       // 0.1875
-    { Sid::ledgerLineLength,        "ledgerLineLength",        Spatium(.76) },        // notehead width + this value
+    { Sid::ledgerLineLength,        "ledgerLineLength",        Spatium(0.35) },        // notehead width + this value
     { Sid::accidentalDistance,      "accidentalDistance",      Spatium(0.22) },
     { Sid::accidentalNoteDistance,  "accidentalNoteDistance",  Spatium(0.22) },
     { Sid::bracketedAccidentalPadding,  "bracketedAccidentalPadding",  Spatium(0.175) }, // Padding inside parentheses for bracketed accidentals

--- a/src/libmscore/sym.cpp
+++ b/src/libmscore/sym.cpp
@@ -6692,11 +6692,11 @@ void ScoreFont::load()
                error.offset, qPrintable(error.errorString()));
     }
 
-    QJsonObject oo = metadataJson.value("glyphsWithAnchors").toObject();
-    for (auto i : oo.keys()) {
+    QJsonObject glyphsWithAnchors = metadataJson.value("glyphsWithAnchors").toObject();
+    for (auto symName : glyphsWithAnchors.keys()) {
         constexpr qreal scale = SPATIUM20;
-        QJsonObject ooo = oo.value(i).toObject();
-        SymId symId = Sym::lnhash.value(i, SymId::noSym);
+        QJsonObject anchors = glyphsWithAnchors.value(symName).toObject();
+        SymId symId = Sym::lnhash.value(symName, SymId::noSym);
         if (symId == SymId::noSym) {
             // currently, Bravura contains a bunch of entries in glyphsWithAnchors
             // for glyph names that will not be found - flag32ndUpStraight, etc.
@@ -6704,35 +6704,43 @@ void ScoreFont::load()
             continue;
         }
         Sym* sym = &_symbols[int(symId)];
-        for (auto j : ooo.keys()) {
+        for (auto j : anchors.keys()) {
             if (j == "stemDownNW") {
-                qreal x = ooo.value(j).toArray().at(0).toDouble();
-                qreal y = ooo.value(j).toArray().at(1).toDouble();
-                sym->setStemDownNW(QPointF(4.0 * DPI_F * x, 4.0 * DPI_F * -y));
+                qreal x = anchors.value(j).toArray().at(0).toDouble();
+                qreal y = anchors.value(j).toArray().at(1).toDouble();
+                sym->setSmuflAnchor(SmuflAnchorId::stemDownNW, QPointF(4.0 * DPI_F * x, 4.0 * DPI_F * -y));
             } else if (j == "stemUpSE") {
-                qreal x = ooo.value(j).toArray().at(0).toDouble();
-                qreal y = ooo.value(j).toArray().at(1).toDouble();
-                sym->setStemUpSE(QPointF(4.0 * DPI_F * x, 4.0 * DPI_F * -y));
+                qreal x = anchors.value(j).toArray().at(0).toDouble();
+                qreal y = anchors.value(j).toArray().at(1).toDouble();
+                sym->setSmuflAnchor(SmuflAnchorId::stemUpSE, QPointF(4.0 * DPI_F * x, 4.0 * DPI_F * -y));
+            } else if (j == "stemDownSW") {
+                qreal x = anchors.value(j).toArray().at(0).toDouble();
+                qreal y = anchors.value(j).toArray().at(1).toDouble();
+                sym->setSmuflAnchor(SmuflAnchorId::stemDownSW, QPointF(4.0 * DPI_F * x, 4.0 * DPI_F * -y));
+            } else if (j == "stemUpNW") {
+                qreal x = anchors.value(j).toArray().at(0).toDouble();
+                qreal y = anchors.value(j).toArray().at(1).toDouble();
+                sym->setSmuflAnchor(SmuflAnchorId::stemUpNW, QPointF(4.0 * DPI_F * x, 4.0 * DPI_F * -y));
             } else if (j == "cutOutNE") {
-                qreal x = ooo.value(j).toArray().at(0).toDouble() * scale;
-                qreal y = ooo.value(j).toArray().at(1).toDouble() * scale;
-                sym->setCutOutNE(QPointF(x, -y));
+                qreal x = anchors.value(j).toArray().at(0).toDouble() * scale;
+                qreal y = anchors.value(j).toArray().at(1).toDouble() * scale;
+                sym->setSmuflAnchor(SmuflAnchorId::cutOutNE, QPointF(x, -y));
             } else if (j == "cutOutNW") {
-                qreal x = ooo.value(j).toArray().at(0).toDouble() * scale;
-                qreal y = ooo.value(j).toArray().at(1).toDouble() * scale;
-                sym->setCutOutNW(QPointF(x, -y));
+                qreal x = anchors.value(j).toArray().at(0).toDouble() * scale;
+                qreal y = anchors.value(j).toArray().at(1).toDouble() * scale;
+                sym->setSmuflAnchor(SmuflAnchorId::cutOutNW, QPointF(x, -y));
             } else if (j == "cutOutSE") {
-                qreal x = ooo.value(j).toArray().at(0).toDouble() * scale;
-                qreal y = ooo.value(j).toArray().at(1).toDouble() * scale;
-                sym->setCutOutSE(QPointF(x, -y));
+                qreal x = anchors.value(j).toArray().at(0).toDouble() * scale;
+                qreal y = anchors.value(j).toArray().at(1).toDouble() * scale;
+                sym->setSmuflAnchor(SmuflAnchorId::cutOutSE, QPointF(x, -y));
             } else if (j == "cutOutSW") {
-                qreal x = ooo.value(j).toArray().at(0).toDouble() * scale;
-                qreal y = ooo.value(j).toArray().at(1).toDouble() * scale;
-                sym->setCutOutSW(QPointF(x, -y));
+                qreal x = anchors.value(j).toArray().at(0).toDouble() * scale;
+                qreal y = anchors.value(j).toArray().at(1).toDouble() * scale;
+                sym->setSmuflAnchor(SmuflAnchorId::cutOutSW, QPointF(x, -y));
             }
         }
     }
-    oo = metadataJson.value("engravingDefaults").toObject();
+    glyphsWithAnchors = metadataJson.value("engravingDefaults").toObject();
     static std::list<std::pair<QString, Sid> > engravingDefaultsMapping = {
         { "staffLineThickness",            Sid::staffLineWidth },
         { "stemThickness",                 Sid::stemWidth },
@@ -6757,12 +6765,12 @@ void ScoreFont::load()
         { "lyricLineThickness",            Sid::lyricsLineThickness },
         { "tupletBracketThickness",        Sid::tupletBracketWidth }
     };
-    for (auto i : oo.keys()) {
+    for (auto i : glyphsWithAnchors.keys()) {
         for (auto mapping : engravingDefaultsMapping) {
             if (i == mapping.first) {
-                _engravingDefaults.push_back(std::make_pair(mapping.second, oo.value(i).toDouble()));
+                _engravingDefaults.push_back(std::make_pair(mapping.second, glyphsWithAnchors.value(i).toDouble()));
             } else if (i == "textEnclosureThickness") {
-                _textEnclosureThickness = oo.value(i).toDouble();
+                _textEnclosureThickness = glyphsWithAnchors.value(i).toDouble();
             }
         }
     }
@@ -7095,52 +7103,12 @@ qreal ScoreFont::width(const std::vector<SymId>& s, qreal mag) const
     return bbox(s, mag).width();
 }
 
-QPointF ScoreFont::stemDownNW(SymId id, qreal mag) const
+QPointF ScoreFont::smuflAnchor(SymId symId, SmuflAnchorId anchorId, qreal mag) const
 {
-    if (useFallbackFont(id)) {
-        return fallbackFont()->stemDownNW(id, mag);
+    if (useFallbackFont(symId)) {
+        return fallbackFont()->smuflAnchor(symId, anchorId, mag);
     }
-    return sym(id).stemDownNW() * mag;
-}
-
-QPointF ScoreFont::stemUpSE(SymId id, qreal mag) const
-{
-    if (useFallbackFont(id)) {
-        return fallbackFont()->stemUpSE(id, mag);
-    }
-    return sym(id).stemUpSE() * mag;
-}
-
-QPointF ScoreFont::cutOutNE(SymId id, qreal mag) const
-{
-    if (useFallbackFont(id)) {
-        return fallbackFont()->cutOutNE(id, mag);
-    }
-    return sym(id).cutOutNE() * mag;
-}
-
-QPointF ScoreFont::cutOutNW(SymId id, qreal mag) const
-{
-    if (useFallbackFont(id)) {
-        return fallbackFont()->cutOutNW(id, mag);
-    }
-    return sym(id).cutOutNW() * mag;
-}
-
-QPointF ScoreFont::cutOutSE(SymId id, qreal mag) const
-{
-    if (useFallbackFont(id)) {
-        return fallbackFont()->cutOutSE(id, mag);
-    }
-    return sym(id).cutOutSE() * mag;
-}
-
-QPointF ScoreFont::cutOutSW(SymId id, qreal mag) const
-{
-    if (useFallbackFont(id)) {
-        return fallbackFont()->cutOutSW(id, mag);
-    }
-    return sym(id).cutOutSW() * mag;
+    return sym(symId).smuflAnchor(anchorId) * mag;
 }
 
 //---------------------------------------------------------

--- a/src/libmscore/sym.h
+++ b/src/libmscore/sym.h
@@ -3019,6 +3019,21 @@ enum class SymId {
 END_QT_REGISTERED_ENUM(SymId)
 
 //---------------------------------------------------------
+//   SmuflAnchorId
+//---------------------------------------------------------
+
+enum class SmuflAnchorId {
+    stemDownNW,
+    stemUpSE,
+    stemDownSW,
+    stemUpNW,
+    cutOutNE,
+    cutOutNW,
+    cutOutSE,
+    cutOutSW,
+};
+
+//---------------------------------------------------------
 //   Sym
 ///   \cond PLUGIN_API \private \endcond
 //---------------------------------------------------------
@@ -3031,13 +3046,8 @@ protected:
     QRectF _bbox;
     qreal _advance = 0.0;
 
-    QPointF _stemDownNW;
-    QPointF _stemUpSE;
-    QPointF _cutOutNE;
-    QPointF _cutOutNW;
-    QPointF _cutOutSE;
-    QPointF _cutOutSW;
-    std::vector<SymId> _ids;              // not empty if this is a compound symbol
+    std::map<SmuflAnchorId, QPointF> smuflAnchors;
+    std::vector<SymId> _ids; // not empty if this is a compound symbol
 
 public:
     Sym() { }
@@ -3059,18 +3069,8 @@ public:
     qreal advance() const { return _advance; }
     void setAdvance(qreal val) { _advance = val; }
 
-    QPointF stemDownNW() const { return _stemDownNW; }
-    void setStemDownNW(const QPointF& r) { _stemDownNW = r; }
-    QPointF stemUpSE() const { return _stemUpSE; }
-    void setStemUpSE(const QPointF& r) { _stemUpSE = r; }
-    QPointF cutOutNE() const { return _cutOutNE; }
-    void setCutOutNE(const QPointF& r) { _cutOutNE = r; }
-    QPointF cutOutNW() const { return _cutOutNW; }
-    void setCutOutNW(const QPointF& r) { _cutOutNW = r; }
-    QPointF cutOutSE() const { return _cutOutSE; }
-    void setCutOutSE(const QPointF& r) { _cutOutSE = r; }
-    QPointF cutOutSW() const { return _cutOutSW; }
-    void setCutOutSW(const QPointF& r) { _cutOutSW = r; }
+    QPointF smuflAnchor(SmuflAnchorId anchorId) { return smuflAnchors[anchorId]; }
+    void setSmuflAnchor(SmuflAnchorId anchorId, const QPointF& newValue) { smuflAnchors[anchorId] = newValue; }
 
     static SymId name2id(const QString& s) { return lnhash.value(s, SymId::noSym); }           // return noSym if not found
     static SymId oldName2id(const QString s) { return lonhash.value(s, SymId::noSym); }
@@ -3192,12 +3192,7 @@ public:
     const QRectF bbox(SymId id, qreal mag) const;
     const QRectF bbox(const std::vector<SymId>& s, const QSizeF& mag) const;
     const QRectF bbox(const std::vector<SymId>& s, qreal mag) const;
-    QPointF stemDownNW(SymId id, qreal mag) const;
-    QPointF stemUpSE(SymId id, qreal mag) const;
-    QPointF cutOutNE(SymId id, qreal mag) const;
-    QPointF cutOutNW(SymId id, qreal mag) const;
-    QPointF cutOutSE(SymId id, qreal mag) const;
-    QPointF cutOutSW(SymId id, qreal mag) const;
+    QPointF smuflAnchor(SymId symId, SmuflAnchorId anchorId, qreal mag) const;
 
     bool isValid(SymId id) const { return sym(id).isValid(); }
     bool useFallbackFont(SymId id) const;

--- a/src/libmscore/tuplet.cpp
+++ b/src/libmscore/tuplet.cpp
@@ -300,7 +300,7 @@ void Tuplet::layout()
     qreal noteRight     = score()->styleP(Sid::tupletNoteRightDistance);
 
     int move = 0;
-    setTrack(cr1->staffIdx() * VOICES + voice());
+    setStaffIdx(cr1->vStaffIdx());
     if (outOfStaff && cr1->isChordRest() && cr2->isChordRest()) {
         // account for staff move when adjusting bracket to avoid staff
         // but don't attempt adjustment unless both endpoints are in same staff
@@ -308,7 +308,7 @@ void Tuplet::layout()
         if (toChordRest(cr1)->staffMove() == toChordRest(cr2)->staffMove() && !tuplet() && !nested) {
             move = toChordRest(cr1)->staffMove();
             if (move == 1) {
-                setTrack(cr1->vStaffIdx() * VOICES + voice());
+                setStaffIdx(cr1->vStaffIdx());
             }
         } else {
             outOfStaff = false;

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -233,9 +233,7 @@ void NotationNoteInput::setCurrentVoiceIndex(int voiceIndex)
     }
 
     Ms::InputState& inputState = score()->inputState();
-    int track = (inputState.track() / VOICES) * VOICES + voiceIndex;
-
-    inputState.setTrack(track);
+    inputState.setVoice(voiceIndex);
 
     if (inputState.segment()) {
         Ms::Segment* segment = inputState.segment()->measure()->first(Ms::SegmentType::ChordRest);


### PR DESCRIPTION
- **Implement new way to get and set SMuFL Anchors for symbols**
  There is a new enum for the currently supported anchors, and the anchors are now stored in a std::map.

- **Fix ledger line length for Chord and Ambitus**
  That is: 
  a) draw with FlatCaps instead of RoundCaps
  b) append the _whole_ ledgerLineLength at both sides of the note, instead of half on each side.

- **Correctly handle note flag placing, respecting bbox**
  A MU4 version for PR #6894

- **Shadow note refactoring**
  In a way a MU4 version of PR #7064
  Give the Shadow Note more information and make better use of its inheritance from Element, so that is can be drawn much more 'realistically'.
  Also implements the corrections made to flag placement / stem height from the previous commit.

- **Fix stem length of notes with mirrored notehead**
  A MU4 version for PR #7050
  At least, the issue is fixed only after a re-layout is triggered. That could suggest two things:
  - It is broken in another place too (but very unclear where)
  - n->mirror() doesn't return the right value at first.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
