### PR TITLE
[MU3] Fix #318034: Make Harmonium SND capable.

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -9141,7 +9141,6 @@ Aeolus organ synthesizer, currently disabled -->
                   <clef staff="2">F</clef>
                   <aPitchRange>29-89</aPitchRange>
                   <pPitchRange>29-89</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
                   <Channel>
                         <program value="20"/> <!--Reed Organ-->
                   </Channel>


### PR DESCRIPTION
Reed Organ is, and is (basically) the same instrument.

Resolves: https://musescore.org/node/318034

See discussion on Telegram too: https://t.me/musescoreeditorchat/104446

Same should go to master too, see #7607