### PR TITLE
[MU3] Fix detection of even/odd lyrics

### DIFF
--- a/libmscore/lyrics.h
+++ b/libmscore/lyrics.h
@@ -83,7 +83,7 @@ class Lyrics final : public TextBase {
       QString subtypeName() const override    { return QObject::tr("Verse %1").arg(_no + 1); }
       void setNo(int n)                               { _no = n; }
       int no() const                                  { return _no; }
-      bool isEven() const                             { return _no % 1; }
+      bool isEven() const                             { return _no & 1; }
       void setSyllabic(Syllabic s)                    { _syllabic = s; }
       Syllabic syllabic() const                       { return _syllabic; }
       void add(Element*) override;


### PR DESCRIPTION
Shamelessly stolen from #7627 and fixed the still wrong logic ;-) (`_no`  is zero based, see discussion in https://github.com/musescore/MuseScore/pull/7627#discussion_r588132894)

Might (!?) resolve:

* https://musescore.org/en/node/9304
* https://musescore.org/en/node/285495
* https://musescore.org/en/node/288604

Well, maybe not, as that `Lyrics::isEven()` isn't actually used anywhere. So yes, it is a bug, but in (currently) unused code, as far as I can tell.
In lyrics.cpp it uses `(_no & 1)` for this purpose and in 3 different places.