### PR TITLE
[MU3] Fix #317319: Remove unneeded skyline extension for time- and key signatures

### DIFF
--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -281,26 +281,6 @@ void KeySig::layout()
       }
 
 //---------------------------------------------------------
-//   shape
-//---------------------------------------------------------
-
-Shape KeySig::shape() const
-      {
-      QRectF box(bbox());
-      const Staff* st = staff();
-      if (st && addToSkyline()) {
-            // Extend key signature shape up and down to
-            // the first ledger line height to ensure that
-            // no notes will be too close to the keysig.
-            const qreal sp = spatium();
-            const qreal y = pos().y();
-            box.setTop(std::min(-sp - y, box.top()));
-            box.setBottom(std::max(st->height() - y + sp, box.bottom()));
-            }
-      return Shape(box);
-      }
-
-//---------------------------------------------------------
 //   set
 //---------------------------------------------------------
 

--- a/libmscore/keysig.h
+++ b/libmscore/keysig.h
@@ -44,7 +44,6 @@ class KeySig final : public Element {
       bool acceptDrop(EditData&) const override;
       Element* drop(EditData&) override;
       void layout() override;
-      Shape shape() const override;
       qreal mag() const override;
 
       //@ sets the key of the key signature

--- a/libmscore/timesig.cpp
+++ b/libmscore/timesig.cpp
@@ -379,26 +379,6 @@ void TimeSig::layout()
       }
 
 //---------------------------------------------------------
-//   shape
-//---------------------------------------------------------
-
-Shape TimeSig::shape() const
-      {
-      QRectF box(bbox());
-      const Staff* st = staff();
-      if (st && addToSkyline()) {
-            // Extend time signature shape up and down to
-            // the first ledger line height to ensure that
-            // no notes will be too close to the timesig.
-            const qreal sp = spatium();
-            const qreal y = pos().y();
-            box.setTop(std::min(-sp - y, box.top()));
-            box.setBottom(std::max(st->height() - y + sp, box.bottom()));
-            }
-      return Shape(box);
-      }
-
-//---------------------------------------------------------
 //   draw
 //---------------------------------------------------------
 

--- a/libmscore/timesig.h
+++ b/libmscore/timesig.h
@@ -79,7 +79,6 @@ class TimeSig final : public Element {
       void write(XmlWriter& xml) const override;
       void read(XmlReader&) override;
       void layout() override;
-      Shape shape() const override;
 
       Fraction sig() const               { return _sig; }
       void setSig(const Fraction& f, TimeSigType st = TimeSigType::NORMAL);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/317319

Should go to master too, so see #7498 (merged there already)