### PR TITLE
[MU4] Fix animations in notehead chooser

### DIFF
--- a/src/inspector/models/notation/notes/noteheads/noteheadtypesmodel.cpp
+++ b/src/inspector/models/notation/notes/noteheads/noteheadtypesmodel.cpp
@@ -52,14 +52,9 @@ QVariant NoteheadTypesModel::data(const QModelIndex& index, int role) const
 
 void NoteheadTypesModel::init(const Ms::NoteHead::Group noteHeadGroup)
 {
-    emit layoutAboutToBeChanged();
-
+    load();
     m_selectedHeadTypeIndex = indexOfHeadGroup(noteHeadGroup);
     emit selectedHeadTypeIndexChanged(m_selectedHeadTypeIndex);
-
-    load();
-
-    emit layoutChanged();
 }
 
 int NoteheadTypesModel::selectedHeadTypeIndex() const
@@ -76,7 +71,7 @@ void NoteheadTypesModel::setSelectedHeadTypeIndex(int selectedHeadTypeIndex)
     m_selectedHeadTypeIndex = selectedHeadTypeIndex;
     emit selectedHeadTypeIndexChanged(m_selectedHeadTypeIndex);
 
-    emit noteHeadGroupSelected(static_cast<int>(m_noteheadTypeDataList.at(selectedHeadTypeIndex).group));
+    emit noteHeadGroupSelected(selectedHeadTypeIndex);
 }
 
 int NoteheadTypesModel::indexOfHeadGroup(const Ms::NoteHead::Group group) const


### PR DESCRIPTION
Resolves: #7770 

Unless I don't understand something, I found signals ```layoutAboutToBeChanged()``` and ```layoutChanged()``` to be unnecessary. Removing them also fixes the animation.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
