### PR TITLE
fix #7641: fix initial template load

### DIFF
--- a/src/userscores/view/templatesmodel.cpp
+++ b/src/userscores/view/templatesmodel.cpp
@@ -29,8 +29,6 @@ void TemplatesModel::load()
 
     updateTemplatesByCategory();
     emit categoriesChanged();
-    emit templatesChanged();
-    emit currentTemplateChanged();
 }
 
 QStringList TemplatesModel::categoriesTitles() const

--- a/src/userscores/view/templatesmodel.cpp
+++ b/src/userscores/view/templatesmodel.cpp
@@ -24,7 +24,9 @@ void TemplatesModel::load()
     }
 
     for (const Template& templ: m_allTemplates) {
-        m_visibleCategoriesTitles << templ.categoryTitle;
+        if (!m_visibleCategoriesTitles.contains(templ.categoryTitle)) {
+            m_visibleCategoriesTitles << templ.categoryTitle;
+        }
     }
 
     updateTemplatesByCategory();
@@ -33,7 +35,7 @@ void TemplatesModel::load()
 
 QStringList TemplatesModel::categoriesTitles() const
 {
-    return m_visibleCategoriesTitles.values();
+    return m_visibleCategoriesTitles;
 }
 
 QString TemplatesModel::currentTemplatePath() const
@@ -114,7 +116,9 @@ void TemplatesModel::updateTemplatesAndCategoriesBySearch()
     for (const Template& templ: m_allTemplates) {
         if (titleAccepted(templ.title) || titleAccepted(templ.categoryTitle)) {
             m_visibleTemplates << templ;
-            m_visibleCategoriesTitles << templ.categoryTitle;
+            if (!m_visibleCategoriesTitles.contains(templ.categoryTitle)) {
+                m_visibleCategoriesTitles << templ.categoryTitle;
+            }
         }
     }
 

--- a/src/userscores/view/templatesmodel.cpp
+++ b/src/userscores/view/templatesmodel.cpp
@@ -23,12 +23,11 @@ void TemplatesModel::load()
         }
     }
 
-    m_visibleTemplates = m_allTemplates;
-
     for (const Template& templ: m_allTemplates) {
         m_visibleCategoriesTitles << templ.categoryTitle;
     }
 
+    updateTemplatesByCategory();
     emit categoriesChanged();
     emit templatesChanged();
     emit currentTemplateChanged();

--- a/src/userscores/view/templatesmodel.h
+++ b/src/userscores/view/templatesmodel.h
@@ -61,7 +61,7 @@ private:
 
     Templates m_allTemplates;
     Templates m_visibleTemplates;
-    QSet<QString> m_visibleCategoriesTitles;
+    QList<QString> m_visibleCategoriesTitles;
 
     QString m_searchText;
 


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/7641)*

*The load method loads all templates into visible templates, if we instead call updateTemplatesByCategory after generating the categories, it will load the relevant templates.*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
