### PR TITLE
Fix #305777: Make applying tremolo a toggle operation

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2681,8 +2681,14 @@ Element* Chord::drop(EditData& data)
                         t->setChords(this, ch2);
                         }
                   }
-                  if (tremolo())
+                  if (tremolo()) {
+                        bool sameType = (e->subtype() == tremolo()->subtype());
                         score()->undoRemoveElement(tremolo());
+                        if (sameType) {
+                              delete e;
+                              return 0;
+                              }
+                        }
                   e->setParent(this);
                   e->setTrack(track());
                   score()->undoAddElement(e);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/305777.

Currently, when a tremolo is added from the palette, any existing tremolo is removed and then the new one is added. With this change, the new tremolo will not be added if it is the same type of tremolo, thus allowing tremolos to be toggled via the palette. This works for one- and two-note tremolos alike.