### PR TITLE
[MU4] Ported #7029, #7209 : Update track mapping in excerpts when order of staves is changed.

### DIFF
--- a/src/libmscore/score.cpp
+++ b/src/libmscore/score.cpp
@@ -2791,6 +2791,8 @@ void Score::sortStaves(QList<int>& dst)
     _parts.clear();
     Part* curPart = 0;
     QList<Staff*> dl;
+    QMap<int, int> trackMap;
+    int track = 0;
     foreach (int idx, dst) {
         Staff* staff = _staves[idx];
         if (staff->part() != curPart) {
@@ -2800,6 +2802,9 @@ void Score::sortStaves(QList<int>& dst)
         }
         curPart->staves()->push_back(staff);
         dl.push_back(staff);
+        for (int itrack = 0; itrack < VOICES; ++itrack) {
+            trackMap.insert(idx * VOICES + itrack, track++);
+        }
     }
     _staves = dl;
 
@@ -2825,6 +2830,25 @@ void Score::sortStaves(QList<int>& dst)
         }
     }
     setLayoutAll();
+}
+
+//---------------------------------------------------------
+//   mapExcerptTracks
+//---------------------------------------------------------
+
+void Score::mapExcerptTracks(QList<int>& dst)
+{
+    for (Excerpt* e : excerpts()) {
+        QMultiMap<int, int> tr = e->tracks();
+        QMultiMap<int, int> tracks;
+        for (QMap<int, int>::iterator it = tr.begin(); it != tr.end(); ++it) {
+            int prvStaffIdx = it.key() / VOICES;
+            int curStaffIdx = dst.indexOf(prvStaffIdx);
+            int offset = (curStaffIdx - prvStaffIdx) * VOICES;
+            tracks.insert(it.key() + offset, it.value());
+        }
+        e->tracks() = tracks;
+    }
 }
 
 //---------------------------------------------------------

--- a/src/libmscore/score.h
+++ b/src/libmscore/score.h
@@ -839,6 +839,7 @@ public:
     void appendPart(const InstrumentTemplate*);
     void updateStaffIndex();
     void sortStaves(QList<int>& dst);
+    void mapExcerptTracks(QList<int>& l);
 
     bool showInvisible() const { return _showInvisible; }
     bool showUnprintable() const { return _showUnprintable; }

--- a/src/libmscore/undo.cpp
+++ b/src/libmscore/undo.cpp
@@ -1123,6 +1123,38 @@ void SortStaves::undo(EditData*)
 }
 
 //---------------------------------------------------------
+//   MapExcerptTracks
+//---------------------------------------------------------
+
+MapExcerptTracks::MapExcerptTracks(Score* s, QList<int> l)
+{
+    score = s;
+
+    /*
+     *    In list l [x] represents the previous index of the staffIdx x.
+     *    If the a staff x is a newly added staff, l[x] = -1.
+     *    For the "undo" all staves which value -1 are *not* remapped since
+     *    it is assumed this staves are removed later.
+     */
+    for (int i = 0; i < l.size(); ++i) {
+        if (l[i] >= 0) {
+            rlist.insert(l[i], i);
+        }
+    }
+    list = l;
+}
+
+void MapExcerptTracks::redo(EditData*)
+{
+    score->mapExcerptTracks(list);
+}
+
+void MapExcerptTracks::undo(EditData*)
+{
+    score->mapExcerptTracks(rlist);
+}
+
+//---------------------------------------------------------
 //   ChangePitch
 //---------------------------------------------------------
 

--- a/src/libmscore/undo.h
+++ b/src/libmscore/undo.h
@@ -364,6 +364,23 @@ public:
 };
 
 //---------------------------------------------------------
+//   MapExcerptTracks
+//---------------------------------------------------------
+
+class MapExcerptTracks : public UndoCommand
+{
+    Score* score;
+    QList<int> list;
+    QList<int> rlist;
+
+public:
+    MapExcerptTracks(Score*, QList<int>);
+    virtual void undo(EditData*) override;
+    virtual void redo(EditData*) override;
+    UNDO_NAME("MapExcerptTracks")
+};
+
+//---------------------------------------------------------
 //   ChangePitch
 //---------------------------------------------------------
 


### PR DESCRIPTION
[MU4] Ported #7029, #7209 : Update track mapping in excerpts when order of staves is changed.