### PR TITLE
issue-319079-shift-selecting-last-word

### DIFF
--- a/src/libmscore/score.cpp
+++ b/src/libmscore/score.cpp
@@ -3418,7 +3418,7 @@ void Score::selectRange(Element* e, int staffIdx)
                 Segment* s1 = tick2segmentMM(t1, true, SegmentType::ChordRest);
                 Segment* s2 = tick2segmentMM(t2, true, SegmentType::ChordRest);
                 if (s2) {
-                    s2 = s2->next1MM(SegmentType::ChordRest);
+                    s2 = s2->next1MM(SegmentType::ChordRest | SegmentType::EndBarLine);
                 }
 
                 if (s1 && s2) {


### PR DESCRIPTION

Resolves: *https://musescore.org/en/node/319079*

*Original code only attempts to find the next ChordRest segment as the end marker for selecting a range, this fix adds the detection for the EndBarLine segment as a potential end marker, which resolves the problem*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
