### PR TITLE
[DAISY] Fix #298147 MusicXML: Handle measure number offsets

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -6621,6 +6621,7 @@ void MeasureNumberStateHandler::updateForMeasure(const Measure* const m)
     }
 
     // update measure numbers and cache result
+    _measureNo += m->noOffset();
     _cachedAttributes = " number=";
     if ((_irregularMeasureNo + _measureNo) == 2 && m->irregular()) {
         _cachedAttributes += "\"0\" implicit=\"yes\"";

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -1708,7 +1708,8 @@ void MusicXMLParserPass2::part()
 #endif
 
     // read the measures
-    int nr = 0;   // current measure sequence number
+    int nr = 0; // current measure sequence number (always increments by one for each measure)
+    _measureNumber = 0; // written measure number (doesn't always increment by 1)
     while (_e.readNextStartElement()) {
         if (_e.name() == "measure") {
             Fraction t = _pass1.getMeasureStart(nr);
@@ -2002,8 +2003,10 @@ static bool hasTempoTextAtTick(const TempoMap* const tempoMap, const int tick)
 
 void MusicXMLParserPass2::measure(const QString& partId, const Fraction time)
 {
-    QString number = _e.attributes().value("number").toString();
-    //qDebug("measure %s start", qPrintable(number));
+    bool isNumericMeasureNumber; // "measure numbers" don't have to be actual numbers in MusicXML
+    int parsedMeasureNumber = _e.attributes().value("number").toInt(&isNumericMeasureNumber);
+
+    //qDebug("measure %d start", parsedMeasureNumber);
 
     Measure* measure = findMeasure(_score, time);
     if (!measure) {
@@ -2012,9 +2015,18 @@ void MusicXMLParserPass2::measure(const QString& partId, const Fraction time)
         return;
     }
 
-    // handle implicit measure
     if (_e.attributes().value("implicit") == "yes") {
+        // Implicit measure: expect measure number to be unchanged.
         measure->setIrregular(true);
+    } else {
+        // Normal measure: expect number to have increased by one.
+        ++_measureNumber;
+    }
+
+    if (isNumericMeasureNumber) {
+        // Actual measure number may differ from expected value.
+        measure->setNoOffset(parsedMeasureNumber - _measureNumber);
+        _measureNumber = parsedMeasureNumber;
     }
 
     // set measure's RepeatFlag to none because musicXML is allowing single measure repeat and no ordering in repeat start and end barlines

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
@@ -341,6 +341,7 @@ private:
     Chord* _tremStart;                            ///< Starting chord for current tremolo
     FiguredBass* _figBass;                        ///< Current figured bass element (to attach to next note)
     int _multiMeasureRestCount;
+    int _measureNumber;                           ///< Current measure number as written in the score
     MusicXmlLyricsExtend _extendedLyrics;         ///< Lyrics with "extend" requiring fixup
 
     MusicXmlSlash _measureStyleSlash;             ///< Are we inside a measure to be displayed as slashes?

--- a/src/importexport/musicxml/tests/data/testFractionTicks.xml
+++ b/src/importexport/musicxml/tests/data/testFractionTicks.xml
@@ -65,7 +65,7 @@
         <type>whole</type>
         </note>
       </measure>
-    <measure number="1">
+    <measure number="2">
       <note>
         <pitch>
           <step>C</step>
@@ -75,7 +75,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="3">
       <note>
         <pitch>
           <step>C</step>
@@ -85,7 +85,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="4">
       <note>
         <pitch>
           <step>C</step>
@@ -95,7 +95,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="5">
       <note>
         <pitch>
           <step>C</step>
@@ -105,7 +105,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="6">
       <note>
         <pitch>
           <step>C</step>
@@ -115,7 +115,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="7">
       <note>
         <pitch>
           <step>C</step>
@@ -125,7 +125,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="8">
       <note>
         <pitch>
           <step>C</step>
@@ -135,7 +135,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="9">
       <note>
         <pitch>
           <step>C</step>
@@ -145,7 +145,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="10">
       <note>
         <pitch>
           <step>C</step>
@@ -155,7 +155,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="11">
       <note>
         <pitch>
           <step>C</step>
@@ -165,7 +165,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="12">
       <note>
         <pitch>
           <step>C</step>
@@ -175,7 +175,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="13">
       <note>
         <pitch>
           <step>C</step>
@@ -185,7 +185,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="14">
       <note>
         <pitch>
           <step>C</step>
@@ -195,7 +195,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="15">
       <note>
         <pitch>
           <step>C</step>
@@ -205,7 +205,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="16">
       <note>
         <pitch>
           <step>C</step>
@@ -215,7 +215,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="17">
       <note>
         <pitch>
           <step>C</step>
@@ -225,7 +225,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="18">
       <note>
         <pitch>
           <step>C</step>
@@ -235,7 +235,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="19">
       <note>
         <pitch>
           <step>C</step>
@@ -245,7 +245,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="20">
       <note>
         <pitch>
           <step>C</step>
@@ -255,7 +255,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="21">
       <note>
         <pitch>
           <step>C</step>
@@ -265,7 +265,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="22">
       <note>
         <pitch>
           <step>C</step>
@@ -275,7 +275,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="23">
       <note>
         <pitch>
           <step>C</step>
@@ -285,7 +285,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="24">
       <note>
         <pitch>
           <step>C</step>
@@ -295,7 +295,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="25">
       <note>
         <pitch>
           <step>C</step>
@@ -305,7 +305,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="26">
       <note>
         <pitch>
           <step>C</step>
@@ -315,7 +315,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="27">
       <note>
         <pitch>
           <step>C</step>
@@ -325,7 +325,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="28">
       <note>
         <pitch>
           <step>C</step>
@@ -335,7 +335,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="29">
       <note>
         <pitch>
           <step>C</step>
@@ -345,7 +345,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="30">
       <note>
         <pitch>
           <step>C</step>
@@ -355,7 +355,7 @@
         <type>whole</type>
         </note>
     </measure>
-    <measure number="1">
+    <measure number="31">
       <note>
         <pitch>
           <step>C</step>
@@ -396,7 +396,7 @@
         <type>quarter</type>
       </note>
     </measure>
-    <measure number="1">
+    <measure number="32">
       <note>
         <pitch>
           <step>C</step>

--- a/src/importexport/musicxml/tests/data/testMeasureNumbers.xml
+++ b/src/importexport/musicxml/tests/data/testMeasureNumbers.xml
@@ -1,0 +1,347 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-number>MuseScore testfile</work-number>
+    <work-title>Measure Numbers</work-title>
+    </work>
+  <identification>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Voice</part-name>
+      <part-abbreviation>Vo.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Voice</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>53</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P2">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P2-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-instrument id="P2-I1">
+        <midi-channel>2</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="0" implicit="yes">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <direction placement="above">
+        <direction-type>
+          <words>(*0) excluded</words>
+          </direction-type>
+        </direction>
+      <note>
+        <rest/>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      </measure>
+    <measure number="1">
+      <direction placement="above">
+        <direction-type>
+          <words>(*1)</words>
+          </direction-type>
+        </direction>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="12">
+      <direction placement="above">
+        <direction-type>
+          <words>(12) +10</words>
+          </direction-type>
+        </direction>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="13">
+      <direction placement="above">
+        <direction-type>
+          <words>(13)</words>
+          </direction-type>
+        </direction>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="X1" implicit="yes">
+      <direction placement="above">
+        <direction-type>
+          <words>(*13) excluded</words>
+          </direction-type>
+        </direction>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="14">
+      <direction placement="above">
+        <direction-type>
+          <words>(14)</words>
+          </direction-type>
+        </direction>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="X2" implicit="yes">
+      <direction placement="above">
+        <direction-type>
+          <words>(*4) -10, excluded</words>
+          </direction-type>
+        </direction>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="5">
+      <direction placement="above">
+        <direction-type>
+          <words>(5)</words>
+          </direction-type>
+        </direction>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P2">
+    <measure number="0" implicit="yes">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note>
+        <rest/>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <staff>1</staff>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>3</duration>
+        </backup>
+      <note>
+        <rest/>
+        <duration>2</duration>
+        <voice>5</voice>
+        <type>half</type>
+        <staff>2</staff>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>quarter</type>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="1">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="12">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="13">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="X1" implicit="yes">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="14">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="X2" implicit="yes">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="5">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/tst_mxml_io.cpp
+++ b/src/importexport/musicxml/tests/tst_mxml_io.cpp
@@ -159,6 +159,7 @@ private slots:
     void lyricsVoice2a() { mxmlIoTest("testLyricsVoice2a"); }
     void lyricsVoice2b() { mxmlIoTestRef("testLyricsVoice2b"); }
     void measureLength() { mxmlIoTestRef("testMeasureLength"); }
+    void measureNumbers() { mxmlIoTest("testMeasureNumbers"); }
     void measureRepeats1() { mxmlIoTestRef("testMeasureRepeats1"); }
     //void measureRepeats2() { mxmlIoTestRef("testMeasureRepeats2"); } fail libmscore/style.cpp Q_ASSERT(idx == textStyles[int(idx)].tid);
     void measureRepeats3() { mxmlIoTest("testMeasureRepeats3"); }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/298147

Previously it was assumed that measure numbers always started at 1 and increased by 1 for each regular measure. Now the actual measure numbers given in the MusicXML are used within MuseScore during import to calculate measure number offsets. During export, these offsets are converted back into absolute numbers for use in the MusicXML.

To-do:

- [x] Check export works as expected
- [x] Check import works as expected
- [x] Add tests and reference files