### PR TITLE
[MU4] Scroll improvements

### DIFF
--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -203,10 +203,10 @@ void NotationPaintView::onViewSizeChanged()
         return;
     }
 
-    QPoint topLeft = toLogical(QPoint(0, 0));
-    QPoint bottomRight = toLogical(QPoint(width(), height()));
-    notation()->setViewSize(QSizeF(bottomRight.x() - topLeft.x(), bottomRight.y() - topLeft.y()));
+    notation()->setViewSize(viewport().size());
 
+    emit horizontalScrollChanged();
+    emit verticalScrollChanged();
     emit viewportChanged(viewport());
 }
 

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -125,7 +125,7 @@ void NotationViewInputController::setZoom(int zoomPercentage, const QPoint& pos)
         configuration()->setCurrentZoom(correctedZoom);
     }
 
-    qreal scaling = static_cast<qreal>(zoomPercentage) / 100.0 * notationScaling();
+    qreal scaling = static_cast<qreal>(correctedZoom) / 100.0 * notationScaling();
     m_view->scale(scaling, pos);
 }
 

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -183,6 +183,12 @@ void NotationViewInputController::mousePressEvent(QMouseEvent* event)
     QPoint logicPos = m_view->toLogical(event->pos());
     Qt::KeyboardModifiers keyState = event->modifiers();
 
+    // When using MiddleButton, just start moving the canvas
+    if (event->button() == Qt::MiddleButton) {
+        m_interactData.beginPoint = logicPos;
+        return;
+    }
+
     // note enter mode
     if (m_view->isNoteEnterMode()) {
         bool replace = keyState & Qt::ShiftModifier;
@@ -260,7 +266,8 @@ bool NotationViewInputController::isDragAllowed() const
 
 void NotationViewInputController::mouseMoveEvent(QMouseEvent* event)
 {
-    if (!isDragAllowed()) {
+    bool middleButton = event->buttons() == Qt::MiddleButton;
+    if (!isDragAllowed() && !middleButton) {
         return;
     }
 
@@ -274,8 +281,8 @@ void NotationViewInputController::mouseMoveEvent(QMouseEvent* event)
     }
 
     // drag element
-    if ((m_interactData.hitElement && m_interactData.hitElement->isMovable())
-        || m_view->notationInteraction()->isGripEditStarted()) {
+    if (!middleButton && ((m_interactData.hitElement && m_interactData.hitElement->isMovable())
+                          || m_view->notationInteraction()->isGripEditStarted())) {
         if (m_interactData.hitElement && !m_view->notationInteraction()->isDragStarted()) {
             startDragElements(m_interactData.hitElement->type(), m_interactData.hitElement->offset());
         }

--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -117,7 +117,6 @@ private:
     QList<int> m_possibleZoomsPercentage;
 
     bool m_readonly = false;
-    int m_currentZoomPercentage = 0;
     bool m_isCanvasDragged = false;
 };
 }


### PR DESCRIPTION
- **Take horizontal scrolling into account**
Most mouses can't scroll horizontally, but some can. Now, MuseScore will also take horizontal scrolling into account.
Furthermore, the scrolling speed will now feel more comfortable and will feel the same at all zoom states and screen resolutions.

- **Update scrollbars when window is resized**

- **Fix minimum/maximum zoom**
And remove unused property.

- **Fix #312574: Always dragging with middle mouse button**
Resolves: https://musescore.org/en/node/312574
Like in many apps, the middle mouse button will now always allow dragging (_only_ dragging).
A very useful aspect of this is that you can now move the canvas using the MiddleButton, without having to leave Note Input mode. And you can now move the canvas without worrying about accidentally selecting items, as the middle mouse button doesn't select things. 

---

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
