### PR TITLE
Set application font for Widgets to theme font

### DIFF
--- a/src/framework/ui/view/theme.cpp
+++ b/src/framework/ui/view/theme.cpp
@@ -385,6 +385,7 @@ void Theme::setupWidgetTheme()
     palette.setColor(QPalette::Disabled, QPalette::PlaceholderText, fontPrimaryColorDisabled);
 
     QApplication::setPalette(palette);
+    QApplication::setFont(bodyFont());
 
     platformTheme()->setAppThemeDark(configuration()->actualThemeType() == IUiConfiguration::ThemeType::DARK_THEME);
 }


### PR DESCRIPTION
<img width="971" alt="Schermafbeelding 2021-02-21 om 12 27 57" src="https://user-images.githubusercontent.com/48658420/108623770-fad62800-7440-11eb-9749-52773958ef9a.png">

TODO: icon buttons in widgets should have the icon font
