### PR TITLE
Fix GH #7828: Fix input validator in IncrementalPropertyControl

### DIFF
--- a/src/appshell/view/dockwindow/docktoolbar.h
+++ b/src/appshell/view/dockwindow/docktoolbar.h
@@ -58,7 +58,7 @@ public:
     bool floating() const;
     bool floatable() const;
     bool movable() const;
-    bool visible() const;
+    bool visible() const override;
 
 public slots:
     void setMinimumHeight(int minimumHeight);
@@ -66,7 +66,7 @@ public slots:
     void setAllowedAreas(Qt::ToolBarAreas allowedAreas);
     void setFloatable(bool floatable);
     void setMovable(bool movable);
-    void setVisible(bool visible);
+    void setVisible(bool visible) override;
 
 signals:
     void orientationChanged(int orientation);

--- a/src/framework/ui/uimodule.h
+++ b/src/framework/ui/uimodule.h
@@ -33,7 +33,7 @@ public:
     void registerResources() override;
     void registerUiTypes() override;
     void onInit(const framework::IApplication::RunMode& mode) override;
-    void onDeinit();
+    void onDeinit() override;
 };
 }
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/IncrementalPropertyControl.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/IncrementalPropertyControl.qml
@@ -60,11 +60,20 @@ Item {
         anchors.top: parent.top
         anchors.bottom: parent.bottom
 
-        validator: DoubleInputValidator {
+        DoubleInputValidator {
+            id: doubleInputValidator
             top: maxValue
             bottom: minValue
             decimal: decimals
         }
+
+        IntInputValidator {
+            id: intInputValidator
+            top: maxValue
+            bottom: minValue
+        }
+
+        validator: decimals > 0 ? doubleInputValidator : intInputValidator
 
         ValueAdjustControl {
             id: valueAdjustControl

--- a/src/framework/uicomponents/view/sortfilterproxymodel.cpp
+++ b/src/framework/uicomponents/view/sortfilterproxymodel.cpp
@@ -36,7 +36,7 @@ SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
     });
 
     connect(m_sorters.notifier(), &QmlListPropertyNotifier::appended, this, [this](int index) {
-        connect(m_sorters.at(index), &SorterValue::dataChanged, this, [this, index]() {
+        connect(m_sorters.at(index), &SorterValue::dataChanged, this, [this]() {
             SorterValue* sorter = currentSorterValue();
             invalidate();
 

--- a/src/libmscore/accidental.cpp
+++ b/src/libmscore/accidental.cpp
@@ -27,9 +27,9 @@ namespace Ms {
 
 struct Acc {
     AccidentalVal offset;     // semitone offset
-    int centOffset;
+    double centOffset;
     SymId sym;
-    Acc(AccidentalVal o, int o2, SymId s)
+    Acc(AccidentalVal o, double o2, SymId s)
         : offset(o), centOffset(o2), sym(s) {}
 };
 

--- a/src/libmscore/draw/drawjson.cpp
+++ b/src/libmscore/draw/drawjson.cpp
@@ -197,7 +197,7 @@ static void fromObj(const QJsonObject& obj, QPainterPath& path)
 
     QJsonArray elsArr = obj["elements"].toArray();
     std::vector<QPainterPath::Element> curveEls;
-    for (const QJsonValue& elVal : elsArr) {
+    for (const QJsonValue elVal : elsArr) {
         QJsonArray elArr = elVal.toArray();
         IF_ASSERT_FAILED(elArr.size() == 3) {
             continue;
@@ -427,13 +427,13 @@ mu::RetVal<DrawDataPtr> DrawBufferJson::fromJson(const QByteArray& json)
     DrawDataPtr buf = std::make_shared<DrawData>();
     buf->name = root["a_name"].toString().toStdString();
     QJsonArray objsArr = root["objects"].toArray();
-    for (const QJsonValue& objVal: objsArr) {
+    for (const QJsonValue objVal: objsArr) {
         QJsonObject objObj = objVal.toObject();
         DrawData::Object obj;
         obj.name = objObj["a_name"].toString().toStdString();
         fromArr(objObj["a_pagePos"].toArray(), obj.pagePos);
         QJsonArray datasArr = objObj["datas"].toArray();
-        for (const QJsonValue& dataVal : datasArr) {
+        for (const QJsonValue dataVal : datasArr) {
             QJsonObject dataObj = dataVal.toObject();
             DrawData::Data data;
             fromObj(dataObj["state"].toObject(), data.state);

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -79,7 +79,7 @@ public:
     QColor layoutBreakColor() const override;
 
     int selectionProximity() const override;
-    void setSelectionProximity(int proxymity);
+    void setSelectionProximity(int proxymity) override;
 
     ZoomType defaultZoomType() const override;
     void setDefaultZoomType(ZoomType zoomType) override;


### PR DESCRIPTION
Resolves: #7828

Use IntInputValidator instead of DoubleInputValidator when `decimals` is zero.
(This commit was part of PR #7814, but I decided to make a separate PR to have this issue fixed quickly.)

Also fixes some Clang compiler warnings. 