### PR TITLE
[MU3] Line width fix

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -686,9 +686,7 @@ void LineSegment::editDrag(EditData& ed)
 void LineSegment::spatiumChanged(qreal ov, qreal nv)
       {
       Element::spatiumChanged(ov, nv);
-      qreal scale = nv / ov;
-      line()->setLineWidth(line()->lineWidth() * scale);
-      _offset2 *= scale;
+      _offset2 *= nv / ov;
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Changing the staff space in the page settings affects the width of the lines( in the preview, see screenshot).
It's pretty weird. It was added in this commit https://github.com/musescore/MuseScore/commit/6eb8dd2df458667313f507951e24af8b4f95899e  as followup to PR #6315

@MarcSabatella, can you explain to me what problem you were solving?

![image](https://user-images.githubusercontent.com/10116828/114420688-d121bd80-9bb4-11eb-9c2d-ba174ee198f3.png)
