### PR TITLE
add shasum check + reduce layer size + add shell pipe safety

### DIFF
--- a/build/Linux+BSD/portable/ARM/jessie-packaging-armhf.Dockerfile
+++ b/build/Linux+BSD/portable/ARM/jessie-packaging-armhf.Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get update
 
 # need to be able to use https for wget
 RUN apt-get --no-install-recommends -y install \
-      ca-certificates \
-      wget
+  ca-certificates \
+  wget
 
 # get prebuilt AppImageKit
 RUN wget "https://bintray.com/artifact/download/ericfont/prebuilt-AppImageKit/AppImageKit-5_built-in-armv7hf-jessie.tar.gz" \
@@ -19,15 +19,15 @@ RUN wget "https://bintray.com/artifact/download/ericfont/prebuilt-AppImageKit/Ap
 
 # add AppImageKit dependencies
 RUN apt-get --no-install-recommends -y install \
-      libfuse-dev \
-      libglib2.0-dev \
-      cmake \
-      git \
-      libc6-dev \
-      binutils \
-      fuse \
-      python \
-      && apt-get clean \
-      && rm -rf /var/lib/apt/lists/*
+  libfuse-dev \
+  libglib2.0-dev \
+  cmake \
+  git \
+  libc6-dev \
+  binutils \
+  fuse \
+  python \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN [ "cross-build-end" ]

--- a/build/Linux+BSD/portable/ARM/jessie-packaging-armhf.Dockerfile
+++ b/build/Linux+BSD/portable/ARM/jessie-packaging-armhf.Dockerfile
@@ -1,18 +1,33 @@
 FROM ericfont/armv7hf-debian-qemu:jessie
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 RUN [ "cross-build-start" ]
 
 RUN apt-get update
 
 # need to be able to use https for wget
-RUN apt-get install ca-certificates wget #git
+RUN apt-get --no-install-recommends -y install \
+      ca-certificates \
+      wget
 
 # get prebuilt AppImageKit
-RUN wget https://bintray.com/artifact/download/ericfont/prebuilt-AppImageKit/AppImageKit-5_built-in-armv7hf-jessie.tar.gz
-RUN tar -xvzf AppImageKit-5_built-in-armv7hf-jessie.tar.gz
-RUN rm AppImageKit-5_built-in-armv7hf-jessie.tar.gz
+RUN wget "https://bintray.com/artifact/download/ericfont/prebuilt-AppImageKit/AppImageKit-5_built-in-armv7hf-jessie.tar.gz" \
+  && echo "1710396680a0b4e0c149885e9ee89bd170455c15e86e2ac3ebd426739bd33ec0  AppImageKit-5_built-in-armv7hf-jessie.tar.gz" | sha256sum -c \
+  && tar -xvzf AppImageKit-5_built-in-armv7hf-jessie.tar.gz  \
+  && rm AppImageKit-5_built-in-armv7hf-jessie.tar.gz
 
 # add AppImageKit dependencies
-RUN apt-get -y install libfuse-dev libglib2.0-dev cmake git libc6-dev binutils fuse python
+RUN apt-get --no-install-recommends -y install \
+      libfuse-dev \
+      libglib2.0-dev \
+      cmake \
+      git \
+      libc6-dev \
+      binutils \
+      fuse \
+      python \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*
 
-RUN [ "cross-build-end" ]  
+RUN [ "cross-build-end" ]


### PR DESCRIPTION
Resolves: Slow build time by improving caching and potential security issue by checking the shasum of `AppImageKit` when downloaded via `wget`

This PR:
* Follows [hadolint](https://github.com/hadolint/hadolint) rules, such as adding `--no-install-recommends` so extra data like docs aren't installed, and rule [DL4006](https://github.com/hadolint/hadolint/wiki/DL4006) to protect from pipe errors
* Newlines installed packages so that `git diff`'s  and `blame`s are cleaner
* Joins `RUN` commands to reduce layers, e.g., previously the seperate `rm` layer of the tarball meant that the size of the wasn't removed from the Dockerfile size

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
