### PR TITLE
[MU4] Added Scrollbar to increase accessibility for Head Settings

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/notation/notes/HeadSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/notes/HeadSettings.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.0
-import QtQuick.Controls 2.0
+import QtQuick.Controls 2.15
 import MuseScore.Inspector 1.0
 import MuseScore.UiComponents 1.0
 import MuseScore.Ui 1.0
@@ -11,200 +11,204 @@ FocusableItem {
 
     property QtObject model: null
 
-    implicitHeight: contentColumn.height
+    implicitHeight: noteheadGridView.height
     width: parent.width
 
-    Column {
-        id: contentColumn
-
+    ScrollView {
+        height: noteheadGridView.height
         width: parent.width
+        clip: true
 
-        spacing: 16
+        Column {
+            id: contentColumn
+            width: root.width
+            spacing: 16
 
-        CheckBox {
-            isIndeterminate: model ? model.isHeadHidden.isUndefined : false
-            checked: model && !isIndeterminate ? model.isHeadHidden.value : false
-            text: qsTrc("inspector", "Hide notehead")
+            CheckBox {
+                isIndeterminate: model ? model.isHeadHidden.isUndefined : false
+                checked: model && !isIndeterminate ? model.isHeadHidden.value : false
+                text: qsTrc("inspector", "Hide notehead")
 
-            onClicked: { model.isHeadHidden.value = !checked }
-        }
-
-        InspectorPropertyView {
-            titleText: qsTrc("inspector", "Noteheads")
-            propertyItem: root.model ? root.model.headGroup : null
-
-            NoteheadsGrid {
-                id: noteheadGridView
-
-                noteHeadTypesModel: root.model ? root.model.noteheadTypesModel : null
+                onClicked: { model.isHeadHidden.value = !checked }
             }
-        }
 
-        InspectorPropertyView {
+            InspectorPropertyView {
+                titleText: qsTrc("inspector", "Noteheads")
+                propertyItem: root.model ? root.model.headGroup : null
 
-            titleText: qsTrc("inspector", "Dotted note position")
-            propertyItem: root.model ? root.model.dotPosition : null
+                NoteheadsGrid {
+                    id: noteheadGridView
 
-            RadioButtonGroup {
-                id: notePositionButtonList
-
-                height: 30
-                width: parent.width
-
-                model: [
-                    { iconRole: IconCode.AUTO, typeRole: NoteHead.DOT_POSITION_AUTO },
-                    { iconRole: IconCode.DOT_ABOVE_LINE, typeRole: NoteHead.DOT_POSITION_DOWN },
-                    { iconRole: IconCode.DOT_BELOW_LINE, typeRole: NoteHead.DOT_POSITION_UP }
-                ]
-
-                delegate: FlatRadioButton {
-
-                    ButtonGroup.group: notePositionButtonList.radioButtonGroup
-
-                    checked: root.model && !root.model.dotPosition.isUndefined ? root.model.dotPosition.value === modelData["typeRole"]
-                                                                               : false
-
-                    onToggled: {
-                        root.model.dotPosition.value = modelData["typeRole"]
-                    }
-
-                    StyledIconLabel {
-                        iconCode: modelData["iconRole"]
-                    }
+                    noteHeadTypesModel: root.model ? root.model.noteheadTypesModel : null
                 }
             }
-        }
 
-        ExpandableBlank {
-            isExpanded: false
+            InspectorPropertyView {
 
-            title: isExpanded ? qsTrc("inspector", "Show less") : qsTrc("inspector", "Show more")
+                titleText: qsTrc("inspector", "Dotted note position")
+                propertyItem: root.model ? root.model.dotPosition : null
 
-            width: parent.width
+                RadioButtonGroup {
+                    id: notePositionButtonList
 
-            contentItemComponent: Column {
-                spacing: 24
-
-                height: implicitHeight
-                width: parent.width
-
-                InspectorPropertyView {
-                    width: root.width
-                    height: implicitHeight
-
-                    titleText: qsTrc("inspector", "Head type (visual only)")
-                    propertyItem: root.model ? root.model.headType : null
-
-                    RadioButtonGroup {
-                        id: headTypeButtonList
-
-                        height: 30
-                        width: parent.width
-
-                        model: [
-                            { iconRole: "qrc:/resources/icons/orientation_auto.svg", typeRole: NoteHead.TYPE_AUTO },
-                            { iconRole: "qrc:/resources/icons/notehead_quarter.svg", typeRole: NoteHead.TYPE_QUARTER },
-                            { iconRole: "qrc:/resources/icons/notehead_half.svg", typeRole: NoteHead.TYPE_HALF },
-                            { iconRole: "qrc:/resources/icons/notehead_whole.svg", typeRole: NoteHead.TYPE_WHOLE },
-                            { iconRole: "qrc:/resources/icons/notehead_brevis.svg", typeRole: NoteHead.TYPE_BREVIS }
-                        ]
-
-                        delegate: FlatRadioButton {
-
-                            ButtonGroup.group: headTypeButtonList.radioButtonGroup
-
-                            checked: root.model && !root.model.headType.isUndefined ? root.model.headType.value === modelData["typeRole"]
-                                                                                    : false
-
-                            onToggled: {
-                                root.model.headType.value = modelData["typeRole"]
-                            }
-
-                            Icon {
-                                anchors.fill: parent
-
-                                icon: modelData["iconRole"]
-                            }
-                        }
-                    }
-                }
-
-                InspectorPropertyView {
-                    width: root.width
-                    height: implicitHeight
-
-                    titleText: qsTrc("inspector", "Note direction")
-                    propertyItem: root.model ? root.model.headDirection : null
-
-                    RadioButtonGroup {
-                        id: noteDirectionButtonList
-
-                        height: 30
-                        width: parent.width
-
-                        model: [
-                            { iconRole: IconCode.AUTO, typeRole: NoteHead.DIRECTION_H_AUTO },
-                            { iconRole: IconCode.ARROW_LEFT, typeRole: NoteHead.DIRECTION_H_LEFT },
-                            { iconRole: IconCode.ARROW_RIGHT, typeRole: NoteHead.DIRECTION_H_RIGHT }
-                        ]
-
-                        delegate: FlatRadioButton {
-
-                            ButtonGroup.group: noteDirectionButtonList.radioButtonGroup
-
-                            checked: root.model && !root.model.headDirection.isUndefined ? root.model.headDirection.value === modelData["typeRole"]
-                                                                                         : false
-
-                            onToggled: {
-                                root.model.headDirection.value = modelData["typeRole"]
-                            }
-
-                            StyledIconLabel {
-                                iconCode: modelData["iconRole"]
-                            }
-                        }
-                    }
-                }
-
-                InspectorPropertyView {
-                    height: childrenRect.height
+                    height: 30
                     width: parent.width
 
-                    titleText: qsTrc("inspector", "Notehead offset")
-                    propertyItem: model ? model.horizontalOffset : null
+                    model: [
+                        { iconRole: IconCode.AUTO, typeRole: NoteHead.DOT_POSITION_AUTO },
+                        { iconRole: IconCode.DOT_ABOVE_LINE, typeRole: NoteHead.DOT_POSITION_DOWN },
+                        { iconRole: IconCode.DOT_BELOW_LINE, typeRole: NoteHead.DOT_POSITION_UP }
+                    ]
 
-                    Item {
+                    delegate: FlatRadioButton {
+
+                        ButtonGroup.group: notePositionButtonList.radioButtonGroup
+
+                        checked: root.model && !root.model.dotPosition.isUndefined ? root.model.dotPosition.value === modelData["typeRole"]
+                                                                                   : false
+
+                        onToggled: {
+                            root.model.dotPosition.value = modelData["typeRole"]
+                        }
+
+                        StyledIconLabel {
+                            iconCode: modelData["iconRole"]
+                        }
+                    }
+                }
+            }
+
+            ExpandableBlank {
+                isExpanded: false
+                title: isExpanded ? qsTrc("inspector", "Show less") : qsTrc("inspector", "Show more")
+
+                width: parent.width
+
+                contentItemComponent: Column {
+                    spacing: 24
+
+                    height: implicitHeight
+                    width: parent.width
+
+                    InspectorPropertyView {
+                        width: root.width
+                        height: implicitHeight
+
+                        titleText: qsTrc("inspector", "Head type (visual only)")
+                        propertyItem: root.model ? root.model.headType : null
+
+                        RadioButtonGroup {
+                            id: headTypeButtonList
+
+                            height: 30
+                            width: parent.width
+
+                            model: [
+                                { iconRole: "qrc:/resources/icons/orientation_auto.svg", typeRole: NoteHead.TYPE_AUTO },
+                                { iconRole: "qrc:/resources/icons/notehead_quarter.svg", typeRole: NoteHead.TYPE_QUARTER },
+                                { iconRole: "qrc:/resources/icons/notehead_half.svg", typeRole: NoteHead.TYPE_HALF },
+                                { iconRole: "qrc:/resources/icons/notehead_whole.svg", typeRole: NoteHead.TYPE_WHOLE },
+                                { iconRole: "qrc:/resources/icons/notehead_brevis.svg", typeRole: NoteHead.TYPE_BREVIS }
+                            ]
+
+                            delegate: FlatRadioButton {
+
+                                ButtonGroup.group: headTypeButtonList.radioButtonGroup
+
+                                checked: root.model && !root.model.headType.isUndefined ? root.model.headType.value === modelData["typeRole"]
+                                                                                        : false
+
+                                onToggled: {
+                                    root.model.headType.value = modelData["typeRole"]
+                                }
+
+                                Icon {
+                                    anchors.fill: parent
+
+                                    icon: modelData["iconRole"]
+                                }
+                            }
+                        }
+                    }
+
+                    InspectorPropertyView {
+                        width: root.width
+                        height: implicitHeight
+
+                        titleText: qsTrc("inspector", "Note direction")
+                        propertyItem: root.model ? root.model.headDirection : null
+
+                        RadioButtonGroup {
+                            id: noteDirectionButtonList
+
+                            height: 30
+                            width: parent.width
+
+                            model: [
+                                { iconRole: IconCode.AUTO, typeRole: NoteHead.DIRECTION_H_AUTO },
+                                { iconRole: IconCode.ARROW_LEFT, typeRole: NoteHead.DIRECTION_H_LEFT },
+                                { iconRole: IconCode.ARROW_RIGHT, typeRole: NoteHead.DIRECTION_H_RIGHT }
+                            ]
+
+                            delegate: FlatRadioButton {
+
+                                ButtonGroup.group: noteDirectionButtonList.radioButtonGroup
+
+                                checked: root.model && !root.model.headDirection.isUndefined ? root.model.headDirection.value === modelData["typeRole"]
+                                                                                             : false
+
+                                onToggled: {
+                                    root.model.headDirection.value = modelData["typeRole"]
+                                }
+
+                                StyledIconLabel {
+                                    iconCode: modelData["iconRole"]
+                                }
+                            }
+                        }
+                    }
+
+                    InspectorPropertyView {
                         height: childrenRect.height
                         width: parent.width
 
-                        IncrementalPropertyControl {
-                            anchors.left: parent.left
-                            anchors.right: parent.horizontalCenter
-                            anchors.rightMargin: 4
+                        titleText: qsTrc("inspector", "Notehead offset")
+                        propertyItem: model ? model.horizontalOffset : null
 
-                            icon: IconCode.HORIZONTAL
-                            enabled: model ? !model.isEmpty : false
-                            isIndeterminate: model ? model.horizontalOffset.isUndefined : false
-                            currentValue: model ? model.horizontalOffset.value : 0
+                        Item {
+                            height: childrenRect.height
+                            width: parent.width
 
-                            onValueEdited: { model.horizontalOffset.value = newValue }
-                        }
+                            IncrementalPropertyControl {
+                                anchors.left: parent.left
+                                anchors.right: parent.horizontalCenter
+                                anchors.rightMargin: 4
 
-                        IncrementalPropertyControl {
-                            anchors.left: parent.horizontalCenter
-                            anchors.leftMargin: 4
-                            anchors.right: parent.right
+                                icon: IconCode.HORIZONTAL
+                                enabled: model ? !model.isEmpty : false
+                                isIndeterminate: model ? model.horizontalOffset.isUndefined : false
+                                currentValue: model ? model.horizontalOffset.value : 0
 
-                            icon: IconCode.VERTICAL
-                            enabled: model ? !model.isEmpty : false
-                            isIndeterminate: model ? model.verticalOffset.isUndefined : false
-                            currentValue: model ? model.verticalOffset.value : 0
+                                onValueEdited: { model.horizontalOffset.value = newValue }
+                            }
 
-                            onValueEdited: { model.verticalOffset.value = newValue }
+                            IncrementalPropertyControl {
+                                anchors.left: parent.horizontalCenter
+                                anchors.leftMargin: 4
+                                anchors.right: parent.right
+
+                                icon: IconCode.VERTICAL
+                                enabled: model ? !model.isEmpty : false
+                                isIndeterminate: model ? model.verticalOffset.isUndefined : false
+                                currentValue: model ? model.verticalOffset.value : 0
+
+                                onValueEdited: { model.verticalOffset.value = newValue }
+                            }
                         }
                     }
                 }
             }
         }
     }
+
 }

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/notes/HeadSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/notes/HeadSettings.qml
@@ -16,13 +16,15 @@ FocusableItem {
 
     ScrollView {
         height: noteheadGridView.height
-        width: parent.width
+        width: parent.width + 10
         clip: true
 
         Column {
             id: contentColumn
-            width: root.width
+            width: root.width - (2 * anchors.leftMargin)
             spacing: 16
+            anchors.left: parent.left
+            anchors.leftMargin: 5
 
             CheckBox {
                 isIndeterminate: model ? model.isHeadHidden.isUndefined : false
@@ -91,7 +93,7 @@ FocusableItem {
                     width: parent.width
 
                     InspectorPropertyView {
-                        width: root.width
+                        width: parent.width
                         height: implicitHeight
 
                         titleText: qsTrc("inspector", "Head type (visual only)")
@@ -132,7 +134,7 @@ FocusableItem {
                     }
 
                     InspectorPropertyView {
-                        width: root.width
+                        width: parent.width
                         height: implicitHeight
 
                         titleText: qsTrc("inspector", "Note direction")


### PR DESCRIPTION
Resolves: #7772 

Added a ScrollBar that allows the user to easily access previously inaccessible/clipped items in the following menu:
_*Inspector*_ -> _*Note Settings*_ (This setting appears when you have a note selected in the ScoreView) -> _*Head*_

[Previous Behaviour](https://github.com/ArjunBoi/ImagesAndFilesForLinks/blob/master/MuseScoreEdits/Old_HeadSettings.gif "Previous Behaviour") (Leads to a Gif i made, describing the issue visually)

[Edited Behaviour](https://github.com/ArjunBoi/ImagesAndFilesForLinks/blob/master/MuseScoreEdits/New_HeadSettings.gif "Edited Behaviour")

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made


