### PR TITLE
[MU4] Implement automatic theme switching for Windows

### DIFF
--- a/src/framework/ui/CMakeLists.txt
+++ b/src/framework/ui/CMakeLists.txt
@@ -34,6 +34,11 @@ if (OS_IS_MAC)
 
     set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosplatformtheme.mm
                                 PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+elseif(OS_IS_WIN)
+    set(PLATFORM_THEME_SRC
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/windows/windowsplatformtheme.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/windows/windowsplatformtheme.h
+    )
 else()
     set(PLATFORM_THEME_SRC
         ${CMAKE_CURRENT_LIST_DIR}/internal/platform/stub/stubplatformtheme.cpp

--- a/src/framework/ui/internal/platform/macos/macosplatformtheme.h
+++ b/src/framework/ui/internal/platform/macos/macosplatformtheme.h
@@ -29,6 +29,8 @@ public:
     MacOSPlatformTheme();
     ~MacOSPlatformTheme();
 
+    void init() override;
+
     bool isFollowSystemThemeAvailable() const override;
 
     bool isDarkMode() const override;

--- a/src/framework/ui/internal/platform/macos/macosplatformtheme.mm
+++ b/src/framework/ui/internal/platform/macos/macosplatformtheme.mm
@@ -41,6 +41,10 @@ MacOSPlatformTheme::~MacOSPlatformTheme()
     [n removeObserver:darkModeObserverToken];
 }
 
+void MacOSPlatformTheme::init()
+{
+}
+
 bool MacOSPlatformTheme::isFollowSystemThemeAvailable() const
 {
     return true;

--- a/src/framework/ui/internal/platform/stub/stubplatformtheme.cpp
+++ b/src/framework/ui/internal/platform/stub/stubplatformtheme.cpp
@@ -22,6 +22,10 @@
 using namespace mu::ui;
 using namespace mu::async;
 
+void StubPlatformTheme::init()
+{
+}
+
 bool StubPlatformTheme::isFollowSystemThemeAvailable() const
 {
     return false;

--- a/src/framework/ui/internal/platform/windows/windowsplatformtheme.cpp
+++ b/src/framework/ui/internal/platform/windows/windowsplatformtheme.cpp
@@ -1,0 +1,157 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2021 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#include "windowsplatformtheme.h"
+#include "log.h"
+#include <Windows.h>
+
+using namespace mu::ui;
+using namespace mu::async;
+
+using ThemeType = IUiConfiguration::ThemeType;
+
+static const std::wstring windowsThemeKey = L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
+static const std::wstring windowsThemeSubkey = L"AppsUseLightTheme";
+
+HKEY hKey = nullptr;
+
+HANDLE hThemeChangeEvent = nullptr;
+HANDLE hStopListeningEvent = nullptr;
+
+WindowsPlatformTheme::WindowsPlatformTheme()
+{
+    using fnRtlGetNtVersionNumbers = void(WINAPI*)(LPDWORD major, LPDWORD minor, LPDWORD build);
+    auto rtlGetNtVersionNumbers
+        = reinterpret_cast<fnRtlGetNtVersionNumbers>(GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "RtlGetNtVersionNumbers"));
+    if (rtlGetNtVersionNumbers) {
+        DWORD major, minor, buildNumber;
+        rtlGetNtVersionNumbers(&major, &minor, &buildNumber);
+        m_buildNumber = buildNumber & ~0xF0000000;
+    }
+}
+
+WindowsPlatformTheme::~WindowsPlatformTheme()
+{
+    stopListening();
+}
+
+void WindowsPlatformTheme::init()
+{
+    updateListeningStatus(configuration()->preferredThemeType());
+
+    configuration()->preferredThemeTypeChanged().onReceive(this, [this](const ThemeType& newThemeType) {
+        updateListeningStatus(newThemeType);
+    });
+}
+
+void WindowsPlatformTheme::updateListeningStatus(ThemeType themeType)
+{
+    if (themeType == ThemeType::FOLLOW_SYSTEM_THEME) {
+        startListening();
+    } else {
+        stopListening();
+    }
+}
+
+void WindowsPlatformTheme::startListening()
+{
+    if (m_isListening) {
+        return;
+    }
+    m_isListening = true;
+    if (RegOpenKeyEx(HKEY_CURRENT_USER, windowsThemeKey.c_str(), 0,
+                     KEY_NOTIFY | KEY_CREATE_SUB_KEY | KEY_ENUMERATE_SUB_KEYS | KEY_QUERY_VALUE | KEY_WOW64_64KEY,
+                     &hKey) == ERROR_SUCCESS) {
+        m_listenThread = std::thread([this]() { th_listen(); });
+    } else {
+        LOGD() << "Failed opening key for listening dark theme changes.";
+    }
+}
+
+void WindowsPlatformTheme::th_listen()
+{
+    static const DWORD dwFilter = REG_NOTIFY_CHANGE_NAME
+                                  | REG_NOTIFY_CHANGE_ATTRIBUTES
+                                  | REG_NOTIFY_CHANGE_LAST_SET
+                                  | REG_NOTIFY_CHANGE_SECURITY;
+
+    while (m_isListening) {
+        hStopListeningEvent = CreateEvent(NULL, FALSE, TRUE, TEXT("StopListening"));
+        hThemeChangeEvent = CreateEvent(NULL, FALSE, TRUE, TEXT("ThemeSettingChange"));
+        if (RegNotifyChangeKeyValue(hKey, TRUE, dwFilter, hThemeChangeEvent, TRUE) == ERROR_SUCCESS) {
+            bool wasDarkMode = isDarkMode();
+            HANDLE handles[2] = { hStopListeningEvent, hThemeChangeEvent };
+            DWORD dwRet = WaitForMultipleObjects(2, handles, FALSE, 4000);
+            if (dwRet != WAIT_TIMEOUT && dwRet != WAIT_FAILED) {
+                if (!m_isListening) {
+                    // then it must have been a stop event
+                } else {
+                    bool isDarkMode = this->isDarkMode();
+                    if (isDarkMode != wasDarkMode) {
+                        m_darkModeSwitched.send(isDarkMode);
+                    }
+                }
+            }
+        } else {
+            LOGD() << "Failed registering for dark theme change notifications.";
+        }
+    }
+    RegCloseKey(hKey);
+}
+
+void WindowsPlatformTheme::stopListening()
+{
+    if (!m_isListening) {
+        return;
+    }
+    m_isListening = false;
+    // The following _might_ fail; in that case, the app won't respond
+    // for max. 4000 ms (or whatever value is specified in th_listen()).
+    SetEvent(hStopListeningEvent);
+    m_listenThread.join();
+}
+
+bool WindowsPlatformTheme::isFollowSystemThemeAvailable() const
+{
+    return m_buildNumber >= 17763; // Dark theme was introduced in Windows 1809
+}
+
+bool WindowsPlatformTheme::isDarkMode() const
+{
+    DWORD data {};
+    DWORD datasize = sizeof(data);
+    if (RegGetValue(HKEY_CURRENT_USER, windowsThemeKey.c_str(), windowsThemeSubkey.c_str(),
+                    RRF_RT_REG_DWORD, nullptr, &data, &datasize) == ERROR_SUCCESS) {
+        return data == 0;
+    }
+    return false;
+}
+
+Channel<bool> WindowsPlatformTheme::darkModeSwitched() const
+{
+    return m_darkModeSwitched;
+}
+
+void WindowsPlatformTheme::setAppThemeDark(bool)
+{
+}
+
+void WindowsPlatformTheme::styleWindow(QWidget*)
+{
+}

--- a/src/framework/ui/internal/platform/windows/windowsplatformtheme.h
+++ b/src/framework/ui/internal/platform/windows/windowsplatformtheme.h
@@ -17,17 +17,23 @@
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
 
-#ifndef MU_UI_STUBPLATFORMTHEME_H
-#define MU_UI_STUBPLATFORMTHEME_H
+#ifndef MU_UI_WINDOWSPLATFORMTHEME_H
+#define MU_UI_WINDOWSPLATFORMTHEME_H
 
 #include "iplatformtheme.h"
 
+#include "modularity/ioc.h"
+#include "async/asyncable.h"
+#include "iuiconfiguration.h"
+
 namespace mu::ui {
-class StubPlatformTheme : public IPlatformTheme
+class WindowsPlatformTheme : public IPlatformTheme, public async::Asyncable
 {
+    INJECT(ui, IUiConfiguration, configuration)
+
 public:
-    StubPlatformTheme() = default;
-    ~StubPlatformTheme() = default;
+    WindowsPlatformTheme();
+    ~WindowsPlatformTheme();
 
     void init() override;
 
@@ -41,7 +47,14 @@ public:
 
 private:
     async::Channel<bool> m_darkModeSwitched;
+    int m_buildNumber = 0;
+    std::atomic<bool> m_isListening = false;
+    std::thread m_listenThread;
+    void updateListeningStatus(IUiConfiguration::ThemeType themeType);
+    void startListening();
+    void th_listen();
+    void stopListening();
 };
 }
 
-#endif // MU_UI_STUBPLATFORMTHEME_H
+#endif // MU_UI_WINDOWSPLATFORMTHEME_H

--- a/src/framework/ui/iplatformtheme.h
+++ b/src/framework/ui/iplatformtheme.h
@@ -33,6 +33,8 @@ class IPlatformTheme : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IPlatformTheme() = default;
 
+    virtual void init() = 0;
+
     virtual bool isFollowSystemThemeAvailable() const = 0;
 
     virtual bool isDarkMode() const = 0;


### PR DESCRIPTION
Implement automatic theme switching for Windows:

![Windows automatic theme switching](https://user-images.githubusercontent.com/48658420/107220590-d034aa00-6a12-11eb-8110-aa962e7aff81.gif)
(Just like on macOS, MuseScore switches much more fluent to dark theme than the OS itself. That must be an advantage of QML 😊)

Note: The window title bar doesn't yet switch. That would be a nice next step for the future, but for now, this was really enough Windows for me.

It was the first time that I wrote code with multiple threads. I hope I didn't do dangerous things, and would really appreciate a review :)

Furthermore, I don't have a computer available with Windows 7, so if somebody would want to test if this PR builds and runs correctly on Windows 7 too, that would be great. 

If this PR gets merged earlier than PR #7447, that PR has to be updated, or the other way round. 

Follow-up for PR #7366 (kind of).

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made