### PR TITLE
WiX QtWebEngineProcess related crash after update

### DIFF
--- a/build/packaging/WIX.template.in
+++ b/build/packaging/WIX.template.in
@@ -33,7 +33,7 @@
         <Property Id="WIXUI_INSTALLDIR" Value="INSTALL_ROOT"/>
 
         <!-- See https://docs.microsoft.com/ru-ru/windows/win32/msi/reinstallmode that explains different modes -->
-        <Property Id='REINSTALLMODE' Value='dmus'/>
+        <Property Id='REINSTALLMODE' Value='amus'/>
 
         <?ifdef CPACK_WIX_PRODUCT_ICON?>
         <Property Id="ARPPRODUCTICON">ProductIcon.ico</Property>


### PR DESCRIPTION
Attempt to force overwrite files in hope that this will prevent missing files if QtWebEngineProcess is left running.

**_Current issue_**: When QWEP is running, the uninstall "old" version fails to close the process and thus also fails to remove its supporting files. At that point, the delete action becomes deferred to next reboot.
After that, the "install" step happens, which skips those files now, as they are not changed between the previous 3.x package and this one; and they are already present.
End result is that those files are removed next reboot cycle, leaving the installation crippled.

My hope is that by forcing file overwrites during install to "always", that the install step will also fail to update them and thus also defer that to the next reboot (and after their deletion).

It would be great if you could make a stable package build out of this PR so I (or you :) ) can test out this theory.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [N/A] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [N/A] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
