### PR TITLE
Fix #316504: Update MusicXML Import of Fretboard Diagrams

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -4935,8 +4935,11 @@ FretDiagram* MusicXMLParserPass2::frame()
                   if (string > 0) {
                         if (fret == 0)
                               fd->setMarker(actualString, FretMarkerType::CIRCLE);
-                        else if (fret > 0)
+                        else if (fret > 0) {
+                              if (fd->marker(actualString).mtype == FretMarkerType::CROSS)
+                                    fd->setMarker(actualString, FretMarkerType::NONE);
                               fd->setDot(actualString, fret, true);
+                              }
                         }
                   else
                         _logger->logError(QString("FretDiagram::readMusicXML: illegal frame-note string %1").arg(string), &_e);

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -273,7 +273,7 @@ void FretDiagram::init(StringData* stringData, Chord* chord)
                   if (stringData->convertPitch(note->pitch(), chord->staff(), chord->segment()->tick(), &string, &fret))
                         setDot(string, fret);
                   }
-            _maxFrets = stringData->frets();
+            _frets = stringData->frets();
             }
       else
             _maxFrets = 6;
@@ -1290,27 +1290,27 @@ void FretDiagram::writeMusicXML(XmlWriter& xml) const
                   xml.tag("fret", "0");
                   xml.etag();
                   }
-            else {
-                  // Write dots
-                  for (auto const& d : dot(i)) {
-                        if (!d.exists())
-                              continue;
-                        xml.stag("frame-note");
-                        xml.tag("string", mxmlString);
-                        xml.tag("fret", d.fret);
-                        // TODO: write fingerings
 
-                        // Also write barre if it starts at this dot
-                        if (std::find(bStarts.begin(), bStarts.end(), d.fret) != bStarts.end()) {
-                              xml.tagE("barre type=\"start\"");
-                              bStarts.erase(std::remove(bStarts.begin(), bStarts.end(), d.fret), bStarts.end());
-                              }
-                        if (std::find(bEnds.begin(), bEnds.end(), d.fret) != bEnds.end()) {
-                              xml.tagE("barre type=\"stop\"");
-                              bEnds.erase(std::remove(bEnds.begin(), bEnds.end(), d.fret), bEnds.end());
-                              }
-                        xml.etag();
+            // Markers may exists alongside with dots
+            // Write dots
+            for (auto const& d : dot(i)) {
+                  if (!d.exists())
+                        continue;
+                  xml.stag("frame-note");
+                  xml.tag("string", mxmlString);
+                  xml.tag("fret", d.fret);
+                  // TODO: write fingerings
+
+                  // Also write barre if it starts at this dot
+                  if (std::find(bStarts.begin(), bStarts.end(), d.fret) != bStarts.end()) {
+                        xml.tagE("barre type=\"start\"");
+                        bStarts.erase(std::remove(bStarts.begin(), bStarts.end(), d.fret), bStarts.end());
                         }
+                  if (std::find(bEnds.begin(), bEnds.end(), d.fret) != bEnds.end()) {
+                        xml.tagE("barre type=\"stop\"");
+                        bEnds.erase(std::remove(bEnds.begin(), bEnds.end(), d.fret), bEnds.end());
+                        }
+                  xml.etag();
                   }
 
             // Write unwritten barres


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/316504

After updating Fret Diagrams to allow for [Open markers + additional fret dots] from within MuseScore's fretboard diagram editor, MusicXML import needed updating to properly form a diagram with potentially both open markers and fret marks on the same string. There was also an issue with extraneous mute markings even with the presence of a fret-dot while being imported (they are implicitly formed during initialization rather than being explicit data like with fret markers). This takes care of issue linked above.

Aside: even though FretDiagram::init() isn't involved in importing from xml, it was erroneously setting _maxFrets rather than _frets from the corresponding "getter" frets() function, so changed that also. 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
