### PR TITLE
[MU4] Ported #7001 : fix #313420 [MusicXML] Instrument brackets are all imp…

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -896,8 +896,7 @@ Score::FileError MusicXMLParserPass1::parse(QIODevice* device)
     dumpPageSize(_pageSize);
     dumpCredits(_credits);
     // Create the measures
-    createMeasuresAndVboxes(_score, _measureLength, _measureStart, _systemStartMeasureNrs, _pageStartMeasureNrs,
-                            _credits, _pageSize);
+    createMeasuresAndVboxes(_score, _measureLength, _measureStart, _systemStartMeasureNrs, _pageStartMeasureNrs, _credits, _pageSize);
 
     return res;
 }
@@ -1031,10 +1030,9 @@ void MusicXMLParserPass1::scorePartwise()
         // add bracket and set the span
         // TODO: use group-symbol default-x to determine horizontal order of brackets
         Staff* staff = il.at(pg->start)->staff(0);
-        if (pg->type == BracketType::NO_BRACKET) {
-            staff->setBracketType(0, BracketType::NO_BRACKET);
-        } else {
-            staff->addBracket(new BracketItem(staff->score(), pg->type, stavesSpan));
+        if (pg->type != BracketType::NO_BRACKET) {
+            staff->setBracketType(pg->column, pg->type);
+            staff->setBracketSpan(pg->column, stavesSpan);
         }
         if (pg->barlineSpan) {
             staff->setBarLineSpan(pg->span);
@@ -1045,7 +1043,9 @@ void MusicXMLParserPass1::scorePartwise()
     // multi-staff parts w/o explicit brackets get a brace
     foreach (Part const* const p, il) {
         if (p->nstaves() > 1 && !partSet.contains(p)) {
-            p->staff(0)->addBracket(new BracketItem(p->score(), BracketType::BRACE, p->nstaves()));
+            const int column = p->staff(0)->bracketLevels() + 1;
+            p->staff(0)->setBracketType(column, BracketType::BRACE);
+            p->staff(0)->setBracketSpan(column, p->nstaves());
             if (allStaffGroupsIdentical(p)) {
                 // span only if the same types
                 p->staff(0)->setBarLineSpan(p->nstaves());
@@ -1687,6 +1687,7 @@ static void partGroupStart(MusicXmlPartGroupMap& pgs, int n, int p, QString s, b
     pg->start = p;
     pg->barlineSpan = barlineSpan,
     pg->type = bracketType;
+    pg->column = n;
     pgs[n] = pg;
 }
 

--- a/src/importexport/musicxml/internal/musicxml/musicxml.h
+++ b/src/importexport/musicxml/internal/musicxml/musicxml.h
@@ -42,6 +42,7 @@ struct MusicXmlPartGroup {
     int start;
     BracketType type;
     bool barlineSpan;
+    int column;
 };
 
 const int MAX_LYRICS       = 16;


### PR DESCRIPTION
Ported #7001 : fix #313420 [MusicXML] Instrument brackets are all imported at column 0

