### PR TITLE
[MU4] Fix 317849 - MuseJazz Curly-Brace switches to another font when beyond 2 staves

### DIFF
--- a/fonts/musejazz/metadata.json
+++ b/fonts/musejazz/metadata.json
@@ -4162,7 +4162,28 @@
             ]
         }
     },
-    "glyphsWithAlternates": {},
+    "glyphsWithAlternates": {
+        "brace":{
+            "alternates":[
+                {
+                    "codepoint":"U+F400",
+                    "name":"braceSmall"
+                },
+                {
+                    "codepoint":"U+F401",
+                    "name":"braceLarge"
+                },
+                {
+                    "codepoint":"U+F402",
+                    "name":"braceLarger"
+                },
+                {
+                    "codepoint":"U+F403",
+                    "name":"braceFlat"
+                }
+            ]
+        }
+    },
     "glyphsWithAnchors": {
         "accidentalBakiyeFlat": {
             "cutOutNE": [


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/317849

Add missing `glyphsWithAlternates` to the Musejazz metadata.

PR [#7784](https://github.com/musescore/MuseScore/pull/7784) is similar for `3.x`.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made