### PR TITLE
Fix #316896: Banjo fifth string fret numbers

### DIFF
--- a/src/libmscore/instrument.h
+++ b/src/libmscore/instrument.h
@@ -349,7 +349,7 @@ public:
     void setMidiActions(const QList<NamedEventList>& l) { _midiActions = l; }
     void setArticulation(const QList<MidiArticulation>& l) { _articulation = l; }
     const StringData* stringData() const { return &_stringData; }
-    void setStringData(const StringData& d) { _stringData.set(d); }
+    void setStringData(const StringData& d) { _stringData = d; }
 
     void setLongName(const QString& f);
     void setShortName(const QString& f);

--- a/src/libmscore/instrument.h
+++ b/src/libmscore/instrument.h
@@ -349,7 +349,7 @@ public:
     void setMidiActions(const QList<NamedEventList>& l) { _midiActions = l; }
     void setArticulation(const QList<MidiArticulation>& l) { _articulation = l; }
     const StringData* stringData() const { return &_stringData; }
-    void setStringData(const StringData& d) { _stringData = d; }
+    void setStringData(const StringData& d) { _stringData.set(d); }
 
     void setLongName(const QString& f);
     void setShortName(const QString& f);

--- a/src/libmscore/stringdata.cpp
+++ b/src/libmscore/stringdata.cpp
@@ -28,7 +28,7 @@ bool StringData::bFretting = false;
 
 StringData::StringData(int numFrets, int numStrings, int strings[])
 {
-    instrString strg = { 0, false };
+    instrString strg = { 0, false, 0 };
     _frets = numFrets;
 
     for (int i = 0; i < numStrings; i++) {
@@ -45,6 +45,14 @@ StringData::StringData(int numFrets, QList<instrString>& strings)
     foreach (instrString i, strings) {
         stringTable.append(i);
     }
+}
+
+// called from import (musicxml/guitarpro/...)
+void StringData::set(const StringData& src)
+{
+      *this = src;
+      if (isFiveStringBanjo())
+            configBanjo5thString();
 }
 
 //---------------------------------------------------------
@@ -67,6 +75,8 @@ void StringData::read(XmlReader& e)
             e.unknown();
         }
     }
+    if (isFiveStringBanjo())
+          configBanjo5thString();
 }
 
 //---------------------------------------------------------
@@ -330,18 +340,36 @@ bool StringData::convertPitch(int pitch, int pitchOffset, int* string, int* fret
         return false;
     }
 
-    // look for a suitable string, starting from the highest
-    // NOTE: this assumes there are always enough frets to fill
-    // the interval between any fretted string and the next
-    for (int i = strings - 1; i >= 0; i--) {
-        instrString strg = stringTable.at(i);
-        if (pitch >= strg.pitch) {
-            if (pitch == strg.pitch || !strg.open) {
-                *string = strings - i - 1;
-            }
-            *fret   = pitch - strg.pitch;
-            return true;
-        }
+    if (isFiveStringBanjo()) {
+          // special case: open banjo 5th string
+          if (pitch == stringTable.at(0).pitch) {
+                *string = 4;
+                *fret = 0;
+                return true;
+          }
+          // test remaining 4 strings from highest to lowest
+          for (int i = 4; i > 0; i--) {
+                instrString strg = stringTable.at(i);
+                if (pitch >= strg.pitch) {
+                      *string = strings - i - 1;
+                      *fret = pitch - strg.pitch;
+                      return true;
+                }
+          }
+    }
+    else {
+          // look for a suitable string, starting from the highest
+          // NOTE: this assumes there are always enough frets to fill
+          // the interval between any fretted string and the next
+          for (int i = strings - 1; i >= 0; i--) {
+                instrString strg = stringTable.at(i);
+                if (pitch >= strg.pitch) {
+                      if (pitch == strg.pitch || !strg.open)
+                            *string = strings - i - 1;
+                      *fret = pitch - strg.pitch;
+                      return true;
+                }
+          }
     }
 
     // if no string found, pitch is below lowest string:
@@ -365,7 +393,10 @@ int StringData::getPitch(int string, int fret, int pitchOffset) const
         return INVALID_PITCH;
     }
     instrString strg = stringTable.at(strings - string - 1);
-    return strg.pitch - pitchOffset + (strg.open ? 0 : fret);
+    int pitch = strg.pitch - pitchOffset + (strg.open ? 0 : fret);
+    if (strg.startFret > 0 && fret >= strg.startFret)
+          pitch -= strg.startFret; // banjo 5th string adjustment
+    return pitch;
 }
 
 //---------------------------------------------------------
@@ -387,11 +418,15 @@ int StringData::fret(int pitch, int string, int pitchOffset) const
 
     pitch += pitchOffset;
 
-    int fret = pitch - stringTable[strings - string - 1].pitch;
-    // fret number is invalid or string cannot be fretted
-    if (fret < 0 || fret >= _frets || (fret > 0 && stringTable[strings - string - 1].open)) {
-        return FRET_NONE;
-    }
+    const instrString& strg = stringTable[strings - string - 1];
+    int fret = pitch - strg.pitch;
+    if (fret > 0 && strg.startFret > 0)
+          fret += strg.startFret;  // banjo 5th string adjustment
+
+   // fret number is invalid or string cannot be fretted
+    if (fret < 0 || fret >= _frets || (fret > 0 && strg.open))
+          return FRET_NONE;
+
     return fret;
 }
 
@@ -427,6 +462,51 @@ void StringData::sortChordNotes(QMap<int, Note*>& sortedNotes, const Chord* chor
         (*count)++;
     }
 }
+
+//---------------------------------------------------------
+//   configBanjo5thString
+//   Assumes isFiveStringBanjo() has already been called.
+//   This method looks at the banjo tuning and sets startFret 
+//   appropriately.
+//---------------------------------------------------------
+
+void StringData::configBanjo5thString()
+      {
+      // banjo 5th string (pitch 67 == G)
+      instrString& strg5 = stringTable[0];
+
+      _frets = 24; // not needed after bug #316931 is fixed
+
+      // adjust startFret if using a 5th string capo (6..12)
+      if (strg5.pitch > 67 && strg5.pitch < 74)
+            strg5.startFret = strg5.pitch - 62;
+      else
+            strg5.startFret = 5;  // no 5th string capo
+      }
+
+//---------------------------------------------------------
+//   adjustBanjo5thFret
+//   Convert 5th string fret number from (0, 1, 2, 3...) to (0, 6, 7, 8...).
+//   Called from import (GuitarPro mostly)
+//   Returns adjusted fret number
+//---------------------------------------------------------
+
+int StringData::adjustBanjo5thFret(int fret) const
+      {
+      return (fret > 0 && isFiveStringBanjo()) ? fret + stringTable[0].startFret : fret;
+      }
+
+//---------------------------------------------------------
+//    isFiveStringBanjo
+//    Based only on number of strings and tuning - other info
+//    may not be available when this is called. Checks 5th string
+//    pitch is higher than 4th (i.e. not a 5 string bass)
+//---------------------------------------------------------
+
+bool StringData::isFiveStringBanjo() const
+      {
+      return stringTable.size() == 5 && stringTable[0].pitch > stringTable[1].pitch;
+      }
 
 #if 0
 //---------------------------------------------------------

--- a/src/libmscore/stringdata.cpp
+++ b/src/libmscore/stringdata.cpp
@@ -28,7 +28,7 @@ bool StringData::bFretting = false;
 
 StringData::StringData(int numFrets, int numStrings, int strings[])
 {
-    instrString strg = { 0, false, 0 };
+    instrString strg = { 0, false };
     _frets = numFrets;
 
     for (int i = 0; i < numStrings; i++) {
@@ -45,14 +45,6 @@ StringData::StringData(int numFrets, QList<instrString>& strings)
     foreach (instrString i, strings) {
         stringTable.append(i);
     }
-}
-
-// called from import (musicxml/guitarpro/...)
-void StringData::set(const StringData& src)
-{
-      *this = src;
-      if (isFiveStringBanjo())
-            configBanjo5thString();
 }
 
 //---------------------------------------------------------
@@ -75,8 +67,6 @@ void StringData::read(XmlReader& e)
             e.unknown();
         }
     }
-    if (isFiveStringBanjo())
-          configBanjo5thString();
 }
 
 //---------------------------------------------------------
@@ -340,36 +330,18 @@ bool StringData::convertPitch(int pitch, int pitchOffset, int* string, int* fret
         return false;
     }
 
-    if (isFiveStringBanjo()) {
-          // special case: open banjo 5th string
-          if (pitch == stringTable.at(0).pitch) {
-                *string = 4;
-                *fret = 0;
-                return true;
-          }
-          // test remaining 4 strings from highest to lowest
-          for (int i = 4; i > 0; i--) {
-                instrString strg = stringTable.at(i);
-                if (pitch >= strg.pitch) {
-                      *string = strings - i - 1;
-                      *fret = pitch - strg.pitch;
-                      return true;
-                }
-          }
-    }
-    else {
-          // look for a suitable string, starting from the highest
-          // NOTE: this assumes there are always enough frets to fill
-          // the interval between any fretted string and the next
-          for (int i = strings - 1; i >= 0; i--) {
-                instrString strg = stringTable.at(i);
-                if (pitch >= strg.pitch) {
-                      if (pitch == strg.pitch || !strg.open)
-                            *string = strings - i - 1;
-                      *fret = pitch - strg.pitch;
-                      return true;
-                }
-          }
+    // look for a suitable string, starting from the highest
+    // NOTE: this assumes there are always enough frets to fill
+    // the interval between any fretted string and the next
+    for (int i = strings - 1; i >= 0; i--) {
+        instrString strg = stringTable.at(i);
+        if (pitch >= strg.pitch) {
+            if (pitch == strg.pitch || !strg.open) {
+                *string = strings - i - 1;
+            }
+            *fret   = pitch - strg.pitch;
+            return true;
+        }
     }
 
     // if no string found, pitch is below lowest string:
@@ -393,10 +365,7 @@ int StringData::getPitch(int string, int fret, int pitchOffset) const
         return INVALID_PITCH;
     }
     instrString strg = stringTable.at(strings - string - 1);
-    int pitch = strg.pitch - pitchOffset + (strg.open ? 0 : fret);
-    if (strg.startFret > 0 && fret >= strg.startFret)
-          pitch -= strg.startFret; // banjo 5th string adjustment
-    return pitch;
+    return strg.pitch - pitchOffset + (strg.open ? 0 : fret);
 }
 
 //---------------------------------------------------------
@@ -418,15 +387,11 @@ int StringData::fret(int pitch, int string, int pitchOffset) const
 
     pitch += pitchOffset;
 
-    const instrString& strg = stringTable[strings - string - 1];
-    int fret = pitch - strg.pitch;
-    if (fret > 0 && strg.startFret > 0)
-          fret += strg.startFret;  // banjo 5th string adjustment
-
-   // fret number is invalid or string cannot be fretted
-    if (fret < 0 || fret >= _frets || (fret > 0 && strg.open))
-          return FRET_NONE;
-
+    int fret = pitch - stringTable[strings - string - 1].pitch;
+    // fret number is invalid or string cannot be fretted
+    if (fret < 0 || fret >= _frets || (fret > 0 && stringTable[strings - string - 1].open)) {
+        return FRET_NONE;
+    }
     return fret;
 }
 
@@ -462,51 +427,6 @@ void StringData::sortChordNotes(QMap<int, Note*>& sortedNotes, const Chord* chor
         (*count)++;
     }
 }
-
-//---------------------------------------------------------
-//   configBanjo5thString
-//   Assumes isFiveStringBanjo() has already been called.
-//   This method looks at the banjo tuning and sets startFret 
-//   appropriately.
-//---------------------------------------------------------
-
-void StringData::configBanjo5thString()
-      {
-      // banjo 5th string (pitch 67 == G)
-      instrString& strg5 = stringTable[0];
-
-      _frets = 24; // not needed after bug #316931 is fixed
-
-      // adjust startFret if using a 5th string capo (6..12)
-      if (strg5.pitch > 67 && strg5.pitch < 74)
-            strg5.startFret = strg5.pitch - 62;
-      else
-            strg5.startFret = 5;  // no 5th string capo
-      }
-
-//---------------------------------------------------------
-//   adjustBanjo5thFret
-//   Convert 5th string fret number from (0, 1, 2, 3...) to (0, 6, 7, 8...).
-//   Called from import (GuitarPro mostly)
-//   Returns adjusted fret number
-//---------------------------------------------------------
-
-int StringData::adjustBanjo5thFret(int fret) const
-      {
-      return (fret > 0 && isFiveStringBanjo()) ? fret + stringTable[0].startFret : fret;
-      }
-
-//---------------------------------------------------------
-//    isFiveStringBanjo
-//    Based only on number of strings and tuning - other info
-//    may not be available when this is called. Checks 5th string
-//    pitch is higher than 4th (i.e. not a 5 string bass)
-//---------------------------------------------------------
-
-bool StringData::isFiveStringBanjo() const
-      {
-      return stringTable.size() == 5 && stringTable[0].pitch > stringTable[1].pitch;
-      }
 
 #if 0
 //---------------------------------------------------------

--- a/src/libmscore/stringdata.cpp
+++ b/src/libmscore/stringdata.cpp
@@ -28,7 +28,7 @@ bool StringData::bFretting = false;
 
 StringData::StringData(int numFrets, int numStrings, int strings[])
 {
-    instrString strg = { 0, false };
+    instrString strg = { 0, false, 0 };
     _frets = numFrets;
 
     for (int i = 0; i < numStrings; i++) {
@@ -44,6 +44,15 @@ StringData::StringData(int numFrets, QList<instrString>& strings)
     stringTable.clear();
     foreach (instrString i, strings) {
         stringTable.append(i);
+    }
+}
+
+// called from import (musicxml/guitarpro/...)
+void StringData::set(const StringData& src)
+{
+    *this = src;
+    if (isFiveStringBanjo()) {
+        configBanjo5thString();
     }
 }
 
@@ -66,6 +75,9 @@ void StringData::read(XmlReader& e)
         } else {
             e.unknown();
         }
+    }
+    if (isFiveStringBanjo()) {
+      configBanjo5thString();
     }
 }
 
@@ -330,17 +342,35 @@ bool StringData::convertPitch(int pitch, int pitchOffset, int* string, int* fret
         return false;
     }
 
-    // look for a suitable string, starting from the highest
-    // NOTE: this assumes there are always enough frets to fill
-    // the interval between any fretted string and the next
-    for (int i = strings - 1; i >= 0; i--) {
-        instrString strg = stringTable.at(i);
-        if (pitch >= strg.pitch) {
-            if (pitch == strg.pitch || !strg.open) {
-                *string = strings - i - 1;
-            }
-            *fret   = pitch - strg.pitch;
+    if (isFiveStringBanjo()) {
+        // special case: open banjo 5th string
+        if (pitch == stringTable.at(0).pitch) {
+            *string = 4;
+            *fret = 0;
             return true;
+        }
+        // test remaining 4 strings from highest to lowest
+        for (int i = 4; i > 0; i--) {
+            instrString strg = stringTable.at(i);
+            if (pitch >= strg.pitch) {
+                *string = strings - i - 1;
+                *fret = pitch - strg.pitch;
+                return true;
+            }
+        }
+    } else {
+        // look for a suitable string, starting from the highest
+        // NOTE: this assumes there are always enough frets to fill
+        // the interval between any fretted string and the next
+        for (int i = strings - 1; i >= 0; i--) {
+            instrString strg = stringTable.at(i);
+            if (pitch >= strg.pitch) {
+                if (pitch == strg.pitch || !strg.open) {
+                    *string = strings - i - 1;
+                }
+                *fret = pitch - strg.pitch;
+                return true;
+            }
         }
     }
 
@@ -365,7 +395,11 @@ int StringData::getPitch(int string, int fret, int pitchOffset) const
         return INVALID_PITCH;
     }
     instrString strg = stringTable.at(strings - string - 1);
-    return strg.pitch - pitchOffset + (strg.open ? 0 : fret);
+    int pitch = strg.pitch - pitchOffset + (strg.open ? 0 : fret);
+    if (strg.startFret > 0 && fret >= strg.startFret) {
+        pitch -= strg.startFret; // banjo 5th string adjustment
+    }
+    return pitch;
 }
 
 //---------------------------------------------------------
@@ -387,9 +421,14 @@ int StringData::fret(int pitch, int string, int pitchOffset) const
 
     pitch += pitchOffset;
 
-    int fret = pitch - stringTable[strings - string - 1].pitch;
-    // fret number is invalid or string cannot be fretted
-    if (fret < 0 || fret >= _frets || (fret > 0 && stringTable[strings - string - 1].open)) {
+    const instrString& strg = stringTable[strings - string - 1];
+    int fret = pitch - strg.pitch;
+    if (fret > 0 && strg.startFret > 0) {
+        fret += strg.startFret;  // banjo 5th string adjustment
+    }
+
+   // fret number is invalid or string cannot be fretted
+    if (fret < 0 || fret >= _frets || (fret > 0 && strg.open)) {
         return FRET_NONE;
     }
     return fret;
@@ -426,6 +465,52 @@ void StringData::sortChordNotes(QMap<int, Note*>& sortedNotes, const Chord* chor
         sortedNotes.insert(key, note);
         (*count)++;
     }
+}
+
+//---------------------------------------------------------
+//   configBanjo5thString
+//   Assumes isFiveStringBanjo() has already been called.
+//   This method looks at the banjo tuning and sets startFret 
+//   appropriately.
+//---------------------------------------------------------
+
+void StringData::configBanjo5thString()
+{
+    // banjo 5th string (pitch 67 == G)
+    instrString& strg5 = stringTable[0];
+
+    _frets = 24; // not needed after bug #316931 is fixed
+
+    // adjust startFret if using a 5th string capo (6..12)
+    if (strg5.pitch > 67 && strg5.pitch < 74) {
+        strg5.startFret = strg5.pitch - 62;
+    } else {
+        strg5.startFret = 5;  // no 5th string capo
+    }
+}
+
+//---------------------------------------------------------
+//   adjustBanjo5thFret
+//   Convert 5th string fret number from (0, 1, 2, 3...) to (0, 6, 7, 8...).
+//   Called from import (GuitarPro mostly)
+//   Returns adjusted fret number
+//---------------------------------------------------------
+
+int StringData::adjustBanjo5thFret(int fret) const
+{
+    return (fret > 0 && isFiveStringBanjo()) ? fret + stringTable[0].startFret : fret;
+}
+
+//---------------------------------------------------------
+//    isFiveStringBanjo
+//    Based only on number of strings and tuning - other info
+//    may not be available when this is called. Checks 5th string
+//    pitch is higher than 4th (i.e. not a 5 string bass)
+//---------------------------------------------------------
+
+bool StringData::isFiveStringBanjo() const
+{
+    return stringTable.size() == 5 && stringTable[0].pitch > stringTable[1].pitch;
 }
 
 #if 0

--- a/src/libmscore/stringdata.h
+++ b/src/libmscore/stringdata.h
@@ -25,8 +25,10 @@ class Note;
 
 // defines the string of an instrument
 struct instrString {
+    instrString(int p = 0, bool o = false, int s = 0) : pitch(p), open(o), startFret(s) {};
     int pitch;          // the pitch of the string
     bool open;          // true: string is open | false: string is fretted
+    int  startFret;     // banjo 5th string starts on 5th fret
 
     bool operator==(const instrString& d) const { return d.pitch == pitch && d.open == open; }
 };
@@ -49,6 +51,7 @@ public:
     StringData() {}
     StringData(int numFrets, int numStrings, int strings[]);
     StringData(int numFrets, QList<instrString>& strings);
+    void        set(const StringData& src);
     bool        convertPitch(int pitch, Staff* staff, const Fraction& tick, int* string, int* fret) const;
     int         fret(int pitch, int string, Staff* staff, const Fraction& tick) const;
     void        fretChords(Chord* chord) const;
@@ -64,6 +67,9 @@ public:
     void        write(XmlWriter&) const;
     void        writeMusicXML(XmlWriter& xml) const;
     bool operator==(const StringData& d) const { return d._frets == _frets && d.stringTable == stringTable; }
+    void        configBanjo5thString();
+    int         adjustBanjo5thFret(int fret) const;
+    bool        isFiveStringBanjo() const;
 };
 }     // namespace Ms
 #endif

--- a/src/libmscore/stringdata.h
+++ b/src/libmscore/stringdata.h
@@ -25,8 +25,11 @@ class Note;
 
 // defines the string of an instrument
 struct instrString {
+    instrString(int p = 0, bool o = false, int s = 0) 
+        : pitch(p), open(o), startFret(s) {};
     int pitch;          // the pitch of the string
     bool open;          // true: string is open | false: string is fretted
+    int startFret;      // banjo 5th string starts on 5th fret
 
     bool operator==(const instrString& d) const { return d.pitch == pitch && d.open == open; }
 };
@@ -49,6 +52,7 @@ public:
     StringData() {}
     StringData(int numFrets, int numStrings, int strings[]);
     StringData(int numFrets, QList<instrString>& strings);
+    void        set(const StringData& src);
     bool        convertPitch(int pitch, Staff* staff, const Fraction& tick, int* string, int* fret) const;
     int         fret(int pitch, int string, Staff* staff, const Fraction& tick) const;
     void        fretChords(Chord* chord) const;
@@ -64,6 +68,9 @@ public:
     void        write(XmlWriter&) const;
     void        writeMusicXML(XmlWriter& xml) const;
     bool operator==(const StringData& d) const { return d._frets == _frets && d.stringTable == stringTable; }
+    void        configBanjo5thString();
+    int         adjustBanjo5thFret(int fret) const;
+    bool        isFiveStringBanjo() const;
 };
 }     // namespace Ms
 #endif

--- a/src/libmscore/stringdata.h
+++ b/src/libmscore/stringdata.h
@@ -25,10 +25,8 @@ class Note;
 
 // defines the string of an instrument
 struct instrString {
-    instrString(int p = 0, bool o = false, int s = 0) : pitch(p), open(o), startFret(s) {};
     int pitch;          // the pitch of the string
     bool open;          // true: string is open | false: string is fretted
-    int  startFret;     // banjo 5th string starts on 5th fret
 
     bool operator==(const instrString& d) const { return d.pitch == pitch && d.open == open; }
 };
@@ -51,7 +49,6 @@ public:
     StringData() {}
     StringData(int numFrets, int numStrings, int strings[]);
     StringData(int numFrets, QList<instrString>& strings);
-    void        set(const StringData& src);
     bool        convertPitch(int pitch, Staff* staff, const Fraction& tick, int* string, int* fret) const;
     int         fret(int pitch, int string, Staff* staff, const Fraction& tick) const;
     void        fretChords(Chord* chord) const;
@@ -67,9 +64,6 @@ public:
     void        write(XmlWriter&) const;
     void        writeMusicXML(XmlWriter& xml) const;
     bool operator==(const StringData& d) const { return d._frets == _frets && d.stringTable == stringTable; }
-    void        configBanjo5thString();
-    int         adjustBanjo5thFret(int fret) const;
-    bool        isFiveStringBanjo() const;
 };
 }     // namespace Ms
 #endif


### PR DESCRIPTION
The banjo 5th string starts at the 5th fret, so valid fret
numbers are 0,6,7,8... Musescore displays 0,1,2,3...

This fix requires no UI changes and no file format changes.

Resolves: 316896

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://musescore.org/en/cla)
- x[ ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x ] I made sure the code compiles on my machine
- [x ] I made sure there are no unnecessary changes in the code
- [x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
