### PR TITLE
Fix #317084: SVG honors z-order of staff-lines and includes Staff Typ…

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -70,6 +70,7 @@
 #include "scoretab.h"
 #include "libmscore/beam.h"
 #include "libmscore/stafftype.h"
+#include "libmscore/stafftypechange.h"
 #include "seq.h"
 #include "libmscore/revisions.h"
 #include "libmscore/lyrics.h"
@@ -2967,109 +2968,113 @@ bool MuseScore::saveSvg(Score* score, QIODevice* device, int pageNumber, bool dr
       if (drawPageBackground)
             p.fillRect(r, Qt::white);
 
-      // 1st pass: StaffLines
-      for  (System* s : page->systems()) {
-            for (int i = 0, n = s->staves()->size(); i < n; i++) {
-                  if (score->staff(i)->invisible(Fraction(0,1)) || !score->staff(i)->show()) 
-                        continue;  // ignore invisible staves
-                  if (s->staves()->isEmpty() || !s->staff(i)->show())
-                        continue;
-                  Measure* fm = s->firstMeasure();
-                  if (!fm) // only boxes, hence no staff lines
-                        continue;
-
-                  // The goal here is to draw SVG staff lines more efficiently.
-                  // MuseScore draws staff lines by measure, but for SVG they can
-                  // generally be drawn once for each system. This makes a big
-                  // difference for scores that scroll horizontally on a single
-                  // page. But there are exceptions to this rule:
-                  //
-                  //   ~ One (or more) invisible measure(s) in a system/staff ~
-                  //   ~ One (or more) elements of type HBOX or VBOX          ~
-                  //
-                  // In these cases the SVG staff lines for the system/staff
-                  // are drawn by measure.
-                  //
-                  bool byMeasure = false;
-                  for (MeasureBase* mb = fm; mb; mb = s->nextMeasure(mb)) {
-                        if (!mb->isMeasure() || !toMeasure(mb)->visible(i)) {
-                              byMeasure = true;
-                              break;
-                              }
-                        }
-                  if (byMeasure) { // Draw visible staff lines by measure
-                        for (MeasureBase* mb = fm; mb; mb = s->nextMeasure(mb)) {
-                              if (mb->isMeasure() && toMeasure(mb)->visible(i)) {
-                                    StaffLines* sl = toMeasure(mb)->staffLines(i);
-                                    printer.setElement(sl);
-                                    paintElement(p, sl);
-                                    }
-                              }
-                        }
-                  else { // Draw staff lines once per system
-                        StaffLines* firstSL = s->firstMeasure()->staffLines(i)->clone();
-                        StaffLines*  lastSL =  s->lastMeasure()->staffLines(i);
-
-                        qreal lastX =  lastSL->bbox().right()
-                                    +  lastSL->pagePos().x()
-                                    - firstSL->pagePos().x();
-                        QVector<QLineF>& lines = firstSL->getLines();
-                        for (int l = 0, c = lines.size(); l < c; l++)
-                              lines[l].setP2(QPointF(lastX, lines[l].p2().y()));
-
-                        printer.setElement(firstSL);
-                        paintElement(p, firstSL);
-                        }
-                  }
-            }
-      // 2nd pass: the rest of the elements
       QList<Element*> pel = page->elements();
       std::stable_sort(pel.begin(), pel.end(), elementLessThan);
-      ElementType eType;
 
       int lastNoteIndex = -1;
       for (int i = 0; i < pageNumber; ++i) {
-          for (const Element* element: score->pages()[i]->elements()) {
-              if (element->type() == ElementType::NOTE) {
-                  lastNoteIndex++;
-              }
-          }
-      }
+            for (const Element* element: score->pages()[i]->elements()) {
+                  if (element->type() == ElementType::NOTE) {
+                        lastNoteIndex++;
+                        }
+                  }
+            }
 
+      System* previouslyDrawnSystemStaves = nullptr;
+      System* currentSystem = nullptr;
+      Measure* firstMeasureOfSystem = nullptr;
+      const Measure* currentMeasure = nullptr;
       for (const Element* e : pel) {
             // Always exclude invisible elements
             if (!e->visible())
                   continue;
+            if (e->type() == ElementType::STAFF_LINES) {
+                  currentMeasure = e->findMeasure();
+                  currentSystem = currentMeasure->system();
+                  if (previouslyDrawnSystemStaves == currentSystem)
+                        continue; // skip staff lines that have been drawn
 
-            eType = e->type();
-            switch (eType) { // In future sub-type code, this switch() grows, and eType gets used
-            case ElementType::STAFF_LINES : // Handled in the 1st pass above
-                  continue; // Exclude from 2nd pass
-                  break;
-            default:
-                  break;
-            } // switch(eType)
+                  firstMeasureOfSystem = currentSystem->firstMeasure();
+                  if (!firstMeasureOfSystem) // only boxes, hence no staff lines
+                        continue;
+                  for (int i = 0, n = currentSystem->staves()->size(); i < n; i++) {
+                        if (score->staff(i)->invisible(Fraction(0,1)) || !score->staff(i)->show())
+                              continue;  // ignore invisible staves
+                        if (currentSystem->staves()->isEmpty() || !currentSystem->staff(i)->show())
+                              continue;
+
+                        // Draw SVG lines per entire system for efficiency
+                        // Exceptions (draw SVG staff lines by measure instead):
+                        //
+                        //   One (or more) invisible measure(s) in a system/staff
+                        //   One (or more) elements of type HBOX or VBOX
+                        //   One (or more) Staff Type Change(s) within a system
+                        //
+                        bool byMeasure = false;
+                        for (MeasureBase* mb = firstMeasureOfSystem;
+                             mb && !byMeasure;
+                             mb = currentSystem->nextMeasure(mb)) {
+                              if (!mb->isMeasure() || !toMeasure(mb)->visible(i)) {
+                                    byMeasure = true;
+                                    break;
+                                    }
+                              for (Element* element : toMeasure(mb)->el()) {
+                                    if (element->isStaffTypeChange()) {
+                                          byMeasure = true;
+                                          break;
+                                          }
+                                    }
+                              }
+                        if (byMeasure) {
+                              // Draw visible staff lines by measure (all of current system)
+                              for (MeasureBase* mb = firstMeasureOfSystem; mb; mb = currentSystem->nextMeasure(mb)) {
+                                    if (mb->isMeasure() && toMeasure(mb)->visible(i)) {
+                                          StaffLines* sl = toMeasure(mb)->staffLines(i);
+                                          printer.setElement(sl);
+                                          paintElement(p, sl);
+                                          }
+                                    }
+                              previouslyDrawnSystemStaves = currentSystem;
+                              }
+                        else { // Draw staff lines once per system
+                              StaffLines* firstSL = firstMeasureOfSystem->staffLines(i)->clone();
+                              StaffLines*  lastSL = currentSystem->lastMeasure()->staffLines(i);
+
+                              qreal lastX = lastSL->bbox().right()
+                                            + lastSL->pagePos().x()
+                                            - firstSL->pagePos().x();
+                              QVector<QLineF>& lines = firstSL->getLines();
+                              for (int l = 0, c = lines.size(); l < c; l++)
+                                    lines[l].setP2(QPointF(lastX, lines[l].p2().y()));
+
+                              printer.setElement(firstSL);
+                              paintElement(p, firstSL);
+                              previouslyDrawnSystemStaves = currentSystem;
+                              }
+                        }
+                  continue; // drawing of staff-lines for measure/system complete - skip to next element
+                  }
 
             // Set the Element pointer inside SvgGenerator/SvgPaintEngine
             printer.setElement(e);
 
             // Paint it
             if (e->type() == ElementType::NOTE && !notesColors.isEmpty()) {
-                QColor color = e->color();
-                int currentNoteIndex = (++lastNoteIndex);
+                  QColor color = e->color();
+                  int currentNoteIndex = (++lastNoteIndex);
 
-                if (notesColors.contains(currentNoteIndex)) {
-                    color = notesColors[currentNoteIndex];
-                }
+                  if (notesColors.contains(currentNoteIndex)) {
+                        color = notesColors[currentNoteIndex];
+                        }
 
-                Element *note = dynamic_cast<const Note*>(e)->clone();
-                note->setColor(color);
-                paintElement(p, note);
-                delete note;
-            } else {
-                paintElement(p, e);
+                  Element *note = dynamic_cast<const Note*>(e)->clone();
+                  note->setColor(color);
+                  paintElement(p, note);
+                  delete note;
+                  }
+            else paintElement(p, e);
             }
-            }
+
       p.end(); // Writes MuseScore SVG file to disk, finally
 
       // Clean up and return

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -2980,10 +2980,10 @@ bool MuseScore::saveSvg(Score* score, QIODevice* device, int pageNumber, bool dr
                   }
             }
 
-      System* previouslyDrawnSystemStaves = nullptr;
-      System* currentSystem = nullptr;
-      Measure* firstMeasureOfSystem = nullptr;
-      const Measure* currentMeasure = nullptr;
+      System* currentSystem               { nullptr };
+      Measure* firstMeasureOfSystem       { nullptr };
+      const Measure* currentMeasure       { nullptr };
+      std::vector<System*> printedSystems;
       for (const Element* e : pel) {
             // Always exclude invisible elements
             if (!e->visible())
@@ -2991,8 +2991,9 @@ bool MuseScore::saveSvg(Score* score, QIODevice* device, int pageNumber, bool dr
             if (e->type() == ElementType::STAFF_LINES) {
                   currentMeasure = e->findMeasure();
                   currentSystem = currentMeasure->system();
-                  if (previouslyDrawnSystemStaves == currentSystem)
-                        continue; // skip staff lines that have been drawn
+
+                  if (std::find(printedSystems.begin(), printedSystems.end(), currentSystem) != printedSystems.end())
+                        continue; // Skip lines if current system has been drawn already
 
                   firstMeasureOfSystem = currentSystem->firstMeasure();
                   if (!firstMeasureOfSystem) // only boxes, hence no staff lines
@@ -3034,7 +3035,6 @@ bool MuseScore::saveSvg(Score* score, QIODevice* device, int pageNumber, bool dr
                                           paintElement(p, sl);
                                           }
                                     }
-                              previouslyDrawnSystemStaves = currentSystem;
                               }
                         else { // Draw staff lines once per system
                               StaffLines* firstSL = firstMeasureOfSystem->staffLines(i)->clone();
@@ -3049,12 +3049,11 @@ bool MuseScore::saveSvg(Score* score, QIODevice* device, int pageNumber, bool dr
 
                               printer.setElement(firstSL);
                               paintElement(p, firstSL);
-                              previouslyDrawnSystemStaves = currentSystem;
                               }
                         }
-                  continue; // drawing of staff-lines for measure/system complete - skip to next element
+                  printedSystems.push_back(currentSystem);
+                  continue; // Drawing of staff-line element complete
                   }
-
             // Set the Element pointer inside SvgGenerator/SvgPaintEngine
             printer.setElement(e);
 
@@ -3073,7 +3072,7 @@ bool MuseScore::saveSvg(Score* score, QIODevice* device, int pageNumber, bool dr
                   delete note;
                   }
             else paintElement(p, e);
-            }
+            } // End of element loop
 
       p.end(); // Writes MuseScore SVG file to disk, finally
 


### PR DESCRIPTION
…e Changes

Resolves: https://musescore.org/en/node/317084

Staff lines have a z-stack order which weren't being honored during SVG output (PDF/PNG/Main program are fine). So for instance, if an image is given lower z-order below staves, it would end up stacking on top of the staves in exported SVG files. This PR fixes this by not drawing staff-lines before all other elements but having them conjoined in the process while being careful not to draw extra ones since there's custom code from @sidewayss, but also in the process, it was realized that because staff lines were being drawn per system before Staff Type Changes were implemented, those also were not taken into consideration. This also updates so they are taken care of, but there may be a better way to do so. For now, at least this gets the ball rolling. Any comments are appreciated

In the meantime, a quick fix up of some non-conformity to the "banner" style in 3.x was cleaned up. For all main purposes, the code is practically the same as it was even though it shows huge portions deleted. it was merely reformed within a one-pass system, and I've had no problems so far,but I would much appreciate some extra testing to be sure!

Update: So far working fine with a lo-z image + Staff Type Changes have passed testing (along with intermixed horizontal frames to be sure related with STCs)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
