### PR TITLE
Fix #7903: Play panel/toolbar shows a 16th note on a tempo text using…

### DIFF
--- a/src/playback/view/playbacktoolbarmodel.cpp
+++ b/src/playback/view/playbacktoolbarmodel.cpp
@@ -41,8 +41,8 @@ static MusicalSymbolCodes::Code tempoDurationToNoteIcon(DurationType durationTyp
         { DurationType::V_WHOLE, MusicalSymbolCodes::Code::SEMIBREVE },
         { DurationType::V_HALF, MusicalSymbolCodes::Code::MINIM },
         { DurationType::V_QUARTER, MusicalSymbolCodes::Code::CROTCHET },
-        { DurationType::V_EIGHTH, MusicalSymbolCodes::Code::SEMIQUAVER },
-        { DurationType::V_16TH, MusicalSymbolCodes::Code::DEMISEMIQUAVER }
+        { DurationType::V_EIGHTH, MusicalSymbolCodes::Code::QUAVER },
+        { DurationType::V_16TH, MusicalSymbolCodes::Code::SEMIQUAVER }
     };
 
     return durationToNoteIcon[durationType];


### PR DESCRIPTION
… an 8th note

Resolves: *#7903*

8th and 16th notes were associated to the wrong note symbol. Fixed mapping to point to the correct note.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
