### PR TITLE
[MU4] Fix #318646: Crash when changing key signature on staff with Instruments change and transposing instruments

### DIFF
--- a/src/libmscore/edit.cpp
+++ b/src/libmscore/edit.cpp
@@ -4584,7 +4584,6 @@ void Score::updateInstrumentChangeTranspositions(KeySigEvent& key, Staff* staff,
                 Measure* m = tick2measure(Fraction::fromTicks(nextTick));
                 Segment* s = m->tick2segment(Fraction::fromTicks(nextTick), SegmentType::KeySig);
                 int track = staff->idx() * VOICES;
-                KeySig* keySig = toKeySig(s->element(track));
                 if (key.isAtonal() && !e.isAtonal()) {
                     e.setMode(KeyMode::NONE);
                     e.setKey(Key::C);
@@ -4597,7 +4596,10 @@ void Score::updateInstrumentChangeTranspositions(KeySigEvent& key, Staff* staff,
                     nkey = transposeKey(nkey, previousTranspose);
                     e.setKey(nkey);
                 }
-                undo(new ChangeKeySig(keySig, e, keySig->showCourtesy()));
+                KeySig* keySig = toKeySig(s->element(track));
+                if (keySig) {
+                    undo(new ChangeKeySig(keySig, e, keySig->showCourtesy()));
+                }
                 nextTick = kl->nextKeyTick(nextTick);
             } else {
                 nextTick = -1;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/318646

This is for master what #7719 is for 3.x