### PR TITLE
[MU3] fix #317368: fix Score.staves property

### DIFF
--- a/mscore/plugin/api/qmlpluginapi.cpp
+++ b/mscore/plugin/api/qmlpluginapi.cpp
@@ -309,6 +309,7 @@ void PluginAPI::registerQmlTypes()
       qmlRegisterType<Segment>();
       qmlRegisterType<Measure>();
       qmlRegisterType<Part>();
+      qmlRegisterType<Staff>();
       qmlRegisterType<Instrument>();
       qmlRegisterType<Channel>();
       qmlRegisterType<StringData>();

--- a/mscore/plugin/api/score.h
+++ b/mscore/plugin/api/score.h
@@ -113,7 +113,7 @@ class Score : public Ms::PluginAPI::ScoreElement {
 
       /**
        * List of staves in this score.
-       * \since MuseScore 3.5
+       * \since MuseScore 3.6.3
        */
       Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::Staff> staves    READ staves)
 


### PR DESCRIPTION
Adds Staff type registration that was missed in 4ea5007b76251658cee2cd6a012b7896aade682a.
Changes \since statement for Score.staves property because the property
appears to be broken in earlier versions. The other relevant property
(Element.staff) works fine in the previous versions, therefore no changes for it.

Resolves: https://musescore.org/en/node/317368