### PR TITLE
Fix #316137: Slurs on the TAB Staff move upward when inserting multiple measures

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -5157,7 +5157,7 @@ void Score::undoChangeSpannerElements(Spanner* spanner, Element* startElement, E
             if (sp != spanner) {
                   if (startElement) {
                         // determine the track where to expect the 'parallel' start element
-                        int newTrack = sp->startElement() ? sp->startElement()->track() + startDeltaTrack : 0;
+                        int newTrack = sp->startElement() ? sp->startElement()->track() + startDeltaTrack : sp->track();
                         // look in elements linked to new start element for an element with
                         // same score as linked spanner and appropriate track
                         for (ScoreElement* ee : startElement->linkList()) {
@@ -5170,7 +5170,7 @@ void Score::undoChangeSpannerElements(Spanner* spanner, Element* startElement, E
                         }
                   // similarly to determine the 'parallel' end element
                   if (endElement) {
-                        int newTrack = sp->endElement() ? sp->endElement()->track() + endDeltaTrack : 0;
+                        int newTrack = sp->endElement() ? sp->endElement()->track() + endDeltaTrack : sp->track2();
                         for (ScoreElement* ee : endElement->linkList()) {
                               Element* e = toElement(ee);
                               if (e->score() == sp->score() && e->track() == newTrack) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/316137.

In #5432, Score::undoChangeSpannerElements() was modified to allow for changing one or both of the elements to or from nullptr. However, in the case of a linked spanner, where we have to look for parallel elements in another track, we cannot use the track of the old spanner elements if they are null. A default track of 0 was arbitrarily chosen in this case, but that causes the spanner to be attached to the wrong staff. Fortunately, we can use the spanner's track() and track2() functions even if its elements are null.