### PR TITLE
[MU4] Do not save unused images in the MSCZ archive.

### DIFF
--- a/src/libmscore/imageStore.cpp
+++ b/src/libmscore/imageStore.cpp
@@ -55,7 +55,7 @@ void ImageStoreItem::reference(Image* image)
 bool ImageStoreItem::isUsed(Score* score) const
 {
     foreach (Image* image, _references) {
-        if (image->score() == score) {
+        if (image->score() == score && image->parent() && image->parent()->treeChildIdx(image) != -1) {
             return true;
         }
     }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/318772.

When checking whether an image is used in a given score, also check whether the image's parent actually contains the image. If not, this means that the image has been removed, but is being kept alive in the undo stack, and should not be saved in the MSCZ archive.