### PR TITLE
[MU4] Implement add to selection next/previous chord shortcut

### DIFF
--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -45,6 +45,7 @@ public:
     // Select
     virtual Element* hitElement(const QPointF& pos, float width) const = 0;
     virtual int hitStaffIndex(const QPointF& pos) const = 0;
+    virtual void addChordToSelection(MoveDirection d) = 0;
     virtual void select(const std::vector<Element*>& elements, SelectType type, int staffIndex = 0) = 0;
     virtual void selectAll() = 0;
     virtual void selectSection() = 0;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -141,6 +141,8 @@ void NotationActionController::init()
     dispatcher()->reg(this, UNDO_ACTION_CODE, this, &NotationActionController::undo);
     dispatcher()->reg(this, REDO_ACTION_CODE, this, &NotationActionController::redo);
 
+    dispatcher()->reg(this, "select-next-chord", [this]() { addChordToSelection(MoveDirection::Right); });
+    dispatcher()->reg(this, "select-prev-chord", [this]() { addChordToSelection(MoveDirection::Left); });
     dispatcher()->reg(this, "select-similar", this, &NotationActionController::selectAllSimilarElements);
     dispatcher()->reg(this, "select-similar-staff", this, &NotationActionController::selectAllSimilarElementsInStaff);
     dispatcher()->reg(this, "select-similar-range", this, &NotationActionController::selectAllSimilarElementsInRange);
@@ -860,6 +862,21 @@ void NotationActionController::redo()
     }
 
     notation->undoStack()->redo();
+}
+
+void NotationActionController::addChordToSelection(MoveDirection direction)
+{
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+
+    if (interaction->selection()->elements().size() == 1
+        && interaction->selection()->elements().front()->type() == ElementType::SLUR) {
+        return;
+    }
+
+    interaction->addChordToSelection(direction);
 }
 
 void NotationActionController::selectAllSimilarElements()

--- a/src/notation/internal/notationactioncontroller.h
+++ b/src/notation/internal/notationactioncontroller.h
@@ -92,6 +92,7 @@ private:
     void undo();
     void redo();
 
+    void addChordToSelection(MoveDirection direction);
     void selectAllSimilarElements();
     void selectAllSimilarElementsInStaff();
     void selectAllSimilarElementsInRange();

--- a/src/notation/internal/notationactions.cpp
+++ b/src/notation/internal/notationactions.cpp
@@ -76,6 +76,16 @@ const ActionList NotationActions::m_actions = {
                QT_TRANSLATE_NOOP("action", "Previous staff or voice"),
                QT_TRANSLATE_NOOP("action", "Previous staff or voice")
                ),
+    ActionItem("select-next-chord",
+               ShortcutContext::NotationActive,
+               QT_TRANSLATE_NOOP("action", "Add next chord to selection"),
+               QT_TRANSLATE_NOOP("action", "Add next chord to selection")
+               ),
+    ActionItem("select-prev-chord",
+               ShortcutContext::NotationActive,
+               QT_TRANSLATE_NOOP("action", "Add previous chord to selection"),
+               QT_TRANSLATE_NOOP("action", "Add previous chord to selection")
+               ),
     ActionItem("pitch-up",
                ShortcutContext::NotationActive,
                QT_TRANSLATE_NOOP("action", "Up"),

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -408,6 +408,23 @@ bool NotationInteraction::elementIsLess(const Ms::Element* e1, const Ms::Element
     return e1->z() <= e2->z();
 }
 
+void NotationInteraction::addChordToSelection(MoveDirection d)
+{
+    IF_ASSERT_FAILED(MoveDirection::Left == d || MoveDirection::Right == d) {
+        return;
+    }
+
+    QString cmd;
+    if (MoveDirection::Left == d) {
+        cmd = "select-prev-chord";
+    } else if (MoveDirection::Right == d) {
+        cmd = "select-next-chord";
+    }
+
+    score()->selectMove(cmd);
+    notifyAboutSelectionChanged();
+}
+
 void NotationInteraction::select(const std::vector<Element*>& elements, SelectType type, int staffIndex)
 {
     if (needEndTextEditing(elements)) {

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -63,6 +63,7 @@ public:
     // Select
     Element* hitElement(const QPointF& pos, float width) const override;
     int hitStaffIndex(const QPointF& pos) const override;
+    void addChordToSelection(MoveDirection d) override;
     void select(const std::vector<Element*>& elements, SelectType type, int staffIndex = 0) override;
     void selectAll() override;
     void selectSection() override;


### PR DESCRIPTION
Implements the next/previous chord shortcut from MU3.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
