### PR TITLE
Fix #316896: Banjo fifth string fret numbers

### DIFF
--- a/libmscore/instrument.h
+++ b/libmscore/instrument.h
@@ -331,7 +331,7 @@ class Instrument {
       void setMidiActions(const QList<NamedEventList>& l)    { _midiActions = l;  }
       void setArticulation(const QList<MidiArticulation>& l) { _articulation = l; }
       const StringData* stringData() const                   { return &_stringData; }
-      void setStringData(const StringData& d)                { _stringData = d;     }
+      void setStringData(const StringData& d)                { _stringData.set(d);  }
 
       void setLongName(const QString& f);
       void setShortName(const QString& f);

--- a/libmscore/stringdata.h
+++ b/libmscore/stringdata.h
@@ -26,8 +26,10 @@ class Note;
 
 // defines the string of an instrument
 struct instrString {
+      instrString(int p=0, bool o=false, int s=0) : pitch(p), open(o), startFret(s) {};
       int   pitch;      // the pitch of the string
       bool  open;       // true: string is open | false: string is fretted
+      int   startFret;  // banjo 5th string starts on 5th fret
 
       bool operator==(const instrString& d) const { return d.pitch == pitch && d.open == open; }
       };
@@ -49,6 +51,7 @@ public:
       StringData() {}
       StringData(int numFrets, int numStrings, int strings[]);
       StringData(int numFrets, QList<instrString>& strings);
+      void        set(const StringData& src);
       bool        convertPitch(int pitch, Staff* staff, const Fraction& tick, int* string, int* fret) const;
       int         fret(int pitch, int string, Staff* staff, const Fraction& tick) const;
       void        fretChords(Chord * chord) const;
@@ -64,6 +67,9 @@ public:
       void        write(XmlWriter&) const;
       void        writeMusicXML(XmlWriter& xml) const;
       bool operator==(const StringData& d) const { return d._frets == _frets && d.stringTable == stringTable; }
+      void        configBanjo5thString();
+      int         adjustBanjo5thFret(int fret) const;
+      bool        isFiveStringBanjo() const;
       };
 
 }     // namespace Ms


### PR DESCRIPTION
The banjo 5th string starts at the 5th fret, so valid fret
numbers are 0,6,7,8... Musescore displays 0,1,2,3...

This fix requires no UI changes and no file format changes.

Resolves: 316896

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://musescore.org/en/cla)
- [ x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x ] I made sure the code compiles on my machine
- [x ] I made sure there are no unnecessary changes in the code
- [x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
