### PR TITLE
fix #313977: avoid adding a palette element twice on double-click

### DIFF
--- a/mscore/qml/palettes/Palette.qml
+++ b/mscore/qml/palettes/Palette.qml
@@ -691,9 +691,7 @@ GridView {
                 }
 
                 onDoubleClicked: {
-                    const index = paletteCell.modelIndex;
-                    paletteView.selectionModel.setCurrentIndex(index, ItemSelectionModel.Current);
-                    paletteView.paletteController.applyPaletteElement(index, mouse.modifiers);
+                    // Empty handler to avoid onClicked being triggered twice on double-click.
                 }
             }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/313977

The issue doesn't happen in MuseScore 3.4.2 but happens in the 3.5 version. The possible reason is that #5474 has occasionally reverted the previous commit which had fixed this issue, 77e4347f10d7c520048165f01ce0b01fce6ff9b8. This pull request returns the empty double-click handler back. Removing the handler entirely causes two `onClicked` events being triggered and results in identical elements being added as well, so we have to put an empty handler there to prevent this.