### PR TITLE
g/c unused lastFocusWidget

### DIFF
--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -330,7 +330,6 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
 
       Inspector* _inspector          { 0 };
       OmrPanel* omrPanel             { 0 };
-      QWidget* lastFocusWidget       { 0 };
 
       QPushButton* showMidiImportButton {0};
 


### PR DESCRIPTION
left over from commit 0c907ab8222859a645d9a2549da7d18ef11f8326

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
