### PR TITLE
[MU3] Ignore SF_VERSION (from master) in 3.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,6 @@ MuseScore_General_License.md
 MuseScore_General_Changelog.txt
 MuseScore_General_Readme.md
 VERSION
+SF_VERSION
 /mscore/data/mscore.aps
 /msvc.*


### PR DESCRIPTION
Helps when switching between master and 3.x and building those. This syncs .gitgnore from master what that from 3.x.