### PR TITLE
[MU4] Port of PR #7377 from 3.x to master

### DIFF
--- a/src/libmscore/system.cpp
+++ b/src/libmscore/system.cpp
@@ -1434,7 +1434,7 @@ qreal System::minDistance(System* s2) const
     Staff* staff = score()->staff(firstStaff);
     qreal userDist = staff ? staff->userDist() : 0.0;
     dist = qMax(dist, userDist);
-    fixedSpacer = nullptr;
+    fixedDownDistance = false;
 
     for (MeasureBase* mb1 : ml) {
         if (mb1->isMeasure()) {
@@ -1442,8 +1442,8 @@ qreal System::minDistance(System* s2) const
             Spacer* sp = m->vspacerDown(lastStaff);
             if (sp) {
                 if (sp->spacerType() == SpacerType::FIXED) {
-                    fixedSpacer = sp;
                     dist = sp->gap();
+                    fixedDownDistance = true;
                     break;
                 } else {
                     dist = qMax(dist, sp->gap());
@@ -1451,7 +1451,7 @@ qreal System::minDistance(System* s2) const
             }
         }
     }
-    if (!getFixedSpacer()) {
+    if (!fixedDownDistance) {
         for (MeasureBase* mb2 : s2->ml) {
             if (mb2->isMeasure()) {
                 Measure* m = toMeasure(mb2);
@@ -1581,16 +1581,22 @@ qreal System::spacerDistance(bool up) const
         return 0.0;
     }
     qreal dist = 0.0;
+    activeSpacer = nullptr;
     for (MeasureBase* mb : measures()) {
         if (mb->isMeasure()) {
             Measure* m = toMeasure(mb);
             Spacer* sp = up ? m->vspacerUp(staff) : m->vspacerDown(staff);
             if (sp) {
                 if (sp->spacerType() == SpacerType::FIXED) {
+                    activeSpacer = sp;
                     dist = sp->gap();
                     break;
                 } else {
                     dist = qMax(dist, sp->gap());
+                    if (sp->gap() > dist) {
+                        activeSpacer = sp;
+                        dist = sp->gap();
+                    }
                 }
             }
         }

--- a/src/libmscore/system.h
+++ b/src/libmscore/system.h
@@ -96,10 +96,11 @@ class System final : public Element
     QList<Bracket*> _brackets;
     QList<SpannerSegment*> _spannerSegments;
 
-    qreal _leftMargin           { 0.0 };           ///< left margin for instrument name, brackets etc.
-    mutable Spacer* fixedSpacer { nullptr };
-    qreal _distance             { 0.0 };           // temp. variable used during layout
-    qreal _systemHeight         { 0.0 };
+    qreal _leftMargin              { 0.0 };     ///< left margin for instrument name, brackets etc.
+    mutable bool fixedDownDistance { false };
+    mutable Spacer* activeSpacer   { nullptr };
+    qreal _distance                { 0.0 };     /// temp. variable used during layout
+    qreal _systemHeight            { 0.0 };
 
     int firstVisibleSysStaff() const;
     int lastVisibleSysStaff() const;
@@ -198,7 +199,8 @@ public:
     qreal firstNoteRestSegmentX(bool leading = false);
 
     void moveBracket(int staffIdx, int srcCol, int dstCol);
-    Spacer* getFixedSpacer() const { return fixedSpacer; }
+    bool hasFixedDownDistance() const { return fixedDownDistance; }
+    Spacer* getActiveSpacer() const { return activeSpacer; }
     int firstVisibleStaff() const;
     int nextVisibleStaff(int) const;
     qreal distance() const { return _distance; }


### PR DESCRIPTION
Port of PR #7377 from <code>3.x</code> to <code>master</code>

Fix #316610 - Staff spacer down does not work on last system of page

Check for an active spacer (a fixed spacer or the up/down spacer with the largest gap) for a system use this as a fixed gap for vertical staff adjustment. To make sure the spacers also work between the last staff and the bottom margin of the pages, the calculated space to be used for the spread algorithm ("spaceLeft") is reduced by this gap.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
