### PR TITLE
[MU3] On Mac don't 'install' Leland and don't 'build in' (musical) text fonts

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -514,7 +514,6 @@ if (APPLE)
       ../fonts/mscoreTab.ttf
       ../fonts/mscore-BC.ttf
       ../fonts/bravura/BravuraText.otf
-      ../fonts/leland/Leland.otf
       ../fonts/leland/LelandText.otf
       ../fonts/petaluma/PetalumaText.otf
       ../fonts/petaluma/PetalumaScript.otf

--- a/mscore/musescorefonts-Mac.qrc
+++ b/mscore/musescorefonts-Mac.qrc
@@ -1,11 +1,6 @@
 <RCC>
     <qresource prefix="/">
         <file alias="fonts/leland/Leland.otf">../fonts/leland/Leland.otf</file>
-        <file alias="fonts/leland/LelandText.otf">../fonts/leland/LelandText.otf</file>
-        <file alias="fonts/edwin/Edwin-Roman.otf">../fonts/edwin/Edwin-Roman.otf</file>
-        <file alias="fonts/edwin/Edwin-Italic.otf">../fonts/edwin/Edwin-Italic.otf</file>
-        <file alias="fonts/edwin/Edwin-Bold.otf">../fonts/edwin/Edwin-Bold.otf</file>
-        <file alias="fonts/edwin/Edwin-BdIta.otf">../fonts/edwin/Edwin-BdIta.otf</file>
         <file alias="fonts/mscore/mscore.ttf">../fonts/mscore/mscore.ttf</file>
         <file alias="fonts/gootville/Gootville.otf">../fonts/gootville/Gootville.otf</file>
         <file alias="fonts/bravura/Bravura.otf">../fonts/bravura/Bravura.otf</file>


### PR DESCRIPTION
For Leland rather the build in version should get used and for Leland Text and the Edwin fonts the installed version should get used.

See also #7900 (for master, merged already)

May resolve (testing/testers needed): https://musescore.org/en/node/316152  (actually that is being fxed by #8578, as confirmed by several users)