### PR TITLE
[MU4] Correct wrong creating of score by the NewScore dialog.

### DIFF
--- a/src/instruments/qml/MuseScore/Instruments/InstrumentsDialog.qml
+++ b/src/instruments/qml/MuseScore/Instruments/InstrumentsDialog.qml
@@ -62,6 +62,7 @@ QmlDialog {
                 width: buttons.buttonWidth
 
                 text: qsTrc("global", "OK")
+                enabled: instrumentsPage.hasSelectedInstruments
 
                 onClicked: {
                     var selectedInstruments = instrumentsPage.selectedInstruments()

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -169,7 +169,7 @@ mu::Ret MasterNotation::createNew(const ScoreCreateOptions& scoreOptions)
     ks.setKey(scoreOptions.key);
     Ms::VBox* nvb = nullptr;
 
-    bool pickupMeasure = scoreOptions.measureTimesigNumerator > 0 && scoreOptions.measureTimesigDenominator > 0;
+    bool pickupMeasure = scoreOptions.withPickupMeasure;
     if (pickupMeasure) {
         measures += 1;
     }

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -136,10 +136,6 @@ void NotationParts::setInstruments(const mu::instruments::InstrumentList& instru
     removeMissingInstruments(instruments);
     appendNewInstruments(instruments);
 
-    if (score()->measures()->empty()) {
-        score()->insertMeasure(ElementType::MEASURE, 0, false);
-    }
-
     sortParts(instruments);
 
     updateScore();


### PR DESCRIPTION
When creating a new score without a pick measure the score looks like:

![Screenshot_20210221_171852](https://user-images.githubusercontent.com/48352523/108631203-ec9c0200-7468-11eb-9fec-a5d9a81beeae.png)

This score shows 2 issues:
 -1) There is a pickup measure (measure 2) of 1 quarter note. This is solved in <code>MasterNotation::createNew()</code> which used a wrong check for the pick measure.

 -2) The number of measures in the score is 1 more as specified in the dialog. The is causes by creating a measure in <code>NotationParts::setInstruments()</code> when the score doesn't contain any measures.

With this PR the created score is correct:

![Screenshot_20210221_172737](https://user-images.githubusercontent.com/48352523/108631396-23264c80-746a-11eb-8ef7-0890b87f5200.png)

Or with a pickup measure:

![Screenshot_20210221_172828](https://user-images.githubusercontent.com/48352523/108631429-3afdd080-746a-11eb-9826-2ceffe67be0f.png)

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
