### PR TITLE
[MU4] Fix #292716, #319525: Shortcut 5 doesn't work on AZERTY keyboards

### DIFF
--- a/src/framework/shortcuts/data/shortcuts_AZERTY.xml
+++ b/src/framework/shortcuts/data/shortcuts_AZERTY.xml
@@ -1028,7 +1028,7 @@
     </SC>
   <SC>
     <key>add-parentheses</key>
-    <seq>(</seq>
+    <seq>)</seq>
     </SC>
   <SC>
     <key>toggle-mmrest</key>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/292716 and https://musescore.org/en/node/319525

By changing the parentheses shortcut from `(` to `)` , on AZERTY only, for the startup wizzard

This is for master what #7887 is for 3.x.