### PR TITLE
[MU4] Ported #6948 : Make AutoSize default for new scores but disable it fo…

### DIFF
--- a/src/libmscore/box.cpp
+++ b/src/libmscore/box.cpp
@@ -241,6 +241,9 @@ void Box::read(XmlReader& e)
     _boxHeight       = Spatium(0);       // override default set in constructor
     _boxWidth        = Spatium(0);
     MeasureBase::read(e);
+    if (score()->mscVersion() < 302) {
+        _isAutoSizeEnabled = false;     // disable auto-size for older scores by default.
+    }
 }
 
 //---------------------------------------------------------

--- a/src/libmscore/read114.cpp
+++ b/src/libmscore/read114.cpp
@@ -2344,6 +2344,7 @@ static void readBox(XmlReader& e, Box* b)
     b->setBottomMargin(0.0);
     b->setBoxHeight(Spatium(0));       // override default set in constructor
     b->setBoxWidth(Spatium(0));
+    b->setAutoSizeEnabled(false);
 
     while (e.readNextStartElement()) {
         const QStringRef& tag(e.name());

--- a/src/libmscore/read206.cpp
+++ b/src/libmscore/read206.cpp
@@ -3469,6 +3469,7 @@ static void readBox(Box* b, XmlReader& e)
     b->setBottomMargin(0.0);
     b->setTopGap(0.0);
     b->setBottomGap(0.0);
+    b->setAutoSizeEnabled(false);
     b->setPropertyFlags(Pid::TOP_GAP, PropertyFlags::UNSTYLED);
     b->setPropertyFlags(Pid::BOTTOM_GAP, PropertyFlags::UNSTYLED);
 


### PR DESCRIPTION
Ported #6948 : Make AutoSize default for new scores but disable it fo…

Separately needs port mtests, see https://github.com/musescore/MuseScore/pull/6948/files