### PR TITLE
Fix #317747: Measure number appears after edit in first measure after section break with intervening frame

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -4981,8 +4981,8 @@ void Score::doLayoutRange(const Fraction& st, const Fraction& et)
             else {
                   const MeasureBase* mb = lc.nextMeasure->prev();
                   if (mb)
-                        mb->findPotentialSectionBreak();
-                  LayoutBreak* sectionBreak = mb->sectionBreakElement();
+                        mb = mb->findPotentialSectionBreak();
+                  LayoutBreak* sectionBreak = mb ? mb->sectionBreakElement() : nullptr;
                   // TODO: also use mb in else clause here?
                   // probably not, only actual measures have meaningful numbers
                   if (sectionBreak && sectionBreak->startWithMeasureOne())


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/317747.

This was just a simple case of forgetting to update `mb` with the result of `mb->findPotentialSectionBreak()`.