### PR TITLE
Update PlatformTheme: now also detects System High Contrast

### DIFF
--- a/src/appshell/qml/Preferences/internal/ThemeSample.qml
+++ b/src/appshell/qml/Preferences/internal/ThemeSample.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.15
+import MuseScore.UiComponents 1.0
 
 Rectangle {
     id: root
@@ -10,16 +11,15 @@ Rectangle {
     property color buttonColor
     property color accentColor
 
+    signal clicked
+
     width: 112
     height: 84
 
     radius: 4
     color: backgroundPrimaryColor
 
-    border.color: strokeColor
-    border.width: 1
-
-    Rectangle {
+    RoundedRectangle {
         anchors.fill: parent
         anchors.topMargin: 12
         anchors.leftMargin: 16
@@ -28,6 +28,8 @@ Rectangle {
 
         border.color: root.strokeColor
         border.width: 1
+
+        bottomRightRadius: borderRect.radius
 
         Column {
             anchors.fill: parent
@@ -103,5 +105,21 @@ Rectangle {
                 }
             }
         }
+    }
+
+    Rectangle {
+        id: borderRect
+        anchors.fill: parent
+        color: "transparent"
+        radius: 4
+        border.width: 1
+        border.color: mouseArea.containsMouse ? root.accentColor : root.strokeColor
+    }
+
+    MouseArea {
+        id: mouseArea
+        anchors.fill: parent
+        hoverEnabled: true
+        onClicked: root.clicked()
     }
 }

--- a/src/appshell/qml/Preferences/internal/ThemesSection.qml
+++ b/src/appshell/qml/Preferences/internal/ThemesSection.qml
@@ -43,21 +43,8 @@ Column {
                 buttonColor: modelData.buttonColor
                 accentColor: modelData.accentColor
 
-                MouseArea {
-                    anchors.fill: parent
-                    hoverEnabled: true
-
-                    onClicked: {
-                        root.themeChangeRequested(model.index)
-                    }
-
-                    onEntered: {
-                        parent.border.color = modelData.accentColor
-                    }
-
-                    onExited: {
-                        parent.border.color = modelData.backgroundPrimaryColor
-                    }
+                onClicked: {
+                    root.themeChangeRequested(model.index)
                 }
             }
 

--- a/src/framework/ui/internal/iplatformtheme.h
+++ b/src/framework/ui/internal/iplatformtheme.h
@@ -23,7 +23,7 @@
 #include "modularity/imoduleexport.h"
 #include "async/channel.h"
 
-#include <QWidget>
+class QWidget;
 
 namespace mu::ui {
 class IPlatformTheme : MODULE_EXPORT_INTERFACE
@@ -38,14 +38,11 @@ public:
 
     virtual bool isFollowSystemThemeAvailable() const = 0;
 
-    virtual bool isDarkMode() const = 0;
-    virtual async::Channel<bool> darkModeSwitched() const = 0;
+    virtual std::string themeCode() const = 0;
+    virtual async::Channel<std::string> themeCodeChanged() const = 0;
 
-    /// Performs platform-specific styling of the application.
-    virtual void setAppThemeDark(bool isDark) = 0;
-
-    /// Performs platform-specific styling of the window.
-    virtual void applyPlatformStyle(QWidget* window) = 0;
+    virtual void applyPlatformStyleOnAppForTheme(std::string themeCode) = 0;
+    virtual void applyPlatformStyleOnWindowForTheme(QWidget* window, std::string themeCode) = 0;
 };
 }
 

--- a/src/framework/ui/internal/iplatformtheme.h
+++ b/src/framework/ui/internal/iplatformtheme.h
@@ -22,6 +22,7 @@
 
 #include "modularity/imoduleexport.h"
 #include "async/channel.h"
+#include "uitypes.h"
 
 class QWidget;
 
@@ -38,11 +39,11 @@ public:
 
     virtual bool isFollowSystemThemeAvailable() const = 0;
 
-    virtual std::string themeCode() const = 0;
-    virtual async::Channel<std::string> themeCodeChanged() const = 0;
+    virtual ThemeCode themeCode() const = 0;
+    virtual async::Channel<ThemeCode> themeCodeChanged() const = 0;
 
-    virtual void applyPlatformStyleOnAppForTheme(std::string themeCode) = 0;
-    virtual void applyPlatformStyleOnWindowForTheme(QWidget* window, std::string themeCode) = 0;
+    virtual void applyPlatformStyleOnAppForTheme(ThemeCode themeCode) = 0;
+    virtual void applyPlatformStyleOnWindowForTheme(QWidget* window, ThemeCode themeCode) = 0;
 };
 }
 

--- a/src/framework/ui/internal/platform/macos/macosplatformtheme.h
+++ b/src/framework/ui/internal/platform/macos/macosplatformtheme.h
@@ -31,14 +31,17 @@ public:
 
     bool isFollowSystemThemeAvailable() const override;
 
-    bool isDarkMode() const override;
-    async::Channel<bool> darkModeSwitched() const override;
+    std::string themeCode() const override;
+    async::Channel<std::string> themeCodeChanged() const override;
 
-    void setAppThemeDark(bool) override;
-    void applyPlatformStyle(QWidget*) override;
+    void applyPlatformStyleOnAppForTheme(std::string themeCode) override;
+    void applyPlatformStyleOnWindowForTheme(QWidget* window, std::string themeCode) override;
 
 private:
-    async::Channel<bool> m_darkModeSwitched;
+    bool isSystemDarkMode() const;
+    bool isSystemHighContrast() const;
+
+    async::Channel<std::string> m_channel;
 };
 }
 

--- a/src/framework/ui/internal/platform/macos/macosplatformtheme.h
+++ b/src/framework/ui/internal/platform/macos/macosplatformtheme.h
@@ -31,17 +31,17 @@ public:
 
     bool isFollowSystemThemeAvailable() const override;
 
-    std::string themeCode() const override;
-    async::Channel<std::string> themeCodeChanged() const override;
+    ThemeCode themeCode() const override;
+    async::Channel<ThemeCode> themeCodeChanged() const override;
 
-    void applyPlatformStyleOnAppForTheme(std::string themeCode) override;
-    void applyPlatformStyleOnWindowForTheme(QWidget* window, std::string themeCode) override;
+    void applyPlatformStyleOnAppForTheme(ThemeCode themeCode) override;
+    void applyPlatformStyleOnWindowForTheme(QWidget* window, ThemeCode themeCode) override;
 
 private:
     bool isSystemDarkMode() const;
     bool isSystemHighContrast() const;
 
-    async::Channel<std::string> m_channel;
+    async::Channel<ThemeCode> m_channel;
 };
 }
 

--- a/src/framework/ui/internal/platform/macos/macosplatformtheme.mm
+++ b/src/framework/ui/internal/platform/macos/macosplatformtheme.mm
@@ -18,7 +18,6 @@
 //=============================================================================
 
 #include "macosplatformtheme.h"
-#include "uitypes.h"
 #include "log.h"
 
 #include <Cocoa/Cocoa.h>
@@ -72,7 +71,7 @@ bool MacOSPlatformTheme::isFollowSystemThemeAvailable() const
     return true;
 }
 
-std::string MacOSPlatformTheme::themeCode() const
+ThemeCode MacOSPlatformTheme::themeCode() const
 {
     if (isSystemDarkMode()) {
         if (isSystemHighContrast()) {
@@ -86,7 +85,7 @@ std::string MacOSPlatformTheme::themeCode() const
     return LIGHT_THEME_CODE;
 }
 
-Channel<std::string> MacOSPlatformTheme::themeCodeChanged() const
+Channel<ThemeCode> MacOSPlatformTheme::themeCodeChanged() const
 {
     return m_channel;
 }
@@ -102,7 +101,7 @@ bool MacOSPlatformTheme::isSystemHighContrast() const
     return [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldIncreaseContrast];
 }
 
-void MacOSPlatformTheme::applyPlatformStyleOnAppForTheme(std::string themeCode)
+void MacOSPlatformTheme::applyPlatformStyleOnAppForTheme(ThemeCode themeCode)
 {
     // The system will turn these appearance names into their high contrast
     // counterparts automatically if system high contrast is enabled
@@ -113,7 +112,7 @@ void MacOSPlatformTheme::applyPlatformStyleOnAppForTheme(std::string themeCode)
     }
 }
 
-void MacOSPlatformTheme::applyPlatformStyleOnWindowForTheme(QWidget* widget, std::string)
+void MacOSPlatformTheme::applyPlatformStyleOnWindowForTheme(QWidget* widget, ThemeCode)
 {
     QColor backgroundColor = widget->palette().window().color();
     NSView* nsView = (__bridge NSView*)reinterpret_cast<void*>(widget->winId());

--- a/src/framework/ui/internal/platform/stub/stubplatformtheme.cpp
+++ b/src/framework/ui/internal/platform/stub/stubplatformtheme.cpp
@@ -18,6 +18,7 @@
 //=============================================================================
 
 #include "stubplatformtheme.h"
+#include "uitypes.h"
 
 using namespace mu::ui;
 using namespace mu::async;
@@ -35,20 +36,20 @@ bool StubPlatformTheme::isFollowSystemThemeAvailable() const
     return false;
 }
 
-bool StubPlatformTheme::isDarkMode() const
+std::string StubPlatformTheme::themeCode() const
 {
-    return false;
+    return LIGHT_THEME_CODE;
 }
 
-Channel<bool> StubPlatformTheme::darkModeSwitched() const
+Channel<std::string> StubPlatformTheme::themeCodeChanged() const
 {
-    return m_darkModeSwitched;
+    return m_channel;
 }
 
-void StubPlatformTheme::setAppThemeDark(bool)
+void StubPlatformTheme::applyPlatformStyleOnAppForTheme(std::string)
 {
 }
 
-void StubPlatformTheme::applyPlatformStyle(QWidget*)
+void StubPlatformTheme::applyPlatformStyleOnWindowForTheme(QWidget*, std::string)
 {
 }

--- a/src/framework/ui/internal/platform/stub/stubplatformtheme.cpp
+++ b/src/framework/ui/internal/platform/stub/stubplatformtheme.cpp
@@ -18,7 +18,6 @@
 //=============================================================================
 
 #include "stubplatformtheme.h"
-#include "uitypes.h"
 
 using namespace mu::ui;
 using namespace mu::async;
@@ -36,20 +35,20 @@ bool StubPlatformTheme::isFollowSystemThemeAvailable() const
     return false;
 }
 
-std::string StubPlatformTheme::themeCode() const
+ThemeCode StubPlatformTheme::themeCode() const
 {
     return LIGHT_THEME_CODE;
 }
 
-Channel<std::string> StubPlatformTheme::themeCodeChanged() const
+Channel<ThemeCode> StubPlatformTheme::themeCodeChanged() const
 {
     return m_channel;
 }
 
-void StubPlatformTheme::applyPlatformStyleOnAppForTheme(std::string)
+void StubPlatformTheme::applyPlatformStyleOnAppForTheme(ThemeCode)
 {
 }
 
-void StubPlatformTheme::applyPlatformStyleOnWindowForTheme(QWidget*, std::string)
+void StubPlatformTheme::applyPlatformStyleOnWindowForTheme(QWidget*, ThemeCode)
 {
 }

--- a/src/framework/ui/internal/platform/stub/stubplatformtheme.h
+++ b/src/framework/ui/internal/platform/stub/stubplatformtheme.h
@@ -31,14 +31,14 @@ public:
 
     bool isFollowSystemThemeAvailable() const override;
 
-    std::string themeCode() const override;
-    async::Channel<std::string> themeCodeChanged() const override;
+    ThemeCode themeCode() const override;
+    async::Channel<ThemeCode> themeCodeChanged() const override;
 
-    void applyPlatformStyleOnAppForTheme(std::string themeCode) override;
-    void applyPlatformStyleOnWindowForTheme(QWidget* window, std::string themeCode) override;
+    void applyPlatformStyleOnAppForTheme(ThemeCode themeCode) override;
+    void applyPlatformStyleOnWindowForTheme(QWidget* window, ThemeCode themeCode) override;
 
 private:
-    async::Channel<std::string> m_channel;
+    async::Channel<ThemeCode> m_channel;
 };
 }
 

--- a/src/framework/ui/internal/platform/stub/stubplatformtheme.h
+++ b/src/framework/ui/internal/platform/stub/stubplatformtheme.h
@@ -31,14 +31,14 @@ public:
 
     bool isFollowSystemThemeAvailable() const override;
 
-    bool isDarkMode() const override;
-    async::Channel<bool> darkModeSwitched() const override;
+    std::string themeCode() const override;
+    async::Channel<std::string> themeCodeChanged() const override;
 
-    void setAppThemeDark(bool) override;
-    void applyPlatformStyle(QWidget*) override;
+    void applyPlatformStyleOnAppForTheme(std::string themeCode) override;
+    void applyPlatformStyleOnWindowForTheme(QWidget* window, std::string themeCode) override;
 
 private:
-    async::Channel<bool> m_darkModeSwitched;
+    async::Channel<std::string> m_channel;
 };
 }
 

--- a/src/framework/ui/internal/platform/windows/windowsplatformtheme.cpp
+++ b/src/framework/ui/internal/platform/windows/windowsplatformtheme.cpp
@@ -18,14 +18,18 @@
 //=============================================================================
 
 #include "windowsplatformtheme.h"
+
 #include "log.h"
+#include "uitypes.h"
+
 #include <Windows.h>
 
 using namespace mu::ui;
 using namespace mu::async;
 
-static const std::wstring windowsThemeKey = L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
-static const std::wstring windowsThemeSubkey = L"AppsUseLightTheme";
+static const std::wstring windowsThemesKey = L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes";
+static const std::wstring windowsThemesPersonalizeKey = L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
+static const std::wstring windowsThemesPersonalizeSubkey = L"AppsUseLightTheme";
 
 HKEY hKey = nullptr;
 
@@ -50,44 +54,13 @@ void WindowsPlatformTheme::startListening()
         return;
     }
     m_isListening = true;
-    if (RegOpenKeyExW(HKEY_CURRENT_USER, windowsThemeKey.c_str(), 0,
+    if (RegOpenKeyExW(HKEY_CURRENT_USER, windowsThemesKey.c_str(), 0,
                       KEY_NOTIFY | KEY_CREATE_SUB_KEY | KEY_ENUMERATE_SUB_KEYS | KEY_QUERY_VALUE | KEY_WOW64_64KEY,
                       &hKey) == ERROR_SUCCESS) {
         m_listenThread = std::thread([this]() { th_listen(); });
     } else {
-        LOGD() << "Failed opening key for listening dark theme changes.";
+        LOGW() << "Failed opening key for listening dark theme changes.";
     }
-}
-
-void WindowsPlatformTheme::th_listen()
-{
-    static const DWORD dwFilter = REG_NOTIFY_CHANGE_NAME
-                                  | REG_NOTIFY_CHANGE_ATTRIBUTES
-                                  | REG_NOTIFY_CHANGE_LAST_SET
-                                  | REG_NOTIFY_CHANGE_SECURITY;
-
-    while (m_isListening) {
-        hStopListeningEvent = CreateEvent(NULL, FALSE, TRUE, TEXT("StopListening"));
-        hThemeChangeEvent = CreateEvent(NULL, FALSE, TRUE, TEXT("ThemeSettingChange"));
-        if (RegNotifyChangeKeyValue(hKey, TRUE, dwFilter, hThemeChangeEvent, TRUE) == ERROR_SUCCESS) {
-            bool wasDarkMode = isDarkMode();
-            HANDLE handles[2] = { hStopListeningEvent, hThemeChangeEvent };
-            DWORD dwRet = WaitForMultipleObjects(2, handles, FALSE, 4000);
-            if (dwRet != WAIT_TIMEOUT && dwRet != WAIT_FAILED) {
-                if (!m_isListening) {
-                    // then it must have been a stop event
-                } else {
-                    bool isDarkMode = this->isDarkMode();
-                    if (isDarkMode != wasDarkMode) {
-                        m_darkModeSwitched.send(isDarkMode);
-                    }
-                }
-            }
-        } else {
-            LOGD() << "Failed registering for dark theme change notifications.";
-        }
-    }
-    RegCloseKey(hKey);
 }
 
 void WindowsPlatformTheme::stopListening()
@@ -107,26 +80,84 @@ bool WindowsPlatformTheme::isFollowSystemThemeAvailable() const
     return m_buildNumber >= 17763; // Dark theme was introduced in Windows 1809
 }
 
-bool WindowsPlatformTheme::isDarkMode() const
+std::string WindowsPlatformTheme::themeCode() const
+{
+    if (isSystemHighContrast()) {
+        return HIGH_CONTRAST_THEME_CODE;
+    }
+
+    if (isSystemDarkMode()) {
+        return DARK_THEME_CODE;
+    }
+
+    //! NOTE When system is in light mode, don't automatically use
+    //! high contrast theme, because it is too dark.
+    //! Light high contrast theme would be nice.
+    return LIGHT_THEME_CODE;
+}
+
+Channel<std::string> WindowsPlatformTheme::themeCodeChanged() const
+{
+    return m_channel;
+}
+
+bool WindowsPlatformTheme::isSystemDarkMode() const
 {
     DWORD data {};
     DWORD datasize = sizeof(data);
-    if (RegGetValue(HKEY_CURRENT_USER, windowsThemeKey.c_str(), windowsThemeSubkey.c_str(),
+    if (RegGetValue(HKEY_CURRENT_USER, windowsThemesPersonalizeKey.c_str(), windowsThemesPersonalizeSubkey.c_str(),
                     RRF_RT_REG_DWORD, nullptr, &data, &datasize) == ERROR_SUCCESS) {
         return data == 0;
     }
     return false;
 }
 
-Channel<bool> WindowsPlatformTheme::darkModeSwitched() const
+bool WindowsPlatformTheme::isSystemHighContrast() const
 {
-    return m_darkModeSwitched;
+    HIGHCONTRAST info;
+    info.cbSize = sizeof(HIGHCONTRAST);
+    if (SystemParametersInfoW(SPI_GETHIGHCONTRAST, 0, &info, 0)) {
+        return info.dwFlags & HCF_HIGHCONTRASTON;
+    }
+    return false;
 }
 
-void WindowsPlatformTheme::setAppThemeDark(bool)
+void WindowsPlatformTheme::th_listen()
+{
+    static const DWORD dwFilter = REG_NOTIFY_CHANGE_NAME
+                                  | REG_NOTIFY_CHANGE_ATTRIBUTES
+                                  | REG_NOTIFY_CHANGE_LAST_SET
+                                  | REG_NOTIFY_CHANGE_SECURITY;
+
+    while (m_isListening) {
+        hStopListeningEvent = CreateEvent(NULL, FALSE, TRUE, TEXT("StopListening"));
+        hThemeChangeEvent = CreateEvent(NULL, FALSE, TRUE, TEXT("ThemeSettingChange"));
+        if (RegNotifyChangeKeyValue(hKey, TRUE, dwFilter, hThemeChangeEvent, TRUE) == ERROR_SUCCESS) {
+            std::string oldBestSuited = themeCode();
+            HANDLE handles[2] = { hStopListeningEvent, hThemeChangeEvent };
+            DWORD dwRet = WaitForMultipleObjects(2, handles, FALSE, 4000);
+            if (dwRet != WAIT_TIMEOUT && dwRet != WAIT_FAILED) {
+                if (m_isListening) {
+                    //! NOTE There might be some delay before `isSystemHighContrast` returns the correct value
+                    Sleep(100);
+                    std::string newBestSuited = themeCode();
+                    if (newBestSuited != oldBestSuited) {
+                        m_channel.send(newBestSuited);
+                    }
+                }
+                // Else, the received event must have been a stop event
+            }
+        } else {
+            LOGD() << "Failed registering for dark theme change notifications.";
+        }
+    }
+    RegCloseKey(hKey);
+}
+
+void WindowsPlatformTheme::applyPlatformStyleOnAppForTheme(std::string)
 {
 }
 
-void WindowsPlatformTheme::applyPlatformStyle(QWidget*)
+void WindowsPlatformTheme::applyPlatformStyleOnWindowForTheme(QWidget*, std::string)
 {
 }

--- a/src/framework/ui/internal/platform/windows/windowsplatformtheme.cpp
+++ b/src/framework/ui/internal/platform/windows/windowsplatformtheme.cpp
@@ -18,9 +18,7 @@
 //=============================================================================
 
 #include "windowsplatformtheme.h"
-
 #include "log.h"
-#include "uitypes.h"
 
 #include <Windows.h>
 
@@ -80,7 +78,7 @@ bool WindowsPlatformTheme::isFollowSystemThemeAvailable() const
     return m_buildNumber >= 17763; // Dark theme was introduced in Windows 1809
 }
 
-std::string WindowsPlatformTheme::themeCode() const
+ThemeCode WindowsPlatformTheme::themeCode() const
 {
     if (isSystemHighContrast()) {
         return HIGH_CONTRAST_THEME_CODE;
@@ -96,7 +94,7 @@ std::string WindowsPlatformTheme::themeCode() const
     return LIGHT_THEME_CODE;
 }
 
-Channel<std::string> WindowsPlatformTheme::themeCodeChanged() const
+Channel<ThemeCode> WindowsPlatformTheme::themeCodeChanged() const
 {
     return m_channel;
 }
@@ -133,14 +131,14 @@ void WindowsPlatformTheme::th_listen()
         hStopListeningEvent = CreateEvent(NULL, FALSE, TRUE, TEXT("StopListening"));
         hThemeChangeEvent = CreateEvent(NULL, FALSE, TRUE, TEXT("ThemeSettingChange"));
         if (RegNotifyChangeKeyValue(hKey, TRUE, dwFilter, hThemeChangeEvent, TRUE) == ERROR_SUCCESS) {
-            std::string oldBestSuited = themeCode();
+            ThemeCode oldBestSuited = themeCode();
             HANDLE handles[2] = { hStopListeningEvent, hThemeChangeEvent };
             DWORD dwRet = WaitForMultipleObjects(2, handles, FALSE, 4000);
             if (dwRet != WAIT_TIMEOUT && dwRet != WAIT_FAILED) {
                 if (m_isListening) {
                     //! NOTE There might be some delay before `isSystemHighContrast` returns the correct value
                     Sleep(100);
-                    std::string newBestSuited = themeCode();
+                    ThemeCode newBestSuited = themeCode();
                     if (newBestSuited != oldBestSuited) {
                         m_channel.send(newBestSuited);
                     }
@@ -154,10 +152,10 @@ void WindowsPlatformTheme::th_listen()
     RegCloseKey(hKey);
 }
 
-void WindowsPlatformTheme::applyPlatformStyleOnAppForTheme(std::string)
+void WindowsPlatformTheme::applyPlatformStyleOnAppForTheme(ThemeCode)
 {
 }
 
-void WindowsPlatformTheme::applyPlatformStyleOnWindowForTheme(QWidget*, std::string)
+void WindowsPlatformTheme::applyPlatformStyleOnWindowForTheme(QWidget*, ThemeCode)
 {
 }

--- a/src/framework/ui/internal/platform/windows/windowsplatformtheme.h
+++ b/src/framework/ui/internal/platform/windows/windowsplatformtheme.h
@@ -33,16 +33,16 @@ public:
 
     bool isFollowSystemThemeAvailable() const override;
 
-    std::string themeCode() const override;
-    async::Channel<std::string> themeCodeChanged() const override;
+    ThemeCode themeCode() const override;
+    async::Channel<ThemeCode> themeCodeChanged() const override;
 
-    void applyPlatformStyleOnAppForTheme(std::string themeCode) override;
-    void applyPlatformStyleOnWindowForTheme(QWidget* window, std::string themeCode) override;
+    void applyPlatformStyleOnAppForTheme(ThemeCode themeCode) override;
+    void applyPlatformStyleOnWindowForTheme(QWidget* window, ThemeCode themeCode) override;
 
 private:
     int m_buildNumber = 0;
 
-    async::Channel<std::string> m_channel;
+    async::Channel<ThemeCode> m_channel;
     std::atomic<bool> m_isListening = false;
     std::thread m_listenThread;
 

--- a/src/framework/ui/internal/platform/windows/windowsplatformtheme.h
+++ b/src/framework/ui/internal/platform/windows/windowsplatformtheme.h
@@ -22,15 +22,9 @@
 
 #include "internal/iplatformtheme.h"
 
-#include "modularity/ioc.h"
-#include "async/asyncable.h"
-#include "iuiconfiguration.h"
-
 namespace mu::ui {
-class WindowsPlatformTheme : public IPlatformTheme, public async::Asyncable
+class WindowsPlatformTheme : public IPlatformTheme
 {
-    INJECT(ui, IUiConfiguration, configuration)
-
 public:
     WindowsPlatformTheme();
 
@@ -39,18 +33,23 @@ public:
 
     bool isFollowSystemThemeAvailable() const override;
 
-    bool isDarkMode() const override;
-    async::Channel<bool> darkModeSwitched() const override;
+    std::string themeCode() const override;
+    async::Channel<std::string> themeCodeChanged() const override;
 
-    void setAppThemeDark(bool isDark) override;
-    void applyPlatformStyle(QWidget* window) override;
+    void applyPlatformStyleOnAppForTheme(std::string themeCode) override;
+    void applyPlatformStyleOnWindowForTheme(QWidget* window, std::string themeCode) override;
 
 private:
-    async::Channel<bool> m_darkModeSwitched;
     int m_buildNumber = 0;
+
+    async::Channel<std::string> m_channel;
     std::atomic<bool> m_isListening = false;
     std::thread m_listenThread;
+
     void th_listen();
+
+    bool isSystemDarkMode() const;
+    bool isSystemHighContrast() const;
 };
 }
 

--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -153,11 +153,11 @@ bool UiConfiguration::needFollowSystemTheme() const
 
 void UiConfiguration::initThemes()
 {
-    platformTheme()->themeCodeChanged().onReceive(nullptr, [this](std::string) {
+    platformTheme()->themeCodeChanged().onReceive(nullptr, [this](ThemeCode) {
         notifyAboutCurrentThemeChanged();
     });
 
-    for (const std::string& codeKey : allStandardThemeCodes()) {
+    for (const ThemeCode& codeKey : allStandardThemeCodes()) {
         m_themes.push_back(makeStandardTheme(codeKey));
     }
 
@@ -173,7 +173,7 @@ void UiConfiguration::updateCurrentTheme()
         platformTheme()->stopListening();
     }
 
-    std::string currentCodeKey = currentThemeCodeKey();
+    ThemeCode currentCodeKey = currentThemeCodeKey();
 
     for (size_t i = 0; i < m_themes.size(); ++i) {
         if (m_themes[i].codeKey == currentCodeKey) {
@@ -207,7 +207,7 @@ void UiConfiguration::notifyAboutCurrentThemeChanged()
     m_currentThemeChanged.notify();
 }
 
-ThemeInfo UiConfiguration::makeStandardTheme(const std::string& codeKey) const
+ThemeInfo UiConfiguration::makeStandardTheme(const ThemeCode& codeKey) const
 {
     ThemeInfo theme;
     theme.codeKey = codeKey;
@@ -318,18 +318,18 @@ ThemeInfo UiConfiguration::currentTheme() const
     return m_themes[m_currentThemeIndex];
 }
 
-std::string UiConfiguration::currentThemeCodeKey() const
+ThemeCode UiConfiguration::currentThemeCodeKey() const
 {
-    std::string preferredThemeCode = settings()->value(UI_CURRENT_THEME_CODE_KEY).toString();
-
     if (needFollowSystemTheme()) {
         return platformTheme()->themeCode();
     }
 
+    ThemeCode preferredThemeCode = settings()->value(UI_CURRENT_THEME_CODE_KEY).toString();
+
     return preferredThemeCode.empty() ? LIGHT_THEME_CODE : preferredThemeCode;
 }
 
-void UiConfiguration::setCurrentTheme(const std::string& codeKey)
+void UiConfiguration::setCurrentTheme(const ThemeCode& codeKey)
 {
     settings()->setValue(UI_CURRENT_THEME_CODE_KEY, Val(codeKey));
 }

--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -153,11 +153,7 @@ bool UiConfiguration::needFollowSystemTheme() const
 
 void UiConfiguration::initThemes()
 {
-    if (needFollowSystemTheme()) {
-        platformTheme()->startListening();
-    }
-
-    platformTheme()->darkModeSwitched().onReceive(nullptr, [this](bool) {
+    platformTheme()->themeCodeChanged().onReceive(nullptr, [this](std::string) {
         notifyAboutCurrentThemeChanged();
     });
 
@@ -171,6 +167,12 @@ void UiConfiguration::initThemes()
 
 void UiConfiguration::updateCurrentTheme()
 {
+    if (needFollowSystemTheme()) {
+        platformTheme()->startListening();
+    } else {
+        platformTheme()->stopListening();
+    }
+
     std::string currentCodeKey = currentThemeCodeKey();
 
     for (size_t i = 0; i < m_themes.size(); ++i) {
@@ -180,7 +182,7 @@ void UiConfiguration::updateCurrentTheme()
         }
     }
 
-    platformTheme()->setAppThemeDark(currentCodeKey == DARK_THEME_CODE);
+    platformTheme()->applyPlatformStyleOnAppForTheme(currentCodeKey);
 }
 
 void UiConfiguration::updateThemes()
@@ -321,7 +323,7 @@ std::string UiConfiguration::currentThemeCodeKey() const
     std::string preferredThemeCode = settings()->value(UI_CURRENT_THEME_CODE_KEY).toString();
 
     if (needFollowSystemTheme()) {
-        return platformTheme()->isDarkMode() ? DARK_THEME_CODE : LIGHT_THEME_CODE;
+        return platformTheme()->themeCode();
     }
 
     return preferredThemeCode.empty() ? LIGHT_THEME_CODE : preferredThemeCode;
@@ -499,7 +501,7 @@ Notification UiConfiguration::pageStateChanged() const
 
 void UiConfiguration::applyPlatformStyle(QWidget* window)
 {
-    platformTheme()->applyPlatformStyle(window);
+    platformTheme()->applyPlatformStyleOnWindowForTheme(window, currentThemeCodeKey());
 }
 
 QByteArray UiConfiguration::stringToByteArray(const std::string& string) const

--- a/src/framework/ui/internal/uiconfiguration.h
+++ b/src/framework/ui/internal/uiconfiguration.h
@@ -44,7 +44,7 @@ public:
     QStringList possibleAccentColors() const override;
 
     ThemeInfo currentTheme() const override;
-    void setCurrentTheme(const std::string& codeKey) override;
+    void setCurrentTheme(const ThemeCode& codeKey) override;
     void setCurrentThemeStyleValue(ThemeStyleKey key, const Val& val) override;
     async::Notification currentThemeChanged() const override;
 
@@ -81,8 +81,8 @@ private:
     void updateCurrentTheme();
     void updateThemes();
 
-    std::string currentThemeCodeKey() const;
-    ThemeInfo makeStandardTheme(const std::string& codeKey) const;
+    ThemeCode currentThemeCodeKey() const;
+    ThemeInfo makeStandardTheme(const ThemeCode& codeKey) const;
 
     ThemeList readThemes() const;
     void writeThemes(const ThemeList& themes);

--- a/src/framework/ui/iuiconfiguration.h
+++ b/src/framework/ui/iuiconfiguration.h
@@ -42,7 +42,7 @@ public:
     virtual QStringList possibleAccentColors() const = 0;
 
     virtual ThemeInfo currentTheme() const = 0;
-    virtual void setCurrentTheme(const std::string& codeKey) = 0;
+    virtual void setCurrentTheme(const ThemeCode& codeKey) = 0;
     virtual void setCurrentThemeStyleValue(ThemeStyleKey key, const Val& val) = 0;
     virtual async::Notification currentThemeChanged() const = 0;
 

--- a/src/framework/ui/uitypes.h
+++ b/src/framework/ui/uitypes.h
@@ -31,11 +31,13 @@
 #include "view/iconcodes.h"
 
 namespace mu::ui {
-static std::string DARK_THEME_CODE("dark");
-static std::string LIGHT_THEME_CODE("light");
-static std::string HIGH_CONTRAST_THEME_CODE("high_contrast");
+using ThemeCode = std::string;
 
-inline std::vector<std::string> allStandardThemeCodes()
+static ThemeCode DARK_THEME_CODE("dark");
+static ThemeCode LIGHT_THEME_CODE("light");
+static ThemeCode HIGH_CONTRAST_THEME_CODE("high_contrast");
+
+inline std::vector<ThemeCode> allStandardThemeCodes()
 {
     return {
         LIGHT_THEME_CODE,
@@ -72,7 +74,7 @@ enum ThemeStyleKey
 
 struct ThemeInfo
 {
-    std::string codeKey;
+    ThemeCode codeKey;
     std::string title;
     QMap<ThemeStyleKey, QVariant> values;
 };


### PR DESCRIPTION
- **Update PlatformTheme: now also detects System High Contrast**
  Works now with all three themes, instead of only Light/Dark.


- **Improve border of ThemeSample**
  - Make the bottom right corner also round
  - Realize border color in a more 'declarative' way
  - Border on all sides; not overlapped by border of inner rect


Note:  Automatic Theme Detection does not work at this moment; it can't be enabled via Preferences. This will be implemented later. 