### PR TITLE
fix #314950: fix inability to download extensions

### DIFF
--- a/mscore/resourceManager.cpp
+++ b/mscore/resourceManager.cpp
@@ -22,6 +22,8 @@ namespace Ms {
 extern QString dataPath;
 extern QString mscoreGlobalShare;
 
+static constexpr int extensionDownloadTimeoutMs = 20 * 60 * 1000;
+
 ResourceManager::ResourceManager(QWidget *parent) :
       QDialog(parent)
       {
@@ -379,7 +381,7 @@ void ResourceManager::downloadExtension()
       QString localPath = QDir::tempPath() + "/" + path.split('/')[1];
       QFile::remove(localPath);
       dl.setLocalFile(localPath);
-      dl.download(true);
+      dl.download(true, extensionDownloadTimeoutMs);
       bool saveFileRes = dl.saveFile();
       bool verifyFileRes = saveFileRes && verifyFile(localPath, hash);
       if(!verifyFileRes) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/314950

The following issues in the tracker are also probably describing the same issue:
 - https://musescore.org/en/node/315198
 - https://musescore.org/en/node/312737

The reason of those download issues is a 20 seconds download timeout introduced in #6546. For most applications within MuseScore it works fine but this timeout is too small for downloading extensions of tens of megabytes in size (which, of course, depends on the Internet connection speed). This pull requests increases the timeout up to 2 hours for downloading extensions, I am not sure though whether a timeout makes sense in this context.