### PR TITLE
Fix #318546: Musescore > Preferences > I/O > MIDI Output Latency field won't keep changes from 0ms

### DIFF
--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -1439,6 +1439,7 @@ void PreferenceDialog::apply()
       #ifdef USE_PORTMIDI
             preferences.setPreference(PREF_IO_PORTMIDI_INPUTDEVICE, portMidiInput->currentText());
             preferences.setPreference(PREF_IO_PORTMIDI_OUTPUTDEVICE, portMidiOutput->currentText());
+            preferences.setPreference(PREF_IO_PORTMIDI_OUTPUTLATENCYMILLISECONDS, portMidiOutputLatencyMilliseconds->value());
             if (seq->driver() && static_cast<PortMidiDriver*>(static_cast<Portaudio*>(seq->driver())->mididriver())->isSameCoreMidiIacBus(preferences.getString(PREF_IO_PORTMIDI_INPUTDEVICE), preferences.getString(PREF_IO_PORTMIDI_OUTPUTDEVICE))) {
                   QMessageBox msgBox;
                   msgBox.setWindowTitle(tr("Possible MIDI Loopback"));


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/318546

This does not (yet) apply to master, which is (currently) lacking the entire (?) preferences settings stuff.
In that respect it similar to #7546, #7168, #7145, #7000, 