### PR TITLE
[MU4] Bring back style options for multi-measure rests

### DIFF
--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -143,6 +143,13 @@ EditStyle::EditStyle(QWidget* parent)
         { StyleId::frameSystemDistance,     false, frameSystemDistance,     resetFrameSystemDistance },
         { StyleId::minMeasureWidth,         false, minMeasureWidth_2,       resetMinMeasureWidth },
         { StyleId::measureSpacing,          false, measureSpacing,          resetMeasureSpacing },
+        // TODO !!! See https://github.com/musescore/MuseScore/pull/6365
+//        { StyleId::measureRepeatNumberPos,  false, measureRepeatNumberPos,  resetMeasureRepeatNumberPos },
+//        { StyleId::mrNumberSeries,          false, mrNumberSeries,          0 },
+//        { StyleId::mrNumberEveryXMeasures,  false, mrNumberEveryXMeasures,  resetMRNumberEveryXMeasures },
+//        { StyleId::mrNumberSeriesWithParentheses, false, mrNumberSeriesWithParentheses, resetMRNumberSeriesWithParentheses },
+//        { StyleId::oneMeasureRepeatShow1,   false, oneMeasureRepeatShow1,   resetOneMeasureRepeatShow1 },
+//        { StyleId::fourMeasureRepeatShowExtenders, false, fourMeasureRepeatShowExtenders, resetFourMeasureRepeatShowExtenders },
 
         { StyleId::barWidth,                false, barWidth,                resetBarWidth },
         { StyleId::endBarWidth,             false, endBarWidth,             resetEndBarWidth },
@@ -172,6 +179,14 @@ EditStyle::EditStyle(QWidget* parent)
         { StyleId::minEmptyMeasures,        false, minEmptyMeasures,        0 },
         { StyleId::minMMRestWidth,          false, minMeasureWidth,         resetMinMMRestWidth },
         { StyleId::mmRestNumberPos,         false, mmRestNumberPos,         resetMMRestNumberPos },
+        { StyleId::mmRestNumberMaskHBar,    false, mmRestNumberMaskHBar,    resetMMRestNumberMaskHBar },
+        { StyleId::mmRestHBarThickness,     false, mmRestHBarThickness,     resetMMRestHBarThickness },
+        { StyleId::multiMeasureRestMargin,  false, multiMeasureRestMargin,  resetMultiMeasureRestMargin },
+        { StyleId::mmRestHBarVStrokeThickness, false, mmRestHBarVStrokeThickness, resetMMRestHBarVStrokeThickness },
+        { StyleId::mmRestHBarVStrokeHeight, false, mmRestHBarVStrokeHeight, resetMMRestHBarVStrokeHeight },
+        { StyleId::oldStyleMultiMeasureRests, false, oldStyleMultiMeasureRests, 0 },
+        { StyleId::mmRestOldStyleMaxMeasures, false, mmRestOldStyleMaxMeasures, resetMMRestOldStyleMaxMeasures },
+        { StyleId::mmRestOldStyleSpacing,   false, mmRestOldStyleSpacing,   resetMMRestOldStyleSpacing },
         { StyleId::hideEmptyStaves,         false, hideEmptyStaves,         0 },
         { StyleId::dontHideStavesInFirstSystem, false, dontHideStavesInFirstSystem, 0 },
         { StyleId::enableIndentationOnFirstSystem, false, enableIndentationOnFirstSystem, 0 },
@@ -186,7 +201,6 @@ EditStyle::EditStyle(QWidget* parent)
         { StyleId::minNoteDistance,         false, minNoteDistance,         resetMinNoteDistance },
         { StyleId::barNoteDistance,         false, barNoteDistance,         resetBarNoteDistance },
         { StyleId::barAccidentalDistance,   false, barAccidentalDistance,   resetBarAccidentalDistance },
-        { StyleId::multiMeasureRestMargin,  false, multiMeasureRestMargin,  resetMultiMeasureRestMargin },
         { StyleId::noteBarDistance,         false, noteBarDistance,         resetNoteBarDistance },
         { StyleId::clefLeftMargin,          false, clefLeftMargin,          resetClefLeftMargin },
         { StyleId::keysigLeftMargin,        false, keysigLeftMargin,        resetKeysigLeftMargin },
@@ -301,9 +315,8 @@ EditStyle::EditStyle(QWidget* parent)
         { StyleId::measureNumberAllStaves,   false, showAllStavesMeasureNumber,   0 },
         { StyleId::measureNumberVPlacement,  false, measureNumberVPlacement,      resetMeasureNumberVPlacement },
         { StyleId::measureNumberHPlacement,  false, measureNumberHPlacement,      resetMeasureNumberHPlacement },
-        // TODO !!!
-//        { StyleId::measureNumberPosAbove,    false, measureNumberPosAbove,        resetMeasureNumberPosAbove },
-//        { StyleId::measureNumberPosBelow,    false, measureNumberPosBelow,        resetMeasureNumberPosBelow },
+        { StyleId::measureNumberPosAbove,    false, measureNumberPosAbove,        resetMeasureNumberPosAbove },
+        { StyleId::measureNumberPosBelow,    false, measureNumberPosBelow,        resetMeasureNumberPosBelow },
 
         { StyleId::mmRestShowMeasureNumberRange, false, mmRestShowMeasureNumberRange, 0 },
         { StyleId::mmRestRangeBracketType,   false, mmRestRangeBracketType,       resetMmRestRangeBracketType },
@@ -962,7 +975,6 @@ EditStylePage EditStyle::pageForElement(Element* e)
     case ElementType::KEYSIG:
         return &EditStyle::PageAccidentals;
     case ElementType::MEASURE:
-    case ElementType::REST:
         return &EditStyle::PageMeasure;
     case ElementType::BAR_LINE:
         return &EditStyle::PageBarlines;
@@ -973,6 +985,12 @@ EditStylePage EditStyle::pageForElement(Element* e)
     case ElementType::STEM_SLASH:
     case ElementType::LEDGER_LINE:
         return &EditStyle::PageNotes;
+    case ElementType::REST:
+    case ElementType::MMREST:
+        return &EditStyle::PageRests;
+// TODO !!!
+//    case ElementType::MEASURE_REPEAT:
+//        return &EditStyle:PageMeasureRepeats;
     case ElementType::BEAM:
         return &EditStyle::PageBeams;
     case ElementType::TUPLET:

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -95,6 +95,11 @@
       </item>
       <item>
        <property name="text">
+        <string>Rests</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
         <string>Beams</string>
        </property>
       </item>
@@ -388,134 +393,6 @@
                  <property name="text">
                   <string>Display in concert pitch</string>
                  </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="multiMeasureRests">
-                 <property name="title">
-                  <string>Create multimeasure rests</string>
-                 </property>
-                 <property name="checkable">
-                  <bool>true</bool>
-                 </property>
-                 <property name="checked">
-                  <bool>false</bool>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_52">
-                  <item row="2" column="1">
-                   <widget class="QDoubleSpinBox" name="mmRestNumberPos">
-                    <property name="suffix">
-                     <string>sp</string>
-                    </property>
-                    <property name="minimum">
-                     <double>-99.989999999999995</double>
-                    </property>
-                    <property name="singleStep">
-                     <double>0.500000000000000</double>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="label_16">
-                    <property name="text">
-                     <string>Minimum width of measure:</string>
-                    </property>
-                    <property name="buddy">
-                     <cstring>minMeasureWidth</cstring>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="label_92">
-                    <property name="text">
-                     <string>Vertical position of number:</string>
-                    </property>
-                    <property name="buddy">
-                     <cstring>mmRestNumberPos</cstring>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="2">
-                   <widget class="QToolButton" name="resetMinMMRestWidth">
-                    <property name="toolTip">
-                     <string>Reset to default</string>
-                    </property>
-                    <property name="accessibleName">
-                     <string>Reset 'Minimum width of measure' value</string>
-                    </property>
-                    <property name="text">
-                     <string notr="true"/>
-                    </property>
-                    <property name="icon">
-                     <iconset>
-                      <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="3" rowspan="3">
-                   <spacer name="horizontalSpacer_32">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>0</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="2" column="2">
-                   <widget class="QToolButton" name="resetMMRestNumberPos">
-                    <property name="toolTip">
-                     <string>Reset to default</string>
-                    </property>
-                    <property name="accessibleName">
-                     <string>Reset 'Vertical position of number' value</string>
-                    </property>
-                    <property name="text">
-                     <string notr="true"/>
-                    </property>
-                    <property name="icon">
-                     <iconset>
-                      <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="1">
-                   <widget class="QSpinBox" name="minEmptyMeasures">
-                    <property name="minimum">
-                     <number>1</number>
-                    </property>
-                    <property name="value">
-                     <number>2</number>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="label_15">
-                    <property name="text">
-                     <string>Minimum number of empty measures:</string>
-                    </property>
-                    <property name="buddy">
-                     <cstring>minEmptyMeasures</cstring>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="1">
-                   <widget class="QDoubleSpinBox" name="minMeasureWidth">
-                    <property name="suffix">
-                     <string>sp</string>
-                    </property>
-                    <property name="minimum">
-                     <double>2.000000000000000</double>
-                    </property>
-                    <property name="value">
-                     <double>4.000000000000000</double>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
                 </widget>
                </item>
                <item>
@@ -4201,16 +4078,6 @@ By default, they will be placed such as that their right end are at the same lev
                  </property>
                 </widget>
                </item>
-               <item row="26" column="0">
-                <widget class="QLabel" name="label_103">
-                 <property name="text">
-                  <string>Multimeasure rest margin:</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>multiMeasureRestMargin</cstring>
-                 </property>
-                </widget>
-               </item>
                <item row="1" column="2">
                 <widget class="QToolButton" name="resetMeasureSpacing">
                  <property name="toolTip">
@@ -4225,16 +4092,6 @@ By default, they will be placed such as that their right end are at the same lev
                  <property name="icon">
                   <iconset>
                    <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-                 </property>
-                </widget>
-               </item>
-               <item row="26" column="1">
-                <widget class="QDoubleSpinBox" name="multiMeasureRestMargin">
-                 <property name="suffix">
-                  <string>sp</string>
-                 </property>
-                 <property name="singleStep">
-                  <double>0.100000000000000</double>
                  </property>
                 </widget>
                </item>
@@ -4561,23 +4418,6 @@ By default, they will be placed such as that their right end are at the same lev
                  </property>
                 </widget>
                </item>
-               <item row="26" column="2">
-                <widget class="QToolButton" name="resetMultiMeasureRestMargin">
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Multimeasure rest margin' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                 <property name="icon">
-                  <iconset>
-                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-                 </property>
-                </widget>
-               </item>
                <item row="20" column="0">
                 <widget class="QLabel" name="label_20">
                  <property name="text">
@@ -4792,13 +4632,6 @@ By default, they will be placed such as that their right end are at the same lev
                </item>
                <item row="25" column="0" colspan="3">
                 <widget class="Line" name="line_15">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                </widget>
-               </item>
-               <item row="27" column="0" colspan="3">
-                <widget class="Line" name="line_16">
                  <property name="orientation">
                   <enum>Qt::Horizontal</enum>
                  </property>
@@ -5566,6 +5399,384 @@ By default, they will be placed such as that their right end are at the same lev
            <size>
             <width>0</width>
             <height>0</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="PageRests">
+       <layout class="QVBoxLayout" name="verticalLayout_8">
+        <item>
+         <widget class="QGroupBox" name="multiMeasureRests">
+          <property name="title">
+           <string>Multimeasure Rests</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_46">
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_15">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Minimum number of empty measures:</string>
+             </property>
+             <property name="buddy">
+              <cstring>minEmptyMeasures</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="minEmptyMeasures">
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="value">
+              <number>2</number>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="3">
+            <widget class="QLabel" name="label_16">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Minimum width:</string>
+             </property>
+             <property name="buddy">
+              <cstring>minMeasureWidth</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="4">
+            <widget class="QDoubleSpinBox" name="minMeasureWidth">
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="minimum">
+              <double>2.000000000000000</double>
+             </property>
+             <property name="value">
+              <double>4.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="5">
+            <widget class="QToolButton" name="resetMinMMRestWidth">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Minimum width of measure' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset>
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_92">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Vertical position of number:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QDoubleSpinBox" name="mmRestNumberPos">
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="minimum">
+              <double>-99.989999999999995</double>
+             </property>
+             <property name="singleStep">
+              <double>0.500000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="2">
+            <widget class="QToolButton" name="resetMMRestNumberPos">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Vertical position of number' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset>
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="3" colspan="2">
+            <widget class="QCheckBox" name="mmRestNumberMaskHBar">
+             <property name="text">
+              <string>Mask H-bar around number</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="5">
+            <widget class="QToolButton" name="resetMMRestNumberMaskHBar">
+             <property name="text">
+              <string notr="true">…</string>
+             </property>
+             <property name="icon">
+              <iconset>
+               <normaloff>data/icons/edit-reset.svg</normaloff>data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_119">
+             <property name="text">
+              <string>H-bar horizontal stroke thickness:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QDoubleSpinBox" name="mmRestHBarThickness">
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="maximum">
+              <double>4.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.100000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="2">
+            <widget class="QToolButton" name="resetMMRestHBarThickness">
+             <property name="text">
+              <string notr="true">…</string>
+             </property>
+             <property name="icon">
+              <iconset>
+               <normaloff>data/icons/edit-reset.svg</normaloff>data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="3">
+            <widget class="QLabel" name="label_103">
+             <property name="text">
+              <string>H-bar margin within barlines:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="4">
+            <widget class="QDoubleSpinBox" name="multiMeasureRestMargin">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="singleStep">
+              <double>0.100000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="5">
+            <widget class="QToolButton" name="resetMultiMeasureRestMargin">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Multimeasure rest margin' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset>
+               <normaloff>data/icons/edit-reset.svg</normaloff>data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_123">
+             <property name="text">
+              <string>H-bar vertical stroke thickness:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QDoubleSpinBox" name="mmRestHBarVStrokeThickness">
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="maximum">
+              <double>4.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.050000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="2">
+            <widget class="QToolButton" name="resetMMRestHBarVStrokeThickness">
+             <property name="text">
+              <string notr="true">…</string>
+             </property>
+             <property name="icon">
+              <iconset>
+               <normaloff>data/icons/edit-reset.svg</normaloff>data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="3">
+            <widget class="QLabel" name="label_145">
+             <property name="text">
+              <string>H-bar vertical stroke height:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="4">
+            <widget class="QDoubleSpinBox" name="mmRestHBarVStrokeHeight">
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="maximum">
+              <double>10.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.500000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="5">
+            <widget class="QToolButton" name="resetMMRestHBarVStrokeHeight">
+             <property name="text">
+              <string notr="true">…</string>
+             </property>
+             <property name="icon">
+              <iconset>
+               <normaloff>data/icons/edit-reset.svg</normaloff>data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0" colspan="6">
+            <widget class="QGroupBox" name="oldStyleMultiMeasureRests">
+             <property name="title">
+              <string>Old-Style Multimeasure Rests</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_30">
+              <item row="0" column="3">
+               <spacer name="horizontalSpacer_15">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_146">
+                <property name="text">
+                 <string>Maximum number of measures:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="QToolButton" name="resetMMRestOldStyleMaxMeasures">
+                <property name="text">
+                 <string notr="true">…</string>
+                </property>
+                <property name="icon">
+                 <iconset>
+                  <normaloff>data/icons/edit-reset.svg</normaloff>data/icons/edit-reset.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QSpinBox" name="mmRestOldStyleMaxMeasures"/>
+              </item>
+              <item row="1" column="1">
+               <widget class="QDoubleSpinBox" name="mmRestOldStyleSpacing">
+                <property name="suffix">
+                 <string>sp</string>
+                </property>
+                <property name="maximum">
+                 <double>4.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.010000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_147">
+                <property name="text">
+                 <string>Spacing of symbols:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="2">
+               <widget class="QToolButton" name="resetMMRestOldStyleSpacing">
+                <property name="text">
+                 <string notr="true">…</string>
+                </property>
+                <property name="icon">
+                 <iconset>
+                  <normaloff>data/icons/edit-reset.svg</normaloff>data/icons/edit-reset.svg</iconset>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_34">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
            </size>
           </property>
          </spacer>
@@ -12451,12 +12662,6 @@ By default, they will be placed such as that their right end are at the same lev
   <tabstop>optimizeStyleCheckbox</tabstop>
   <tabstop>musicalTextFont</tabstop>
   <tabstop>concertPitch</tabstop>
-  <tabstop>multiMeasureRests</tabstop>
-  <tabstop>minEmptyMeasures</tabstop>
-  <tabstop>minMeasureWidth</tabstop>
-  <tabstop>resetMinMMRestWidth</tabstop>
-  <tabstop>mmRestNumberPos</tabstop>
-  <tabstop>resetMMRestNumberPos</tabstop>
   <tabstop>enableIndentationOnFirstSystem</tabstop>
   <tabstop>indentationValue</tabstop>
   <tabstop>resetFirstSystemIndentation</tabstop>
@@ -12626,8 +12831,6 @@ By default, they will be placed such as that their right end are at the same lev
   <tabstop>resetSystemHeaderDistance</tabstop>
   <tabstop>systemHeaderTimeSigDistance</tabstop>
   <tabstop>resetSystemHeaderTimeSigDistance</tabstop>
-  <tabstop>multiMeasureRestMargin</tabstop>
-  <tabstop>resetMultiMeasureRestMargin</tabstop>
   <tabstop>staffLineWidth</tabstop>
   <tabstop>resetStaffLineWidth</tabstop>
   <tabstop>showRepeatBarTips</tabstop>
@@ -12661,6 +12864,27 @@ By default, they will be placed such as that their right end are at the same lev
   <tabstop>stemWidth</tabstop>
   <tabstop>ledgerLineWidth</tabstop>
   <tabstop>ledgerLineLength</tabstop>
+  <tabstop>multiMeasureRests</tabstop>
+  <tabstop>minEmptyMeasures</tabstop>
+  <tabstop>minMeasureWidth</tabstop>
+  <tabstop>resetMinMMRestWidth</tabstop>
+  <tabstop>mmRestNumberPos</tabstop>
+  <tabstop>resetMMRestNumberPos</tabstop>
+  <tabstop>mmRestNumberMaskHBar</tabstop>
+  <tabstop>resetMMRestNumberMaskHBar</tabstop>
+  <tabstop>mmRestHBarThickness</tabstop>
+  <tabstop>resetMMRestHBarThickness</tabstop>
+  <tabstop>multiMeasureRestMargin</tabstop>
+  <tabstop>resetMultiMeasureRestMargin</tabstop>
+  <tabstop>mmRestHBarVStrokeThickness</tabstop>
+  <tabstop>resetMMRestHBarVStrokeThickness</tabstop>
+  <tabstop>mmRestHBarVStrokeHeight</tabstop>
+  <tabstop>resetMMRestHBarVStrokeHeight</tabstop>
+  <tabstop>oldStyleMultiMeasureRests</tabstop>
+  <tabstop>mmRestOldStyleMaxMeasures</tabstop>
+  <tabstop>resetMMRestOldStyleMaxMeasures</tabstop>
+  <tabstop>mmRestOldStyleSpacing</tabstop>
+  <tabstop>resetMMRestOldStyleSpacing</tabstop>
   <tabstop>beamWidth</tabstop>
   <tabstop>beamDistance</tabstop>
   <tabstop>beamMinLen</tabstop>
@@ -12917,6 +13141,7 @@ By default, they will be placed such as that their right end are at the same lev
   <tabstop>textStyleFrameBorderRadius</tabstop>
   <tabstop>resetTextStyleFrameBorderRadius</tabstop>
   <tabstop>buttonTogglePagelist</tabstop>
+  <tabstop>resetStylesButton</tabstop>
  </tabstops>
  <resources>
   <include location="../../notationscene.qrc"/>


### PR DESCRIPTION
They were introduced in PR #6211 by @IsaacWeiss, but got lost in PR #7462. Now, they are back again.

<img width="998" alt="Schermafbeelding 2021-02-12 om 17 11 27" src="https://user-images.githubusercontent.com/48658420/107793161-49efcf00-6d56-11eb-9fd8-3afce005da63.png">

TODO: the same for the Measure Repeat options from PR #6365. Those got lost longer ago, and to me it is unclear when and why. 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
