### PR TITLE
Fix #315779: Disable auto-size of vertical frame when dragging the height handle

### DIFF
--- a/libmscore/box.cpp
+++ b/libmscore/box.cpp
@@ -796,6 +796,20 @@ void VBox::layout()
       }
 
 //---------------------------------------------------------
+//   startEditDrag
+//---------------------------------------------------------
+
+void VBox::startEditDrag(EditData& ed)
+      {
+      if (isAutoSizeEnabled()) {
+            setAutoSizeEnabled(false);
+            setBoxHeight(Spatium(height() / spatium()));
+      }
+      Box::startEditDrag(ed);
+      }
+
+
+//---------------------------------------------------------
 //   layout
 //---------------------------------------------------------
 

--- a/libmscore/box.h
+++ b/libmscore/box.h
@@ -153,6 +153,8 @@ class VBox : public Box {
       QVariant getProperty(Pid propertyId) const override;
       void layout() override;
 
+      void startEditDrag(EditData&) override;
+
       std::vector<QPointF> gripsPositions(const EditData&) const override;
       };
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/315779

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
