### PR TITLE
fix #315897: unreadable chord symbols with custom description file

### DIFF
--- a/libmscore/chordlist.cpp
+++ b/libmscore/chordlist.cpp
@@ -1662,7 +1662,7 @@ void ChordList::configureAutoAdjust(qreal emag, qreal eadjust, qreal mmag, qreal
 
 void ChordList::read(XmlReader& e)
       {
-      int fontIdx = 0;
+      int fontIdx = fonts.size();
       _autoAdjust = false;
       while (e.readNextStartElement()) {
             const QStringRef& tag(e.name());

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -3015,7 +3015,7 @@ void MStyle::load(XmlReader& e)
             else if (tag == "displayInConcertPitch")
                   set(Sid::concertPitch, QVariant(bool(e.readInt())));
             else if (tag == "ChordList") {
-                  _chordList.clear();
+                  _chordList.unload();
                   _chordList.read(e);
                   _customChordList = true;
                   chordListTag = true;

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1723,6 +1723,7 @@ void ChangeStyleVal::flip(EditData*)
                         if (score->styleB(Sid::chordsXmlFile))
                             score->style().chordList()->read("chords.xml");
                         score->style().chordList()->read(score->styleSt(Sid::chordDescriptionFile));
+                        score->style().setCustomChordList(score->styleSt(Sid::chordStyle) == "custom");
                         }
                         break;
                   case Sid::spatium:


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/315897

There is a style setting to allow custom chord description files,
which is an advanced feautr eused by few today
but was the the standard/supported way of getting "jazz" chords
in older versions.
Scores using this option will have chord symbols rendering info
embedded within the score, in a ChordList tag.
Thus far, at the point where this tag was encountered,
the score's chord list was empty, and reading the chord list
worked as expected.
Now, however, the reading of the style defaults file for the score
results in the chord list having three "font" entries
before the actual chord list is read.
This results in the font references all being off,
meaning that the various special symbols used in chord symbols
get rendered as nonsense characters because they are in fonts
that do not support these special symbols.

Solution is simply to unlaod the existing chord list
when we encounter a ChordList tag, before reading the list.
Previously there was a clear() call, but that's not enough,
we need to clear the fonts and other settings too.

But also, to be safe, I changed the initiation of of the font index
in ChordList::read() so that if there *are* any fonts
already present in the list, they are accounted for,
at least partially.