### PR TITLE
[MU3] [DAISY] backport of master fixes to 3.x

### DIFF
--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -2678,12 +2678,14 @@ static void writeChordLines(const Chord* const chord, XmlWriter& xml, Notations&
 void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technical& technical,
                                      TrillHash& trillStart, TrillHash& trillStop)
       {
-      QVector<Element*> fl;
-      for (Element* e : chord->segment()->annotations()) {
-            if (e->track() == chord->track() && e->isFermata())
-                  fl.push_back(e);
+      if (!chord->isGrace()) {
+            QVector<Element*> fl;
+            for (Element* e : chord->segment()->annotations()) {
+                  if (e->track() == chord->track() && e->isFermata())
+                        fl.push_back(e);
+                  }
+            fermatas(fl, _xml, notations);
             }
-      fermatas(fl, _xml, notations);
 
       const QVector<Articulation*> na = chord->articulations();
       // first the attributes whose elements are children of <articulations>

--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -4779,14 +4779,20 @@ static void directionMarker(XmlWriter& xml, const Marker* const m)
 //  findTrackForAnnotations
 //---------------------------------------------------------
 
-// An annotation is attached to the staff, with track set
-// to the lowest track in the staff. Find a track for it
-// (the lowest track in this staff that has a chord or rest)
+// Annotations must be attached to chords or rests. If there is no chord or
+// rest in the annotation's track then we must use a different track that
+// does have a chord or a rest.
 
 static int findTrackForAnnotations(int track, Segment* seg)
       {
       if (seg->segmentType() != SegmentType::ChordRest)
             return -1;
+
+      if (seg->element(track))
+            return track; // able to use annotation's own track
+
+      // No chords or rests in the annotation's own track so look for chord and
+      // rests in the other tracks in this staff.
 
       int staff = track / VOICES;
       int strack = staff * VOICES;      // start track of staff containing track

--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -6130,6 +6130,7 @@ void MeasureNumberStateHandler::updateForMeasure(const Measure* const m)
             }
 
       // update measure numbers and cache result
+      _measureNo += m->noOffset();
       _cachedAttributes = " number=";
       if ((_irregularMeasureNo + _measureNo) == 2 && m->irregular()) {
             _cachedAttributes += "\"0\" implicit=\"yes\"";

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -1969,8 +1969,8 @@ void MusicXMLParserPass2::measure(const QString& partId,
                                   const Fraction time)
       {
       Q_ASSERT(_e.isStartElement() && _e.name() == "measure");
-      //QString number = _e.attributes().value("number").toString();
-      //qDebug("measure %s start", qPrintable(number));
+      int number = _e.attributes().value("number").toInt();
+      //qDebug("measure %d start", number);
 
       Measure* measure = findMeasure(_score, time);
       if (!measure) {
@@ -1978,6 +1978,8 @@ void MusicXMLParserPass2::measure(const QString& partId,
             skipLogCurrElem();
             return;
             }
+
+      measure->setNoOffset(measure->no() - number);
 
       // handle implicit measure
       if (_e.attributes().value("implicit") == "yes")

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -716,7 +716,8 @@ QString ChordRest::durationUserName() const
                         tupletType = QObject::tr("Nonuplet");
                         break;
                   default:
-                        tupletType = QObject::tr("Custom tuplet");
+                        //: %1 is tuplet ratio numerator (i.e. the number of notes in the tuplet)
+                        tupletType = QObject::tr("%1 note tuplet").arg(tuplet()->ratio().numerator());
                   }
             }
       QString dotString = "";

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -3071,7 +3071,9 @@ QString Note::screenReaderInfo() const
       else if (staff()->isTabStaff(tick()))
             pitchName = QObject::tr("%1; String: %2; Fret: %3").arg(tpcUserName(true), QString::number(string() + 1), QString::number(fret()));
       else
-            pitchName = tpcUserName(true);
+            pitchName = _headGroup == NoteHead::Group::HEAD_NORMAL
+                        ? tpcUserName(true)
+                        : QObject::tr("%1 head %2").arg(subtypeName()).arg(tpcUserName(true));
       return QString("%1 %2 %3%4").arg(noteTypeUserName(), pitchName, duration, (chord()->isGrace() ? "" : QString("; %1").arg(voice)));
       }
 


### PR DESCRIPTION
@shoogle's fixes (all still in draft currently):

* [DAISY] Fix [#298147](https://musescore.org/en/node/298147) MusicXML: Handle measure number offsets _(#7617)_
* [DAISY] Fix [#269926](https://musescore.org/en/node/269926) MusicXML: Fermatas on notes with grace notes _(#7621)_
* [DAISY] Fix [#303450](https://musescore.org/en/node/303450) MusicXML: Text in voice 2 not placed correctly _(#7863)_
* [DAISY] Fix [#307442](https://musescore.org/en/node/307442) Accessibility: Speech for tuplets with more than 9 notes _(#8877, part 1)_
* [DAISY] Fix [#312625 ](https://musescore.org/en/node/312625) Accessibility: Speak notehead group type _(#8877, part 2)_

For the [DAISY Music Braille Project](https://daisy.org/activities/projects/music-braille/)

