### PR TITLE
Fix #305387: Add spinner for controlling glissando line thickness in inspector

### DIFF
--- a/mscore/inspector/inspectorGlissando.cpp
+++ b/mscore/inspector/inspectorGlissando.cpp
@@ -37,6 +37,7 @@ InspectorGlissando::InspectorGlissando(QWidget* parent)
             { Pid::FONT_FACE,       0, g.fontFace,       g.resetFontFace       },
             { Pid::FONT_SIZE,       0, g.fontSize,       g.resetFontSize       },
             { Pid::FONT_STYLE,      0, g.fontStyle,      g.resetFontStyle      },
+            { Pid::LINE_WIDTH,      0, g.lineWidthSpin,  g.resetLineWidth      },
             };
       const std::vector<InspectorPanel> ppList = {
             { g.title, g.panel }
@@ -76,6 +77,8 @@ void InspectorGlissando::valueChanged(int n)
             g.easeInOutCanvas->setEaseInOut(g.easeInSpin->value(), g.easeOutSpin->value());
       else if (iList[n].t == Pid::GLISS_STYLE)
             updateEvents();
+      else if (iList[n].t == Pid::GLISS_TYPE)
+            g.lineWidthWidget->setHidden(g.type->currentIndex() == 1);
       update();
       }
 

--- a/mscore/inspector/inspector_glissando.ui
+++ b/mscore/inspector/inspector_glissando.ui
@@ -508,6 +508,63 @@
         </layout>
        </widget>
       </item>
+      <item row="4" column="0" colspan="3">
+       <widget class="QWidget" name="lineWidthWidget" native="true">
+        <layout class="QGridLayout" name="gridLayout_2">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <property name="spacing">
+          <number>3</number>
+         </property>
+         <item row="0" column="1">
+          <widget class="QDoubleSpinBox" name="lineWidthSpin">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimum">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>1.500000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="lineWidthLabel">
+           <property name="text">
+            <string>Line Thickness:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="Ms::ResetButton" name="resetLineWidth" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -25,6 +25,12 @@
 #include "macos/cocoabridge.h"
 #endif
 
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#include <Winreg.h>
+#include <string>
+#endif
+
 namespace Ms {
 //! Note: see musescore.h getSharePath(). This copy is needed for build without MuseScore
 QString sharePath()
@@ -511,6 +517,19 @@ MuseScoreEffectiveStyleType Preferences::effectiveGlobalStyle() const
 #ifdef Q_OS_MAC // On Mac, follow system theme if desired
       if (s == MuseScorePreferredStyleType::FOLLOW_SYSTEM)
             return CocoaBridge::isSystemDarkTheme() ? MuseScoreEffectiveStyleType::DARK_FUSION : MuseScoreEffectiveStyleType::LIGHT_FUSION;
+#endif
+#ifdef Q_OS_WIN
+      if (s == MuseScorePreferredStyleType::FOLLOW_SYSTEM) {
+            std::wstring subKey = L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
+            std::wstring keyVal = L"AppsUseLightTheme";
+            DWORD data{};
+            DWORD datasize = sizeof(data);
+            LONG retCode = RegGetValue(HKEY_CURRENT_USER, subKey.c_str(), keyVal.c_str(), RRF_RT_REG_DWORD, nullptr, &data, &datasize);
+            if (retCode == ERROR_SUCCESS)
+                return data == 0 ? MuseScoreEffectiveStyleType::DARK_FUSION : MuseScoreEffectiveStyleType::LIGHT_FUSION;
+            else
+                return MuseScoreEffectiveStyleType::LIGHT_FUSION;
+            }
 #endif
       return MuseScoreEffectiveStyleType(s);
       }

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -68,7 +68,7 @@ enum {
 enum class MuseScorePreferredStyleType : char {
       LIGHT_FUSION = 0,
       DARK_FUSION,
-#ifdef Q_OS_MAC
+#if defined(Q_OS_MAC) || defined(Q_OS_WIN)
       FOLLOW_SYSTEM,
 #endif
       };

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -46,6 +46,34 @@
 
 namespace Ms {
 
+#ifdef Q_OS_WIN
+//---------------------------------------------------------
+//   checkWindowsDarkSupport
+//---------------------------------------------------------
+bool checkWindowsDarkSupport()
+      {
+      std::wstring subKey = L"Software\\Microsoft\\Windows NT\\CurrentVersion";
+      std::wstring keyVal = L"CurrentMajorVersionNumber";
+
+      DWORD version{};
+      DWORD datasize = sizeof(version);
+      LONG retCode = RegGetValue(HKEY_LOCAL_MACHINE, subKey.c_str(), keyVal.c_str(), RRF_RT_REG_DWORD, nullptr, &version, &datasize);
+
+      std::string build;
+      keyVal = L"ReleaseId";
+      retCode = RegGetValue(HKEY_LOCAL_MACHINE, subKey.c_str(), keyVal.c_str(), RRF_RT_REG_SZ, nullptr, nullptr, &datasize);	
+      build.resize(datasize / sizeof(char));
+      retCode = RegGetValue(HKEY_LOCAL_MACHINE, subKey.c_str(), keyVal.c_str(), RRF_RT_REG_SZ, nullptr, &build[0], &datasize);
+
+      std::string buildNumber = { build[0], build[2], build[4], build[6] };
+
+      if (retCode == ERROR_SUCCESS)
+            return version >= 10 && std::stoi(buildNumber) >= 1809;
+      else
+            return false;
+      }
+#endif
+
 //---------------------------------------------------------
 //   startPreferenceDialog
 //---------------------------------------------------------
@@ -80,6 +108,10 @@ PreferenceDialog::PreferenceDialog(QWidget* parent)
       styleName->addItem(tr("Dark"));
 #ifdef Q_OS_MAC // On Mac, we have a theme option to follow the system's Dark Mode
       if (CocoaBridge::isSystemDarkModeSupported())
+            styleName->addItem(tr("System"));
+#endif
+#ifdef Q_OS_WIN
+      if (checkWindowsDarkSupport())
             styleName->addItem(tr("System"));
 #endif
 
@@ -652,6 +684,10 @@ void PreferenceDialog::updateValues(bool useDefaultValues, bool setup)
       styleName->addItem(tr("Dark"));
 #ifdef Q_OS_MAC // On Mac, we have a theme option to follow the system's Dark Mode
       if (CocoaBridge::isSystemDarkModeSupported())
+            styleName->addItem(tr("System"));
+#endif
+#ifdef Q_OS_WIN
+      if (checkWindowsDarkSupport())
             styleName->addItem(tr("System"));
 #endif
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/305387

This patch allows users to change the thickness of the glissando line directly from the inspector

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
