### PR TITLE
[MU4] Fix #7818 Fixed Scrolling past the score

### DIFF
--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -562,11 +562,9 @@ void NotationPaintView::moveCanvas(int dx, int dy)
         return;
     }
 
-    if (configuration()->isLimitCanvasScrollArea()) {
-        std::pair<int, int> corrected = constraintCanvas(dx, dy);
-        dx = corrected.first;
-        dy = corrected.second;
-    }
+    std::pair<int, int> corrected = constraintCanvas(dx, dy);
+    dx = corrected.first;
+    dy = corrected.second;
 
     m_matrix.translate(dx, dy);
     update();


### PR DESCRIPTION
Resolves: #7818 

Fixed the scroll past the page. 
Creates another issue: Initial Scroll jumps the score from left to center

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
