### PR TITLE
Fix compilation with MinGW on Windows

### DIFF
--- a/build/cmake/SetupBuildEnvironment.cmake
+++ b/build/cmake/SetupBuildEnvironment.cmake
@@ -53,6 +53,9 @@ elseif(CC_IS_MINGW)
         set(CMAKE_EXE_LINKER_FLAGS "-Wl,--large-address-aware")
     endif (NOT BUILD_64)
 
+    add_definitions(-D_UNICODE)
+    add_definitions(-DUNICODE)
+
 elseif(CC_IS_CLANG)
     message(STATUS "Using Compiler CLANG ${CMAKE_CXX_COMPILER_VERSION}")
 

--- a/src/framework/ui/internal/platform/windows/windowsplatformtheme.cpp
+++ b/src/framework/ui/internal/platform/windows/windowsplatformtheme.cpp
@@ -75,9 +75,9 @@ void WindowsPlatformTheme::startListening()
         return;
     }
     m_isListening = true;
-    if (RegOpenKeyEx(HKEY_CURRENT_USER, windowsThemeKey.c_str(), 0,
-                     KEY_NOTIFY | KEY_CREATE_SUB_KEY | KEY_ENUMERATE_SUB_KEYS | KEY_QUERY_VALUE | KEY_WOW64_64KEY,
-                     &hKey) == ERROR_SUCCESS) {
+    if (RegOpenKeyExW(HKEY_CURRENT_USER, windowsThemeKey.c_str(), 0,
+                      KEY_NOTIFY | KEY_CREATE_SUB_KEY | KEY_ENUMERATE_SUB_KEYS | KEY_QUERY_VALUE | KEY_WOW64_64KEY,
+                      &hKey) == ERROR_SUCCESS) {
         m_listenThread = std::thread([this]() { th_listen(); });
     } else {
         LOGD() << "Failed opening key for listening dark theme changes.";

--- a/src/libmscore/scorefile.cpp
+++ b/src/libmscore/scorefile.cpp
@@ -449,16 +449,7 @@ bool MasterScore::saveFile(bool generateBackup)
             dir.mkdir(backupSubdirString);
 #ifdef Q_OS_WIN
             const QString backupDirNativePath = QDir::toNativeSeparators(backupDirString);
-#if (defined (_MSCVER) || defined (_MSC_VER))
-   #if (defined (UNICODE))
-            SetFileAttributes((LPCTSTR)backupDirNativePath.unicode(), FILE_ATTRIBUTE_HIDDEN);
-   #else
-            // Use byte-based Windows function
-            SetFileAttributes((LPCTSTR)backupDirNativePath.toLocal8Bit(), FILE_ATTRIBUTE_HIDDEN);
-   #endif
-#else
-            SetFileAttributes((LPCTSTR)backupDirNativePath.toLocal8Bit(), FILE_ATTRIBUTE_HIDDEN);
-#endif
+            SetFileAttributesW(reinterpret_cast<LPCWSTR>(backupDirNativePath.utf16()), FILE_ATTRIBUTE_HIDDEN);
 #endif
         }
         const QString backupName = QString(".") + info.fileName() + QString(",");


### PR DESCRIPTION
Errors fixed:

__Unicode__

```
src/framework/ui/internal/platform/windows/windowsplatformtheme.cpp: In member function 'void mu::ui::WindowsPlatformTheme::startListening()':
src/framework/ui/internal/platform/windows/windowsplatformtheme.cpp:78:62: error: cannot convert 'const wchar_t' to 'LPCSTR' {aka 'const char'}
     if (RegOpenKeyEx(HKEY_CURRENT_USER, windowsThemeKey.c_str(), 0,
                                                              ^
```

__Type__

```
src/libmscore/scorefile.cpp: In member function 'bool Ms::MasterScore::saveFile(bool)':
src/libmscore/scorefile.cpp:460:72: error: invalid cast from type 'QByteArray' to type 'LPCTSTR' {aka 'const wchar_t*'}
             SetFileAttributes((LPCTSTR)backupDirNativePath.toLocal8Bit(), FILE_ATTRIBUTE_HIDDEN);
                                                                        ^
```