### PR TITLE
Fix #317631: Deleting all text in edit mode breaks Undo

### DIFF
--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -135,6 +135,7 @@ void TextBase::endEdit(EditData& ed)
             // command. Text shouldn't happen to be empty in other cases though.
             Q_ASSERT(newlyAdded || textWasEdited);
 
+            setXmlText(ted->oldXmlText);    // reset text to value before editing
             undo->reopen();
             score()->undoRemoveElement(this);
             ed.element = 0;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/317631.

If all text is deleted from a text element, the element itself is deleted. In order for undo to restore the text that was deleted, we must reset the element's text to what it was before editing, just prior to removing the element.