### PR TITLE
Fix #317426: Rests grouped incorrectly after adding 256th note or smaller

### DIFF
--- a/libmscore/durationtype.cpp
+++ b/libmscore/durationtype.cpp
@@ -565,6 +565,7 @@ void populateRhythmicList(std::vector<TDuration>* dList, const Fraction& l, bool
       if ((startLevel < 0) || (endLevel < 0) || (strongestLevelCrossed < 0)) {
             // Beyond maximum subbeat level so just split into largest possible durations.
             std::vector<TDuration> dList2 = toDurationList(l, maxDots > 0, maxDots, false);
+            std::reverse(dList2.begin(), dList2.end());
             dList->insert(dList->end(), dList2.begin(), dList2.end());
             return;
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/317426.

The functions that deal with rhythm grouping operate on integer ticks, but they are smart enough to realize that integers can only be split in half so many times. If and when this limit is exceeded, populateRhythmicList gives up trying to group rhythms based on subbeats, and simply appends the result of toDurationList() to the current duration list that is being built. But toDurationList() returns a list that is ordered from largest to smallest, so it really ought to be appended in the reverse order.