### PR TITLE
[MU3] Fix #318326 - System Text Line missing in existing parts when added via drag&drop to non-top staff

### DIFF
--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -428,9 +428,12 @@ void ScoreView::dropEvent(QDropEvent* event)
             Q_ASSERT(editData.dropElement->score() == score());
             _score->addRefresh(editData.dropElement->canvasBoundingRect());
             switch (editData.dropElement->type()) {
+                  case ElementType::TEXTLINE:
+                        firstStaffOnly = editData.dropElement->systemFlag();
+                        // fall-thru
                   case ElementType::VOLTA:
                         // voltas drop to first staff by default, or closest staff if Control is held
-                        firstStaffOnly = !(editData.modifiers & Qt::ControlModifier);
+                        firstStaffOnly = firstStaffOnly || !(editData.modifiers & Qt::ControlModifier);
                         // fall-thru
                   case ElementType::OTTAVA:
                   case ElementType::TRILL:
@@ -439,7 +442,6 @@ void ScoreView::dropEvent(QDropEvent* event)
                   case ElementType::VIBRATO:
                   case ElementType::PALM_MUTE:
                   case ElementType::HAIRPIN:
-                  case ElementType::TEXTLINE:
                         {
                         Spanner* spanner = static_cast<Spanner*>(editData.dropElement);
                         score()->cmdAddSpanner(spanner, pos, firstStaffOnly);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/318326

If a TEXTLINE is dropped in a `ScoreView`, set `firstStaffOnly` to `true` if the dropped textline is a System TextLine.

PR #7761 is a similar PR for `master`.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
