### PR TITLE
[MU3] Vertical staves adjustment and single line staves

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -5117,7 +5117,7 @@ VerticalGapData::VerticalGapData(bool first, System *sys, Staff *st, SysStaff *s
             _maxActualSpacing = _normalisedSpacing;
             }
       else {
-            _normalisedSpacing = system->y() + (sysStaff ? sysStaff->y() : 0.0) - y;
+            _normalisedSpacing = system->y() + (sysStaff ? sysStaff->bbox().y() : 0.0) - y;
             _maxActualSpacing = system->score()->styleP(Sid::maxStaffSpread);
 
             Spacer* spacer { staff ? system->upSpacer(staff->idx(), nextSpacer) : nullptr };


### PR DESCRIPTION
In `VerticalGapData` use `SysStaff.bbox().y()` for the Y-coordinate instead of `SysStaff.y()` when calculating the vertical position of the `SysStaff` because in case of single line staves, `SysStaff.y()` the returned value includes an offset. This resulted in wrong initial `spacing` between staves when one of the staves was a single line staff.
`SysStaff.bbox().y()` returns the uncorrected Y-coordinate which is required to calculate the correct spacing between staves.

PR #7854 is a similar PR for `master`.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
