### PR TITLE
[MU4] Add missing methods from IInstrumentsConfiguration to instrumentsconfigurationstub.h/.cpp.

### DIFF
--- a/src/stubs/instruments/instrumentsconfigurationstub.cpp
+++ b/src/stubs/instruments/instrumentsconfigurationstub.cpp
@@ -20,7 +20,40 @@
 
 using namespace mu::instruments;
 
-mu::io::paths InstrumentsConfigurationStub::instrumentPaths() const
+mu::io::paths InstrumentsConfigurationStub::instrumentListPaths() const
 {
     return {};
+}
+
+mu::async::Notification InstrumentsConfigurationStub::instrumentListPathsChanged() const
+{
+    return mu::async::Notification();
+}
+
+mu::io::paths InstrumentsConfigurationStub::userInstrumentListPaths() const
+{
+    return {};
+}
+
+void InstrumentsConfigurationStub::setUserInstrumentListPaths(const io::paths& /*paths*/)
+{
+}
+
+mu::io::paths InstrumentsConfigurationStub::scoreOrderListPaths() const
+{
+    return {};
+}
+
+mu::async::Notification InstrumentsConfigurationStub::scoreOrderListPathsChanged() const
+{
+    return mu::async::Notification();
+}
+
+mu::io::paths InstrumentsConfigurationStub::userScoreOrderListPaths() const
+{
+    return {};
+}
+
+void InstrumentsConfigurationStub::setUserScoreOrderListPaths(const io::paths& /*paths*/)
+{
 }

--- a/src/stubs/instruments/instrumentsconfigurationstub.h
+++ b/src/stubs/instruments/instrumentsconfigurationstub.h
@@ -25,7 +25,17 @@ namespace mu::instruments {
 class InstrumentsConfigurationStub : public IInstrumentsConfiguration
 {
 public:
-    io::paths instrumentPaths() const override;
+    io::paths instrumentListPaths() const override;
+    async::Notification instrumentListPathsChanged() const override;
+
+    io::paths userInstrumentListPaths() const override;
+    void setUserInstrumentListPaths(const io::paths& paths) override;
+
+    io::paths scoreOrderListPaths() const override;
+    async::Notification scoreOrderListPathsChanged() const override;
+
+    io::paths userScoreOrderListPaths() const override;
+    void setUserScoreOrderListPaths(const io::paths& paths) override;
 };
 }
 


### PR DESCRIPTION
Add missing methods from `IInstrumentsConfiguration` to` instrumentsconfigurationstub.h/.cpp`.
With commit `bb4851348e78bc7a5b7d68c73f8ac7ed001fbf58` the interface `IInstrumentsConfiguration` is changed but the change is not applied to the `instruments` stub.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
