### PR TITLE
[MU4] vst ressurection part2

### DIFF
--- a/src/appshell/qml/DevTools/VST/VSTTests.qml
+++ b/src/appshell/qml/DevTools/VST/VSTTests.qml
@@ -33,20 +33,31 @@ Rectangle {
     }
 
     Column {
+        anchors {
+            top: parent.top
+            topMargin: 24
+            left: parent.left
+            leftMargin: 24
+        }
 
-        ValueList {
+        ListView {
+
             width: 560
             height: 226
 
-            keyRoleName: "idRole"
-            keyTitle: "id"
-            valueRoleName: "nameRole"
-            valueTitle: "Name"
-
             model: pluginListModel
 
-            onClicked: {
-                pluginListModel.selectedItemIndex = index
+            spacing: 12
+
+            delegate: RoundedRadioButton {
+                width: parent.width
+
+                checked: pluginListModel.selectedItemIndex === model.index
+                text: nameRole
+
+                onClicked: {
+                    pluginListModel.selectedItemIndex = index
+                }
             }
         }
 

--- a/src/framework/audio/internal/synthesizers/synthesizercontroller.cpp
+++ b/src/framework/audio/internal/synthesizers/synthesizercontroller.cpp
@@ -39,7 +39,7 @@ void SynthesizerController::init()
         return;
     }
 
-    m_synthRegister->synthesizerAddedNotify().onReceive(this, [this](const ISynthesizerPtr& synth) {
+    m_synthRegister->synthesizerAdded().onReceive(this, [](const ISynthesizerPtr& synth) {
         synth->init();
     });
 

--- a/src/framework/audio/internal/synthesizers/synthesizercontroller.cpp
+++ b/src/framework/audio/internal/synthesizers/synthesizercontroller.cpp
@@ -39,6 +39,10 @@ void SynthesizerController::init()
         return;
     }
 
+    m_synthRegister->synthesizerAddedNotify().onReceive(this, [this](const ISynthesizerPtr& synth) {
+        synth->init();
+    });
+
     std::vector<ISynthesizerPtr> synthesizers = m_synthRegister->synthesizers();
     for (ISynthesizerPtr& synth : synthesizers) {
         synth->init();

--- a/src/framework/audio/internal/synthesizers/synthesizersregister.cpp
+++ b/src/framework/audio/internal/synthesizers/synthesizersregister.cpp
@@ -29,7 +29,7 @@ void SynthesizersRegister::registerSynthesizer(const SynthName& name, ISynthesiz
     std::lock_guard<std::mutex> lock(m_mutex);
     m_synths[name] = std::make_shared<SanitySynthesizer>(s);
 
-    m_synthNotificationChannel.send(m_synths[name]);
+    m_synthAdded.send(m_synths[name]);
 }
 
 std::shared_ptr<ISynthesizer> SynthesizersRegister::synthesizer(const SynthName& name) const
@@ -54,9 +54,9 @@ std::vector<std::shared_ptr<ISynthesizer> > SynthesizersRegister::synthesizers()
     return synths;
 }
 
-async::Channel<ISynthesizerPtr> SynthesizersRegister::synthesizerAddedNotify() const
+async::Channel<ISynthesizerPtr> SynthesizersRegister::synthesizerAdded() const
 {
-    return m_synthNotificationChannel;
+    return m_synthAdded;
 }
 
 void SynthesizersRegister::setDefaultSynthesizer(const SynthName& name)

--- a/src/framework/audio/internal/synthesizers/synthesizersregister.h
+++ b/src/framework/audio/internal/synthesizers/synthesizersregister.h
@@ -21,16 +21,18 @@
 
 #include <map>
 #include <mutex>
+#include "async/asyncable.h"
 #include "isynthesizersregister.h"
 
 namespace mu::audio::synth {
-class SynthesizersRegister : public ISynthesizersRegister
+class SynthesizersRegister : public ISynthesizersRegister, public async::Asyncable
 {
 public:
 
     void registerSynthesizer(const SynthName& name, ISynthesizerPtr s) override;
     std::shared_ptr<ISynthesizer> synthesizer(const SynthName& name) const override;
     std::vector<std::shared_ptr<ISynthesizer> > synthesizers() const override;
+    async::Channel<ISynthesizerPtr> synthesizerAddedNotify() const override;
 
     void setDefaultSynthesizer(const SynthName& name) override;
     std::shared_ptr<ISynthesizer> defaultSynthesizer() const override;
@@ -39,6 +41,7 @@ private:
 
     mutable std::mutex m_mutex;
     std::map<std::string, std::shared_ptr<ISynthesizer> > m_synths;
+    async::Channel<ISynthesizerPtr> m_synthNotificationChannel;
     SynthName m_defaultName;
 };
 }

--- a/src/framework/audio/internal/synthesizers/synthesizersregister.h
+++ b/src/framework/audio/internal/synthesizers/synthesizersregister.h
@@ -32,7 +32,7 @@ public:
     void registerSynthesizer(const SynthName& name, ISynthesizerPtr s) override;
     std::shared_ptr<ISynthesizer> synthesizer(const SynthName& name) const override;
     std::vector<std::shared_ptr<ISynthesizer> > synthesizers() const override;
-    async::Channel<ISynthesizerPtr> synthesizerAddedNotify() const override;
+    async::Channel<ISynthesizerPtr> synthesizerAdded() const override;
 
     void setDefaultSynthesizer(const SynthName& name) override;
     std::shared_ptr<ISynthesizer> defaultSynthesizer() const override;
@@ -41,7 +41,7 @@ private:
 
     mutable std::mutex m_mutex;
     std::map<std::string, std::shared_ptr<ISynthesizer> > m_synths;
-    async::Channel<ISynthesizerPtr> m_synthNotificationChannel;
+    async::Channel<ISynthesizerPtr> m_synthAdded;
     SynthName m_defaultName;
 };
 }

--- a/src/framework/audio/internal/worker/audioengine.cpp
+++ b/src/framework/audio/internal/worker/audioengine.cpp
@@ -99,11 +99,14 @@ void AudioEngine::onDriverOpened(unsigned int sampleRate, uint16_t readBufferSiz
     setSampleRate(sampleRate);
     setReadBufferSize(readBufferSize);
 
-    //! TODO Add a subscription to add or remove synthesizers
     std::vector<ISynthesizerPtr> synths = synthesizersRegister()->synthesizers();
     for (const ISynthesizerPtr& synth : synths) {
         m_mixer->addChannel(synth);
     }
+
+    synthesizersRegister()->synthesizerAddedNotify().onReceive(this, [this](const ISynthesizerPtr& synth) {
+       m_mixer->addChannel(synth);
+    });
 }
 
 void AudioEngine::setSampleRate(unsigned int sampleRate)

--- a/src/framework/audio/internal/worker/audioengine.cpp
+++ b/src/framework/audio/internal/worker/audioengine.cpp
@@ -104,8 +104,8 @@ void AudioEngine::onDriverOpened(unsigned int sampleRate, uint16_t readBufferSiz
         m_mixer->addChannel(synth);
     }
 
-    synthesizersRegister()->synthesizerAddedNotify().onReceive(this, [this](const ISynthesizerPtr& synth) {
-       m_mixer->addChannel(synth);
+    synthesizersRegister()->synthesizerAdded().onReceive(this, [this](const ISynthesizerPtr& synth) {
+        m_mixer->addChannel(synth);
     });
 }
 

--- a/src/framework/audio/isynthesizersregister.h
+++ b/src/framework/audio/isynthesizersregister.h
@@ -36,7 +36,7 @@ public:
     virtual void registerSynthesizer(const SynthName& name, ISynthesizerPtr synthesizer) = 0;
     virtual ISynthesizerPtr synthesizer(const SynthName& name) const = 0;
     virtual std::vector<ISynthesizerPtr> synthesizers() const = 0;
-    virtual async::Channel<ISynthesizerPtr> synthesizerAddedNotify() const = 0;
+    virtual async::Channel<ISynthesizerPtr> synthesizerAdded() const = 0;
 
     virtual void setDefaultSynthesizer(const SynthName& name) = 0;
     virtual ISynthesizerPtr defaultSynthesizer() const = 0;

--- a/src/framework/audio/isynthesizersregister.h
+++ b/src/framework/audio/isynthesizersregister.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <memory>
 
+#include "async/channel.h"
 #include "modularity/imoduleexport.h"
 #include "isynthesizer.h"
 
@@ -35,6 +36,7 @@ public:
     virtual void registerSynthesizer(const SynthName& name, ISynthesizerPtr synthesizer) = 0;
     virtual ISynthesizerPtr synthesizer(const SynthName& name) const = 0;
     virtual std::vector<ISynthesizerPtr> synthesizers() const = 0;
+    virtual async::Channel<ISynthesizerPtr> synthesizerAddedNotify() const = 0;
 
     virtual void setDefaultSynthesizer(const SynthName& name) = 0;
     virtual ISynthesizerPtr defaultSynthesizer() const = 0;

--- a/src/framework/audio/synthtypes.h
+++ b/src/framework/audio/synthtypes.h
@@ -35,6 +35,7 @@ enum class SoundFontFormat {
     SF2,
     SF3,
     SFZ,
+    Embedded
 };
 using SoundFontFormats = std::set<SoundFontFormat>;
 

--- a/src/framework/midi/midievent.h
+++ b/src/framework/midi/midievent.h
@@ -979,15 +979,24 @@ struct Event {
     }
 
 private:
+    //!Note Temporarily disabled until the end of the investigation, looks like we're not supporting some 'custom' messages from MU3
+    //! v.pereverzev@wsmgroup.ru
     void assertMessageType(const std::set<MessageType>& supportedTypes) const
     {
         UNUSED(supportedTypes);
         //assert(isMessageTypeIn(supportedTypes));
     }
 
+    //!Note Temporarily disabled until the end of the investigation, looks like we're not supporting some 'custom' messages from MU3
+    //! v.pereverzev@wsmgroup.ru
     void assertChannelVoice() const { /*assert(isChannelVoice());*/ }
 
-    void assertOpcode(const std::set<Opcode>& supportedOpcodes) const { UNUSED(supportedOpcodes); /*assert(isOpcodeIn(supportedOpcodes));*/ }
+    //!Note Temporarily disabled until the end of the investigation, looks like we're not supporting some 'custom' messages from MU3
+    //! v.pereverzev@wsmgroup.ru
+    void assertOpcode(const std::set<Opcode>& supportedOpcodes) const
+    {
+        UNUSED(supportedOpcodes); /*assert(isOpcodeIn(supportedOpcodes));*/
+    }
 
     static uint32_t scaleUp(uint32_t srcVal, size_t srcBits, size_t dstBits)
     {

--- a/src/framework/midi/midievent.h
+++ b/src/framework/midi/midievent.h
@@ -372,7 +372,7 @@ struct Event {
     }
 
     //!return velocity in range [0.f, 1.f] independent from message type
-    float velocityFraction()
+    float velocityFraction() const
     {
         return velocity() / static_cast<float>(maxVelocity());
     }
@@ -982,12 +982,12 @@ private:
     void assertMessageType(const std::set<MessageType>& supportedTypes) const
     {
         UNUSED(supportedTypes);
-        assert(isMessageTypeIn(supportedTypes));
+        //assert(isMessageTypeIn(supportedTypes));
     }
 
-    void assertChannelVoice() const { assert(isChannelVoice()); }
+    void assertChannelVoice() const { /*assert(isChannelVoice());*/ }
 
-    void assertOpcode(const std::set<Opcode>& supportedOpcodes) const { UNUSED(supportedOpcodes); assert(isOpcodeIn(supportedOpcodes)); }
+    void assertOpcode(const std::set<Opcode>& supportedOpcodes) const { UNUSED(supportedOpcodes); /*assert(isOpcodeIn(supportedOpcodes));*/ }
 
     static uint32_t scaleUp(uint32_t srcVal, size_t srcBits, size_t dstBits)
     {

--- a/src/framework/vst/CMakeLists.txt
+++ b/src/framework/vst/CMakeLists.txt
@@ -41,6 +41,10 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/vstconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/vstplugin.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/vstplugin.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/synth/vstaudioclient.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/synth/vstaudioclient.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/synth/vstsynthesiser.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/synth/vstsynthesiser.h
     ${CMAKE_CURRENT_LIST_DIR}/devtools/vstpluginlistmodelexample.cpp
     ${CMAKE_CURRENT_LIST_DIR}/devtools/vstpluginlistmodelexample.h
     ${CMAKE_CURRENT_LIST_DIR}/view/vstplugineditorview.cpp

--- a/src/framework/vst/devtools/vstpluginlistmodelexample.cpp
+++ b/src/framework/vst/devtools/vstpluginlistmodelexample.cpp
@@ -56,7 +56,7 @@ void VstPluginListModelExample::showPluginEditor()
 
     VstPluginMeta meta = m_pluginMetaList.at(m_selectedItemIndex);
 
-    interactive()->open("musescore://vst/editor?pluginId=" + meta.id);
+    interactive()->open("musescore://vst/editor?sync=false&pluginId=" + meta.id);
 }
 
 int VstPluginListModelExample::rowCount(const QModelIndex&) const

--- a/src/framework/vst/internal/synth/vstaudioclient.cpp
+++ b/src/framework/vst/internal/synth/vstaudioclient.cpp
@@ -1,0 +1,153 @@
+#include "vstaudioclient.h"
+
+#include "audio/synthtypes.h"
+
+using namespace mu;
+using namespace mu::vst;
+
+VstAudioClient::~VstAudioClient()
+{
+    IAudioProcessorPtr processor = m_pluginComponent;
+    if (!processor) {
+        return;
+    }
+
+    processor->setProcessing(false);
+    m_pluginComponent->setActive(false);
+}
+
+void VstAudioClient::init(PluginComponentPtr component)
+{
+    if (!component) {
+        return;
+    }
+
+    m_pluginComponent = component;
+}
+
+bool VstAudioClient::handleEvent(const mu::midi::Event& e)
+{
+    if (m_eventList.addEvent(vstFromMidi(e)) == Steinberg::kResultTrue) {
+        return true;
+    }
+
+    return false;
+}
+
+void VstAudioClient::process(float* output, unsigned int samples)
+{
+    IAudioProcessorPtr processor = m_pluginComponent;
+    if (!processor || !output) {
+        return;
+    }
+
+    m_processData.numSamples = samples;
+
+    if (processor->process(m_processData) != Steinberg::kResultOk) {
+        return;
+    }
+
+    m_eventList.clear();
+
+    fillOutputBuffer(samples, output);
+}
+
+void VstAudioClient::setBlockSize(unsigned int samples)
+{
+    m_samplesInfo.samplesPerBlock = samples;
+
+    updateProcessSetup();
+}
+
+void VstAudioClient::setSampleRate(unsigned int sampleRate)
+{
+    m_samplesInfo.sampleRate = sampleRate;
+
+    updateProcessSetup();
+}
+
+void VstAudioClient::setUpProcessData()
+{
+    m_processContext.sampleRate = m_samplesInfo.sampleRate;
+
+    m_processData.inputEvents = &m_eventList;
+    m_processData.processContext = &m_processContext;
+
+    m_processData.prepare(*m_pluginComponent, m_samplesInfo.samplesPerBlock, Steinberg::Vst::kSample32);
+}
+
+void VstAudioClient::updateProcessSetup()
+{
+    if (!m_samplesInfo.isValid()) {
+        return;
+    }
+
+    IAudioProcessorPtr processor = m_pluginComponent;
+    if (!processor) {
+        return;
+    }
+
+    VstProcessSetup setup;
+    setup.processMode = Steinberg::Vst::kRealtime;
+    setup.symbolicSampleSize = Steinberg::Vst::kSample32;
+    setup.maxSamplesPerBlock = m_samplesInfo.samplesPerBlock;
+    setup.sampleRate = m_samplesInfo.sampleRate;
+
+    if (processor->setupProcessing(setup) != Steinberg::kResultOk) {
+        return;
+    }
+
+    processor->setProcessing(true);
+    m_pluginComponent->setActive(true);
+
+    setUpProcessData();
+}
+
+void VstAudioClient::fillOutputBuffer(unsigned int samples, float* output)
+{
+    for (unsigned int i = 0; i < samples; ++i) {
+        for (unsigned int s = 0; s < audio::synth::AUDIO_CHANNELS; ++s) {
+            auto getFromChannel = std::min<unsigned int>(s, m_processData.outputs[0].numChannels - 1);
+            output[i * audio::synth::AUDIO_CHANNELS + s] = m_processData.outputs[0].channelBuffers32[getFromChannel][i];
+        }
+    }
+}
+
+VstEvent VstAudioClient::vstFromMidi(const mu::midi::Event& event)
+{
+    VstEvent result;
+
+    if (!event.isValid()) {
+        return result;
+    }
+
+    result.busIndex = event.group();
+    result.sampleOffset = 0;
+    result.ppqPosition = 0;
+    result.flags = VstEvent::kIsLive;
+
+    switch (event.opcode()) {
+    case midi::Event::Opcode::NoteOn:
+        result.type = VstEvent::kNoteOnEvent;
+        result.noteOn.noteId = event.note();
+        result.noteOn.channel = event.channel();
+        result.noteOn.pitch = event.pitchNote();
+        result.noteOn.tuning = event.pitchTuningCents();
+        result.noteOn.velocity = event.velocityFraction();
+        break;
+
+    case midi::Event::Opcode::NoteOff:
+        result.type = VstEvent::kNoteOffEvent;
+        result.noteOff.noteId = event.note();
+        result.noteOff.channel = event.channel();
+        result.noteOff.pitch = event.pitchNote();
+        result.noteOff.tuning = event.pitchTuningCents();
+        result.noteOff.velocity = event.velocityFraction();
+        break;
+
+    default:
+        break;
+    }
+
+    return result;
+}

--- a/src/framework/vst/internal/synth/vstaudioclient.h
+++ b/src/framework/vst/internal/synth/vstaudioclient.h
@@ -1,0 +1,48 @@
+#ifndef VSTAUDIOCLIENT_H
+#define VSTAUDIOCLIENT_H
+
+#include "vsttypes.h"
+
+namespace mu::vst {
+class VstAudioClient
+{
+public:
+    VstAudioClient() = default;
+    ~VstAudioClient();
+
+    void init(PluginComponentPtr component);
+
+    bool handleEvent(const midi::Event& e);
+
+    void process(float* output, unsigned int samples);
+
+    void setBlockSize(unsigned int samples);
+    void setSampleRate(unsigned int sampleRate);
+
+private:
+    struct SamplesInfo {
+        unsigned int sampleRate = 0;
+        unsigned int samplesPerBlock = 0;
+
+        bool isValid() {
+            return sampleRate > 0 && samplesPerBlock > 0;
+        }
+    };
+
+    void setUpProcessData();
+    void updateProcessSetup();
+    void fillOutputBuffer(unsigned int samples, float* output);
+
+    VstEvent vstFromMidi(const mu::midi::Event& event);
+
+    PluginComponentPtr m_pluginComponent = nullptr;
+
+    SamplesInfo m_samplesInfo;
+
+    VstEventList m_eventList;
+    VstProcessData m_processData;
+    VstProcessContext m_processContext;
+};
+}
+
+#endif // VSTAUDIOCLIENT_H

--- a/src/framework/vst/internal/synth/vstaudioclient.h
+++ b/src/framework/vst/internal/synth/vstaudioclient.h
@@ -24,16 +24,18 @@ private:
         unsigned int sampleRate = 0;
         unsigned int samplesPerBlock = 0;
 
-        bool isValid() {
+        bool isValid()
+        {
             return sampleRate > 0 && samplesPerBlock > 0;
         }
     };
 
+    IAudioProcessorPtr pluginProcessor() const;
     void setUpProcessData();
     void updateProcessSetup();
     void fillOutputBuffer(unsigned int samples, float* output);
 
-    VstEvent vstFromMidi(const mu::midi::Event& event);
+    bool convertMidiToVst(const mu::midi::Event& in, VstEvent& out) const;
 
     PluginComponentPtr m_pluginComponent = nullptr;
 

--- a/src/framework/vst/internal/synth/vstsynthesiser.cpp
+++ b/src/framework/vst/internal/synth/vstsynthesiser.cpp
@@ -1,0 +1,163 @@
+#include "vstsynthesiser.h"
+
+#include "log.h"
+
+#include "internal/vstplugin.h"
+
+using namespace mu;
+using namespace mu::vst;
+
+VstSynthesiser::VstSynthesiser(const VstPluginMeta& meta)
+    : m_pluginMeta(meta), m_vstAudioClient(std::make_unique<VstAudioClient>())
+{
+}
+
+Ret VstSynthesiser::init()
+{
+    RetVal plugin = repository()->findPluginById(m_pluginMeta.id);
+
+    if (!plugin.ret) {
+        return plugin.ret;
+    }
+
+    m_pluginPtr = plugin.val;
+
+    m_vstAudioClient->init(m_pluginPtr->component());
+
+    return make_ret(Ret::Code::Ok);
+}
+
+bool VstSynthesiser::isValid() const
+{
+    if (!m_pluginPtr) {
+        return false;
+    }
+
+    return m_pluginPtr->isValid();
+}
+
+bool VstSynthesiser::isActive() const
+{
+    return m_isActive;
+}
+
+void VstSynthesiser::setIsActive(bool arg)
+{
+    m_isActive = arg;
+}
+
+std::string VstSynthesiser::name() const
+{
+    return m_pluginMeta.name;
+}
+
+audio::synth::SoundFontFormats VstSynthesiser::soundFontFormats() const
+{
+    NOT_SUPPORTED;
+    return { audio::synth::SoundFontFormat::Undefined };
+}
+
+Ret VstSynthesiser::addSoundFonts(const std::vector<io::path>& /*sfonts*/)
+{
+    NOT_SUPPORTED;
+    return Ret(Ret::Code::NotSupported);
+}
+
+Ret VstSynthesiser::removeSoundFonts()
+{
+    NOT_SUPPORTED;
+    return Ret(Ret::Code::NotSupported);
+}
+
+bool VstSynthesiser::handleEvent(const midi::Event& e)
+{
+    if (!m_vstAudioClient) {
+        return false;
+    }
+
+    return m_vstAudioClient->handleEvent(e);
+}
+
+void VstSynthesiser::writeBuf(float* stream, unsigned int samples)
+{
+    m_vstAudioClient->process(stream, samples);
+}
+
+void VstSynthesiser::allSoundsOff()
+{
+    NOT_IMPLEMENTED;
+}
+
+void VstSynthesiser::flushSound()
+{
+    NOT_IMPLEMENTED;
+}
+
+Ret VstSynthesiser::setupChannels(const std::vector<midi::Event>& /*events*/)
+{
+    NOT_IMPLEMENTED;
+    return Ret(Ret::Code::Ok);
+}
+
+void VstSynthesiser::channelSoundsOff(midi::channel_t /*chan*/)
+{
+    NOT_IMPLEMENTED;
+}
+
+bool VstSynthesiser::channelVolume(midi::channel_t /*chan*/, float /*val*/)
+{
+    NOT_IMPLEMENTED;
+    return true;
+}
+
+bool VstSynthesiser::channelBalance(midi::channel_t /*chan*/, float /*val*/)
+{
+    NOT_IMPLEMENTED;
+    return true;
+}
+
+bool VstSynthesiser::channelPitch(midi::channel_t /*chan*/, int16_t /*val*/)
+{
+    NOT_IMPLEMENTED;
+    return true;
+}
+
+void VstSynthesiser::setSampleRate(unsigned int sampleRate)
+{
+    m_vstAudioClient->setSampleRate(sampleRate);
+}
+
+unsigned int VstSynthesiser::streamCount() const
+{
+    return audio::synth::AUDIO_CHANNELS;
+}
+
+async::Channel<unsigned int> VstSynthesiser::streamsCountChanged() const
+{
+    return m_streamsCountChanged;
+}
+
+void VstSynthesiser::forward(unsigned int sampleCount)
+{
+    writeBuf(m_buffer.data(), sampleCount);
+}
+
+const float* VstSynthesiser::data() const
+{
+    return m_buffer.data();
+}
+
+void VstSynthesiser::setBufferSize(unsigned int samples)
+{
+    LOGI() << "SET BUFFER SIZE = " << samples;
+
+    unsigned int newSize = samples * streamCount();
+
+    if (newSize == 0 || m_buffer.size() == newSize) {
+        return;
+    }
+
+    m_buffer.resize(newSize);
+
+    m_vstAudioClient->setBlockSize(samples);
+}

--- a/src/framework/vst/internal/synth/vstsynthesiser.cpp
+++ b/src/framework/vst/internal/synth/vstsynthesiser.cpp
@@ -54,7 +54,7 @@ std::string VstSynthesiser::name() const
 audio::synth::SoundFontFormats VstSynthesiser::soundFontFormats() const
 {
     NOT_SUPPORTED;
-    return { audio::synth::SoundFontFormat::Undefined };
+    return { audio::synth::SoundFontFormat::Embedded };
 }
 
 Ret VstSynthesiser::addSoundFonts(const std::vector<io::path>& /*sfonts*/)

--- a/src/framework/vst/internal/synth/vstsynthesiser.h
+++ b/src/framework/vst/internal/synth/vstsynthesiser.h
@@ -1,0 +1,84 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2021 MuseScore BVBA and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef MU_VST_VSTSYNTHESISER_H
+#define MU_VST_VSTSYNTHESISER_H
+
+#include "audio/isynthesizer.h"
+#include "modularity/ioc.h"
+
+#include "vsttypes.h"
+#include "ivstpluginrepository.h"
+#include "vstaudioclient.h"
+
+namespace mu::vst {
+class VstSynthesiser : public audio::synth::ISynthesizer
+{
+    INJECT(vst, IVstPluginRepository, repository)
+
+public:
+    explicit VstSynthesiser(const VstPluginMeta& meta);
+
+    Ret init() override;
+
+    bool isValid() const override;
+    bool isActive() const override;
+    void setIsActive(bool arg) override;
+
+    std::string name() const override;
+
+    audio::synth::SoundFontFormats soundFontFormats() const override;
+    Ret addSoundFonts(const std::vector<io::path>& sfonts) override;
+    Ret removeSoundFonts() override;
+
+    bool handleEvent(const midi::Event& e) override;
+    void writeBuf(float* stream, unsigned int samples) override;
+    void allSoundsOff() override;
+    void flushSound() override;
+
+    Ret setupChannels(const std::vector<midi::Event>& events) override;
+    void channelSoundsOff(midi::channel_t chan) override;
+    bool channelVolume(midi::channel_t chan, float val) override;
+    bool channelBalance(midi::channel_t chan, float val) override;
+    bool channelPitch(midi::channel_t chan, int16_t val) override;
+
+    // IAudioSource
+    void setSampleRate(unsigned int sampleRate) override;
+    unsigned int streamCount() const override;
+    async::Channel<unsigned int> streamsCountChanged() const override;
+    void forward(unsigned int sampleCount) override;
+    const float* data() const override;
+    void setBufferSize(unsigned int samples) override;
+
+private:
+
+    VstPluginMeta m_pluginMeta;
+    VstPluginPtr m_pluginPtr = nullptr;
+
+    std::unique_ptr<VstAudioClient> m_vstAudioClient = nullptr;
+
+    bool m_isActive = false;
+
+    std::vector<float> m_buffer;
+
+    async::Channel<unsigned int> m_streamsCountChanged;
+};
+}
+
+#endif // MU_VST_VSTSYNTHESISER_H

--- a/src/framework/vst/internal/vstplugin.cpp
+++ b/src/framework/vst/internal/vstplugin.cpp
@@ -101,7 +101,7 @@ VstPluginMeta VstPlugin::meta() const
     return result;
 }
 
-PluginView VstPlugin::view()
+PluginViewPtr VstPlugin::view()
 {
     if (m_pluginView) {
         return m_pluginView;
@@ -110,6 +110,17 @@ PluginView VstPlugin::view()
     m_pluginView = owned(m_pluginController->createView(PluginEditorViewType::kEditor));
 
     return m_pluginView;
+}
+
+PluginComponentPtr VstPlugin::component()
+{
+    if (m_pluginComponent) {
+        return m_pluginComponent;
+    }
+
+    m_pluginComponent = m_pluginProvider->getComponent();
+
+    return m_pluginComponent;
 }
 
 bool VstPlugin::isValid() const

--- a/src/framework/vst/internal/vstplugin.cpp
+++ b/src/framework/vst/internal/vstplugin.cpp
@@ -101,7 +101,7 @@ VstPluginMeta VstPlugin::meta() const
     return result;
 }
 
-PluginViewPtr VstPlugin::view()
+PluginViewPtr VstPlugin::view() const
 {
     if (m_pluginView) {
         return m_pluginView;
@@ -112,7 +112,7 @@ PluginViewPtr VstPlugin::view()
     return m_pluginView;
 }
 
-PluginComponentPtr VstPlugin::component()
+PluginComponentPtr VstPlugin::component() const
 {
     if (m_pluginComponent) {
         return m_pluginComponent;

--- a/src/framework/vst/internal/vstplugin.h
+++ b/src/framework/vst/internal/vstplugin.h
@@ -35,8 +35,8 @@ public:
 
     PluginId id() const;
     VstPluginMeta meta() const;
-    PluginViewPtr view();
-    PluginComponentPtr component();
+    PluginViewPtr view() const;
+    PluginComponentPtr component() const;
 
     bool isValid() const;
 
@@ -46,8 +46,8 @@ private:
     PluginFactory m_factory;
     PluginProviderPtr m_pluginProvider = nullptr;
     PluginControllerPtr m_pluginController = nullptr;
-    PluginComponentPtr m_pluginComponent = nullptr;
-    PluginViewPtr m_pluginView = nullptr;
+    mutable PluginComponentPtr m_pluginComponent = nullptr;
+    mutable PluginViewPtr m_pluginView = nullptr;
 
     PluginContext m_pluginContext;
 };

--- a/src/framework/vst/internal/vstplugin.h
+++ b/src/framework/vst/internal/vstplugin.h
@@ -35,7 +35,8 @@ public:
 
     PluginId id() const;
     VstPluginMeta meta() const;
-    PluginView view();
+    PluginViewPtr view();
+    PluginComponentPtr component();
 
     bool isValid() const;
 
@@ -44,8 +45,9 @@ private:
     PluginModulePtr m_module = nullptr;
     PluginFactory m_factory;
     PluginProviderPtr m_pluginProvider = nullptr;
-    PluginController m_pluginController = nullptr;
-    PluginView m_pluginView = nullptr;
+    PluginControllerPtr m_pluginController = nullptr;
+    PluginComponentPtr m_pluginComponent = nullptr;
+    PluginViewPtr m_pluginView = nullptr;
 
     PluginContext m_pluginContext;
 };

--- a/src/framework/vst/view/vstplugineditorview.cpp
+++ b/src/framework/vst/view/vstplugineditorview.cpp
@@ -41,6 +41,13 @@ VstPluginEditorView::VstPluginEditorView(const VstPluginEditorView& copy)
 {
 }
 
+VstPluginEditorView::~VstPluginEditorView()
+{
+    if (m_view) {
+        m_view->removed();
+    }
+}
+
 tresult VstPluginEditorView::resizeView(IPlugView* view, ViewRect* newSize)
 {
     setGeometry(QRect(geometry().x(), geometry().y(), newSize->getWidth(), newSize->getHeight()));

--- a/src/framework/vst/view/vstplugineditorview.h
+++ b/src/framework/vst/view/vstplugineditorview.h
@@ -39,6 +39,7 @@ class VstPluginEditorView : public QDialog, public Steinberg::IPlugFrame
 public:
     VstPluginEditorView(QWidget* parent = nullptr);
     VstPluginEditorView(const VstPluginEditorView& copy);
+    ~VstPluginEditorView();
 
     Steinberg::tresult resizeView(Steinberg::IPlugView* view, Steinberg::ViewRect* newSize) override;
 
@@ -55,7 +56,7 @@ private:
 
     FIDString currentPlatformUiType() const;
 
-    PluginView m_view = nullptr;
+    PluginViewPtr m_view = nullptr;
     QString m_pluginId;
 };
 }

--- a/src/framework/vst/vstmodule.cpp
+++ b/src/framework/vst/vstmodule.cpp
@@ -21,6 +21,7 @@
 #include <QQmlEngine>
 
 #include "ui/iinteractiveuriregister.h"
+#include "audio/isynthesizersregister.h"
 #include "ui/iuiengine.h"
 #include "log.h"
 #include "settings.h"
@@ -28,6 +29,7 @@
 
 #include "internal/vstconfiguration.h"
 #include "internal/vstpluginrepository.h"
+#include "internal/synth/vstsynthesiser.h"
 
 #include "devtools/vstpluginlistmodelexample.h"
 #include "view/vstplugineditorview.h"
@@ -83,4 +85,11 @@ void VSTModule::onInit(const IApplication::RunMode& mode)
     }
 
     s_pluginRepo->loadAvailablePlugins();
+
+    //!Note Please, don't remove this code, needed for tests of VST implementation
+    /*auto sreg = ioc()->resolve<audio::synth::ISynthesizersRegister>(moduleName());
+
+    if (sreg) {
+        sreg->registerSynthesizer("Vst", std::make_shared<VstSynthesiser>(s_pluginRepo->pluginsMetaList().val.at(0)));
+    }*/
 }

--- a/src/framework/vst/vsttypes.h
+++ b/src/framework/vst/vsttypes.h
@@ -23,9 +23,13 @@
 #include "public.sdk/source/vst/hosting/module.h"
 #include "public.sdk/source/vst/hosting/plugprovider.h"
 #include "public.sdk/source/vst/hosting/hostclasses.h"
+#include "public.sdk/source/vst/hosting/eventlist.h"
+#include "public.sdk/source/vst/hosting/processdata.h"
 #include "pluginterfaces/gui/iplugview.h"
 #include "pluginterfaces/vst/ivstaudioprocessor.h"
 #include "pluginterfaces/vst/ivsteditcontroller.h"
+
+#include "framework/midi/miditypes.h"
 
 namespace mu::vst {
 class VstPlugin;
@@ -40,10 +44,11 @@ using PluginContextFactory = Steinberg::Vst::PluginContextFactory;
 using PluginContext = Steinberg::Vst::HostApplication;
 using PluginProviderPtr = Steinberg::IPtr<Steinberg::Vst::PlugProvider>;
 using PluginProvider = Steinberg::Vst::PlugProvider;
-using PluginController = Steinberg::IPtr<Steinberg::Vst::IEditController>;
-using PluginView = Steinberg::IPtr<Steinberg::IPlugView>;
+using PluginControllerPtr = Steinberg::IPtr<Steinberg::Vst::IEditController>;
+using PluginComponentPtr = Steinberg::IPtr<Steinberg::Vst::IComponent>;
+using PluginViewPtr = Steinberg::IPtr<Steinberg::IPlugView>;
+using IAudioProcessorPtr = Steinberg::FUnknownPtr<Steinberg::Vst::IAudioProcessor>;
 using FIDString = Steinberg::FIDString;
-namespace PluginEditorViewType = Steinberg::Vst::ViewType;
 
 struct VstPluginMeta {
     PluginId id;
@@ -52,5 +57,13 @@ struct VstPluginMeta {
 };
 
 using VstPluginMetaList = std::vector<VstPluginMeta>;
+
+using VstEventList = Steinberg::Vst::EventList;
+using VstEvent = Steinberg::Vst::Event;
+using VstProcessData = Steinberg::Vst::HostProcessData;
+using VstProcessContext = Steinberg::Vst::ProcessContext;
+using VstProcessSetup = Steinberg::Vst::ProcessSetup;
+
+namespace PluginEditorViewType = Steinberg::Vst::ViewType;
 }
 #endif // MU_VST_VSTTYPES_H


### PR DESCRIPTION
This PR introduces VST audio processing infrastructure. Currently we're able to work with VSTi plugins. We will also need to implement support for regular VST audio effects soon.

Here is an example of work with BBC Orchestral plugin:

https://user-images.githubusercontent.com/57620349/114443997-a9d7ea00-9bce-11eb-94e8-969b567be1e1.mp4

Important note: this PR should be followed by - https://github.com/musescore/MuseScore/pull/7945


