### PR TITLE
[MU3] Image paste crashes

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -1125,10 +1125,12 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view, Fraction scale)
                   addRefresh(target->abbox());   // layout() ?!
                   EditData ddata(view);
                   ddata.view       = view;
-                  ddata.dropElement    = nel;
-                  target->drop(ddata);
-                  if (_selection.element())
-                        addRefresh(_selection.element()->abbox());
+                  if (target->acceptDrop(ddata)) {
+                        ddata.dropElement    = nel;
+                        target->drop(ddata);
+                        if (_selection.element())
+                              addRefresh(_selection.element()->abbox());
+                        }
                   }
             delete image;
             }


### PR DESCRIPTION
Resolves: 

* [Fix #318388](https://musescore.org/en/node/318388): Crash when trying to attach an image to key signature (3.x counterpart to #7698)
* [Fix #318370](https://musescore.org/en/node/318370): crash when pasting an image onto a (title) text (may not be needed after the above fix, but won't harm)
