### PR TITLE
[MU3] Reimplement spacers in vertical staves adjustment to make sure all spacers are taken into account.

### DIFF
--- a/libmscore/layout.h
+++ b/libmscore/layout.h
@@ -28,6 +28,7 @@ class Page;
 class VerticalGapData {
    private:
       bool  _fixedHeight          { false };
+      bool  _fixedSpacer          { false };
       qreal _factor               { 1.0   };
       qreal _normalisedSpacing    { 0.0   };
       qreal _maxActualSpacing     { 0.0   };
@@ -41,7 +42,7 @@ class VerticalGapData {
       SysStaff* sysStaff { nullptr };
       Staff*    staff    { nullptr };
 
-      VerticalGapData(bool first, System* sys, Staff* st, SysStaff* sst, const Spacer* spacer, qreal y);
+      VerticalGapData(bool first, System* sys, Staff* st, SysStaff* sst, Spacer* nextSpacer, qreal y);
 
       void addSpaceBetweenSections();
       void addSpaceAroundVBox(bool above);

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -1540,27 +1540,78 @@ qreal System::spacerDistance(bool up) const
       if (staff < 0)
             return 0.0;
       qreal dist = 0.0;
-      activeSpacer = nullptr;
       for (MeasureBase* mb : measures()) {
             if (mb->isMeasure()) {
                   Measure* m = toMeasure(mb);
                   Spacer* sp = up ? m->vspacerUp(staff) : m->vspacerDown(staff);
                   if (sp) {
                         if (sp->spacerType() == SpacerType::FIXED) {
-                              activeSpacer = sp;
                               dist = sp->gap();
                               break;
                               }
-                        else {
-                              if (sp->gap() > dist) {
-                                    activeSpacer = sp;
-                                    dist = sp->gap();
-                                    }
-                              }
+                        else
+                              dist = qMax(dist, sp->gap());
                         }
                   }
             }
       return dist;
+      }
+
+//---------------------------------------------------------
+//   upSpacer
+//    Return largest upSpacer for this system. This can
+//    be a downSpacer of the previous system.
+//---------------------------------------------------------
+
+Spacer* System::upSpacer(int staffIdx, Spacer* prevDownSpacer) const
+      {
+      if (staffIdx < 0)
+            return nullptr;
+
+      if (prevDownSpacer && (prevDownSpacer->spacerType() == SpacerType::FIXED))
+            return prevDownSpacer;
+
+      Spacer* spacer { prevDownSpacer };
+      for (MeasureBase* mb : measures()) {
+            if (!(mb && mb->isMeasure()))
+                  continue;
+            Spacer* sp { toMeasure(mb)->vspacerUp(staffIdx)} ;
+            if (sp) {
+                  if (!spacer || ((spacer->spacerType() == SpacerType::UP) && (sp->gap() > spacer->gap()))) {
+                        spacer = sp;
+                        }
+                  continue;
+                  }
+            }
+      return spacer;
+      }
+
+//---------------------------------------------------------
+//   downSpacer
+//    Return the largest downSpacer for this system.
+//---------------------------------------------------------
+
+Spacer* System::downSpacer(int staffIdx) const
+      {
+      if (staffIdx < 0)
+            return nullptr;
+
+      Spacer* spacer { nullptr };
+      for (MeasureBase* mb : measures()) {
+            if (!(mb && mb->isMeasure()))
+                  continue;
+            Spacer* sp { toMeasure(mb)->vspacerDown(staffIdx) };
+            if (sp) {
+                  if (sp->spacerType() == SpacerType::FIXED) {
+                        return sp;
+                        }
+                  else {
+                        if (!spacer || (sp->gap() > spacer->gap()))
+                              spacer = sp;
+                        }
+                  }
+            }
+      return spacer;
       }
 
 //---------------------------------------------------------

--- a/libmscore/system.h
+++ b/libmscore/system.h
@@ -95,11 +95,10 @@ class System final : public Element {
       QList<Bracket*> _brackets;
       QList<SpannerSegment*> _spannerSegments;
 
-      qreal _leftMargin              { 0.0     };     ///< left margin for instrument name, brackets etc.
-      mutable bool fixedDownDistance { false   };
-      mutable Spacer* activeSpacer   { nullptr };
-      qreal _distance                { 0.0     };     // temp. variable used during layout
-      qreal _systemHeight            { 0.0     };
+      qreal _leftMargin              { 0.0   };     ///< left margin for instrument name, brackets etc.
+      mutable bool fixedDownDistance { false };
+      qreal _distance                { 0.0   };     // temp. variable used during layout
+      qreal _systemHeight            { 0.0   };
 
       int firstVisibleSysStaff() const;
       int lastVisibleSysStaff() const;
@@ -188,12 +187,13 @@ public:
       qreal minTop() const;
       qreal minBottom() const;
       qreal spacerDistance(bool up) const;
+      Spacer* upSpacer(int staffIdx, Spacer* prevDownSpacer) const;
+      Spacer* downSpacer(int staffIdx) const;
 
       qreal firstNoteRestSegmentX(bool leading = false);
 
       void moveBracket(int staffIdx, int srcCol, int dstCol);
       bool hasFixedDownDistance() const { return fixedDownDistance; }
-      Spacer* getActiveSpacer() const { return activeSpacer; }
       int firstVisibleStaff() const;
       int nextVisibleStaff(int) const;
       qreal distance() const { return _distance; }


### PR DESCRIPTION
Solves the ignored spacer between last staff and bottom of the page.
Also it was found some combination were not handled correctly. To solve this <code>distributeStaves()</code> now implements it own code for finding the correct <code>Spacer</code> for every spacing.

A dedicated PR for <code>master</code> will be created shortly.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
