### PR TITLE
[MU4] Completed ported #6109 : fix #305717: chord symbols attached to fret …

### DIFF
--- a/src/libmscore/excerpt.cpp
+++ b/src/libmscore/excerpt.cpp
@@ -597,6 +597,12 @@ void Excerpt::cloneStaves(Score* oscore, Score* score, const QList<int>& sourceS
                             if (ne->isHarmony()) {
                                 Harmony* h = toHarmony(ne);
                                 h->render();
+                            } else if (ne->isFretDiagram()) {
+                                Harmony* h = toHarmony(toFretDiagram(ne)->harmony());
+                                if (h) {
+                                    processLinkedClone(h, score, strack);
+                                    h->render();
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Completed ported #6109 : fix #305717: chord symbols attached to fret diagrams don't link to parts

