### PR TITLE
[MU4] Solve a crash when score contains a vbox which is not on top of a page.

### DIFF
--- a/src/libmscore/layout.cpp
+++ b/src/libmscore/layout.cpp
@@ -5443,7 +5443,7 @@ VerticalGapData::VerticalGapData(bool first, System* sys, Staff* st, SysStaff* s
         _normalisedSpacing = system->y() + (sysStaff ? sysStaff->y() : 0.0) - y;
         _maxActualSpacing = system->score()->styleP(Sid::maxStaffSpread);
 
-        Spacer* spacer { sys->upSpacer(st->idx(), nextSpacer) };
+        Spacer* spacer { staff ? system->upSpacer(staff->idx(), nextSpacer) : nullptr };
 
         if (spacer) {
             _fixedSpacer = spacer->spacerType() == SpacerType::FIXED;


### PR DESCRIPTION
When a `VBox` found, a `VerticalGapData` object is created but if this `VBox` wasn't the first element on a page, the application crashed because the constructor was looking for a `Spacer` on a non-existing staff.

PR [#7778](https://github.com/musescore/MuseScore/pull/7778) is similar for `3.x`.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
