### PR TITLE
[MU3] Don't save default settings to pre 3.6 score after 'reset to defaults'

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1729,6 +1729,9 @@ void ChangeStyleVal::flip(EditData*)
                   case Sid::spatium:
                         score->spatiumChanged(v.toDouble(), value.toDouble());
                         break;
+                  case Sid::defaultsVersion:
+                        score->style().setDefaultStyleVersion(value.toInt());
+                        break;
                   default:
                         break;
                   }


### PR DESCRIPTION
Resolves: Lengthy discussion in the Developers' chat on Telegram  ;-)

Importing a pre-3.6 score into 3.6, and then using Format > Style.. > Reset All Styles to Default, then saving the score does result in all the default settings being written into the score, including the tag `<usePre_3_6_defaults>1</usePre_3_6_defaults>`.
Closing, opening it again and saving it again (with **or without** any change results in the score to now (correctly!) **not** contain any of the default settings anymore, and that `<usePre_3_6_defaults>1</usePre_3_6_defaults>` is gone too.

With the change from this PR that workaround of a 2nd save is no longer needed.

Helps a lot if you want to open that score in a pre-3.6 version, it then no longer errnously falls back from Leland to Bravura rather then Emmentaler as the Musical font, from Leland Text to **nothing** for the Musical Text font rather than Emmentaler Text and, worst, from Edwin to "MS Shell Dlg2" (on Windows, on Mac and Linux it'd be some other fallback font) rather than FreeSerif.

What I'm unsure about is the use, need and sense of `<metaTag name="mscVersion">3.02</metaTag>`, and whether we'd not better get rid of it altogether, or at least remove it again on score write, As we do have `<museScore version="3.02">` this seems to be just (very) redundant. But this might be for a different PR...