### PR TITLE
[MU4] Ported #7315 : custom gliss text reverts to default gliss

### DIFF
--- a/src/libmscore/glissando.cpp
+++ b/src/libmscore/glissando.cpp
@@ -408,7 +408,7 @@ void Glissando::read(XmlReader& e)
         const QStringRef& tag = e.name();
         if (tag == "text") {
             _showText = true;
-            _text = e.readElementText();
+            readProperty(e, Pid::GLISS_TEXT);
         } else if (tag == "subtype") {
             _glissandoType = GlissandoType(e.readInt());
         } else if (tag == "glissandoStyle") {


### PR DESCRIPTION
Ported #7315 : custom gliss text reverts to default gliss