### PR TITLE
Fix Edwin on macOS and add other missing fonts to install

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -456,24 +456,29 @@ elseif(OS_IS_MAC)
     install(FILES "${PROJECT_SOURCE_DIR}/src/main/res/musescoreDocument.icns" DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME})
 
     install(FILES
-            ${PROJECT_SOURCE_DIR}/fonts/gootville/GootvilleText.otf
-            ${PROJECT_SOURCE_DIR}/fonts/mscore/MScoreText.ttf
-            ${PROJECT_SOURCE_DIR}/fonts/mscore/MusescoreIcon.ttf
-            ${PROJECT_SOURCE_DIR}/fonts/musejazz/MuseJazzText.otf
+            ${PROJECT_SOURCE_DIR}/fonts/bravura/BravuraText.otf
             ${PROJECT_SOURCE_DIR}/fonts/campania/Campania.otf
+            ${PROJECT_SOURCE_DIR}/fonts/edwin/Edwin-BdIta.otf
+            ${PROJECT_SOURCE_DIR}/fonts/edwin/Edwin-Bold.otf
+            ${PROJECT_SOURCE_DIR}/fonts/edwin/Edwin-Italic.otf
+            ${PROJECT_SOURCE_DIR}/fonts/edwin/Edwin-Roman.otf
+            ${PROJECT_SOURCE_DIR}/fonts/firasans/FiraSans-Regular.ttf
+            ${PROJECT_SOURCE_DIR}/fonts/firasans/FiraSans-SemiBold.ttf
+            ${PROJECT_SOURCE_DIR}/fonts/gootville/GootvilleText.otf
+            ${PROJECT_SOURCE_DIR}/fonts/FreeSans.ttf
             ${PROJECT_SOURCE_DIR}/fonts/FreeSerif.ttf
             ${PROJECT_SOURCE_DIR}/fonts/FreeSerifBold.ttf
             ${PROJECT_SOURCE_DIR}/fonts/FreeSerifItalic.ttf
             ${PROJECT_SOURCE_DIR}/fonts/FreeSerifBoldItalic.ttf
-            ${PROJECT_SOURCE_DIR}/fonts/FreeSans.ttf
-            ${PROJECT_SOURCE_DIR}/fonts/mscoreTab.ttf
-            ${PROJECT_SOURCE_DIR}/fonts/mscore-BC.ttf
-            ${PROJECT_SOURCE_DIR}/fonts/bravura/BravuraText.otf
             ${PROJECT_SOURCE_DIR}/fonts/leland/Leland.otf
-            ${PROJECT_SOURCE_DIR}/fonts/petaluma/PetalumaText.otf
+            ${PROJECT_SOURCE_DIR}/fonts/leland/LelandText.otf
+            ${PROJECT_SOURCE_DIR}/fonts/mscore-BC.ttf
+            ${PROJECT_SOURCE_DIR}/fonts/mscoreTab.ttf
+            ${PROJECT_SOURCE_DIR}/fonts/mscore/MScoreText.ttf
+            ${PROJECT_SOURCE_DIR}/fonts/mscore/MusescoreIcon.ttf
+            ${PROJECT_SOURCE_DIR}/fonts/musejazz/MuseJazzText.otf
             ${PROJECT_SOURCE_DIR}/fonts/petaluma/PetalumaScript.otf
-            ${PROJECT_SOURCE_DIR}/fonts/firasans/FiraSans-Regular.ttf
-            ${PROJECT_SOURCE_DIR}/fonts/firasans/FiraSans-SemiBold.ttf
+            ${PROJECT_SOURCE_DIR}/fonts/petaluma/PetalumaText.otf
             DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME}fonts
     )
 


### PR DESCRIPTION
The following fonts were in the fonts folder, but were not installed on macOS:
- `${PROJECT_SOURCE_DIR}/fonts/bravura/Bravura.otf`
- `${PROJECT_SOURCE_DIR}/fonts/edwin/Edwin-*`
- `${PROJECT_SOURCE_DIR}/fonts/gootville/Gootville.otf`
- `${PROJECT_SOURCE_DIR}/fonts/leland/LelandText.otf`
- `${PROJECT_SOURCE_DIR}/fonts/musejazz/MuseJazz.otf`
- `${PROJECT_SOURCE_DIR}/fonts/petaluma/Petaluma.otf`

For this reason, Edwin didn't work on Mac. Now, all fonts seem to work correctly in MU4. 

About the other fonts that were not installed: this has also been the case with MuseScore 3, and I have not really noticed problems with it. Does somebody know whether they were left out on purpose??

Anyway, it seems strange to me that for Leland the "Text" variant was left out, and for the other fonts the "normal" version. This might be the cause of some issues.