### PR TITLE
Fix #315408: Mixer panel not fully shown when opened

### DIFF
--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -191,7 +191,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_IO_MIDI_PEDAL_EVENTS_MIN_TICKS,                  new IntPreference(1)},
             {PREF_IO_MIDI_REALTIMEDELAY,                           new IntPreference(750 /* ms */, false)},
             {PREF_IO_MIDI_SHORTESTNOTE,                            new IntPreference(MScore::division/4, false)},
-            {PREF_IO_MIDI_SHOWCONTROLSINMIXER,                     new BoolPreference(false, false)},
+            {PREF_IO_MIDI_SHOWCONTROLSINMIXER,                     new BoolPreference(true, false)},
             {PREF_IO_MIDI_USEREMOTECONTROL,                        new BoolPreference(false, false)},
             {PREF_IO_OSC_PORTNUMBER,                               new IntPreference(5282, false)},
             {PREF_IO_OSC_USEREMOTECONTROL,                         new BoolPreference(false, false)},


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/315408

Before #7145, to fix https://musescore.org/en/node/286153, that setting got ignored, so it always showed the full mixer.

