### PR TITLE
[MU3] "Add Frame Text" shortcut doesn't work

### DIFF
--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -131,6 +131,12 @@ void ScoreView::createElementPropertyMenu(Element* e, QMenu* popup)
             popup->addAction(getAction("flip"));
       else if (e->isHook())
             popup->addAction(getAction("flip"));
+      else if (e->isTBox()) {
+            QMenu* textMenu = popup->addMenu(tr("Add"));
+            // borrow translation info from global actions
+            // but create new actions with local handler
+            textMenu->addAction(getAction("frame-text")->text())->setData("frame-text");
+            }
       else if (e->isHBox()) {
             QMenu* textMenu = popup->addMenu(tr("Add"));
             // borrow translation info from global actions

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2207,6 +2207,9 @@ void ScoreView::cmd(const char* s)
                   cv->changeState(ViewState::NORMAL);
                   cv->cmdAddChordName(HarmonyType::NASHVILLE);
                   }},
+            {{"frame-text"}, [](ScoreView* cv, const QByteArray&) {
+                  cv->cmdAddText(Tid::FRAME);
+                  }},
             {{"title-text"}, [](ScoreView* cv, const QByteArray&) {
                   cv->cmdAddText(Tid::TITLE);
                   }},
@@ -4645,6 +4648,7 @@ void ScoreView::cmdAddText(Tid tid, Tid customTid, PropertyFlags pf, Placement p
       if (tid == Tid::STAFF && customTid == Tid::EXPRESSION)
             tid = customTid;  // expression is not first class element, but treat as such
       switch (tid) {
+            case Tid::FRAME:
             case Tid::TITLE:
             case Tid::SUBTITLE:
             case Tid::COMPOSER:


### PR DESCRIPTION
Came up in the MuseScore translators' chat, see https://t.me/MuseScoreTranslation/7269 ff.

While at it, add a Context menu to text frames too.

Dioesn't seem to apply to the master branch (yet?)