### PR TITLE
[MU3] Fix #319476: Allow plugins to add symbols to rests

### DIFF
--- a/mscore/plugin/api/cursor.cpp
+++ b/mscore/plugin/api/cursor.cpp
@@ -310,8 +310,14 @@ void Cursor::add(Element* wrapped)
                         break;
                         }
 
-                  // To be added to a note
-                  case ElementType::SYMBOL:
+                  // To be added to a note (and in case of SYMBOL also to a rest)
+                  case ElementType::SYMBOL: {
+                        Ms::Element* curElement = currentElement();
+                        if (curElement->isRest()) {
+                              s->setParent(curElement);
+                              _score->undoAddElement(s);
+                              }
+                        } // FALLTHROUGH
                   case ElementType::FINGERING:
                   case ElementType::BEND:
                   case ElementType::NOTEHEAD: {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/319476

Corresponding change for master in #7869