### PR TITLE
Update design of ColorPicker

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/ColorPicker.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/ColorPicker.qml
@@ -10,24 +10,15 @@ Rectangle {
 
     signal newColorSelected(var newColor)
 
-    height: 26
+    height: 30
     width: parent.width
 
     opacity: enabled ? 1 : ui.theme.itemOpacityDisabled
 
-    radius: 2
+    radius: 3
     color: "#000000"
 
-    Rectangle {
-        id: backgroundRect
-
-        anchors.fill: parent
-        anchors.margins: -2
-
-        radius: 2
-        color: "transparent"
-        border.width: 1
-    }
+    border.width: 1
 
     StyledIconLabel {
         anchors.fill: parent
@@ -38,7 +29,7 @@ Rectangle {
     }
 
     MouseArea {
-        id: cliickableArea
+        id: clickableArea
 
         anchors.fill: parent
 
@@ -63,23 +54,23 @@ Rectangle {
     states: [
         State {
             name: "NORMAL"
-            when: !cliickableArea.containsMouse && !colorDialog.visible
+            when: !clickableArea.containsMouse && !colorDialog.visible
 
-            PropertyChanges { target: backgroundRect; border.color: ui.theme.buttonColor }
+            PropertyChanges { target: root; border.color: ui.theme.buttonColor }
         },
 
         State {
             name: "HOVERED"
-            when: cliickableArea.containsMouse && !cliickableArea.pressed && !colorDialog.visible
+            when: clickableArea.containsMouse && !clickableArea.pressed && !colorDialog.visible
 
-            PropertyChanges { target: backgroundRect; border.color: ui.theme.accentColor }
+            PropertyChanges { target: root; border.color: ui.theme.accentColor }
         },
 
         State {
             name: "PRESSED"
-            when: cliickableArea.pressed || colorDialog.visible
+            when: clickableArea.pressed || colorDialog.visible
 
-            PropertyChanges { target: backgroundRect; border.color: ui.theme.fontPrimaryColor }
+            PropertyChanges { target: root; border.color: ui.theme.fontPrimaryColor }
         }
     ]
 }


### PR DESCRIPTION
| Before | After |
|-|-|
| <img width="851" alt="Schermafbeelding 2021-03-30 om 19 04 19" src="https://user-images.githubusercontent.com/48658420/113033103-ed733280-9190-11eb-8704-7413dedf08be.png"> | <img width="851" alt="Naamloos 3" src="https://user-images.githubusercontent.com/48658420/113033123-f5cb6d80-9190-11eb-8a5e-1e35fabdd978.png"> |

Update ColorPicker to match the design on Figma. 
- The border is now _inside_ the frame, so it is now in line with other components
- The space between the border and the background color was removed
- The height has been increased to 30px, to match other components