### PR TITLE
[MU4] Fixed shortcuts activating when editing notation text

### DIFF
--- a/src/instruments/view/instrumentpaneltreemodel.cpp
+++ b/src/instruments/view/instrumentpaneltreemodel.cpp
@@ -146,6 +146,11 @@ void InstrumentPanelTreeModel::selectRow(const QModelIndex& rowIndex)
 
 void InstrumentPanelTreeModel::addInstruments()
 {
+    notation::INotationInteractionPtr interaction = context()->currentNotation()->interaction();
+    if (interaction->isTextEditingStarted()) {
+        return;
+    }
+
     auto mode = ISelectInstrumentsScenario::SelectInstrumentsMode::ShowCurrentInstruments;
     RetVal<InstrumentList> selectedInstruments = selectInstrumentsScenario()->selectInstruments(mode);
     if (!selectedInstruments.ret) {


### PR DESCRIPTION
Previously, when editing notation text and pressing a shortcut key, for example "I", the instruments panel would open. That would make it impossible to write the letter "i".

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
