### PR TITLE
fix #311788: gap between staff and end barline with courtesy clef

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3873,6 +3873,8 @@ qreal Measure::createEndBarLines(bool isLastMeasureInSystem)
             bool wasVisible = clefSeg->visible();
             int visibleInt = 0;
             for (int staffIdx = 0; staffIdx < nstaves; ++staffIdx) {
+                  if (!score()->staff(staffIdx)->show())
+                        continue;
                   int track    = staffIdx * VOICES;
                   Clef* clef = toClef(clefSeg->element(track));
                   if (clef) {

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1397,6 +1397,8 @@ void ScoreView::paint(const QRect& r, QPainter& p)
                         if (MScore::showSkylines) {
                               for (const System* system : page->systems()) {
                                     for (SysStaff* ss : *system->staves()) {
+                                          if (!ss->show())
+                                                continue;
                                           QPointF pt(system->ipos().x(), system->ipos().y() + ss->y());
                                           p.translate(pt);
                                           ss->skyline().paint(p);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/311788

A recent commit fixed some issues with courtesy clefs,
but introduced a regression - courtesy clefs on invisible staves
were not being ignored, causing the segment to be marked visible
and rhen in turn the measure width to be recalculated
as if the clef were visible.
This puts the barline too far to the right,
with gap between the end of the staff and the barline.
The clef itself was still ignored in the width calculation,
so the discrepancy is not large -
only the size of the margins before and after the clef.

Fix is to skip invisible staves in the code that is checking
for measures that need their width recalculated.

AIn debugging this, I became aware this clef on an invisible staff
was also appearing to affect the skyline of the visible staff,
leading me on a wild goose chase,
But that turns out to be an illusion -
the clef is not added to the skyline of the visible staff at all.
It's just that the skyline drawing code
(used when turning "Show Skylines" in the Debug menu)
is *also* failing to skip invisible staves.
So I have fixed that as well.