### PR TITLE
[MU4] Fix #319210: MusicXML import corrupted when xml is stripped from whitespace

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -5804,7 +5804,6 @@ void MusicXMLParserNotations::ornaments()
         } else if (_e.name() == "inverted-mordent"
                    || _e.name() == "mordent") {
             mordentNormalOrInverted();
-            _e.readNext();
         } else {
             skipLogCurrElem();
         }


### PR DESCRIPTION
Culprit seems an (empty) `<mordent/>` tag if that is not followed by a newline.

Resolves: https://musescore.org/en/node/319210

This is for master what #7799 is for 3.x