### PR TITLE
[MU3] Backporting some master PRs to 3.x

### DIFF
--- a/libmscore/check.cpp
+++ b/libmscore/check.cpp
@@ -319,7 +319,7 @@ bool Score::checkClefs()
 //   fillGap
 //---------------------------------------------------------
 
-void Measure::fillGap(const Fraction& pos, const Fraction& len, int track, const Fraction& stretch)
+void Measure::fillGap(const Fraction& pos, const Fraction& len, int track, const Fraction& stretch, bool useGapRests)
       {
       qDebug("measure %6d pos %d, len %d/%d, stretch %d/%d track %d",
          tick().ticks(),
@@ -334,7 +334,7 @@ void Measure::fillGap(const Fraction& pos, const Fraction& len, int track, const
             rest->setTicks(len);
             rest->setDurationType(d);
             rest->setTrack(track);
-            rest->setGap(true);
+            rest->setGap(useGapRests);
             score()->undoAddCR(rest, this, (pos / stretch) + tick());
             }
       }
@@ -346,7 +346,7 @@ void Measure::fillGap(const Fraction& pos, const Fraction& len, int track, const
 //    with invisible rests
 //---------------------------------------------------------
 
-void Measure::checkMeasure(int staffIdx)
+void Measure::checkMeasure(int staffIdx, bool useGapRests)
       {
       if (isMMRest())
             return;
@@ -388,7 +388,7 @@ void Measure::checkMeasure(int staffIdx)
             if (f > expectedPos) {
                   // don't fill empty voices
                   if (expectedPos.isNotZero())
-                        fillGap(expectedPos, f - expectedPos, track, stretch);
+                        fillGap(expectedPos, f - expectedPos, track, stretch, useGapRests);
                   }
             else if (f < expectedPos)
                   qDebug("measure overrun %6d, %d > %d, track %d", tick().ticks(), expectedPos.ticks(), f.ticks(), track);

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1370,8 +1370,11 @@ bool ChordRest::isBefore(const ChordRest* o) const
             bool oGrace      = o->isGrace();
             bool grace       = isGrace();
             // normal note are initialized at graceIndex 0 and graceIndex is 0 based
-            int oGraceIndex  = oGrace ? toChord(o)->graceIndex() +  1 : 0;
-            int graceIndex   = grace ? toChord(this)->graceIndex() + 1 : 0;
+            int oGraceIndex  = toChord(o)->graceIndex();
+            int graceIndex   = toChord(this)->graceIndex();
+            // Smaller indexes are further away from the note, and larger indexes are closer to the note.
+            // We want to reverse that. Subtracting a 0-based index from the size results in a 1-based index,
+            // which is exactly what we want.
             if (oGrace)
                   oGraceIndex = toChord(o->parent())->graceNotes().size() - oGraceIndex;
             if (grace)

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1262,7 +1262,10 @@ void Score::cmdAddTie(bool addToChord)
       for (Note* note : noteList) {
             if (note->tieFor()) {
                   qDebug("cmdAddTie: note %p has already tie? noteFor: %p", note, note->tieFor());
-                  continue;
+                  if (addToChord)
+                        continue;
+                  else
+                        undoRemoveElement(note->tieFor());
                   }
 
             if (noteEntryMode()) {

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1272,11 +1272,12 @@ const ChordDescription* Harmony::getDescription(const QString& name, const Parse
 
 const RealizedHarmony& Harmony::getRealizedHarmony()
       {
-      int offset = 0; //semitone offset for pitch adjustment
       Staff* st = staff();
+      int capo = st->capo(tick()) - 1;
+      int offset = (capo < 0 ? 0 : capo);   //semitone offset for pitch adjustment
       Interval interval = st->part()->instrument(tick())->transpose();
       if (!score()->styleB(Sid::concertPitch))
-            offset = interval.chromatic;
+            offset += interval.chromatic;
 
       //Adjust for Nashville Notation, might be temporary
       // TODO: set dirty on add/remove of keysig

--- a/libmscore/image.cpp
+++ b/libmscore/image.cpp
@@ -43,6 +43,7 @@ Image::Image(Score* s)
       _autoScale       = defaultAutoScale;
       _sizeIsSpatium   = defaultSizeIsSpatium;
       _linkIsValid     = false;
+      _used            = false;
       }
 
 Image::Image(const Image& img)
@@ -60,6 +61,7 @@ Image::Image(const Image& img)
             _storeItem->reference(this);
       _linkPath        = img._linkPath;
       _linkIsValid     = img._linkIsValid;
+      _used            = false;
       if (imageType == ImageType::RASTER)
             rasterDoc = img.rasterDoc ? new QImage(*img.rasterDoc) : 0;
       else if (imageType == ImageType::SVG)

--- a/libmscore/image.h
+++ b/libmscore/image.h
@@ -46,6 +46,7 @@ class Image final : public BSymbol {
       bool _autoScale;              ///< fill parent frame
       bool _sizeIsSpatium;
       mutable bool _dirty;
+      bool _used;
 
       bool isEditable() const override { return true; }
       void startEditDrag(EditData&) override;
@@ -75,6 +76,8 @@ class Image final : public BSymbol {
       ImageStoreItem* storeItem() const  { return _storeItem;     }
       bool sizeIsSpatium() const         { return _sizeIsSpatium; }
       void setSizeIsSpatium(bool val)    { _sizeIsSpatium = val;  }
+      bool isUsed() const                { return _used;          }
+      void setUsed(bool val)             { _used = val;           }
 
       QVariant getProperty(Pid ) const override;
       bool setProperty(Pid propertyId, const QVariant&) override;

--- a/libmscore/imageStore.cpp
+++ b/libmscore/imageStore.cpp
@@ -56,7 +56,7 @@ void ImageStoreItem::reference(Image* image)
 bool ImageStoreItem::isUsed(Score* score) const
       {
       foreach(Image* image, _references) {
-            if (image->score() == score)
+            if (image->score() == score && image->isUsed())
                   return true;
             }
       return false;

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -87,7 +87,7 @@ class Measure final : public MeasureBase {
       void push_back(Segment* e);
       void push_front(Segment* e);
 
-      void fillGap(const Fraction& pos, const Fraction& len, int track, const Fraction& stretch);
+      void fillGap(const Fraction& pos, const Fraction& len, int track, const Fraction& stretch, bool useGapRests = true);
       void computeMinWidth(Segment* s, qreal x, bool isSystemHeader);
 
       void readVoice(XmlReader& e, int staffIdx, bool irregular);
@@ -110,7 +110,7 @@ class Measure final : public MeasureBase {
       void writeBox(XmlWriter&) const;
       void readBox(XmlReader&);
       bool isEditable() const override { return false; }
-      void checkMeasure(int idx);
+      void checkMeasure(int idx, bool useGapRests = true);
 
       void add(Element*) override;
       void remove(Element*) override;

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -484,7 +484,7 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff, Fraction scale)
             Measure* endM = tick2measure(dstTick + tickLen);
             for (int i = dstStaff; i < endStaff; i++) {
                   for (Measure* m = dstM; m && m != endM->nextMeasure(); m = m->nextMeasure())
-                        m->checkMeasure(i);
+                        m->checkMeasure(i, false);
                   }
             _selection.setRangeTicks(dstTick, dstTick + tickLen, dstStaff, endStaff);
 

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -137,7 +137,10 @@ void Score::updateCapo()
       if (!fm)
             return;
       for (Segment* s = fm->first(SegmentType::ChordRest); s; s = s->next1(SegmentType::ChordRest)) {
-            for (const Element* e : s->annotations()) {
+            for (Element* e : s->annotations()) {
+                  if (e->isHarmony()) {
+                        toHarmony(e)->realizedHarmony().setDirty(true);
+                        }
                   if (!e->isStaffTextBase())
                         continue;
                   const StaffTextBase* st = toStaffTextBase(e);

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -74,6 +74,7 @@
 #include "breath.h"
 #include "instrchange.h"
 #include "synthesizerstate.h"
+#include "image.h"
 
 namespace Ms {
 
@@ -1439,6 +1440,9 @@ void Score::addElement(Element* element)
             case ElementType::HARMONY:
                   element->part()->updateHarmonyChannels(true);
                   break;
+            case ElementType::IMAGE:
+                  toImage(element)->setUsed(true);
+                  break;
 
             default:
                   break;
@@ -1602,6 +1606,9 @@ void Score::removeElement(Element* element)
                   break;
             case ElementType::HARMONY:
                   element->part()->updateHarmonyChannels(true, true);
+                  break;
+            case ElementType::IMAGE:
+                  toImage(element)->setUsed(false);
                   break;
 
             default:

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -589,7 +589,7 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
                   LayoutBreak* breakElement = toLayoutBreak(element);
                   score->cmdToggleLayoutBreak(breakElement->layoutBreakType());
                   }
-            else if (element->isSlur() && addSingle) {
+            else if (element->isSlur()) {
                   viewer->cmdAddSlur(toSlur(element));
                   }
             else if (element->isSLine() && !element->isGlissando() && addSingle) {

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3997,9 +3997,9 @@ void ScoreView::cmdAddSlur(const Slur* slurTemplate)
                         if (!e->isChord())
                               continue;
                         ChordRest* cr = toChordRest(e);
-                        if (!cr1 || cr1->tick() > cr->tick())
+                        if (!cr1 || cr->isBefore(cr1))
                               cr1 = cr;
-                        if (!cr2 || cr2->tick() < cr->tick())
+                        if (!cr2 || cr2->isBefore(cr))
                               cr2 = cr;
                         }
                   if (cr1 && (cr1 != cr2))
@@ -4065,7 +4065,7 @@ void ScoreView::addSlur(ChordRest* cr1, ChordRest* cr2, const Slur* slurTemplate
             _score->inputState().setSlur(slur);
             ss->setSelected(true);
             }
-      else if (switchToSlur) {
+      else if (switchToSlur && score()->selection().isSingle()) {
             startEditMode(ss);
             }
       }

--- a/mtest/libmscore/copypaste/copypaste14-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste14-ref.mscx
@@ -180,6 +180,9 @@
               <tpc>14</tpc>
               </Note>
             </Chord>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
           </voice>
         </Measure>
       <Measure>

--- a/mtest/libmscore/copypaste/copypaste15-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste15-ref.mscx
@@ -180,6 +180,9 @@
               <tpc>18</tpc>
               </Note>
             </Chord>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
           </voice>
         </Measure>
       <Measure>

--- a/mtest/libmscore/copypaste/copypaste16-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste16-ref.mscx
@@ -163,6 +163,9 @@
               <tpc>18</tpc>
               </Note>
             </Chord>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
           </voice>
         </Measure>
       <Measure>

--- a/mtest/libmscore/copypaste/copypaste21-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste21-ref.mscx
@@ -178,6 +178,9 @@
               <tpc>18</tpc>
               </Note>
             </Chord>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
           </voice>
         </Measure>
       <Measure>

--- a/mtest/libmscore/copypaste/copypaste_tremolo-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste_tremolo-ref.mscx
@@ -178,6 +178,9 @@
               <tpc>18</tpc>
               </Note>
             </Chord>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
           </voice>
         </Measure>
       <Measure>
@@ -229,6 +232,9 @@
               <tpc>13</tpc>
               </Note>
             </Chord>
+          <Rest>
+            <durationType>quarter</durationType>
+            </Rest>
           </voice>
         </Measure>
       <Measure>


### PR DESCRIPTION
Backporting @mattmcclinch's PRs for master to 3.x:

* [Fix #307704](https://musescore.org/en/node/307704): Capo settings applied via staff text do not affect chord symbols _(#7700, merged)_
* [Fix #302104](https://musescore.org/en/node/302104): Slur and grace note (acciaccatura) fails _(#5802, this one actually needs to get "forward ported" to master, at least rebased)_
* [Fix #301768](https://musescore.org/en/node/301768): Unexpected tieing behaviour _(#5777 this one actually needs to get forward "ported to master", at least rebased)_
* [Fix #301016](https://musescore.org/en/node/301016): Copying a partial measure leaves rest(s) missing in voices 2-4. _(#5702, this one actually needs to get "forward ported" to master, at least rebased)_
* [Fix #318772](https://musescore.org/en/node/318772): Don't save unused images in MSCZ file _(not quite the same, but similar to #7740, merged)_

