### PR TITLE
[MU4] PopupView component

### DIFF
--- a/src/appshell/qml/DevTools/Gallery/GeneralComponentsGallery.qml
+++ b/src/appshell/qml/DevTools/Gallery/GeneralComponentsGallery.qml
@@ -42,6 +42,7 @@ Rectangle {
                     { textRole: "IncrementalPropertyControl (Hidden icon, Icon left, Icon right)", componentRole: incrementalPropertyControlSample },
                     { textRole: "FlatToogleButton", componentRole: flatToogleButtonSample },
                     { textRole: "RoundedRectangle (which allows to round the particular corners)", componentRole: roundedRectangleSample },
+                    { textRole: "StyledPopupView", componentRole: styledPopupViewComponent },
                     { textRole: "TextInputField", componentRole: textInputFieldSample },
                     { textRole: "SearchField", componentRole: searchFieldSample },
                     { textRole: "TabPanel", componentRole: tabPanelSample },
@@ -523,6 +524,53 @@ Rectangle {
         id: searchFieldSample
 
         SearchField {}
+    }
+
+    Component {
+        id: styledPopupViewComponent
+
+        FlatButton {
+            text: "Show popup view"
+
+            onClicked: {
+                if (!popupView.isOpened) {
+                    popupView.open()
+                } else {
+                    popupView.close()
+                }
+            }
+
+            StyledPopupView {
+                id: popupView
+
+                positionDisplacementX: parent.width/2 - width/2
+                positionDisplacementY: parent.height
+
+                padding: 24
+
+                Column {
+                    spacing: 12
+
+                    CheckBox {
+                        text: "Some checkbox"
+                    }
+
+                    FlatButton {
+                        text: "Some buton"
+                    }
+
+                    FlatButton {
+                        text: "Accent button 1"
+                        accentButton: true
+                    }
+
+                    FlatButton {
+                        text: "Accent button 2"
+                        accentButton: true
+                    }
+                }
+            }
+        }
     }
 
     Component {

--- a/src/appshell/qml/DevTools/Interactive/InteractiveTests.qml
+++ b/src/appshell/qml/DevTools/Interactive/InteractiveTests.qml
@@ -119,24 +119,10 @@ Rectangle {
             onClicked: testModel.openWidgetDialog()
         }
 
-        PopupView {
-            id: popup
-
-            Rectangle {
-                color: "red"
-                width: 300
-                height: 300
-            }
-        }
-
         FlatButton {
             width: 200
             text: "Widget dialogg async"
-            onClicked: popup.show()//testModel.openWidgetDialogAsync()
-
-            Component.onCompleted: {
-                var i = 0
-            }
+            onClicked: testModel.openWidgetDialogAsync()
         }
     }
 }

--- a/src/appshell/qml/DevTools/Interactive/InteractiveTests.qml
+++ b/src/appshell/qml/DevTools/Interactive/InteractiveTests.qml
@@ -119,10 +119,24 @@ Rectangle {
             onClicked: testModel.openWidgetDialog()
         }
 
+        PopupView {
+            id: popup
+
+            Rectangle {
+                color: "red"
+                width: 300
+                height: 300
+            }
+        }
+
         FlatButton {
             width: 200
-            text: "Widget dialog async"
-            onClicked: testModel.openWidgetDialogAsync()
+            text: "Widget dialogg async"
+            onClicked: popup.show()//testModel.openWidgetDialogAsync()
+
+            Component.onCompleted: {
+                var i = 0
+            }
         }
     }
 }

--- a/src/appshell/view/dockwindow/docktoolbar.cpp
+++ b/src/appshell/view/dockwindow/docktoolbar.cpp
@@ -50,7 +50,7 @@ DockToolBar::DockToolBar(QQuickItem* parent)
 
     m_eventsWatcher = new EventsWatcher(this);
     m_tool.bar->installEventFilter(m_eventsWatcher);
-    connect(m_eventsWatcher, &EventsWatcher::eventReceived, this, &DockToolBar::onToolbarEvent);
+    connect(m_eventsWatcher, &EventsWatcher::eventReceived, this, &DockToolBar::onWidgetEvent);
 }
 
 DockToolBar::~DockToolBar()
@@ -77,13 +77,15 @@ void DockToolBar::updateStyle()
     m_tool.bar->setStyleSheet(TOOLBAR_QSS.arg(theme, color().name()));
 }
 
-void DockToolBar::onToolbarEvent(QEvent* e)
+void DockToolBar::onWidgetEvent(QEvent* e)
 {
     if (QEvent::Resize == e->type()) {
         QResizeEvent* resizeEvent = static_cast<QResizeEvent*>(e);
         resize(resizeEvent->size());
     } else if (QEvent::ShowToParent == e->type()) {
         resize(m_tool.bar->size());
+    } else {
+        DockView::onWidgetEvent(e);
     }
 }
 

--- a/src/appshell/view/dockwindow/docktoolbar.h
+++ b/src/appshell/view/dockwindow/docktoolbar.h
@@ -67,7 +67,7 @@ protected:
     void updateStyle() override;
 
 private slots:
-    void onToolbarEvent(QEvent* e);
+    void onWidgetEvent(QEvent* e) override;
 
 private:
     void resize(const QSize& size);

--- a/src/appshell/view/dockwindow/dockview.cpp
+++ b/src/appshell/view/dockwindow/dockview.cpp
@@ -77,8 +77,8 @@ void DockView::onWidgetEvent(QEvent* event)
     if (QEvent::Resize == event->type()) {
         QResizeEvent* re = static_cast<QResizeEvent*>(event);
         setSize(QSizeF(re->size()));
-    } else if (QEvent::Move == e->type()) {
-        QMoveEvent* me = static_cast<QMoveEvent*>(e);
+    } else if (QEvent::Move == event->type()) {
+        QMoveEvent* me = static_cast<QMoveEvent*>(event);
         setPosition(me->pos());
         emit positionChanged(me->pos());
     }

--- a/src/appshell/view/dockwindow/dockview.cpp
+++ b/src/appshell/view/dockwindow/dockview.cpp
@@ -77,6 +77,10 @@ void DockView::onWidgetEvent(QEvent* event)
     if (QEvent::Resize == event->type()) {
         QResizeEvent* re = static_cast<QResizeEvent*>(event);
         setSize(QSizeF(re->size()));
+    } else if (QEvent::Move == e->type()) {
+        QMoveEvent* me = static_cast<QMoveEvent*>(e);
+        setPosition(me->pos());
+        emit positionChanged(me->pos());
     }
 }
 

--- a/src/appshell/view/dockwindow/dockview.h
+++ b/src/appshell/view/dockwindow/dockview.h
@@ -64,8 +64,8 @@ signals:
     void borderColorChanged(QColor color);
     void positionChanged(const QPointF& pos);
 
-private slots:
-    void onWidgetEvent(QEvent* event);
+protected slots:
+    virtual void onWidgetEvent(QEvent* event);
 
 protected:
     virtual void onComponentCompleted() {}

--- a/src/appshell/view/dockwindow/dockview.h
+++ b/src/appshell/view/dockwindow/dockview.h
@@ -62,6 +62,7 @@ signals:
     void contentChanged();
     void colorChanged(QColor color);
     void borderColorChanged(QColor color);
+    void positionChanged(const QPointF& pos);
 
 private slots:
     void onWidgetEvent(QEvent* event);

--- a/src/framework/uicomponents/CMakeLists.txt
+++ b/src/framework/uicomponents/CMakeLists.txt
@@ -43,6 +43,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/itemmultiselectionmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/qmllistproperty.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/qmllistproperty.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/popupview.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/popupview.h
     )
 
 include(${PROJECT_SOURCE_DIR}/build/module.cmake)

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledPopupView.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledPopupView.qml
@@ -1,3 +1,22 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2021 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtGraphicalEffects 1.0
@@ -18,6 +37,9 @@ PopupView {
     closePolicy: PopupView.CloseOnPressOutsideParent
 
     onAboutToShow: {
+        //!Note For some reason the call of mapToGlobal in the QML scope and in C++ on the same object produces different results
+        //      The only reliable option is QML version, that's why we have to do get globalPos from QML for now.
+        //      Makes sense to check it again on next QT update
         globalPos = mapToGlobal(x, y)
     }
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledPopupView.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledPopupView.qml
@@ -1,0 +1,128 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtGraphicalEffects 1.0
+import MuseScore.UiComponents 1.0
+import MuseScore.Ui 1.0
+
+PopupView {
+    id: root
+
+    property bool opensUpward: false
+    property var arrowX: width / 2
+    property alias arrowHeight: arrow.height
+
+    property color borderColor: ui.theme.strokeColor
+    property color fillColor: ui.theme.backgroundPrimaryColor
+    readonly property int borderWidth: 1
+
+    closePolicy: PopupView.CloseOnPressOutsideParent
+
+    onAboutToShow: {
+        globalPos = mapToGlobal(x, y)
+    }
+
+    backgroundItem: Item {
+        anchors.fill: parent
+        anchors.leftMargin: 12
+        anchors.rightMargin: 12
+        anchors.bottomMargin: 12
+
+        Item {
+            id: mainBackground
+            anchors.fill: parent
+
+            Canvas {
+                id: arrow
+                anchors.top: opensUpward ? undefined : parent.top
+                anchors.bottom: opensUpward ? parent.bottom : undefined
+                z: 1
+                height: 12
+                width: 22
+                x: Math.floor(root.arrowX - 12 - (width / 2))
+
+                onPaint: {
+                    var ctx = getContext("2d");
+                    ctx.lineWidth = 2;
+                    ctx.fillStyle = fillColor;
+                    ctx.strokeStyle = borderColor;
+                    ctx.beginPath();
+
+                    if (opensUpward) {
+                        ctx.moveTo(0, 0);
+                        ctx.lineTo(width / 2, height - 1);
+                        ctx.lineTo(width, 0);
+                    } else {
+                        ctx.moveTo(0, height);
+                        ctx.lineTo(width / 2, 1);
+                        ctx.lineTo(width, height);
+                    }
+
+                    ctx.stroke();
+                    ctx.fill();
+                }
+            }
+
+            Rectangle {
+                color: fillColor
+                border { width: root.borderWidth; color: root.borderColor }
+
+                anchors {
+                    top: opensUpward ? parent.top : arrow.bottom
+                    topMargin: opensUpward ? 0 : -1
+                    bottom: opensUpward ? arrow.top : parent.bottom
+                    bottomMargin: opensUpward ? -1 : 0
+                    left: parent.left
+                    right: parent.right
+                }
+            }
+        }
+
+        DropShadow {
+            anchors.fill: parent
+            source: mainBackground
+            color: "#75000000"
+            verticalOffset: 4
+            samples: 30
+        }
+    }
+
+    states: [
+        State {
+            name: "OPENED"
+            when: root.isOpened
+
+            PropertyChanges {
+                target: root.backgroundItem
+                scale: 1.0
+                opacity: 1.0
+            }
+
+            PropertyChanges {
+                target: root.contentItem
+                scale: 1.0
+                opacity: 1.0
+            }
+        },
+
+        State {
+            name: "CLOSED"
+            when: !root.isOpened
+
+            PropertyChanges {
+                target: root.backgroundItem
+                scale: 0.0
+                opacity: 0.0
+            }
+
+            PropertyChanges {
+                target: root.contentItem
+                scale: 0.0
+                opacity: 0.0
+            }
+        }
+    ]
+
+    transitions: Transition {
+        NumberAnimation { properties: "scale, opacity"; easing.type: Easing.OutQuint; duration: 140 }
+    }
+}

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/qmldir
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/qmldir
@@ -34,3 +34,4 @@ ListItemBlank 1.0 ListItemBlank.qml
 StyledSlider 1.0 StyledSlider.qml
 NumberInputField 1.0 NumberInputField.qml
 TimeInputField 1.0 TimeInputField.qml
+StyledPopupView 1.0 StyledPopupView.qml

--- a/src/framework/uicomponents/uicomponents.qrc
+++ b/src/framework/uicomponents/uicomponents.qrc
@@ -38,5 +38,6 @@
         <file>qml/MuseScore/UiComponents/TimeInputField.qml</file>
         <file>qml/MuseScore/UiComponents/internal/GridViewDelegate.qml</file>
         <file>qml/MuseScore/UiComponents/internal/GridViewSection.qml</file>
+        <file>qml/MuseScore/UiComponents/StyledPopupView.qml</file>
     </qresource>
 </RCC>

--- a/src/framework/uicomponents/uicomponentsmodule.cpp
+++ b/src/framework/uicomponents/uicomponentsmodule.cpp
@@ -6,6 +6,7 @@
 #include "view/validators/intinputvalidator.h"
 #include "view/iconview.h"
 #include "view/filterproxymodel.h"
+#include "view/popupview.h"
 
 #include "modularity/ioc.h"
 #include "ui/iuiengine.h"
@@ -43,6 +44,8 @@ void UiComponentsModule::registerUiTypes()
     qmlRegisterType<FilterProxyModel>("MuseScore.UiComponents", 1, 0, "FilterProxyModel");
     qmlRegisterType<FilterValue>("MuseScore.UiComponents", 1, 0, "FilterValue");
     qmlRegisterUncreatableType<CompareType>("MuseScore.UiComponents", 1, 0, "CompareType", "Cannot create a CompareType");
+
+    qmlRegisterType<PopupView>("MuseScore.UiComponents", 1, 0, "PopupView");
 
     framework::ioc()->resolve<ui::IUiEngine>(moduleName())->addSourceImportPath(uicomponents_QML_IMPORT);
 }

--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -1,0 +1,62 @@
+#include "popupview.h"
+
+#include <QWidget>
+#include <QQmlEngine>
+#include <QUrl>
+
+PopupView::PopupView(QQuickItem* parent) : QQuickItem(parent)
+{
+    setFlag(QQuickItem::ItemHasContents, true);
+}
+
+QQmlComponent* PopupView::contentItem() const
+{
+    return m_contentItem;
+}
+
+void PopupView::show()
+{
+    if (!m_view) {
+        return;
+    }
+
+    m_view->show();
+}
+
+void PopupView::hide()
+{
+    if (!m_view) {
+        return;
+    }
+
+    m_view->hide();
+}
+
+void PopupView::setContentItem(QQmlComponent *contentItem)
+{
+    if (m_contentItem == contentItem)
+        return;
+
+    m_contentItem = contentItem;
+    emit contentItemChanged(m_contentItem);
+}
+
+void PopupView::componentComplete()
+{
+    QQuickItem::componentComplete();
+
+    if (!m_contentItem) {
+        return;
+    }
+
+    m_view = new QQuickView(m_contentItem->engine(), nullptr);
+    m_view->setResizeMode(QQuickView::SizeViewToRootObject);
+
+    QWidget* windowContainer = QWidget::createWindowContainer(m_view, nullptr, Qt::Popup | Qt::FramelessWindowHint |  Qt::WindowStaysOnTopHint);
+    windowContainer->setAttribute(Qt::WA_TranslucentBackground);
+    windowContainer->setAttribute(Qt::WA_ShowWithoutActivating);
+
+    QQmlContext* ctx = QQmlEngine::contextForObject(this);
+    QQuickItem* obj = qobject_cast<QQuickItem*>(m_contentItem->create(ctx));
+    m_view->setContent(QUrl(), m_contentItem, obj);
+}

--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -1,38 +1,95 @@
 #include "popupview.h"
 
-#include <QWidget>
 #include <QQmlEngine>
 #include <QUrl>
+#include <QQmlContext>
 
 PopupView::PopupView(QQuickItem* parent) : QQuickItem(parent)
 {
     setFlag(QQuickItem::ItemHasContents, true);
+
+    qApp->installEventFilter(this);
 }
 
-QQmlComponent* PopupView::contentItem() const
+void PopupView::open()
+{
+    if (!m_containerView) {
+        return;
+    }
+
+    emit aboutToShow();
+
+    m_containerView->show();
+
+    setIsOpened(true);
+
+    emit opened();
+}
+
+void PopupView::close()
+{
+    if (!m_containerView) {
+        return;
+    }
+
+    emit aboutToHide();
+
+    m_containerView->hide();
+    setIsOpened(false);
+
+    emit closed();
+}
+
+QQuickItem* PopupView::backgroundItem() const
+{
+    return m_backgroundItem;
+}
+
+QQuickItem* PopupView::contentItem() const
 {
     return m_contentItem;
 }
 
-void PopupView::show()
+qreal PopupView::positionDisplacementX() const
 {
-    if (!m_view) {
-        return;
-    }
-
-    m_view->show();
+    return m_positionDisplacementX;
 }
 
-void PopupView::hide()
+qreal PopupView::positionDisplacementY() const
 {
-    if (!m_view) {
-        return;
-    }
-
-    m_view->hide();
+    return m_positionDisplacementY;
 }
 
-void PopupView::setContentItem(QQmlComponent *contentItem)
+QPointF PopupView::globalPos() const
+{
+    return m_globalPos;
+}
+
+PopupView::ClosePolicy PopupView::closePolicy() const
+{
+    return m_closePolicy;
+}
+
+bool PopupView::isOpened() const
+{
+    return m_isOpened;
+}
+
+qreal PopupView::padding() const
+{
+    return m_padding;
+}
+
+void PopupView::setBackgroundItem(QQuickItem* backgroundItem)
+{
+    if (m_backgroundItem == backgroundItem)
+        return;
+
+    m_backgroundItem = backgroundItem;
+    emit backgroundItemChanged(m_backgroundItem);
+}
+
+void PopupView::setContentItem(QQuickItem* contentItem)
 {
     if (m_contentItem == contentItem)
         return;
@@ -41,22 +98,165 @@ void PopupView::setContentItem(QQmlComponent *contentItem)
     emit contentItemChanged(m_contentItem);
 }
 
+void PopupView::setClosePolicy(PopupView::ClosePolicy closePolicy)
+{
+    if (m_closePolicy == closePolicy)
+        return;
+
+    m_closePolicy = closePolicy;
+    emit closePolicyChanged(m_closePolicy);
+}
+
+void PopupView::setIsOpened(bool isOpened)
+{
+    if (m_isOpened == isOpened)
+        return;
+
+    m_isOpened = isOpened;
+    emit isOpenedChanged(m_isOpened);
+}
+
+void PopupView::setPadding(qreal padding)
+{
+    if (qFuzzyCompare(m_padding, padding))
+        return;
+
+    m_padding = padding;
+    emit paddingChanged(m_padding);
+}
+
+void PopupView::setPositionDisplacementX(qreal positionDisplacementX)
+{
+    if (qFuzzyCompare(m_positionDisplacementX, positionDisplacementX))
+        return;
+
+    m_positionDisplacementX = positionDisplacementX;
+    setX(positionDisplacementX);
+    emit positionDisplacementXChanged(m_positionDisplacementX);
+}
+
+void PopupView::setPositionDisplacementY(qreal positionDisplacementY)
+{
+    if (qFuzzyCompare(m_positionDisplacementY, positionDisplacementY))
+        return;
+
+    m_positionDisplacementY = positionDisplacementY;
+    setY(positionDisplacementY);
+    emit positionDisplacementYChanged(m_positionDisplacementY);
+}
+
+void PopupView::setGlobalPos(QPointF globalPos)
+{
+    if (m_globalPos == globalPos)
+        return;
+
+    m_globalPos = globalPos;
+    m_containerView->setPosition(globalPos.toPoint());
+    emit globalPosChanged(m_globalPos);
+}
+
 void PopupView::componentComplete()
 {
     QQuickItem::componentComplete();
 
-    if (!m_contentItem) {
+    QQmlEngine* engine = qmlEngine(this);
+    QQmlContext* ctx = qmlContext(this);
+
+    setupContentComponent(engine);
+    setupContainerView(engine);
+    QQuickItem* obj = loadContentItem(ctx);
+
+    m_containerView->setContent(QUrl(), m_contentComponent, obj);
+    setSize(obj->size());
+}
+
+bool PopupView::eventFilter(QObject* watched, QEvent* event)
+{
+    if (QEvent::MouseButtonPress == event->type()) {
+        mousePressEvent(static_cast<QMouseEvent*>(event));
+    } else if (QEvent::MouseButtonRelease == event->type()) {
+        mouseReleaseEvent(static_cast<QMouseEvent*>(event));
+    }
+
+    return QObject::eventFilter(watched, event);
+}
+
+void PopupView::mousePressEvent(QMouseEvent* event)
+{
+    if (!m_isOpened) {
         return;
     }
 
-    m_view = new QQuickView(m_contentItem->engine(), nullptr);
-    m_view->setResizeMode(QQuickView::SizeViewToRootObject);
+    if (m_closePolicy == ClosePolicy::CloseOnPressOutsideParent) {
 
-    QWidget* windowContainer = QWidget::createWindowContainer(m_view, nullptr, Qt::Popup | Qt::FramelessWindowHint |  Qt::WindowStaysOnTopHint);
-    windowContainer->setAttribute(Qt::WA_TranslucentBackground);
-    windowContainer->setAttribute(Qt::WA_ShowWithoutActivating);
+        if (!isMouseWithinBoundaries(event->globalPos())) {
+            close();
+        }
+    }
+}
 
-    QQmlContext* ctx = QQmlEngine::contextForObject(this);
-    QQuickItem* obj = qobject_cast<QQuickItem*>(m_contentItem->create(ctx));
-    m_view->setContent(QUrl(), m_contentItem, obj);
+void PopupView::mouseReleaseEvent(QMouseEvent* event)
+{
+    if (!m_isOpened) {
+        return;
+    }
+
+    if (m_closePolicy == ClosePolicy::CloseOnReleaseOutsideParent) {
+
+        if (!isMouseWithinBoundaries(event->globalPos())) {
+            close();
+        }
+    }
+}
+
+bool PopupView::isMouseWithinBoundaries(const QPoint& mousePos) const
+{
+    if (!parentItem()) {
+        return false;
+    }
+
+    QRectF parentRect = QRectF(parentItem()->x(),
+                               parentItem()->y(),
+                               parentItem()->width(),
+                               parentItem()->height());
+
+    QRectF boundRect = QRectF(x(), y(), width(), height());
+    QRectF contentRect = boundRect.united(parentRect);
+
+    QPointF parentGlobalPos = parentItem()->mapToGlobal(parentItem()->position());
+
+    QRectF globalContentRect = QRectF(qMin(globalPos().x(), parentGlobalPos.x()),
+                                      qMin(globalPos().y(), parentGlobalPos.y()),
+                                      contentRect.width(),
+                                      contentRect.height());
+
+    return globalContentRect.contains(mousePos);
+}
+
+void PopupView::setupContentComponent(QQmlEngine* engine)
+{
+    m_contentComponent = new QQmlComponent(engine, this);
+
+    QString dataStr;
+    dataStr.append("import QtQuick 2.15\n");
+    dataStr.append("import QtQuick.Controls 2.15\n");
+    dataStr.append("Control { }");
+    m_contentComponent->setData(dataStr.toUtf8(), QUrl());
+}
+
+void PopupView::setupContainerView(QQmlEngine* engine)
+{
+    m_containerView = new QQuickView(engine, nullptr);
+    m_containerView->setFlags(Qt::Popup | Qt::FramelessWindowHint);
+    m_containerView->setResizeMode(QQuickView::SizeViewToRootObject);
+    m_containerView->setColor("#00000000");
+}
+
+QQuickItem* PopupView::loadContentItem(QQmlContext* ctx)
+{
+    QVariantMap initialProperties;
+    initialProperties.insert("background", QVariant::fromValue(m_backgroundItem));
+    initialProperties.insert("contentItem", QVariant::fromValue(m_contentItem));
+    initialProperties.insert("padding", m_padding);
+    return qobject_cast<QQuickItem*>(m_contentComponent->createWithInitialProperties(initialProperties, ctx));
 }

--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -1,8 +1,29 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2021 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
 #include "popupview.h"
 
 #include <QQmlEngine>
 #include <QUrl>
 #include <QQmlContext>
+
+using namespace mu::uicomponents;
 
 PopupView::PopupView(QQuickItem* parent)
     : QQuickItem(parent)

--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -4,7 +4,8 @@
 #include <QUrl>
 #include <QQmlContext>
 
-PopupView::PopupView(QQuickItem* parent) : QQuickItem(parent)
+PopupView::PopupView(QQuickItem* parent)
+    : QQuickItem(parent)
 {
     setFlag(QQuickItem::ItemHasContents, true);
 
@@ -82,8 +83,9 @@ qreal PopupView::padding() const
 
 void PopupView::setBackgroundItem(QQuickItem* backgroundItem)
 {
-    if (m_backgroundItem == backgroundItem)
+    if (m_backgroundItem == backgroundItem) {
         return;
+    }
 
     m_backgroundItem = backgroundItem;
     emit backgroundItemChanged(m_backgroundItem);
@@ -91,8 +93,9 @@ void PopupView::setBackgroundItem(QQuickItem* backgroundItem)
 
 void PopupView::setContentItem(QQuickItem* contentItem)
 {
-    if (m_contentItem == contentItem)
+    if (m_contentItem == contentItem) {
         return;
+    }
 
     m_contentItem = contentItem;
     emit contentItemChanged(m_contentItem);
@@ -100,8 +103,9 @@ void PopupView::setContentItem(QQuickItem* contentItem)
 
 void PopupView::setClosePolicy(PopupView::ClosePolicy closePolicy)
 {
-    if (m_closePolicy == closePolicy)
+    if (m_closePolicy == closePolicy) {
         return;
+    }
 
     m_closePolicy = closePolicy;
     emit closePolicyChanged(m_closePolicy);
@@ -109,8 +113,9 @@ void PopupView::setClosePolicy(PopupView::ClosePolicy closePolicy)
 
 void PopupView::setIsOpened(bool isOpened)
 {
-    if (m_isOpened == isOpened)
+    if (m_isOpened == isOpened) {
         return;
+    }
 
     m_isOpened = isOpened;
     emit isOpenedChanged(m_isOpened);
@@ -118,8 +123,9 @@ void PopupView::setIsOpened(bool isOpened)
 
 void PopupView::setPadding(qreal padding)
 {
-    if (qFuzzyCompare(m_padding, padding))
+    if (qFuzzyCompare(m_padding, padding)) {
         return;
+    }
 
     m_padding = padding;
     emit paddingChanged(m_padding);
@@ -127,8 +133,9 @@ void PopupView::setPadding(qreal padding)
 
 void PopupView::setPositionDisplacementX(qreal positionDisplacementX)
 {
-    if (qFuzzyCompare(m_positionDisplacementX, positionDisplacementX))
+    if (qFuzzyCompare(m_positionDisplacementX, positionDisplacementX)) {
         return;
+    }
 
     m_positionDisplacementX = positionDisplacementX;
     setX(positionDisplacementX);
@@ -137,8 +144,9 @@ void PopupView::setPositionDisplacementX(qreal positionDisplacementX)
 
 void PopupView::setPositionDisplacementY(qreal positionDisplacementY)
 {
-    if (qFuzzyCompare(m_positionDisplacementY, positionDisplacementY))
+    if (qFuzzyCompare(m_positionDisplacementY, positionDisplacementY)) {
         return;
+    }
 
     m_positionDisplacementY = positionDisplacementY;
     setY(positionDisplacementY);
@@ -147,8 +155,9 @@ void PopupView::setPositionDisplacementY(qreal positionDisplacementY)
 
 void PopupView::setGlobalPos(QPointF globalPos)
 {
-    if (m_globalPos == globalPos)
+    if (m_globalPos == globalPos) {
         return;
+    }
 
     m_globalPos = globalPos;
     m_containerView->setPosition(globalPos.toPoint());
@@ -188,7 +197,6 @@ void PopupView::mousePressEvent(QMouseEvent* event)
     }
 
     if (m_closePolicy == ClosePolicy::CloseOnPressOutsideParent) {
-
         if (!isMouseWithinBoundaries(event->globalPos())) {
             close();
         }
@@ -202,7 +210,6 @@ void PopupView::mouseReleaseEvent(QMouseEvent* event)
     }
 
     if (m_closePolicy == ClosePolicy::CloseOnReleaseOutsideParent) {
-
         if (!isMouseWithinBoundaries(event->globalPos())) {
             close();
         }

--- a/src/framework/uicomponents/view/popupview.h
+++ b/src/framework/uicomponents/view/popupview.h
@@ -8,8 +8,8 @@ class PopupView : public QQuickItem
 {
     Q_OBJECT
 
-    Q_PROPERTY(QQuickItem* backgroundItem READ backgroundItem WRITE setBackgroundItem NOTIFY backgroundItemChanged)
-    Q_PROPERTY(QQuickItem* contentItem READ contentItem WRITE setContentItem NOTIFY contentItemChanged)
+    Q_PROPERTY(QQuickItem * backgroundItem READ backgroundItem WRITE setBackgroundItem NOTIFY backgroundItemChanged)
+    Q_PROPERTY(QQuickItem * contentItem READ contentItem WRITE setContentItem NOTIFY contentItemChanged)
     Q_PROPERTY(ClosePolicy closePolicy READ closePolicy WRITE setClosePolicy NOTIFY closePolicyChanged)
 
     Q_PROPERTY(QPointF globalPos READ globalPos WRITE setGlobalPos NOTIFY globalPosChanged)

--- a/src/framework/uicomponents/view/popupview.h
+++ b/src/framework/uicomponents/view/popupview.h
@@ -1,0 +1,36 @@
+#ifndef POPUPVIEW_H
+#define POPUPVIEW_H
+
+#include <QQuickItem>
+#include <QQuickView>
+
+class PopupView : public QQuickItem
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QQmlComponent* contentItem READ contentItem WRITE setContentItem NOTIFY contentItemChanged)
+
+    Q_CLASSINFO("DefaultProperty", "contentItem")
+
+public:
+    explicit PopupView(QQuickItem* parent = nullptr);
+
+    QQmlComponent* contentItem() const;
+
+    Q_INVOKABLE void show();
+    Q_INVOKABLE void hide();
+
+public slots:
+    void setContentItem(QQmlComponent* contentItem);
+
+signals:
+    void contentItemChanged(QQmlComponent* contentItem);
+
+private:
+    void componentComplete() override;
+
+    QQmlComponent* m_contentItem = nullptr;
+    QQuickView* m_view = nullptr;
+};
+
+#endif // POPUPVIEW_H

--- a/src/framework/uicomponents/view/popupview.h
+++ b/src/framework/uicomponents/view/popupview.h
@@ -1,9 +1,29 @@
-#ifndef POPUPVIEW_H
-#define POPUPVIEW_H
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2021 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef MU_UICOMPONENTS_POPUPVIEW_H
+#define MU_UICOMPONENTS_POPUPVIEW_H
 
 #include <QQuickItem>
 #include <QQuickView>
 
+namespace mu::uicomponents {
 class PopupView : public QQuickItem
 {
     Q_OBJECT
@@ -102,5 +122,6 @@ private:
     qreal m_positionDisplacementX = 0.0;
     qreal m_positionDisplacementY = 0.0;
 };
+}
 
-#endif // POPUPVIEW_H
+#endif // MU_UICOMPONENTS_POPUPVIEW_H

--- a/src/framework/uicomponents/view/popupview.h
+++ b/src/framework/uicomponents/view/popupview.h
@@ -8,29 +8,99 @@ class PopupView : public QQuickItem
 {
     Q_OBJECT
 
-    Q_PROPERTY(QQmlComponent* contentItem READ contentItem WRITE setContentItem NOTIFY contentItemChanged)
+    Q_PROPERTY(QQuickItem* backgroundItem READ backgroundItem WRITE setBackgroundItem NOTIFY backgroundItemChanged)
+    Q_PROPERTY(QQuickItem* contentItem READ contentItem WRITE setContentItem NOTIFY contentItemChanged)
+    Q_PROPERTY(ClosePolicy closePolicy READ closePolicy WRITE setClosePolicy NOTIFY closePolicyChanged)
+
+    Q_PROPERTY(QPointF globalPos READ globalPos WRITE setGlobalPos NOTIFY globalPosChanged)
+    Q_PROPERTY(qreal positionDisplacementX READ positionDisplacementX WRITE setPositionDisplacementX NOTIFY positionDisplacementXChanged)
+    Q_PROPERTY(qreal positionDisplacementY READ positionDisplacementY WRITE setPositionDisplacementY NOTIFY positionDisplacementYChanged)
+
+    Q_PROPERTY(bool isOpened READ isOpened WRITE setIsOpened NOTIFY isOpenedChanged)
+
+    Q_PROPERTY(qreal padding READ padding WRITE setPadding NOTIFY paddingChanged)
 
     Q_CLASSINFO("DefaultProperty", "contentItem")
 
+    Q_ENUMS(ClosePolicy)
 public:
+    enum ClosePolicy {
+        NoAutoClose = 0,
+        CloseOnPressOutsideParent,
+        CloseOnReleaseOutsideParent
+    };
+
     explicit PopupView(QQuickItem* parent = nullptr);
 
-    QQmlComponent* contentItem() const;
+    Q_INVOKABLE void open();
+    Q_INVOKABLE void close();
 
-    Q_INVOKABLE void show();
-    Q_INVOKABLE void hide();
+    QQuickItem* backgroundItem() const;
+    QQuickItem* contentItem() const;
+    ClosePolicy closePolicy() const;
+
+    bool isOpened() const;
+
+    qreal padding() const;
+
+    QPointF globalPos() const;
+    qreal positionDisplacementX() const;
+    qreal positionDisplacementY() const;
 
 public slots:
-    void setContentItem(QQmlComponent* contentItem);
+    void setBackgroundItem(QQuickItem* backgroundItem);
+    void setContentItem(QQuickItem* contentItem);
+    void setClosePolicy(ClosePolicy closePolicy);
+
+    void setIsOpened(bool isOpened);
+    void setPadding(qreal padding);
+
+    void setGlobalPos(QPointF globalPos);
+    void setPositionDisplacementX(qreal positionDisplacementX);
+    void setPositionDisplacementY(qreal positionDisplacementY);
 
 signals:
-    void contentItemChanged(QQmlComponent* contentItem);
+    void backgroundItemChanged(QQuickItem* backgroundItem);
+    void contentItemChanged(QQuickItem* contentItem);
+    void closePolicyChanged(ClosePolicy closePolicy);
+
+    void isOpenedChanged(bool isOpened);
+
+    void aboutToShow();
+    void aboutToHide();
+    void opened();
+    void closed();
+
+    void paddingChanged(qreal padding);
+
+    void globalPosChanged(QPointF globalPos);
+    void positionDisplacementXChanged(qreal positionDisplacementX);
+    void positionDisplacementYChanged(qreal positionDisplacementY);
 
 private:
     void componentComplete() override;
+    bool eventFilter(QObject* watched, QEvent* event) override;
+    void mousePressEvent(QMouseEvent* event);
+    void mouseReleaseEvent(QMouseEvent* event);
 
-    QQmlComponent* m_contentItem = nullptr;
-    QQuickView* m_view = nullptr;
+    bool isMouseWithinBoundaries(const QPoint& mousePos) const;
+
+    void setupContentComponent(QQmlEngine* engine);
+    void setupContainerView(QQmlEngine* engine);
+    QQuickItem* loadContentItem(QQmlContext* ctx);
+
+    QQmlComponent* m_contentComponent = nullptr;
+    QQuickView* m_containerView = nullptr;
+
+    QQuickItem* m_backgroundItem = nullptr;
+    QQuickItem* m_contentItem = nullptr;
+
+    ClosePolicy m_closePolicy = ClosePolicy::CloseOnPressOutsideParent;
+    bool m_isOpened = false;
+    qreal m_padding = 0.0;
+    QPointF m_globalPos;
+    qreal m_positionDisplacementX = 0.0;
+    qreal m_positionDisplacementY = 0.0;
 };
 
 #endif // POPUPVIEW_H

--- a/tools/codestyle/uncrustify_musescore.cfg
+++ b/tools/codestyle/uncrustify_musescore.cfg
@@ -1590,7 +1590,7 @@ pp_define_at_level                       = false    # false/true
 #
 # true:  indentation will be used only once
 # false: indentation will be used every time (default)
-indent_cpp_lambda_only_once     = true    # true/false
+#indent_cpp_lambda_only_once     = true    # true/false
 
 # You can force a token to be a type with the 'type' option.
 # Example:

--- a/tools/codestyle/uncrustify_musescore.cfg
+++ b/tools/codestyle/uncrustify_musescore.cfg
@@ -1590,7 +1590,7 @@ pp_define_at_level                       = false    # false/true
 #
 # true:  indentation will be used only once
 # false: indentation will be used every time (default)
-#indent_cpp_lambda_only_once     = true    # true/false
+indent_cpp_lambda_only_once     = true    # true/false
 
 # You can force a token to be a type with the 'type' option.
 # Example:


### PR DESCRIPTION
This PR introduces a new component PopupView and it's "musescored" version called "StyledPopupView".

Currently, we're not able to use QML Popup inside dockwidgets, which already blocks several of our new features. 
So the main difference between QtQuick Popup and PopupView is that it could be used within the DockWidgets.

Basically, it uses the common interface of QtQuick.Controls with two main properties "backgroundItem" and "contentItem".

Issues that are not covered by this PR:
- we'd need to replace usages of the current StyledPopup with the new component
- Auto-close policy doesn't support "Esc" key-press yet - https://doc.qt.io/qt-5/qml-enumeration.html. The support of this case will be available later.

![Peek 2021-02-08 23-48](https://user-images.githubusercontent.com/57620349/107285700-35ff5100-6a68-11eb-86da-122493136911.gif)
