### PR TITLE
[MU4] Port of PR #7544 to master.

### DIFF
--- a/src/instruments/view/instrumentpaneltreemodel.cpp
+++ b/src/instruments/view/instrumentpaneltreemodel.cpp
@@ -568,7 +568,7 @@ AbstractInstrumentPanelTreeItem* InstrumentPanelTreeModel::buildPartItem(const P
 void InstrumentPanelTreeModel::updatePartItem(PartTreeItem* item, const Part* part)
 {
     item->setId(part->id());
-    item->setTitle(part->partName());
+    item->setTitle(part->partName().isEmpty() ? part->instrument()->name() : part->partName());
     item->setIsVisible(part->show());
     item->setInstrumentId(part->instrumentId());
     item->setInstrumentName(part->instrument()->name());


### PR DESCRIPTION
Prevents empty part name. If name part is empty the instrument panel will show the instrument name instead of an empty string.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
