### PR TITLE
[MU3] Fix #319242, fix #319020:  Volta/Ottava/Pedal lines disappear when switching language

### DIFF
--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -80,7 +80,7 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       fbStyle->addButton(radioFBModern, 0);
       fbStyle->addButton(radioFBHistoric, 1);
 
-      int dta = 1;
+      int dta = 0;
       voltaLineStyle->clear();
       ottavaLineStyle->clear();
       pedalLineStyle->clear();
@@ -449,10 +449,8 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       accidentalsGroup->setVisible(false); // disable, not yet implemented
 
       musicalSymbolFont->clear();
-      int idx = 0;
       for (auto i : ScoreFont::scoreFonts()) {
             musicalSymbolFont->addItem(i.name(), i.name());
-            ++idx;
             }
 
       static const SymId ids[] = {
@@ -773,7 +771,6 @@ void EditStyle::retranslate()
       int index = 0;
       for (const char* p : lineStyles) {
             QString trs = qApp->translate("EditStyleBase", p);
-            voltaLineStyle->setItemText(index, trs);
             voltaLineStyle->setItemText(index, trs);
             ottavaLineStyle->setItemText(index, trs);
             pedalLineStyle->setItemText(index, trs);


### PR DESCRIPTION
and while at it also remove a duplicate line and an unused variable

Resolves: https://musescore.org/en/node/319242 and https://musescore.org/en/node/319020

Unfortunately I wasn't able to reproduce the issue in my local build, without this change (but was able to in 3.6.2), so I'm not 100% sure it fixes the issue. User feedback and testing with the GitHub artifact myself indicates that it does not fix the issue :-(
Also whether https://musescore.org/en/node/319020 really is the same issue is unclear.

To me the changes do make perfect sense though and are worth being done in any case, as the current code obviously is just wrong resp. superfluous.

This does not apply to master (which correctly starts with `idx = 0` in both cases)