### PR TITLE
[MU3] Fix #319079: Shift Selecting Last Word

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3278,7 +3278,7 @@ void Score::selectRange(Element* e, int staffIdx)
                         Segment* s2 = tick2segmentMM(t2, true, SegmentType::ChordRest);
                         if (s2)
                               s2 = s2->next1MM(SegmentType::ChordRest);
-                        if (s1 && s2) {
+                        if (s1) {
                               _selection.setRange(s1, s2, idx1, idx2 + 1);
                               selectSimilarInRange(e);
                               if (selectedElement->track() == e->track()) {

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3266,6 +3266,11 @@ void Score::selectRange(Element* e, int staffIdx)
             if (selectedElement && e->type() == selectedElement->type()) {
                   int idx1 = selectedElement->staffIdx();
                   int idx2 = e->staffIdx();
+                  if (idx2 < idx1) {
+                      int temp = idx1;
+                      idx1 = idx2;
+                      idx2 = temp;
+                  }
                   if (idx1 >= 0 && idx2 >= 0) {
                         Fraction t1 = selectedElement->tick();
                         Fraction t2 = e->tick();


### PR DESCRIPTION
Resolves: *https://musescore.org/en/node/319079*

Original code only attempts to find the next ChordRest segment as the end marker for selecting a range, this fix adds the detection for the EndBarLine segment as a potential end marker, which resolves the issue.

Backport of #7793 to the 3.x branch