### PR TITLE
[MU4] Enable vertical staves adjustment

### DIFF
--- a/src/libmscore/layout.cpp
+++ b/src/libmscore/layout.cpp
@@ -1700,10 +1700,10 @@ static void distributeStaves(Page* page)
                 Spacer* activeSpacer { nextSpacer };
                 nextSpacer = nullptr;
                 for (MeasureBase* mb : system->measures()) {
-                    Measure* m = toMeasure(mb);
-                    if (!mb->isMeasure()) {
+                    if (!(mb && mb->isMeasure())) {
                         continue;
                     }
+                    Measure* m = toMeasure(mb);
                     Spacer* sp = m->vspacerUp(staff->idx());
                     if (sp) {
                         if (!activeSpacer || ((activeSpacer->spacerType() == SpacerType::UP) && (sp->gap() > activeSpacer->gap()))) {

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -1579,8 +1579,6 @@ void EditStyle::enableStyleWidget(const StyleId idx, bool enable)
 void EditStyle::enableVerticalSpreadClicked(bool checked)
 {
     disableVerticalSpread->setChecked(!checked);
-    NOT_IMPLEMENTED;
-//    cs->setLayoutAll(); // TODO
 }
 
 //---------------------------------------------------------
@@ -1590,9 +1588,7 @@ void EditStyle::enableVerticalSpreadClicked(bool checked)
 void EditStyle::disableVerticalSpreadClicked(bool checked)
 {
     setStyleValue(StyleId::enableVerticalSpread, !checked);
-    NOT_IMPLEMENTED;
     enableVerticalSpread->setChecked(!checked);
-//    cs->setLayoutAll(); // TODO
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
This PR does actually 2 things:

 1. In both <code>EditStyle::enableVerticalSpreadClicked()</code> and >code>EditStyle::disableVerticalSpreadClicked()</code> the line <code> cs->setLayoutAll(); // TODO</code> is removed since this isn't necessary. <code>setLayoutAll()</code> is already called in <code>setStyleValue()</code>.
 
 2. Solves a potential crash because the test <code>if (!mb->isMeasure())</code> was at the wrong place. 

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
