### PR TITLE
[MU3] Push updated strings to Transifex, leaving old strings in place

### DIFF
--- a/.github/workflows/ci_lupdate.yml
+++ b/.github/workflows/ci_lupdate.yml
@@ -9,7 +9,7 @@ on:
       publish:
         description: 'Publish to Transifex: on - publish'
         required: false
-        default: 'off'
+        default: 'on'
 jobs:
   lupdate:
     runs-on: macos-10.15

--- a/build/ci/lupdate/run_lupdate.sh
+++ b/build/ci/lupdate/run_lupdate.sh
@@ -6,7 +6,7 @@ source $ENV_FILE
 # Translation routines
 # update translation on transifex
 # remove obsolete strings
-OBSOLETE=-no-obsolete # '-noobsolete' in older QT versions
+#OBSOLETE=-no-obsolete # '-noobsolete' in older QT versions
 
 ./build/gen-qt-projectfile . > mscore.pro
 lupdate ${OBSOLETE} mscore.pro


### PR DESCRIPTION
* `-no-obsolete` should get used only once on every switch of translation resources, like between major releases, maybe between minor ones too, but vever on patch releases, never without also switching translations resources on S3.
* New/changed strings should get push to Transifex automatically and not only manually and on constant nagging of a certain user who prefers to remain unnamed ;-)

In the MuseScore Translators' chat on Telegram it had been discussed and verfied out that this should work just fine, see https://t.me/MuseScoreTranslation/7385 ff. and that it doesn't even harm if there won't ever be a 3.6.3, but still help those that are checking out development builds.

This change does not (yet) apply to master, it does after a new translation round for MuseScore 4 starts, with a new S3 resource and after the 1st set with the `-no-obsolete` option has been push up to Transifex. Actually the `-no-obsolete` could/should be in place until string freeze or max. until first release.