### PR TITLE
Enabled changing of themes by clicking on the theme icons

### DIFF
--- a/src/appshell/qml/Preferences/internal/PreferencesButtonsPanel.qml
+++ b/src/appshell/qml/Preferences/internal/PreferencesButtonsPanel.qml
@@ -26,7 +26,7 @@ Rectangle {
 
             width: 160
 
-            text: qsTrc("appshell", "Reset factory settings")
+            text: qsTrc("appshell", "Reset preferences")
 
             onClicked: {
                 root.revertFactorySettingsRequested()

--- a/src/appshell/qml/Preferences/internal/ThemesSection.qml
+++ b/src/appshell/qml/Preferences/internal/ThemesSection.qml
@@ -42,6 +42,23 @@ Column {
                 fontPrimaryColor: modelData.fontPrimaryColor
                 buttonColor: modelData.buttonColor
                 accentColor: modelData.accentColor
+
+                MouseArea{
+                    anchors.fill: parent
+                    hoverEnabled: true
+
+                    onClicked: {
+                        root.themeChangeRequested(model.index)
+                    }
+
+                    onEntered: {
+                        parent.border.color = modelData.accentColor
+                    }
+
+                    onExited: {
+                        parent.border.color = modelData.backgroundPrimaryColor
+                    }
+                }
             }
 
             RoundedRadioButton {


### PR DESCRIPTION
Resolves:
https://github.com/musescore/MuseScore/issues/7827
https://github.com/musescore/MuseScore/issues/7829

Added Mouse Area on the Theme icons to register mouse clicks. Added a border popup while hovering over the icons to let user know that the icon can be clicked. The border popup color is set to the respective accent colors.

Changed the displayed text on the reset preferences button

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
