### PR TITLE
Fix #305387: Add spinner for controlling glissando line thickness in inspector

### DIFF
--- a/mscore/inspector/inspectorGlissando.cpp
+++ b/mscore/inspector/inspectorGlissando.cpp
@@ -37,6 +37,7 @@ InspectorGlissando::InspectorGlissando(QWidget* parent)
             { Pid::FONT_FACE,       0, g.fontFace,       g.resetFontFace       },
             { Pid::FONT_SIZE,       0, g.fontSize,       g.resetFontSize       },
             { Pid::FONT_STYLE,      0, g.fontStyle,      g.resetFontStyle      },
+            { Pid::LINE_WIDTH,      0, g.lineWidthSpin,  g.resetLineWidth      },
             };
       const std::vector<InspectorPanel> ppList = {
             { g.title, g.panel }
@@ -61,6 +62,7 @@ void InspectorGlissando::setElement()
       g.easeInSlider->setSliderPosition(g.easeInSpin->value());
       g.easeOutSlider->setSliderPosition(g.easeOutSpin->value());
       g.easeInOutCanvas->setEaseInOut(g.easeInSpin->value(), g.easeOutSpin->value());
+      g.lineWidthWidget->setHidden(g.type->currentIndex() == 1);
 
       updateEvents();
       }
@@ -76,6 +78,8 @@ void InspectorGlissando::valueChanged(int n)
             g.easeInOutCanvas->setEaseInOut(g.easeInSpin->value(), g.easeOutSpin->value());
       else if (iList[n].t == Pid::GLISS_STYLE)
             updateEvents();
+      else if (iList[n].t == Pid::GLISS_TYPE)
+            g.lineWidthWidget->setHidden(g.type->currentIndex() == 1);
       update();
       }
 

--- a/mscore/inspector/inspector_glissando.ui
+++ b/mscore/inspector/inspector_glissando.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>349</width>
-    <height>436</height>
+    <height>459</height>
    </rect>
   </property>
   <property name="accessibleName">
@@ -502,6 +502,69 @@
              <width>100</width>
              <height>180</height>
             </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="3">
+       <widget class="QWidget" name="lineWidthWidget" native="true">
+        <layout class="QGridLayout" name="gridLayout_2">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <property name="spacing">
+          <number>3</number>
+         </property>
+         <item row="0" column="1">
+          <widget class="QDoubleSpinBox" name="lineWidthSpin">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="specialValueText">
+            <string/>
+           </property>
+           <property name="suffix">
+            <string>sp</string>
+           </property>
+           <property name="minimum">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>1.500000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="lineWidthLabel">
+           <property name="text">
+            <string>Line Thickness:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="Ms::ResetButton" name="resetLineWidth" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/305387

This patch allows the user to directly change the thickness of the glissando line from the inspector

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
