### PR TITLE
[MU3] Fix #297613: (Linux) File save can't determine file type without extension

### DIFF
--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -239,7 +239,11 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_UI_APP_RASTER_HORIZONTAL,                        new IntPreference(2)},
             {PREF_UI_APP_RASTER_VERTICAL,                          new IntPreference(2)},
             {PREF_UI_APP_SHOWSTATUSBAR,                            new BoolPreference(true)},
+#if defined(Q_OS_MAC) || defined(Q_OS_WIN) // use system native file dialog, Qt file dialog is very slow on Windows and Mac
             {PREF_UI_APP_USENATIVEDIALOGS,                         new BoolPreference(true)},
+#else // don't use system native file dialog, this is causing issues on some Linuxes
+            {PREF_UI_APP_USENATIVEDIALOGS,                         new BoolPreference(false)},
+#endif
             {PREF_UI_PIANO_HIGHLIGHTCOLOR,                         new ColorPreference(QColor(0x0065BF))},
             {PREF_UI_PIANO_SHOWPITCHHELP,                          new BoolPreference(true)},
             {PREF_UI_SCORE_NOTE_DROPCOLOR,                         new ColorPreference(QColor(0x0065BF))},


### PR DESCRIPTION
This basically reverts 3390aab, so for Mac and Windows nothing changes, but for Linux it now defaults to use the Qt file dialogs rather than the native ones. Can still get changed in the advanced properties, by ticking `ui/Application/useNativeDialogs`.

Resolves: https://musescore.org/en/node/297613

As far as I can tell this is not yet needed/feasible for master