### PR TITLE
Give Toolbars a title, which appears in context menu

### DIFF
--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -63,6 +63,8 @@ DockPage {
 
         color: notationPage.color
 
+        title: qsTrc("appshell", "Note Input")
+
         content: NoteInputBar {
             color: notationNoteInputBar.color
             orientation: notationNoteInputBar.orientation

--- a/src/appshell/qml/Window.qml
+++ b/src/appshell/qml/Window.qml
@@ -88,6 +88,8 @@ DockWindow {
             color: dockWindow.color
             allowedAreas: Qt.TopToolBarArea
 
+            title: qsTrc("appshell", "Main Toolbar")
+
             content: MainToolBar {
                 color: dockWindow.color
                 keynav.section: topToolKeyNavSec
@@ -108,6 +110,8 @@ DockWindow {
 
             color: dockWindow.color
             allowedAreas: Qt.TopToolBarArea
+
+            title: qsTrc("appshell", "Notation Toolbar")
 
             content: NotationToolBar {
                 id: notationToolBarContent
@@ -137,6 +141,8 @@ DockWindow {
 
             color: dockWindow.color
             allowedAreas: Qt.TopToolBarArea
+
+            title: qsTrc("appshell", "Playback Controls")
 
             content: PlaybackToolBar {
                 id: playbackToolBarContent
@@ -169,6 +175,8 @@ DockWindow {
             color: dockWindow.color
             floatable: false
             movable: false
+
+            title: qsTrc("appshell", "Undo/Redo Toolbar")
 
             content: UndoRedoToolBar {
                 id: undoRedoToolBarContent

--- a/src/appshell/view/dockwindow/docktoolbar.cpp
+++ b/src/appshell/view/dockwindow/docktoolbar.cpp
@@ -55,6 +55,8 @@ DockToolBar::DockToolBar(QQuickItem* parent)
         setFloating(floating);
     });
 
+    connect(m_tool.bar, &QToolBar::windowTitleChanged, this, &DockToolBar::titleChanged);
+
     m_eventsWatcher = new EventsWatcher(this);
     m_tool.bar->installEventFilter(m_eventsWatcher);
     connect(m_eventsWatcher, &EventsWatcher::eventReceived, this, &DockToolBar::onWidgetEvent);
@@ -166,6 +168,11 @@ bool DockToolBar::visible() const
     return toolBar()->isVisible();
 }
 
+QString DockToolBar::title() const
+{
+    return toolBar()->windowTitle();
+}
+
 void DockToolBar::setMinimumHeight(int minimumHeight)
 {
     if (m_minimumHeight == minimumHeight) {
@@ -231,4 +238,13 @@ void DockToolBar::setVisible(bool visible)
 
     m_visible = visible;
     emit visibleEdited(m_visible);
+}
+
+void DockToolBar::setTitle(const QString& title)
+{
+    if (title == this->title()) {
+        return;
+    }
+
+    toolBar()->setWindowTitle(title);
 }

--- a/src/appshell/view/dockwindow/docktoolbar.h
+++ b/src/appshell/view/dockwindow/docktoolbar.h
@@ -37,6 +37,7 @@ class DockToolBar : public DockView
     Q_PROPERTY(bool floatable READ floatable WRITE setFloatable NOTIFY floatableChanged)
     Q_PROPERTY(bool movable READ movable WRITE setMovable NOTIFY movableChanged)
     Q_PROPERTY(bool visible READ visible WRITE setVisible NOTIFY visibleEdited)
+    Q_PROPERTY(QString title READ title WRITE setTitle NOTIFY titleChanged)
 
 public:
     explicit DockToolBar(QQuickItem* parent = nullptr);
@@ -59,6 +60,7 @@ public:
     bool floatable() const;
     bool movable() const;
     bool visible() const override;
+    QString title() const;
 
 public slots:
     void setMinimumHeight(int minimumHeight);
@@ -67,6 +69,7 @@ public slots:
     void setFloatable(bool floatable);
     void setMovable(bool movable);
     void setVisible(bool visible) override;
+    void setTitle(const QString& title);
 
 signals:
     void orientationChanged(int orientation);
@@ -76,8 +79,8 @@ signals:
     void floatingChanged(bool floating);
     void floatableChanged(bool floatable);
     void movableChanged(bool movable);
-
     void visibleEdited(bool visible);
+    void titleChanged(QString title);
 
 protected:
     void onComponentCompleted() override;


### PR DESCRIPTION
This is the context menu which appears when right-clicking the titlebar of a DockWidget or a grip of a toolbar.
|Before|After|
|-|-|
|<img width="195" alt="Schermafbeelding 2021-04-09 om 18 17 24" src="https://user-images.githubusercontent.com/48658420/114211690-38dfca80-9961-11eb-9bac-707eb450e199.png">|<img width="237" alt="Schermafbeelding 2021-04-09 om 18 25 45" src="https://user-images.githubusercontent.com/48658420/114211705-409f6f00-9961-11eb-93ce-e26ae85a5ad4.png">|
