### PR TITLE
[MU3] Fix #317264 - instruments window staves column doesn't show changed part names

### DIFF
--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -426,7 +426,7 @@ PartListItem::PartListItem(Part* p, QTreeWidget* lv)
       part = p;
       it   = 0;
       op   = ListItemOp::KEEP;
-      _name = QString(p->instrument()->trackName());
+      _name = QString(p->partName().isEmpty() ? p->instrument()->trackName() : p->partName());
       setSoloist(false); //TODO, must be taken from part.
       setFlags(flags() | Qt::ItemIsUserCheckable);
       }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/317264

<code>PartListItem::PartListItem(Part* p, QTreeWidget* lv)</code> now takes the part name for the name, as it used to be, instead of the instrument name. Unless the instrument name is an empty string, in which case the part name is used.

**NOTE  1**
This is a <code>3.x</code> only PR and **not** required for <code>master</code> because this issue doesn't apply to <code>master</code>. 

**NOTE 2**
PR #7571 implements preventing an empty string in the instrument list for <code>master</code>.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
