### PR TITLE
[MU3] fix #316176: Activating the Multimeasure rests prevents the "SmoothPan" function from working.

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -672,6 +672,10 @@ void ScoreView::moveControlCursor(const Fraction& tick)
       _controlCursor->setColor(c);
       _controlCursor->setTick(tick);
 
+      if (_timeElapsed < 0) {
+            _timeElapsed = 0;
+            }
+
       int realX = _cursor->rect().x();
       int controlX = _controlCursor->rect().x();
       double distance = realX - controlX;
@@ -718,8 +722,8 @@ void ScoreView::moveControlCursor(const Fraction& tick)
             _timeElapsed += addition;
             }
       else { // reposition the cursor when distance is too great
-            double curOffset = _cursor->rect().x() - score()->firstMeasure()->pos().x();
-            double length = score()->lastMeasure()->pos().x() - score()->firstMeasure()->pos().x();
+            double curOffset = _cursor->rect().x() - score()->firstMeasureMM()->pos().x();
+            double length = score()->lastMeasureMM()->pos().x() - score()->firstMeasureMM()->pos().x();
             _timeElapsed = (curOffset / length) * score()->durationWithoutRepeats() * 1000;
             _controlModifier = _panSettings.controlModifierBase;
             }
@@ -743,7 +747,7 @@ void ScoreView::moveControlCursor(const Fraction& tick)
 
 
       // Calculate the position of the controlCursor based on the timeElapsed (which is not the real time that has passed)
-      qreal x = score()->firstMeasure()->pos().x() + (score()->lastMeasure()->pos().x() - score()->firstMeasure()->pos().x()) * (_timeElapsed / (score()->durationWithoutRepeats() * 1000));
+      qreal x = score()->firstMeasureMM()->pos().x() + (score()->lastMeasureMM()->pos().x() - score()->firstMeasureMM()->pos().x()) * (_timeElapsed / (score()->durationWithoutRepeats() * 1000));
       x -= score()->spatium();
       _controlCursor->setRect(QRectF(x, _cursor->rect().y(), _cursor->rect().width(), _cursor->rect().height()));
       update(_matrix.mapRect(_controlCursor->rect()).toRect().adjusted(-1,-1,1,1));


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/316176

Changed calls to `firstMeasure` and `lastMeasure` to `firstMeasureMM` and `lastMeasureMM` respectively. Also created a check for invalid timer values.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [n\a] I created the test (mtest, vtest, script test) to verify the changes I made
