### PR TITLE
[MU3] Disable debug output for QML palette

### DIFF
--- a/mscore/qml/palettes/Palette.qml
+++ b/mscore/qml/palettes/Palette.qml
@@ -568,10 +568,6 @@ GridView {
                 }
             }
 
-            onStateChanged: {
-                console.debug("STATE CHANGED " + state)
-            }
-
             states: [
                 // Note: if "when" is true for multiple states then
                 // the first state listed here takes precendence.


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/299600#comment-1065170

As `console.debug` output from within Plugins should still get printed even in release mode, other methods like via environment variables as [`QML_IMPORT_TRACE`](https://doc.qt.io/qt-5/qtquick-debugging.html#debugging-module-imports) or C pre-processor definitions as [`QT_DECLARATIVE_DEBUG` and `QT_QML_DEBUG`](https://doc.qt.io/qt-5/qtquick-debugging.html#enabling-the-infrastructure) can't get used here. Also this particular `console.debug` statement pretty much looks like an acient debugging artifact.

This issue seesms to not exist in the master branch, or even if, I'd a) don't see where and b) being in development, disabling it now would be to early anyhow.