### PR TITLE
[MU4] Fixed twice triggering of actions on menu bar

### DIFF
--- a/src/appshell/view/dockwindow/dockmenubar.cpp
+++ b/src/appshell/view/dockwindow/dockmenubar.cpp
@@ -74,7 +74,9 @@ void DockMenuBar::updateMenus()
 {
     QList<QMenu*> menus;
     for (const QVariant& item: m_items) {
-        menus << makeMenu(item.toMap());
+        QMenu* menu = makeMenu(item.toMap());
+        connect(menu, &QMenu::triggered, this, &DockMenuBar::onActionTriggered);
+        menus << menu;
     }
 
     emit changed(menus);
@@ -100,7 +102,6 @@ QMenu* DockMenuBar::makeMenu(const QVariantMap& menuItem) const
         }
     }
 
-    connect(menu, &QMenu::triggered, this, &DockMenuBar::onActionTriggered);
     return menu;
 }
 


### PR DESCRIPTION
Note from the documentation: This signal is emitted for the main parent menu in a hierarchy. Hence, only the parent menu needs to be connected to a slot; sub-menus need not be connected