### PR TITLE
Fix #316797: Deleting a breath/caesura selects the wrong note.

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2499,6 +2499,15 @@ void Score::cmdDeleteSelection()
                               tick = toRest(e)->tick();
                         else if (e->isSpannerSegment())
                               tick = toSpannerSegment(e)->spanner()->tick();
+                        else if (e->isBreath()) {
+                              // we want the tick of the ChordRest that precedes the breath mark (in the same track)
+                              for (Segment* s = toBreath(e)->segment()->prev(); s; s = s->prev()) {
+                                    if (s->isChordRestType() && s->element(e->track())) {
+                                          tick = s->tick();
+                                          break;
+                                          }
+                                    }
+                              }
                         else if (e->parent()
                            && (e->parent()->isSegment() || e->parent()->isChord() || e->parent()->isNote() || e->parent()->isRest()))
                               tick = e->parent()->tick();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/316797.

Since caesuras are placed after the selected note/rest, it makes sense that when the caesura is deleted, we should select the note/rest that precedes the caesura (in the same track).