### PR TITLE
[MU4] Update pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ Resolves: *(direct link to the issue)*
 <!-- Use "x" to fill the checkboxes below like [x] -->
 
 - [ ] I signed [CLA](https://musescore.org/en/cla)
-- [ ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
+- [ ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
 - [ ] I made sure the code compiles on my machine
 - [ ] I made sure there are no unnecessary changes in the code
 - [ ] I made sure the title of the PR reflects the core meaning of the issue you are solving


### PR DESCRIPTION
Resolves a 404 error, apparently needed for master only (3.x has it correct, still even on 3.x PRs the  master template comes up, see #7587, probably because master is the default branch)