### PR TITLE
Fix #316555: Invisible breath shouldn't impact layout.

### DIFF
--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -1069,7 +1069,7 @@ bool Segment::hasElements(int minTrack, int maxTrack) const
 
 bool Segment::allElementsInvisible() const
       {
-      if (isType(SegmentType::BarLineType | SegmentType::ChordRest | SegmentType::Breath))
+      if (isType(SegmentType::BarLineType | SegmentType::ChordRest))
             return false;
 
       for (Element* e : _elist) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/316555.

Allows Segment::allElementsInvisible() to return true for breath segments if all elements in the segment are invisible.