### PR TITLE
[MU3] Fix deprecation warnings with Qt 5.15.2 and some palette qml files

### DIFF
--- a/mscore/qml/palettes/Palette.qml
+++ b/mscore/qml/palettes/Palette.qml
@@ -767,7 +767,7 @@ GridView {
                 // force not hiding palette cell if it is being dragged to a score
                 enabled: paletteCell.paletteDrag
                 target: mscore
-                onElementDraggedToScoreView: paletteCell.paletteDrag = false
+                function onElementDraggedToScoreView() { paletteCell.paletteDrag = false; }
             }
         } // end ItemDelegate
     } // end DelegateModel

--- a/mscore/qml/palettes/PaletteTree.qml
+++ b/mscore/qml/palettes/PaletteTree.qml
@@ -771,7 +771,7 @@ ListView {
 
     Connections {
         target: palettesWidget
-        onHasFocusChanged: {
+        function onHasFocusChanged () {
             if (!palettesWidget.hasFocus) {
                 paletteSelectionModel.clearSelection();
                 expandedPopupIndex = null;

--- a/mscore/qml/palettes/PalettesWidgetHeader.qml
+++ b/mscore/qml/palettes/PalettesWidgetHeader.qml
@@ -224,7 +224,7 @@ Item {
 
     Connections {
         target: palettesWidget
-        onHasFocusChanged: {
+        function onHasFocusChanged () {
             if (!palettesWidget.hasFocus && !palettesListPopup.inMenuAction)
                 palettesListPopup.visible = false;
         }


### PR DESCRIPTION
These warnings (lots of them) show at run time, not at compile time and may be quite irritating esp. for/on Linux, where MuseScore may use a newer Qt version.

Many times during startup and again on palette use:

    Warning: qrc:/qml/palettes/Palette.qml:766:13: QML Connections: Implicitly defined onFoo properties in Connections are deprecated. Use this syntax instead: function onFoo(<arguments>) { ... } (qrc:/qml/palettes/Palette.qml:766, )

Once per startup:

    Warning: qrc:/qml/palettes/PaletteTree.qml:772:5: QML Connections: Implicitly defined onFoo properties in Connections are deprecated. Use this syntax instead: function onFoo(<arguments>) { ... } (qrc:/qml/palettes/PaletteTree.qml:772, )
    Warning: qrc:/qml/palettes/PalettesWidgetHeader.qml:225:5: QML Connections: Implicitly defined onFoo properties in Connections are deprecated. Use this syntax instead: function onFoo(<arguments>) { ... } (qrc:/qml/palettes/PalettesWidgetHeader.qml:225, )

See also https://doc.qt.io/qt-5/qml-qtqml-connections.html

For now a test, need to check the artifacts, which would use the older Qt 5.9.9 (which I don't have installed any more)
As per https://stackoverflow.com/questions/62297192/qml-connections-implicitly-defined-onfoo-properties-in-connections-are-deprecat as of QT 5.15.1 that new warning can get avoided by `QT_LOGGING_RULES="qt.qml.connections=false"` and that new/changed  syntax is not supported by Qt 5.12 :-(

The artifact (for Windows) seems to work just fine though!?
What operations would need to get tested to verify? Selecting a score element and applying a palette element via double click works, as does dragging a palette element to a score element