### PR TITLE
[MU4] Fix #319476: Allow plugins to add symbols to rests

### DIFF
--- a/src/plugins/api/cursor.cpp
+++ b/src/plugins/api/cursor.cpp
@@ -313,8 +313,14 @@ void Cursor::add(Element* wrapped)
             break;
         }
 
-        // To be added to a note
-        case ElementType::SYMBOL:
+        // To be added to a note (and in case of SYMBOL also to a rest)
+        case ElementType::SYMBOL: {
+            Ms::Element* curElement = currentElement();
+            if (curElement->isRest()) {
+                s->setParent(curElement);
+                _score->undoAddElement(s);
+            }
+        } // FALLTHROUGH
         case ElementType::FINGERING:
         case ElementType::BEND:
         case ElementType::NOTEHEAD: {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/319476

 This is for master what #7868 is for 3.x