### PR TITLE
Fix #307704: Capo settings applied via staff text do not affect chord symbols

### DIFF
--- a/src/libmscore/harmony.cpp
+++ b/src/libmscore/harmony.cpp
@@ -1307,11 +1307,12 @@ const ChordDescription* Harmony::getDescription(const QString& name, const Parse
 
 const RealizedHarmony& Harmony::getRealizedHarmony() const
 {
-    int offset = 0;   //semitone offset for pitch adjustment
     Staff* st = staff();
+    int capo = st->capo(tick()) - 1;
+    int offset = (capo < 0 ? 0 : capo);   //semitone offset for pitch adjustment
     Interval interval = st->part()->instrument(tick())->transpose();
     if (!score()->styleB(Sid::concertPitch)) {
-        offset = interval.chromatic;
+        offset += interval.chromatic;
     }
 
     //Adjust for Nashville Notation, might be temporary

--- a/src/libmscore/rendermidi.cpp
+++ b/src/libmscore/rendermidi.cpp
@@ -143,7 +143,10 @@ void Score::updateCapo()
         return;
     }
     for (Segment* s = fm->first(SegmentType::ChordRest); s; s = s->next1(SegmentType::ChordRest)) {
-        for (const Element* e : s->annotations()) {
+        for (Element* e : s->annotations()) {
+            if (e->isHarmony()) {
+                toHarmony(e)->realizedHarmony().setDirty(true);
+            }
             if (!e->isStaffTextBase()) {
                 continue;
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/307704.

The code for the realization of chord symbols was ignoring the capo settings from the staff text. Fortunately, `RealizedHarmony::update()` already has a `transposeOffset` parameter which can be leveraged to account for the current capo setting.

There is an opportunity here to clean up the way that capo settings are stored in the capo list. A capo value of 0 means "no change", and all other values are offset by 1. So the actual transposition due to the capo is one less than the capo value, unless the capo value is zero. But capo values of zero are not even stored in the capo list. However, `Staff::capo()` will return 0 if the capo list is empty. It would make more sense to subtract 1 from the capo value before storing it in the list, so that `Staff::capo()` always returns the actual transposition. Making this change would not affect the way that capo values are saved in the score, but it would simplify the process of retrieving the capo value from the list. But since that change is not strictly necessary in order to solve this issue, I have left it alone for now. But I can easily modify this PR if it is agreed that that change is desired.