### PR TITLE
New System methods upSpacer/downSpacer for finding active spacers of a system.

### DIFF
--- a/src/libmscore/layout.h
+++ b/src/libmscore/layout.h
@@ -31,7 +31,6 @@ class VerticalGapData
 {
 private:
     bool _fixedHeight        { false };
-    bool _hasSpacer          { false };
     bool _fixedSpacer        { false };
     qreal _factor               { 1.0 };
     qreal _normalisedSpacing    { 0.0 };
@@ -46,7 +45,7 @@ public:
     SysStaff* sysStaff { nullptr };
     Staff* staff    { nullptr };
 
-    VerticalGapData(bool first, System* sys, Staff* st, SysStaff* sst, const Spacer* spacer, qreal y);
+    VerticalGapData(bool first, System* sys, Staff* st, SysStaff* sst, Spacer* nextSpacer, qreal y);
 
     void addSpaceBetweenSections();
     void addSpaceAroundVBox(bool above);

--- a/src/libmscore/system.cpp
+++ b/src/libmscore/system.cpp
@@ -1599,6 +1599,68 @@ qreal System::spacerDistance(bool up) const
 }
 
 //---------------------------------------------------------
+//   upSpacer
+//    Return largest upSpacer for this system. This can
+//    be a downSpacer of the previous system.
+//---------------------------------------------------------
+
+Spacer* System::upSpacer(int staffIdx, Spacer* prevDownSpacer) const
+{
+    if (staffIdx < 0) {
+        return nullptr;
+    }
+
+    if (prevDownSpacer && (prevDownSpacer->spacerType() == SpacerType::FIXED)) {
+        return prevDownSpacer;
+    }
+
+    Spacer* spacer { prevDownSpacer };
+    for (MeasureBase* mb : measures()) {
+        if (!(mb && mb->isMeasure())) {
+            continue;
+        }
+        Spacer* sp { toMeasure(mb)->vspacerUp(staffIdx) };
+        if (sp) {
+            if (!spacer || ((spacer->spacerType() == SpacerType::UP) && (sp->gap() > spacer->gap()))) {
+                spacer = sp;
+            }
+            continue;
+        }
+    }
+    return spacer;
+}
+
+//---------------------------------------------------------
+//   downSpacer
+//    Return the largest downSpacer for this system.
+//---------------------------------------------------------
+
+Spacer* System::downSpacer(int staffIdx) const
+{
+    if (staffIdx < 0) {
+        return nullptr;
+    }
+
+    Spacer* spacer { nullptr };
+    for (MeasureBase* mb : measures()) {
+        if (!(mb && mb->isMeasure())) {
+            continue;
+        }
+        Spacer* sp { toMeasure(mb)->vspacerDown(staffIdx) };
+        if (sp) {
+            if (sp->spacerType() == SpacerType::FIXED) {
+                return sp;
+            } else {
+                if (!spacer || (sp->gap() > spacer->gap())) {
+                    spacer = sp;
+                }
+            }
+        }
+    }
+    return spacer;
+}
+
+//---------------------------------------------------------
 //   firstNoteRestSegmentX
 //    in System() coordinates
 //    returns the position of the first note or rest,

--- a/src/libmscore/system.h
+++ b/src/libmscore/system.h
@@ -194,6 +194,8 @@ public:
     qreal minTop() const;
     qreal minBottom() const;
     qreal spacerDistance(bool up) const;
+    Spacer* upSpacer(int staffIdx, Spacer* prevDownSpacer) const;
+    Spacer* downSpacer(int staffIdx) const;
 
     qreal firstNoteRestSegmentX(bool leading = false);
 


### PR DESCRIPTION
This PR add two now method to the `System` class:

 1. `System::upSpacer(int staffIdx, Spacer* prevDownSpacer)`
 This method return the active up spacer for the the gives `staffIdx`. This is the spacer with the largest gap of all up spacers and the specified `prevDownSpacer`. Unless `prevDownSpacer` is a fixed spacer, in which case `prevDownSpacer` is returned.

 2. `System::downSpacer(int staffIdx,)`
 This method returns the up spacer with the largest gap or the the first fixed spacer.

 `distrubuteStaves()` will now use these routines, another PR will replace all places where dedicated code is used for finding an active spacer by these methods.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
