### PR TITLE
[MU4] Port of PR #7405 from 3.x to master

### DIFF
--- a/src/libmscore/instrtemplate.cpp
+++ b/src/libmscore/instrtemplate.cpp
@@ -352,7 +352,7 @@ void InstrumentTemplate::write(XmlWriter& xml) const
             ma.write(xml);
         }
     }
-    if (!family) {
+    if (family) {
         xml.tag("family", family->id);
     }
     xml.etag();


### PR DESCRIPTION
Port of PR #7405 from <code>3.x</code> to <code>master</code> : Solves potential crash when an extended instruments.xml is written. It never happened because that function is disabled at 2018-06-05.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
