### PR TITLE
Fix #316125: Dock widgets are now focused on visibilty toggle

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -3020,6 +3020,9 @@ void MuseScore::reDisplayDockWidget(QDockWidget* widget, bool visible)
             widget->setFloating(true);
             }
       widget->setVisible(visible);
+
+      //Bring the widget to the top of the dock
+      widget->raise();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/316125

This patch modifies the ```reDisplayDockWidget``` function in musescore.cpp to make sure that when the visibility of docked widgets like the mixer/inspector is toggled, the widget is focused and appears on top in the dock

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
