### PR TITLE
Correct typo "usescores" to "userscores"

### DIFF
--- a/src/userscores/internal/userscoresconfiguration.h
+++ b/src/userscores/internal/userscoresconfiguration.h
@@ -28,7 +28,7 @@
 namespace mu::userscores {
 class UserScoresConfiguration : public IUserScoresConfiguration
 {
-    INJECT(usescores, framework::IGlobalConfiguration, globalConfiguration)
+    INJECT(userscores, framework::IGlobalConfiguration, globalConfiguration)
     INJECT(userscores, extensions::IExtensionsConfiguration, extensionsConfiguration)
     INJECT(userscores, notation::INotationConfiguration, notationConfiguration)
 

--- a/src/userscores/internal/userscoresservice.h
+++ b/src/userscores/internal/userscoresservice.h
@@ -28,8 +28,8 @@
 namespace mu::userscores {
 class UserScoresService : public IUserScoresService, public async::Asyncable
 {
-    INJECT(usescores, IUserScoresConfiguration, configuration)
-    INJECT(usescores, notation::IMsczMetaReader, msczMetaReader)
+    INJECT(userscores, IUserScoresConfiguration, configuration)
+    INJECT(userscores, notation::IMsczMetaReader, msczMetaReader)
 
 public:
     void init();

--- a/src/userscores/view/recentscoresmodel.h
+++ b/src/userscores/view/recentscoresmodel.h
@@ -32,8 +32,8 @@ class RecentScoresModel : public QAbstractListModel, public async::Asyncable
 {
     Q_OBJECT
 
-    INJECT(usescores, actions::IActionsDispatcher, dispatcher)
-    INJECT(usescores, IUserScoresConfiguration, configuration)
+    INJECT(userscores, actions::IActionsDispatcher, dispatcher)
+    INJECT(userscores, IUserScoresConfiguration, configuration)
     INJECT(userscores, IUserScoresService, userScoresService)
 
 public:


### PR DESCRIPTION
Correct typo <code>usescores</code> to <code>userscores</code>.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
