### PR TITLE
Fix #316507: Application now supports using the system theme option i…

### DIFF
--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -25,6 +25,12 @@
 #include "macos/cocoabridge.h"
 #endif
 
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#include <Winreg.h>
+#include <string>
+#endif
+
 namespace Ms {
 //! Note: see musescore.h getSharePath(). This copy is needed for build without MuseScore
 QString sharePath()
@@ -511,6 +517,19 @@ MuseScoreEffectiveStyleType Preferences::effectiveGlobalStyle() const
 #ifdef Q_OS_MAC // On Mac, follow system theme if desired
       if (s == MuseScorePreferredStyleType::FOLLOW_SYSTEM)
             return CocoaBridge::isSystemDarkTheme() ? MuseScoreEffectiveStyleType::DARK_FUSION : MuseScoreEffectiveStyleType::LIGHT_FUSION;
+#endif
+#ifdef Q_OS_WIN
+      if (s == MuseScorePreferredStyleType::FOLLOW_SYSTEM) {
+            std::wstring subKey = L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
+            std::wstring keyVal = L"AppsUseLightTheme";
+            DWORD data{};
+            DWORD datasize = sizeof(data);
+            LONG retCode = RegGetValue(HKEY_CURRENT_USER, subKey.c_str(), keyVal.c_str(), RRF_RT_REG_DWORD, nullptr, &data, &datasize);
+            if (retCode == ERROR_SUCCESS)
+                return data == 0 ? MuseScoreEffectiveStyleType::DARK_FUSION : MuseScoreEffectiveStyleType::LIGHT_FUSION;
+            else
+                return MuseScoreEffectiveStyleType::LIGHT_FUSION;
+            }
 #endif
       return MuseScoreEffectiveStyleType(s);
       }

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -68,7 +68,7 @@ enum {
 enum class MuseScorePreferredStyleType : char {
       LIGHT_FUSION = 0,
       DARK_FUSION,
-#ifdef Q_OS_MAC
+#if defined(Q_OS_MAC) || defined(Q_OS_WIN)
       FOLLOW_SYSTEM,
 #endif
       };

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -46,6 +46,34 @@
 
 namespace Ms {
 
+#ifdef Q_OS_WIN
+//---------------------------------------------------------
+//   checkWindowsDarkSupport
+//---------------------------------------------------------
+bool checkWindowsDarkSupport()
+      {
+      std::wstring subKey = L"Software\\Microsoft\\Windows NT\\CurrentVersion";
+      std::wstring keyVal = L"CurrentMajorVersionNumber";
+
+      DWORD version{};
+      DWORD datasize = sizeof(version);
+      LONG retCode = RegGetValue(HKEY_LOCAL_MACHINE, subKey.c_str(), keyVal.c_str(), RRF_RT_REG_DWORD, nullptr, &version, &datasize);
+
+      std::string build;
+      keyVal = L"ReleaseId";
+      retCode = RegGetValue(HKEY_LOCAL_MACHINE, subKey.c_str(), keyVal.c_str(), RRF_RT_REG_SZ, nullptr, nullptr, &datasize);	
+      build.resize(datasize / sizeof(char));
+      retCode = RegGetValue(HKEY_LOCAL_MACHINE, subKey.c_str(), keyVal.c_str(), RRF_RT_REG_SZ, nullptr, &build[0], &datasize);
+
+      std::string buildNumber = { build[0], build[2], build[4], build[6] };
+
+      if (retCode == ERROR_SUCCESS)
+            return version >= 10 && std::stoi(buildNumber) >= 1809;
+      else
+            return false;
+      }
+#endif
+
 //---------------------------------------------------------
 //   startPreferenceDialog
 //---------------------------------------------------------
@@ -80,6 +108,10 @@ PreferenceDialog::PreferenceDialog(QWidget* parent)
       styleName->addItem(tr("Dark"));
 #ifdef Q_OS_MAC // On Mac, we have a theme option to follow the system's Dark Mode
       if (CocoaBridge::isSystemDarkModeSupported())
+            styleName->addItem(tr("System"));
+#endif
+#ifdef Q_OS_WIN
+      if (checkWindowsDarkSupport())
             styleName->addItem(tr("System"));
 #endif
 
@@ -652,6 +684,10 @@ void PreferenceDialog::updateValues(bool useDefaultValues, bool setup)
       styleName->addItem(tr("Dark"));
 #ifdef Q_OS_MAC // On Mac, we have a theme option to follow the system's Dark Mode
       if (CocoaBridge::isSystemDarkModeSupported())
+            styleName->addItem(tr("System"));
+#endif
+#ifdef Q_OS_WIN
+      if (checkWindowsDarkSupport())
             styleName->addItem(tr("System"));
 #endif
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/316507

This patch allows Windows users to choose the system theme option and changes the theme accordingly. (Works on versions later than Windows 10 build 1809, where dark theme was first introduced. On older builds, defaults to light theme which is the system default)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
