### PR TITLE
[MU4] Completed ported #7036 : Fix #314029: Order of Text styles in Inspect…

### DIFF
--- a/src/libmscore/read114.cpp
+++ b/src/libmscore/read114.cpp
@@ -600,7 +600,7 @@ static void readFingering114(XmlReader& e, Fingering* fing)
             auto subtype = e.readElementText();
             if (subtype == "StringNumber") {
                 isStringNumber = true;
-                fing->setProperty(Pid::SUB_STYLE, QVariant(10));
+                fing->setProperty(Pid::SUB_STYLE, QVariant(int(Tid::STRING_NUMBER)));
                 fing->setPropertyFlags(Pid::SUB_STYLE, PropertyFlags::UNSTYLED);
             }
         } else if (tag == "frame") {


### PR DESCRIPTION
Completed ported #7036 : Fix #314029: Order of Text styles in Inspector dropdown and Styles dialog is different
