### PR TITLE
[MU4] Ported #7260 : fix #290356: Allow copy-pasting of the LetRing, PalmMu…

### DIFF
--- a/src/libmscore/paste.cpp
+++ b/src/libmscore/paste.cpp
@@ -553,6 +553,9 @@ void Score::readAddConnector(ConnectorInfoReader* info, bool pasteMode)
     case ElementType::TRILL:
     case ElementType::TEXTLINE:
     case ElementType::VOLTA:
+    case ElementType::PALM_MUTE:
+    case ElementType::LET_RING:
+    case ElementType::VIBRATO:
     {
         Spanner* sp = toSpanner(info->connector());
         const Location& l = info->location();


### PR DESCRIPTION
Ported #7260 : fix #290356: Allow copy-pasting of the LetRing, PalmMute and Vibrato elements.

