### PR TITLE
Banjo fretted fifth string bug 316896

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -954,7 +954,7 @@ if (MSVC)
    set(CMAKE_SKIP_PACKAGE_ALL_DEPENDENCY true)
 
    # Set the startup project to "mscore".
-   if (NOT ${CMAKE_VERSION} VERSION_LESS "3.6.0")
+   if (NOT ${CMAKE_VERSION} VERSION_LESS "3.6.1")
       set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT mscore)
    endif ()
 

--- a/libmscore/instrument.h
+++ b/libmscore/instrument.h
@@ -331,7 +331,7 @@ class Instrument {
       void setMidiActions(const QList<NamedEventList>& l)    { _midiActions = l;  }
       void setArticulation(const QList<MidiArticulation>& l) { _articulation = l; }
       const StringData* stringData() const                   { return &_stringData; }
-      void setStringData(const StringData& d)                { _stringData = d;     }
+      void setStringData(const StringData& d)                { _stringData.set(d); }
 
       void setLongName(const QString& f);
       void setShortName(const QString& f);

--- a/libmscore/stringdata.h
+++ b/libmscore/stringdata.h
@@ -17,54 +17,59 @@
 
 namespace Ms {
 
-class Chord;
-class Note;
+    class Chord;
+    class Note;
 
-//---------------------------------------------------------
-//   StringData
-//---------------------------------------------------------
+    //---------------------------------------------------------
+    //   StringData
+    //---------------------------------------------------------
 
-// defines the string of an instrument
-struct instrString {
-      int   pitch;      // the pitch of the string
-      bool  open;       // true: string is open | false: string is fretted
+    // defines the string of an instrument
+    struct instrString {
+        int   pitch;      // the pitch of the string
+        bool  open;       // true: string is open | false: string is fretted
+        int   startFret = 0;  // banjo 5th string starts on 5th fret
 
-      bool operator==(const instrString& d) const { return d.pitch == pitch && d.open == open; }
-      };
+        bool operator==(const instrString& d) const { return d.pitch == pitch && d.open == open; }
+    };
 
-class StringData {
-//      QList<int>  stringTable { 40, 45, 50, 55, 59, 64 };   // guitar is default
-//      int         _frets = 19;
-      QList<instrString>  stringTable {  };                   // no strings by default
-      int         _frets = 0;
+    class StringData {
+    //      QList<int>  stringTable { 40, 45, 50, 55, 59, 64 };   // guitar is default
+    //      int         _frets = 19;
+        QList<instrString>  stringTable {  };                   // no strings by default
+        int         _frets = 0;
 
-      static bool bFretting;
+        static bool bFretting;
 
-      bool        convertPitch(int pitch, int pitchOffset, int* string, int* fret) const;
-      int         fret(int pitch, int string, int pitchOffset) const;
-      int         getPitch(int string, int fret, int pitchOffset) const;
-      void        sortChordNotes(QMap<int, Note *>& sortedNotes, const Chord* chord, int pitchOffset, int* count) const;
+        bool        convertPitch(int pitch, int pitchOffset, int* string, int* fret) const;
+        int         fret(int pitch, int string, int pitchOffset) const;
+        int         getPitch(int string, int fret, int pitchOffset) const;
+        void        sortChordNotes(QMap<int, Note *>& sortedNotes, const Chord* chord, int pitchOffset, int* count) const;
 
-public:
-      StringData() {}
-      StringData(int numFrets, int numStrings, int strings[]);
-      StringData(int numFrets, QList<instrString>& strings);
-      bool        convertPitch(int pitch, Staff* staff, const Fraction& tick, int* string, int* fret) const;
-      int         fret(int pitch, int string, Staff* staff, const Fraction& tick) const;
-      void        fretChords(Chord * chord) const;
-      int         getPitch(int string, int fret, Staff* staff, const Fraction& tick) const;
-      static int  pitchOffsetAt(Staff* staff, const Fraction& tick);
-      int         strings() const                   { return stringTable.size(); }
-      int         frettedStrings() const;
-      const QList<instrString>&  stringList() const { return stringTable; }
-      QList<instrString>&  stringList()         { return stringTable; }
-      int         frets() const                 { return _frets; }
-      void        setFrets(int val)             { _frets = val; }
-      void        read(XmlReader&);
-      void        write(XmlWriter&) const;
-      void        writeMusicXML(XmlWriter& xml) const;
-      bool operator==(const StringData& d) const { return d._frets == _frets && d.stringTable == stringTable; }
-      };
+    public:
+        StringData() {}
+        StringData(int numFrets, int numStrings, int strings[]);
+        StringData(int numFrets, QList<instrString>& strings);
+        void        set(const StringData& src);
+        bool        convertPitch(int pitch, Staff* staff, const Fraction& tick, int* string, int* fret) const;
+        int         fret(int pitch, int string, Staff* staff, const Fraction& tick) const;
+        void        fretChords(Chord * chord) const;
+        int         getPitch(int string, int fret, Staff* staff, const Fraction& tick) const;
+        static int  pitchOffsetAt(Staff* staff, const Fraction& tick);
+        int         strings() const                   { return stringTable.size(); }
+        int         frettedStrings() const;
+        const QList<instrString>&  stringList() const { return stringTable; }
+        QList<instrString>&  stringList()         { return stringTable; }
+        int         frets() const                 { return _frets; }
+        void        setFrets(int val)             { _frets = val; }
+        void        read(XmlReader&);
+        void        write(XmlWriter&) const;
+        void        writeMusicXML(XmlWriter& xml) const;
+        bool operator==(const StringData& d) const { return d._frets == _frets && d.stringTable == stringTable; }
+        void        configBanjo5thString();
+        int         adjustBanjo5thFret(int fret) const;
+        bool        isFiveStringBanjo() const;
+    };
 
 }     // namespace Ms
 #endif

--- a/share/templates/My_First_Score.mscx
+++ b/share/templates/My_First_Score.mscx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="3.02">
-  <programVersion>3.6.0</programVersion>
+  <programVersion>3.6.1</programVersion>
   <programRevision></programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>


### PR DESCRIPTION
Resolves: #316896

Fixes fret numbers for banjo 5th string in tablature. Currently fret numbers
are 0,1,2,3... Should be 0,6,7,8... because the 5th string starts on the 5th fret.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://musescore.org/en/cla)
- [x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x ] I made sure the code compiles on my machine
- [x ] I made sure there are no unnecessary changes in the code
- [ x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
