### PR TITLE
Port PRs from 3.x

### DIFF
--- a/src/libmscore/beam.cpp
+++ b/src/libmscore/beam.cpp
@@ -1826,7 +1826,7 @@ void Beam::layout2(std::vector<ChordRest*> crl, SpannerSegmentType, int frag)
             for (; i < n; ++i) {
                 ChordRest* c = crl[i];
                 ChordRest* p = i ? crl[i - 1] : 0;
-                int l = c->durationType().hooks() - 1;
+                int l = c->isChord() ? c->durationType().hooks() - 1 : beamLevel;
 
                 Mode bm = Groups::endBeam(c, p);
                 b32 = (beamLevel >= 1) && (bm == Mode::BEGIN32);

--- a/src/libmscore/chord.cpp
+++ b/src/libmscore/chord.cpp
@@ -2759,7 +2759,12 @@ Element* Chord::drop(EditData& data)
         }
     }
         if (tremolo()) {
+            bool sameType = (e->subtype() == tremolo()->subtype());
             score()->undoRemoveElement(tremolo());
+            if (sameType) {
+                delete e;
+                return 0;
+            }
         }
         e->setParent(this);
         e->setTrack(track());

--- a/src/libmscore/edit.cpp
+++ b/src/libmscore/edit.cpp
@@ -3066,6 +3066,14 @@ void Score::cmdDeleteSelection()
                     tick = toMeasureRepeat(e)->firstMeasureOfGroup()->first()->tick();
                 } else if (e->isSpannerSegment()) {
                     tick = toSpannerSegment(e)->spanner()->tick();
+                } else if (e->isBreath()) {
+                    // we want the tick of the ChordRest that precedes the breath mark (in the same track)
+                    for (Segment* s = toBreath(e)->segment()->prev(); s; s = s->prev()) {
+                        if (s->isChordRestType() && s->element(e->track())) {
+                            tick = s->tick();
+                            break;
+                        }
+                    }
                 } else if (e->parent()
                            && (e->parent()->isSegment() || e->parent()->isChord() || e->parent()->isNote() || e->parent()->isRest())) {
                     tick = e->parent()->tick();

--- a/src/libmscore/edit.cpp
+++ b/src/libmscore/edit.cpp
@@ -1016,12 +1016,6 @@ bool Score::rewriteMeasures(Measure* fm, const Fraction& ns, int staffIdx)
                             break;
                         }
                     }
-                } else {
-                    // this can be hit for local time signatures as well
-                    // (if we are rewriting all staves, but one has a local time signature)
-                    // TODO: detect error conditions better, have clearer error messages
-                    // and perform necessary fixups
-                    MScore::setError(MsError::TUPLET_CROSSES_BAR);
                 }
                 for (Measure* m = fm1; m; m = m->nextMeasure()) {
                     if (m->first(SegmentType::TimeSig)) {

--- a/src/libmscore/layout.cpp
+++ b/src/libmscore/layout.cpp
@@ -2735,8 +2735,7 @@ void Score::createBeams(LayoutContext& lc, Measure* measure)
                         if (!beamNoContinue(prevCR->beamMode())
                             && !pm->lineBreak() && !pm->pageBreak() && !pm->sectionBreak()
                             && lc.prevMeasure
-                            && prevCR->durationType().type() >= TDuration::DurationType::V_EIGHTH
-                            && prevCR->durationType().type() <= TDuration::DurationType::V_1024TH) {
+                            && !(prevCR->isChord() && prevCR->durationType().type() <= TDuration::DurationType::V_QUARTER)) {
                             beam = prevCR->beam();
                             //a1 = beam ? beam->elements().front() : prevCR;
                             a1 = beam ? nullptr : prevCR;               // when beam is found, a1 is no longer required.
@@ -2801,7 +2800,7 @@ void Score::createBeams(LayoutContext& lc, Measure* measure)
                 bm = Beam::Mode::NONE;
             }
 
-            if ((cr->durationType().type() <= TDuration::DurationType::V_QUARTER) || (bm == Beam::Mode::NONE)) {
+            if ((cr->isChord() && cr->durationType().type() <= TDuration::DurationType::V_QUARTER) || (bm == Beam::Mode::NONE)) {
                 bool removeBeam = true;
                 if (beam) {
                     beam->layout1();

--- a/src/libmscore/layoutbreak.h
+++ b/src/libmscore/layoutbreak.h
@@ -56,6 +56,7 @@ public:
 
     LayoutBreak* clone() const override { return new LayoutBreak(*this); }
     ElementType type() const override { return ElementType::LAYOUT_BREAK; }
+    int subtype() const override { return static_cast<int>(_layoutBreakType); }
 
     void setLayoutBreakType(Type);
     Type layoutBreakType() const { return _layoutBreakType; }

--- a/src/libmscore/mscore.cpp
+++ b/src/libmscore/mscore.cpp
@@ -169,6 +169,8 @@ std::vector<MScoreError> MScore::errorList {
     { MsError::DEST_NO_CR,                      "p7", QT_TRANSLATE_NOOP("error", "Destination is not a chord or rest") },
     { MsError::CANNOT_CHANGE_LOCAL_TIMESIG,     "l1",
       QT_TRANSLATE_NOOP("error", "Cannot change local time signature:\nMeasure is not empty") },
+    { MsError::CORRUPTED_MEASURE,               "c1", QT_TRANSLATE_NOOP("error",
+                                                                        "Cannot change time signature in front of a corrupted measure") },
 };
 
 MsError MScore::_error { MsError::MS_NO_ERROR };

--- a/src/libmscore/mscore.h
+++ b/src/libmscore/mscore.h
@@ -1,4 +1,4 @@
-﻿//=============================================================================
+//=============================================================================
 //  MuseScore
 //  Music Composition & Notation
 //
@@ -264,6 +264,7 @@ enum class MsError {
     NO_MIME,
     DEST_NO_CR,
     CANNOT_CHANGE_LOCAL_TIMESIG,
+    CORRUPTED_MEASURE,
 };
 
 /// \cond PLUGIN_API \private \endcond

--- a/src/libmscore/segment.cpp
+++ b/src/libmscore/segment.cpp
@@ -1125,7 +1125,7 @@ bool Segment::hasElements(int minTrack, int maxTrack) const
 
 bool Segment::allElementsInvisible() const
 {
-    if (isType(SegmentType::BarLineType | SegmentType::ChordRest | SegmentType::Breath)) {
+    if (isType(SegmentType::BarLineType | SegmentType::ChordRest)) {
         return false;
     }
 

--- a/src/libmscore/textbase.cpp
+++ b/src/libmscore/textbase.cpp
@@ -1856,6 +1856,12 @@ void TextBase::createLayout()
                 if (rows() <= cursor.row()) {
                     _layout.append(TextBlock());
                 }
+
+                if (cursor.row() < rows()) {
+                    if (_layout[cursor.row()].fragments().size() == 0) {
+                        _layout[cursor.row()].insertEmptyFragmentIfNeeded(&cursor); // an empty fragment may be needed on either side of the newline
+                    }
+                }
             } else {
                 if (symState) {
                     sym += c;

--- a/src/libmscore/textedit.cpp
+++ b/src/libmscore/textedit.cpp
@@ -571,13 +571,10 @@ void SplitJoinText::join(EditData* ed)
     t->textBlock(line - 1).fragments().append(*fragmentsList);
     delete fragmentsList;
 
-    int lines = t->rows();
-    if (line < lines) {
-        t->textBlock(line).setEol(eol);
-    }
     t->textBlockList().removeAt(line);
 
     c.setRow(line - 1);
+    c.curLine().setEol(eol);
     c.setColumn(col);
     c.setFormat(*charFmt);             // restore orig. format at new line
     c.clearSelection();
@@ -592,12 +589,13 @@ void SplitJoinText::split(EditData* ed)
 {
     TextBase* t   = c.text();
     int line      = c.row();
+    bool eol      = c.curLine().eol();
     t->setTextInvalid();
     t->triggerLayout();
 
     CharFormat* charFmt = c.format();           // take current format
     t->textBlockList().insert(line + 1, c.curLine().split(c.column(), t->cursorFromEditData(*ed)));
-    c.curLine().setEol(true);
+    c.curLine().setEol(eol);
 
     c.setRow(line + 1);
     c.curLine().setEol(true);

--- a/vtest/scores/frametext.mscx
+++ b/vtest/scores/frametext.mscx
@@ -154,8 +154,7 @@
         <Text>
           <size>12</size>
           <align>right,center</align>
-          <text>rightCenter<font face=""></font>
-</text>
+          <text>rightCenter<font face=""></font></text>
           </Text>
         <Text>
           <size>12</size>


### PR DESCRIPTION
This is a port of the following PRs from 3.x to the master branch:

#7261 Allow beaming across crotchet rests.
#7373 Fix #316441: Crash when changing time signature in front of a corrupted measure.
#7384 Fix #316797: Deleting a breath/caesura selects the wrong note.
#7396 Fix #316754: Empty rehearsal mark not deleted after entering a line break.
#7403 Fix #305777: Make applying tremolo a toggle operation.
#7407 Fix #316679: Segmentation Fault when opening a file with a missing section break element.
#7412 Fix #316555: Invisible breath shouldn't impact layout. 