### PR TITLE
[MU4] Fix #319584: Many percussions elements/sounds are not getting translated in status bar and Edit Drumset dialog

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -5853,7 +5853,7 @@
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>Snare Drum 2</name>
+                        <name>Electric Snare</name>
                         <stem>2</stem>
                         <shortcut>B</shortcut>
                   </Drum>
@@ -5909,42 +5909,42 @@
                         <head>normal</head>
                         <line>6</line>
                         <voice>0</voice>
-                        <name>Low Tom 2</name>
+                        <name>Low Floor Tom</name>
                         <stem>1</stem>
                   </Drum>
                   <Drum pitch="43"> <!--Low Tom 1-->
                         <head>normal</head>
                         <line>5</line>
                         <voice>0</voice>
-                        <name>Low Tom 1</name>
+                        <name>High Floor Tom</name>
                         <stem>1</stem>
                   </Drum>
                   <Drum pitch="45"> <!--Mid Tom 2-->
                         <head>normal</head>
                         <line>4</line>
                         <voice>0</voice>
-                        <name>Mid Tom 2</name>
+                        <name>Low Tom</name>
                         <stem>1</stem>
                   </Drum>
                   <Drum pitch="47"> <!--Mid Tom 1-->
                         <head>normal</head>
                         <line>2</line>
                         <voice>0</voice>
-                        <name>Mid Tom 1</name>
+                        <name>Low-Mid Tom</name>
                         <stem>1</stem>
                   </Drum>
                   <Drum pitch="48"> <!--High Tom 2-->
                         <head>normal</head>
                         <line>1</line>
                         <voice>0</voice>
-                        <name>High Tom 2</name>
+                        <name>Hi-Mid Tom</name>
                         <stem>1</stem>
                   </Drum>
                   <Drum pitch="50"> <!--High Tom 1-->
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>High Tom 1</name>
+                        <name>High Tom</name>
                         <stem>1</stem>
                   </Drum>
                   <Channel>
@@ -5995,7 +5995,7 @@
                         <head>normal</head>
                         <line>-1</line>
                         <voice>0</voice>
-                        <name>High Bongo</name>
+                        <name>Hi Bongo</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
@@ -6033,7 +6033,7 @@
                         <head>cross</head>
                         <line>-1</line>
                         <voice>0</voice>
-                        <name>Mute High Conga</name>
+                        <name>Mute Hi Conga</name>
                         <stem>1</stem>
                         <shortcut>B</shortcut>
                   </Drum>
@@ -6041,7 +6041,7 @@
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>High Conga</name>
+                        <name>Open Hi Conga</name>
                         <stem>1</stem>
                         <shortcut>C</shortcut>
                   </Drum>
@@ -6113,7 +6113,7 @@
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>MiTom 2</name>
+                        <name>Low Tom</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
@@ -6137,7 +6137,7 @@
                         <head>normal</head>
                         <line>-1</line>
                         <voice>0</voice>
-                        <name>Mute High Conga</name>
+                        <name>Mute Hi Conga</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
@@ -6316,7 +6316,7 @@
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>Cabasa</name>
+                        <name>Sleigh Bell</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
@@ -6341,7 +6341,7 @@
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>Vibra Slap</name>
+                        <name>Vibraslap</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
@@ -6555,7 +6555,7 @@
                         <head>normal</head>
                         <line>-1</line>
                         <voice>0</voice>
-                        <name>High Wood Block</name>
+                        <name>Hi Wood Block</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
@@ -6592,7 +6592,7 @@
                         <head>normal</head>
                         <line>-1</line>
                         <voice>0</voice>
-                        <name>High Wood Block</name>
+                        <name>Hi Wood Block</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
@@ -6986,7 +6986,7 @@
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>Vibra Slap</name>
+                        <name>Vibraslap</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
@@ -7036,7 +7036,7 @@
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>High Wood Block</name>
+                        <name>Hi Wood Block</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
@@ -7337,14 +7337,14 @@
                         <head>cross</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>Ride</name>
+                        <name>Ride Cymbal 1</name>
                         <stem>1</stem>
                   </Drum>
                   <Drum pitch="36">
                         <head>normal</head>
                         <line>7</line>
                         <voice>1</voice>
-                        <name>Concert Bass Drum</name>
+                        <name>Bass Drum 1</name>
                         <stem>2</stem>
                         <shortcut>B</shortcut>
                   </Drum>
@@ -7352,14 +7352,14 @@
                         <head>cross</head>
                         <line>3</line>
                         <voice>0</voice>
-                        <name>Snare Side Stick</name>
+                        <name>Side Stick</name>
                         <stem>1</stem>
                   </Drum>
                   <Drum pitch="38">
                         <head>normal</head>
                         <line>3</line>
                         <voice>0</voice>
-                        <name>Concert Snare Drum</name>
+                        <name>Acoustic Snare</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
@@ -7367,7 +7367,7 @@
                         <head>normal</head>
                         <line>1</line>
                         <voice>0</voice>
-                        <name>Castanets</name>
+                        <name>Hand Clap</name>
                         <stem>1</stem>
                   </Drum>
                   <Drum pitch="54">
@@ -7402,7 +7402,7 @@
                         <head>cross</head>
                         <line>-2</line>
                         <voice>0</voice>
-                        <name>Concert Cymbal</name>
+                        <name>Ride Cymbal 2</name>
                         <stem>1</stem>
                         <shortcut>C</shortcut>
                   </Drum>
@@ -7410,14 +7410,14 @@
                         <head>cross</head>
                         <line>2</line>
                         <voice>0</voice>
-                        <name>Mute High Conga </name>
+                        <name>Mute Hi Conga</name>
                         <stem>1</stem>
                   </Drum>
                   <Drum pitch="63">
                         <head>cross</head>
                         <line>4</line>
                         <voice>0</voice>
-                        <name>Open High Conga</name>
+                        <name>Open Hi Conga</name>
                         <stem>1</stem>
                   </Drum>
                   <Drum pitch="64">
@@ -7461,6 +7461,13 @@
                         <line>2</line>
                         <voice>0</voice>
                         <name>Mark Tree</name>
+                        <stem>1</stem>
+                  </Drum>
+                  <Drum pitch="85">
+                        <head>normal</head>
+                        <line>1</line>
+                        <voice>0</voice>
+                        <name>Castanets</name>
                         <stem>1</stem>
                   </Drum>
                   <Channel>
@@ -7545,7 +7552,7 @@
                         <head>cross</head>
                         <line>1</line>
                         <voice>2</voice>
-                        <name>Ride Cymbal</name>
+                        <name>Ride Cymbal 1</name>
                   </Drum>
                   <Drum pitch="74">
                         <head>xcircle</head>
@@ -8071,11 +8078,11 @@
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="41">
+                  <Drum pitch="28">
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>Low Tom 2</name>
+                        <name>Slap</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
@@ -8102,7 +8109,7 @@
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>Bass Drum 2</name>
+                        <name>Acoustic Bass Drum</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
@@ -9442,7 +9449,7 @@
                   <longName>Percussion Synthesizer</longName>
                   <shortName>Perc. Syn.</shortName>
                   <description>Percussion Synthesizer</description>
-                  <musicXMLid>drum.tom-tom.synth</musicXMLid>
+                  <musicXMLid>drum.snare-drum.electric</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
@@ -9451,7 +9458,7 @@
                         <head>normal</head>
                         <line>4</line>
                         <voice>0</voice>
-                        <name>Snare Drum 2</name>
+                        <name>Electric Snare</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -359,7 +359,7 @@ void GuitarPro::initGuitarProDrumset()
     gpDrumset->drum(81) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Open Triangle"), NoteHead::Group::HEAD_NORMAL, 3, Direction::UP);
     gpDrumset->drum(82) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Shaker"), NoteHead::Group::HEAD_NORMAL, 3, Direction::UP);
     gpDrumset->drum(83) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Sleigh Bell"), NoteHead::Group::HEAD_NORMAL, 3, Direction::UP);
-    gpDrumset->drum(84) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Bell Tree"), NoteHead::Group::HEAD_NORMAL, 3, Direction::UP);
+    gpDrumset->drum(84) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Mark Tree"), NoteHead::Group::HEAD_NORMAL, 3, Direction::UP);
     gpDrumset->drum(85) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Castanets"), NoteHead::Group::HEAD_NORMAL, 3, Direction::UP);
     gpDrumset->drum(86) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Mute Surdo"), NoteHead::Group::HEAD_NORMAL, 3, Direction::UP);
     gpDrumset->drum(87) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Open Surdo"), NoteHead::Group::HEAD_NORMAL, 3, Direction::UP);

--- a/src/importexport/guitarpro/tests/data/all-percussion.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/all-percussion.gp5-ref.mscx
@@ -437,7 +437,7 @@
           <head>normal</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Bell Tree</name>
+          <name>Mark Tree</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="85">
@@ -1694,7 +1694,7 @@
             <head>normal</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Bell Tree</name>
+            <name>Mark Tree</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="85">

--- a/src/libmscore/tests/midimapping_data/test14-ref.mscx
+++ b/src/libmscore/tests/midimapping_data/test14-ref.mscx
@@ -553,7 +553,7 @@
           <head>normal</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Bell Tree</name>
+          <name>Mark Tree</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="85">
@@ -1698,7 +1698,7 @@
             <head>normal</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Bell Tree</name>
+            <name>Mark Tree</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="85">

--- a/src/libmscore/tests/midimapping_data/test15-ref.mscx
+++ b/src/libmscore/tests/midimapping_data/test15-ref.mscx
@@ -545,7 +545,7 @@
           <head>normal</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Bell Tree</name>
+          <name>Mark Tree</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="85">
@@ -1721,7 +1721,7 @@
             <head>normal</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Bell Tree</name>
+            <name>Mark Tree</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="85">

--- a/src/libmscore/tests/midimapping_data/test16-ref.mscx
+++ b/src/libmscore/tests/midimapping_data/test16-ref.mscx
@@ -545,7 +545,7 @@
           <head>normal</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Bell Tree</name>
+          <name>Mark Tree</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="85">
@@ -1680,7 +1680,7 @@
             <head>normal</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Bell Tree</name>
+            <name>Mark Tree</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="85">

--- a/src/libmscore/tests/midimapping_data/test17-ref.mscx
+++ b/src/libmscore/tests/midimapping_data/test17-ref.mscx
@@ -679,7 +679,7 @@
           <head>normal</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Bell Tree</name>
+          <name>Mark Tree</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="85">
@@ -2317,7 +2317,7 @@
             <head>normal</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Bell Tree</name>
+            <name>Mark Tree</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="85">


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/319584

We'd need to mix and match https://github.com/musescore/MuseScore/blob/6fe71f9ed129e502b0ab4030d4672833efbbd6de/src/libmscore/drumset.cpp#L256-L312 and the more complete https://github.com/musescore/MuseScore/blob/6fe71f9ed129e502b0ab4030d4672833efbbd6de/src/importexport/guitarpro/internal/importgtp.cpp#L303-L373
with instruments.xml

* Fix missing translations for Hi Congas
* Fix missing translation for Hi Bongo
* Fix missing translation for Hi Woodblock
* Fix missing translation for Vibraslap
* Fix wrong translation/name for Sleigh Bell
* Fix missing translations for Snare drums
* Fix missing translations for Bell Tree by changing it to the apparently more correct "Mark Tree", requires updated translations though
* Fix missing translations for Toms
* Fix missing/wrong translation/name and sound for Slap
* Fix/add wrong translation/missing name and sound for Castanets/Hand Clap
* Fix missing translations for Bass Drums
* Fix missing translations for Ride Cymbal

To do: Look after the marching percussion stuff, it seems to be using an entirely different number-to-name mapping? Here we may need to add strings (and subsequently translate them), and by other means than done in ths PR so far. I'd rather not though this here and now...

This is for master what #7891 is for 3.x