### PR TITLE
[MU4] Fix blank inspector by scrolling to top

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/InspectorForm.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/InspectorForm.qml
@@ -82,6 +82,7 @@ FocusableItem {
                     property var contentHeight: implicitHeight
 
                     function viewBySectionType() {
+                        flickableArea.contentY = 0
 
                         switch (inspectorData.sectionType) {
                         case Inspector.SECTION_GENERAL: return generalInspector


### PR DESCRIPTION
Resolves: #7771 

I believe the problem is that the inspector is not blank, it's just that it's scrolled down to where no content is present.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
