### PR TITLE
Bring back style options for Measure Repeats introduced in PR #6365

### DIFF
--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -143,13 +143,12 @@ EditStyle::EditStyle(QWidget* parent)
         { StyleId::frameSystemDistance,     false, frameSystemDistance,     resetFrameSystemDistance },
         { StyleId::minMeasureWidth,         false, minMeasureWidth_2,       resetMinMeasureWidth },
         { StyleId::measureSpacing,          false, measureSpacing,          resetMeasureSpacing },
-        // TODO !!! See https://github.com/musescore/MuseScore/pull/6365
-//        { StyleId::measureRepeatNumberPos,  false, measureRepeatNumberPos,  resetMeasureRepeatNumberPos },
-//        { StyleId::mrNumberSeries,          false, mrNumberSeries,          0 },
-//        { StyleId::mrNumberEveryXMeasures,  false, mrNumberEveryXMeasures,  resetMRNumberEveryXMeasures },
-//        { StyleId::mrNumberSeriesWithParentheses, false, mrNumberSeriesWithParentheses, resetMRNumberSeriesWithParentheses },
-//        { StyleId::oneMeasureRepeatShow1,   false, oneMeasureRepeatShow1,   resetOneMeasureRepeatShow1 },
-//        { StyleId::fourMeasureRepeatShowExtenders, false, fourMeasureRepeatShowExtenders, resetFourMeasureRepeatShowExtenders },
+        { StyleId::measureRepeatNumberPos,  false, measureRepeatNumberPos,  resetMeasureRepeatNumberPos },
+        { StyleId::mrNumberSeries,          false, mrNumberSeries,          0 },
+        { StyleId::mrNumberEveryXMeasures,  false, mrNumberEveryXMeasures,  resetMRNumberEveryXMeasures },
+        { StyleId::mrNumberSeriesWithParentheses, false, mrNumberSeriesWithParentheses, resetMRNumberSeriesWithParentheses },
+        { StyleId::oneMeasureRepeatShow1,   false, oneMeasureRepeatShow1,   resetOneMeasureRepeatShow1 },
+        { StyleId::fourMeasureRepeatShowExtenders, false, fourMeasureRepeatShowExtenders, resetFourMeasureRepeatShowExtenders },
 
         { StyleId::barWidth,                false, barWidth,                resetBarWidth },
         { StyleId::endBarWidth,             false, endBarWidth,             resetEndBarWidth },
@@ -988,9 +987,8 @@ EditStylePage EditStyle::pageForElement(Element* e)
     case ElementType::REST:
     case ElementType::MMREST:
         return &EditStyle::PageRests;
-// TODO !!!
-//    case ElementType::MEASURE_REPEAT:
-//        return &EditStyle:PageMeasureRepeats;
+    case ElementType::MEASURE_REPEAT:
+        return &EditStyle::PageMeasureRepeats;
     case ElementType::BEAM:
         return &EditStyle::PageBeams;
     case ElementType::TUPLET:

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -100,6 +100,11 @@
       </item>
       <item>
        <property name="text">
+        <string>Measure Repeats</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
         <string>Beams</string>
        </property>
       </item>
@@ -263,29 +268,16 @@
                 <height>696</height>
                </rect>
               </property>
-              <layout class="QVBoxLayout" name="verticalLayout_8">
+              <layout class="QVBoxLayout" name="verticalLayout_10">
                <item>
                 <layout class="QGridLayout" name="gridLayout">
-                 <item row="1" column="0">
-                  <widget class="QLabel" name="label_4">
+                 <item row="0" column="0">
+                  <widget class="QLabel" name="label_musicalSymbolFont">
                    <property name="text">
-                    <string>Musical text font:</string>
+                    <string>Musical symbols font:</string>
                    </property>
                    <property name="buddy">
-                    <cstring>musicalTextFont</cstring>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="2">
-                  <widget class="QCheckBox" name="optimizeStyleCheckbox">
-                   <property name="toolTip">
-                    <string>MuseScore will change the style to suit the font better</string>
-                   </property>
-                   <property name="text">
-                    <string>Automatically load style settings based on font</string>
-                   </property>
-                   <property name="checked">
-                    <bool>true</bool>
+                    <cstring>musicalSymbolFont</cstring>
                    </property>
                   </widget>
                  </item>
@@ -329,6 +321,42 @@
                    </item>
                   </widget>
                  </item>
+                 <item row="0" column="2">
+                  <widget class="QCheckBox" name="optimizeStyleCheckbox">
+                   <property name="toolTip">
+                    <string>MuseScore will change the style to suit the font better</string>
+                   </property>
+                   <property name="text">
+                    <string>Automatically load style settings based on font</string>
+                   </property>
+                   <property name="checked">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="3">
+                  <spacer name="horizontalSpacer_2">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>0</width>
+                     <height>0</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item row="1" column="0">
+                  <widget class="QLabel" name="label_musicalTextFont">
+                   <property name="text">
+                    <string>Musical text font:</string>
+                   </property>
+                   <property name="buddy">
+                    <cstring>musicalTextFont</cstring>
+                   </property>
+                  </widget>
+                 </item>
                  <item row="1" column="1">
                   <widget class="QComboBox" name="musicalTextFont">
                    <item>
@@ -363,28 +391,45 @@
                    </item>
                   </widget>
                  </item>
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="label_63">
+                 <item row="2" column="0">
+                  <widget class="QLabel" name="label_staffLineWidth">
                    <property name="text">
-                    <string>Musical symbols font:</string>
+                    <string>Staff line thickness:</string>
+                   </property>
+                   <property name="wordWrap">
+                    <bool>false</bool>
                    </property>
                    <property name="buddy">
-                    <cstring>musicalSymbolFont</cstring>
+                    <cstring>staffLineWidth</cstring>
                    </property>
                   </widget>
                  </item>
-                 <item row="0" column="3">
-                  <spacer name="horizontalSpacer_2">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                 <item row="2" column="1">
+                  <widget class="QDoubleSpinBox" name="staffLineWidth">
+                   <property name="suffix">
+                    <string extracomment="spatium unit">sp</string>
                    </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>0</width>
-                     <height>0</height>
-                    </size>
+                   <property name="singleStep">
+                    <double>0.100000000000000</double>
                    </property>
-                  </spacer>
+                  </widget>
+                 </item>
+                 <item row="2" column="2">
+                  <widget class="QToolButton" name="resetStaffLineWidth">
+                   <property name="toolTip">
+                    <string>Reset to default</string>
+                   </property>
+                   <property name="accessibleName">
+                    <string>Reset 'Staff line thickness' value</string>
+                   </property>
+                   <property name="text">
+                    <string notr="true"/>
+                   </property>
+                   <property name="icon">
+                    <iconset>
+                     <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                   </property>
+                  </widget>
                  </item>
                 </layout>
                </item>
@@ -3904,144 +3949,10 @@ By default, they will be placed such as that their right end are at the same lev
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_56">
-               <item row="17" column="2">
-                <widget class="QToolButton" name="resetKeyBarlineDistance">
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Key to barline distance' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                 <property name="icon">
-                  <iconset>
-                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-                 </property>
-                </widget>
-               </item>
-               <item row="11" column="1">
-                <widget class="QDoubleSpinBox" name="clefBarlineDistance">
-                 <property name="suffix">
-                  <string extracomment="spatium unit">sp</string>
-                 </property>
-                 <property name="singleStep">
-                  <double>0.010000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="28" column="2">
-                <widget class="QToolButton" name="resetStaffLineWidth">
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Staff line thickness' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                 <property name="icon">
-                  <iconset>
-                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QDoubleSpinBox" name="measureSpacing">
-                 <property name="decimals">
-                  <number>3</number>
-                 </property>
-                 <property name="minimum">
-                  <double>1.000000000000000</double>
-                 </property>
-                 <property name="singleStep">
-                  <double>0.100000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="7" column="0">
-                <widget class="QLabel" name="label_61">
-                 <property name="text">
-                  <string>Barline to grace note distance:</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>barGraceDistance</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="24" column="1">
-                <widget class="QDoubleSpinBox" name="systemHeaderTimeSigDistance">
-                 <property name="suffix">
-                  <string extracomment="spatium unit">sp</string>
-                 </property>
-                 <property name="singleStep">
-                  <double>0.100000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="0">
-                <widget class="QLabel" name="label_89">
-                 <property name="text">
-                  <string>Minimum measure width:</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>minMeasureWidth_2</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="22" column="0" colspan="3">
-                <widget class="Line" name="line_14">
+               <item row="15" column="0" colspan="3">
+                <widget class="Line" name="line_12">
                  <property name="orientation">
                   <enum>Qt::Horizontal</enum>
-                 </property>
-                </widget>
-               </item>
-               <item row="28" column="0">
-                <widget class="QLabel" name="label">
-                 <property name="text">
-                  <string>Staff line thickness:</string>
-                 </property>
-                 <property name="wordWrap">
-                  <bool>false</bool>
-                 </property>
-                 <property name="buddy">
-                  <cstring>staffLineWidth</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="2">
-                <widget class="QToolButton" name="resetBarNoteDistance">
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Note left margin' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                 <property name="icon">
-                  <iconset>
-                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-                 </property>
-                </widget>
-               </item>
-               <item row="6" column="0" colspan="3">
-                <widget class="Line" name="line_10">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                </widget>
-               </item>
-               <item row="24" column="0">
-                <widget class="QLabel" name="label_112">
-                 <property name="text">
-                  <string>System header with time signature distance:</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>systemHeaderTimeSigDistance</cstring>
                  </property>
                 </widget>
                </item>
@@ -4068,57 +3979,13 @@ By default, they will be placed such as that their right end are at the same lev
                  </property>
                 </widget>
                </item>
-               <item row="8" column="1">
-                <widget class="QDoubleSpinBox" name="barAccidentalDistance">
-                 <property name="suffix">
-                  <string>sp</string>
-                 </property>
-                 <property name="singleStep">
-                  <double>0.100000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="2">
-                <widget class="QToolButton" name="resetMeasureSpacing">
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Spacing' value</string>
-                 </property>
+               <item row="24" column="0">
+                <widget class="QLabel" name="label_112">
                  <property name="text">
-                  <string notr="true"/>
-                 </property>
-                 <property name="icon">
-                  <iconset>
-                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-                 </property>
-                </widget>
-               </item>
-               <item row="5" column="0">
-                <widget class="QLabel" name="label_13">
-                 <property name="text">
-                  <string>Note to barline distance:</string>
+                  <string>System header with time signature distance:</string>
                  </property>
                  <property name="buddy">
-                  <cstring>noteBarDistance</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="23" column="2">
-                <widget class="QToolButton" name="resetSystemHeaderDistance">
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'System header distance' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                 <property name="icon">
-                  <iconset>
-                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                  <cstring>systemHeaderTimeSigDistance</cstring>
                  </property>
                 </widget>
                </item>
@@ -4132,77 +3999,13 @@ By default, they will be placed such as that their right end are at the same lev
                  </property>
                 </widget>
                </item>
-               <item row="28" column="1">
-                <widget class="QDoubleSpinBox" name="staffLineWidth">
-                 <property name="suffix">
-                  <string extracomment="spatium unit">sp</string>
-                 </property>
-                 <property name="singleStep">
-                  <double>0.100000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <widget class="QLabel" name="label_11">
-                 <property name="text">
-                  <string>Spacing (1=tight):</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>measureSpacing</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="24" column="2">
-                <widget class="QToolButton" name="resetSystemHeaderTimeSigDistance">
+               <item row="3" column="2">
+                <widget class="QToolButton" name="resetMinNoteDistance">
                  <property name="toolTip">
                   <string>Reset to default</string>
                  </property>
                  <property name="accessibleName">
-                  <string>Reset 'System header with time signature distance' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                 <property name="icon">
-                  <iconset>
-                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="1">
-                <widget class="QDoubleSpinBox" name="barNoteDistance">
-                 <property name="suffix">
-                  <string>sp</string>
-                 </property>
-                 <property name="singleStep">
-                  <double>0.100000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="10" column="2">
-                <widget class="QToolButton" name="resetClefLeftMargin">
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Clef left margin' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                 <property name="icon">
-                  <iconset>
-                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="2">
-                <widget class="QToolButton" name="resetMinMeasureWidth">
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Minimum measure width' value</string>
+                  <string>Reset 'Minimum note distance' value</string>
                  </property>
                  <property name="text">
                   <string notr="true"/>
@@ -4233,23 +4036,97 @@ By default, they will be placed such as that their right end are at the same lev
                  </property>
                 </widget>
                </item>
-               <item row="21" column="1">
-                <widget class="QDoubleSpinBox" name="timesigBarlineDistance">
+               <item row="22" column="0" colspan="3">
+                <widget class="Line" name="line_14">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="label_12">
+                 <property name="text">
+                  <string>Note left margin:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>barNoteDistance</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item row="24" column="1">
+                <widget class="QDoubleSpinBox" name="systemHeaderTimeSigDistance">
                  <property name="suffix">
-                  <string>sp</string>
+                  <string extracomment="spatium unit">sp</string>
                  </property>
                  <property name="singleStep">
                   <double>0.100000000000000</double>
                  </property>
                 </widget>
                </item>
-               <item row="23" column="1">
-                <widget class="QDoubleSpinBox" name="systemHeaderDistance">
+               <item row="27" column="0">
+                <spacer name="verticalSpacer_11">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="16" column="2">
+                <widget class="QToolButton" name="resetKeysigLeftMargin">
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Key signature left margin' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                 <property name="icon">
+                  <iconset>
+                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="1">
+                <widget class="QDoubleSpinBox" name="clefBarlineDistance">
                  <property name="suffix">
                   <string extracomment="spatium unit">sp</string>
                  </property>
                  <property name="singleStep">
-                  <double>0.100000000000000</double>
+                  <double>0.010000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="0">
+                <widget class="QLabel" name="label_108">
+                 <property name="text">
+                  <string>Clef to time signature distance:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>clefTimesigDistance</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="2">
+                <widget class="QToolButton" name="resetClefTimesigDistance">
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Clef to time signature distance' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                 <property name="icon">
+                  <iconset>
+                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
                  </property>
                 </widget>
                </item>
@@ -4260,33 +4137,6 @@ By default, they will be placed such as that their right end are at the same lev
                  </property>
                  <property name="singleStep">
                   <double>0.100000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="18" column="0">
-                <widget class="QLabel" name="label_109">
-                 <property name="text">
-                  <string>Key to time signature distance:</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>keyTimesigDistance</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="20" column="2">
-                <widget class="QToolButton" name="resetTimesigLeftMargin">
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Time signature left margin' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                 <property name="icon">
-                  <iconset>
-                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
                  </property>
                 </widget>
                </item>
@@ -4310,13 +4160,303 @@ By default, they will be placed such as that their right end are at the same lev
                  </property>
                 </widget>
                </item>
-               <item row="3" column="2">
-                <widget class="QToolButton" name="resetMinNoteDistance">
+               <item row="19" column="0" colspan="3">
+                <widget class="Line" name="line_13">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="label_11">
+                 <property name="text">
+                  <string>Spacing (1=tight):</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>measureSpacing</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item row="16" column="1">
+                <widget class="QDoubleSpinBox" name="keysigLeftMargin">
+                 <property name="suffix">
+                  <string>sp</string>
+                 </property>
+                 <property name="singleStep">
+                  <double>0.100000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="18" column="2">
+                <widget class="QToolButton" name="resetKeyTimesigDistance">
                  <property name="toolTip">
                   <string>Reset to default</string>
                  </property>
                  <property name="accessibleName">
-                  <string>Reset 'Minimum note distance' value</string>
+                  <string>Reset 'Key to time signature distance' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                 <property name="icon">
+                  <iconset>
+                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                 </property>
+                </widget>
+               </item>
+               <item row="17" column="0">
+                <widget class="QLabel" name="label_110">
+                 <property name="text">
+                  <string>Key to barline distance:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>keyBarlineDistance</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item row="21" column="0">
+                <widget class="QLabel" name="label_113">
+                 <property name="text">
+                  <string>Time signature to barline distance:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>timesigBarlineDistance</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0" colspan="3">
+                <widget class="Line" name="line_10">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                </widget>
+               </item>
+               <item row="17" column="2">
+                <widget class="QToolButton" name="resetKeyBarlineDistance">
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Key to barline distance' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                 <property name="icon">
+                  <iconset>
+                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="label_61">
+                 <property name="text">
+                  <string>Barline to grace note distance:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>barGraceDistance</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="2">
+                <widget class="QToolButton" name="resetNoteBarDistance">
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Note to barline distance' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                 <property name="icon">
+                  <iconset>
+                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="1">
+                <widget class="QDoubleSpinBox" name="clefLeftMargin">
+                 <property name="suffix">
+                  <string>sp</string>
+                 </property>
+                 <property name="singleStep">
+                  <double>0.100000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="18" column="0">
+                <widget class="QLabel" name="label_109">
+                 <property name="text">
+                  <string>Key to time signature distance:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>keyTimesigDistance</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QDoubleSpinBox" name="barNoteDistance">
+                 <property name="suffix">
+                  <string>sp</string>
+                 </property>
+                 <property name="singleStep">
+                  <double>0.100000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="2">
+                <widget class="QToolButton" name="resetClefKeyRightMargin">
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Clef/Key right margin' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                 <property name="icon">
+                  <iconset>
+                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="0">
+                <widget class="QLabel" name="label_18">
+                 <property name="text">
+                  <string>Clef left margin:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>clefLeftMargin</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item row="18" column="1">
+                <widget class="QDoubleSpinBox" name="keyTimesigDistance">
+                 <property name="suffix">
+                  <string extracomment="spatium unit">sp</string>
+                 </property>
+                 <property name="singleStep">
+                  <double>0.010000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
+                <widget class="QToolButton" name="resetMinMeasureWidth">
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Minimum measure width' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                 <property name="icon">
+                  <iconset>
+                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="2">
+                <widget class="QToolButton" name="resetClefKeyDistance">
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Clef to key distance' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                 <property name="icon">
+                  <iconset>
+                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                 </property>
+                </widget>
+               </item>
+               <item row="23" column="0">
+                <widget class="QLabel" name="label_111">
+                 <property name="text">
+                  <string>System header distance:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>systemHeaderDistance</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="1">
+                <widget class="QDoubleSpinBox" name="barAccidentalDistance">
+                 <property name="suffix">
+                  <string>sp</string>
+                 </property>
+                 <property name="singleStep">
+                  <double>0.100000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="0">
+                <widget class="QLabel" name="label_94">
+                 <property name="text">
+                  <string>Clef to key distance:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>clefKeyDistance</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item row="16" column="0">
+                <widget class="QLabel" name="label_19">
+                 <property name="text">
+                  <string>Key signature left margin:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>keysigLeftMargin</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="2">
+                <widget class="QToolButton" name="resetBarGraceDistance">
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Barline to grace note distance' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                 <property name="icon">
+                  <iconset>
+                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="2">
+                <widget class="QToolButton" name="resetClefBarlineDistance">
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Clef to barline distance' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                 <property name="icon">
+                  <iconset>
+                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="2">
+                <widget class="QToolButton" name="resetMeasureSpacing">
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Spacing' value</string>
                  </property>
                  <property name="text">
                   <string notr="true"/>
@@ -4344,23 +4484,13 @@ By default, they will be placed such as that their right end are at the same lev
                  </property>
                 </widget>
                </item>
-               <item row="14" column="1">
-                <widget class="QDoubleSpinBox" name="clefTimesigDistance">
-                 <property name="suffix">
-                  <string extracomment="spatium unit">sp</string>
-                 </property>
-                 <property name="singleStep">
-                  <double>0.010000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="13" column="2">
-                <widget class="QToolButton" name="resetClefKeyDistance">
+               <item row="20" column="2">
+                <widget class="QToolButton" name="resetTimesigLeftMargin">
                  <property name="toolTip">
                   <string>Reset to default</string>
                  </property>
                  <property name="accessibleName">
-                  <string>Reset 'Clef to key distance' value</string>
+                  <string>Reset 'Time signature left margin' value</string>
                  </property>
                  <property name="text">
                   <string notr="true"/>
@@ -4371,13 +4501,47 @@ By default, they will be placed such as that their right end are at the same lev
                  </property>
                 </widget>
                </item>
-               <item row="3" column="0">
-                <widget class="QLabel" name="label_14">
+               <item row="0" column="0">
+                <widget class="QLabel" name="label_89">
                  <property name="text">
-                  <string>Minimum note distance:</string>
+                  <string>Minimum measure width:</string>
                  </property>
                  <property name="buddy">
-                  <cstring>minNoteDistance</cstring>
+                  <cstring>minMeasureWidth_2</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="2">
+                <widget class="QToolButton" name="resetClefLeftMargin">
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Clef left margin' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                 <property name="icon">
+                  <iconset>
+                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="1">
+                <widget class="QDoubleSpinBox" name="clefTimesigDistance">
+                 <property name="suffix">
+                  <string extracomment="spatium unit">sp</string>
+                 </property>
+                 <property name="singleStep">
+                  <double>0.010000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="0" colspan="3">
+                <widget class="Line" name="line_11">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
                  </property>
                 </widget>
                </item>
@@ -4391,23 +4555,13 @@ By default, they will be placed such as that their right end are at the same lev
                  </property>
                 </widget>
                </item>
-               <item row="18" column="1">
-                <widget class="QDoubleSpinBox" name="keyTimesigDistance">
-                 <property name="suffix">
-                  <string extracomment="spatium unit">sp</string>
-                 </property>
-                 <property name="singleStep">
-                  <double>0.010000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="18" column="2">
-                <widget class="QToolButton" name="resetKeyTimesigDistance">
+               <item row="23" column="2">
+                <widget class="QToolButton" name="resetSystemHeaderDistance">
                  <property name="toolTip">
                   <string>Reset to default</string>
                  </property>
                  <property name="accessibleName">
-                  <string>Reset 'Key to time signature distance' value</string>
+                  <string>Reset 'System header distance' value</string>
                  </property>
                  <property name="text">
                   <string notr="true"/>
@@ -4428,137 +4582,6 @@ By default, they will be placed such as that their right end are at the same lev
                  </property>
                 </widget>
                </item>
-               <item row="12" column="2">
-                <widget class="QToolButton" name="resetClefKeyRightMargin">
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Clef/Key right margin' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                 <property name="icon">
-                  <iconset>
-                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-                 </property>
-                </widget>
-               </item>
-               <item row="17" column="0">
-                <widget class="QLabel" name="label_110">
-                 <property name="text">
-                  <string>Key to barline distance:</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>keyBarlineDistance</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="12" column="0">
-                <widget class="QLabel" name="label_21">
-                 <property name="text">
-                  <string>Clef/Key right margin:</string>
-                 </property>
-                 <property name="textFormat">
-                  <enum>Qt::PlainText</enum>
-                 </property>
-                 <property name="buddy">
-                  <cstring>clefKeyRightMargin</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="10" column="1">
-                <widget class="QDoubleSpinBox" name="clefLeftMargin">
-                 <property name="suffix">
-                  <string>sp</string>
-                 </property>
-                 <property name="singleStep">
-                  <double>0.100000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="16" column="0">
-                <widget class="QLabel" name="label_19">
-                 <property name="text">
-                  <string>Key signature left margin:</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>keysigLeftMargin</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="13" column="0">
-                <widget class="QLabel" name="label_94">
-                 <property name="text">
-                  <string>Clef to key distance:</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>clefKeyDistance</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="16" column="1">
-                <widget class="QDoubleSpinBox" name="keysigLeftMargin">
-                 <property name="suffix">
-                  <string>sp</string>
-                 </property>
-                 <property name="singleStep">
-                  <double>0.100000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="14" column="2">
-                <widget class="QToolButton" name="resetClefTimesigDistance">
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Clef to time signature distance' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                 <property name="icon">
-                  <iconset>
-                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-                 </property>
-                </widget>
-               </item>
-               <item row="7" column="2">
-                <widget class="QToolButton" name="resetBarGraceDistance">
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Barline to grace note distance' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                 <property name="icon">
-                  <iconset>
-                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-                 </property>
-                </widget>
-               </item>
-               <item row="11" column="0">
-                <widget class="QLabel" name="label_53">
-                 <property name="text">
-                  <string>Clef to barline distance:</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>clefBarlineDistance</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="0" colspan="3">
-                <widget class="Line" name="line_9">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                </widget>
-               </item>
                <item row="8" column="2">
                 <widget class="QToolButton" name="resetBarAccidentalDistance">
                  <property name="toolTip">
@@ -4576,6 +4599,52 @@ By default, they will be placed such as that their right end are at the same lev
                  </property>
                 </widget>
                </item>
+               <item row="1" column="1">
+                <widget class="QDoubleSpinBox" name="measureSpacing">
+                 <property name="decimals">
+                  <number>3</number>
+                 </property>
+                 <property name="minimum">
+                  <double>1.000000000000000</double>
+                 </property>
+                 <property name="singleStep">
+                  <double>0.100000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="label_14">
+                 <property name="text">
+                  <string>Minimum note distance:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>minNoteDistance</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="0">
+                <widget class="QLabel" name="label_21">
+                 <property name="text">
+                  <string>Clef/Key right margin:</string>
+                 </property>
+                 <property name="textFormat">
+                  <enum>Qt::PlainText</enum>
+                 </property>
+                 <property name="buddy">
+                  <cstring>clefKeyRightMargin</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="0">
+                <widget class="QLabel" name="label_53">
+                 <property name="text">
+                  <string>Clef to barline distance:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>clefBarlineDistance</cstring>
+                 </property>
+                </widget>
+               </item>
                <item row="13" column="1">
                 <widget class="QDoubleSpinBox" name="clefKeyDistance">
                  <property name="suffix">
@@ -4586,40 +4655,33 @@ By default, they will be placed such as that their right end are at the same lev
                  </property>
                 </widget>
                </item>
-               <item row="4" column="0">
-                <widget class="QLabel" name="label_12">
-                 <property name="text">
-                  <string>Note left margin:</string>
+               <item row="21" column="1">
+                <widget class="QDoubleSpinBox" name="timesigBarlineDistance">
+                 <property name="suffix">
+                  <string>sp</string>
                  </property>
-                 <property name="buddy">
-                  <cstring>barNoteDistance</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="19" column="0" colspan="3">
-                <widget class="Line" name="line_13">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                 <property name="singleStep">
+                  <double>0.100000000000000</double>
                  </property>
                 </widget>
                </item>
-               <item row="21" column="0">
-                <widget class="QLabel" name="label_113">
-                 <property name="text">
-                  <string>Time signature to barline distance:</string>
+               <item row="23" column="1">
+                <widget class="QDoubleSpinBox" name="systemHeaderDistance">
+                 <property name="suffix">
+                  <string extracomment="spatium unit">sp</string>
                  </property>
-                 <property name="buddy">
-                  <cstring>timesigBarlineDistance</cstring>
+                 <property name="singleStep">
+                  <double>0.100000000000000</double>
                  </property>
                 </widget>
                </item>
-               <item row="16" column="2">
-                <widget class="QToolButton" name="resetKeysigLeftMargin">
+               <item row="24" column="2">
+                <widget class="QToolButton" name="resetSystemHeaderTimeSigDistance">
                  <property name="toolTip">
                   <string>Reset to default</string>
                  </property>
                  <property name="accessibleName">
-                  <string>Reset 'Key signature left margin' value</string>
+                  <string>Reset 'System header with time signature distance' value</string>
                  </property>
                  <property name="text">
                   <string notr="true"/>
@@ -4630,40 +4692,30 @@ By default, they will be placed such as that their right end are at the same lev
                  </property>
                 </widget>
                </item>
-               <item row="25" column="0" colspan="3">
-                <widget class="Line" name="line_15">
+               <item row="5" column="0">
+                <widget class="QLabel" name="label_13">
+                 <property name="text">
+                  <string>Note to barline distance:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>noteBarDistance</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0" colspan="3">
+                <widget class="Line" name="line_9">
                  <property name="orientation">
                   <enum>Qt::Horizontal</enum>
                  </property>
                 </widget>
                </item>
-               <item row="14" column="0">
-                <widget class="QLabel" name="label_108">
-                 <property name="text">
-                  <string>Clef to time signature distance:</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>clefTimesigDistance</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="10" column="0">
-                <widget class="QLabel" name="label_18">
-                 <property name="text">
-                  <string>Clef left margin:</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>clefLeftMargin</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="5" column="2">
-                <widget class="QToolButton" name="resetNoteBarDistance">
+               <item row="4" column="2">
+                <widget class="QToolButton" name="resetBarNoteDistance">
                  <property name="toolTip">
                   <string>Reset to default</string>
                  </property>
                  <property name="accessibleName">
-                  <string>Reset 'Note to barline distance' value</string>
+                  <string>Reset 'Note left margin' value</string>
                  </property>
                  <property name="text">
                   <string notr="true"/>
@@ -4673,54 +4725,6 @@ By default, they will be placed such as that their right end are at the same lev
                    <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
                  </property>
                 </widget>
-               </item>
-               <item row="9" column="0" colspan="3">
-                <widget class="Line" name="line_11">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                </widget>
-               </item>
-               <item row="23" column="0">
-                <widget class="QLabel" name="label_111">
-                 <property name="text">
-                  <string>System header distance:</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>systemHeaderDistance</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="15" column="0" colspan="3">
-                <widget class="Line" name="line_12">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                </widget>
-               </item>
-               <item row="11" column="2">
-                <widget class="QToolButton" name="resetClefBarlineDistance">
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Clef to barline distance' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                 <property name="icon">
-                  <iconset>
-                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-                 </property>
-                </widget>
-               </item>
-               <item row="29" column="0">
-                <spacer name="verticalSpacer_11">
-                 <property name="orientation">
-                  <enum>Qt::Vertical</enum>
-                 </property>
-                </spacer>
                </item>
               </layout>
              </widget>
@@ -5777,6 +5781,196 @@ By default, they will be placed such as that their right end are at the same lev
            <size>
             <width>20</width>
             <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="PageMeasureRepeats">
+       <layout class="QGridLayout" name="gridLayout_58">
+        <item row="0" column="0">
+         <widget class="QGroupBox" name="groupBox_2">
+          <property name="title">
+           <string>Measure Repeats</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_52">
+           <item row="3" column="0" colspan="2">
+            <widget class="QCheckBox" name="fourMeasureRepeatShowExtenders">
+             <property name="text">
+              <string>Show extenders on 4-measure repeats</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="3">
+            <spacer name="horizontalSpacer_25">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="4" column="0" colspan="3">
+            <widget class="QGroupBox" name="mrNumberSeries">
+             <property name="title">
+              <string>Number consecutive measure repeats</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_53">
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_163">
+                <property name="text">
+                 <string>Every</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QSpinBox" name="mrNumberEveryXMeasures">
+                <property name="minimum">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <number>10</number>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="QLabel" name="label_170">
+                <property name="text">
+                 <string>measures</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="3">
+               <spacer name="horizontalSpacer_7">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>64</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="1" column="5">
+               <widget class="QToolButton" name="resetMRNumberSeriesWithParentheses">
+                <property name="text">
+                 <string>...</string>
+                </property>
+                <property name="icon">
+                 <iconset>
+                  <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="5">
+               <widget class="QToolButton" name="resetMRNumberEveryXMeasures">
+                <property name="text">
+                 <string>...</string>
+                </property>
+                <property name="icon">
+                 <iconset>
+                  <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0" colspan="4">
+               <widget class="QCheckBox" name="mrNumberSeriesWithParentheses">
+                <property name="text">
+                 <string>With parentheses</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item row="3" column="2">
+            <widget class="QToolButton" name="resetFourMeasureRepeatShowExtenders">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Time signature to barline distance' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset>
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_148">
+             <property name="text">
+              <string>Number position:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0" colspan="2">
+            <widget class="QCheckBox" name="oneMeasureRepeatShow1">
+             <property name="text">
+              <string>Show &quot;1&quot; on 1-measure repeats</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QDoubleSpinBox" name="measureRepeatNumberPos">
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="minimum">
+              <double>-99.989999999999995</double>
+             </property>
+             <property name="singleStep">
+              <double>0.500000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="2">
+            <widget class="QToolButton" name="resetMeasureRepeatNumberPos">
+             <property name="text">
+              <string>...</string>
+             </property>
+             <property name="icon">
+              <iconset>
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="2">
+            <widget class="QToolButton" name="resetOneMeasureRepeatShow1">
+             <property name="text">
+              <string>...</string>
+             </property>
+             <property name="icon">
+              <iconset>
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <spacer name="verticalSpacer_36">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>0</width>
+            <height>0</height>
            </size>
           </property>
          </spacer>
@@ -12661,6 +12855,8 @@ By default, they will be placed such as that their right end are at the same lev
   <tabstop>musicalSymbolFont</tabstop>
   <tabstop>optimizeStyleCheckbox</tabstop>
   <tabstop>musicalTextFont</tabstop>
+  <tabstop>staffLineWidth</tabstop>
+  <tabstop>resetStaffLineWidth</tabstop>
   <tabstop>concertPitch</tabstop>
   <tabstop>enableIndentationOnFirstSystem</tabstop>
   <tabstop>indentationValue</tabstop>
@@ -12831,8 +13027,6 @@ By default, they will be placed such as that their right end are at the same lev
   <tabstop>resetSystemHeaderDistance</tabstop>
   <tabstop>systemHeaderTimeSigDistance</tabstop>
   <tabstop>resetSystemHeaderTimeSigDistance</tabstop>
-  <tabstop>staffLineWidth</tabstop>
-  <tabstop>resetStaffLineWidth</tabstop>
   <tabstop>showRepeatBarTips</tabstop>
   <tabstop>resetShowRepeatBarTips</tabstop>
   <tabstop>showStartBarlineSingle</tabstop>
@@ -12885,6 +13079,16 @@ By default, they will be placed such as that their right end are at the same lev
   <tabstop>resetMMRestOldStyleMaxMeasures</tabstop>
   <tabstop>mmRestOldStyleSpacing</tabstop>
   <tabstop>resetMMRestOldStyleSpacing</tabstop>
+  <tabstop>measureRepeatNumberPos</tabstop>
+  <tabstop>resetMeasureRepeatNumberPos</tabstop>
+  <tabstop>oneMeasureRepeatShow1</tabstop>
+  <tabstop>resetOneMeasureRepeatShow1</tabstop>
+  <tabstop>fourMeasureRepeatShowExtenders</tabstop>
+  <tabstop>resetFourMeasureRepeatShowExtenders</tabstop>
+  <tabstop>mrNumberSeries</tabstop>
+  <tabstop>mrNumberEveryXMeasures</tabstop>
+  <tabstop>mrNumberSeriesWithParentheses</tabstop>
+  <tabstop>resetMRNumberSeriesWithParentheses</tabstop>
   <tabstop>beamWidth</tabstop>
   <tabstop>beamDistance</tabstop>
   <tabstop>beamMinLen</tabstop>


### PR DESCRIPTION
For details, please see the comments here: https://github.com/musescore/MuseScore/pull/7462#issuecomment-779359037

The style options for Measure Repeats are back: 
<img width="948" alt="Schermafbeelding 2021-02-19 om 20 03 02" src="https://user-images.githubusercontent.com/48658420/108549474-7a52e280-72ed-11eb-94c3-0d7a1a7919db.png">

Additionally, the "staff line thickness" control was moved from the "Measure" page to the "Score" page. This was also done in PR #6365. I think that makes sense, but to be sure, is this still what we want?
<img width="978" alt="Schermafbeelding 2021-02-19 om 20 06 05" src="https://user-images.githubusercontent.com/48658420/108549759-e7667800-72ed-11eb-8215-8131a77e3cef.png">

