### PR TITLE
Fix #316679: Segmentation Fault when opening a file with a missing section break element

### DIFF
--- a/libmscore/layoutbreak.h
+++ b/libmscore/layoutbreak.h
@@ -54,6 +54,7 @@ class LayoutBreak final : public Element {
 
       LayoutBreak* clone() const override { return new LayoutBreak(*this); }
       ElementType type() const override   { return ElementType::LAYOUT_BREAK; }
+      int subtype() const override        { return static_cast<int>(_layoutBreakType); }
 
       void setLayoutBreakType(Type);
       Type layoutBreakType() const  { return _layoutBreakType; }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/316679.

The LayoutBreak class failed to override Element::subtype(), causing a LayoutBreak of type LINE to be considered a match for a LayoutBreak of type SECTION when determining which elements to reuse from a previous incarnation of an MMRest.