### PR TITLE
Fix #7917: Refresh Inspector when switching to another Notation

### DIFF
--- a/src/inspector/models/inspectorlistmodel.cpp
+++ b/src/inspector/models/inspectorlistmodel.cpp
@@ -214,14 +214,12 @@ void InspectorListModel::subscribeOnSelectionChanges()
             return;
         }
 
+        auto elements = m_notation->interaction()->selection()->elements();
+        setElementList(QList(elements.cbegin(), elements.cend()));
+
         m_notation->interaction()->selectionChanged().onNotify(this, [this]() {
-            QList<Ms::Element*> elements;
-
-            for (Ms::Element* element: m_notation->interaction()->selection()->elements()) {
-                elements << element;
-            }
-
-            setElementList(elements);
+            auto elements = m_notation->interaction()->selection()->elements();
+            setElementList(QList(elements.cbegin(), elements.cend()));
         });
     });
 }

--- a/src/inspector/models/score/scoreappearancesettingsmodel.cpp
+++ b/src/inspector/models/score/scoreappearancesettingsmodel.cpp
@@ -41,9 +41,8 @@ void ScoreAppearanceSettingsModel::loadProperties()
 
     m_pageTypeListModel->setCurrentPageSizeId(static_cast<int>(QPageSize::id(pageSize, QPageSize::Inch, QPageSize::FuzzyOrientationMatch)));
 
-    ScoreAppearanceTypes::OrientationType pageOrientationType = pageSize.width()
-                                                                > pageSize.height() ? ScoreAppearanceTypes::OrientationType::
-                                                                ORIENTATION_LANDSCAPE
+    ScoreAppearanceTypes::OrientationType pageOrientationType = pageSize.width() > pageSize.height()
+                                                                ? ScoreAppearanceTypes::OrientationType::ORIENTATION_LANDSCAPE
                                                                 : ScoreAppearanceTypes::OrientationType::ORIENTATION_PORTRAIT;
 
     setOrientationType(static_cast<int>(pageOrientationType));


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/7917