### PR TITLE
[MU3] Fix #319210: MusicXML import corrupted when xml is stripped from whitespace

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -5633,7 +5633,6 @@ void MusicXMLParserNotations::ornaments()
             else if (_e.name() == "inverted-mordent"
                      || _e.name() == "mordent") {
                   mordentNormalOrInverted();
-                  _e.readNext();
                   }
             else {
                   skipLogCurrElem();


### PR DESCRIPTION
Culprit seems an (empty) `<mordent/>` tag if that is not followed by a newline.

Resolves: https://musescore.org/en/node/319210

A corresponding PR for master is to follow, as soon as this PR here got @lvinken's official blessing ;-)

Edit: see #7809 for master