### PR TITLE
[DAISY] Fix #269926 MusicXML: Fermatas on notes with grace notes

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -2827,13 +2827,15 @@ static void writeChordLines(const Chord* const chord, XmlWriter& xml, Notations&
 void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technical& technical,
                                      TrillHash& trillStart, TrillHash& trillStop)
 {
-    QVector<Element*> fl;
-    for (Element* e : chord->segment()->annotations()) {
-        if (e->track() == chord->track() && e->isFermata()) {
-            fl.push_back(e);
+    if (!chord->isGrace()) {
+        QVector<Element*> fl;
+        for (Element* e : chord->segment()->annotations()) {
+            if (e->track() == chord->track() && e->isFermata()) {
+                fl.push_back(e);
+            }
         }
+        fermatas(fl, _xml, notations);
     }
-    fermatas(fl, _xml, notations);
 
     const QVector<Articulation*> na = chord->articulations();
     // first the attributes whose elements are children of <articulations>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/269926

Previously, if a note had both a fermata and a grace note then the grace note would gain a fermata during export.

To-do:

- [x] Check export works as expected
- [ ] Check import works as expected (can't do this yet because import is currently disabled in MU4)
- [ ] Add tests and reference files