### PR TITLE
fix #317163: properties lost on save/reload

### DIFF
--- a/libmscore/pedal.cpp
+++ b/libmscore/pedal.cpp
@@ -107,7 +107,10 @@ void Pedal::read(XmlReader& e)
       if (score()->mscVersion() < 301)
             e.addSpanner(e.intAttribute("id", -1), this);
       while (e.readNextStartElement()) {
-            if (!TextLineBase::readProperties(e))
+            const QStringRef& tag(e.name());
+            if (readStyledProperty(e, tag))
+                  ;
+            else if (!TextLineBase::readProperties(e))
                   e.unknown();
             }
       }

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -968,6 +968,7 @@ void Rest::write(XmlWriter& xml) const
             return;
       writeBeam(xml);
       xml.stag(this);
+      writeStyledProperties(xml);
       ChordRest::writeProperties(xml);
       el().write(xml);
       bool write_dots = false;
@@ -1011,6 +1012,8 @@ void Rest::read(XmlReader& e)
                   dot->read(e);
                   add(dot);
                   }
+            else if (readStyledProperty(e, tag))
+                  ;
             else if (ChordRest::readProperties(e))
                   ;
             else

--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -188,6 +188,12 @@ void Tuplet::layout()
                   _number->setVisible(visible());
                   resetNumberProperty();
                   }
+            // tuplet properties are propagated to number automatically by setProperty()
+            // but we need to make sure flags are as well
+            _number->setPropertyFlags(Pid::FONT_FACE, propertyFlags(Pid::FONT_FACE));
+            _number->setPropertyFlags(Pid::FONT_SIZE, propertyFlags(Pid::FONT_SIZE));
+            _number->setPropertyFlags(Pid::FONT_STYLE, propertyFlags(Pid::FONT_STYLE));
+            _number->setPropertyFlags(Pid::ALIGN, propertyFlags(Pid::ALIGN));
             if (_numberType == TupletNumberType::SHOW_NUMBER)
                   _number->setXmlText(QString("%1").arg(_ratio.numerator()));
             else
@@ -783,7 +789,8 @@ void Tuplet::write(XmlWriter& xml) const
 
       if (_number) {
             xml.stag("Number", _number);
-            _number->writeProperties(xml);
+            _number->writeProperty(xml, Pid::SUB_STYLE);
+            _number->writeProperty(xml, Pid::TEXT);
             xml.etag();
             }
 
@@ -821,19 +828,22 @@ bool Tuplet::readProperties(XmlReader& e)
             ;
       else if (tag == "bold") { //important that these properties are read after number is created
             bool val = e.readInt();
-            _number->setBold(val);
+            if (_number)
+                  _number->setBold(val);
             if (isStyled(Pid::FONT_STYLE))
                   setPropertyFlags(Pid::FONT_STYLE, PropertyFlags::UNSTYLED);
             }
       else if (tag == "italic") {
             bool val = e.readInt();
-            _number->setItalic(val);
+            if (_number)
+                  _number->setItalic(val);
             if (isStyled(Pid::FONT_STYLE))
                   setPropertyFlags(Pid::FONT_STYLE, PropertyFlags::UNSTYLED);
             }
       else if (tag == "underline") {
             bool val = e.readInt();
-            _number->setUnderline(val);
+            if (_number)
+                  _number->setUnderline(val);
             if (isStyled(Pid::FONT_STYLE))
                   setPropertyFlags(Pid::FONT_STYLE, PropertyFlags::UNSTYLED);
             }

--- a/libmscore/volta.cpp
+++ b/libmscore/volta.cpp
@@ -149,6 +149,8 @@ void Volta::read(XmlReader& e)
                         _endings.append(i);
                         }
                   }
+            else if (readStyledProperty(e, tag))
+                  ;
             else if (!readProperties(e))
                   e.unknown();
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/317163

The recent changes to style handling
result in an extra styleChanged() call on load,
which is not a problem in itself
but exposes some existing problems in various read() functions.
If styled properties were not marked as unstyled during the read,
they get reset by this styleChanged() call,
meaning any custom settings are lost on load.

In fact, they would mostly have been lost after a *second* save/reload
even in older versions, since the properties are not marked as unstyled
and thus won't get written.
But now they are lost immediately upon the first save/reload.

The fix is to to be sure we mark the property unstyled on read,
which basically means inserting calls to readStyledProperty()
in the read() or readProperties() functions of various element types.

This was originally reported for volta line style,
and I quickly discovered it also appplies to line width,
and to pedal line width.
I then scanned the code looking for read() functions
that did not handle styledProperties.
I can't guarantee I foudn them all,
but I did find the mmrest number offset and tuplet number text.
The latter actually *seemed* to be handling the styled properties,
but only for the tuplet itself, not the number.
The font property flags needed to be copied to the number.