### PR TITLE
[MU4] Used mu::draw::Painter instead QPainter

### DIFF
--- a/src/commonscene/exampleview.cpp
+++ b/src/commonscene/exampleview.cpp
@@ -161,7 +161,7 @@ Element* ExampleView::elementNear(QPointF)
     return 0;
 }
 
-void ExampleView::drawBackground(QPainter* p, const QRectF& r) const
+void ExampleView::drawBackground(mu::draw::Painter* p, const QRectF& r) const
 {
     if (_fgPixmap == 0 || _fgPixmap->isNull()) {
         p->fillRect(r, _fgColor);
@@ -175,7 +175,7 @@ void ExampleView::drawBackground(QPainter* p, const QRectF& r) const
 //   drawElements
 //---------------------------------------------------------
 
-void ExampleView::drawElements(QPainter& painter, const QList<Element*>& el)
+void ExampleView::drawElements(mu::draw::Painter& painter, const QList<Element*>& el)
 {
     for (Element* e : el) {
         e->itemDiscovered = 0;
@@ -193,9 +193,10 @@ void ExampleView::drawElements(QPainter& painter, const QList<Element*>& el)
 void ExampleView::paintEvent(QPaintEvent* ev)
 {
     if (_score) {
-        QPainter p(this);
-        p.setRenderHint(QPainter::Antialiasing, true);
-        p.setRenderHint(QPainter::TextAntialiasing, true);
+        QPainter qp(this);
+        mu::draw::Painter p(&qp);
+        p.setRenderHint(mu::draw::Painter::Antialiasing, true);
+        p.setRenderHint(mu::draw::Painter::TextAntialiasing, true);
         const QRect r(ev->rect());
 
         drawBackground(&p, r);

--- a/src/commonscene/exampleview.h
+++ b/src/commonscene/exampleview.h
@@ -57,7 +57,7 @@ class ExampleView : public QFrame, public MuseScoreView
 
     double m_defaultScaling = 0;
 
-    void drawElements(QPainter& painter, const QList<Element*>& el);
+    void drawElements(mu::draw::Painter& painter, const QList<Element*>& el);
     void setDropTarget(const Element* el) override;
 
     virtual void paintEvent(QPaintEvent*) override;
@@ -91,7 +91,7 @@ public:
     virtual void setDropRectangle(const QRectF&) override;
     virtual void cmdAddSlur(Note* firstNote, Note* lastNote);
     virtual Element* elementNear(QPointF) override;
-    virtual void drawBackground(QPainter*, const QRectF&) const override;
+    virtual void drawBackground(mu::draw::Painter*, const QRectF&) const override;
     void dragExampleView(QMouseEvent* ev);
     virtual const QRect geometry() const override { return QFrame::geometry(); }
 };

--- a/src/importexport/imagesexport/internal/pdfwriter.cpp
+++ b/src/importexport/imagesexport/internal/pdfwriter.cpp
@@ -49,14 +49,16 @@ mu::Ret PdfWriter::write(const notation::INotationPtr notation, IODevice& destin
     pdfWriter.setTitle(documentTitle(*score));
     pdfWriter.setPageMargins(QMarginsF());
 
-    QPainter painter;
-    if (!painter.begin(&pdfWriter)) {
+    QPainter qp;
+    if (!qp.begin(&pdfWriter)) {
         return false;
     }
 
+    mu::draw::Painter painter(&qp);
+
     QSizeF size(score->styleD(Sid::pageWidth), score->styleD(Sid::pageHeight));
-    painter.setRenderHint(QPainter::Antialiasing, true);
-    painter.setRenderHint(QPainter::TextAntialiasing, true);
+    painter.setRenderHint(mu::draw::Painter::Antialiasing, true);
+    painter.setRenderHint(mu::draw::Painter::TextAntialiasing, true);
     painter.setViewport(QRect(0.0, 0.0, size.width() * pdfWriter.logicalDpiX(),
                               size.height() * pdfWriter.logicalDpiY()));
     painter.setWindow(QRect(0.0, 0.0, size.width() * DPI, size.height() * DPI));

--- a/src/importexport/imagesexport/internal/pngwriter.cpp
+++ b/src/importexport/imagesexport/internal/pngwriter.cpp
@@ -77,9 +77,10 @@ mu::Ret PngWriter::write(const notation::INotationPtr notation, IODevice& destin
     double scaling = CANVAS_DPI / Ms::DPI;
     Ms::MScore::pixelRatio = 1.0 / scaling;
 
-    QPainter painter(&image);
-    painter.setRenderHint(QPainter::Antialiasing, true);
-    painter.setRenderHint(QPainter::TextAntialiasing, true);
+    QPainter qp(&image);
+    mu::draw::Painter painter(&qp);
+    painter.setRenderHint(mu::draw::Painter::Antialiasing, true);
+    painter.setRenderHint(mu::draw::Painter::TextAntialiasing, true);
     painter.scale(scaling, scaling);
     if (TRIM_MARGIN_SIZE >= 0) {
         painter.translate(-pageRect.topLeft());

--- a/src/importexport/imagesexport/internal/svgwriter.cpp
+++ b/src/importexport/imagesexport/internal/svgwriter.cpp
@@ -78,9 +78,10 @@ mu::Ret SvgWriter::write(const notation::INotationPtr notation, IODevice& destin
     printer.setSize(QSize(width, height));
     printer.setViewBox(QRectF(0, 0, width, height));
 
-    QPainter painter(&printer);
-    painter.setRenderHint(QPainter::Antialiasing, true);
-    painter.setRenderHint(QPainter::TextAntialiasing, true);
+    QPainter qp(&printer);
+    mu::draw::Painter painter(&qp);
+    painter.setRenderHint(mu::draw::Painter::Antialiasing, true);
+    painter.setRenderHint(mu::draw::Painter::TextAntialiasing, true);
     if (TRIM_MARGINS_SIZE >= 0) {
         painter.translate(-pageRect.topLeft());
     }

--- a/src/libmscore/CMakeLists.txt
+++ b/src/libmscore/CMakeLists.txt
@@ -352,6 +352,8 @@ set(MODULE_SRC
     xml.h
     xmlreader.cpp
     xmlwriter.cpp
+    draw/painter.cpp
+    draw/painter.h
     )
 
 set(MODULE_INCLUDE

--- a/src/libmscore/accidental.cpp
+++ b/src/libmscore/accidental.cpp
@@ -495,7 +495,7 @@ AccidentalType Accidental::value2subtype(AccidentalVal v)
 //   draw
 //---------------------------------------------------------
 
-void Accidental::draw(QPainter* painter) const
+void Accidental::draw(mu::draw::Painter* painter) const
 {
     // don't show accidentals for tab or slash notation
     if (onTabStaff() || (note() && note()->fixed())) {

--- a/src/libmscore/accidental.h
+++ b/src/libmscore/accidental.h
@@ -102,7 +102,7 @@ public:
     void layout() override;
     void layoutMultiGlyphAccidental();
     void layoutSingleGlyphAccidental();
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     bool isEditable() const override { return true; }
     void startEdit(EditData&) override { setGenerated(false); }
 

--- a/src/libmscore/ambitus.cpp
+++ b/src/libmscore/ambitus.cpp
@@ -463,7 +463,7 @@ void Ambitus::layout()
 //   draw
 //---------------------------------------------------------
 
-void Ambitus::draw(QPainter* p) const
+void Ambitus::draw(mu::draw::Painter* p) const
 {
     qreal _spatium = spatium();
     qreal lw = lineWidth().val() * _spatium;

--- a/src/libmscore/ambitus.h
+++ b/src/libmscore/ambitus.h
@@ -84,7 +84,7 @@ public:
     qreal headWidth() const;
 
     // re-implemented virtual functions
-    void      draw(QPainter*) const override;
+    void      draw(mu::draw::Painter*) const override;
     void      layout() override;
     QPointF   pagePos() const override;        ///< position in page coordinates
     void      read(XmlReader&) override;

--- a/src/libmscore/arpeggio.cpp
+++ b/src/libmscore/arpeggio.cpp
@@ -215,7 +215,7 @@ void Arpeggio::layout()
 //   draw
 //---------------------------------------------------------
 
-void Arpeggio::draw(QPainter* p) const
+void Arpeggio::draw(mu::draw::Painter* p) const
 {
     if (_hidden) {
         return;

--- a/src/libmscore/arpeggio.h
+++ b/src/libmscore/arpeggio.h
@@ -67,7 +67,7 @@ public:
     bool acceptDrop(EditData&) const override;
     Element* drop(EditData&) override;
     void layout() override;
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     bool isEditable() const override { return true; }
     void editDrag(EditData&) override;
     bool edit(EditData&) override;

--- a/src/libmscore/articulation.cpp
+++ b/src/libmscore/articulation.cpp
@@ -206,7 +206,7 @@ QString Articulation::userName() const
 //   Symbol::draw
 //---------------------------------------------------------
 
-void Articulation::draw(QPainter* painter) const
+void Articulation::draw(mu::draw::Painter* painter) const
 {
 #if 0 //TODO
     SymId sym = symId();

--- a/src/libmscore/articulation.h
+++ b/src/libmscore/articulation.h
@@ -82,7 +82,7 @@ class Articulation final : public Element
     MScore::OrnamentStyle _ornamentStyle;       // for use in ornaments such as trill
     bool _playArticulation;
 
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
 
     enum class AnchorGroup {
         ARTICULATION,

--- a/src/libmscore/bagpembell.cpp
+++ b/src/libmscore/bagpembell.cpp
@@ -548,7 +548,7 @@ void BagpipeEmbellishment::layout()
 //      x2,y is the other side of the top beam
 //---------------------------------------------------------
 
-static void drawBeams(QPainter* painter, const qreal spatium,
+static void drawBeams(mu::draw::Painter* painter, const qreal spatium,
                       const qreal x1, const qreal x2, qreal y)
 {
     // draw the beams
@@ -566,7 +566,7 @@ static void drawBeams(QPainter* painter, const qreal spatium,
 //      x,y2 is the bottom of the stem
 //---------------------------------------------------------
 
-void BagpipeEmbellishment::drawGraceNote(QPainter* painter,
+void BagpipeEmbellishment::drawGraceNote(mu::draw::Painter* painter,
                                          const BEDrawingDataX& dx,
                                          const BEDrawingDataY& dy,
                                          SymId flagsym, const qreal x, const bool drawFlag) const
@@ -589,7 +589,7 @@ void BagpipeEmbellishment::drawGraceNote(QPainter* painter,
 //      y = 0 is the top staff line
 //---------------------------------------------------------
 
-void BagpipeEmbellishment::draw(QPainter* painter) const
+void BagpipeEmbellishment::draw(mu::draw::Painter* painter) const
 {
     SymId headsym = SymId::noteheadBlack;
     SymId flagsym = SymId::flag32ndUp;

--- a/src/libmscore/bagpembell.h
+++ b/src/libmscore/bagpembell.h
@@ -50,7 +50,7 @@ struct BEDrawingDataY;
 class BagpipeEmbellishment final : public Element
 {
     int _embelType;
-    void drawGraceNote(QPainter*, const BEDrawingDataX&, const BEDrawingDataY&,SymId, const qreal x,const bool drawFlag) const;
+    void drawGraceNote(mu::draw::Painter*, const BEDrawingDataX&, const BEDrawingDataY&,SymId, const qreal x,const bool drawFlag) const;
 
 public:
     BagpipeEmbellishment(Score* s)
@@ -65,7 +65,7 @@ public:
     void write(XmlWriter&) const override;
     void read(XmlReader&) override;
     void layout() override;
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     static BagpipeEmbellishmentInfo BagpipeEmbellishmentList[];
     static int nEmbellishments();
     static BagpipeNoteInfo BagpipeNoteInfoList[];

--- a/src/libmscore/barline.cpp
+++ b/src/libmscore/barline.cpp
@@ -514,7 +514,7 @@ void BarLine::getY() const
 //   drawDots
 //---------------------------------------------------------
 
-void BarLine::drawDots(QPainter* painter, qreal x) const
+void BarLine::drawDots(mu::draw::Painter* painter, qreal x) const
 {
     qreal _spatium = spatium();
 
@@ -547,7 +547,7 @@ void BarLine::drawDots(QPainter* painter, qreal x) const
 //   drawTips
 //---------------------------------------------------------
 
-void BarLine::drawTips(QPainter* painter, bool reversed, qreal x) const
+void BarLine::drawTips(mu::draw::Painter* painter, bool reversed, qreal x) const
 {
     if (reversed) {
         if (isTop()) {
@@ -601,7 +601,7 @@ bool BarLine::isBottom() const
 //   draw
 //---------------------------------------------------------
 
-void BarLine::draw(QPainter* painter) const
+void BarLine::draw(mu::draw::Painter* painter) const
 {
     switch (barLineType()) {
     case BarLineType::NORMAL: {
@@ -776,7 +776,7 @@ void BarLine::draw(QPainter* painter) const
 //   drawEditMode
 //---------------------------------------------------------
 
-void BarLine::drawEditMode(QPainter* p, EditData& ed)
+void BarLine::drawEditMode(mu::draw::Painter* p, EditData& ed)
 {
     Element::drawEditMode(p, ed);
     BarLineEditData* bed = static_cast<BarLineEditData*>(ed.getData(this));

--- a/src/libmscore/barline.h
+++ b/src/libmscore/barline.h
@@ -66,11 +66,11 @@ class BarLine final : public Element
     ElementList _el;          ///< fermata or other articulations
 
     void getY() const;
-    void drawDots(QPainter* painter, qreal x) const;
-    void drawTips(QPainter* painter, bool reversed, qreal x) const;
+    void drawDots(mu::draw::Painter* painter, qreal x) const;
+    void drawTips(mu::draw::Painter* painter, bool reversed, qreal x) const;
     bool isTop() const;
     bool isBottom() const;
-    void drawEditMode(QPainter*, EditData&) override;
+    void drawEditMode(mu::draw::Painter*, EditData&) override;
 
 public:
     BarLine(Score* s = 0);
@@ -88,7 +88,7 @@ public:
     Fraction playTick() const override;
     void write(XmlWriter& xml) const override;
     void read(XmlReader&) override;
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     QPointF canvasPos() const override;      ///< position in canvas coordinates
     QPointF pagePos() const override;        ///< position in page coordinates
     void layout() override;

--- a/src/libmscore/beam.cpp
+++ b/src/libmscore/beam.cpp
@@ -215,7 +215,7 @@ void Beam::removeChordRest(ChordRest* a)
 //   draw
 //---------------------------------------------------------
 
-void Beam::draw(QPainter* painter) const
+void Beam::draw(mu::draw::Painter* painter) const
 {
     if (beamSegments.empty()) {
         return;

--- a/src/libmscore/beam.h
+++ b/src/libmscore/beam.h
@@ -126,7 +126,7 @@ public:
     void remove(Element*) override;
 
     void move(const QPointF&) override;
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
 
     bool up() const { return _up; }
     void setUp(bool v) { _up = v; }

--- a/src/libmscore/bend.cpp
+++ b/src/libmscore/bend.cpp
@@ -242,7 +242,7 @@ void Bend::layout()
 //   draw
 //---------------------------------------------------------
 
-void Bend::draw(QPainter* painter) const
+void Bend::draw(mu::draw::Painter* painter) const
 {
     qreal _spatium = spatium();
     qreal _lw = _lineWidth;

--- a/src/libmscore/bend.h
+++ b/src/libmscore/bend.h
@@ -45,7 +45,7 @@ public:
     Bend* clone() const override { return new Bend(*this); }
     ElementType type() const override { return ElementType::BEND; }
     void layout() override;
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void write(XmlWriter&) const override;
     void read(XmlReader& e) override;
     QList<PitchValue>& points() { return m_points; }

--- a/src/libmscore/box.cpp
+++ b/src/libmscore/box.cpp
@@ -88,7 +88,7 @@ void HBox::computeMinWidth()
 //   draw
 //---------------------------------------------------------
 
-void Box::draw(QPainter* painter) const
+void Box::draw(mu::draw::Painter* painter) const
 {
     if (score() && score()->printing()) {
         return;

--- a/src/libmscore/box.h
+++ b/src/libmscore/box.h
@@ -49,7 +49,7 @@ public:
 
     void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
 
-    virtual void draw(QPainter*) const override;
+    virtual void draw(mu::draw::Painter*) const override;
     virtual bool isEditable() const override { return true; }
 
     virtual void startEdit(EditData&) override;

--- a/src/libmscore/bracket.cpp
+++ b/src/libmscore/bracket.cpp
@@ -236,7 +236,7 @@ void Bracket::layout()
 //   draw
 //---------------------------------------------------------
 
-void Bracket::draw(QPainter* painter) const
+void Bracket::draw(mu::draw::Painter* painter) const
 {
     if (h2 == 0.0) {
         return;

--- a/src/libmscore/bracket.h
+++ b/src/libmscore/bracket.h
@@ -80,7 +80,7 @@ public:
 
     Shape shape() const override { return _shape; }
 
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void layout() override;
 
     void write(XmlWriter& xml) const override;

--- a/src/libmscore/breath.cpp
+++ b/src/libmscore/breath.cpp
@@ -137,7 +137,7 @@ qreal Breath::mag() const
 //   draw
 //---------------------------------------------------------
 
-void Breath::draw(QPainter* p) const
+void Breath::draw(mu::draw::Painter* p) const
 {
     p->setPen(curColor());
     drawSymbol(_symId, p);

--- a/src/libmscore/breath.h
+++ b/src/libmscore/breath.h
@@ -52,7 +52,7 @@ public:
 
     Segment* segment() const { return (Segment*)parent(); }
 
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void layout() override;
     void write(XmlWriter&) const override;
     void read(XmlReader&) override;

--- a/src/libmscore/chordline.cpp
+++ b/src/libmscore/chordline.cpp
@@ -231,7 +231,7 @@ void ChordLine::write(XmlWriter& xml) const
 //   Symbol::draw
 //---------------------------------------------------------
 
-void ChordLine::draw(QPainter* painter) const
+void ChordLine::draw(mu::draw::Painter* painter) const
 {
     qreal _spatium = spatium();
 

--- a/src/libmscore/chordline.h
+++ b/src/libmscore/chordline.h
@@ -60,7 +60,7 @@ public:
     void read(XmlReader&) override;
     void write(XmlWriter& xml) const override;
     void layout() override;
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
 
     void startEditDrag(EditData&) override;
     void editDrag(EditData&) override;

--- a/src/libmscore/clef.cpp
+++ b/src/libmscore/clef.cpp
@@ -254,7 +254,7 @@ void Clef::layout()
 //   draw
 //---------------------------------------------------------
 
-void Clef::draw(QPainter* painter) const
+void Clef::draw(mu::draw::Painter* painter) const
 {
     if (symId == SymId::noSym || (staff() && !const_cast<const Staff*>(staff())->staffType(tick())->genClef())) {
         return;

--- a/src/libmscore/clef.h
+++ b/src/libmscore/clef.h
@@ -151,7 +151,7 @@ public:
     bool acceptDrop(EditData&) const override;
     Element* drop(EditData&) override;
     void layout() override;
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void read(XmlReader&) override;
     void write(XmlWriter&) const override;
 

--- a/src/libmscore/draw/painter.cpp
+++ b/src/libmscore/draw/painter.cpp
@@ -1,0 +1,293 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2021 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#include "painter.h"
+
+using namespace mu::draw;
+
+Painter::Painter(QPainter* painter)
+    : m_painter(painter)
+{
+}
+
+QPaintDevice* Painter::device() const
+{
+    return m_painter->device();
+}
+
+QPainter* Painter::qpainter() const
+{
+    return m_painter;
+}
+
+bool Painter::begin(QPaintDevice* d)
+{
+    return m_painter->begin(d);
+}
+
+bool Painter::end()
+{
+    return m_painter->end();
+}
+
+bool Painter::isActive() const
+{
+    return m_painter->isActive();
+}
+
+void Painter::setRenderHint(RenderHint hint, bool on)
+{
+    m_painter->setRenderHint(static_cast<QPainter::RenderHint>(hint), on);
+}
+
+void Painter::setCompositionMode(QPainter::CompositionMode mode)
+{
+    m_painter->setCompositionMode(mode);
+}
+
+void Painter::setFont(const QFont& f)
+{
+    m_painter->setFont(f);
+}
+
+const QFont& Painter::font() const
+{
+    return m_painter->font();
+}
+
+void Painter::setPen(const QColor& color)
+{
+    m_painter->setPen(color);
+}
+
+void Painter::setPen(const QPen& pen)
+{
+    m_painter->setPen(pen);
+}
+
+void Painter::setPen(Qt::PenStyle style)
+{
+    m_painter->setPen(style);
+}
+
+const QPen& Painter::pen() const
+{
+    return m_painter->pen();
+}
+
+void Painter::setBrush(const QBrush& brush)
+{
+    m_painter->setBrush(brush);
+}
+
+void Painter::setBrush(Qt::BrushStyle style)
+{
+    m_painter->setBrush(style);
+}
+
+const QBrush& Painter::brush() const
+{
+    return m_painter->brush();
+}
+
+void Painter::save()
+{
+    m_painter->save();
+}
+
+void Painter::restore()
+{
+    m_painter->restore();
+}
+
+void Painter::setWorldTransform(const QTransform& matrix, bool combine)
+{
+    m_painter->setWorldTransform(matrix, combine);
+}
+
+const QTransform& Painter::worldTransform() const
+{
+    return m_painter->worldTransform();
+}
+
+void Painter::setTransform(const QTransform& transform, bool combine)
+{
+    m_painter->setTransform(transform, combine);
+}
+
+const QTransform& Painter::transform() const
+{
+    return m_painter->transform();
+}
+
+void Painter::setMatrix(const QMatrix& matrix, bool combine)
+{
+    m_painter->setMatrix(matrix, combine);
+}
+
+void Painter::scale(qreal sx, qreal sy)
+{
+    m_painter->scale(sx, sy);
+}
+
+void Painter::rotate(qreal a)
+{
+    m_painter->rotate(a);
+}
+
+void Painter::translate(const QPointF& offset)
+{
+    m_painter->translate(offset);
+}
+
+QRect Painter::window() const
+{
+    return m_painter->window();
+}
+
+void Painter::setWindow(const QRect& window)
+{
+    m_painter->setWindow(window);
+}
+
+QRect Painter::viewport() const
+{
+    return m_painter->viewport();
+}
+
+void Painter::setViewport(const QRect& viewport)
+{
+    m_painter->setViewport(viewport);
+}
+
+// drawing functions
+
+void Painter::strokePath(const QPainterPath& path, const QPen& pen)
+{
+    m_painter->strokePath(path, pen);
+}
+
+void Painter::fillPath(const QPainterPath& path, const QBrush& brush)
+{
+    m_painter->fillPath(path, brush);
+}
+
+void Painter::drawPath(const QPainterPath& path)
+{
+    m_painter->drawPath(path);
+}
+
+void Painter::drawLines(const QLineF* lines, int lineCount)
+{
+    m_painter->drawLines(lines, lineCount);
+}
+
+void Painter::drawLines(const QLine* lines, int lineCount)
+{
+    m_painter->drawLines(lines, lineCount);
+}
+
+void Painter::drawLines(const QPointF* pointPairs, int lineCount)
+{
+    m_painter->drawLines(pointPairs, lineCount);
+}
+
+void Painter::drawRects(const QRectF* rects, int rectCount)
+{
+    m_painter->drawRects(rects, rectCount);
+}
+
+void Painter::drawRects(const QRect* rects, int rectCount)
+{
+    m_painter->drawRects(rects, rectCount);
+}
+
+void Painter::drawEllipse(const QRectF& r)
+{
+    m_painter->drawEllipse(r);
+}
+
+void Painter::drawEllipse(const QRect& r)
+{
+    m_painter->drawEllipse(r);
+}
+
+void Painter::drawPolyline(const QPointF* points, int pointCount)
+{
+    m_painter->drawPolyline(points, pointCount);
+}
+
+void Painter::drawPolyline(const QPoint* points, int pointCount)
+{
+    m_painter->drawPolyline(points, pointCount);
+}
+
+void Painter::drawPolygon(const QPointF* points, int pointCount, Qt::FillRule fillRule)
+{
+    m_painter->drawPolygon(points, pointCount, fillRule);
+}
+
+void Painter::drawPolygon(const QPoint* points, int pointCount, Qt::FillRule fillRule)
+{
+    m_painter->drawPolygon(points, pointCount, fillRule);
+}
+
+void Painter::drawConvexPolygon(const QPointF* points, int pointCount)
+{
+    m_painter->drawConvexPolygon(points, pointCount);
+}
+
+void Painter::drawArc(const QRectF& rect, int a, int alen)
+{
+    m_painter->drawArc(rect, a, alen);
+}
+
+void Painter::drawRoundedRect(const QRectF& rect, qreal xRadius, qreal yRadius, Qt::SizeMode mode)
+{
+    m_painter->drawRoundedRect(rect, xRadius, yRadius, mode);
+}
+
+void Painter::drawText(const QPointF& p, const QString& s)
+{
+    m_painter->drawText(p, s);
+}
+
+void Painter::drawText(const QRectF& r, int flags, const QString& text, QRectF* br)
+{
+    m_painter->drawText(r, flags, text, br);
+}
+
+void Painter::drawGlyphRun(const QPointF& position, const QGlyphRun& glyphRun)
+{
+    m_painter->drawGlyphRun(position, glyphRun);
+}
+
+void Painter::fillRect(const QRectF& r, const QColor& color)
+{
+    m_painter->fillRect(r, color);
+}
+
+void Painter::drawPixmap(const QPointF& p, const QPixmap& pm)
+{
+    m_painter->drawPixmap(p, pm);
+}
+
+void Painter::drawTiledPixmap(const QRectF& rect, const QPixmap& pm, const QPointF& offset)
+{
+    m_painter->drawTiledPixmap(rect, pm, offset);
+}

--- a/src/libmscore/draw/painter.h
+++ b/src/libmscore/draw/painter.h
@@ -1,0 +1,304 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2021 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+#ifndef MU_DOM_PAINTER_H
+#define MU_DOM_PAINTER_H
+
+#include <QPoint>
+#include <QPointF>
+#include <QPen>
+#include <QColor>
+#include <QFont>
+#include <QPainter>
+
+class QPaintDevice;
+class QImage;
+
+namespace mu::draw {
+class Painter
+{
+public:
+    Painter(QPainter* painter);
+
+    enum RenderHint {
+        Antialiasing = 0x01,
+        TextAntialiasing = 0x02,
+        SmoothPixmapTransform = 0x04,
+        LosslessImageRendering = 0x40,
+    };
+
+    QPaintDevice* device() const;
+    QPainter* qpainter() const;
+
+    bool begin(QPaintDevice*);
+    bool end();
+    bool isActive() const;
+
+    void setRenderHint(RenderHint hint, bool on = true);
+    void setCompositionMode(QPainter::CompositionMode mode);
+
+    void setFont(const QFont& f);
+    const QFont& font() const;
+
+    void setPen(const QColor& color);
+    void setPen(const QPen& pen);
+    void setPen(Qt::PenStyle style);
+    const QPen& pen() const;
+
+    void setBrush(const QBrush& brush);
+    void setBrush(Qt::BrushStyle style);
+    const QBrush& brush() const;
+
+    void save();
+    void restore();
+
+    void setWorldTransform(const QTransform& matrix, bool combine = false);
+    const QTransform& worldTransform() const;
+
+    void setTransform(const QTransform& transform, bool combine = false);
+    const QTransform& transform() const;
+
+    void setMatrix(const QMatrix& matrix, bool combine = false);
+
+    void scale(qreal sx, qreal sy);
+    void rotate(qreal a);
+
+    void translate(const QPointF& offset);
+    inline void translate(const QPoint& offset);
+    inline void translate(qreal dx, qreal dy);
+
+    QRect window() const;
+    void setWindow(const QRect& window);
+    inline void setWindow(int x, int y, int w, int h);
+
+    QRect viewport() const;
+    void setViewport(const QRect& viewport);
+    inline void setViewport(int x, int y, int w, int h);
+
+    // drawing functions
+    void strokePath(const QPainterPath& path, const QPen& pen);
+    void fillPath(const QPainterPath& path, const QBrush& brush);
+    void drawPath(const QPainterPath& path);
+
+    inline void drawLine(const QLineF& line);
+    inline void drawLine(const QPointF& p1, const QPointF& p2);
+    inline void drawLine(int x1, int y1, int x2, int y2);
+
+    void drawLines(const QLineF* lines, int lineCount);
+    inline void drawLines(const QVector<QLineF>& lines);
+    void drawLines(const QLine* lines, int lineCount);
+    void drawLines(const QPointF* pointPairs, int lineCount);
+
+    inline void drawRect(const QRectF& rect);
+    inline void drawRect(int x1, int y1, int w, int h);
+    inline void drawRect(const QRect& rect);
+
+    void drawRects(const QRectF* rects, int rectCount);
+    inline void drawRects(const QVector<QRectF>& rectangles);
+    void drawRects(const QRect* rects, int rectCount);
+    inline void drawRects(const QVector<QRect>& rectangles);
+
+    void drawRoundedRect(const QRectF& rect, qreal xRadius, qreal yRadius, Qt::SizeMode mode = Qt::AbsoluteSize);
+    inline void drawRoundedRect(int x, int y, int w, int h, qreal xRadius, qreal yRadius, Qt::SizeMode mode = Qt::AbsoluteSize);
+    inline void drawRoundedRect(const QRect& rect, qreal xRadius, qreal yRadius, Qt::SizeMode mode = Qt::AbsoluteSize);
+
+    void drawEllipse(const QRectF& r);
+    void drawEllipse(const QRect& r);
+    inline void drawEllipse(int x, int y, int w, int h);
+    inline void drawEllipse(const QPointF& center, qreal rx, qreal ry);
+    inline void drawEllipse(const QPoint& center, int rx, int ry);
+
+    void drawPolyline(const QPointF* points, int pointCount);
+    inline void drawPolyline(const QPolygonF& polyline);
+    void drawPolyline(const QPoint* points, int pointCount);
+    inline void drawPolyline(const QPolygon& polygon);
+
+    void drawPolygon(const QPointF* points, int pointCount, Qt::FillRule fillRule = Qt::OddEvenFill);
+    inline void drawPolygon(const QPolygonF& polygon, Qt::FillRule fillRule = Qt::OddEvenFill);
+    void drawPolygon(const QPoint* points, int pointCount, Qt::FillRule fillRule = Qt::OddEvenFill);
+    inline void drawPolygon(const QPolygon& polygon, Qt::FillRule fillRule = Qt::OddEvenFill);
+
+    void drawConvexPolygon(const QPointF* points, int pointCount);
+    inline void drawConvexPolygon(const QPolygonF& polygon);
+
+    void drawArc(const QRectF& rect, int a, int alen);
+    inline void drawArc(const QRect&, int a, int alen);
+    inline void drawArc(int x, int y, int w, int h, int a, int alen);
+
+    void drawText(const QPointF& p, const QString& s);
+    void drawText(const QRectF& r, int flags, const QString& text, QRectF* br = nullptr);
+    inline void drawText(const QPoint& p, const QString& s);
+    inline void drawText(int x, int y, const QString& s);
+
+    void drawGlyphRun(const QPointF& position, const QGlyphRun& glyphRun);
+
+    void fillRect(const QRectF& r, const QColor& color);
+
+    void drawPixmap(const QPointF& p, const QPixmap& pm);
+    inline void drawPixmap(int x, int y, const QPixmap& pm);
+
+    void drawTiledPixmap(const QRectF& rect, const QPixmap& pm, const QPointF& offset = QPointF());
+
+private:
+    QPainter* m_painter = nullptr;
+};
+
+inline void Painter::translate(qreal dx, qreal dy)
+{
+    translate(QPointF(dx, dy));
+}
+
+inline void Painter::translate(const QPoint& offset)
+{
+    translate(offset.x(), offset.y());
+}
+
+inline void Painter::setViewport(int x, int y, int w, int h)
+{
+    setViewport(QRect(x, y, w, h));
+}
+
+inline void Painter::setWindow(int x, int y, int w, int h)
+{
+    setWindow(QRect(x, y, w, h));
+}
+
+inline void Painter::drawLine(const QLineF& l)
+{
+    drawLines(&l, 1);
+}
+
+inline void Painter::drawLine(const QPointF& p1, const QPointF& p2)
+{
+    drawLine(QLineF(p1, p2));
+}
+
+inline void Painter::drawLine(int x1, int y1, int x2, int y2)
+{
+    QLine l(x1, y1, x2, y2);
+    drawLines(&l, 1);
+}
+
+inline void Painter::drawLines(const QVector<QLineF>& lines)
+{
+    drawLines(lines.constData(), lines.size());
+}
+
+inline void Painter::drawRect(const QRectF& rect)
+{
+    drawRects(&rect, 1);
+}
+
+inline void Painter::drawRect(int x, int y, int w, int h)
+{
+    QRect r(x, y, w, h);
+    drawRects(&r, 1);
+}
+
+inline void Painter::drawRect(const QRect& r)
+{
+    drawRects(&r, 1);
+}
+
+inline void Painter::drawRects(const QVector<QRectF>& rects)
+{
+    drawRects(rects.constData(), rects.size());
+}
+
+inline void Painter::drawRects(const QVector<QRect>& rects)
+{
+    drawRects(rects.constData(), rects.size());
+}
+
+inline void Painter::drawRoundedRect(int x, int y, int w, int h, qreal xRadius, qreal yRadius, Qt::SizeMode mode)
+{
+    drawRoundedRect(QRectF(x, y, w, h), xRadius, yRadius, mode);
+}
+
+inline void Painter::drawRoundedRect(const QRect& rect, qreal xRadius, qreal yRadius, Qt::SizeMode mode)
+{
+    drawRoundedRect(QRectF(rect), xRadius, yRadius, mode);
+}
+
+inline void Painter::drawEllipse(int x, int y, int w, int h)
+{
+    drawEllipse(QRect(x, y, w, h));
+}
+
+inline void Painter::drawEllipse(const QPointF& center, qreal rx, qreal ry)
+{
+    drawEllipse(QRectF(center.x() - rx, center.y() - ry, 2 * rx, 2 * ry));
+}
+
+inline void Painter::drawEllipse(const QPoint& center, int rx, int ry)
+{
+    drawEllipse(QRect(center.x() - rx, center.y() - ry, 2 * rx, 2 * ry));
+}
+
+inline void Painter::drawPolyline(const QPolygonF& polyline)
+{
+    drawPolyline(polyline.constData(), polyline.size());
+}
+
+inline void Painter::drawPolyline(const QPolygon& polyline)
+{
+    drawPolyline(polyline.constData(), polyline.size());
+}
+
+inline void Painter::drawPolygon(const QPolygonF& polygon, Qt::FillRule fillRule)
+{
+    drawPolygon(polygon.constData(), polygon.size(), fillRule);
+}
+
+inline void Painter::drawPolygon(const QPolygon& polygon, Qt::FillRule fillRule)
+{
+    drawPolygon(polygon.constData(), polygon.size(), fillRule);
+}
+
+inline void Painter::drawConvexPolygon(const QPolygonF& poly)
+{
+    drawConvexPolygon(poly.constData(), poly.size());
+}
+
+inline void Painter::drawArc(const QRect& r, int a, int alen)
+{
+    drawArc(QRectF(r), a, alen);
+}
+
+inline void Painter::drawArc(int x, int y, int w, int h, int a, int alen)
+{
+    drawArc(QRectF(x, y, w, h), a, alen);
+}
+
+inline void Painter::drawText(const QPoint& p, const QString& s)
+{
+    drawText(QPointF(p), s);
+}
+
+inline void Painter::drawText(int x, int y, const QString& s)
+{
+    drawText(QPointF(x, y), s);
+}
+
+inline void Painter::drawPixmap(int x, int y, const QPixmap& pm)
+{
+    drawPixmap(QPointF(x, y), pm);
+}
+}
+
+#endif // MU_DOM_PAINTER_H

--- a/src/libmscore/element.cpp
+++ b/src/libmscore/element.cpp
@@ -956,7 +956,7 @@ Compound::Compound(const Compound& c)
 //   draw
 //---------------------------------------------------------
 
-void Compound::draw(QPainter* painter) const
+void Compound::draw(mu::draw::Painter* painter) const
 {
     foreach (Element* e, elements) {
         QPointF pt(e->pos());
@@ -1315,7 +1315,7 @@ void collectElements(void* data, Element* e)
     el->append(e);
 }
 
-void paintElement(QPainter& painter, const Element* element)
+void paintElement(mu::draw::Painter& painter, const Element* element)
 {
     element->itemDiscovered = false;
     QPointF elementPosition(element->pagePos());
@@ -1325,7 +1325,7 @@ void paintElement(QPainter& painter, const Element* element)
     painter.translate(-elementPosition);
 }
 
-void paintElements(QPainter& painter, const QList<Element*>& elements)
+void paintElements(mu::draw::Painter& painter, const QList<Element*>& elements)
 {
     QList<Ms::Element*> sortedElements = elements;
 
@@ -1701,22 +1701,22 @@ void Element::undoSetVisible(bool v)
 //   drawSymbol
 //---------------------------------------------------------
 
-void Element::drawSymbol(SymId id, QPainter* p, const QPointF& o, qreal scale) const
+void Element::drawSymbol(SymId id, mu::draw::Painter* p, const QPointF& o, qreal scale) const
 {
     score()->scoreFont()->draw(id, p, magS() * scale, o);
 }
 
-void Element::drawSymbol(SymId id, QPainter* p, const QPointF& o, int n) const
+void Element::drawSymbol(SymId id, mu::draw::Painter* p, const QPointF& o, int n) const
 {
     score()->scoreFont()->draw(id, p, magS(), o, n);
 }
 
-void Element::drawSymbols(const std::vector<SymId>& s, QPainter* p, const QPointF& o, qreal scale) const
+void Element::drawSymbols(const std::vector<SymId>& s, mu::draw::Painter* p, const QPointF& o, qreal scale) const
 {
     score()->scoreFont()->draw(s, p, magS() * scale, o);
 }
 
-void Element::drawSymbols(const std::vector<SymId>& s, QPainter* p, const QPointF& o, const QSizeF& scale) const
+void Element::drawSymbols(const std::vector<SymId>& s, mu::draw::Painter* p, const QPointF& o, const QSizeF& scale) const
 {
     score()->scoreFont()->draw(s, p, magS() * scale, o);
 }
@@ -2109,7 +2109,7 @@ void EditData::addData(ElementEditData* ed)
 //   drawEditMode
 //---------------------------------------------------------
 
-void Element::drawEditMode(QPainter* p, EditData& ed)
+void Element::drawEditMode(mu::draw::Painter* p, EditData& ed)
 {
     QPen pen(MScore::defaultColor, 0.0);
     p->setPen(pen);

--- a/src/libmscore/element.h
+++ b/src/libmscore/element.h
@@ -21,6 +21,8 @@
 #include "sig.h"
 #include "sym.h"
 
+#include "draw/painter.h"
+
 namespace Ms {
 #ifdef Q_OS_MAC
 #define CONTROL_MODIFIER Qt::AltModifier
@@ -325,8 +327,8 @@ public:
 
     virtual int subtype() const { return -1; }                    // for select gui
 
-    virtual void draw(QPainter*) const {}
-    void drawAt(QPainter* p, const QPointF& pt) const { p->translate(pt); draw(p); p->translate(-pt); }
+    virtual void draw(mu::draw::Painter*) const {}
+    void drawAt(mu::draw::Painter* p, const QPointF& pt) const { p->translate(pt); draw(p); p->translate(-pt); }
 
     virtual void writeProperties(XmlWriter& xml) const;
     virtual bool readProperties(XmlReader&);
@@ -510,10 +512,10 @@ public:
     bool custom(Pid) const;
     virtual bool isUserModified() const;
 
-    void drawSymbol(SymId id, QPainter* p, const QPointF& o = QPointF(), qreal scale = 1.0) const;
-    void drawSymbol(SymId id, QPainter* p, const QPointF& o, int n) const;
-    void drawSymbols(const std::vector<SymId>&, QPainter* p, const QPointF& o = QPointF(), qreal scale = 1.0) const;
-    void drawSymbols(const std::vector<SymId>&, QPainter* p, const QPointF& o, const QSizeF& scale) const;
+    void drawSymbol(SymId id, mu::draw::Painter* p, const QPointF& o = QPointF(), qreal scale = 1.0) const;
+    void drawSymbol(SymId id, mu::draw::Painter* p, const QPointF& o, int n) const;
+    void drawSymbols(const std::vector<SymId>&, mu::draw::Painter* p, const QPointF& o = QPointF(), qreal scale = 1.0) const;
+    void drawSymbols(const std::vector<SymId>&, mu::draw::Painter* p, const QPointF& o, const QSizeF& scale) const;
     qreal symHeight(SymId id) const;
     qreal symWidth(SymId id) const;
     qreal symWidth(const std::vector<SymId>&) const;
@@ -545,7 +547,7 @@ public:
 
     virtual void triggerLayout() const;
     virtual void triggerLayoutAll() const;
-    virtual void drawEditMode(QPainter*, EditData&);
+    virtual void drawEditMode(mu::draw::Painter*, EditData&);
 
     void autoplaceSegmentElement(bool above, bool add);          // helper functions
     void autoplaceMeasureElement(bool above, bool add);
@@ -626,7 +628,7 @@ public:
     Compound(Score*);
     Compound(const Compound&);
 
-    virtual void draw(QPainter*) const;
+    virtual void draw(mu::draw::Painter*) const;
     virtual void addElement(Element*, qreal x, qreal y);
     void clear();
     virtual void setSelected(bool f);
@@ -637,8 +639,8 @@ public:
 extern bool elementLessThan(const Element* const, const Element* const);
 extern void collectElements(void* data, Element* e);
 
-extern void paintElement(QPainter& painter, const Element* element);
-extern void paintElements(QPainter& painter, const QList<Element*>& elements);
+extern void paintElement(mu::draw::Painter& painter, const Element* element);
+extern void paintElements(mu::draw::Painter& painter, const QList<Element*>& elements);
 }     // namespace Ms
 
 Q_DECLARE_METATYPE(Ms::ElementType);

--- a/src/libmscore/fermata.cpp
+++ b/src/libmscore/fermata.cpp
@@ -144,7 +144,7 @@ QString Fermata::userName() const
 //   Symbol::draw
 //---------------------------------------------------------
 
-void Fermata::draw(QPainter* painter) const
+void Fermata::draw(mu::draw::Painter* painter) const
 {
 #if 0
     SymId sym = symId();

--- a/src/libmscore/fermata.h
+++ b/src/libmscore/fermata.h
@@ -34,7 +34,7 @@ class Fermata final : public Element
     qreal _timeStretch;
     bool _play;
 
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     Sid getPropertyStyle(Pid) const override;
 
 public:

--- a/src/libmscore/figuredbass.cpp
+++ b/src/libmscore/figuredbass.cpp
@@ -601,7 +601,7 @@ void FiguredBassItem::layout()
 //   FiguredBassItem draw()
 //---------------------------------------------------------
 
-void FiguredBassItem::draw(QPainter* painter) const
+void FiguredBassItem::draw(mu::draw::Painter* painter) const
 {
     int font = 0;
     qreal _spatium = spatium();
@@ -1329,7 +1329,7 @@ void FiguredBass::layoutLines()
 //   draw
 //---------------------------------------------------------
 
-void FiguredBass::draw(QPainter* painter) const
+void FiguredBass::draw(mu::draw::Painter* painter) const
 {
     // if not printing, draw duration line(s)
     if (!score()->printing() && score()->showUnprintable()) {

--- a/src/libmscore/figuredbass.h
+++ b/src/libmscore/figuredbass.h
@@ -154,7 +154,7 @@ public:
     // standard re-implemented virtual functions
     FiguredBassItem* clone() const override { return new FiguredBassItem(*this); }
     ElementType       type() const override { return ElementType::INVALID; }
-    void              draw(QPainter* painter) const override;
+    void              draw(mu::draw::Painter* painter) const override;
     void              layout() override;
     void              read(XmlReader&) override;
     void              write(XmlWriter& xml) const override;
@@ -258,7 +258,7 @@ public:
     // standard re-implemented virtual functions
     FiguredBass* clone() const override { return new FiguredBass(*this); }
     ElementType   type() const override { return ElementType::FIGURED_BASS; }
-    void      draw(QPainter* painter) const override;
+    void      draw(mu::draw::Painter* painter) const override;
     void      endEdit(EditData&) override;
     void      layout() override;
     void      read(XmlReader&) override;

--- a/src/libmscore/fingering.cpp
+++ b/src/libmscore/fingering.cpp
@@ -230,7 +230,7 @@ void Fingering::layout()
 //   draw
 //---------------------------------------------------------
 
-void Fingering::draw(QPainter* painter) const
+void Fingering::draw(mu::draw::Painter* painter) const
 {
     TextBase::draw(painter);
 }

--- a/src/libmscore/fingering.h
+++ b/src/libmscore/fingering.h
@@ -33,7 +33,7 @@ public:
     ElementType layoutType();
     Placement calculatePlacement() const;
 
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void layout() override;
 
     QVariant propertyDefault(Pid id) const override;

--- a/src/libmscore/fret.cpp
+++ b/src/libmscore/fret.cpp
@@ -294,7 +294,7 @@ void FretDiagram::init(StringData* stringData, Chord* chord)
 //   draw
 //---------------------------------------------------------
 
-void FretDiagram::draw(QPainter* painter) const
+void FretDiagram::draw(mu::draw::Painter* painter) const
 {
     QPointF translation = -QPointF(stringDist * (_strings - 1), 0);
     if (_orientation == Orientation::HORIZONTAL) {

--- a/src/libmscore/fret.h
+++ b/src/libmscore/fret.h
@@ -169,7 +169,7 @@ public:
     ScoreElement* treeChild(int idx) const override;
     int treeChildCount() const override;
 
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     Element* linkedClone() override;
     FretDiagram* clone() const override { return new FretDiagram(*this); }
 

--- a/src/libmscore/glissando.cpp
+++ b/src/libmscore/glissando.cpp
@@ -78,7 +78,7 @@ void GlissandoSegment::layout()
 //   draw
 //---------------------------------------------------------
 
-void GlissandoSegment::draw(QPainter* painter) const
+void GlissandoSegment::draw(mu::draw::Painter* painter) const
 {
     painter->save();
     qreal _spatium = spatium();

--- a/src/libmscore/glissando.h
+++ b/src/libmscore/glissando.h
@@ -40,7 +40,7 @@ public:
 
     ElementType type() const override { return ElementType::GLISSANDO_SEGMENT; }
     GlissandoSegment* clone() const override { return new GlissandoSegment(*this); }
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void layout() override;
 
     Element* propertyDelegate(Pid) override;

--- a/src/libmscore/hairpin.cpp
+++ b/src/libmscore/hairpin.cpp
@@ -467,7 +467,7 @@ void HairpinSegment::editDrag(EditData& ed)
 //   draw
 //---------------------------------------------------------
 
-void HairpinSegment::draw(QPainter* painter) const
+void HairpinSegment::draw(mu::draw::Painter* painter) const
 {
     TextLineBaseSegment::draw(painter);
 

--- a/src/libmscore/hairpin.h
+++ b/src/libmscore/hairpin.h
@@ -46,7 +46,7 @@ class HairpinSegment final : public TextLineBaseSegment
     void startEditDrag(EditData&) override;
     void editDrag(EditData&) override;
 
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     Sid getPropertyStyle(Pid) const override;
 
     bool acceptDrop(EditData&) const override;

--- a/src/libmscore/harmony.cpp
+++ b/src/libmscore/harmony.cpp
@@ -1512,7 +1512,7 @@ qreal Harmony::xShapeOffset() const
 //   draw
 //---------------------------------------------------------
 
-void Harmony::draw(QPainter* painter) const
+void Harmony::draw(mu::draw::Painter* painter) const
 {
     // painter->setPen(curColor());
     if (textList.empty()) {
@@ -1559,7 +1559,7 @@ void Harmony::draw(QPainter* painter) const
 //   drawEditMode
 //---------------------------------------------------------
 
-void Harmony::drawEditMode(QPainter* p, EditData& ed)
+void Harmony::drawEditMode(mu::draw::Painter* p, EditData& ed)
 {
     TextBase::drawEditMode(p, ed);
 

--- a/src/libmscore/harmony.h
+++ b/src/libmscore/harmony.h
@@ -98,8 +98,8 @@ class Harmony final : public TextBase
     NoteCaseType _rootRenderCase, _baseRenderCase;    // case to render
 
     void determineRootBaseSpelling();
-    void draw(QPainter*) const override;
-    void drawEditMode(QPainter* p, EditData& ed) override;
+    void draw(mu::draw::Painter*) const override;
+    void drawEditMode(mu::draw::Painter* p, EditData& ed) override;
     void render(const QString&, qreal&, qreal&);
     void render(const QList<RenderAction>& renderList, qreal&, qreal&, int tpc,NoteSpellingType noteSpelling = NoteSpellingType::STANDARD,
                 NoteCaseType noteCase = NoteCaseType::AUTO);

--- a/src/libmscore/hook.cpp
+++ b/src/libmscore/hook.cpp
@@ -97,7 +97,7 @@ void Hook::layout()
 //   draw
 //---------------------------------------------------------
 
-void Hook::draw(QPainter* painter) const
+void Hook::draw(mu::draw::Painter* painter) const
 {
     // hide if belonging to the second chord of a cross-measure pair
     if (chord() && chord()->crossMeasure() == CrossMeasure::SECOND) {

--- a/src/libmscore/hook.h
+++ b/src/libmscore/hook.h
@@ -36,7 +36,7 @@ public:
     void setHookType(int v);
     int hookType() const { return _hookType; }
     void layout() override;
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     Chord* chord() const { return (Chord*)parent(); }
 };
 }     // namespace Ms

--- a/src/libmscore/icon.cpp
+++ b/src/libmscore/icon.cpp
@@ -60,7 +60,7 @@ void Icon::layout()
 //   draw
 //---------------------------------------------------------
 
-void Icon::draw(QPainter* p) const
+void Icon::draw(mu::draw::Painter* p) const
 {
     QPixmap pm(_icon.pixmap(_extent, QIcon::Normal, QIcon::On));
     p->drawPixmap(0, 0, pm);

--- a/src/libmscore/icon.h
+++ b/src/libmscore/icon.h
@@ -45,7 +45,7 @@ public:
     int extent() const { return _extent; }
     void write(XmlWriter&) const override;
     void read(XmlReader&) override;
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void layout() override;
 
     QVariant getProperty(Pid) const override;

--- a/src/libmscore/image.cpp
+++ b/src/libmscore/image.cpp
@@ -116,14 +116,14 @@ QSizeF Image::imageSize() const
 //   draw
 //---------------------------------------------------------
 
-void Image::draw(QPainter* painter) const
+void Image::draw(mu::draw::Painter* painter) const
 {
     bool emptyImage = false;
     if (imageType == ImageType::SVG) {
         if (!svgDoc) {
             emptyImage = true;
         } else {
-            svgDoc->render(painter, bbox());
+            svgDoc->render(painter->qpainter(), bbox());
         }
     } else if (imageType == ImageType::RASTER) {
         if (rasterDoc == nullptr) {

--- a/src/libmscore/image.h
+++ b/src/libmscore/image.h
@@ -68,7 +68,7 @@ public:
     bool load(const QString& s);
     bool loadFromData(const QString&, const QByteArray&);
     void layout() override;
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
 
     bool isImageFramed() const;
     qreal imageAspectRatio() const;

--- a/src/libmscore/keysig.cpp
+++ b/src/libmscore/keysig.cpp
@@ -309,7 +309,7 @@ void KeySig::layout()
 //   set
 //---------------------------------------------------------
 
-void KeySig::draw(QPainter* p) const
+void KeySig::draw(mu::draw::Painter* p) const
 {
     p->setPen(curColor());
     for (const KeySym& ks: _sig.keySymbols()) {

--- a/src/libmscore/keysig.h
+++ b/src/libmscore/keysig.h
@@ -39,7 +39,7 @@ public:
     KeySig(const KeySig&);
 
     KeySig* clone() const override { return new KeySig(*this); }
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     ElementType type() const override { return ElementType::KEYSIG; }
     bool acceptDrop(EditData&) const override;
     Element* drop(EditData&) override;

--- a/src/libmscore/lasso.cpp
+++ b/src/libmscore/lasso.cpp
@@ -30,7 +30,7 @@ Lasso::Lasso(Score* s)
 //   draw
 //---------------------------------------------------------
 
-void Lasso::draw(QPainter* painter) const
+void Lasso::draw(mu::draw::Painter* painter) const
 {
     painter->setBrush(QBrush(QColor(0, 0, 50, 50)));
     // always 2 pixel width

--- a/src/libmscore/lasso.h
+++ b/src/libmscore/lasso.h
@@ -26,7 +26,7 @@ public:
     Lasso(Score*);
     virtual Lasso* clone() const override { return new Lasso(*this); }
     ElementType type() const final { return ElementType::LASSO; }
-    virtual void draw(QPainter*) const override;
+    virtual void draw(mu::draw::Painter*) const override;
     virtual bool isEditable() const override { return true; }
     virtual void editDrag(EditData&) override;
     virtual void endDrag(EditData&) override {}

--- a/src/libmscore/layoutbreak.cpp
+++ b/src/libmscore/layoutbreak.cpp
@@ -104,7 +104,7 @@ void LayoutBreak::read(XmlReader& e)
 //   draw
 //---------------------------------------------------------
 
-void LayoutBreak::draw(QPainter* painter) const
+void LayoutBreak::draw(mu::draw::Painter* painter) const
 {
     if (score()->printing() || !score()->showUnprintable()) {
         return;

--- a/src/libmscore/layoutbreak.h
+++ b/src/libmscore/layoutbreak.h
@@ -46,7 +46,7 @@ private:
     bool _firstSystemIdentation;
     Type _layoutBreakType;
 
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void layout0();
     void spatiumChanged(qreal oldValue, qreal newValue) override;
 

--- a/src/libmscore/ledgerline.cpp
+++ b/src/libmscore/ledgerline.cpp
@@ -83,7 +83,7 @@ void LedgerLine::layout()
 //   draw
 //---------------------------------------------------------
 
-void LedgerLine::draw(QPainter* painter) const
+void LedgerLine::draw(mu::draw::Painter* painter) const
 {
     if (chord()->crossMeasure() == CrossMeasure::SECOND) {
         return;

--- a/src/libmscore/ledgerline.h
+++ b/src/libmscore/ledgerline.h
@@ -51,7 +51,7 @@ public:
     void setLineWidth(qreal v) { _width = v; }
 
     void layout() override;
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
 
     qreal measureXPos() const;
     LedgerLine* next() const { return _next; }

--- a/src/libmscore/lyrics.h
+++ b/src/libmscore/lyrics.h
@@ -147,7 +147,7 @@ public:
 
     LyricsLineSegment* clone() const override { return new LyricsLineSegment(*this); }
     ElementType type() const override { return ElementType::LYRICSLINE_SEGMENT; }
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void layout() override;
     // helper functions
     LyricsLine* lyricsLine() const { return toLyricsLine(spanner()); }

--- a/src/libmscore/lyricsline.cpp
+++ b/src/libmscore/lyricsline.cpp
@@ -455,7 +455,7 @@ void LyricsLineSegment::layout()
 //   draw
 //---------------------------------------------------------
 
-void LyricsLineSegment::draw(QPainter* painter) const
+void LyricsLineSegment::draw(mu::draw::Painter* painter) const
 {
     if (_numOfDashes < 1) {               // nothing to draw
         return;

--- a/src/libmscore/measurerepeat.cpp
+++ b/src/libmscore/measurerepeat.cpp
@@ -42,7 +42,7 @@ MeasureRepeat::MeasureRepeat(Score* score)
 //   draw
 //---------------------------------------------------------
 
-void MeasureRepeat::draw(QPainter* painter) const
+void MeasureRepeat::draw(mu::draw::Painter* painter) const
 {
     painter->setPen(curColor());
     drawSymbol(symId(), painter);

--- a/src/libmscore/measurerepeat.h
+++ b/src/libmscore/measurerepeat.h
@@ -46,7 +46,7 @@ public:
 
     Measure* firstMeasureOfGroup() const { return measure()->firstOfMeasureRepeatGroup(staffIdx()); }
 
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void layout() override;
     Fraction ticks() const override;
     Fraction actualTicks() const { return Rest::ticks(); }

--- a/src/libmscore/mmrest.cpp
+++ b/src/libmscore/mmrest.cpp
@@ -53,7 +53,7 @@ MMRest::MMRest(const MMRest& r, bool link)
 //   MMRest::draw
 //---------------------------------------------------------
 
-void MMRest::draw(QPainter* painter) const
+void MMRest::draw(mu::draw::Painter* painter) const
 {
     if (shouldNotBeDrawn() || (track() % VOICES)) {     //only on voice 1
         return;

--- a/src/libmscore/mmrest.h
+++ b/src/libmscore/mmrest.h
@@ -35,7 +35,7 @@ public:
     MMRest* clone() const override { return new MMRest(*this, false); }
     Element* linkedClone() override { return new MMRest(*this, true); }
 
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void layout() override;
     void setWidth(qreal width) override { m_width = width; }
     qreal width() const override { return m_width; }

--- a/src/libmscore/mscoreview.h
+++ b/src/libmscore/mscoreview.h
@@ -18,6 +18,8 @@
 #include <QCursor>
 #include <QRectF>
 
+#include "draw/painter.h"
+
 namespace Ms {
 class Element;
 class Score;
@@ -64,7 +66,7 @@ public:
     virtual void addSlur(ChordRest*, ChordRest*, const Slur* /* slurTemplate */) {}
     virtual void startEdit(Element*, Grip /*startGrip*/) {}
     virtual void startNoteEntryMode() {}
-    virtual void drawBackground(QPainter*, const QRectF&) const = 0;
+    virtual void drawBackground(mu::draw::Painter*, const QRectF&) const = 0;
     virtual void setDropTarget(const Element*) {}
 
     virtual void textTab(bool /*back*/) {}

--- a/src/libmscore/note.cpp
+++ b/src/libmscore/note.cpp
@@ -1336,7 +1336,7 @@ bool Note::isNoteName() const
 //   draw
 //---------------------------------------------------------
 
-void Note::draw(QPainter* painter) const
+void Note::draw(mu::draw::Painter* painter) const
 {
     if (_hidden) {
         return;

--- a/src/libmscore/note.h
+++ b/src/libmscore/note.h
@@ -443,7 +443,7 @@ public:
 
     Chord* chord() const { return (Chord*)parent(); }
     void setChord(Chord* a) { setParent((Element*)a); }
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
 
     void read(XmlReader&) override;
     bool readProperties(XmlReader&) override;

--- a/src/libmscore/notedot.cpp
+++ b/src/libmscore/notedot.cpp
@@ -33,7 +33,7 @@ NoteDot::NoteDot(Score* s)
 //   NoteDot::draw
 //---------------------------------------------------------
 
-void NoteDot::draw(QPainter* p) const
+void NoteDot::draw(mu::draw::Painter* p) const
 {
     if (note() && note()->dotsHidden()) {     // don't draw dot if note is hidden
         return;

--- a/src/libmscore/notedot.h
+++ b/src/libmscore/notedot.h
@@ -32,7 +32,7 @@ public:
     ElementType type() const override { return ElementType::NOTEDOT; }
     qreal mag() const override;
 
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void read(XmlReader&) override;
     void layout() override;
 

--- a/src/libmscore/page.cpp
+++ b/src/libmscore/page.cpp
@@ -98,7 +98,7 @@ void Page::appendSystem(System* s)
 //    bounding rectangle fr is relative to page QPointF
 //---------------------------------------------------------
 
-void Page::draw(QPainter* painter) const
+void Page::draw(mu::draw::Painter* painter) const
 {
     if (score()->layoutMode() != LayoutMode::PAGE) {
         return;
@@ -151,7 +151,7 @@ void Page::draw(QPainter* painter) const
 //   drawHeaderFooter
 //---------------------------------------------------------
 
-void Page::drawHeaderFooter(QPainter* p, int area, const QString& ss) const
+void Page::drawHeaderFooter(mu::draw::Painter* p, int area, const QString& ss) const
 {
     QString s = replaceTextMacros(ss);
     if (s.isEmpty()) {

--- a/src/libmscore/page.h
+++ b/src/libmscore/page.h
@@ -41,7 +41,7 @@ class Page final : public Element
     bool bspTreeValid;
 
     QString replaceTextMacros(const QString&) const;
-    void drawHeaderFooter(QPainter*, int area, const QString&) const;
+    void drawHeaderFooter(mu::draw::Painter*, int area, const QString&) const;
 
 public:
     Page(Score*);
@@ -71,7 +71,7 @@ public:
     qreal lm() const;
     qreal rm() const;
 
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
 
     QList<Element*> items(const QRectF& r);

--- a/src/libmscore/rest.cpp
+++ b/src/libmscore/rest.cpp
@@ -76,7 +76,7 @@ Rest::Rest(const Rest& r, bool link)
 //   Rest::draw
 //---------------------------------------------------------
 
-void Rest::draw(QPainter* painter) const
+void Rest::draw(mu::draw::Painter* painter) const
 {
     if (shouldNotBeDrawn()) {
         return;

--- a/src/libmscore/rest.h
+++ b/src/libmscore/rest.h
@@ -46,7 +46,7 @@ public:
     Measure* measure() const override { return parent() ? toMeasure(parent()->parent()) : 0; }
     qreal mag() const override;
 
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void scanElements(void* data, void (* func)(void*, Element*), bool all = true) override;
     void setTrack(int val) override;
 

--- a/src/libmscore/score.h
+++ b/src/libmscore/score.h
@@ -861,7 +861,7 @@ public:
     bool saveCompressedFile(QFileInfo&, bool onlySelection, bool createThumbnail = true);
     bool saveCompressedFile(QIODevice*, const QString& fileName, bool onlySelection, bool createThumbnail = true);
 
-    void print(QPainter* printer, int page);
+    void print(mu::draw::Painter* printer, int page);
     ChordRest* getSelectedChordRest() const;
     QSet<ChordRest*> getSelectedChordRests() const;
     void getSelectedChordRest2(ChordRest** cr1, ChordRest** cr2) const;

--- a/src/libmscore/scorefile.cpp
+++ b/src/libmscore/scorefile.cpp
@@ -566,9 +566,10 @@ QImage Score::createThumbnail()
     double pr = MScore::pixelRatio;
     MScore::pixelRatio = 1.0;
 
-    QPainter p(&pm);
-    p.setRenderHint(QPainter::Antialiasing, true);
-    p.setRenderHint(QPainter::TextAntialiasing, true);
+    QPainter qp(&pm);
+    mu::draw::Painter p(&qp);
+    p.setRenderHint(mu::draw::Painter::Antialiasing, true);
+    p.setRenderHint(mu::draw::Painter::TextAntialiasing, true);
     p.scale(mag, mag);
     print(&p, 0);
     p.end();
@@ -1040,7 +1041,7 @@ Score::FileError MasterScore::read1(XmlReader& e, bool ignoreVersionError)
 //   print
 //---------------------------------------------------------
 
-void Score::print(QPainter* painter, int pageNo)
+void Score::print(mu::draw::Painter* painter, int pageNo)
 {
     _printing  = true;
     MScore::pdfPrinting = true;

--- a/src/libmscore/shadownote.cpp
+++ b/src/libmscore/shadownote.cpp
@@ -128,7 +128,7 @@ bool ShadowNote::computeUp() const
 //   draw
 //---------------------------------------------------------
 
-void ShadowNote::draw(QPainter* painter) const
+void ShadowNote::draw(mu::draw::Painter* painter) const
 {
     if (!visible() || !isValid()) {
         return;
@@ -217,7 +217,7 @@ void ShadowNote::draw(QPainter* painter) const
     painter->translate(-ap);
 }
 
-void ShadowNote::drawArticulations(QPainter* painter) const
+void ShadowNote::drawArticulations(mu::draw::Painter* painter) const
 {
     qreal noteheadWidth = symWidth(m_noteheadSymbol);
     qreal ms = spatium();
@@ -240,7 +240,7 @@ void ShadowNote::drawArticulations(QPainter* painter) const
     }
 }
 
-void ShadowNote::drawMarcato(QPainter* painter, const SymId& articulation, QRectF& boundRect) const
+void ShadowNote::drawMarcato(mu::draw::Painter* painter, const SymId& articulation, QRectF& boundRect) const
 {
     QPointF coord;
     qreal spacing = spatium();
@@ -255,7 +255,7 @@ void ShadowNote::drawMarcato(QPainter* painter, const SymId& articulation, QRect
     drawSymbol(articulation, painter, coord);
 }
 
-void ShadowNote::drawArticulation(QPainter* painter, const SymId& articulation, QRectF& boundRect) const
+void ShadowNote::drawArticulation(mu::draw::Painter* painter, const SymId& articulation, QRectF& boundRect) const
 {
     QPointF coord;
     qreal spacing = spatium();

--- a/src/libmscore/shadownote.h
+++ b/src/libmscore/shadownote.h
@@ -58,10 +58,10 @@ public:
 
     void layout() override;
 
-    void draw(QPainter*) const override;
-    void drawArticulations(QPainter* painter) const;
-    void drawMarcato(QPainter* painter, const SymId& articulation, QRectF& boundRect) const;
-    void drawArticulation(QPainter* painter, const SymId& articulation, QRectF& boundRect) const;
+    void draw(mu::draw::Painter*) const override;
+    void drawArticulations(mu::draw::Painter* painter) const;
+    void drawMarcato(mu::draw::Painter* painter, const SymId& articulation, QRectF& boundRect) const;
+    void drawArticulation(mu::draw::Painter* painter, const SymId& articulation, QRectF& boundRect) const;
 
     bool computeUp() const;
     SymId noteheadSymbol() const { return m_noteheadSymbol; }

--- a/src/libmscore/slur.cpp
+++ b/src/libmscore/slur.cpp
@@ -29,7 +29,7 @@ namespace Ms {
 //   draw
 //---------------------------------------------------------
 
-void SlurSegment::draw(QPainter* painter) const
+void SlurSegment::draw(mu::draw::Painter* painter) const
 {
     QPen pen(curColor());
     qreal mag = staff() ? staff()->staffMag(slur()->tick()) : 1.0;

--- a/src/libmscore/slur.h
+++ b/src/libmscore/slur.h
@@ -36,7 +36,7 @@ public:
     SlurSegment* clone() const override { return new SlurSegment(*this); }
     ElementType type() const override { return ElementType::SLUR_SEGMENT; }
     int subtype() const override { return static_cast<int>(spanner()->type()); }
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
 
     void layoutSegment(const QPointF& p1, const QPointF& p2);
 

--- a/src/libmscore/slurtie.cpp
+++ b/src/libmscore/slurtie.cpp
@@ -378,7 +378,7 @@ void SlurTieSegment::read(XmlReader& e)
 //   drawEditMode
 //---------------------------------------------------------
 
-void SlurTieSegment::drawEditMode(QPainter* p, EditData& ed)
+void SlurTieSegment::drawEditMode(mu::draw::Painter* p, EditData& ed)
 {
     QPolygonF polygon(7);
     polygon[0] = QPointF(ed.grip[int(Grip::START)].center());

--- a/src/libmscore/slurtie.h
+++ b/src/libmscore/slurtie.h
@@ -122,7 +122,7 @@ public:
 
     void writeSlur(XmlWriter& xml, int no) const;
     void read(XmlReader&) override;
-    virtual void drawEditMode(QPainter*, EditData&) override;
+    virtual void drawEditMode(mu::draw::Painter*, EditData&) override;
     virtual void computeBezier(QPointF so = QPointF()) = 0;
 };
 

--- a/src/libmscore/spacer.cpp
+++ b/src/libmscore/spacer.cpp
@@ -41,7 +41,7 @@ Spacer::Spacer(const Spacer& s)
 //   draw
 //---------------------------------------------------------
 
-void Spacer::draw(QPainter* painter) const
+void Spacer::draw(mu::draw::Painter* painter) const
 {
     if (score()->printing() || !score()->showUnprintable()) {
         return;

--- a/src/libmscore/spacer.h
+++ b/src/libmscore/spacer.h
@@ -53,7 +53,7 @@ public:
     void write(XmlWriter&) const override;
     void read(XmlReader&) override;
 
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
 
     void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
 

--- a/src/libmscore/stafflines.cpp
+++ b/src/libmscore/stafflines.cpp
@@ -175,7 +175,7 @@ void StaffLines::layoutPartialWidth(qreal w, qreal wPartial, bool alignRight)
 //   draw
 //---------------------------------------------------------
 
-void StaffLines::draw(QPainter* painter) const
+void StaffLines::draw(mu::draw::Painter* painter) const
 {
     painter->setPen(QPen(curColor(), lw, Qt::SolidLine, Qt::FlatCap));
     painter->drawLines(lines);

--- a/src/libmscore/stafflines.h
+++ b/src/libmscore/stafflines.h
@@ -30,7 +30,7 @@ public:
     StaffLines* clone() const override { return new StaffLines(*this); }
     ElementType type() const override { return ElementType::STAFF_LINES; }
     void layout() override;
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     QPointF pagePos() const override;      ///< position in page coordinates
     QPointF canvasPos() const override;    ///< position in page coordinates
 

--- a/src/libmscore/staffstate.cpp
+++ b/src/libmscore/staffstate.cpp
@@ -79,7 +79,7 @@ void StaffState::read(XmlReader& e)
 //   draw
 //---------------------------------------------------------
 
-void StaffState::draw(QPainter* painter) const
+void StaffState::draw(mu::draw::Painter* painter) const
 {
     if (score()->printing() || !score()->showUnprintable()) {
         return;

--- a/src/libmscore/staffstate.h
+++ b/src/libmscore/staffstate.h
@@ -38,7 +38,7 @@ class StaffState final : public Element
 
     Instrument* _instrument { nullptr };
 
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void layout() override;
 
 public:

--- a/src/libmscore/stafftype.cpp
+++ b/src/libmscore/stafftype.cpp
@@ -1009,7 +1009,7 @@ void TabDurationSymbol::layout2()
 //   draw
 //---------------------------------------------------------
 
-void TabDurationSymbol::draw(QPainter* painter) const
+void TabDurationSymbol::draw(mu::draw::Painter* painter) const
 {
     if (!_tab) {
         return;

--- a/src/libmscore/stafftype.h
+++ b/src/libmscore/stafftype.h
@@ -440,7 +440,7 @@ public:
     TabDurationSymbol(Score* s, const StaffType* tab, TDuration::DurationType type, int dots);
     TabDurationSymbol(const TabDurationSymbol&);
     TabDurationSymbol* clone() const override { return new TabDurationSymbol(*this); }
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     bool isEditable() const override { return false; }
     void layout() override;
     ElementType type() const override { return ElementType::TAB_DURATION_SYMBOL; }

--- a/src/libmscore/stafftypechange.cpp
+++ b/src/libmscore/stafftypechange.cpp
@@ -97,7 +97,7 @@ void StaffTypeChange::layout()
 //   draw
 //---------------------------------------------------------
 
-void StaffTypeChange::draw(QPainter* painter) const
+void StaffTypeChange::draw(mu::draw::Painter* painter) const
 {
     if (score()->printing() || !score()->showUnprintable()) {
         return;

--- a/src/libmscore/stafftypechange.h
+++ b/src/libmscore/stafftypechange.h
@@ -29,7 +29,7 @@ class StaffTypeChange final : public Element
 
     void layout() override;
     void spatiumChanged(qreal oldValue, qreal newValue) override;
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
 
 public:
     StaffTypeChange(Score* = 0);

--- a/src/libmscore/stem.cpp
+++ b/src/libmscore/stem.cpp
@@ -158,7 +158,7 @@ void Stem::spatiumChanged(qreal oldValue, qreal newValue)
 //   draw
 //---------------------------------------------------------
 
-void Stem::draw(QPainter* painter) const
+void Stem::draw(mu::draw::Painter* painter) const
 {
     if (!chord()) { // may be need assert?
         return;

--- a/src/libmscore/stem.h
+++ b/src/libmscore/stem.h
@@ -36,7 +36,7 @@ public:
 
     Stem* clone() const override { return new Stem(*this); }
     ElementType type() const override { return ElementType::STEM; }
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     bool isEditable() const override { return true; }
     void layout() override;
     void spatiumChanged(qreal /*oldValue*/, qreal /*newValue*/) override;

--- a/src/libmscore/stemslash.cpp
+++ b/src/libmscore/stemslash.cpp
@@ -19,7 +19,7 @@ namespace Ms {
 //   draw
 //---------------------------------------------------------
 
-void StemSlash::draw(QPainter* painter) const
+void StemSlash::draw(mu::draw::Painter* painter) const
 {
     qreal lw = score()->styleP(Sid::stemWidth);
     painter->setPen(QPen(curColor(), lw, Qt::SolidLine, Qt::FlatCap));

--- a/src/libmscore/stemslash.h
+++ b/src/libmscore/stemslash.h
@@ -35,7 +35,7 @@ public:
 
     StemSlash* clone() const override { return new StemSlash(*this); }
     ElementType type() const override { return ElementType::STEM_SLASH; }
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void layout() override;
     Chord* chord() const { return (Chord*)parent(); }
 };

--- a/src/libmscore/sym.cpp
+++ b/src/libmscore/sym.cpp
@@ -6390,24 +6390,24 @@ Sym ScoreFont::sym(SymId id) const
 //   draw
 //---------------------------------------------------------
 
-void ScoreFont::draw(SymId id, QPainter* painter, qreal mag, const QPointF& pos) const
+void ScoreFont::draw(SymId id, mu::draw::Painter* painter, qreal mag, const QPointF& pos) const
 {
     qreal worldScale = painter->worldTransform().m11();
     draw(id, painter, mag, pos, worldScale);
 }
 
-void ScoreFont::draw(SymId id, QPainter* painter, const QSizeF& mag, const QPointF& pos) const
+void ScoreFont::draw(SymId id, mu::draw::Painter* painter, const QSizeF& mag, const QPointF& pos) const
 {
     qreal worldScale = painter->worldTransform().m11();
     draw(id, painter, mag, pos, worldScale);
 }
 
-void ScoreFont::draw(SymId id, QPainter* painter, qreal mag, const QPointF& pos, qreal worldScale) const
+void ScoreFont::draw(SymId id, mu::draw::Painter* painter, qreal mag, const QPointF& pos, qreal worldScale) const
 {
     draw(id, painter, QSizeF(mag, mag), pos, worldScale);
 }
 
-void ScoreFont::draw(SymId id, QPainter* painter, const QSizeF& mag, const QPointF& pos, qreal worldScale) const
+void ScoreFont::draw(SymId id, mu::draw::Painter* painter, const QSizeF& mag, const QPointF& pos, qreal worldScale) const
 {
     if (!sym(id).symList().empty()) {    // is this a compound symbol?
         draw(sym(id).symList(), painter, mag, pos);
@@ -6510,7 +6510,7 @@ void ScoreFont::draw(SymId id, QPainter* painter, const QSizeF& mag, const QPoin
     painter->drawPixmap(pos + pm->offset, pm->pm);
 }
 
-void ScoreFont::draw(SymId id, QPainter* painter, qreal mag, const QPointF& pos, int n) const
+void ScoreFont::draw(SymId id, mu::draw::Painter* painter, qreal mag, const QPointF& pos, int n) const
 {
     std::vector<SymId> d;
     for (int i = 0; i < n; ++i) {
@@ -6519,7 +6519,7 @@ void ScoreFont::draw(SymId id, QPainter* painter, qreal mag, const QPointF& pos,
     draw(d, painter, mag, pos);
 }
 
-void ScoreFont::draw(const std::vector<SymId>& ids, QPainter* p, qreal mag, const QPointF& _pos, qreal scale) const
+void ScoreFont::draw(const std::vector<SymId>& ids, mu::draw::Painter* p, qreal mag, const QPointF& _pos, qreal scale) const
 {
     QPointF pos(_pos);
     for (SymId id : ids) {
@@ -6528,13 +6528,13 @@ void ScoreFont::draw(const std::vector<SymId>& ids, QPainter* p, qreal mag, cons
     }
 }
 
-void ScoreFont::draw(const std::vector<SymId>& ids, QPainter* p, const QSizeF& mag, const QPointF& _pos) const
+void ScoreFont::draw(const std::vector<SymId>& ids, mu::draw::Painter* p, const QSizeF& mag, const QPointF& _pos) const
 {
     qreal scale = p->worldTransform().m11();
     draw(ids, p, mag, _pos, scale);
 }
 
-void ScoreFont::draw(const std::vector<SymId>& ids, QPainter* p, const QSizeF& mag, const QPointF& _pos, qreal scale) const
+void ScoreFont::draw(const std::vector<SymId>& ids, mu::draw::Painter* p, const QSizeF& mag, const QPointF& _pos, qreal scale) const
 {
     QPointF pos(_pos);
     for (SymId id : ids) {
@@ -6543,7 +6543,7 @@ void ScoreFont::draw(const std::vector<SymId>& ids, QPainter* p, const QSizeF& m
     }
 }
 
-void ScoreFont::draw(const std::vector<SymId>& ids, QPainter* p, qreal mag, const QPointF& _pos) const
+void ScoreFont::draw(const std::vector<SymId>& ids, mu::draw::Painter* p, qreal mag, const QPointF& _pos) const
 {
     qreal scale = p->worldTransform().m11();
     draw(ids, p, mag, _pos, scale);

--- a/src/libmscore/sym.h
+++ b/src/libmscore/sym.h
@@ -19,6 +19,8 @@
 #include "style.h"
 #include "qtenum.h"
 
+#include "draw/painter.h"
+
 #include "ft2build.h"
 #include FT_FREETYPE_H
 
@@ -3188,15 +3190,15 @@ public:
     QString toString(SymId) const;
     QPixmap sym2pixmap(SymId, qreal) { return QPixmap(); }        // TODOxxxx
 
-    void draw(SymId id,                  QPainter*, const QSizeF& mag, const QPointF& pos, qreal scale) const;
-    void draw(SymId id,                  QPainter*, qreal mag,         const QPointF& pos, qreal scale) const;
-    void draw(SymId id,                  QPainter*, qreal mag,         const QPointF& pos) const;
-    void draw(SymId id,                  QPainter*, const QSizeF& mag, const QPointF& pos) const;
-    void draw(SymId id,                  QPainter*, qreal mag,         const QPointF& pos, int n) const;
-    void draw(const std::vector<SymId>&, QPainter*, qreal mag,         const QPointF& pos) const;
-    void draw(const std::vector<SymId>&, QPainter*, const QSizeF& mag, const QPointF& pos) const;
-    void draw(const std::vector<SymId>&, QPainter*, qreal mag,         const QPointF& pos, qreal scale) const;
-    void draw(const std::vector<SymId>&, QPainter*, const QSizeF& mag, const QPointF& pos, qreal scale) const;
+    void draw(SymId id,                  mu::draw::Painter*, const QSizeF& mag, const QPointF& pos, qreal scale) const;
+    void draw(SymId id,                  mu::draw::Painter*, qreal mag,         const QPointF& pos, qreal scale) const;
+    void draw(SymId id,                  mu::draw::Painter*, qreal mag,         const QPointF& pos) const;
+    void draw(SymId id,                  mu::draw::Painter*, const QSizeF& mag, const QPointF& pos) const;
+    void draw(SymId id,                  mu::draw::Painter*, qreal mag,         const QPointF& pos, int n) const;
+    void draw(const std::vector<SymId>&, mu::draw::Painter*, qreal mag,         const QPointF& pos) const;
+    void draw(const std::vector<SymId>&, mu::draw::Painter*, const QSizeF& mag, const QPointF& pos) const;
+    void draw(const std::vector<SymId>&, mu::draw::Painter*, qreal mag,         const QPointF& pos, qreal scale) const;
+    void draw(const std::vector<SymId>&, mu::draw::Painter*, const QSizeF& mag, const QPointF& pos, qreal scale) const;
 
     qreal height(SymId id, qreal mag) const { return bbox(id, mag).height(); }
     qreal width(SymId id, qreal mag) const { return bbox(id, mag).width(); }

--- a/src/libmscore/symbol.cpp
+++ b/src/libmscore/symbol.cpp
@@ -80,7 +80,7 @@ void Symbol::layout()
 //   Symbol::draw
 //---------------------------------------------------------
 
-void Symbol::draw(QPainter* p) const
+void Symbol::draw(mu::draw::Painter* p) const
 {
     if (!isNoteDot() || !staff()->isTabStaff(tick())) {
         p->setPen(curColor());
@@ -208,7 +208,7 @@ FSymbol::FSymbol(const FSymbol& s)
 //   draw
 //---------------------------------------------------------
 
-void FSymbol::draw(QPainter* painter) const
+void FSymbol::draw(mu::draw::Painter* painter) const
 {
     QString s;
     QFont f(_font);

--- a/src/libmscore/symbol.h
+++ b/src/libmscore/symbol.h
@@ -46,7 +46,7 @@ public:
     SymId sym() const { return _sym; }
     QString symName() const;
 
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void write(XmlWriter& xml) const override;
     void read(XmlReader&) override;
     void layout() override;
@@ -75,7 +75,7 @@ public:
     FSymbol* clone() const override { return new FSymbol(*this); }
     ElementType type() const override { return ElementType::FSYMBOL; }
 
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void write(XmlWriter& xml) const override;
     void read(XmlReader&) override;
     void layout() override;

--- a/src/libmscore/textbase.cpp
+++ b/src/libmscore/textbase.cpp
@@ -873,7 +873,7 @@ bool TextFragment::operator ==(const TextFragment& f) const
 //   draw
 //---------------------------------------------------------
 
-void TextFragment::draw(QPainter* p, const TextBase* t) const
+void TextFragment::draw(mu::draw::Painter* p, const TextBase* t) const
 {
     QFont f(font(t));
     f.setPointSizeF(f.pointSizeF() * MScore::pixelRatio);
@@ -889,7 +889,7 @@ void TextFragment::draw(QPainter* p, const TextBase* t) const
 //   drawTextWorkaround
 //---------------------------------------------------------
 
-void TextBase::drawTextWorkaround(QPainter* p, QFont& f, const QPointF pos, const QString text)
+void TextBase::drawTextWorkaround(mu::draw::Painter* p, QFont& f, const QPointF pos, const QString text)
 {
     qreal mm = p->worldTransform().m11();
     if (!(MScore::pdfPrinting) && (mm < 1.0) && f.bold() && !(f.underline())) {
@@ -1055,7 +1055,7 @@ QFont TextFragment::font(const TextBase* t) const
 //   draw
 //---------------------------------------------------------
 
-void TextBlock::draw(QPainter* p, const TextBase* t) const
+void TextBlock::draw(mu::draw::Painter* p, const TextBase* t) const
 {
     p->translate(0.0, _y);
     for (const TextFragment& f : _fragments) {
@@ -1741,7 +1741,7 @@ TextBase::TextBase(const TextBase& st)
 //   drawSelection
 //---------------------------------------------------------
 
-void TextBase::drawSelection(QPainter* p, const QRectF& r) const
+void TextBase::drawSelection(mu::draw::Painter* p, const QRectF& r) const
 {
     QBrush bg(QColor("steelblue"));
     p->setCompositionMode(QPainter::CompositionMode_HardLight);
@@ -3372,7 +3372,7 @@ TextCursor* TextBase::cursorFromEditData(const EditData& ed)
 //   draw
 //---------------------------------------------------------
 
-void TextBase::draw(QPainter* p) const
+void TextBase::draw(mu::draw::Painter* p) const
 {
     if (hasFrame()) {
         qreal baseSpatium = MScore::baseStyle().value(Sid::spatium).toDouble();
@@ -3412,7 +3412,7 @@ void TextBase::draw(QPainter* p) const
 //    draw edit mode decorations
 //---------------------------------------------------------
 
-void TextBase::drawEditMode(QPainter* p, EditData& ed)
+void TextBase::drawEditMode(mu::draw::Painter* p, EditData& ed)
 {
     QPointF pos(canvasPos());
     p->translate(pos);

--- a/src/libmscore/textbase.h
+++ b/src/libmscore/textbase.h
@@ -175,7 +175,7 @@ public:
     TextFragment(const QString& s);
     TextFragment(TextCursor*, const QString&);
     TextFragment split(int column);
-    void draw(QPainter*, const TextBase*) const;
+    void draw(mu::draw::Painter*, const TextBase*) const;
     QFont font(const TextBase*) const;
     int columns() const;
     void changeFormat(FormatId id, QVariant data);
@@ -200,7 +200,7 @@ public:
     TextBlock() {}
     bool operator ==(const TextBlock& x) { return _fragments == x._fragments; }
     bool operator !=(const TextBlock& x) { return _fragments != x._fragments; }
-    void draw(QPainter*, const TextBase*) const;
+    void draw(mu::draw::Painter*, const TextBase*) const;
     void layout(TextBase*);
     const QList<TextFragment>& fragments() const { return _fragments; }
     QList<TextFragment>& fragments() { return _fragments; }
@@ -262,7 +262,7 @@ class TextBase : public Element
 
     TextCursor* _cursor           { nullptr };
 
-    void drawSelection(QPainter*, const QRectF&) const;
+    void drawSelection(mu::draw::Painter*, const QRectF&) const;
     void insert(TextCursor*, uint code);
     void genText() const;
     virtual int getPropertyFlagsIdx(Pid id) const override;
@@ -286,9 +286,9 @@ public:
 
     Text& operator=(const Text&) = delete;
 
-    virtual void draw(QPainter*) const override;
-    virtual void drawEditMode(QPainter* p, EditData& ed) override;
-    static void drawTextWorkaround(QPainter* p, QFont& f, const QPointF pos, const QString text);
+    virtual void draw(mu::draw::Painter*) const override;
+    virtual void drawEditMode(mu::draw::Painter* p, EditData& ed) override;
+    static void drawTextWorkaround(mu::draw::Painter* p, QFont& f, const QPointF pos, const QString text);
 
     static QString plainToXmlText(const QString& s) { return s.toHtmlEscaped(); }
     void setPlainText(const QString& t) { setXmlText(plainToXmlText(t)); }

--- a/src/libmscore/textlinebase.cpp
+++ b/src/libmscore/textlinebase.cpp
@@ -72,7 +72,7 @@ void TextLineBaseSegment::setSelected(bool f)
 //   draw
 //---------------------------------------------------------
 
-void TextLineBaseSegment::draw(QPainter* painter) const
+void TextLineBaseSegment::draw(mu::draw::Painter* painter) const
 {
     TextLineBase* tl   = textLineBase();
 

--- a/src/libmscore/textlinebase.h
+++ b/src/libmscore/textlinebase.h
@@ -43,7 +43,7 @@ public:
     ~TextLineBaseSegment();
 
     TextLineBase* textLineBase() const { return (TextLineBase*)spanner(); }
-    virtual void draw(QPainter*) const override;
+    virtual void draw(mu::draw::Painter*) const override;
 
     virtual void layout() override;
     virtual void setSelected(bool f) override;

--- a/src/libmscore/tie.cpp
+++ b/src/libmscore/tie.cpp
@@ -27,7 +27,7 @@ Note* Tie::editEndNote;
 //   draw
 //---------------------------------------------------------
 
-void TieSegment::draw(QPainter* painter) const
+void TieSegment::draw(mu::draw::Painter* painter) const
 {
     // hide tie toward the second chord of a cross-measure value
     if (tie()->endNote() && tie()->endNote()->chord()->crossMeasure() == CrossMeasure::SECOND) {

--- a/src/libmscore/tie.h
+++ b/src/libmscore/tie.h
@@ -41,7 +41,7 @@ public:
     TieSegment* clone() const override { return new TieSegment(*this); }
     ElementType type() const override { return ElementType::TIE_SEGMENT; }
     int subtype() const override { return static_cast<int>(spanner()->type()); }
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
 
     void layoutSegment(const QPointF& p1, const QPointF& p2);
 

--- a/src/libmscore/timesig.cpp
+++ b/src/libmscore/timesig.cpp
@@ -379,7 +379,7 @@ void TimeSig::layout()
 //   draw
 //---------------------------------------------------------
 
-void TimeSig::draw(QPainter* painter) const
+void TimeSig::draw(mu::draw::Painter* painter) const
 {
     if (staff() && !const_cast<const Staff*>(staff())->staffType(tick())->genTimesig()) {
         return;

--- a/src/libmscore/timesig.h
+++ b/src/libmscore/timesig.h
@@ -75,7 +75,7 @@ public:
     bool operator!=(const TimeSig& ts) const { return !(*this == ts); }
 
     qreal mag() const override;
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void write(XmlWriter& xml) const override;
     void read(XmlReader&) override;
     void layout() override;

--- a/src/libmscore/tremolo.cpp
+++ b/src/libmscore/tremolo.cpp
@@ -95,7 +95,7 @@ qreal Tremolo::minHeight() const
 //   draw
 //---------------------------------------------------------
 
-void Tremolo::draw(QPainter* painter) const
+void Tremolo::draw(mu::draw::Painter* painter) const
 {
     if (isBuzzRoll()) {
         painter->setPen(curColor());

--- a/src/libmscore/tremolo.h
+++ b/src/libmscore/tremolo.h
@@ -78,7 +78,7 @@ public:
 
     qreal chordMag() const;
     qreal mag() const override;
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void layout() override;
     void layout2();
     void write(XmlWriter& xml) const override;

--- a/src/libmscore/tremolobar.cpp
+++ b/src/libmscore/tremolobar.cpp
@@ -94,7 +94,7 @@ void TremoloBar::layout()
 //   draw
 //---------------------------------------------------------
 
-void TremoloBar::draw(QPainter* painter) const
+void TremoloBar::draw(mu::draw::Painter* painter) const
 {
     QPen pen(curColor(), m_lw.val(), Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
     painter->setPen(pen);

--- a/src/libmscore/tremolobar.h
+++ b/src/libmscore/tremolobar.h
@@ -44,7 +44,7 @@ public:
     ElementType type() const override { return ElementType::TREMOLOBAR; }
 
     void layout() override;
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
 
     void write(XmlWriter&) const override;
     void read(XmlReader& e) override;

--- a/src/libmscore/trill.cpp
+++ b/src/libmscore/trill.cpp
@@ -56,7 +56,7 @@ static const ElementStyle trillStyle {
 //   draw
 //---------------------------------------------------------
 
-void TrillSegment::draw(QPainter* painter) const
+void TrillSegment::draw(mu::draw::Painter* painter) const
 {
     painter->setPen(spanner()->curColor());
     drawSymbols(_symbols, painter);

--- a/src/libmscore/trill.h
+++ b/src/libmscore/trill.h
@@ -41,7 +41,7 @@ public:
     Trill* trill() const { return (Trill*)spanner(); }
     ElementType type() const override { return ElementType::TRILL_SEGMENT; }
     TrillSegment* clone() const override { return new TrillSegment(*this); }
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     bool acceptDrop(EditData&) const override;
     Element* drop(EditData&) override;
     void layout() override;

--- a/src/libmscore/tuplet.cpp
+++ b/src/libmscore/tuplet.cpp
@@ -692,7 +692,7 @@ void Tuplet::layout()
 //   draw
 //---------------------------------------------------------
 
-void Tuplet::draw(QPainter* painter) const
+void Tuplet::draw(mu::draw::Painter* painter) const
 {
     // if in a TAB without stems, tuplets are not shown
     const StaffType* stt = staffType();

--- a/src/libmscore/tuplet.h
+++ b/src/libmscore/tuplet.h
@@ -115,7 +115,7 @@ public:
 
     void reset() override;
 
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     int id() const { return _id; }
     void setId(int i) const { _id = i; }
 

--- a/src/libmscore/vibrato.cpp
+++ b/src/libmscore/vibrato.cpp
@@ -46,7 +46,7 @@ int vibratoTableSize()
 //   draw
 //---------------------------------------------------------
 
-void VibratoSegment::draw(QPainter* painter) const
+void VibratoSegment::draw(mu::draw::Painter* painter) const
 {
     painter->setPen(spanner()->curColor());
     drawSymbols(_symbols, painter);

--- a/src/libmscore/vibrato.h
+++ b/src/libmscore/vibrato.h
@@ -41,7 +41,7 @@ public:
 
     Vibrato* vibrato() const { return toVibrato(spanner()); }
 
-    void draw(QPainter*) const override;
+    void draw(mu::draw::Painter*) const override;
     void layout() override;
 
     Element* propertyDelegate(Pid) override;

--- a/src/notation/inotation.h
+++ b/src/notation/inotation.h
@@ -52,7 +52,7 @@ public:
     virtual void setViewSize(const QSizeF& vs) = 0;
     virtual void setViewMode(const ViewMode& vm) = 0;
     virtual ViewMode viewMode() const = 0;
-    virtual void paint(QPainter* painter, const QRectF& frameRect) = 0;
+    virtual void paint(mu::draw::Painter* painter, const QRectF& frameRect) = 0;
 
     virtual ValCh<bool> opened() const = 0;
     virtual void setOpened(bool opened) = 0;

--- a/src/notation/internal/notation.cpp
+++ b/src/notation/internal/notation.cpp
@@ -239,7 +239,7 @@ ViewMode Notation::viewMode() const
     return score()->layoutMode();
 }
 
-void Notation::paint(QPainter* painter, const QRectF& frameRect)
+void Notation::paint(mu::draw::Painter* painter, const QRectF& frameRect)
 {
     const QList<Ms::Page*>& pages = score()->pages();
     if (pages.empty()) {
@@ -263,7 +263,7 @@ void Notation::paint(QPainter* painter, const QRectF& frameRect)
     static_cast<NotationInteraction*>(m_interaction.get())->paint(painter);
 }
 
-void Notation::paintPages(QPainter* painter, const QRectF& frameRect, const QList<Ms::Page*>& pages, bool paintBorders) const
+void Notation::paintPages(draw::Painter* painter, const QRectF& frameRect, const QList<Ms::Page*>& pages, bool paintBorders) const
 {
     for (Ms::Page* page : pages) {
         QRectF pageRect(page->abbox().translated(page->pos()));
@@ -291,7 +291,7 @@ void Notation::paintPages(QPainter* painter, const QRectF& frameRect, const QLis
     }
 }
 
-void Notation::paintPageBorder(QPainter* painter, const Ms::Page* page) const
+void Notation::paintPageBorder(draw::Painter* painter, const Ms::Page* page) const
 {
     QRectF boundingRect(page->canvasBoundingRect());
 

--- a/src/notation/internal/notation.h
+++ b/src/notation/internal/notation.h
@@ -52,7 +52,7 @@ public:
     void setViewSize(const QSizeF& vs) override;
     void setViewMode(const ViewMode& viewMode) override;
     ViewMode viewMode() const override;
-    void paint(QPainter* painter, const QRectF& frameRect) override;
+    void paint(draw::Painter* painter, const QRectF& frameRect) override;
 
     ValCh<bool> opened() const override;
     void setOpened(bool opened) override;
@@ -77,8 +77,8 @@ protected:
 private:
     friend class NotationInteraction;
 
-    void paintPages(QPainter* painter, const QRectF& frameRect, const QList<Ms::Page*>& pages, bool paintBorders) const;
-    void paintPageBorder(QPainter* painter, const Ms::Page* page) const;
+    void paintPages(mu::draw::Painter* painter, const QRectF& frameRect, const QList<Ms::Page*>& pages, bool paintBorders) const;
+    void paintPageBorder(mu::draw::Painter* painter, const Ms::Page* page) const;
 
     QSizeF viewSize() const;
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -129,7 +129,7 @@ void NotationInteraction::notifyAboutSelectionChanged()
     m_selectionChanged.notify();
 }
 
-void NotationInteraction::paint(QPainter* painter)
+void NotationInteraction::paint(mu::draw::Painter* painter)
 {
     m_shadowNote->draw(painter);
 
@@ -1544,7 +1544,7 @@ void NotationInteraction::resetAnchorLines()
     m_anchorLines.clear();
 }
 
-void NotationInteraction::drawAnchorLines(QPainter* painter)
+void NotationInteraction::drawAnchorLines(mu::draw::Painter* painter)
 {
     if (m_anchorLines.empty()) {
         return;
@@ -1569,7 +1569,7 @@ void NotationInteraction::drawAnchorLines(QPainter* painter)
     }
 }
 
-void NotationInteraction::drawTextEditMode(QPainter* painter)
+void NotationInteraction::drawTextEditMode(draw::Painter* painter)
 {
     if (!isTextEditingStarted()) {
         return;
@@ -1578,7 +1578,7 @@ void NotationInteraction::drawTextEditMode(QPainter* painter)
     m_textEditData.element->drawEditMode(painter, m_textEditData);
 }
 
-void NotationInteraction::drawSelectionRange(QPainter* painter)
+void NotationInteraction::drawSelectionRange(draw::Painter* painter)
 {
     if (!m_selection->isRange()) {
         return;
@@ -1607,7 +1607,7 @@ void NotationInteraction::drawSelectionRange(QPainter* painter)
     }
 }
 
-void NotationInteraction::drawGripPoints(QPainter* painter)
+void NotationInteraction::drawGripPoints(draw::Painter* painter)
 {
     if (!selection()->element() || !m_gripEditData.element) {
         return;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -51,7 +51,7 @@ public:
     ~NotationInteraction() override;
 
     void init();
-    void paint(QPainter* painter);
+    void paint(draw::Painter* painter);
 
     // Put notes
     INotationNoteInputPtr noteInput() const override;
@@ -179,10 +179,10 @@ private:
 
     void setAnchorLines(const std::vector<QLineF>& anchorList);
     void resetAnchorLines();
-    void drawAnchorLines(QPainter* painter);
-    void drawTextEditMode(QPainter* painter);
-    void drawSelectionRange(QPainter* painter);
-    void drawGripPoints(QPainter* painter);
+    void drawAnchorLines(draw::Painter* painter);
+    void drawTextEditMode(mu::draw::Painter* painter);
+    void drawSelectionRange(mu::draw::Painter* painter);
+    void drawGripPoints(mu::draw::Painter* painter);
     void moveElementSelection(MoveDirection d);
 
     Element* dropTarget(Ms::EditData& ed) const;

--- a/src/notation/internal/scorecallbacks.cpp
+++ b/src/notation/internal/scorecallbacks.cpp
@@ -32,7 +32,7 @@ void ScoreCallbacks::updateAll()
     NOT_IMPLEMENTED;
 }
 
-void ScoreCallbacks::drawBackground(QPainter*, const QRectF&) const
+void ScoreCallbacks::drawBackground(draw::Painter*, const QRectF&) const
 {
     NOT_IMPLEMENTED;
 }

--- a/src/notation/internal/scorecallbacks.h
+++ b/src/notation/internal/scorecallbacks.h
@@ -35,7 +35,7 @@ public:
 
     void dataChanged(const QRectF&) override;
     void updateAll() override;
-    void drawBackground(QPainter*, const QRectF&) const override;
+    void drawBackground(mu::draw::Painter*, const QRectF&) const override;
     const QRect geometry() const override;
 };
 }

--- a/src/notation/view/loopmarker.cpp
+++ b/src/notation/view/loopmarker.cpp
@@ -41,7 +41,7 @@ void LoopMarker::setStyle(INotationStylePtr style)
     m_style = style;
 }
 
-void LoopMarker::paint(QPainter* painter)
+void LoopMarker::paint(mu::draw::Painter* painter)
 {
     if (!m_visible || !m_style) {
         return;

--- a/src/notation/view/loopmarker.h
+++ b/src/notation/view/loopmarker.h
@@ -36,7 +36,7 @@ public:
     void setVisible(bool visible);
     void setStyle(INotationStylePtr style);
 
-    void paint(QPainter* painter);
+    void paint(draw::Painter* painter);
 
 private:
     LoopBoundaryType m_type = LoopBoundaryType::Unknown;

--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -317,11 +317,14 @@ void NotationPaintView::showContextMenu(const ElementType& elementType, const QP
     emit openContextMenuRequested(menuItems, pos);
 }
 
-void NotationPaintView::paint(QPainter* painter)
+void NotationPaintView::paint(QPainter* qp)
 {
     if (!notation()) {
         return;
     }
+
+    mu::draw::Painter mup(qp);
+    mu::draw::Painter* painter = &mup;
 
     QRect rect(0, 0, width(), height());
     painter->fillRect(rect, m_backgroundColor);

--- a/src/notation/view/noteinputcursor.cpp
+++ b/src/notation/view/noteinputcursor.cpp
@@ -22,7 +22,7 @@
 
 using namespace mu::notation;
 
-void NoteInputCursor::paint(QPainter* painter)
+void NoteInputCursor::paint(mu::draw::Painter* painter)
 {
     if (!isNoteInputMode()) {
         return;

--- a/src/notation/view/noteinputcursor.h
+++ b/src/notation/view/noteinputcursor.h
@@ -38,7 +38,7 @@ public:
 
     NoteInputCursor() = default;
 
-    void paint(QPainter* painter);
+    void paint(draw::Painter* painter);
 
 private:
     INotationNoteInputPtr currentNoteInput() const;

--- a/src/notation/view/playbackcursor.cpp
+++ b/src/notation/view/playbackcursor.cpp
@@ -22,7 +22,7 @@
 
 using namespace mu::notation;
 
-void PlaybackCursor::paint(QPainter* painter)
+void PlaybackCursor::paint(mu::draw::Painter* painter)
 {
     if (!m_visible) {
         return;

--- a/src/notation/view/playbackcursor.h
+++ b/src/notation/view/playbackcursor.h
@@ -36,7 +36,7 @@ public:
 
     PlaybackCursor() = default;
 
-    void paint(QPainter* painter);
+    void paint(draw::Painter* painter);
     void move(const QRect& rect);
 
     const QRect& rect() const;

--- a/src/palette/internal/palette/palette.cpp
+++ b/src/palette/internal/palette/palette.cpp
@@ -822,7 +822,7 @@ PaletteCell* Palette::add(int idx, Element* s, const QString& name, QString tag,
 
 void Palette::paintPaletteElement(void* data, Element* element)
 {
-    QPainter* painter = static_cast<QPainter*>(data);
+    mu::draw::Painter* painter = static_cast<mu::draw::Painter*>(data);
     painter->save();
     painter->translate(element->pos()); // necessary for drawing child elements
 

--- a/src/palette/internal/palette/palettetree.cpp
+++ b/src/palette/internal/palette/palettetree.cpp
@@ -1060,7 +1060,7 @@ void PaletteTree::retranslate()
 /// aspect ratio, and leaving a small margin around the edges.
 //---------------------------------------------------------
 
-static void paintIconElement(QPainter& painter, const QRect& rect, Element* e)
+static void paintIconElement(mu::draw::Painter& painter, const QRect& rect, Element* e)
 {
     Q_ASSERT(e && e->isIcon());
     painter.save();   // so we can restore it after we are done using it
@@ -1088,7 +1088,7 @@ static void paintIconElement(QPainter& painter, const QRect& rect, Element* e)
 /// appear at the correct height on the staff.
 //---------------------------------------------------------
 
-void PaletteCellIconEngine::paintScoreElement(QPainter& p, Element* e, qreal spatium, bool alignToStaff) const
+void PaletteCellIconEngine::paintScoreElement(mu::draw::Painter& p, Element* e, qreal spatium, bool alignToStaff) const
 {
     Q_ASSERT(e && !e->isIcon());
     p.save();   // so we can restore painter after we are done using it
@@ -1117,7 +1117,7 @@ void PaletteCellIconEngine::paintScoreElement(QPainter& p, Element* e, qreal spa
 /// distance from the top of the QRect to the uppermost staff line.
 //---------------------------------------------------------
 
-qreal PaletteCellIconEngine::paintStaff(QPainter& p, const QRect& rect, qreal spatium)
+qreal PaletteCellIconEngine::paintStaff(mu::draw::Painter& p, const QRect& rect, qreal spatium)
 {
     p.save();   // so we can restore painter after we are done using it
     QPen pen(configuration()->elementsColor());
@@ -1148,7 +1148,7 @@ qreal PaletteCellIconEngine::paintStaff(QPainter& p, const QRect& rect, qreal sp
 //   paintBackground
 //---------------------------------------------------------
 
-void PaletteCellIconEngine::paintBackground(QPainter& p, const QRect& r, bool selected, bool current)
+void PaletteCellIconEngine::paintBackground(mu::draw::Painter& p, const QRect& r, bool selected, bool current)
 {
     QColor c(configuration()->accentColor());
     if (current || selected) {
@@ -1161,7 +1161,7 @@ void PaletteCellIconEngine::paintBackground(QPainter& p, const QRect& r, bool se
 //   paintTag
 //---------------------------------------------------------
 
-void PaletteCellIconEngine::paintTag(QPainter& painter, const QRect& rect, QString tag)
+void PaletteCellIconEngine::paintTag(mu::draw::Painter& painter, const QRect& rect, QString tag)
 {
     if (tag.isEmpty()) {
         return;
@@ -1186,7 +1186,7 @@ void PaletteCellIconEngine::paintTag(QPainter& painter, const QRect& rect, QStri
 //   PaletteCellIconEngine::paintCell
 //---------------------------------------------------------
 
-void PaletteCellIconEngine::paintCell(QPainter& p, const QRect& r, bool selected, bool current) const
+void PaletteCellIconEngine::paintCell(mu::draw::Painter& p, const QRect& r, bool selected, bool current) const
 {
     const qreal _yOffset = 0.0;   // TODO
 
@@ -1230,11 +1230,11 @@ void PaletteCellIconEngine::paintCell(QPainter& p, const QRect& r, bool selected
 //   PaletteCellIconEngine::paint
 //---------------------------------------------------------
 
-void PaletteCellIconEngine::paint(QPainter* painter, const QRect& r, QIcon::Mode mode, QIcon::State state)
+void PaletteCellIconEngine::paint(QPainter* qp, const QRect& r, QIcon::Mode mode, QIcon::State state)
 {
-    QPainter& p = *painter;
+    mu::draw::Painter p(qp);
     p.save();   // so we can restore it later
-    p.setRenderHint(QPainter::Antialiasing, true);
+    p.setRenderHint(mu::draw::Painter::Antialiasing, true);
     paintCell(p, r, mode == QIcon::Selected, state == QIcon::On);
     p.restore();   // return painter to saved initial state (undo any changes to pen, coordinates, font, etc.)
 }

--- a/src/palette/internal/palette/palettetree.h
+++ b/src/palette/internal/palette/palettetree.h
@@ -94,12 +94,12 @@ class PaletteCellIconEngine : public QIconEngine
     INJECT_STATIC(palette, mu::palette::IPaletteConfiguration, configuration)
 
 private:
-    void paintCell(QPainter& p, const QRect& r, bool selected, bool current) const;
-    void paintScoreElement(QPainter& p, Element* e, qreal spatium, bool alignToStaff) const;
+    void paintCell(mu::draw::Painter& p, const QRect& r, bool selected, bool current) const;
+    void paintScoreElement(mu::draw::Painter& p, Element* e, qreal spatium, bool alignToStaff) const;
 
-    static qreal paintStaff(QPainter& p, const QRect& rect, qreal spatium);
-    static void paintTag(QPainter& painter, const QRect& rect, QString tag);
-    static void paintBackground(QPainter& p, const QRect& r, bool selected, bool current);
+    static qreal paintStaff(mu::draw::Painter& p, const QRect& rect, qreal spatium);
+    static void paintTag(mu::draw::Painter& painter, const QRect& rect, QString tag);
+    static void paintBackground(mu::draw::Painter& p, const QRect& r, bool selected, bool current);
 
 public:
     PaletteCellIconEngine(PaletteCellConstPtr cell, qreal extraMag = 1.0)

--- a/src/palette/internal/widgets/keyedit.cpp
+++ b/src/palette/internal/widgets/keyedit.cpp
@@ -103,8 +103,9 @@ void KeyCanvas::clear()
 
 void KeyCanvas::paintEvent(QPaintEvent*)
 {
-    QPainter painter(this);
-    painter.setRenderHint(QPainter::Antialiasing, true);
+    QPainter qp(this);
+    mu::draw::Painter painter(&qp);
+    painter.setRenderHint(mu::draw::Painter::Antialiasing, true);
     qreal wh = double(height());
     qreal ww = double(width());
     double y = wh * .5 - 2 * mu::palette::PALETTE_SPATIUM * extraMag;

--- a/src/plugins/api/util.cpp
+++ b/src/plugins/api/util.cpp
@@ -169,10 +169,12 @@ void ScoreView::setScore(Ms::Score* s)
 //   paint
 //---------------------------------------------------------
 
-void ScoreView::paint(QPainter* p)
+void ScoreView::paint(QPainter* qp)
 {
-    p->setRenderHint(QPainter::Antialiasing, true);
-    p->setRenderHint(QPainter::TextAntialiasing, true);
+    mu::draw::Painter mup(qp);
+    mu::draw::Painter* p = &mup;
+    p->setRenderHint(mu::draw::Painter::Antialiasing, true);
+    p->setRenderHint(mu::draw::Painter::TextAntialiasing, true);
     p->fillRect(QRect(0, 0, width(), height()), _color);
     if (!score) {
         return;

--- a/src/plugins/api/util.h
+++ b/src/plugins/api/util.h
@@ -165,7 +165,7 @@ class ScoreView : public QQuickPaintedItem, public MuseScoreView
     virtual void paint(QPainter*) override;
 
     virtual QRectF boundingRect() const override { return _boundingRect; }
-    virtual void drawBackground(QPainter*, const QRectF&) const override {}
+    virtual void drawBackground(mu::draw::Painter*, const QRectF&) const override {}
 
 public slots:
     //@ --


### PR DESCRIPTION
We have some reasons for using our Painter instead QPainter: 
1. Currently the paint method is not called on the main thread, this is potentially dangerous. We probably need to "draw" to the buffer in the main thread and in the real paint method draw this buffer.
2. We want to make a draw testing system. For it needs to draw to geometry primitives and sterilize it
3. Strategically, we want to gradually get rid of Qt in libmscore.

This is the first step for solve these issues.