### PR TITLE
[MU3] Fix missing translations

### DIFF
--- a/mscore/cloud/uploadscoredialog.cpp
+++ b/mscore/cloud/uploadscoredialog.cpp
@@ -29,7 +29,7 @@ namespace Ms {
 void MuseScore::showUploadScoreDialog()
       {
       if (MuseScore::unstable()) {
-            QMessageBox::warning(this, tr("Save online"), tr("Saving scores online is disabled in this unstable prerelease version of MuseScore."));
+            QMessageBox::warning(this, QObject::tr("Save online"), QObject::tr("Saving scores online is disabled in this unstable prerelease version of MuseScore."));
             return;
       }
       if (!currentScore())
@@ -37,7 +37,7 @@ void MuseScore::showUploadScoreDialog()
       if (!currentScore()->sanityCheck(QString())) {
             QMessageBox msgBox;
             msgBox.setWindowTitle(QObject::tr("Upload Error"));
-            msgBox.setText(tr("This score cannot be saved online. Please fix the corrupted measures and try again."));
+            msgBox.setText(QObject::tr("This score cannot be saved online. Please fix the corrupted measures and try again."));
             msgBox.setDetailedText(MScore::lastError);
             msgBox.setTextFormat(Qt::RichText);
             msgBox.setIcon(QMessageBox::Warning);


### PR DESCRIPTION
Not really sure why these strings don't show translated, but the string that has the additional `QObject::` does show translated, so adding it in those other 3 cases too should fix the issue by giving them the same context, from `MuseScore` (non-working in these cases) to `QObject` (working currently for that other string).

These strings would need to get pushed up to Transifex (for that added string in the already merged #7435 this has to happen for 3.6.3 anyhow). This would **not** affect the current translation for 3.6-3.6.2 though (the additional string from PR #7435 won't harm and the changed context for strings of this PR here won't make any difference, they's still not show translated), so could (and should) be done any time (after the merge)!
As these strings are on Transifex already and translated, but under a different context, they'd need to get translated again, most probably by just taking Transifex' recomendation, or possibly even just getting marked as reviewed again.

Not needed in master (so far).