### PR TITLE
Fix #316754: Empty rehearsal mark not deleted after entering a line break

### DIFF
--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -1656,6 +1656,8 @@ void TextBase::createLayout()
                         cursor.setColumn(0);
                         if (rows() <= cursor.row())
                               _layout.append(TextBlock());
+                        if (_layout[cursor.row()].fragments().size() == 0)
+                              _layout[cursor.row()].insertEmptyFragmentIfNeeded(&cursor); // an empty fragment may be needed on either side of the newline
                         }
                   else {
                         if (symState)

--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -537,12 +537,10 @@ void SplitJoinText::join(EditData* ed)
             t->textBlock(line-1).removeEmptyFragment();
       t->textBlock(line-1).fragments().append(*fragmentsList);
       delete fragmentsList;
-      int lines = t->rows();
-      if (line < lines)
-            t->textBlock(line).setEol(eol);
       t->textBlockList().removeAt(line);
 
       c.setRow(line-1);
+      c.curLine().setEol(eol);
       c.setColumn(col);
       c.setFormat(*charFmt);             // restore orig. format at new line
       c.clearSelection();
@@ -556,6 +554,7 @@ void SplitJoinText::split(EditData* ed)
       {
       TextBase* t   = c.text();
       int line      = c.row();
+      bool eol      = c.curLine().eol();
       t->setTextInvalid();
       t->triggerLayout();
 
@@ -564,7 +563,7 @@ void SplitJoinText::split(EditData* ed)
       c.curLine().setEol(true);
 
       c.setRow(line+1);
-      c.curLine().setEol(true);
+      c.curLine().setEol(eol);
       c.setColumn(0);
       c.setFormat(*charFmt);             // restore orig. format at new line
       c.clearSelection();

--- a/vtest/frametext.mscx
+++ b/vtest/frametext.mscx
@@ -154,8 +154,7 @@
         <Text>
           <size>12</size>
           <align>right,center</align>
-          <text>rightCenter<font face=""></font>
-</text>
+          <text>rightCenter<font face=""></font></text>
           </Text>
         <Text>
           <size>12</size>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/316754.

When #4359 attempted to fix https://musescore.org/en/node/278068 (and was shortly followed up by #4364), the end result was that when a newline is inserted into a text block (causing it to split into two text blocks), the second text block would always end with a newline, even if the original text block did not. This is fixed here by setting the second text block's EOL flag to that of the original text block.

This is what is attempted by the function that joins two text blocks when a newline is deleted, but that function wasn't getting it right either. So that has been corrected here as well.

Taken together, these two errors meant that there would be a blank line at the end of any text element that had ever contained a newline. This blank line would be small, but it would always be present, even if you tried to delete it.

Because this blank was always present in multiline text elements, and because it was small enough to not attract much attention, #5881 only added an empty text fragment before a newline, and not after. But now that we do not have to have unwanted newline characters, in order to preserve the font size on a blank line, an empty text fragment may be needed after a newline also.