### PR TITLE
[MU4] Ported #6560 : add extended fermata symbols to MusicXML I/O

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -1823,20 +1823,18 @@ static void fermata(const Fermata* const a, XmlWriter& xml)
     SymId id = a->symId();
     if (id == SymId::fermataAbove || id == SymId::fermataBelow) {
         xml.tagE(tagName);
-    }
-    // MusicXML does not support the very short fermata nor short fermata (Henze),
-    // export as short fermata (better than not exporting at all)
-    else if (id == SymId::fermataShortAbove || id == SymId::fermataShortBelow
-             || id == SymId::fermataShortHenzeAbove || id == SymId::fermataShortHenzeBelow
-             || id == SymId::fermataVeryShortAbove || id == SymId::fermataVeryShortBelow) {
+    } else if (id == SymId::fermataShortAbove || id == SymId::fermataShortBelow) {
         xml.tag(tagName, "angled");
-    }
-    // MusicXML does not support the very long fermata  nor long fermata (Henze),
-    // export as long fermata (better than not exporting at all)
-    else if (id == SymId::fermataLongAbove || id == SymId::fermataLongBelow
-             || id == SymId::fermataLongHenzeAbove || id == SymId::fermataLongHenzeBelow
-             || id == SymId::fermataVeryLongAbove || id == SymId::fermataVeryLongBelow) {
+    } else if (id == SymId::fermataLongAbove || id == SymId::fermataLongBelow) {
         xml.tag(tagName, "square");
+    } else if (id == SymId::fermataVeryShortAbove || id == SymId::fermataVeryShortBelow) {
+        xml.tag(tagName, "double-angled");
+    } else if (id == SymId::fermataVeryLongAbove || id == SymId::fermataVeryLongBelow) {
+        xml.tag(tagName, "double-square");
+    } else if (id == SymId::fermataLongHenzeAbove || id == SymId::fermataLongHenzeBelow) {
+        xml.tag(tagName, "double-dot");
+    } else if (id == SymId::fermataShortHenzeAbove || id == SymId::fermataShortHenzeBelow) {
+        xml.tag(tagName, "half-curve");
     } else {
         qDebug("unknown fermata sim id %d", static_cast<int>(id));
     }

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -6435,6 +6435,14 @@ void MusicXMLParserNotations::fermata()
         notation.setSymId(SymId::fermataShortAbove);
     } else if (fermataText == "square") {
         notation.setSymId(SymId::fermataLongAbove);
+    } else if (fermataText == "double-angled") {
+        notation.setSymId(SymId::fermataVeryShortAbove);
+    } else if (fermataText == "double-square") {
+        notation.setSymId(SymId::fermataVeryLongAbove);
+    } else if (fermataText == "double-dot") {
+        notation.setSymId(SymId::fermataLongHenzeAbove);
+    } else if (fermataText == "half-curve") {
+        notation.setSymId(SymId::fermataShortHenzeAbove);
     }
 
     if (notation.symId() != SymId::noSym) {


### PR DESCRIPTION
Ported #6560 : add extended fermata symbols to MusicXML I/O