### PR TITLE
[MU4] Fix submenus on macOS

### DIFF
--- a/src/appshell/view/dockwindow/dockmenubar.cpp
+++ b/src/appshell/view/dockwindow/dockmenubar.cpp
@@ -75,7 +75,6 @@ void DockMenuBar::updateMenus()
     QList<QMenu*> menus;
     for (const QVariant& item: m_items) {
         QMenu* menu = makeMenu(item.toMap());
-        connect(menu, &QMenu::triggered, this, &DockMenuBar::onActionTriggered);
         menus << menu;
     }
 
@@ -95,7 +94,9 @@ QMenu* DockMenuBar::makeMenu(const QVariantMap& menuItem) const
         if (menuMap.value("title").toString().isEmpty()) {
             menu->addSeparator();
         } else if (!menuMap.value("subitems").toList().empty()) {
-            menu->addMenu(makeMenu(menuMap));
+            QMenu* subMenu = makeMenu(menuMap);
+            subMenu->setParent(menu);
+            menu->addMenu(subMenu);
         } else {
             bool isFromGroup = menuMap.value("selectable").toBool();
             menu->addAction(makeAction(menuMap, isFromGroup ? group : nullptr));

--- a/src/appshell/view/dockwindow/dockwindow.cpp
+++ b/src/appshell/view/dockwindow/dockwindow.cpp
@@ -290,6 +290,7 @@ void DockWindow::onMenusChanged(const QList<QMenu*>& menus)
     menuBar->clear();
 
     for (QMenu* menu: menus) {
+        menu->setParent(menuBar);
         menuBar->addMenu(menu);
     }
 
@@ -419,6 +420,7 @@ void DockWindow::setMenuBar(DockMenuBar* menuBar)
     m_menuBar = menuBar;
 
     connect(menuBar, &DockMenuBar::changed, this, &DockWindow::onMenusChanged);
+    connect(m_window->menuBar(), &QMenuBar::triggered, menuBar, &DockMenuBar::onActionTriggered);
 
     emit menuBarChanged(m_menuBar);
 }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/pull/7801#issuecomment-808331900

QMenu::addMenu() does not actually set the parent of the child menu, which on macOS means that the parent menu is not triggered when an action on the child menu is triggered. This PR makes sure to set the parent of each menu, so that the menubar will be triggered when any menu or submenu inside it is triggered. 