### PR TITLE
[MU3] Allow the user to customize background when exporting as PDF/PNG/SVG

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -66,6 +66,8 @@
 #define PREF_EXPORT_PDF_DPI                                 "export/pdf/dpi"
 #define PREF_EXPORT_PNG_RESOLUTION                          "export/png/resolution"
 #define PREF_EXPORT_PNG_USETRANSPARENCY                     "export/png/useTransparency"
+#define PREF_EXPORT_BG_STYLE                                "export/bg/style"
+#define PREF_EXPORT_BG_CUSTOM_COLOR                         "export/bg/customcolor"
 #define PREF_IMPORT_GUITARPRO_CHARSET                       "import/guitarpro/charset"
 #define PREF_IMPORT_MUSICXML_IMPORTBREAKS                   "import/musicXML/importBreaks"
 #define PREF_IMPORT_MUSICXML_IMPORTLAYOUT                   "import/musicXML/importLayout"

--- a/mscore/exportdialog.h
+++ b/mscore/exportdialog.h
@@ -54,6 +54,7 @@ class ExportDialog : public AbstractDialog, public Ui::ExportDialog {
       Q_OBJECT
       
       QButtonGroup* pdfSeparateOrSingleFiles;
+      QButtonGroup* exportBackgroundOption;
       
       Score* cs = nullptr;
       

--- a/mscore/exportdialog.ui
+++ b/mscore/exportdialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>691</width>
-    <height>383</height>
+    <width>757</width>
+    <height>424</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -23,108 +23,43 @@
    <string>Export</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_4" columnstretch="1,1">
-   <item row="0" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="topMargin">
-      <number>8</number>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="exportWhatGroupBox">
+     <property name="title">
+      <string>What to export</string>
      </property>
-     <property name="bottomMargin">
-      <number>8</number>
-     </property>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QLabel" name="fileTypeLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Export To:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="fileTypeComboBox">
-       <item>
-        <property name="text">
-         <string>PDF File</string>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="5" column="0">
+       <widget class="QPushButton" name="selectAllButton">
+        <property name="accessibleName">
+         <string>Select all</string>
         </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>PNG Images</string>
+        <property name="accessibleDescription">
+         <string>Select the score and all parts</string>
         </property>
-       </item>
-       <item>
         <property name="text">
-         <string>SVG Images</string>
+         <string>Select all</string>
         </property>
-       </item>
-       <item>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QPushButton" name="clearSelectionButton">
+        <property name="accessibleName">
+         <string>Select nothing</string>
+        </property>
+        <property name="accessibleDescription">
+         <string>Select nothing</string>
+        </property>
         <property name="text">
-         <string>MP3 Audio</string>
+         <string>Clear selection</string>
         </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>WAV Audio</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>FLAC Audio</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>OGG Audio</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>MIDI</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>MusicXML</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Uncompressed MuseScore File</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+       </widget>
+      </item>
+      <item row="1" column="0" rowspan="4" colspan="2">
+       <widget class="QListWidget" name="listWidget"/>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item row="1" column="1">
     <widget class="QGroupBox" name="exportOptionsGroupBox">
@@ -137,189 +72,388 @@
         <property name="currentIndex">
          <number>0</number>
         </property>
-        <widget class="QWidget" name="pdfPage">
-         <layout class="QFormLayout" name="formLayout_7">
-          <item row="0" column="0">
-           <widget class="QLabel" name="pdfDpiLabel">
-            <property name="text">
-             <string>Resolution:</string>
-            </property>
+        <widget class="QWidget" name="visualPage">
+         <layout class="QFormLayout" name="formLayout_4">
+          <item row="0" column="0" colspan="2">
+           <widget class="QWidget" name="pdfDpiWidget" native="true">
+            <layout class="QGridLayout" name="gridLayout_7">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item row="0" column="0">
+              <layout class="QHBoxLayout" name="pdfDpiHorizontalLayout">
+               <item>
+                <widget class="QLabel" name="pdfDpiLabel">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Resolution:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QSpinBox" name="pdfDpiSpinbox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>62</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <property name="suffix">
+                  <string>DPI</string>
+                 </property>
+                 <property name="prefix">
+                  <string/>
+                 </property>
+                 <property name="maximum">
+                  <number>720</number>
+                 </property>
+                 <property name="value">
+                  <number>300</number>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="pdfDpiSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+            </layout>
            </widget>
           </item>
-          <item row="0" column="1">
-           <layout class="QHBoxLayout" name="pdfDpiHorizontalLayout">
-            <item>
-             <widget class="QSpinBox" name="pdfDpiSpinbox">
-              <property name="accessibleName">
-               <string>Resolution DPI</string>
-              </property>
-              <property name="accessibleDescription">
-               <string>Choose resolution DPI</string>
-              </property>
-              <property name="suffix">
-               <string extracomment="dots per inch">DPI</string>
-              </property>
-              <property name="minimum">
-               <number>75</number>
-              </property>
-              <property name="maximum">
-               <number>2400</number>
-              </property>
-              <property name="value">
-               <number>300</number>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="pdfDpiSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
           <item row="1" column="0" colspan="2">
-           <widget class="QRadioButton" name="pdfSeparateFilesRadioButton">
-            <property name="text">
-             <string>Export each score as a separate file</string>
+           <widget class="QWidget" name="pngDpiWidget" native="true">
+            <layout class="QGridLayout" name="gridLayout_8">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item row="0" column="0">
+              <layout class="QHBoxLayout" name="pngDpiHorizontalLayout">
+               <item>
+                <widget class="QLabel" name="pngDpiLabel">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Resolution:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QSpinBox" name="pngDpiSpinbox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>62</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <property name="suffix">
+                  <string>DPI</string>
+                 </property>
+                 <property name="prefix">
+                  <string/>
+                 </property>
+                 <property name="maximum">
+                  <number>720</number>
+                 </property>
+                 <property name="value">
+                  <number>300</number>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="pngDpiSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QWidget" name="pdfFileOptionWidget" native="true">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
             </property>
+            <layout class="QGridLayout" name="gridLayout_10">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <item row="0" column="0">
+              <widget class="QLabel" name="pdfFileOptionsLabel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Export each score</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QRadioButton" name="pdfSeparateFilesRadioButton">
+               <property name="text">
+                <string>As a separate file</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QRadioButton" name="pdfOneFileRadioButton">
+               <property name="text">
+                <string>Combined into a single file</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="5" column="0" colspan="2">
+           <widget class="QWidget" name="pngFileOptionWidget" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_11">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item row="0" column="0">
+              <spacer name="verticalSpacer_3">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Expanding</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="pngHintLabel">
+               <property name="text">
+                <string>Each page of the selected scores will be exported as a separate PNG file.</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="6" column="0" colspan="2">
+           <widget class="QWidget" name="svgFileOptionWidget" native="true">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_12">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item row="0" column="0">
+              <spacer name="verticalSpacer_7">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label">
+               <property name="text">
+                <string>Each page of the selected scores will be exported as a separate SVG file.</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
           <item row="2" column="0" colspan="2">
-           <widget class="QRadioButton" name="pdfOneFileRadioButton">
-            <property name="text">
-             <string>All scores combined into one file</string>
+           <widget class="QWidget" name="bgOptionsWidget" native="true">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
             </property>
+            <layout class="QGridLayout" name="gridLayout_9">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item row="1" column="0">
+              <widget class="QRadioButton" name="transparentBackgroundRadioButton">
+               <property name="text">
+                <string>Export with transparent background</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QRadioButton" name="scoreBackgroundRadioButton">
+               <property name="text">
+                <string>Export with background present in score</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QRadioButton" name="customBackgroundRadioButton">
+               <property name="text">
+                <string>Export with custom background color</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="backgroundOptionsLabel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Background Options:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="Awl::ColorLabel" name="customBackgroundColorLabel">
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="pngPage">
-         <layout class="QFormLayout" name="formLayout">
-          <item row="0" column="0">
-           <widget class="QLabel" name="pngDpiLabel">
-            <property name="text">
-             <string>Resolution:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <layout class="QHBoxLayout" name="pngDpiHorizontalLayout">
-            <item>
-             <widget class="QSpinBox" name="pngDpiSpinbox">
-              <property name="accessibleName">
-               <string>Resolution DPI</string>
-              </property>
-              <property name="accessibleDescription">
-               <string>Choose resolution DPI</string>
-              </property>
-              <property name="suffix">
-               <string extracomment="dots per inch">DPI</string>
-              </property>
-              <property name="minimum">
-               <number>32</number>
-              </property>
-              <property name="maximum">
-               <number>5000</number>
-              </property>
-              <property name="value">
-               <number>360</number>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="pngDpiSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item row="1" column="0" colspan="2">
-           <widget class="QCheckBox" name="pngTransparentBackgroundCheckBox">
-            <property name="accessibleName">
-             <string>Transparent background</string>
-            </property>
-            <property name="text">
-             <string>Transparent background</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="2">
+          <item row="4" column="0">
            <spacer name="verticalSpacer_4">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>0</width>
-              <height>0</height>
+              <width>20</width>
+              <height>40</height>
              </size>
             </property>
            </spacer>
-          </item>
-          <item row="3" column="0" colspan="2">
-           <widget class="QLabel" name="pngHintLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Each page of the selected scores will be exported as a separate PNG file.</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="svgPage">
-         <layout class="QVBoxLayout" name="verticalLayout">
-          <item>
-           <spacer name="verticalSpacer_5">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QLabel" name="svgHintLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Each page of the selected scores will be exported as a separate SVG file.</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
           </item>
          </layout>
         </widget>
@@ -776,50 +910,133 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QGroupBox" name="exportWhatGroupBox">
-     <property name="title">
-      <string>What to export</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="5" column="0">
-       <widget class="QPushButton" name="selectAllButton">
-        <property name="accessibleName">
-         <string>Select all</string>
-        </property>
-        <property name="accessibleDescription">
-         <string>Select the score and all parts</string>
-        </property>
-        <property name="text">
-         <string>Select all</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QPushButton" name="clearSelectionButton">
-        <property name="accessibleName">
-         <string>Select nothing</string>
-        </property>
-        <property name="accessibleDescription">
-         <string>Select nothing</string>
-        </property>
-        <property name="text">
-         <string>Clear selection</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" rowspan="4" colspan="2">
-       <widget class="QListWidget" name="listWidget"/>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <item row="2" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
     </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="topMargin">
+      <number>8</number>
+     </property>
+     <property name="bottomMargin">
+      <number>8</number>
+     </property>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="fileTypeLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Export To:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="fileTypeComboBox">
+       <item>
+        <property name="text">
+         <string>PDF File</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>PNG Images</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>SVG Images</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>MP3 Audio</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>WAV Audio</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>FLAC Audio</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>OGG Audio</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>MIDI</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>MusicXML</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Uncompressed MuseScore File</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
@@ -831,6 +1048,12 @@
    <slots>
     <signal>clicked()</signal>
    </slots>
+  </customwidget>
+  <customwidget>
+   <class>Awl::ColorLabel</class>
+   <extends>QPushButton</extends>
+   <header>awl/colorlabel.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>
@@ -900,22 +1123,6 @@
    </hints>
   </connection>
   <connection>
-   <sender>musicxmlExportAllBreaksLabel</sender>
-   <signal>clicked()</signal>
-   <receiver>musicxmlExportAllBreaks</receiver>
-   <slot>animateClick()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>563</x>
-     <y>227</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>412</x>
-     <y>228</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>musicxmlExportAllLayoutLabel</sender>
    <signal>clicked()</signal>
    <receiver>musicxmlExportAllLayout</receiver>
@@ -932,6 +1139,22 @@
    </hints>
   </connection>
   <connection>
+   <sender>musicxmlExportAllBreaksLabel</sender>
+   <signal>clicked()</signal>
+   <receiver>musicxmlExportAllBreaks</receiver>
+   <slot>animateClick()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>563</x>
+     <y>227</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>412</x>
+     <y>228</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
    <sender>musicxmlExportManualBreaksLabel</sender>
    <signal>clicked()</signal>
    <receiver>musicxmlExportManualBreaks</receiver>
@@ -944,6 +1167,22 @@
     <hint type="destinationlabel">
      <x>412</x>
      <y>260</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>customBackgroundRadioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>customBackgroundColorLabel</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>495</x>
+     <y>212</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>673</x>
+     <y>212</y>
     </hint>
    </hints>
   </connection>

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -2107,10 +2107,31 @@ bool MuseScore::savePdf(Score* cs_, QPrinter& printer)
       const QList<Page*> pl = cs_->pages();
       int pages = pl.size();
       bool firstPage = true;
+
+      const QRect fillRect(0.0, 0.0, size.width() * DPI, size.height() * DPI);
+      int exportBgStyle = preferences.getInt(PREF_EXPORT_BG_STYLE);
+      bool useFgColor = preferences.getBool(PREF_UI_CANVAS_FG_USECOLOR);
+      const QColor fgColor = preferences.getColor(PREF_UI_CANVAS_FG_COLOR);
+      const QColor customColor = preferences.getColor(PREF_EXPORT_BG_CUSTOM_COLOR);
+      const QPixmap fgPixMap(preferences.getString(PREF_UI_CANVAS_FG_WALLPAPER));
+
       for (int n = 0; n < pages; ++n) {
             if (!firstPage)
                   printer.newPage();
             firstPage = false;
+            switch (exportBgStyle) {
+                  case 1:
+                        if (useFgColor)
+                              p.fillRect(fillRect, fgColor);
+                        else
+                              p.drawTiledPixmap(fillRect, fgPixMap, fillRect.topLeft());
+                        break;
+                  case 2:
+                        p.fillRect(fillRect, customColor);
+                        break;
+                  default:
+                        break;
+                  }
             cs_->print(&p, n);
             }
       p.end();
@@ -2161,6 +2182,14 @@ bool MuseScore::savePdf(QList<Score*> cs_, const QString& saveName)
       double pr = MScore::pixelRatio;
 
       bool firstPage = true;
+
+      const QRect fillRect(0.0, 0.0, size.width() * DPI, size.height() * DPI);
+      int exportBgStyle = preferences.getInt(PREF_EXPORT_BG_STYLE);
+      bool useFgColor = preferences.getBool(PREF_UI_CANVAS_FG_USECOLOR);
+      const QColor fgColor = preferences.getColor(PREF_UI_CANVAS_FG_COLOR);
+      const QColor customColor = preferences.getColor(PREF_EXPORT_BG_CUSTOM_COLOR);
+      const QPixmap fgPixMap(preferences.getString(PREF_UI_CANVAS_FG_WALLPAPER));
+
       for (Score* s : cs_) {
             LayoutMode layoutMode = s->layoutMode();
             if (layoutMode != LayoutMode::PAGE) {
@@ -2187,6 +2216,21 @@ bool MuseScore::savePdf(QList<Score*> cs_, const QString& saveName)
                   if (!firstPage)
                         printer.newPage();
                   firstPage = false;
+
+                  switch (exportBgStyle) {
+                        case 1:
+                            if (useFgColor)
+                                p.fillRect(fillRect, fgColor);
+                            else
+                                p.drawTiledPixmap(fillRect, fgPixMap, fillRect.topLeft());
+                            break;
+                        case 2:
+                            p.fillRect(fillRect, customColor);
+                            break;
+                        default:
+                            break;
+                        }
+
                   s->print(&p, n);
                   }
             MScore::pixelRatio = pr;
@@ -2654,7 +2698,6 @@ bool MuseScore::savePng(Score* score, const QString& name, SaveReplacePolicy* re
 bool MuseScore::savePng(Score* score, QIODevice* device, int pageNumber, bool drawPageBackground)
       {
       const bool screenshot = false;
-      const bool transparent = preferences.getBool(PREF_EXPORT_PNG_USETRANSPARENCY) && !drawPageBackground;
       const double convDpi = preferences.getDouble(PREF_EXPORT_PNG_RESOLUTION);
       const int localTrimMargin = trimMargin;
       const QImage::Format format = QImage::Format_ARGB32_Premultiplied;
@@ -2686,7 +2729,31 @@ bool MuseScore::savePng(Score* score, QIODevice* device, int pageNumber, bool dr
       printer.setDotsPerMeterX(lrint((convDpi * 1000) / INCH));
       printer.setDotsPerMeterY(lrint((convDpi * 1000) / INCH));
 
-      printer.fill(transparent ? 0 : 0xffffffff);
+      int exportBgStyle = preferences.getInt(PREF_EXPORT_BG_STYLE);
+      bool useFgColor = preferences.getBool(PREF_UI_CANVAS_FG_USECOLOR);
+      const QColor fgColor = preferences.getColor(PREF_UI_CANVAS_FG_COLOR);
+      const QColor customColor = preferences.getColor(PREF_EXPORT_BG_CUSTOM_COLOR);
+      const QPixmap fgPixMap(preferences.getString(PREF_UI_CANVAS_FG_WALLPAPER));
+
+      switch (exportBgStyle) {
+            case 0:
+                  printer.fill(0);
+                  break;
+            case 1:
+                  if (useFgColor)
+                        printer.fill(fgColor);
+                  else {
+                        QPainter painter(&printer);
+                        painter.drawTiledPixmap(r, fgPixMap, r.topLeft());
+                  }  
+                  break;
+            case 2:
+                  printer.fill(customColor);
+                  break;
+            default:
+                  break;
+            }
+
       double mag_ = convDpi / DPI;
       MScore::pixelRatio = 1.0 / mag_;
 
@@ -2704,7 +2771,7 @@ bool MuseScore::savePng(Score* score, QIODevice* device, int pageNumber, bool dr
             //convert to grayscale & respect alpha
             QVector<QRgb> colorTable;
             colorTable.push_back(QColor(0, 0, 0, 0).rgba());
-            if (!transparent) {
+            if (exportBgStyle != 0) {
                   for (int i = 1; i < 256; i++)
                         colorTable.push_back(QColor(i, i, i).rgb());
                   }
@@ -2964,8 +3031,25 @@ bool MuseScore::saveSvg(Score* score, QIODevice* device, int pageNumber, bool dr
             p.translate(-r.topLeft());
       MScore::pixelRatio = DPI / printer.logicalDpiX();
 
-      if (drawPageBackground)
-            p.fillRect(r, Qt::white);
+      int exportBgStyle = preferences.getInt(PREF_EXPORT_BG_STYLE);
+      bool useFgColor = preferences.getBool(PREF_UI_CANVAS_FG_USECOLOR);
+      const QColor fgColor = preferences.getColor(PREF_UI_CANVAS_FG_COLOR);
+      const QColor customColor = preferences.getColor(PREF_EXPORT_BG_CUSTOM_COLOR);
+      const QPixmap fgPixMap(preferences.getString(PREF_UI_CANVAS_FG_WALLPAPER));
+
+      switch (exportBgStyle) {
+            case 1:
+                  if (useFgColor)
+                        p.fillRect(r, fgColor);
+                  else
+                        p.drawTiledPixmap(r, fgPixMap, r.topLeft());
+                  break;
+            case 2:
+                  p.fillRect(r, customColor);
+                  break;
+            default:
+                  break;
+      }
 
       // 1st pass: StaffLines
       for  (System* s : page->systems()) {

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -169,6 +169,8 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_EXPORT_PDF_DPI,                                  new IntPreference(DPI, false)},
             {PREF_EXPORT_PNG_RESOLUTION,                           new DoublePreference(DPI, false)},
             {PREF_EXPORT_PNG_USETRANSPARENCY,                      new BoolPreference(true, false)},
+            {PREF_EXPORT_BG_STYLE,                                 new IntPreference(0, false)},
+            {PREF_EXPORT_BG_CUSTOM_COLOR,                          new ColorPreference(QColor(0xffffff), false)},
             {PREF_IMPORT_GUITARPRO_CHARSET,                        new StringPreference("UTF-8", false)},
             {PREF_IMPORT_MUSICXML_IMPORTBREAKS,                    new BoolPreference(true, false)},
             {PREF_IMPORT_MUSICXML_IMPORTLAYOUT,                    new BoolPreference(true, false)},


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/293370

This patch provides the user complete control over the background when exporting the score to a PDF/PNG/SVG file, allowing the user to choose between a transparent background, the background currently used in the score (both solid colors and images) or a custom color.

![image](https://user-images.githubusercontent.com/55060749/107772564-6560d700-6d62-11eb-9896-2660b4f6ecea.png)

Note: To be able to see  the transparent background when exporting as a pdf, you will have to turn on the "Show Transparency Grid" or equivalent option in your pdf viewer or the transparent area gets filled with white by default.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
