### PR TITLE
Fix #318388: Crash when trying to attach an image to key signature

### DIFF
--- a/src/libmscore/paste.cpp
+++ b/src/libmscore/paste.cpp
@@ -1173,9 +1173,11 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view, Fraction scale)
             EditData ddata(view);
             ddata.view       = view;
             ddata.dropElement    = nel;
-            target->drop(ddata);
-            if (_selection.element()) {
-                addRefresh(_selection.element()->abbox());
+            if (target->acceptDrop(ddata)) {
+                target->drop(ddata);
+                if (_selection.element()) {
+                    addRefresh(_selection.element()->abbox());
+                }
             }
         }
         delete image;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/318388.

`target->drop(data)` should never be called unless `target->acceptDrop(data)` returns `true`.