### PR TITLE
Fix #287598: Do not remove spanners from the measures outside of the …

### DIFF
--- a/src/libmscore/edit.cpp
+++ b/src/libmscore/edit.cpp
@@ -903,7 +903,7 @@ bool Score::rewriteMeasures(Measure* fm, Measure* lm, const Fraction& ns, int st
         Fraction tick2 = m2->endTick();
         auto spanners = s->spannerMap().findOverlapping(tick1.ticks(), tick2.ticks());
         for (auto i : spanners) {
-            if (i.value->tick() >= tick1) {
+            if (i.value->tick() >= tick1 && i.value->tick() < tick2) {
                 undo(new RemoveElement(i.value));
             }
         }


### PR DESCRIPTION
…rewrite range.

Resolves: https://musescore.org/en/node/287598

Spanners in the measure following a range of measures were deleted during a rewrite.

Port of #7359

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/Documentation/blob/master/CodeGuidelines.md)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
