### PR TITLE
[MU4] Fix crash while saving as MSCZ or exporting as PDF or SVG

### DIFF
--- a/src/libmscore/draw/bufferedpaintprovider.cpp
+++ b/src/libmscore/draw/bufferedpaintprovider.cpp
@@ -52,8 +52,10 @@ void BufferedPaintProvider::beforeEndTargetHook(Painter*)
 bool BufferedPaintProvider::endTarget(bool endDraw)
 {
     UNUSED(endDraw);
-    m_isActive = false;
-    endObject();
+    if (m_isActive) {
+        m_isActive = false;
+        endObject();
+    }
     return true;
 }
 


### PR DESCRIPTION
When a Painter object goes out of scope, its endTarget() method will be executed, which in turn calls the endTarget() method of the concrete subclasses of IPaintProvider. But if the Painter has already called endDraw(), then BufferedPaintProvider::endObject() will already have been called, and must not be called again. BufferedPaintProvider::endTarget() must only call endObject() if m_isActive is true.