### PR TITLE
[MU4] Add invisibility and colour to staff type change inspector

### DIFF
--- a/src/inspector/models/notation/stafftype/stafftypesettingsmodel.cpp
+++ b/src/inspector/models/notation/stafftype/stafftypesettingsmodel.cpp
@@ -25,6 +25,8 @@ void StaffTypeSettingsModel::createProperties()
     m_lineCount = buildPropertyItem(Ms::Pid::STAFF_LINES); // int
     m_lineDistance = buildPropertyItem(Ms::Pid::LINE_DISTANCE);
     m_stepOffset = buildPropertyItem(Ms::Pid::STEP_OFFSET); // int
+    m_isInvisible = buildPropertyItem(Ms::Pid::STAFF_INVISIBLE);
+    m_color = buildPropertyItem(Ms::Pid::STAFF_COLOR);
 
     m_noteheadSchemeType = buildPropertyItem(Ms::Pid::HEAD_SCHEME);
     m_isStemless = buildPropertyItem(Ms::Pid::STAFF_STEMLESS);
@@ -55,6 +57,8 @@ void StaffTypeSettingsModel::loadProperties()
     loadPropertyItem(m_lineCount);
     loadPropertyItem(m_lineDistance, formatDoubleFunc);
     loadPropertyItem(m_stepOffset);
+    loadPropertyItem(m_isInvisible);
+    loadPropertyItem(m_color);
 
     loadPropertyItem(m_noteheadSchemeType);
     loadPropertyItem(m_isStemless);
@@ -74,6 +78,8 @@ void StaffTypeSettingsModel::resetProperties()
     m_lineCount->resetToDefault();
     m_lineDistance->resetToDefault();
     m_stepOffset->resetToDefault();
+    m_isInvisible->resetToDefault();
+    m_color->resetToDefault();
 
     m_noteheadSchemeType->resetToDefault();
     m_isStemless->resetToDefault();
@@ -112,6 +118,16 @@ PropertyItem* StaffTypeSettingsModel::lineDistance() const
 PropertyItem* StaffTypeSettingsModel::stepOffset() const
 {
     return m_stepOffset;
+}
+
+PropertyItem* StaffTypeSettingsModel::isInvisible() const
+{
+    return m_isInvisible;
+}
+
+PropertyItem* StaffTypeSettingsModel::color() const
+{
+    return m_color;
 }
 
 PropertyItem* StaffTypeSettingsModel::noteheadSchemeType() const

--- a/src/inspector/models/notation/stafftype/stafftypesettingsmodel.h
+++ b/src/inspector/models/notation/stafftype/stafftypesettingsmodel.h
@@ -15,6 +15,8 @@ class StaffTypeSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(PropertyItem * lineCount READ lineCount CONSTANT)
     Q_PROPERTY(PropertyItem * lineDistance READ lineDistance CONSTANT)
     Q_PROPERTY(PropertyItem * stepOffset READ stepOffset CONSTANT)
+    Q_PROPERTY(PropertyItem * isInvisible READ isInvisible CONSTANT)
+    Q_PROPERTY(PropertyItem * color READ color CONSTANT)
 
     Q_PROPERTY(PropertyItem * noteheadSchemeType READ noteheadSchemeType CONSTANT)
     Q_PROPERTY(PropertyItem * isStemless READ isStemless CONSTANT)
@@ -38,6 +40,8 @@ public:
     PropertyItem* lineCount() const;
     PropertyItem* lineDistance() const;
     PropertyItem* stepOffset() const;
+    PropertyItem* isInvisible() const;
+    PropertyItem* color() const;
 
     PropertyItem* noteheadSchemeType() const;
     PropertyItem* isStemless() const;
@@ -55,6 +59,8 @@ private:
     PropertyItem* m_lineCount = nullptr;
     PropertyItem* m_lineDistance = nullptr;
     PropertyItem* m_stepOffset = nullptr;
+    PropertyItem* m_isInvisible = nullptr;
+    PropertyItem* m_color = nullptr;
 
     PropertyItem* m_noteheadSchemeType = nullptr;
     PropertyItem* m_isStemless = nullptr;

--- a/src/inspector/view/inspector_resources.qrc
+++ b/src/inspector/view/inspector_resources.qrc
@@ -64,7 +64,6 @@
         <file>qml/MuseScore/Inspector/general/appearance/internal/HorizontalSpacingSection.qml</file>
         <file>qml/MuseScore/Inspector/general/appearance/internal/OffsetSection.qml</file>
         <file>qml/MuseScore/Inspector/general/appearance/internal/ArrangeSection.qml</file>
-        <file>qml/MuseScore/Inspector/general/appearance/internal/ColorSection.qml</file>
         <file>qml/MuseScore/Inspector/general/appearance/internal/VerticalSpacingSection.qml</file>
         <file>resources/icons/question_mark.svg</file>
         <file>qml/MuseScore/Inspector/notation/fermatas/FermataPopup.qml</file>
@@ -159,5 +158,6 @@
         <file>qml/MuseScore/Inspector/notation/tremolos/TremoloPopup.qml</file>
         <file>qml/MuseScore/Inspector/notation/measurerepeats/MeasureRepeatPopup.qml</file>
         <file>qml/MuseScore/Inspector/notation/measurerepeats/MeasureRepeatSettings.qml</file>
+        <file>qml/MuseScore/Inspector/common/ColorSection.qml</file>
     </qresource>
 </RCC>

--- a/src/inspector/view/qml/MuseScore/Inspector/common/ColorSection.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/common/ColorSection.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.9
 import QtQuick.Dialogs 1.2
 import MuseScore.UiComponents 1.0
-import "../../../common"
 
 InspectorPropertyView {
     id: root
@@ -11,7 +10,7 @@ InspectorPropertyView {
     height: implicitHeight
     width: parent.width
 
-    titleText: qsTrc("inspector", "Colour")
+    titleText: qsTrc("inspector", "Color")
     propertyItem: root.color
 
     ColorPicker {

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/stafftype/StaffTypePopup.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/stafftype/StaffTypePopup.qml
@@ -166,6 +166,19 @@ StyledPopup {
             }
         }
 
+        CheckBox {
+            isIndeterminate: root.model ? root.model.isInvisible.isUndefined : false
+            checked: root.model && !isIndeterminate ? root.model.isInvisible.value : false
+            text: qsTrc("inspector", "Invisible staff lines")
+
+            onClicked: { root.model.isInvisible.value = !checked }
+        }
+
+        ColorSection {
+            titleText: qsTrc("inspector", "Staff line color")
+            color: root.model ? root.model.color : null
+        }
+
         SeparatorLine { anchors.margins: -10 }
 
         InspectorPropertyView {


### PR DESCRIPTION
Port #6425 part 2

Is there a better place to move `ColorSection.qml`? Right now it is needed in both the Appearance Popup in General section and the Staff Type Change Popup in Notation section.

![屏幕截图 2021-02-03 150952](https://user-images.githubusercontent.com/46259489/106712118-79565b80-6633-11eb-86c4-bdc140a9cd7d.png)