### PR TITLE
[MU4] Ported #6696 : Fix #272172: Remove tuplets after inserting measures c…

### DIFF
--- a/src/libmscore/measure.cpp
+++ b/src/libmscore/measure.cpp
@@ -1158,6 +1158,7 @@ void Measure::moveTicks(const Fraction& diff)
                     ChordRest* cr = toChordRest(e);
                     Tuplet* tuplet = cr->tuplet();
                     if (tuplet && tuplets.count(tuplet) == 0) {
+                        tuplet->setTick(tuplet->tick() + diff);
                         tuplets.insert(tuplet);
                     }
                 }


### PR DESCRIPTION
Ported #6696 : Fix #272172: Remove tuplets after inserting measures causes corruption/crash

