### PR TITLE
[MU3] Fix #317227, fix #317185: Disable centering score when opening score or switching LayoutMode

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2661,10 +2661,6 @@ void MuseScore::setCurrentScoreView(ScoreView* view)
                   }
             cs = cv->score();
             cv->setFocusRect();
-            if (!cv->wasShown) {
-                  cv->wasShown = true;
-                  cv->pageTop();
-                  }
             }
       else
             cs = 0;

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -236,6 +236,7 @@ void ScoreView::setScore(Score* s)
                   }
             else
                   _score->addViewer(this);
+            pageTop(); // (re)set position
             }
 
       if (shadowNote == 0) {
@@ -3579,46 +3580,7 @@ void ScoreView::screenPrev()
 
 void ScoreView::pageTop()
       {
-      switch (score()->layoutMode()) {
-            case LayoutMode::PAGE:
-                  {
-                  qreal dx = thinPadding, dy = thinPadding;
-                  Page* firstPage = score()->pages().front();
-                  Page* lastPage  = score()->pages().back();
-                  if (firstPage && lastPage) {
-                        QPointF offsetPt(xoffset(), yoffset());
-                        QRectF firstPageRect(firstPage->pos().x() * physicalZoomLevel(),
-                                             firstPage->pos().y() * physicalZoomLevel(),
-                                             firstPage->width() * physicalZoomLevel(),
-                                             firstPage->height() * physicalZoomLevel());
-                        QRectF lastPageRect(lastPage->pos().x() * physicalZoomLevel(),
-                                            lastPage->pos().y() * physicalZoomLevel(),
-                                            lastPage->width() * physicalZoomLevel(),
-                                            lastPage->height() * physicalZoomLevel());
-                        QRectF pagesRect = firstPageRect.united(lastPageRect);
-                        dx = qMax(thinPadding, (width() - pagesRect.width()) / 2);
-                        dy = qMax(thinPadding, (height() - pagesRect.height()) / 2);
-                        }
-                  setOffset(dx, dy);
-                  break;
-                  }
-            case LayoutMode::LINE:
-                  setOffset(thinPadding, 0.0);
-                  break;
-            case LayoutMode::SYSTEM:
-                  {
-                  qreal dx = thinPadding, dy = thinPadding;
-                  Page* page = score()->pages().front();
-                  if (page) {
-                        dx = qMax(thinPadding, (width() - page->width() * physicalZoomLevel()) / 2);
-                        }
-                  setOffset(dx, dy);
-                  break;
-                  }
-            default:
-                  setOffset(thinPadding, thinPadding);
-                  break;
-      }
+      setOffset(thinPadding, score()->layoutMode() == LayoutMode::LINE ? 0.0 : thinPadding);
       update();
       }
 

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -428,7 +428,6 @@ class ScoreView : public QWidget, public MuseScoreView {
       void setEditElement(Element*);
       void updateEditElement();
 
-      bool wasShown = false;
       bool noteEntryMode() const { return state == ViewState::NOTE_ENTRY; }
       bool editMode() const      { return state == ViewState::EDIT; }
       bool textEditMode() const  { return editMode() && editData.element && editData.element->isTextBase(); }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/317227, https://musescore.org/en/node/317185

Centering the score was maybe esthetically a nice idea, but in practice, it turns out to be less ergonomic / efficient. Therefore, it's now disabled; the score will be loaded with a bit of padding in the top left corner, like it was in 3.5.2 when you switched to another LayoutMode.
The way in which centering the score on opening was implemented also caused https://musescore.org/en/node/317185.

<img width="1408" alt="Schermafbeelding 2021-03-01 om 16 23 15" src="https://user-images.githubusercontent.com/48658420/109518318-6dcb4880-7aaa-11eb-9788-bfa0b38825ee.png">