### PR TITLE
[MU4] vst ressurection part3

### DIFF
--- a/src/framework/audio/audiomodule.cpp
+++ b/src/framework/audio/audiomodule.cpp
@@ -163,6 +163,8 @@ void AudioModule::onInit(const framework::IApplication::RunMode&)
     // Init configuration
     s_audioConfiguration->init();
 
+    s_audioBuffer->init();
+
     // Setup rpc system and worker
     s_rpcSequencer->setup();
     s_audioWorker->channel()->setupMainThread();
@@ -187,8 +189,8 @@ void AudioModule::onInit(const framework::IApplication::RunMode&)
     requiredSpec.channels = 2; // stereo
     requiredSpec.samples = s_audioConfiguration->driverBufferSize();
     requiredSpec.callback = [](void* /*userdata*/, uint8_t* stream, int byteCount) {
-        auto samples = byteCount / (2 * sizeof(float));
-        s_audioBuffer->pop(reinterpret_cast<float*>(stream), samples);
+        auto samplesPerChannel = byteCount / (2 * sizeof(float));
+        s_audioBuffer->pop(reinterpret_cast<float*>(stream), samplesPerChannel);
     };
 
     IAudioDriver::Spec activeSpec;

--- a/src/framework/audio/iaudioconfiguration.h
+++ b/src/framework/audio/iaudioconfiguration.h
@@ -40,7 +40,7 @@ public:
     virtual std::string currentAudioApi() const = 0;
     virtual void setCurrentAudioApi(const std::string& name) = 0;
 
-    virtual int requiredAudioChannelsCount() const = 0;
+    virtual int audioChannelsCount() const = 0;
     virtual unsigned int driverBufferSize() const = 0; // samples
 
     virtual bool isShowControlsInMixer() const = 0;

--- a/src/framework/audio/iaudioconfiguration.h
+++ b/src/framework/audio/iaudioconfiguration.h
@@ -40,6 +40,7 @@ public:
     virtual std::string currentAudioApi() const = 0;
     virtual void setCurrentAudioApi(const std::string& name) = 0;
 
+    virtual int requiredAudioChannelsCount() const = 0;
     virtual unsigned int driverBufferSize() const = 0; // samples
 
     virtual bool isShowControlsInMixer() const = 0;

--- a/src/framework/audio/iaudiosource.h
+++ b/src/framework/audio/iaudiosource.h
@@ -42,7 +42,7 @@ public:
     virtual async::Channel<unsigned int> streamsCountChanged() const = 0;
 
     //! move buffer forward for sampleCount samples
-    virtual void forward(float* buffer, unsigned int sampleCount) = 0;
+    virtual void process(float* buffer, unsigned int sampleCount) = 0;
 };
 
 using IAudioSourcePtr = std::shared_ptr<IAudioSource>;

--- a/src/framework/audio/iaudiosource.h
+++ b/src/framework/audio/iaudiosource.h
@@ -42,13 +42,7 @@ public:
     virtual async::Channel<unsigned int> streamsCountChanged() const = 0;
 
     //! move buffer forward for sampleCount samples
-    virtual void forward(unsigned int sampleCount) = 0;
-
-    //! const access to the source's output buffer
-    virtual const float* data() const = 0;
-
-    //! set the mix step in samples
-    virtual void setBufferSize(unsigned int samples) = 0;
+    virtual void forward(float* buffer, unsigned int sampleCount) = 0;
 };
 
 using IAudioSourcePtr = std::shared_ptr<IAudioSource>;

--- a/src/framework/audio/iaudiosource.h
+++ b/src/framework/audio/iaudiosource.h
@@ -37,9 +37,9 @@ public:
     virtual void setSampleRate(unsigned int sampleRate) = 0;
 
     //! return substream count for this source: 1 for mono, 2 for stereo, 6 for surround
-    virtual unsigned int streamCount() const = 0;
+    virtual unsigned int audioChannelsCount() const = 0;
 
-    virtual async::Channel<unsigned int> streamsCountChanged() const = 0;
+    virtual async::Channel<unsigned int> audioChannelsCountChanged() const = 0;
 
     //! move buffer forward for sampleCount samples
     virtual void process(float* buffer, unsigned int sampleCount) = 0;

--- a/src/framework/audio/internal/audiobuffer.cpp
+++ b/src/framework/audio/internal/audiobuffer.cpp
@@ -122,7 +122,7 @@ void AudioBuffer::fillup()
     static float buffer[FILL_SAMPLES * 2] = {};
 
     while (sampleLag() < m_minSampleLag + FILL_OVER) {
-        m_source->forward(buffer, FILL_SAMPLES);
+        m_source->process(buffer, FILL_SAMPLES);
         push(buffer, FILL_SAMPLES);
     }
 }

--- a/src/framework/audio/internal/audiobuffer.cpp
+++ b/src/framework/audio/internal/audiobuffer.cpp
@@ -22,13 +22,13 @@
 #include "audiobuffer.h"
 #include <cstring>
 #include "log.h"
+#include "synthtypes.h"
 
 using namespace mu::audio;
 
-AudioBuffer::AudioBuffer(unsigned int streamsPerSample, unsigned int size)
-    : m_streamsPerSample(streamsPerSample)
+AudioBuffer::AudioBuffer(unsigned int size)
 {
-    m_data.resize(size * m_streamsPerSample, 0.f);
+    m_data.resize(size * synth::AUDIO_CHANNELS, 0.f);
 }
 
 void AudioBuffer::setSource(std::shared_ptr<IAudioSource> source)
@@ -49,7 +49,7 @@ void AudioBuffer::push(const float* source, int sampleCount)
 
     unsigned int from = m_writeIndex;
     auto memStep = sizeof(float);
-    auto to = m_writeIndex + sampleCount * m_streamsPerSample;
+    auto to = m_writeIndex + sampleCount * synth::AUDIO_CHANNELS;
     if (to > m_data.size()) {
         to = m_data.size() - 1;
     }
@@ -57,7 +57,7 @@ void AudioBuffer::push(const float* source, int sampleCount)
     std::memcpy(m_data.data() + m_writeIndex, source, count * memStep);
     m_writeIndex += count;
 
-    int left = sampleCount * m_streamsPerSample - count;
+    int left = sampleCount * synth::AUDIO_CHANNELS - count;
     if (left > 0) {
         std::memcpy(m_data.data(), source + count, left * memStep);
         m_writeIndex = left;
@@ -81,7 +81,7 @@ void AudioBuffer::pop(float* dest, unsigned int sampleCount)
 
     unsigned int from = m_readIndex;
     auto memStep = sizeof(float);
-    auto to = m_readIndex + sampleCount * m_streamsPerSample;
+    auto to = m_readIndex + sampleCount * synth::AUDIO_CHANNELS;
     if (to > m_data.size()) {
         to = m_data.size();
     }
@@ -89,7 +89,7 @@ void AudioBuffer::pop(float* dest, unsigned int sampleCount)
     std::memcpy(dest, m_data.data() + from, count * memStep);
     m_readIndex += count;
 
-    int left = sampleCount * m_streamsPerSample - count;
+    int left = sampleCount * synth::AUDIO_CHANNELS - count;
     if (left > 0) {
         std::memcpy(dest + count, m_data.data(), left * memStep);
         m_readIndex = left;
@@ -108,8 +108,8 @@ void AudioBuffer::setMinSampleLag(unsigned int lag)
         lag = m_data.size();
     }
     m_minSampleLag = lag;
-    if (m_data.size() < 2 * m_minSampleLag * m_streamsPerSample) {
-        m_data.resize(2 * m_minSampleLag * m_streamsPerSample, 0.f);
+    if (m_data.size() < 2 * m_minSampleLag * synth::AUDIO_CHANNELS) {
+        m_data.resize(2 * m_minSampleLag * synth::AUDIO_CHANNELS, 0.f);
     }
 }
 
@@ -119,10 +119,11 @@ void AudioBuffer::fillup()
         return;
     }
 
+    static float buffer[FILL_SAMPLES * 2] = {};
+
     while (sampleLag() < m_minSampleLag + FILL_OVER) {
-        m_source->setBufferSize(FILL_SAMPLES);
-        m_source->forward(FILL_SAMPLES);
-        push(m_source->data(), FILL_SAMPLES);
+        m_source->forward(buffer, FILL_SAMPLES);
+        push(buffer, FILL_SAMPLES);
     }
 }
 
@@ -135,5 +136,5 @@ unsigned int AudioBuffer::sampleLag() const
         lag = m_writeIndex + m_data.size() - m_readIndex;
     }
 
-    return lag / m_streamsPerSample;
+    return lag / synth::AUDIO_CHANNELS;
 }

--- a/src/framework/audio/internal/audiobuffer.cpp
+++ b/src/framework/audio/internal/audiobuffer.cpp
@@ -22,14 +22,13 @@
 #include "audiobuffer.h"
 #include <cstring>
 #include "log.h"
-#include "synthtypes.h"
 
 using namespace mu::audio;
 
 void AudioBuffer::init(int samplesPerChannel)
 {
-    m_writeCache.resize(config()->driverBufferSize() * config()->requiredAudioChannelsCount(), 0.f);
-    m_data.resize(samplesPerChannel * config()->requiredAudioChannelsCount(), 0.f);
+    m_audioChannelsCount = config()->audioChannelsCount();
+    m_data.resize(samplesPerChannel * m_audioChannelsCount, 0.f);
 }
 
 void AudioBuffer::setSource(std::shared_ptr<IAudioSource> source)
@@ -42,25 +41,6 @@ void AudioBuffer::forward()
 {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
     fillup();
-}
-
-void AudioBuffer::push(const float* source, int samplesPerChannel)
-{
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-
-    unsigned int from = m_writeIndex;
-    auto memStep = sizeof(float);
-    auto to = m_writeIndex + samplesPerChannel * config()->requiredAudioChannelsCount();
-    if (to > m_data.size()) {
-        to = m_data.size() - 1;
-    }
-    auto count = to - from;
-    std::memcpy(m_data.data() + m_writeIndex, source, count * memStep);
-    m_writeIndex += count;
-
-    if (m_writeIndex >= m_data.size()) {
-        m_writeIndex -= m_data.size();
-    }
 }
 
 void AudioBuffer::pop(float* dest, unsigned int sampleCount)
@@ -76,7 +56,7 @@ void AudioBuffer::pop(float* dest, unsigned int sampleCount)
 
     unsigned int from = m_readIndex;
     auto memStep = sizeof(float);
-    auto to = m_readIndex + sampleCount * config()->requiredAudioChannelsCount();
+    auto to = m_readIndex + sampleCount * m_audioChannelsCount;
     if (to > m_data.size()) {
         to = m_data.size();
     }
@@ -84,7 +64,7 @@ void AudioBuffer::pop(float* dest, unsigned int sampleCount)
     std::memcpy(dest, m_data.data() + from, count * memStep);
     m_readIndex += count;
 
-    int left = sampleCount * config()->requiredAudioChannelsCount() - count;
+    int left = sampleCount * m_audioChannelsCount - count;
     if (left > 0) {
         std::memcpy(dest + count, m_data.data(), left * memStep);
         m_readIndex = left;
@@ -103,9 +83,6 @@ void AudioBuffer::setMinSampleLag(unsigned int lag)
         lag = m_data.size();
     }
     m_minSampleLag = lag;
-    if (m_data.size() < 2 * m_minSampleLag * config()->requiredAudioChannelsCount()) {
-        m_data.resize(2 * m_minSampleLag * config()->requiredAudioChannelsCount(), 0.f);
-    }
 }
 
 void AudioBuffer::fillup()
@@ -115,8 +92,26 @@ void AudioBuffer::fillup()
     }
 
     while (sampleLag() < m_minSampleLag + FILL_OVER) {
-        m_source->process(m_writeCache.data(), FILL_SAMPLES);
-        push(m_writeCache.data(), FILL_SAMPLES);
+        m_source->process(m_data.data() + m_writeIndex, FILL_SAMPLES);
+        updateWriteIndex(FILL_SAMPLES);
+    }
+}
+
+void AudioBuffer::updateWriteIndex(const unsigned int samplesPerChannel)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+
+    unsigned int from = m_writeIndex;
+
+    auto to = m_writeIndex + samplesPerChannel * m_audioChannelsCount;
+    if (to > m_data.size()) {
+        to = m_data.size() - 1;
+    }
+    auto count = to - from;
+    m_writeIndex += count;
+
+    if (m_writeIndex >= m_data.size()) {
+        m_writeIndex -= m_data.size();
     }
 }
 
@@ -129,5 +124,5 @@ unsigned int AudioBuffer::sampleLag() const
         lag = m_writeIndex + m_data.size() - m_readIndex;
     }
 
-    return lag / config()->requiredAudioChannelsCount();
+    return lag / m_audioChannelsCount;
 }

--- a/src/framework/audio/internal/audiobuffer.h
+++ b/src/framework/audio/internal/audiobuffer.h
@@ -46,7 +46,6 @@ public:
     void setSource(std::shared_ptr<IAudioSource> source) override;
     void forward() override;
 
-    void push(const float* source, int samplesPerChannel) override;
     void pop(float* dest, unsigned int sampleCount) override;
     void setMinSampleLag(unsigned int lag) override;
 
@@ -54,13 +53,14 @@ private:
 
     unsigned int sampleLag() const;
     void fillup();
+    void updateWriteIndex(const unsigned int samplesPerChannel);
 
     std::recursive_mutex m_mutex; //! TODO get rid *recursive*
     unsigned int m_minSampleLag = FILL_SAMPLES;
     unsigned int m_writeIndex = 0;
     unsigned int m_readIndex = 0;
+    int m_audioChannelsCount = 2;
 
-    std::vector<float> m_writeCache;
     std::vector<float> m_data = {};
     std::shared_ptr<IAudioSource> m_source = nullptr;
 };

--- a/src/framework/audio/internal/audiobuffer.h
+++ b/src/framework/audio/internal/audiobuffer.h
@@ -35,7 +35,7 @@ class AudioBuffer : public IAudioBuffer
     const static unsigned int FILL_OVER    = 1024;
 
 public:
-    AudioBuffer(unsigned int streamsPerSample = 2, unsigned int size = DEFAULT_SIZE);
+    AudioBuffer(unsigned int size = DEFAULT_SIZE);
 
     void setSource(std::shared_ptr<IAudioSource> source) override;
     void forward() override;
@@ -50,7 +50,6 @@ private:
     void fillup();
 
     std::recursive_mutex m_mutex; //! TODO get rid *recursive*
-    unsigned int m_streamsPerSample = 0;
     unsigned int m_minSampleLag = FILL_SAMPLES;
     unsigned int m_writeIndex = 0;
     unsigned int m_readIndex = 0;

--- a/src/framework/audio/internal/audiobuffer.h
+++ b/src/framework/audio/internal/audiobuffer.h
@@ -26,21 +26,27 @@
 #include <memory>
 #include <atomic>
 #include "iaudiobuffer.h"
+#include "iaudioconfiguration.h"
+#include "modularity/ioc.h"
 
 namespace mu::audio {
 class AudioBuffer : public IAudioBuffer
 {
-    const static unsigned int DEFAULT_SIZE = 16384;
-    const static unsigned int FILL_SAMPLES = 1024;
-    const static unsigned int FILL_OVER    = 1024;
+    static const int DEFAULT_SIZE = 16384;
+    static const unsigned int FILL_SAMPLES = 1024;
+    static const unsigned int FILL_OVER    = 1024;
+
+    INJECT(audio, IAudioConfiguration, config)
 
 public:
-    AudioBuffer(unsigned int size = DEFAULT_SIZE);
+    AudioBuffer() = default;
+
+    void init(int samplesPerChannel = DEFAULT_SIZE);
 
     void setSource(std::shared_ptr<IAudioSource> source) override;
     void forward() override;
 
-    void push(const float* source, int sampleCount) override;
+    void push(const float* source, int samplesPerChannel) override;
     void pop(float* dest, unsigned int sampleCount) override;
     void setMinSampleLag(unsigned int lag) override;
 
@@ -53,6 +59,8 @@ private:
     unsigned int m_minSampleLag = FILL_SAMPLES;
     unsigned int m_writeIndex = 0;
     unsigned int m_readIndex = 0;
+
+    std::vector<float> m_writeCache;
     std::vector<float> m_data = {};
     std::shared_ptr<IAudioSource> m_source = nullptr;
 };

--- a/src/framework/audio/internal/audioconfiguration.cpp
+++ b/src/framework/audio/internal/audioconfiguration.cpp
@@ -36,6 +36,8 @@ using namespace mu::framework;
 using namespace mu::audio;
 using namespace mu::audio::synth;
 
+static const int AUDIO_CHANNELS = 2;
+
 //TODO: add other setting: audio device etc
 static const Settings::Key AUDIO_API_KEY("audio", "io/audioApi");
 static const Settings::Key AUDIO_BUFFER_SIZE("audio", "driver_buffer");
@@ -82,6 +84,11 @@ std::string AudioConfiguration::currentAudioApi() const
 void AudioConfiguration::setCurrentAudioApi(const std::string& name)
 {
     settings()->setValue(AUDIO_API_KEY, Val(name));
+}
+
+int AudioConfiguration::requiredAudioChannelsCount() const
+{
+    return AUDIO_CHANNELS;
 }
 
 unsigned int AudioConfiguration::driverBufferSize() const

--- a/src/framework/audio/internal/audioconfiguration.cpp
+++ b/src/framework/audio/internal/audioconfiguration.cpp
@@ -86,7 +86,7 @@ void AudioConfiguration::setCurrentAudioApi(const std::string& name)
     settings()->setValue(AUDIO_API_KEY, Val(name));
 }
 
-int AudioConfiguration::requiredAudioChannelsCount() const
+int AudioConfiguration::audioChannelsCount() const
 {
     return AUDIO_CHANNELS;
 }

--- a/src/framework/audio/internal/audioconfiguration.h
+++ b/src/framework/audio/internal/audioconfiguration.h
@@ -40,7 +40,7 @@ public:
     std::string currentAudioApi() const override;
     void setCurrentAudioApi(const std::string& name) override;
 
-    int requiredAudioChannelsCount() const override;
+    int audioChannelsCount() const override;
     unsigned int driverBufferSize() const override;
 
     std::vector<io::path> soundFontPaths() const override;

--- a/src/framework/audio/internal/audioconfiguration.h
+++ b/src/framework/audio/internal/audioconfiguration.h
@@ -40,6 +40,7 @@ public:
     std::string currentAudioApi() const override;
     void setCurrentAudioApi(const std::string& name) override;
 
+    int requiredAudioChannelsCount() const override;
     unsigned int driverBufferSize() const override;
 
     std::vector<io::path> soundFontPaths() const override;

--- a/src/framework/audio/internal/iaudiobuffer.h
+++ b/src/framework/audio/internal/iaudiobuffer.h
@@ -34,7 +34,6 @@ public:
     virtual void setSource(std::shared_ptr<IAudioSource> source) = 0;
     virtual void forward() = 0;
 
-    virtual void push(const float* source, int sampleCount) = 0;
     virtual void pop(float* dest, unsigned int sampleCount) = 0;
     virtual void setMinSampleLag(unsigned int lag) = 0;
 };

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
@@ -374,13 +374,13 @@ void FluidSynth::writeBuf(float* stream, unsigned int samples)
     }
 
     fluid_synth_write_float(m_fluid->synth, static_cast<int>(samples),
-                            stream, 0, config()->requiredAudioChannelsCount(),
-                            stream, 1, config()->requiredAudioChannelsCount());
+                            stream, 0, config()->audioChannelsCount(),
+                            stream, 1, config()->audioChannelsCount());
 }
 
 unsigned int FluidSynth::audioChannelsCount() const
 {
-    return config()->requiredAudioChannelsCount();
+    return config()->audioChannelsCount();
 }
 
 void FluidSynth::process(float* buffer, unsigned int sampleCount)

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
@@ -383,26 +383,12 @@ unsigned int FluidSynth::streamCount() const
     return synth::AUDIO_CHANNELS;
 }
 
-void FluidSynth::forward(unsigned int sampleCount)
+void FluidSynth::forward(float* buffer, unsigned int sampleCount)
 {
-    writeBuf(m_buffer.data(), sampleCount);
+    writeBuf(buffer, sampleCount);
 }
 
 async::Channel<unsigned int> FluidSynth::streamsCountChanged() const
 {
     return m_streamsCountChanged;
-}
-
-const float* FluidSynth::data() const
-{
-    return m_buffer.data();
-}
-
-void FluidSynth::setBufferSize(unsigned int samples)
-{
-    auto sc = streamCount();
-    auto targetSize = samples * sc;
-    if (targetSize > 0 && m_buffer.size() < targetSize) {
-        m_buffer.resize(samples * streamCount());
-    }
 }

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
@@ -383,7 +383,7 @@ unsigned int FluidSynth::streamCount() const
     return synth::AUDIO_CHANNELS;
 }
 
-void FluidSynth::forward(float* buffer, unsigned int sampleCount)
+void FluidSynth::process(float* buffer, unsigned int sampleCount)
 {
     writeBuf(buffer, sampleCount);
 }

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
@@ -202,7 +202,7 @@ Ret FluidSynth::removeSoundFonts()
     return ok ? make_ret(Err::NoError) : make_ret(Err::SoundFontFailedUnload);
 }
 
-Ret FluidSynth::setupChannels(const std::vector<Event>& events)
+Ret FluidSynth::setupMidiChannels(const std::vector<Event>& events)
 {
     IF_ASSERT_FAILED(m_fluid->synth) {
         return make_ret(Err::SynthNotInited);
@@ -302,7 +302,7 @@ void FluidSynth::flushSound()
     fluid_synth_write_float(m_fluid->synth, size, &m_preallocated[0], 0, 1, &m_preallocated[0], size, 1);
 }
 
-void FluidSynth::channelSoundsOff(channel_t chan)
+void FluidSynth::midiChannelSoundsOff(channel_t chan)
 {
     IF_ASSERT_FAILED(m_fluid->synth) {
         return;
@@ -311,7 +311,7 @@ void FluidSynth::channelSoundsOff(channel_t chan)
     fluid_synth_all_sounds_off(m_fluid->synth, chan);
 }
 
-bool FluidSynth::channelVolume(channel_t chan, float volume)
+bool FluidSynth::midiChannelVolume(channel_t chan, float volume)
 {
     IF_ASSERT_FAILED(m_fluid->synth) {
         return false;
@@ -324,7 +324,7 @@ bool FluidSynth::channelVolume(channel_t chan, float volume)
     return ret == FLUID_OK;
 }
 
-bool FluidSynth::channelBalance(channel_t chan, float balance)
+bool FluidSynth::midiChannelBalance(channel_t chan, float balance)
 {
     IF_ASSERT_FAILED(m_fluid->synth) {
         return false;
@@ -339,7 +339,7 @@ bool FluidSynth::channelBalance(channel_t chan, float balance)
     return ret == FLUID_OK;
 }
 
-bool FluidSynth::channelPitch(channel_t chan, int16_t pitch)
+bool FluidSynth::midiChannelPitch(channel_t chan, int16_t pitch)
 {
     // 0-16383 with 8192 being center
 
@@ -378,7 +378,7 @@ void FluidSynth::writeBuf(float* stream, unsigned int samples)
                             stream, 1, AUDIO_CHANNELS);
 }
 
-unsigned int FluidSynth::streamCount() const
+unsigned int FluidSynth::audioChannelsCount() const
 {
     return synth::AUDIO_CHANNELS;
 }
@@ -388,7 +388,7 @@ void FluidSynth::process(float* buffer, unsigned int sampleCount)
     writeBuf(buffer, sampleCount);
 }
 
-async::Channel<unsigned int> FluidSynth::streamsCountChanged() const
+async::Channel<unsigned int> FluidSynth::audioChannelsCountChanged() const
 {
     return m_streamsCountChanged;
 }

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
@@ -374,13 +374,13 @@ void FluidSynth::writeBuf(float* stream, unsigned int samples)
     }
 
     fluid_synth_write_float(m_fluid->synth, static_cast<int>(samples),
-                            stream, 0, AUDIO_CHANNELS,
-                            stream, 1, AUDIO_CHANNELS);
+                            stream, 0, config()->requiredAudioChannelsCount(),
+                            stream, 1, config()->requiredAudioChannelsCount());
 }
 
 unsigned int FluidSynth::audioChannelsCount() const
 {
-    return synth::AUDIO_CHANNELS;
+    return config()->requiredAudioChannelsCount();
 }
 
 void FluidSynth::process(float* buffer, unsigned int sampleCount)

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.h
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.h
@@ -63,7 +63,7 @@ public:
     bool channelPitch(midi::channel_t chan, int16_t pitch) override; // -12 - 12
 
     unsigned int streamCount() const override;
-    void forward(float* buffer, unsigned int sampleCount) override;
+    void process(float* buffer, unsigned int sampleCount) override;
     async::Channel<unsigned int> streamsCountChanged() const override;
 
 private:

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.h
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.h
@@ -28,12 +28,17 @@
 #include <cstdint>
 #include <functional>
 
+#include "modularity/ioc.h"
+#include "iaudioconfiguration.h"
+
 #include "isynthesizer.h"
 
 namespace mu::audio::synth {
 struct Fluid;
 class FluidSynth : public ISynthesizer
 {
+    INJECT(audio, IAudioConfiguration, config)
+
 public:
     FluidSynth();
 

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.h
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.h
@@ -50,21 +50,21 @@ public:
     bool isActive() const override;
     void setIsActive(bool arg) override;
 
-    Ret setupChannels(const std::vector<midi::Event>& events) override;
+    Ret setupMidiChannels(const std::vector<midi::Event>& events) override;
     bool handleEvent(const midi::Event& e) override;
     void writeBuf(float* stream, unsigned int samples) override;
 
     void allSoundsOff() override; // all channels
     void flushSound() override;
 
-    void channelSoundsOff(midi::channel_t chan) override;
-    bool channelVolume(midi::channel_t chan, float val) override;  // 0. - 1.
-    bool channelBalance(midi::channel_t chan, float val) override; // -1. - 1.
-    bool channelPitch(midi::channel_t chan, int16_t pitch) override; // -12 - 12
+    void midiChannelSoundsOff(midi::channel_t chan) override;
+    bool midiChannelVolume(midi::channel_t chan, float val) override;  // 0. - 1.
+    bool midiChannelBalance(midi::channel_t chan, float val) override; // -1. - 1.
+    bool midiChannelPitch(midi::channel_t chan, int16_t pitch) override; // -12 - 12
 
-    unsigned int streamCount() const override;
+    unsigned int audioChannelsCount() const override;
     void process(float* buffer, unsigned int sampleCount) override;
-    async::Channel<unsigned int> streamsCountChanged() const override;
+    async::Channel<unsigned int> audioChannelsCountChanged() const override;
 
 private:
 

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.h
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.h
@@ -63,10 +63,8 @@ public:
     bool channelPitch(midi::channel_t chan, int16_t pitch) override; // -12 - 12
 
     unsigned int streamCount() const override;
-    void forward(unsigned int sampleCount) override;
+    void forward(float* buffer, unsigned int sampleCount) override;
     async::Channel<unsigned int> streamsCountChanged() const override;
-    const float* data() const override;
-    void setBufferSize(unsigned int samples) override;
 
 private:
 
@@ -92,7 +90,6 @@ private:
     bool m_isActive = false;
 
     unsigned int m_sampleRate = 0;
-    std::vector<float> m_buffer = {};
     async::Channel<unsigned int> m_streamsCountChanged;
 };
 }

--- a/src/framework/audio/internal/synthesizers/sanitysynthesizer.cpp
+++ b/src/framework/audio/internal/synthesizers/sanitysynthesizer.cpp
@@ -151,7 +151,7 @@ async::Channel<unsigned int> SanitySynthesizer::streamsCountChanged() const
     return m_synth->streamsCountChanged();
 }
 
-void SanitySynthesizer::forward(float* buffer, unsigned int sampleCount)
+void SanitySynthesizer::process(float* buffer, unsigned int sampleCount)
 {
     ONLY_AUDIO_WORKER_THREAD;
     m_synth->forward(buffer, sampleCount);

--- a/src/framework/audio/internal/synthesizers/sanitysynthesizer.cpp
+++ b/src/framework/audio/internal/synthesizers/sanitysynthesizer.cpp
@@ -151,20 +151,8 @@ async::Channel<unsigned int> SanitySynthesizer::streamsCountChanged() const
     return m_synth->streamsCountChanged();
 }
 
-void SanitySynthesizer::forward(unsigned int sampleCount)
+void SanitySynthesizer::forward(float* buffer, unsigned int sampleCount)
 {
     ONLY_AUDIO_WORKER_THREAD;
-    m_synth->forward(sampleCount);
-}
-
-const float* SanitySynthesizer::data() const
-{
-    ONLY_AUDIO_WORKER_THREAD;
-    return m_synth->data();
-}
-
-void SanitySynthesizer::setBufferSize(unsigned int samples)
-{
-    ONLY_AUDIO_WORKER_THREAD;
-    return m_synth->setBufferSize(samples);
+    m_synth->forward(buffer, sampleCount);
 }

--- a/src/framework/audio/internal/synthesizers/sanitysynthesizer.cpp
+++ b/src/framework/audio/internal/synthesizers/sanitysynthesizer.cpp
@@ -78,10 +78,10 @@ void SanitySynthesizer::setIsActive(bool arg)
     m_synth->setIsActive(arg);
 }
 
-Ret SanitySynthesizer::setupChannels(const std::vector<midi::Event>& events)
+Ret SanitySynthesizer::setupMidiChannels(const std::vector<midi::Event>& events)
 {
     ONLY_AUDIO_WORKER_THREAD;
-    return m_synth->setupChannels(events);
+    return m_synth->setupMidiChannels(events);
 }
 
 bool SanitySynthesizer::handleEvent(const midi::Event& e)
@@ -108,28 +108,28 @@ void SanitySynthesizer::flushSound()
     m_synth->flushSound();
 }
 
-void SanitySynthesizer::channelSoundsOff(midi::channel_t chan)
+void SanitySynthesizer::midiChannelSoundsOff(midi::channel_t chan)
 {
     ONLY_AUDIO_WORKER_THREAD;
-    m_synth->channelSoundsOff(chan);
+    m_synth->midiChannelSoundsOff(chan);
 }
 
-bool SanitySynthesizer::channelVolume(midi::channel_t chan, float val)
+bool SanitySynthesizer::midiChannelVolume(midi::channel_t chan, float val)
 {
     ONLY_AUDIO_WORKER_THREAD;
-    return m_synth->channelVolume(chan, val);
+    return m_synth->midiChannelVolume(chan, val);
 }
 
-bool SanitySynthesizer::channelBalance(midi::channel_t chan, float val)
+bool SanitySynthesizer::midiChannelBalance(midi::channel_t chan, float val)
 {
     ONLY_AUDIO_WORKER_THREAD;
-    return m_synth->channelBalance(chan, val);
+    return m_synth->midiChannelBalance(chan, val);
 }
 
-bool SanitySynthesizer::channelPitch(midi::channel_t chan, int16_t val)
+bool SanitySynthesizer::midiChannelPitch(midi::channel_t chan, int16_t val)
 {
     ONLY_AUDIO_WORKER_THREAD;
-    return m_synth->channelPitch(chan, val);
+    return m_synth->midiChannelPitch(chan, val);
 }
 
 // IAudioSource
@@ -139,20 +139,20 @@ void SanitySynthesizer::setSampleRate(unsigned int sampleRate)
     m_synth->setSampleRate(sampleRate);
 }
 
-unsigned int SanitySynthesizer::streamCount() const
+unsigned int SanitySynthesizer::audioChannelsCount() const
 {
     ONLY_AUDIO_WORKER_THREAD;
-    return m_synth->streamCount();
+    return m_synth->audioChannelsCount();
 }
 
-async::Channel<unsigned int> SanitySynthesizer::streamsCountChanged() const
+async::Channel<unsigned int> SanitySynthesizer::audioChannelsCountChanged() const
 {
     ONLY_AUDIO_WORKER_THREAD;
-    return m_synth->streamsCountChanged();
+    return m_synth->audioChannelsCountChanged();
 }
 
 void SanitySynthesizer::process(float* buffer, unsigned int sampleCount)
 {
     ONLY_AUDIO_WORKER_THREAD;
-    m_synth->forward(buffer, sampleCount);
+    m_synth->process(buffer, sampleCount);
 }

--- a/src/framework/audio/internal/synthesizers/sanitysynthesizer.h
+++ b/src/framework/audio/internal/synthesizers/sanitysynthesizer.h
@@ -42,21 +42,21 @@ public:
     bool isActive() const override;
     void setIsActive(bool arg) override;
 
-    Ret setupChannels(const std::vector<midi::Event>& events) override;
+    Ret setupMidiChannels(const std::vector<midi::Event>& events) override;
     bool handleEvent(const midi::Event& e) override;
     void writeBuf(float* stream, unsigned int samples) override;
 
     void allSoundsOff() override;  // all channels
     void flushSound() override;
-    void channelSoundsOff(midi::channel_t chan) override;
-    bool channelVolume(midi::channel_t chan, float val) override;   // 0. - 1.
-    bool channelBalance(midi::channel_t chan, float val) override;  // -1. - 1.
-    bool channelPitch(midi::channel_t chan, int16_t val) override;  // -12 - 12
+    void midiChannelSoundsOff(midi::channel_t chan) override;
+    bool midiChannelVolume(midi::channel_t chan, float val) override;   // 0. - 1.
+    bool midiChannelBalance(midi::channel_t chan, float val) override;  // -1. - 1.
+    bool midiChannelPitch(midi::channel_t chan, int16_t val) override;  // -12 - 12
 
     // IAudioSource
     void setSampleRate(unsigned int sampleRate) override;
-    unsigned int streamCount() const override;
-    async::Channel<unsigned int> streamsCountChanged() const override;
+    unsigned int audioChannelsCount() const override;
+    async::Channel<unsigned int> audioChannelsCountChanged() const override;
     void process(float* buffer, unsigned int sampleCount) override;
 
 private:

--- a/src/framework/audio/internal/synthesizers/sanitysynthesizer.h
+++ b/src/framework/audio/internal/synthesizers/sanitysynthesizer.h
@@ -57,9 +57,7 @@ public:
     void setSampleRate(unsigned int sampleRate) override;
     unsigned int streamCount() const override;
     async::Channel<unsigned int> streamsCountChanged() const override;
-    void forward(unsigned int sampleCount) override;
-    const float* data() const override;
-    void setBufferSize(unsigned int samples) override;
+    void forward(float* buffer, unsigned int sampleCount) override;
 
 private:
 

--- a/src/framework/audio/internal/synthesizers/sanitysynthesizer.h
+++ b/src/framework/audio/internal/synthesizers/sanitysynthesizer.h
@@ -57,7 +57,7 @@ public:
     void setSampleRate(unsigned int sampleRate) override;
     unsigned int streamCount() const override;
     async::Channel<unsigned int> streamsCountChanged() const override;
-    void forward(float* buffer, unsigned int sampleCount) override;
+    void process(float* buffer, unsigned int sampleCount) override;
 
 private:
 

--- a/src/framework/audio/internal/synthesizers/zerberus/zerberussynth.cpp
+++ b/src/framework/audio/internal/synthesizers/zerberus/zerberussynth.cpp
@@ -272,7 +272,7 @@ unsigned int ZerberusSynth::streamCount() const
     return synth::AUDIO_CHANNELS;
 }
 
-void ZerberusSynth::forward(float* buffer, unsigned int sampleCount)
+void ZerberusSynth::process(float* buffer, unsigned int sampleCount)
 {
     writeBuf(buffer, sampleCount);
 }

--- a/src/framework/audio/internal/synthesizers/zerberus/zerberussynth.cpp
+++ b/src/framework/audio/internal/synthesizers/zerberus/zerberussynth.cpp
@@ -272,26 +272,12 @@ unsigned int ZerberusSynth::streamCount() const
     return synth::AUDIO_CHANNELS;
 }
 
-void ZerberusSynth::forward(unsigned int sampleCount)
+void ZerberusSynth::forward(float* buffer, unsigned int sampleCount)
 {
-    writeBuf(m_buffer.data(), sampleCount);
+    writeBuf(buffer, sampleCount);
 }
 
 async::Channel<unsigned int> ZerberusSynth::streamsCountChanged() const
 {
     return m_streamsCountChanged;
-}
-
-const float* ZerberusSynth::data() const
-{
-    return m_buffer.data();
-}
-
-void ZerberusSynth::setBufferSize(unsigned int samples)
-{
-    auto sc = streamCount();
-    auto targetSize = samples * sc;
-    if (targetSize > 0 && m_buffer.size() < targetSize) {
-        m_buffer.resize(samples * streamCount());
-    }
 }

--- a/src/framework/audio/internal/synthesizers/zerberus/zerberussynth.cpp
+++ b/src/framework/audio/internal/synthesizers/zerberus/zerberussynth.cpp
@@ -119,7 +119,7 @@ Ret ZerberusSynth::removeSoundFonts()
     return ok ? make_ret(Err::NoError) : make_ret(Err::SoundFontFailedUnload);
 }
 
-Ret ZerberusSynth::setupChannels(const std::vector<Event>& events)
+Ret ZerberusSynth::setupMidiChannels(const std::vector<Event>& events)
 {
     IF_ASSERT_FAILED(m_zerb) {
         return make_ret(Err::SynthNotInited);
@@ -206,7 +206,7 @@ void ZerberusSynth::flushSound()
     m_zerb->process(samples, m_preallocated.data(), nullptr, nullptr);
 }
 
-void ZerberusSynth::channelSoundsOff(channel_t chan)
+void ZerberusSynth::midiChannelSoundsOff(channel_t chan)
 {
     IF_ASSERT_FAILED(m_zerb) {
         return;
@@ -215,7 +215,7 @@ void ZerberusSynth::channelSoundsOff(channel_t chan)
     m_zerb->allSoundsOff(chan);
 }
 
-bool ZerberusSynth::channelVolume(channel_t chan, float volume)
+bool ZerberusSynth::midiChannelVolume(channel_t chan, float volume)
 {
     int val = static_cast<int>(volume * 100.f);
     val = std::clamp(val, 0, 127);
@@ -224,7 +224,7 @@ bool ZerberusSynth::channelVolume(channel_t chan, float volume)
     return false;
 }
 
-bool ZerberusSynth::channelBalance(channel_t chan, float val)
+bool ZerberusSynth::midiChannelBalance(channel_t chan, float val)
 {
     UNUSED(chan);
     UNUSED(val);
@@ -232,7 +232,7 @@ bool ZerberusSynth::channelBalance(channel_t chan, float val)
     return false;
 }
 
-bool ZerberusSynth::channelPitch(channel_t chan, int16_t pitch)
+bool ZerberusSynth::midiChannelPitch(channel_t chan, int16_t pitch)
 {
     UNUSED(chan);
     UNUSED(pitch);
@@ -267,7 +267,7 @@ void ZerberusSynth::writeBuf(float* stream, unsigned int samples)
     m_zerb->process(samples, stream, nullptr, nullptr);
 }
 
-unsigned int ZerberusSynth::streamCount() const
+unsigned int ZerberusSynth::audioChannelsCount() const
 {
     return synth::AUDIO_CHANNELS;
 }
@@ -277,7 +277,7 @@ void ZerberusSynth::process(float* buffer, unsigned int sampleCount)
     writeBuf(buffer, sampleCount);
 }
 
-async::Channel<unsigned int> ZerberusSynth::streamsCountChanged() const
+async::Channel<unsigned int> ZerberusSynth::audioChannelsCountChanged() const
 {
     return m_streamsCountChanged;
 }

--- a/src/framework/audio/internal/synthesizers/zerberus/zerberussynth.cpp
+++ b/src/framework/audio/internal/synthesizers/zerberus/zerberussynth.cpp
@@ -74,7 +74,7 @@ void ZerberusSynth::setSampleRate(unsigned int sampleRate)
     m_sampleRate = sampleRate;
     if (m_zerb) {
         m_zerb->setSampleRate(sampleRate);
-        m_preallocated.resize(int(sampleRate) * config()->requiredAudioChannelsCount(), 0);
+        m_preallocated.resize(int(sampleRate) * config()->audioChannelsCount(), 0);
     }
 }
 
@@ -269,7 +269,7 @@ void ZerberusSynth::writeBuf(float* stream, unsigned int samples)
 
 unsigned int ZerberusSynth::audioChannelsCount() const
 {
-    return config()->requiredAudioChannelsCount();
+    return config()->audioChannelsCount();
 }
 
 void ZerberusSynth::process(float* buffer, unsigned int sampleCount)

--- a/src/framework/audio/internal/synthesizers/zerberus/zerberussynth.cpp
+++ b/src/framework/audio/internal/synthesizers/zerberus/zerberussynth.cpp
@@ -74,7 +74,7 @@ void ZerberusSynth::setSampleRate(unsigned int sampleRate)
     m_sampleRate = sampleRate;
     if (m_zerb) {
         m_zerb->setSampleRate(sampleRate);
-        m_preallocated.resize(int(sampleRate) * AUDIO_CHANNELS, 0);
+        m_preallocated.resize(int(sampleRate) * config()->requiredAudioChannelsCount(), 0);
     }
 }
 
@@ -269,7 +269,7 @@ void ZerberusSynth::writeBuf(float* stream, unsigned int samples)
 
 unsigned int ZerberusSynth::audioChannelsCount() const
 {
-    return synth::AUDIO_CHANNELS;
+    return config()->requiredAudioChannelsCount();
 }
 
 void ZerberusSynth::process(float* buffer, unsigned int sampleCount)

--- a/src/framework/audio/internal/synthesizers/zerberus/zerberussynth.h
+++ b/src/framework/audio/internal/synthesizers/zerberus/zerberussynth.h
@@ -62,7 +62,7 @@ public:
     bool channelPitch(midi::channel_t chan, int16_t pitch) override; // -12 - 12
 
     unsigned int streamCount() const override;
-    void forward(float* buffer, unsigned int sampleCount) override;
+    void process(float* buffer, unsigned int sampleCount) override;
     async::Channel<unsigned int> streamsCountChanged() const override;
 
 private:

--- a/src/framework/audio/internal/synthesizers/zerberus/zerberussynth.h
+++ b/src/framework/audio/internal/synthesizers/zerberus/zerberussynth.h
@@ -22,7 +22,6 @@
 #ifndef MU_AUDIO_ZERBERUSSYNTH_H
 #define MU_AUDIO_ZERBERUSSYNTH_H
 
-
 #include "modularity/ioc.h"
 #include "iaudioconfiguration.h"
 

--- a/src/framework/audio/internal/synthesizers/zerberus/zerberussynth.h
+++ b/src/framework/audio/internal/synthesizers/zerberus/zerberussynth.h
@@ -62,10 +62,8 @@ public:
     bool channelPitch(midi::channel_t chan, int16_t pitch) override; // -12 - 12
 
     unsigned int streamCount() const override;
-    void forward(unsigned int sampleCount) override;
+    void forward(float* buffer, unsigned int sampleCount) override;
     async::Channel<unsigned int> streamsCountChanged() const override;
-    const float* data() const override;
-    void setBufferSize(unsigned int samples) override;
 
 private:
 
@@ -75,7 +73,6 @@ private:
     bool m_isActive = false;
 
     unsigned int m_sampleRate = 1;
-    std::vector<float> m_buffer = {};
     async::Channel<unsigned int> m_streamsCountChanged;
 };
 }

--- a/src/framework/audio/internal/synthesizers/zerberus/zerberussynth.h
+++ b/src/framework/audio/internal/synthesizers/zerberus/zerberussynth.h
@@ -22,6 +22,10 @@
 #ifndef MU_AUDIO_ZERBERUSSYNTH_H
 #define MU_AUDIO_ZERBERUSSYNTH_H
 
+
+#include "modularity/ioc.h"
+#include "iaudioconfiguration.h"
+
 #include "isynthesizer.h"
 
 namespace mu::zerberus {
@@ -31,6 +35,8 @@ class Zerberus;
 namespace mu::audio::synth {
 class ZerberusSynth : public ISynthesizer
 {
+    INJECT(audio, IAudioConfiguration, config)
+
 public:
 
     ZerberusSynth();

--- a/src/framework/audio/internal/synthesizers/zerberus/zerberussynth.h
+++ b/src/framework/audio/internal/synthesizers/zerberus/zerberussynth.h
@@ -49,21 +49,21 @@ public:
     bool isActive() const override;
     void setIsActive(bool arg) override;
 
-    Ret setupChannels(const std::vector<midi::Event>& events) override;
+    Ret setupMidiChannels(const std::vector<midi::Event>& events) override;
     bool handleEvent(const midi::Event& e) override;
     void writeBuf(float* stream, unsigned int samples) override;
 
     void allSoundsOff() override; // all channels
     void flushSound() override;
 
-    void channelSoundsOff(midi::channel_t chan) override;
-    bool channelVolume(midi::channel_t chan, float val) override;  // 0. - 1.
-    bool channelBalance(midi::channel_t chan, float val) override; // -1. - 1.
-    bool channelPitch(midi::channel_t chan, int16_t pitch) override; // -12 - 12
+    void midiChannelSoundsOff(midi::channel_t chan) override;
+    bool midiChannelVolume(midi::channel_t chan, float val) override;  // 0. - 1.
+    bool midiChannelBalance(midi::channel_t chan, float val) override; // -1. - 1.
+    bool midiChannelPitch(midi::channel_t chan, int16_t pitch) override; // -12 - 12
 
-    unsigned int streamCount() const override;
+    unsigned int audioChannelsCount() const override;
     void process(float* buffer, unsigned int sampleCount) override;
-    async::Channel<unsigned int> streamsCountChanged() const override;
+    async::Channel<unsigned int> audioChannelsCountChanged() const override;
 
 private:
 

--- a/src/framework/audio/internal/worker/abstractaudiosource.cpp
+++ b/src/framework/audio/internal/worker/abstractaudiosource.cpp
@@ -28,7 +28,7 @@ void AbstractAudioSource::setSampleRate(unsigned int sampleRate)
     m_sampleRate = sampleRate;
 }
 
-mu::async::Channel<unsigned int> AbstractAudioSource::streamsCountChanged() const
+mu::async::Channel<unsigned int> AbstractAudioSource::audioChannelsCountChanged() const
 {
     return m_streamsCountChanged;
 }

--- a/src/framework/audio/internal/worker/abstractaudiosource.cpp
+++ b/src/framework/audio/internal/worker/abstractaudiosource.cpp
@@ -32,17 +32,3 @@ mu::async::Channel<unsigned int> AbstractAudioSource::streamsCountChanged() cons
 {
     return m_streamsCountChanged;
 }
-
-const float* AbstractAudioSource::data() const
-{
-    return m_buffer.data();
-}
-
-void AbstractAudioSource::setBufferSize(unsigned int samples)
-{
-    auto sc = streamCount();
-    auto targetSize = samples * sc;
-    if (targetSize > 0 && m_buffer.size() < targetSize) {
-        m_buffer.resize(samples * streamCount());
-    }
-}

--- a/src/framework/audio/internal/worker/abstractaudiosource.h
+++ b/src/framework/audio/internal/worker/abstractaudiosource.h
@@ -32,7 +32,7 @@ public:
 
     virtual void setSampleRate(unsigned int sampleRate) override;
 
-    mu::async::Channel<unsigned int> streamsCountChanged() const override;
+    mu::async::Channel<unsigned int> audioChannelsCountChanged() const override;
 
 protected:
     unsigned int m_sampleRate = 1;

--- a/src/framework/audio/internal/worker/abstractaudiosource.h
+++ b/src/framework/audio/internal/worker/abstractaudiosource.h
@@ -33,12 +33,9 @@ public:
     virtual void setSampleRate(unsigned int sampleRate) override;
 
     mu::async::Channel<unsigned int> streamsCountChanged() const override;
-    const float* data() const override;
-    virtual void setBufferSize(unsigned int samples) override;
 
 protected:
     unsigned int m_sampleRate = 1;
-    std::vector<float> m_buffer = {};
     async::Channel<unsigned int> m_streamsCountChanged;
 };
 }

--- a/src/framework/audio/internal/worker/audioplayer.cpp
+++ b/src/framework/audio/internal/worker/audioplayer.cpp
@@ -63,7 +63,7 @@ mu::Ret AudioPlayer::load(const std::shared_ptr<IAudioStream>& stream)
     setStatus(Stoped);
     m_position = 0;
     m_stream = stream;
-    m_streamsCountChanged.send(streamCount());
+    m_streamsCountChanged.send(audioChannelsCount());
 
     return Ret(Ret::Code::Ok);
 }
@@ -117,7 +117,7 @@ void AudioPlayer::forwardTime(unsigned long milliseconds)
     //here can be placed methods for preparing automatization
 }
 
-unsigned int AudioPlayer::streamCount() const
+unsigned int AudioPlayer::audioChannelsCount() const
 {
     if (m_stream) {
         return m_stream->channelsCount();

--- a/src/framework/audio/internal/worker/audioplayer.cpp
+++ b/src/framework/audio/internal/worker/audioplayer.cpp
@@ -125,7 +125,7 @@ unsigned int AudioPlayer::streamCount() const
     return 0;
 }
 
-void AudioPlayer::forward(float* buffer, unsigned int sampleCount)
+void AudioPlayer::process(float* buffer, unsigned int sampleCount)
 {
     //copy shared_ptr in case it can be changed during forward
     auto stream = m_stream;

--- a/src/framework/audio/internal/worker/audioplayer.cpp
+++ b/src/framework/audio/internal/worker/audioplayer.cpp
@@ -125,20 +125,19 @@ unsigned int AudioPlayer::streamCount() const
     return 0;
 }
 
-void AudioPlayer::forward(unsigned int sampleCount)
+void AudioPlayer::forward(float* buffer, unsigned int sampleCount)
 {
     //copy shared_ptr in case it can be changed during forward
     auto stream = m_stream;
     if (!stream) {
         return;
     }
-    std::fill(m_buffer.begin() + 0, m_buffer.end(), 0.f);
 
     if (status() != Running) {
         return;
     }
 
-    auto displacement = stream->copySamplesToBuffer(m_buffer.data(), m_position, sampleCount, m_sampleRate);
+    auto displacement = stream->copySamplesToBuffer(buffer, m_position, sampleCount, m_sampleRate);
     m_position += displacement;
 
     if (!displacement) {

--- a/src/framework/audio/internal/worker/audioplayer.h
+++ b/src/framework/audio/internal/worker/audioplayer.h
@@ -52,7 +52,7 @@ public:
 
     // IAudioSource (AbstractAudioSource)
     unsigned int streamCount() const override;
-    void forward(unsigned int sampleCount) override;
+    void forward(float* buffer, unsigned int sampleCount) override;
 
 private:
     void setStatus(const Status& status);

--- a/src/framework/audio/internal/worker/audioplayer.h
+++ b/src/framework/audio/internal/worker/audioplayer.h
@@ -52,7 +52,7 @@ public:
 
     // IAudioSource (AbstractAudioSource)
     unsigned int streamCount() const override;
-    void forward(float* buffer, unsigned int sampleCount) override;
+    void process(float* buffer, unsigned int sampleCount) override;
 
 private:
     void setStatus(const Status& status);

--- a/src/framework/audio/internal/worker/audioplayer.h
+++ b/src/framework/audio/internal/worker/audioplayer.h
@@ -51,7 +51,7 @@ public:
     IAudioSourcePtr audioSource() override;
 
     // IAudioSource (AbstractAudioSource)
-    unsigned int streamCount() const override;
+    unsigned int audioChannelsCount() const override;
     void process(float* buffer, unsigned int sampleCount) override;
 
 private:

--- a/src/framework/audio/internal/worker/midiplayer.cpp
+++ b/src/framework/audio/internal/worker/midiplayer.cpp
@@ -123,7 +123,7 @@ void MIDIPlayer::setupChannels()
     }
 
     for (const SynthState& st : m_synthStates) {
-        st.synth->setupChannels(m_midiData.initEventsForChannels(st.channels));
+        st.synth->setupMidiChannels(m_midiData.initEventsForChannels(st.channels));
     }
 }
 
@@ -500,7 +500,7 @@ void MIDIPlayer::setIsTrackMuted(track_t trackIndex, bool mute)
     auto setMuted = [this, mute](channel_t ch) {
         ChanState& state = m_chanStates[ch];
         state.muted = mute;
-        synth(ch)->channelSoundsOff(ch);
+        synth(ch)->midiChannelSoundsOff(ch);
     };
 
     const Track& track = m_midiData.tracks[trackIndex];
@@ -518,7 +518,7 @@ void MIDIPlayer::setTrackVolume(track_t trackIndex, float volume)
 
     const Track& track = m_midiData.tracks[trackIndex];
     for (channel_t ch : track.channels) {
-        synth(ch)->channelVolume(ch, volume);
+        synth(ch)->midiChannelVolume(ch, volume);
     }
 }
 
@@ -531,6 +531,6 @@ void MIDIPlayer::setTrackBalance(track_t trackIndex, float balance)
 
     const Track& track = m_midiData.tracks[trackIndex];
     for (channel_t ch : track.channels) {
-        synth(ch)->channelBalance(ch, balance);
+        synth(ch)->midiChannelBalance(ch, balance);
     }
 }

--- a/src/framework/audio/internal/worker/mixer.cpp
+++ b/src/framework/audio/internal/worker/mixer.cpp
@@ -155,7 +155,7 @@ std::shared_ptr<IMixerChannel> Mixer::channel(unsigned int number) const
     return m_inputList.at(number);
 }
 
-void Mixer::forward(float* buffer, unsigned int sampleCount)
+void Mixer::process(float* buffer, unsigned int sampleCount)
 {
     ONLY_AUDIO_WORKER_THREAD;
 

--- a/src/framework/audio/internal/worker/mixer.h
+++ b/src/framework/audio/internal/worker/mixer.h
@@ -60,7 +60,7 @@ public:
 
     unsigned int audioChannelsCount() const override;
 
-    void process(float* buffer, unsigned int sampleCount) override;
+    void process(float* outBuffer, unsigned int samplesPerChannel) override;
 
     // Self
 
@@ -68,11 +68,13 @@ public:
 
 private:
     //! mix the channel in to the buffer
-    void mixinChannel(float* buffer, std::shared_ptr<MixerChannel> channel, unsigned int samplesCount);
-    void mixinChannelStream(float* buffer, std::shared_ptr<MixerChannel> channel, unsigned int streamId, unsigned int samplesCount);
+    void mixinChannel(float* outBuffer, float* inBuffer, std::shared_ptr<MixerChannel> channel, unsigned int samplesCount);
+    void mixinChannelStream(float* outBuffer, float* inBuffer, std::shared_ptr<MixerChannel> channel, unsigned int streamId,
+                            unsigned int samplesCount);
 
     Mode m_mode = STEREO;
     float m_masterLevel = 1.f;
+    std::vector<float> m_writeCacheBuff;
     std::map<ChannelID, std::shared_ptr<MixerChannel> > m_inputList = {};
     std::map<unsigned int, std::shared_ptr<IAudioProcessor> > m_insertList = {};
     std::shared_ptr<Clock> m_clock;

--- a/src/framework/audio/internal/worker/mixer.h
+++ b/src/framework/audio/internal/worker/mixer.h
@@ -58,7 +58,7 @@ public:
     // IAudioSource (AbstractAudioSource)
     void setSampleRate(unsigned int sampleRate) override;
 
-    unsigned int streamCount() const override;
+    unsigned int audioChannelsCount() const override;
 
     void process(float* buffer, unsigned int sampleCount) override;
 

--- a/src/framework/audio/internal/worker/mixer.h
+++ b/src/framework/audio/internal/worker/mixer.h
@@ -68,8 +68,8 @@ public:
 
 private:
     //! mix the channel in to the buffer
-    void mixinChannel(float *buffer, std::shared_ptr<MixerChannel> channel, unsigned int samplesCount);
-    void mixinChannelStream(float *buffer, std::shared_ptr<MixerChannel> channel, unsigned int streamId, unsigned int samplesCount);
+    void mixinChannel(float* buffer, std::shared_ptr<MixerChannel> channel, unsigned int samplesCount);
+    void mixinChannelStream(float* buffer, std::shared_ptr<MixerChannel> channel, unsigned int streamId, unsigned int samplesCount);
 
     Mode m_mode = STEREO;
     float m_masterLevel = 1.f;

--- a/src/framework/audio/internal/worker/mixer.h
+++ b/src/framework/audio/internal/worker/mixer.h
@@ -60,7 +60,7 @@ public:
 
     unsigned int streamCount() const override;
 
-    void forward(float* buffer, unsigned int sampleCount) override;
+    void process(float* buffer, unsigned int sampleCount) override;
 
     // Self
 

--- a/src/framework/audio/internal/worker/mixer.h
+++ b/src/framework/audio/internal/worker/mixer.h
@@ -60,9 +60,7 @@ public:
 
     unsigned int streamCount() const override;
 
-    void forward(unsigned int sampleCount) override;
-
-    void setBufferSize(unsigned int samples) override;
+    void forward(float* buffer, unsigned int sampleCount) override;
 
     // Self
 
@@ -70,8 +68,8 @@ public:
 
 private:
     //! mix the channel in to the buffer
-    void mixinChannel(std::shared_ptr<MixerChannel> channel, unsigned int samplesCount);
-    void mixinChannelStream(std::shared_ptr<MixerChannel> channel, unsigned int streamId, unsigned int samplesCount);
+    void mixinChannel(float *buffer, std::shared_ptr<MixerChannel> channel, unsigned int samplesCount);
+    void mixinChannelStream(float *buffer, std::shared_ptr<MixerChannel> channel, unsigned int streamId, unsigned int samplesCount);
 
     Mode m_mode = STEREO;
     float m_masterLevel = 1.f;

--- a/src/framework/audio/internal/worker/mixerchannel.cpp
+++ b/src/framework/audio/internal/worker/mixerchannel.cpp
@@ -30,17 +30,17 @@ MixerChannel::MixerChannel()
 {
 }
 
-unsigned int MixerChannel::streamCount() const
+unsigned int MixerChannel::audioChannelsCount() const
 {
     IF_ASSERT_FAILED(m_source) {
         return 0;
     }
-    return m_source->streamCount();
+    return m_source->audioChannelsCount();
 }
 
 void MixerChannel::checkStreams()
 {
-    if (streamCount() != m_level.size()) {
+    if (audioChannelsCount() != m_level.size()) {
         updateBalanceLevelMaps();
     }
 }
@@ -75,7 +75,7 @@ void MixerChannel::setSource(std::shared_ptr<IAudioSource> source)
 {
     m_source = source;
     updateBalanceLevelMaps();
-    m_source->streamsCountChanged().onReceive(this, [this](unsigned int) {
+    m_source->audioChannelsCountChanged().onReceive(this, [this](unsigned int) {
         updateBalanceLevelMaps();
     });
     setActive(true);
@@ -141,7 +141,7 @@ IAudioProcessorPtr MixerChannel::processor(unsigned int number) const
 
 void MixerChannel::setProcessor(unsigned int number, IAudioProcessorPtr proc)
 {
-    IF_ASSERT_FAILED(proc->streamCount() == streamCount()) {
+    IF_ASSERT_FAILED(proc->streamCount() == audioChannelsCount()) {
         LOGE() << "Processor's stream count not equal to the channel";
         return;
     }
@@ -151,11 +151,11 @@ void MixerChannel::setProcessor(unsigned int number, IAudioProcessorPtr proc)
 
 void MixerChannel::updateBalanceLevelMaps()
 {
-    for (unsigned int c = 0; c < m_source->streamCount(); ++c) {
+    for (unsigned int c = 0; c < m_source->audioChannelsCount(); ++c) {
         m_level[c] = 1.f;
 
-        if (m_source->streamCount() > 1) {
-            m_balance[c] = 2.f * c / (m_source->streamCount() - 1) - 1.f;
+        if (m_source->audioChannelsCount() > 1) {
+            m_balance[c] = 2.f * c / (m_source->audioChannelsCount() - 1) - 1.f;
         } else {
             m_balance[c] = 0.f;
         }

--- a/src/framework/audio/internal/worker/mixerchannel.cpp
+++ b/src/framework/audio/internal/worker/mixerchannel.cpp
@@ -45,12 +45,12 @@ void MixerChannel::checkStreams()
     }
 }
 
-void MixerChannel::forward(float* buffer, unsigned int sampleCount)
+void MixerChannel::process(float* buffer, unsigned int sampleCount)
 {
     IF_ASSERT_FAILED(m_source) {
         return;
     }
-    m_source->forward(buffer, sampleCount);
+    m_source->process(buffer, sampleCount);
 
     for (std::pair<const unsigned int, IAudioProcessorPtr>& p : m_processorList) {
         if (p.second->active()) {

--- a/src/framework/audio/internal/worker/mixerchannel.cpp
+++ b/src/framework/audio/internal/worker/mixerchannel.cpp
@@ -45,30 +45,18 @@ void MixerChannel::checkStreams()
     }
 }
 
-void MixerChannel::forward(unsigned int sampleCount)
+void MixerChannel::forward(float* buffer, unsigned int sampleCount)
 {
     IF_ASSERT_FAILED(m_source) {
         return;
     }
-    m_source->forward(sampleCount);
-
-    //you can use source's buffer as pre proccesing KEY, current buffer as post processing KEY
-    std::memcpy(m_buffer.data(), m_source->data(), m_buffer.size() * sizeof(float));
+    m_source->forward(buffer, sampleCount);
 
     for (std::pair<const unsigned int, IAudioProcessorPtr>& p : m_processorList) {
         if (p.second->active()) {
-            p.second->process(m_buffer.data(), m_buffer.data(), sampleCount);
+            p.second->process(buffer, buffer, sampleCount);
         }
     }
-}
-
-void MixerChannel::setBufferSize(unsigned int samples)
-{
-    AbstractAudioSource::setBufferSize(samples);
-    IF_ASSERT_FAILED(m_source) {
-        return;
-    }
-    m_source->setBufferSize(samples);
 }
 
 void MixerChannel::setSampleRate(unsigned int sampleRate)

--- a/src/framework/audio/internal/worker/mixerchannel.h
+++ b/src/framework/audio/internal/worker/mixerchannel.h
@@ -37,7 +37,7 @@ class MixerChannel : public IMixerChannel, public AbstractAudioSource, public as
 public:
     MixerChannel();
 
-    unsigned int streamCount() const override;
+    unsigned int audioChannelsCount() const override;
     void checkStreams();
     void process(float* buffer, unsigned int sampleCount) override;
     void setSampleRate(unsigned int sampleRate) override;

--- a/src/framework/audio/internal/worker/mixerchannel.h
+++ b/src/framework/audio/internal/worker/mixerchannel.h
@@ -39,7 +39,7 @@ public:
 
     unsigned int streamCount() const override;
     void checkStreams();
-    void forward(float* buffer, unsigned int sampleCount) override;
+    void process(float* buffer, unsigned int sampleCount) override;
     void setSampleRate(unsigned int sampleRate) override;
 
     void setSource(std::shared_ptr<IAudioSource> source) override;

--- a/src/framework/audio/internal/worker/mixerchannel.h
+++ b/src/framework/audio/internal/worker/mixerchannel.h
@@ -39,8 +39,7 @@ public:
 
     unsigned int streamCount() const override;
     void checkStreams();
-    void forward(unsigned int sampleCount) override;
-    void setBufferSize(unsigned int samples) override;
+    void forward(float* buffer, unsigned int sampleCount) override;
     void setSampleRate(unsigned int sampleRate) override;
 
     void setSource(std::shared_ptr<IAudioSource> source) override;

--- a/src/framework/audio/internal/worker/noisesource.cpp
+++ b/src/framework/audio/internal/worker/noisesource.cpp
@@ -37,7 +37,7 @@ unsigned int NoiseSource::streamCount() const
     return 1;
 }
 
-void NoiseSource::forward(float* buffer, unsigned int sampleCount)
+void NoiseSource::process(float* buffer, unsigned int sampleCount)
 {
     auto streams = streamCount();
     std::uniform_real_distribution<float> distribution{ -1.f, 1.f };

--- a/src/framework/audio/internal/worker/noisesource.cpp
+++ b/src/framework/audio/internal/worker/noisesource.cpp
@@ -32,14 +32,14 @@ void NoiseSource::setType(NoiseSource::Type type)
     m_type = type;
 }
 
-unsigned int NoiseSource::streamCount() const
+unsigned int NoiseSource::audioChannelsCount() const
 {
     return 1;
 }
 
 void NoiseSource::process(float* buffer, unsigned int sampleCount)
 {
-    auto streams = streamCount();
+    auto streams = audioChannelsCount();
     std::uniform_real_distribution<float> distribution{ -1.f, 1.f };
     std::random_device randomDevice{};
     std::mt19937 gen{ randomDevice() };

--- a/src/framework/audio/internal/worker/noisesource.cpp
+++ b/src/framework/audio/internal/worker/noisesource.cpp
@@ -37,7 +37,7 @@ unsigned int NoiseSource::streamCount() const
     return 1;
 }
 
-void NoiseSource::forward(unsigned int sampleCount)
+void NoiseSource::forward(float* buffer, unsigned int sampleCount)
 {
     auto streams = streamCount();
     std::uniform_real_distribution<float> distribution{ -1.f, 1.f };
@@ -52,7 +52,7 @@ void NoiseSource::forward(unsigned int sampleCount)
         default: break;
         }
         for (unsigned int s = 0; s < streams; ++s) {
-            m_buffer[streams * i + s] = sample;
+            buffer[streams * i + s] = sample;
         }
     }
 }

--- a/src/framework/audio/internal/worker/noisesource.h
+++ b/src/framework/audio/internal/worker/noisesource.h
@@ -38,7 +38,7 @@ public:
     void setType(Type type);
     unsigned int streamCount() const override;
 
-    void forward(float* buffer, unsigned int sampleCount) override;
+    void process(float* buffer, unsigned int sampleCount) override;
 
 private:
     float pinkFilter(float white);

--- a/src/framework/audio/internal/worker/noisesource.h
+++ b/src/framework/audio/internal/worker/noisesource.h
@@ -36,7 +36,7 @@ public:
     NoiseSource();
 
     void setType(Type type);
-    unsigned int streamCount() const override;
+    unsigned int audioChannelsCount() const override;
 
     void process(float* buffer, unsigned int sampleCount) override;
 

--- a/src/framework/audio/internal/worker/noisesource.h
+++ b/src/framework/audio/internal/worker/noisesource.h
@@ -38,7 +38,7 @@ public:
     void setType(Type type);
     unsigned int streamCount() const override;
 
-    void forward(unsigned int sampleCount) override;
+    void forward(float* buffer, unsigned int sampleCount) override;
 
 private:
     float pinkFilter(float white);

--- a/src/framework/audio/internal/worker/sinesource.cpp
+++ b/src/framework/audio/internal/worker/sinesource.cpp
@@ -28,14 +28,14 @@ SineSource::SineSource()
 {
 }
 
-unsigned int SineSource::streamCount() const
+unsigned int SineSource::audioChannelsCount() const
 {
     return 1;
 }
 
 void SineSource::process(float* buffer, unsigned int sampleCount)
 {
-    auto streams = streamCount();
+    auto streams = audioChannelsCount();
     for (unsigned int i = 0; i < sampleCount; ++i) {
         m_phase += m_frequency / m_sampleRate * 2 * M_PI;
         if (m_phase > 2 * M_PI) {

--- a/src/framework/audio/internal/worker/sinesource.cpp
+++ b/src/framework/audio/internal/worker/sinesource.cpp
@@ -33,7 +33,7 @@ unsigned int SineSource::streamCount() const
     return 1;
 }
 
-void SineSource::forward(float* buffer, unsigned int sampleCount)
+void SineSource::process(float* buffer, unsigned int sampleCount)
 {
     auto streams = streamCount();
     for (unsigned int i = 0; i < sampleCount; ++i) {

--- a/src/framework/audio/internal/worker/sinesource.cpp
+++ b/src/framework/audio/internal/worker/sinesource.cpp
@@ -33,7 +33,7 @@ unsigned int SineSource::streamCount() const
     return 1;
 }
 
-void SineSource::forward(unsigned int sampleCount)
+void SineSource::forward(float* buffer, unsigned int sampleCount)
 {
     auto streams = streamCount();
     for (unsigned int i = 0; i < sampleCount; ++i) {
@@ -43,7 +43,7 @@ void SineSource::forward(unsigned int sampleCount)
         }
 
         for (unsigned int s = 0; s < streams; ++s) {
-            m_buffer[streams * i + s] = 0.1 * std::sin(m_phase + s * 2 * M_PI / streams);
+            buffer[streams * i + s] = 0.1 * std::sin(m_phase + s * 2 * M_PI / streams);
         }
     }
 }

--- a/src/framework/audio/internal/worker/sinesource.h
+++ b/src/framework/audio/internal/worker/sinesource.h
@@ -33,7 +33,7 @@ public:
 
     unsigned int streamCount() const override;
 
-    void forward(float* buffer, unsigned int sampleCount) override;
+    void process(float* buffer, unsigned int sampleCount) override;
 
 private:
     float m_frequency = 1'000.f;

--- a/src/framework/audio/internal/worker/sinesource.h
+++ b/src/framework/audio/internal/worker/sinesource.h
@@ -33,7 +33,7 @@ public:
 
     unsigned int streamCount() const override;
 
-    void forward(unsigned int sampleCount) override;
+    void forward(float* buffer, unsigned int sampleCount) override;
 
 private:
     float m_frequency = 1'000.f;

--- a/src/framework/audio/internal/worker/sinesource.h
+++ b/src/framework/audio/internal/worker/sinesource.h
@@ -31,7 +31,7 @@ public:
     SineSource();
     ~SineSource() = default;
 
-    unsigned int streamCount() const override;
+    unsigned int audioChannelsCount() const override;
 
     void process(float* buffer, unsigned int sampleCount) override;
 

--- a/src/framework/audio/isynthesizer.h
+++ b/src/framework/audio/isynthesizer.h
@@ -47,16 +47,16 @@ public:
     virtual bool isActive() const = 0;
     virtual void setIsActive(bool arg) = 0;
 
-    virtual Ret setupChannels(const std::vector<midi::Event>& events) = 0;
+    virtual Ret setupMidiChannels(const std::vector<midi::Event>& events) = 0;
     virtual bool handleEvent(const midi::Event& e) = 0;
     virtual void writeBuf(float* stream, unsigned int samples) = 0;
 
     virtual void allSoundsOff() = 0; // all channels
     virtual void flushSound() = 0;
-    virtual void channelSoundsOff(midi::channel_t chan) = 0;
-    virtual bool channelVolume(midi::channel_t chan, float val) = 0;  // 0. - 1.
-    virtual bool channelBalance(midi::channel_t chan, float val) = 0; // -1. - 1.
-    virtual bool channelPitch(midi::channel_t chan, int16_t val) = 0; // -12 - 12
+    virtual void midiChannelSoundsOff(midi::channel_t chan) = 0;
+    virtual bool midiChannelVolume(midi::channel_t chan, float val) = 0;  // 0. - 1.
+    virtual bool midiChannelBalance(midi::channel_t chan, float val) = 0; // -1. - 1.
+    virtual bool midiChannelPitch(midi::channel_t chan, int16_t val) = 0; // -12 - 12
 };
 
 using ISynthesizerPtr = std::shared_ptr<ISynthesizer>;

--- a/src/framework/audio/synthtypes.h
+++ b/src/framework/audio/synthtypes.h
@@ -28,7 +28,6 @@
 #include "midi/miditypes.h"
 
 namespace mu::audio::synth {
-
 using SynthName = midi::SynthName;
 using SynthMap = midi::SynthMap;
 

--- a/src/framework/audio/synthtypes.h
+++ b/src/framework/audio/synthtypes.h
@@ -28,7 +28,6 @@
 #include "midi/miditypes.h"
 
 namespace mu::audio::synth {
-static const unsigned int AUDIO_CHANNELS = 2;
 
 using SynthName = midi::SynthName;
 using SynthMap = midi::SynthMap;

--- a/src/framework/ui/internal/themeconverter.cpp
+++ b/src/framework/ui/internal/themeconverter.cpp
@@ -74,8 +74,8 @@ static ThemeStyleKey themeStyleKeyFromString(const QString& str)
         }
     }
 
-    IF_ASSERT_FAILED_X(false, QString("not found enum key for string key: %1").arg(str)) {
-    }
+    /*IF_ASSERT_FAILED_X(false, QString("not found enum key for string key: %1").arg(str)) {
+    }*/
 
     return ThemeStyleKey::UNKNOWN;
 }

--- a/src/framework/vst/internal/synth/vstaudioclient.cpp
+++ b/src/framework/vst/internal/synth/vstaudioclient.cpp
@@ -142,10 +142,12 @@ void VstAudioClient::updateProcessSetup()
 
 void VstAudioClient::fillOutputBuffer(unsigned int samples, float* output)
 {
+    int audioChannels = config()->requiredAudioChannelsCount();
+
     for (unsigned int i = 0; i < samples; ++i) {
-        for (unsigned int s = 0; s < audio::synth::AUDIO_CHANNELS; ++s) {
+        for (unsigned int s = 0; s < audioChannels; ++s) {
             auto getFromChannel = std::min<unsigned int>(s, m_processData.outputs[0].numChannels - 1);
-            output[i * audio::synth::AUDIO_CHANNELS + s] = m_processData.outputs[0].channelBuffers32[getFromChannel][i];
+            output[i * audioChannels + s] = m_processData.outputs[0].channelBuffers32[getFromChannel][i];
         }
     }
 }

--- a/src/framework/vst/internal/synth/vstaudioclient.cpp
+++ b/src/framework/vst/internal/synth/vstaudioclient.cpp
@@ -142,7 +142,7 @@ void VstAudioClient::updateProcessSetup()
 
 void VstAudioClient::fillOutputBuffer(unsigned int samples, float* output)
 {
-    int audioChannels = config()->requiredAudioChannelsCount();
+    int audioChannels = config()->audioChannelsCount();
 
     for (unsigned int i = 0; i < samples; ++i) {
         for (unsigned int s = 0; s < audioChannels; ++s) {

--- a/src/framework/vst/internal/synth/vstaudioclient.cpp
+++ b/src/framework/vst/internal/synth/vstaudioclient.cpp
@@ -82,6 +82,10 @@ void VstAudioClient::process(float* output, unsigned int samples)
 
 void VstAudioClient::setBlockSize(unsigned int samples)
 {
+    if (m_samplesInfo.samplesPerBlock == samples) {
+        return;
+    }
+
     m_samplesInfo.samplesPerBlock = samples;
 
     updateProcessSetup();

--- a/src/framework/vst/internal/synth/vstaudioclient.h
+++ b/src/framework/vst/internal/synth/vstaudioclient.h
@@ -22,11 +22,16 @@
 #ifndef VSTAUDIOCLIENT_H
 #define VSTAUDIOCLIENT_H
 
+#include "modularity/ioc.h"
+#include "audio/iaudioconfiguration.h"
+
 #include "vsttypes.h"
 
 namespace mu::vst {
 class VstAudioClient
 {
+    INJECT(vst, audio::IAudioConfiguration, config)
+
 public:
     VstAudioClient() = default;
     ~VstAudioClient();

--- a/src/framework/vst/internal/synth/vstsynthesiser.cpp
+++ b/src/framework/vst/internal/synth/vstsynthesiser.cpp
@@ -114,30 +114,30 @@ void VstSynthesiser::flushSound()
     NOT_IMPLEMENTED;
 }
 
-Ret VstSynthesiser::setupChannels(const std::vector<midi::Event>& /*events*/)
+Ret VstSynthesiser::setupMidiChannels(const std::vector<midi::Event>& /*events*/)
 {
     NOT_IMPLEMENTED;
     return Ret(Ret::Code::Ok);
 }
 
-void VstSynthesiser::channelSoundsOff(midi::channel_t /*chan*/)
+void VstSynthesiser::midiChannelSoundsOff(midi::channel_t /*chan*/)
 {
     NOT_IMPLEMENTED;
 }
 
-bool VstSynthesiser::channelVolume(midi::channel_t /*chan*/, float /*val*/)
-{
-    NOT_IMPLEMENTED;
-    return true;
-}
-
-bool VstSynthesiser::channelBalance(midi::channel_t /*chan*/, float /*val*/)
+bool VstSynthesiser::midiChannelVolume(midi::channel_t /*chan*/, float /*val*/)
 {
     NOT_IMPLEMENTED;
     return true;
 }
 
-bool VstSynthesiser::channelPitch(midi::channel_t /*chan*/, int16_t /*val*/)
+bool VstSynthesiser::midiChannelBalance(midi::channel_t /*chan*/, float /*val*/)
+{
+    NOT_IMPLEMENTED;
+    return true;
+}
+
+bool VstSynthesiser::midiChannelPitch(midi::channel_t /*chan*/, int16_t /*val*/)
 {
     NOT_IMPLEMENTED;
     return true;
@@ -148,17 +148,17 @@ void VstSynthesiser::setSampleRate(unsigned int sampleRate)
     m_vstAudioClient->setSampleRate(sampleRate);
 }
 
-unsigned int VstSynthesiser::streamCount() const
+unsigned int VstSynthesiser::audioChannelsCount() const
 {
-    return audio::synth::AUDIO_CHANNELS;
+    return config()->requiredAudioChannelsCount();
 }
 
-async::Channel<unsigned int> VstSynthesiser::streamsCountChanged() const
+async::Channel<unsigned int> VstSynthesiser::audioChannelsCountChanged() const
 {
     return m_streamsCountChanged;
 }
 
-void VstSynthesiser::forward(float* buffer, unsigned int sampleCount)
+void VstSynthesiser::process(float* buffer, unsigned int sampleCount)
 {
     if (!buffer) {
         return;

--- a/src/framework/vst/internal/synth/vstsynthesiser.cpp
+++ b/src/framework/vst/internal/synth/vstsynthesiser.cpp
@@ -158,27 +158,13 @@ async::Channel<unsigned int> VstSynthesiser::streamsCountChanged() const
     return m_streamsCountChanged;
 }
 
-void VstSynthesiser::forward(unsigned int sampleCount)
+void VstSynthesiser::forward(float* buffer, unsigned int sampleCount)
 {
-    writeBuf(m_buffer.data(), sampleCount);
-}
-
-const float* VstSynthesiser::data() const
-{
-    return m_buffer.data();
-}
-
-void VstSynthesiser::setBufferSize(unsigned int samples)
-{
-    LOGI() << "SET BUFFER SIZE = " << samples;
-
-    unsigned int newSize = samples * streamCount();
-
-    if (newSize == 0 || m_buffer.size() == newSize) {
+    if (!buffer) {
         return;
     }
 
-    m_buffer.resize(newSize);
+    m_vstAudioClient->setBlockSize(sampleCount);
 
-    m_vstAudioClient->setBlockSize(samples);
+    writeBuf(buffer, sampleCount);
 }

--- a/src/framework/vst/internal/synth/vstsynthesiser.cpp
+++ b/src/framework/vst/internal/synth/vstsynthesiser.cpp
@@ -150,7 +150,7 @@ void VstSynthesiser::setSampleRate(unsigned int sampleRate)
 
 unsigned int VstSynthesiser::audioChannelsCount() const
 {
-    return config()->requiredAudioChannelsCount();
+    return config()->audioChannelsCount();
 }
 
 async::Channel<unsigned int> VstSynthesiser::audioChannelsCountChanged() const

--- a/src/framework/vst/internal/synth/vstsynthesiser.h
+++ b/src/framework/vst/internal/synth/vstsynthesiser.h
@@ -65,9 +65,7 @@ public:
     void setSampleRate(unsigned int sampleRate) override;
     unsigned int streamCount() const override;
     async::Channel<unsigned int> streamsCountChanged() const override;
-    void forward(unsigned int sampleCount) override;
-    const float* data() const override;
-    void setBufferSize(unsigned int samples) override;
+    void forward(float* buffer, unsigned int sampleCount) override;
 
 private:
 
@@ -77,8 +75,6 @@ private:
     std::unique_ptr<VstAudioClient> m_vstAudioClient = nullptr;
 
     bool m_isActive = false;
-
-    std::vector<float> m_buffer;
 
     async::Channel<unsigned int> m_streamsCountChanged;
 };

--- a/src/framework/vst/internal/synth/vstsynthesiser.h
+++ b/src/framework/vst/internal/synth/vstsynthesiser.h
@@ -24,6 +24,7 @@
 #define MU_VST_VSTSYNTHESISER_H
 
 #include "audio/isynthesizer.h"
+#include "audio/iaudioconfiguration.h"
 #include "modularity/ioc.h"
 
 #include "vsttypes.h"
@@ -34,6 +35,7 @@ namespace mu::vst {
 class VstSynthesiser : public audio::synth::ISynthesizer
 {
     INJECT(vst, IVstPluginRepository, repository)
+    INJECT(vst, audio::IAudioConfiguration, config)
 
 public:
     explicit VstSynthesiser(const VstPluginMeta& meta);
@@ -55,17 +57,17 @@ public:
     void allSoundsOff() override;
     void flushSound() override;
 
-    Ret setupChannels(const std::vector<midi::Event>& events) override;
-    void channelSoundsOff(midi::channel_t chan) override;
-    bool channelVolume(midi::channel_t chan, float val) override;
-    bool channelBalance(midi::channel_t chan, float val) override;
-    bool channelPitch(midi::channel_t chan, int16_t val) override;
+    Ret setupMidiChannels(const std::vector<midi::Event>& events) override;
+    void midiChannelSoundsOff(midi::channel_t chan) override;
+    bool midiChannelVolume(midi::channel_t chan, float val) override;
+    bool midiChannelBalance(midi::channel_t chan, float val) override;
+    bool midiChannelPitch(midi::channel_t chan, int16_t val) override;
 
     // IAudioSource
     void setSampleRate(unsigned int sampleRate) override;
-    unsigned int streamCount() const override;
-    async::Channel<unsigned int> streamsCountChanged() const override;
-    void forward(float* buffer, unsigned int sampleCount) override;
+    unsigned int audioChannelsCount() const override;
+    async::Channel<unsigned int> audioChannelsCountChanged() const override;
+    void process(float* buffer, unsigned int sampleCount) override;
 
 private:
 


### PR DESCRIPTION
An attempt to reduce data copying and reduce memory usage in the audio engine. For some reason, we have an inexplicably large number of buffers (about 5)

Important note: this PR shouldn't be merged before - https://github.com/musescore/MuseScore/pull/7944
