### PR TITLE
[DAISY] Fix #303450: Text in voice 2 not placed correctly

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -5036,15 +5036,22 @@ static void directionMarker(XmlWriter& xml, const Marker* const m)
 //  findTrackForAnnotations
 //---------------------------------------------------------
 
-// An annotation is attached to the staff, with track set
-// to the lowest track in the staff. Find a track for it
-// (the lowest track in this staff that has a chord or rest)
+// Annotations must be attached to chords or rests. If there is no chord or
+// rest in the annotation's track then we must use a different track that
+// does have a chord or a rest.
 
 static int findTrackForAnnotations(int track, Segment* seg)
 {
     if (seg->segmentType() != SegmentType::ChordRest) {
         return -1;
     }
+
+    if (seg->element(track)) {
+        return track; // able to use annotation's own track
+    }
+
+    // No chords or rests in the annotation's own track so look for chord and
+    // rests in the other tracks in this staff.
 
     int staff = track / VOICES;
     int strack = staff * VOICES;        // start track of staff containing track


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/303450

Text and other annotations were always being exported to Voice 1 regardless of the voice that the text or annotation actually belongs to.

To-do:

- [x] Check export works as expected
- [ ] Check import works as expected (can't do this yet because import is currently disabled in MU4)
- [ ] Add tests and reference files