### PR TITLE
[MU3] fix #316536: Add missing baritone-horns and euphoniums to orders.xm…

### DIFF
--- a/share/instruments/orders.xml
+++ b/share/instruments/orders.xml
@@ -16,6 +16,8 @@
             <family>cornets</family>
             <family>flugelhorns</family>
             <family>trombones</family>
+            <family>baritone-horns</family>
+            <family>euphoniums</family>
             <family>tubas</family>
         </section>
         <section id="timpani">
@@ -278,6 +280,8 @@
             <family>cornets</family>
             <family>flugelhorns</family>
             <family>horns</family>
+            <family>baritone-horns</family>
+            <family>euphoniums</family>
             <family>trombones</family>
             <family>tubas</family>
         </section>

--- a/share/templates/01-General/00-Blank.mscx
+++ b/share/templates/01-General/00-Blank.mscx
@@ -42,6 +42,8 @@
         <family>trumpets</family>
         <family>cornets</family>
         <family>trombones</family>
+        <family>baritone-horns</family>
+        <family>euphoniums</family>
         <family>tubas</family>
         </section>
       <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">

--- a/share/templates/01-General/01-Treble_Clef.mscx
+++ b/share/templates/01-General/01-Treble_Clef.mscx
@@ -44,6 +44,8 @@
         <family>trumpets</family>
         <family>cornets</family>
         <family>trombones</family>
+        <family>baritone-horns</family>
+        <family>euphoniums</family>
         <family>tubas</family>
         </section>
       <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">

--- a/share/templates/01-General/02-Bass_Clef.mscx
+++ b/share/templates/01-General/02-Bass_Clef.mscx
@@ -42,6 +42,8 @@
         <family>trumpets</family>
         <family>cornets</family>
         <family>trombones</family>
+        <family>baritone-horns</family>
+        <family>euphoniums</family>
         <family>tubas</family>
         </section>
       <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">

--- a/share/templates/01-General/03-Grand_Staff.mscx
+++ b/share/templates/01-General/03-Grand_Staff.mscx
@@ -42,6 +42,8 @@
         <family>trumpets</family>
         <family>cornets</family>
         <family>trombones</family>
+        <family>baritone-horns</family>
+        <family>euphoniums</family>
         <family>tubas</family>
         </section>
       <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">

--- a/share/templates/03-Chamber_Music/05-Brass_Quartet.mscx
+++ b/share/templates/03-Chamber_Music/05-Brass_Quartet.mscx
@@ -42,6 +42,8 @@
         <family>cornets</family>
         <family>flugelhorns</family>
         <family>horns</family>
+        <family>baritone-horns</family>
+        <family>euphoniums</family>
         <family>trombones</family>
         <family>tubas</family>
         </section>

--- a/share/templates/03-Chamber_Music/06-Brass_Quintet.mscx
+++ b/share/templates/03-Chamber_Music/06-Brass_Quintet.mscx
@@ -89,6 +89,8 @@
         <family>cornets</family>
         <family>flugelhorns</family>
         <family>horns</family>
+        <family>baritone-horns</family>
+        <family>euphoniums</family>
         <family>trombones</family>
         <family>tubas</family>
         </section>

--- a/share/templates/07-Band_and_Percussion/09-European_Concert_Band.mscx
+++ b/share/templates/07-Band_and_Percussion/09-European_Concert_Band.mscx
@@ -109,6 +109,7 @@
         <family>horns</family>
         <family>trombones</family>
         <family>baritone-horns</family>
+        <family>euphoniums</family>>
         <family>tubas</family>
         </section>
       <unsorted group="brass"/>

--- a/share/templates/08-Orchestral/01-Classical_Orchestra.mscx
+++ b/share/templates/08-Orchestral/01-Classical_Orchestra.mscx
@@ -67,6 +67,8 @@
         <family>cornets</family>
         <family>flugelhorns</family>
         <family>trombones</family>
+        <family>baritone-horns</family>
+        <family>euphoniums</family>
         <family>tubas</family>
         </section>
       <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">

--- a/share/templates/08-Orchestral/02-Symphony_Orchestra.mscx
+++ b/share/templates/08-Orchestral/02-Symphony_Orchestra.mscx
@@ -96,6 +96,8 @@
         <family>cornets</family>
         <family>flugelhorns</family>
         <family>trombones</family>
+        <family>baritone-horns</family>
+        <family>euphoniums</family>
         <family>tubas</family>
         </section>
       <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">

--- a/share/templates/08-Orchestral/03-String_Orchestra.mscx
+++ b/share/templates/08-Orchestral/03-String_Orchestra.mscx
@@ -56,6 +56,8 @@
         <family>cornets</family>
         <family>flugelhorns</family>
         <family>trombones</family>
+        <family>baritone-horns</family>
+        <family>euphoniums</family>
         <family>tubas</family>
         </section>
       <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">

--- a/share/templates/My_First_Score.mscx
+++ b/share/templates/My_First_Score.mscx
@@ -42,6 +42,8 @@
         <family>trumpets</family>
         <family>cornets</family>
         <family>trombones</family>
+        <family>baritone-horns</family>
+        <family>euphoniums</family>
         <family>tubas</family>
         </section>
       <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">


### PR DESCRIPTION
…l and templates

Resolves: https://musescore.org/en/node/316536

Adds euphoniums especially to Brass Ensembles and European Concert Bands.
Just for completeness, although not too common, also to orchestral.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [X] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
