### PR TITLE
Fix #317424: Missing tie in part after paste

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -649,8 +649,7 @@ void Score::pasteChordRest(ChordRest* cr, const Fraction& t, const Interval& src
                                           nl2[i]->setTieFor(nl1[i]->tieFor());
                                           tie2->setStartNote(nl2[i]);
                                           }
-                                    nl1[i]->setTieFor(tie);
-                                    nl2[i]->setTieBack(tie);
+                                    undoAddElement(tie);
                                     }
                         c = c2;
                         firstpart = false;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/317424.

When a tie is created as a result of pasting a note that is too long to fit in the measure, ties must be added to the corresponding notes in any and all linked scores. This is accomplished by using the undoAddElement() function to add the tie, rather than simply using setTieFor() and setTieBack() on notes in the current score.