### PR TITLE
Fix drawing of border on RoundedRectangle

### DIFF
--- a/src/appshell/qml/DevTools/Gallery/GeneralComponentsGallery.qml
+++ b/src/appshell/qml/DevTools/Gallery/GeneralComponentsGallery.qml
@@ -480,6 +480,8 @@ Rectangle {
                 topLeftRadius: 40
 
                 color: "gray"
+                border.color: "red"
+                border.width: 3
             }
 
             RoundedRectangle {
@@ -489,6 +491,8 @@ Rectangle {
                 topRightRadius: 30
 
                 color: "gray"
+                border.color: "yellow"
+                border.width: 10
             }
 
             RoundedRectangle {
@@ -498,6 +502,8 @@ Rectangle {
                 bottomLeftRadius: 20
 
                 color: "gray"
+                border.color: "green"
+                border.width: 8
             }
 
             RoundedRectangle {
@@ -507,6 +513,8 @@ Rectangle {
                 bottomRightRadius: 10
 
                 color: "gray"
+                border.color: "blue"
+                border.width: 5
             }
         }
     }

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/Border.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/Border.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.0
+
+QtObject {
+    property int width: 0
+    property color color: "#00000000"
+}

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/RoundedRectangle.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/RoundedRectangle.qml
@@ -3,19 +3,22 @@ import QtQuick 2.0
 Canvas {
     id: root
 
-    property int topLeftRadius: 0
-    property int topRightRadius: 0
-    property int bottomLeftRadius: 0
-    property int bottomRightRadius: 0
+    property int radius: 0
+
+    property int topLeftRadius: radius
+    property int topRightRadius: radius
+    property int bottomLeftRadius: radius
+    property int bottomRightRadius: radius
 
     property color color: "#FFFFFF"
 
-    property QtObject border: QtObject {
-        property int width: 0
-        property color color: "#00000000"
-    }
+    property Border border: Border {}
 
     onColorChanged: {
+        requestPaint()
+    }
+
+    onBorderChanged: {
         requestPaint()
     }
 
@@ -39,26 +42,49 @@ Canvas {
         roundRect(0, 0, width, height)
     }
 
-    function roundRect(x, y, w, h)
+    function roundRect(x1, y1, x2, y2)
     {
         var context = root.getContext("2d")
-        var r = x + w
-        var b = y + h
+        var b = border.width / 2
+        var x1Inner = x1 + b
+        var y1Inner = y1 + b
+        var x2Inner = x2 - b
+        var y2Inner = y2 - b
 
         context.beginPath()
         context.fillStyle = root.color
         context.strokeStyle = root.border.color
         context.lineWidth = root.border.width
 
-        context.moveTo(x + topLeftRadius, y)
-        context.lineTo(r - topRightRadius, y)
-        context.quadraticCurveTo(r, y, r, y + topRightRadius)
-        context.lineTo(r, b - bottomRightRadius)
-        context.quadraticCurveTo(r, b, r - bottomRightRadius, b)
-        context.lineTo(x + bottomLeftRadius, b)
-        context.quadraticCurveTo(x, b, x, b - bottomLeftRadius)
-        context.lineTo(x, y + topLeftRadius)
-        context.quadraticCurveTo(x, y, x + topLeftRadius, y)
+        context.moveTo(x1 + topLeftRadius, y1Inner)
+
+        if (topRightRadius == 0) {
+            context.lineTo(x2Inner, y1Inner)
+        } else {
+            context.lineTo(x2 - topRightRadius, y1Inner)
+            context.quadraticCurveTo(x2Inner, y1Inner, x2Inner, y1 + topRightRadius)
+        }
+
+        if (bottomRightRadius == 0) {
+            context.lineTo(x2Inner, y2Inner)
+        } else {
+            context.lineTo(x2Inner, y2 - bottomRightRadius)
+            context.quadraticCurveTo(x2Inner, y2Inner, x2 - bottomRightRadius, y2Inner)
+        }
+
+        if (bottomLeftRadius == 0) {
+            context.lineTo(x1Inner, y2Inner)
+        } else {
+            context.lineTo(x1 + bottomLeftRadius, y2Inner)
+            context.quadraticCurveTo(x1Inner, y2Inner, x1Inner, y2 - bottomLeftRadius)
+        }
+
+        if (topLeftRadius == 0) {
+            context.lineTo(x1Inner, y1Inner)
+        } else {
+            context.lineTo(x1Inner, y1 + topLeftRadius)
+            context.quadraticCurveTo(x1Inner, y1Inner, x1 + topLeftRadius, y1Inner)
+        }
 
         context.stroke()
         context.fill()

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/qmldir
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/qmldir
@@ -1,4 +1,5 @@
 module MuseScore.UiComponents
+Border 1.0 Border.qml
 CheckBox 1.0 CheckBox.qml
 FocusableItem 1.0 FocusableItem.qml
 StyledIconLabel 1.0 StyledIconLabel.qml

--- a/src/framework/uicomponents/uicomponents.qrc
+++ b/src/framework/uicomponents/uicomponents.qrc
@@ -39,5 +39,6 @@
         <file>qml/MuseScore/UiComponents/internal/GridViewDelegate.qml</file>
         <file>qml/MuseScore/UiComponents/internal/GridViewSection.qml</file>
         <file>qml/MuseScore/UiComponents/StyledPopupView.qml</file>
+        <file>qml/MuseScore/UiComponents/Border.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Before: RoundedRectangle was not used in many places, and nowhere with a border. I tried using it for a ComboBox with a TextInputField, and then discovered that the border was drawn wrong, namely along the edge of the rect, causing the line thickness to be half of the given value, except at the rounded corners. 

After: the border is now drawn inside the rectangle, just like with a normal QML Rectangle.
I added borders to the test on the devtools page, it now looks like this:
<img width="426" alt="Schermafbeelding 2021-02-15 om 19 55 53" src="https://user-images.githubusercontent.com/48658420/107985324-2b920980-6fca-11eb-9c18-a2c27ebb7dec.png">

I also added a Border QML Type for convenience, and a radius property to easily set a radius for all corners but change it for one corner, for example.