### PR TITLE
[MU4] Ported 6510: Fix #298849: The 2nd note in a passage of grace notes wi…

### DIFF
--- a/src/libmscore/utils.cpp
+++ b/src/libmscore/utils.cpp
@@ -817,7 +817,7 @@ Note* searchTieNote(Note* note)
 
         // try to tie to next grace note
 
-        int index = chord->graceIndex();
+        int index = note->chord()->graceIndex();
         for (Chord* c : chord->graceNotes()) {
             if (c->graceIndex() == index + 1) {
                 note2 = c->findNote(note->pitch());


### PR DESCRIPTION
Ported 6510: Fix #298849: The 2nd note in a passage of grace notes will not tie to the main chord

