### PR TITLE
fix: #7772 Popup height fixed and scolling enabled in notehead grid

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/notation/notes/HeadSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/notes/HeadSettings.qml
@@ -32,6 +32,7 @@ FocusableItem {
         InspectorPropertyView {
             titleText: qsTrc("inspector", "Noteheads")
             propertyItem: root.model ? root.model.headGroup : null
+            height: 120
 
             NoteheadsGrid {
                 id: noteheadGridView

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/notes/internal/NoteheadsGrid.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/notes/internal/NoteheadsGrid.qml
@@ -38,24 +38,24 @@ FocusableItem {
         default: return "qrc:/resources/icons/note.svg"
         }
     }
-
-    implicitHeight: gridView.height + 16
     width: parent.width
 
     Rectangle {
-        height: root.implicitHeight
+        id: gridViewEnclosure
+        height: 3 * gridView.cellHeight + 16
         width: parent.width
 
         color: ui.theme.textFieldColor
-
         radius: 3
     }
 
     GridView {
         id: gridView
 
-        height: contentHeight
-        anchors.top: parent.top
+        height: Math.min(contentHeight,3*cellHeight)
+
+        anchors.top: gridViewEnclosure.top
+        anchors.bottom: gridViewEnclosure.bottom
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.margins: 8
@@ -63,10 +63,12 @@ FocusableItem {
         cellHeight: 40
         cellWidth: 40
 
-        interactive: false
+        interactive: true
+        boundsBehavior: Flickable.StopAtBounds
+        clip: true
+        maximumFlickVelocity: 1500
 
         delegate: FocusableItem {
-
             implicitHeight: gridView.cellHeight
             implicitWidth: gridView.cellWidth
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/7772

Initially, the height of the grid was unlimited, so the grid view was not scrollable. Now, the height of the Note Settings --> Head popup is fixed. And the scrolling of the notehead grid view is enabled now. 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
