### PR TITLE
Increased the speed of value change for press and hold

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/IncrementalPropertyControl.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/IncrementalPropertyControl.qml
@@ -109,6 +109,8 @@ Item {
         ValueAdjustControl {
             id: valueAdjustControl
 
+            timerTimeInterval: 100
+
             anchors.verticalCenter: textInputField.verticalCenter
             anchors.right: textInputField.right
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/IncrementalPropertyControl.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/IncrementalPropertyControl.qml
@@ -109,8 +109,6 @@ Item {
         ValueAdjustControl {
             id: valueAdjustControl
 
-            timerTimeInterval: 100
-
             anchors.verticalCenter: textInputField.verticalCenter
             anchors.right: textInputField.right
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/ValueAdjustControl.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/ValueAdjustControl.qml
@@ -9,6 +9,8 @@ Item {
     signal increaseButtonClicked
     signal decreaseButtonClicked
 
+    property int timerTimeInterval: 300
+
     height: childrenRect.height
     width: childrenRect.width
 
@@ -50,7 +52,7 @@ Item {
                 Timer {
                     id: continiousIncreaseTimer
 
-                    interval: 300
+                    interval: timerTimeInterval
 
                     repeat: true
 
@@ -89,7 +91,7 @@ Item {
                 Timer {
                     id: continiousDecreaseTimer
 
-                    interval: 300
+                    interval: timerTimeInterval
                     repeat: true
 
                     running: decreaseMouseArea.pressed

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/ValueAdjustControl.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/ValueAdjustControl.qml
@@ -9,8 +9,6 @@ Item {
     signal increaseButtonClicked
     signal decreaseButtonClicked
 
-    property int timerTimeInterval: 300
-
     height: childrenRect.height
     width: childrenRect.width
 
@@ -52,7 +50,7 @@ Item {
                 Timer {
                     id: continuousIncreaseTimer
 
-                    interval: timerTimeInterval
+                    interval: 100
 
                     repeat: true
 
@@ -91,7 +89,7 @@ Item {
                 Timer {
                     id: continuousDecreaseTimer
 
-                    interval: timerTimeInterval
+                    interval: 100
                     repeat: true
 
                     running: decreaseMouseArea.pressed

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/ValueAdjustControl.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/ValueAdjustControl.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 2.15
 import MuseScore.Ui 1.0
 
 Item {
@@ -34,6 +34,8 @@ Item {
                 anchors.fill: parent
 
                 preventStealing: true
+
+                pressAndHoldInterval: 200
 
                 onClicked: {
                     root.increaseButtonClicked()
@@ -74,6 +76,10 @@ Item {
 
                 anchors.fill: parent
 
+                preventStealing: true
+
+                pressAndHoldInterval: 200
+
                 onClicked: {
                     root.decreaseButtonClicked()
                 }
@@ -90,9 +96,8 @@ Item {
                     id: continuousDecreaseTimer
 
                     interval: 100
-                    repeat: true
 
-                    running: decreaseMouseArea.pressed
+                    repeat: true
 
                     onTriggered: {
                         root.decreaseButtonClicked()

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/ValueAdjustControl.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/ValueAdjustControl.qml
@@ -42,15 +42,15 @@ Item {
                 }
 
                 onPressAndHold: {
-                    continiousIncreaseTimer.running = true
+                    continuousIncreaseTimer.running = true
                 }
 
                 onReleased: {
-                    continiousIncreaseTimer.running = false
+                    continuousIncreaseTimer.running = false
                 }
 
                 Timer {
-                    id: continiousIncreaseTimer
+                    id: continuousIncreaseTimer
 
                     interval: timerTimeInterval
 
@@ -81,15 +81,15 @@ Item {
                 }
 
                 onPressAndHold: {
-                    continiousDecreaseTimer.running = true
+                    continuousDecreaseTimer.running = true
                 }
 
                 onReleased: {
-                    continiousDecreaseTimer.running = false
+                    continuousDecreaseTimer.running = false
                 }
 
                 Timer {
-                    id: continiousDecreaseTimer
+                    id: continuousDecreaseTimer
 
                     interval: timerTimeInterval
                     repeat: true


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/7693

The number changes faster now (currently set to 10 counts per second). The speed can be controlled by changing the value of timerTimeInterval. No acceleration of change in value for now. The constant speed set now must be comfortable.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
