### PR TITLE
fix #7661: Fixed issue of overlapping text

### DIFF
--- a/src/appshell/qml/NotationPage/NotationStatusBar.qml
+++ b/src/appshell/qml/NotationPage/NotationStatusBar.qml
@@ -10,10 +10,15 @@ Rectangle {
     NotationAccessibilityInfo {
         anchors.left: parent.left
         anchors.leftMargin: 20
+        anchors.right: statusBarRow.left
         anchors.verticalCenter: parent.verticalCenter
+
+        horizontalAlignment: Text.AlignLeft
     }
 
     Row {
+        id: statusBarRow
+
         anchors.right: parent.right
         anchors.rightMargin: 20
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/7661

The superimposing of text in the notation page status bar is avoided. The status bar hides the information text about the note selected(on the bottom left of the screen) when space is less than required.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
