### PR TITLE
Fix #316610 - Staff spacer down does not work on last system of page

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1574,7 +1574,7 @@ static void distributeStaves(Page* page)
       qreal  prevYBottom  { page->tm() };
       qreal  yBottom      { 0.0        };
       bool   vbox         { false      };
-      Spacer* fixedSpacer { nullptr    };
+      Spacer* activeSpacer { nullptr    };
       bool transferNormalBracket { false };
       bool transferCurlyBracket  { false };
       for (System* system : page->systems()) {
@@ -1613,8 +1613,8 @@ static void distributeStaves(Page* page)
                         if (!sysStaff->show())
                               continue;
 
-                        VerticalGapData* vgd = new VerticalGapData(!ngaps++, system, staff, sysStaff, fixedSpacer, prevYBottom);
-                        fixedSpacer = nullptr;
+                        VerticalGapData* vgd = new VerticalGapData(!ngaps++, system, staff, sysStaff, activeSpacer, prevYBottom);
+                        activeSpacer = nullptr;
 
                         if (newSystem) {
                               vgd->addSpaceBetweenSections();
@@ -1646,11 +1646,13 @@ static void distributeStaves(Page* page)
                   transferNormalBracket = endNormalBracket >= 0;
                   transferCurlyBracket  = endCurlyBracket >= 0;
                   }
-            fixedSpacer = system->getFixedSpacer();
+            activeSpacer = system->getActiveSpacer();
             }
       --ngaps;
 
       qreal spaceLeft { page->height() - page->bm() - score->styleP(Sid::staffLowerBorder) - yBottom };
+      if (activeSpacer)
+          spaceLeft -= activeSpacer->gap();
       if (spaceLeft <= 0.0)
             return;
 
@@ -1776,7 +1778,7 @@ static void layoutPage(Page* page, qreal restHeight)
             System* s1 = page->systems().at(i);
             System* s2 = page->systems().at(i+1);
             s1->setDistance(s2->y() - s1->y());
-            if (s1->vbox() || s2->vbox() || s1->getFixedSpacer()) {
+            if (s1->vbox() || s2->vbox() || s1->hasFixedDownDistance()) {
                   if (s2->vbox()) {
                         checkDivider(true, s1, 0.0, true);      // remove
                         checkDivider(false, s1, 0.0, true);     // remove
@@ -4764,7 +4766,7 @@ void LayoutContext::collectPage()
                   if (vbox) {
                         dist += vbox->bottomGap();
                         }
-                  else if (!prevSystem->getFixedSpacer()) {
+                  else if (!prevSystem->hasFixedDownDistance()) {
                         qreal margin = qMax(curSystem->minBottom(), curSystem->spacerDistance(false));
                         dist += qMax(margin, slb);
                         }

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -1403,7 +1403,7 @@ qreal System::minDistance(System* s2) const
             }
 
       dist = qMax(dist, score()->staff(firstStaff)->userDist());
-      fixedSpacer = nullptr;
+      fixedDownDistance = false;
 
       for (MeasureBase* mb1 : ml) {
             if (mb1->isMeasure()) {
@@ -1411,8 +1411,8 @@ qreal System::minDistance(System* s2) const
                   Spacer* sp = m->vspacerDown(lastStaff);
                   if (sp) {
                         if (sp->spacerType() == SpacerType::FIXED) {
-                              fixedSpacer = sp;
                               dist = sp->gap();
+                              fixedDownDistance = true;
                               break;
                               }
                         else
@@ -1420,7 +1420,7 @@ qreal System::minDistance(System* s2) const
                         }
                   }
             }
-      if (!getFixedSpacer()) {
+      if (!fixedDownDistance) {
             for (MeasureBase* mb2 : s2->ml) {
                   if (mb2->isMeasure()) {
                         Measure* m = toMeasure(mb2);
@@ -1540,17 +1540,23 @@ qreal System::spacerDistance(bool up) const
       if (staff < 0)
             return 0.0;
       qreal dist = 0.0;
+      activeSpacer = nullptr;
       for (MeasureBase* mb : measures()) {
             if (mb->isMeasure()) {
                   Measure* m = toMeasure(mb);
                   Spacer* sp = up ? m->vspacerUp(staff) : m->vspacerDown(staff);
                   if (sp) {
                         if (sp->spacerType() == SpacerType::FIXED) {
+                              activeSpacer = sp;
                               dist = sp->gap();
                               break;
                               }
-                        else
-                              dist = qMax(dist, sp->gap());
+                        else {
+                              if (sp->gap() > dist) {
+                                    activeSpacer = sp;
+                                    dist = sp->gap();
+                                    }
+                              }
                         }
                   }
             }

--- a/libmscore/system.h
+++ b/libmscore/system.h
@@ -95,10 +95,11 @@ class System final : public Element {
       QList<Bracket*> _brackets;
       QList<SpannerSegment*> _spannerSegments;
 
-      qreal _leftMargin           { 0.0     };     ///< left margin for instrument name, brackets etc.
-      mutable Spacer* fixedSpacer { nullptr };
-      qreal _distance             { 0.0     };     // temp. variable used during layout
-      qreal _systemHeight         { 0.0     };
+      qreal _leftMargin              { 0.0     };     ///< left margin for instrument name, brackets etc.
+      mutable bool fixedDownDistance { false   };
+      mutable Spacer* activeSpacer   { nullptr };
+      qreal _distance                { 0.0     };     // temp. variable used during layout
+      qreal _systemHeight            { 0.0     };
 
       int firstVisibleSysStaff() const;
       int lastVisibleSysStaff() const;
@@ -191,7 +192,8 @@ public:
       qreal firstNoteRestSegmentX(bool leading = false);
 
       void moveBracket(int staffIdx, int srcCol, int dstCol);
-      Spacer* getFixedSpacer() const { return fixedSpacer; }
+      bool hasFixedDownDistance() const { return fixedDownDistance; }
+      Spacer* getActiveSpacer() const { return activeSpacer; }
       int firstVisibleStaff() const;
       int nextVisibleStaff(int) const;
       qreal distance() const { return _distance; }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/316610

Check for an active spacer (a fixed spacer or the up/down spacer with the largest gap) for a system use this as a fixed gap for vertical staff adjustment. To make sure the spacers also work between the last staff and the bottom margin of the pages, the calculated space to be used for the spread algorithm (<code>spaceLeft</code>) is reduced by this gap.
This PR partly reverts PR #7312 which took fixed spacers into account only by using <code>System::minDistance()</code> to detect the (fixed) spacer. In this PR the spacers are detected in <code>System::spacerDistance()</code> which takes **all** spacers into account.


- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
