### PR TITLE
Fix menus on Windows and Linux

### DIFF
--- a/src/appshell/view/dockwindow/dockmenubar.cpp
+++ b/src/appshell/view/dockwindow/dockmenubar.cpp
@@ -40,6 +40,14 @@ static int actionIndexInGroup(const QAction* action)
     return -1;
 }
 
+static void addMenu(QMenu* child, QMenu* parent)
+{
+#ifdef Q_OS_MAC
+    child->setParent(parent);
+#endif
+    parent->addMenu(child);
+}
+
 DockMenuBar::DockMenuBar(QQuickItem* parent)
     : DockView(parent)
 {
@@ -95,8 +103,7 @@ QMenu* DockMenuBar::makeMenu(const QVariantMap& menuItem) const
             menu->addSeparator();
         } else if (!menuMap.value("subitems").toList().empty()) {
             QMenu* subMenu = makeMenu(menuMap);
-            subMenu->setParent(menu);
-            menu->addMenu(subMenu);
+            addMenu(subMenu, menu);
         } else {
             bool isFromGroup = menuMap.value("selectable").toBool();
             menu->addAction(makeAction(menuMap, isFromGroup ? group : nullptr));

--- a/src/appshell/view/dockwindow/dockwindow.h
+++ b/src/appshell/view/dockwindow/dockwindow.h
@@ -32,6 +32,7 @@
 class QMainWindow;
 class QStackedWidget;
 class QStatusBar;
+class QMenuBar;
 
 namespace mu::dock {
 class EventsWatcher;
@@ -68,6 +69,7 @@ public:
     QString currentPageUri() const;
 
     QMainWindow* qMainWindow() override;
+    QMenuBar* qMenuBar();
     void stackUnder(QWidget* w) override;
 
 public slots:


### PR DESCRIPTION
#7837 fixed submenus on macOS, but it broke menus on Windows and Linux. This makes sure to only call `QMenu::setParent()` on macOS, since it is problematic to do so otherwise. This also provides a better solution to the disappearing menu problem on macOS that was addressed in #7782.