### PR TITLE
[MU3] Fix  #292716, #319525: Shortcut 5 doesn't work on AZERTY keyboards

### DIFF
--- a/mscore/data/shortcuts_AZERTY.xml
+++ b/mscore/data/shortcuts_AZERTY.xml
@@ -1028,7 +1028,7 @@
     </SC>
   <SC>
     <key>add-parentheses</key>
-    <seq>(</seq>
+    <seq>)</seq>
     </SC>
   <SC>
     <key>toggle-mmrest</key>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/292716 and https://musescore.org/en/node/319525

By changing the parentheses shortcut from `(` to `)` , on AZERTY only, for the startup wizzard

For master see #7888 