### PR TITLE
fix #317272: page settings dialog shows wrong values in pre-3.6 parts

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -358,6 +358,13 @@ Score* Score::clone()
       XmlWriter xml(this, &buffer);
       xml.header();
 
+      // TODO: this code to set MSC_VERSION explicitly causes the preview score in page settings dialog
+      // to always use current style defaults rather than those of the source score
+      // this clearly wrong for the page settings dialog and causes https://musescore.org/en/node/317272
+      // it's possible this code should be replaced by code that sets version based on the source score
+      // but it's also possible other code relies on the current behavior
+      // it's also possible MasterScore::clone() should contain the same change
+      // but for now, we are simply fixing up the style in PageSettings::setScore()
       xml.stag("museScore version=\"" MSC_VERSION "\"");
       write(xml, false);
       xml.etag();

--- a/mscore/pagesettings.cpp
+++ b/mscore/pagesettings.cpp
@@ -104,6 +104,14 @@ void PageSettings::setScore(Score* s)
       cs = s;
       delete clonedScore;
       clonedScore = s->clone();
+      // HACK: clone doesn't actually copy style completely for older scores;
+      // instead it replaces any style settings that were at the older defaults with the current defaults
+      // this is not desired here, but might be in other places that Score::clone() is used
+      // so instead we simply re-copy the style here
+      int defaultsVersion = s->style().defaultStyleVersion();
+      clonedScore->style().setDefaultStyleVersion(defaultsVersion);
+      clonedScore->style() = s->style();
+
       clonedScore->setLayoutMode(LayoutMode::PAGE);
 
       clonedScore->doLayout();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/317272

When displaying the page settings dialog,
we create a preview by cloning the score,
and the dialog actually manipulates the preview's values.
However, the clone is always forced to current style defaults,
so for pre-3.6 scores that, the preview and the spinboxes show
new 3.6 defaults as opposed to the old.
This causes the preview to display completely unlike the actual score,
and it also means the default values for the margins are wrong.

A full fix for this would involve re-examining the logic used
in the clone() methods for both Score and MasterScore.
But there could be any numebr of side effects to this.
So the fix here is very conservative:
it just overrides the clone's style with the original style
after the fact.
Thus it can only affect the page settings dialog.

It should also be noted this bug only affects parts, not parent scores.
That is because the process of reading/writing the parent score
resets the style again based on version tags encountered.
So probably there is another fix here involving that logic.
This too would almost certain have side effects.