### PR TITLE
[MU3] Fix #314060: Onscreen Keyboard to show actual note events rather than only score selection during playback

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -15,6 +15,7 @@
 #include "musescore.h"
 #include "seq.h"
 #include "texttools.h"
+#include "pianotools.h"
 #include "fotomode.h"
 #include "tourhandler.h"
 #include "scoreaccessibility.h"

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2399,8 +2399,10 @@ void MuseScore::selectionChanged(SelState selectionState)
       if (timeline())
             timeline()->changeSelection(selectionState);
       if (_pianoTools && _pianoTools->isVisible()) {
-            if (cs)
-                  _pianoTools->changeSelection(cs->selection());
+            if (cs) {
+                  if (seq->isStopped())
+                        _pianoTools->changeSelection(cs->selection());
+                  }
             else
                   _pianoTools->clearSelection();
             }

--- a/mscore/pianotools.cpp
+++ b/mscore/pianotools.cpp
@@ -171,12 +171,32 @@ void HPiano::pressPitch(int pitch)
       }
 
 //---------------------------------------------------------
+//   pressPlaybackPitch
+//---------------------------------------------------------
+
+void HPiano::pressPlaybackPitch(int pitch)
+      {
+      _pressedPlaybackPitches.insert(pitch);
+      updateAllKeys();
+      }
+
+//---------------------------------------------------------
 //   releasePitch
 //---------------------------------------------------------
 
 void HPiano::releasePitch(int pitch)
       {
       _pressedPitches.remove(pitch);
+      updateAllKeys();
+      }
+
+//---------------------------------------------------------
+//   releasePlaybackPitch
+//---------------------------------------------------------
+
+void HPiano::releasePlaybackPitch(int pitch)
+      {
+      _pressedPlaybackPitches.remove(pitch);
       updateAllKeys();
       }
 
@@ -448,8 +468,8 @@ void PianoTools::setPlaybackNotes(QList<const Ms::Note *> notes)
       {
       QSet<int> pitches;
       for (const Note* note : notes) {
-          pitches.insert(note->ppitch());
-          }
+            pitches.insert(note->ppitch());
+            }
       _piano->setPressedPlaybackPitches(pitches);
       }
 

--- a/mscore/pianotools.h
+++ b/mscore/pianotools.h
@@ -79,11 +79,16 @@ class HPiano : public QGraphicsView {
       HPiano(QWidget* parent = 0);
       friend class PianoKeyItem;
       void setPressedPlaybackPitches(QSet<int> pitches);
+      // User interaction
       void pressPitch(int pitch);
       void releasePitch(int pitch);
+      // Playback
+      void pressPlaybackPitch(int pitch);
+      void releasePlaybackPitch(int pitch);
       void clearSelection();
       void changeSelection(const Selection& selection);
       void updateAllKeys();
+      QSet<int>& pressedPlaybackPitches() { return _pressedPlaybackPitches; }
       virtual QSize sizeHint() const;
 
    public slots:
@@ -109,11 +114,17 @@ class PianoTools : public QDockWidget {
 
    public:
       PianoTools(QWidget* parent = 0);
+      // User Interaction
       void pressPitch(int pitch)    { _piano->pressPitch(pitch);   }
       void releasePitch(int pitch)  { _piano->releasePitch(pitch); }
+      // Playback
+      void pressPlaybackPitch(int pitch)   { _piano->pressPlaybackPitch(pitch);   }
+      void releasePlaybackPitch(int pitch) { _piano->releasePlaybackPitch(pitch); }
+      QSet<int> pressedPlaybackPitches()   { return _piano->pressedPlaybackPitches(); }
       void setPlaybackNotes(QList<const Note*> notes);
       void clearSelection();
       void changeSelection(const Selection& selection);
+      void updateAllKeys() { _piano->updateAllKeys(); }
       };
 
 


### PR DESCRIPTION
…an score selection during playback

Resolves: https://musescore.org/en/node/314060

Onscreen keyboard didn't update correctly with note events (like trills, tremolos between notes, mordents etc). This in my opinion could actually be considered a major bug rather than minor depending on the stress attached to the onscreen keyboard.

I don't know if the .COM side uses the same code for the production of its SEND-TO-YOUTUBE ability, but even there it also suffers from incorrect keyboard updating. It would be cool if this fixed the .COM side also, but that depends on whatever mechanisms are being utilized, and I don't have any information on that at the moment.

As an example, here is how it looks in 3.6.2 and below:
![no-ornamentarticulation](https://user-images.githubusercontent.com/7139517/107716059-68d26080-6c85-11eb-9b04-1092bbfcc332.gif)

And here is how it is with these changes
![with-ornamentarticulation](https://user-images.githubusercontent.com/7139517/107716071-6cfe7e00-6c85-11eb-97a6-70c9b3df2e29.gif)




<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
