### PR TITLE
[MU4] 'Unify' title bar of main window with the rest of the window on macOS

### DIFF
--- a/src/appshell/view/dockwindow/dockwindow.cpp
+++ b/src/appshell/view/dockwindow/dockwindow.cpp
@@ -94,14 +94,22 @@ void DockWindow::componentComplete()
     m_isComponentComplete = true;
 }
 
-void DockWindow::onMainWindowEvent(QEvent* e)
+void DockWindow::onMainWindowEvent(QEvent* event)
 {
-    if (QEvent::Resize == e->type()) {
-        QResizeEvent* re = static_cast<QResizeEvent*>(e);
-        setSize(QSizeF(re->size()));
+    switch (event->type()) {
+    case QEvent::Paint: {
+        platformTheme()->styleWindow(m_window);
+    } break;
+    case QEvent::Resize: {
+        QResizeEvent* resizeEvent = static_cast<QResizeEvent*>(event);
+        setSize(QSizeF(resizeEvent->size()));
         adjustPanelsSize(currentPage());
-    } else if (QEvent::Close == e->type()) {
+    } break;
+    case QEvent::Close: {
         WidgetStateStore::saveGeometry(m_window);
+    } break;
+    default:
+        break;
     }
 }
 
@@ -261,6 +269,7 @@ void DockWindow::updateStyle()
 {
     m_window->setStyleSheet(WINDOW_QSS.arg(m_color.name()).arg(m_borderColor.name()));
     m_statusbar->setStyleSheet(STATUS_QSS.arg(m_color.name()).arg(m_borderColor.name()));
+    platformTheme()->styleWindow(m_window);
 }
 
 DockPage* DockWindow::currentPage() const

--- a/src/appshell/view/dockwindow/dockwindow.h
+++ b/src/appshell/view/dockwindow/dockwindow.h
@@ -26,6 +26,7 @@
 #include "dockpage.h"
 
 #include "ui/imainwindow.h"
+#include "ui/iplatformtheme.h"
 
 class QMainWindow;
 class QStackedWidget;
@@ -47,6 +48,8 @@ class DockWindow : public QQuickItem, public ui::IMainWindow
 
     Q_CLASSINFO("DefaultProperty", "pages")
     Q_INTERFACES(QQmlParserStatus)
+
+    INJECT(dock, ui::IPlatformTheme, platformTheme)
 
 public:
     explicit DockWindow(QQuickItem* parent = nullptr);
@@ -76,7 +79,7 @@ signals:
     void currentPageUriChanged(QString currentPageUri);
 
 private slots:
-    void onMainWindowEvent(QEvent* e);
+    void onMainWindowEvent(QEvent* event);
     void onPageAppended(int index);
     void updateStyle();
 

--- a/src/framework/ui/internal/platform/macos/macosplatformtheme.h
+++ b/src/framework/ui/internal/platform/macos/macosplatformtheme.h
@@ -20,10 +20,10 @@
 #ifndef MU_UI_MACOSPLATFORMTHEME_H
 #define MU_UI_MACOSPLATFORMTHEME_H
 
-#include "ui/iplatformtheme.h"
+#include "iplatformtheme.h"
 
-namespace mu::framework {
-class MacOSPlatformTheme : public ui::IPlatformTheme
+namespace mu::ui {
+class MacOSPlatformTheme : public IPlatformTheme
 {
 public:
     MacOSPlatformTheme();
@@ -35,6 +35,7 @@ public:
     async::Channel<bool> darkModeSwitched() const override;
 
     void setAppThemeDark(bool) override;
+    void styleWindow(QWidget*) override;
 
 private:
     async::Channel<bool> m_darkModeSwitched;

--- a/src/framework/ui/internal/platform/macos/macosplatformtheme.mm
+++ b/src/framework/ui/internal/platform/macos/macosplatformtheme.mm
@@ -21,7 +21,7 @@
 
 #include <Cocoa/Cocoa.h>
 
-using namespace mu::framework;
+using namespace mu::ui;
 using namespace mu::async;
 
 id<NSObject> darkModeObserverToken;
@@ -60,4 +60,18 @@ Channel<bool> MacOSPlatformTheme::darkModeSwitched() const
 void MacOSPlatformTheme::setAppThemeDark(bool dark)
 {
     [NSApp setAppearance:[NSAppearance appearanceNamed:dark ? NSAppearanceNameDarkAqua : NSAppearanceNameAqua]];
+}
+
+void MacOSPlatformTheme::styleWindow(QWidget* widget)
+{
+    QColor backgroundColor = widget->palette().window().color();
+    NSView* nsView = (__bridge NSView*)reinterpret_cast<void*>(widget->winId());
+    NSWindow* nsWindow = [nsView window];
+    if (nsWindow) {
+        [nsWindow setTitlebarAppearsTransparent:YES];
+        [nsWindow setBackgroundColor:[NSColor colorWithRed:backgroundColor.red() / 255.0
+                                                     green:backgroundColor.green() / 255.0
+                                                      blue:backgroundColor.blue() / 255.0
+                                                     alpha:backgroundColor.alpha() / 255.0]];
+    }
 }

--- a/src/framework/ui/internal/platform/stub/stubplatformtheme.cpp
+++ b/src/framework/ui/internal/platform/stub/stubplatformtheme.cpp
@@ -40,3 +40,7 @@ Channel<bool> StubPlatformTheme::darkModeSwitched() const
 void StubPlatformTheme::setAppThemeDark(bool)
 {
 }
+
+void StubPlatformTheme::styleWindow(QWidget*)
+{
+}

--- a/src/framework/ui/internal/platform/stub/stubplatformtheme.h
+++ b/src/framework/ui/internal/platform/stub/stubplatformtheme.h
@@ -35,6 +35,8 @@ public:
     async::Channel<bool> darkModeSwitched() const override;
 
     void setAppThemeDark(bool) override;
+    void styleWindow(QWidget*) override;
+
 private:
     async::Channel<bool> m_darkModeSwitched;
 };

--- a/src/framework/ui/iplatformtheme.h
+++ b/src/framework/ui/iplatformtheme.h
@@ -23,6 +23,8 @@
 #include "modularity/imoduleexport.h"
 #include "async/channel.h"
 
+#include <QWidget>
+
 namespace mu::ui {
 class IPlatformTheme : MODULE_EXPORT_INTERFACE
 {
@@ -36,7 +38,11 @@ public:
     virtual bool isDarkMode() const = 0;
     virtual async::Channel<bool> darkModeSwitched() const = 0;
 
+    /// Performs platform-specific styling of the application.
     virtual void setAppThemeDark(bool) = 0;
+
+    /// Performs platform-specific styling of the window.
+    virtual void styleWindow(QWidget*) = 0;
 };
 }
 


### PR DESCRIPTION
Before/after:
<img width="1029" alt="MU4 mainwindow titlebar before after" src="https://user-images.githubusercontent.com/48658420/107145177-343a6e00-6940-11eb-8243-80956ef8a052.png">

Also works (and is actually even more effective) on older versions than macOS Big Sur. 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
