### PR TITLE
[MU3] Fix #318035: Prevent (potential) crash on MusicXML import

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -821,6 +821,8 @@ static void addLyrics(MxmlLogger* logger, const QXmlStreamReader* const xmlreade
 
 static void addElemOffset(Element* el, int track, const QString& placement, Measure* measure, const Fraction& tick)
       {
+      if (!measure)
+          return;
       /*
        qDebug("addElem el %p track %d placement %s tick %d",
        el, track, qPrintable(placement), tick);
@@ -1973,6 +1975,7 @@ void MusicXMLParserPass2::measure(const QString& partId,
       if (!measure) {
             _logger->logError(QString("measure at tick %1 not found!").arg(time.ticks()), &_e);
             skipLogCurrElem();
+            return;
             }
 
       // handle implicit measure


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/318035

Prevents the crash reported in that forum topic and another potential one, by not continuing when there is no `measure` to work on.

This is for 3.x, for master see #7603  (it got merged there meanwhile)