### PR TITLE
[MU4] Ported #7328 : fix #315636: no space between barline and note with in…

### DIFF
--- a/src/libmscore/measure.cpp
+++ b/src/libmscore/measure.cpp
@@ -4655,12 +4655,23 @@ void Measure::computeMinWidth(Segment* s, qreal x, bool isSystemHeader)
 
     while (s) {
         s->rxpos() = x;
-        if (!s->enabled() || !s->visible()) {
+        // skip disabled / invisible segments
+        // segments with all elements invisible are skipped,
+        // but only for headers or segments later in the measure -
+        // invisible key or time signatures at the beginning of non-header measures are treated normally here
+        // otherwise we would not allocate enough space for the first note
+        // as it is, this isn't quite right as the space will be given by key or time margins,
+        // not the bar to note distance
+        // TODO: skip these segments entirely and get the correct bar to note distance
+        if (!s->enabled() || !s->visible() || ((header() || s->rtick().isNotZero()) && s->allElementsInvisible())) {
             s->setWidth(0);
             s = s->next();
             continue;
         }
         Segment* ns = s->nextActive();
+        while (ns && ((header() || ns->rtick().isNotZero()) && ns->allElementsInvisible())) {
+            ns = ns->nextActive();
+        }
         // end barline might be disabled
         // but still consider it for spacing of previous segment
         if (!ns) {
@@ -4746,6 +4757,9 @@ void Measure::computeMinWidth()
     //
     // skip disabled segment
     //
+    // TODO: skip segments with all elements invisible also
+    // this will eventually allow us to calculate correct bar to note distance
+    // even if there is an invisible key or time signature present
     for (s = first(); s && !s->enabled(); s = s->next()) {
         s->rxpos() = 0;
         s->setWidth(0);


### PR DESCRIPTION
Ported #7328 : fix #315636: no space between barline and note with invisible key or time signature

