### PR TITLE
fix #7915: Increased the minimum width to prevent overlap

### DIFF
--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -72,7 +72,7 @@ DockPage {
     }
 
     readonly property int defaultPanelWidth: 272
-    readonly property int minimumPanelWidth: 200
+    readonly property int minimumPanelWidth: 220
 
     panels: [
         DockPanel {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/7915

Increased the minimum width of the panels to prevent overlapping of text.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
