### PR TITLE
Fix debugging within Xcode

### DIFF
--- a/Makefile.osx
+++ b/Makefile.osx
@@ -62,7 +62,8 @@ debug:
 xcode:
 	mkdir build.xcode;              \
     cd build.xcode;                                  \
-    cmake -DCMAKE_INSTALL_PREFIX=../build.xcode/main/Debug -DCMAKE_BUILD_TYPE=DEBUG \
+    cmake -DCMAKE_INSTALL_PREFIX=../build.xcode/src/main/Debug -DCMAKE_BUILD_TYPE=DEBUG \
+          -DBUILD_TELEMETRY_MODULE=OFF \
           -DCMAKE_BUILD_NUMBER="${BUILD_NUMBER}"  \
           .. -G Xcode;                         \
     xcodebuild -project ${XCODEPROJ} -target lrelease;


### PR DESCRIPTION
The target for the `mscore` scheme in Xcode is located at `build.xcode/src/main/Debug/mscore.app`. So for the `mscore` scheme to be of any use for debugging, this is where the `install` scheme should install all of the needed resources.

The existence of the `crashpad_handler` executable in `mscore.app` causes CodeSign issues with a subsequent incremental build. Attempting to set `BUILD_CRASHPAD_CLIENT` to `OFF` when generating the Xcode project did not have the desired effect, so the whole telemetry module is disabled instead.

This only relates to the master branch, because in 3.x the `install` scheme installs to the same location as the `mscore` target, and there is no `crashpad_handler` executable in `mscore.app` to cause CodeSign issues.