### PR TITLE
fix #316559: part inherits non-default style from score

### DIFF
--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -3621,7 +3621,10 @@ static bool readScore(Score* score, XmlReader& e)
                         e.tracks().clear();
                         e.clearUserTextStyles();
                         MasterScore* m = score->masterScore();
-                        Score* s = new Score(m, m->style());
+                        Score* s       = new Score(m, MScore::baseStyle());
+                        int defaultsVersion = m->style().defaultStyleVersion();
+                        s->setStyle(*MStyle::resolveStyleDefaults(defaultsVersion));
+                        s->style().setDefaultStyleVersion(defaultsVersion);
                         s->setEnableVerticalSpread(false);
                         Excerpt* ex = new Excerpt(m);
 

--- a/libmscore/read302.cpp
+++ b/libmscore/read302.cpp
@@ -187,7 +187,10 @@ bool Score::read(XmlReader& e)
                   else {
                         e.tracks().clear();     // ???
                         MasterScore* m = masterScore();
-                        Score* s       = new Score(m, m->style());
+                        Score* s       = new Score(m, MScore::baseStyle());
+                        int defaultsVersion = m->style().defaultStyleVersion();
+                        s->setStyle(*MStyle::resolveStyleDefaults(defaultsVersion));
+                        s->style().setDefaultStyleVersion(defaultsVersion);
                         Excerpt* ex    = new Excerpt(m);
 
                         ex->setPartScore(s);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/316559

When reading a score with parts, we currently set the defaults
for all styles in the score to those of the score itself.
This was done to make sure the "keep old style" option worked
for both score and for parts.
But this is not the right answer: scores can and do
often have different style settings from the parts.
Most critically, the score might be concert pitch
while the parts are transposed.
The result right now is that the parts are now somehwat "corrupt":
they claim to be in concert pitch mode and the pitches display that way,
but the key signatures are transposed.

That's the most critical effect of this,
but in general, there are many other situations where the score
can have different style settings from the parts,
and right now this difference is getting lost on save/reload.
Because the default for style in part is set from the score,
this means that if the score has any non-default settings,
these get propagate to the part on read even though the part
was using the actual program default settings.

Fix is to set the default style for the part on read
not to the *current* style of the score,
but to its own *default*.
This uses the same code as when reading the score,
checking the default style version,
and resolving the style defaults accordingly.
Thus, the default values for style settings not overriden in the part
come not from the current score settings,
but from the *defaaults* for the score.
This is consistent with how it worked before 3.6,
when there was just one set of defaults applied always (baseStyle).