### PR TITLE
[MU4] Ported #7195 : fix #312029: don't scale fingering with note size

### DIFF
--- a/src/libmscore/note.cpp
+++ b/src/libmscore/note.cpp
@@ -2232,8 +2232,8 @@ void Note::layout2()
         if (!score()->tagIsValid(e->tag())) {
             continue;
         }
-        e->setMag(mag());
         if (e->isSymbol()) {
+            e->setMag(mag());
             qreal w = headWidth();
             Symbol* sym = toSymbol(e);
             e->layout();
@@ -2248,6 +2248,7 @@ void Note::layout2()
                 e->rxpos() -= symWidth(SymId::noteheadParenthesisLeft);
             }
         } else if (e->isFingering()) {
+            // don't set mag; fingerings should not scale with note
             Fingering* f = toFingering(e);
             if (f->propertyFlags(Pid::PLACEMENT) == PropertyFlags::STYLED) {
                 f->setPlacement(f->calculatePlacement());
@@ -2258,6 +2259,7 @@ void Note::layout2()
                 f->layout();
             }
         } else {
+            e->setMag(mag());
             e->layout();
         }
     }


### PR DESCRIPTION
Ported #7195 : fix #312029: don't scale fingering with note size