### PR TITLE
[MU4] Fix #319079: Shift Selecting Last Word

### DIFF
--- a/src/libmscore/score.cpp
+++ b/src/libmscore/score.cpp
@@ -3421,7 +3421,7 @@ void Score::selectRange(Element* e, int staffIdx)
                     s2 = s2->next1MM(SegmentType::ChordRest);
                 }
 
-                if (s1 && s2) {
+                if (s1) {
                     _selection.setRange(s1, s2, idx1, idx2 + 1);
                     selectSimilarInRange(e);
                     if (selectedElement->track() == e->track()) {

--- a/src/libmscore/score.cpp
+++ b/src/libmscore/score.cpp
@@ -3407,6 +3407,12 @@ void Score::selectRange(Element* e, int staffIdx)
         if (selectedElement && e->type() == selectedElement->type()) {
             int idx1 = selectedElement->staffIdx();
             int idx2 = e->staffIdx();
+            if (idx2 < idx1) {
+                int temp = idx1;
+                idx1 = idx2;
+                idx2 = temp;
+            }
+
             if (idx1 >= 0 && idx2 >= 0) {
                 Fraction t1 = selectedElement->tick();
                 Fraction t2 = e->tick();


### PR DESCRIPTION

Resolves: *https://musescore.org/en/node/319079*

Original code only attempts to find the next ChordRest segment as the end marker for selecting a range, this fix adds the detection for the EndBarLine segment as a potential end marker, which resolves the issue.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla) 
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
