### PR TITLE
Fix #316441: Crash when changing time signature in front of a corrupted measure

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -628,13 +628,6 @@ bool Score::rewriteMeasures(Measure* fm, const Fraction& ns, int staffIdx)
                                           break;
                                     }
                               }
-                        else {
-                              // this can be hit for local time signatures as well
-                              // (if we are rewriting all staves, but one has a local time signature)
-                              // TODO: detect error conditions better, have clearer error messages
-                              // and perform necessary fixups
-                              MScore::setError(TUPLET_CROSSES_BAR);
-                              }
                         for (Measure* m = fm1; m; m = m->nextMeasure()) {
                               if (m->first(SegmentType::TimeSig))
                                     break;

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -151,6 +151,7 @@ std::vector<MScoreError> MScore::errorList {
       { NO_MIME,                         "p6", QT_TRANSLATE_NOOP("error", "Nothing to paste")                                                      },
       { DEST_NO_CR,                      "p7", QT_TRANSLATE_NOOP("error", "Destination is not a chord or rest")                                    },
       { CANNOT_CHANGE_LOCAL_TIMESIG,     "l1", QT_TRANSLATE_NOOP("error", "Cannot change local time signature:\nMeasure is not empty")             },
+      { CORRUPTED_MEASURE,               "c1", QT_TRANSLATE_NOOP("error", "Cannot change time signature in front of a corrupted measure")          },
       };
 
 MsError MScore::_error { MS_NO_ERROR };

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -1,4 +1,4 @@
-﻿//=============================================================================
+//=============================================================================
 //  MuseScore
 //  Music Composition & Notation
 //
@@ -257,6 +257,7 @@ enum MsError {
       NO_MIME,
       DEST_NO_CR,
       CANNOT_CHANGE_LOCAL_TIMESIG,
+      CORRUPTED_MEASURE,
       };
 
 /// \cond PLUGIN_API \private \endcond

--- a/libmscore/range.cpp
+++ b/libmscore/range.cpp
@@ -348,7 +348,7 @@ void TrackList::read(const Segment* fs, const Segment* es)
 //   checkRest
 //---------------------------------------------------------
 
-static void checkRest(Fraction& rest, Measure*& m, const Fraction& d)
+static bool checkRest(Fraction& rest, Measure*& m, const Fraction& d)
       {
       if (rest.isZero()) {
             if (m->nextMeasure()) {
@@ -356,9 +356,11 @@ static void checkRest(Fraction& rest, Measure*& m, const Fraction& d)
                   rest = m->ticks();
                   }
             else {
-                  qFatal("premature end of measure list, rest %d/%d", d.numerator(), d.denominator());
+                  qWarning("premature end of measure list, rest %d/%d", d.numerator(), d.denominator());
+                  return false;
                   }
             }
+      return true;
       }
 
 //---------------------------------------------------------
@@ -477,7 +479,10 @@ bool TrackList::write(Score* score, const Fraction& tick) const
       for (Element* e : *this) {
             if (e->isDurationElement()) {
                   Fraction duration = toDurationElement(e)->ticks();
-                  checkRest(remains, m, duration);     // go to next measure, if necessary
+                  if (!checkRest(remains, m, duration)) {     // go to next measure, if necessary
+                        MScore::setError(CORRUPTED_MEASURE);
+                        return false;
+                        }
                   if (duration > remains && e->isTuplet()) {
                         // experimental: allow tuplet split in the middle
                         if (duration != remains * 2) {
@@ -510,7 +515,10 @@ bool TrackList::write(Score* score, const Fraction& tick) const
                         else if (e->isChordRest()) {
                               Fraction du               = qMin(remains, duration);
                               std::vector<TDuration> dl = toDurationList(du, e->isChord());
-                              Q_ASSERT(!dl.empty());
+                              if (dl.empty()) {
+                                    MScore::setError(CORRUPTED_MEASURE);
+                                    return false;
+                                    }
                               for (const TDuration& k : dl) {
                                     segment       = m->undoGetSegmentR(SegmentType::ChordRest, m->ticks() - remains);
                                     ChordRest* cr = toChordRest(e->clone());
@@ -551,8 +559,12 @@ bool TrackList::write(Score* score, const Fraction& tick) const
                               duration = Fraction();
                               }
                         firstpart = false;
-                        if (duration > Fraction(0,1))
-                              checkRest(remains, m, duration);     // go to next measure, if necessary
+                        if (duration > Fraction(0,1)) {
+                              if (!checkRest(remains, m, duration)) {     // go to next measure, if necessary
+                                    MScore::setError(CORRUPTED_MEASURE);
+                                    return false;
+                                    }
+                              }
                         }
                   }
             else if (e->isBarLine()) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/316441.

Modified checkRest() so that it returns true on success or false on failure, instead of causing the program to crash if the end of the measure list is reached prematurely. This allows us to safely back out of a track list rewrite in the case of a time signature change in front of a corrupted measure.