### PR TITLE
Fix handling actions from NotationPaintView context menu

### DIFF
--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -334,6 +334,11 @@ void NotationPaintView::showContextMenu(const ElementType& elementType, const QP
     emit openContextMenuRequested(menuItems, pos);
 }
 
+void NotationPaintView::handleAction(const QString& actionCode)
+{
+    dispatcher()->dispatch(actionCode.toStdString());
+}
+
 void NotationPaintView::paint(QPainter* qp)
 {
     TRACEFUNC;

--- a/src/notation/view/notationpaintview.h
+++ b/src/notation/view/notationpaintview.h
@@ -83,6 +83,7 @@ public:
     void showShadowNote(const QPointF& pos) override;
 
     void showContextMenu(const ElementType& elementType, const QPoint& pos) override;
+    Q_INVOKABLE void handleAction(const QString& actionCode);
 
     INotationInteractionPtr notationInteraction() const override;
     INotationPlaybackPtr notationPlayback() const override;


### PR DESCRIPTION
The `handleAction` method got lost in commit 42ce82d0e5e58d90f552f47c92abf6bebe609222. Now it's back.

@Eism Did you remove it on purpose or had you just missed that it was still used in NotationView.qml?