### PR TITLE
[MU3] Fix #318646: Crash when changing key signature on staff with Instruments change and transposing instruments

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -3937,7 +3937,6 @@ void Score::updateInstrumentChangeTranspositions(KeySigEvent& key, Staff* staff,
                         Measure* m = tick2measure(Fraction::fromTicks(nextTick));
                         Segment* s = m->tick2segment(Fraction::fromTicks(nextTick), SegmentType::KeySig);
                         int track = staff->idx() * VOICES;
-                        KeySig* keySig = toKeySig(s->element(track));
                         if (key.isAtonal() && !e.isAtonal()) {
                               e.setMode(KeyMode::NONE);
                               e.setKey(Key::C);
@@ -3951,7 +3950,9 @@ void Score::updateInstrumentChangeTranspositions(KeySigEvent& key, Staff* staff,
                               nkey = transposeKey(nkey, previousTranspose);
                               e.setKey(nkey);
                               }
-                        undo(new ChangeKeySig(keySig, e, keySig->showCourtesy()));
+                        KeySig* keySig = toKeySig(s->element(track));
+                        if (keySig)
+                              undo(new ChangeKeySig(keySig, e, keySig->showCourtesy()));
                         nextTick = kl->nextKeyTick(nextTick);
                         }
                   else


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/318646

Very same fix seems needed in master too (at least the very same code is used there currently), see #7720