### PR TITLE
[MU4] Ported #7362: Fix #315779: Disable auto-size of vertical frame when dragging the height handle

### DIFF
--- a/src/libmscore/box.cpp
+++ b/src/libmscore/box.cpp
@@ -815,6 +815,19 @@ void VBox::layout()
 }
 
 //---------------------------------------------------------
+//   startEditDrag
+//---------------------------------------------------------
+
+void VBox::startEditDrag(EditData& ed)
+{
+    if (isAutoSizeEnabled()) {
+        setAutoSizeEnabled(false);
+        setBoxHeight(Spatium(height() / spatium()));
+    }
+    Box::startEditDrag(ed);
+}
+
+//---------------------------------------------------------
 //   layout
 //---------------------------------------------------------
 

--- a/src/libmscore/box.h
+++ b/src/libmscore/box.h
@@ -158,6 +158,8 @@ public:
     QVariant getProperty(Pid propertyId) const override;
     void layout() override;
 
+    void startEditDrag(EditData&) override;
+
     std::vector<QPointF> gripsPositions(const EditData&) const override;
 };
 


### PR DESCRIPTION
Ported #7362: Fix [#315779](https://musescore.org/en/node/315779): Disable auto-size of vertical frame when dragging the height handle
