### PR TITLE
[MU4] Added key navigation for palette panel 

### DIFF
--- a/src/appshell/qml/DevTools/DevToolsPage.qml
+++ b/src/appshell/qml/DevTools/DevToolsPage.qml
@@ -158,7 +158,11 @@ DockPage {
 
     Component {
         id: keynavComp
-        KeyNavExample{}
+        KeyNavExample {
+            onActiveFocusRequested: {
+                devtoolsCentral.forceActiveFocus()
+            }
+        }
     }
 
 }

--- a/src/appshell/qml/DevTools/KeyNav/KeyNavExample.qml
+++ b/src/appshell/qml/DevTools/KeyNav/KeyNavExample.qml
@@ -10,6 +10,8 @@ Rectangle {
 
     property string lastClickedInfo: ""
 
+    signal activeFocusRequested()
+
     Rectangle {
         id: infoPanel
 
@@ -35,6 +37,13 @@ Rectangle {
 
         sectionName: "mainMenu"
         sectionOrder: 101
+
+        onActiveChanged: {
+            if (active) {
+                root.activeFocusRequested()
+                root.forceActiveFocus()
+            }
+        }
 
         RowLayout {
             anchors.fill: parent

--- a/src/appshell/qml/DevTools/KeyNav/KeyNavSection.qml
+++ b/src/appshell/qml/DevTools/KeyNav/KeyNavSection.qml
@@ -9,6 +9,7 @@ Rectangle {
     property alias keynavSection: keynavsec
     property alias sectionName: keynavsec.name
     property alias sectionOrder: keynavsec.order
+    property alias active: keynavsec.active
 
     default property alias content: contentItem.data
 
@@ -20,14 +21,8 @@ Rectangle {
         onActiveChanged: {
             console.debug("KeyNavSection.qml active: " + keynavsec.active)
             if (keynavsec.active) {
+                root.forceActiveFocus()
 
-                var p = root.parent
-                while (p) {
-                    p.focus = true
-                    p = p.parent
-                }
-
-                root.focus = true
             }
         }
     }

--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -45,7 +45,7 @@ DockPage {
     }
 
     property KeyNavigationSubSection keynavRightPanelTabsSubSec: KeyNavigationSubSection {
-        name: "RightPanelTabs "
+        name: "RightPanelTabs"
         section: keynavRightPanelSec
         order: 1
     }
@@ -180,7 +180,7 @@ DockPage {
             objectName: "inspectorPanel"
 
             property string _title: qsTrc("appshell", "Properties")
-            title: instrumentsPanel.keynavTab.active ? ("[" + _title + "]") : _title //! NOTE just for test
+            title: inspectorPanel.keynavTab.active ? ("[" + _title + "]") : _title //! NOTE just for test
 
             width: defaultPanelWidth
             minimumWidth: minimumPanelWidth

--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -133,12 +133,20 @@ DockPage {
             }
 
             property KeyNavigationControl keynavTab: KeyNavigationControl {
-                name: "PanelTab"
+                name: "PaletteTab"
                 order: 1 //! TODO Needs order from DockPanel
                 subsection: notationPage.keynavPanelTabSubSec(palettePanel.area)
+                onActiveChanged: {
+                    if (active) {
+                        palettePanel.forceActiveFocus()
+                    }
+                }
             }
 
-            PalettesWidget {}
+            PalettesWidget {
+                anchors.fill: parent
+                keynavSection: notationPage.keynavPanelSec(palettePanel.area)
+            }
         },
 
         DockPanel {
@@ -167,11 +175,17 @@ DockPage {
                 name: "InstrumentsTab"
                 order: 2 //! TODO Needs order from DockPanel
                 subsection: notationPage.keynavPanelTabSubSec(instrumentsPanel.area)
+                onActiveChanged: {
+                    if (active) {
+                        instrumentsPanel.forceActiveFocus()
+                    }
+                }
             }
 
             InstrumentsPanel {
                 anchors.fill: parent
                 keynavSection: notationPage.keynavPanelSec(instrumentsPanel.area)
+                visible: instrumentsPanel.isShown
             }
         },
 
@@ -201,6 +215,11 @@ DockPage {
                 name: "InspectorTab"
                 order: 3 //! TODO Needs order from DockPanel
                 subsection: notationPage.keynavPanelTabSubSec(inspectorPanel.area)
+                onActiveChanged: {
+                    if (active) {
+                        inspectorPanel.forceActiveFocus()
+                    }
+                }
             }
 
             InspectorForm {

--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -45,7 +45,7 @@ DockPage {
     }
 
     property KeyNavigationSubSection keynavRightPanelTabsSubSec: KeyNavigationSubSection {
-        name: "RightPanelTabs"
+        name: "RightPanelTabs "
         section: keynavRightPanelSec
         order: 1
     }

--- a/src/appshell/qml/Window.qml
+++ b/src/appshell/qml/Window.qml
@@ -81,6 +81,7 @@ DockWindow {
 
     toolbars: [
         DockToolBar {
+            id: mainToolBar
             objectName: "mainToolBar"
             minimumWidth: 296
             minimumHeight: dockWindow.toolbarHeight
@@ -95,6 +96,12 @@ DockWindow {
                 keynav.section: topToolKeyNavSec
                 keynav.order: 1
                 currentUri: dockWindow.currentPageUri
+
+                keynav.onActiveChanged: {
+                    if (keynav.active) {
+                        mainToolBar.forceActiveFocus()
+                    }
+                }
 
                 onSelected: {
                     api.launcher.open(uri)
@@ -120,6 +127,11 @@ DockWindow {
                 keynav.section: topToolKeyNavSec
                 keynav.order: 2
                 keynav.enabled: notationToolBar.visible
+                onActiveFocusRequested: {
+                    if (keynav.active) {
+                        notationToolBar.forceActiveFocus()
+                    }
+                }
 
                 Connections {
                     target: notationToolBar

--- a/src/appshell/view/dockwindow/dockpanel.cpp
+++ b/src/appshell/view/dockwindow/dockpanel.cpp
@@ -37,7 +37,15 @@ DockPanel::DockPanel(QQuickItem* parent)
     connect(this, &DockPanel::visibleEdited, this, [this](bool visible) {
         if (m_dock.panel->isVisible() != visible) {
             m_dock.panel->setVisible(visible);
+            if (!visible) {
+                m_isShown = false;
+            }
         }
+    });
+
+    connect(m_dock.panel, &QDockWidget::visibilityChanged, this, [this](bool vsbl) {
+        m_isShown = vsbl;
+        emit isShownChanged(vsbl);
     });
 
     m_eventsWatcher = new EventsWatcher(this);
@@ -58,6 +66,7 @@ void DockPanel::onComponentCompleted()
     updateStyle();
 
     m_preferedWidth = width();
+    m_isShown = panel()->isVisible();
 
     if (minimumWidth() == 0) {
         panel()->setMinimumWidth(width());
@@ -159,6 +168,11 @@ void DockPanel::setFloatable(bool floatable)
 bool DockPanel::closable() const
 {
     return featureEnabled(QDockWidget::DockWidgetClosable);
+}
+
+bool DockPanel::isShown() const
+{
+    return m_isShown;
 }
 
 bool DockPanel::visible() const

--- a/src/appshell/view/dockwindow/dockpanel.h
+++ b/src/appshell/view/dockwindow/dockpanel.h
@@ -36,6 +36,8 @@ class DockPanel : public DockView
     Q_PROPERTY(bool floatable READ floatable WRITE setFloatable NOTIFY floatableChanged)
     Q_PROPERTY(bool closable READ closable WRITE setClosable NOTIFY closableChanged)
 
+    Q_PROPERTY(bool isShown READ isShown NOTIFY isShownChanged)
+
 public:
     explicit DockPanel(QQuickItem* parent = nullptr);
     ~DockPanel() override;
@@ -49,6 +51,7 @@ public:
 
     bool floatable() const;
     bool closable() const;
+    bool isShown() const;
     bool visible() const override;
 
     struct Widget {
@@ -78,6 +81,7 @@ signals:
     void floatableChanged(bool floatable);
     void closableChanged(bool closable);
     void closed();
+    void isShownChanged(bool isShown);
 
 protected:
     void onComponentCompleted() override;
@@ -94,6 +98,7 @@ private:
     EventsWatcher* m_eventsWatcher = nullptr;
 
     int m_preferedWidth = 0;
+    bool m_isShown = false;
 };
 }
 

--- a/src/framework/shortcuts/data/shortcuts-Mac.xml
+++ b/src/framework/shortcuts/data/shortcuts-Mac.xml
@@ -42,12 +42,28 @@
         <seq>Down</seq>
     </SC>
     <SC>
-      <key>nav-trigger</key>
+      <key>nav-trigger-control</key>
       <seq>Return</seq>
     </SC>
     <SC>
-      <key>nav-trigger</key>
+      <key>nav-trigger-control</key>
       <seq>Space</seq>
+    </SC>
+    <SC>
+      <key>nav-first-control</key>
+      <seq>Home</seq>
+    </SC>
+    <SC>
+      <key>nav-last-control</key>
+      <seq>End</seq>
+    </SC>
+    <SC>
+      <key>nav-nextrow-control</key>
+      <seq>PgDown</seq>
+    </SC>
+    <SC>
+      <key>nav-prevrow-control</key>
+      <seq>PgUp</seq>
     </SC>
 <!-- end Keyboard navigation -->
 

--- a/src/framework/shortcuts/data/shortcuts.xml
+++ b/src/framework/shortcuts/data/shortcuts.xml
@@ -42,13 +42,30 @@
         <seq>Down</seq>
     </SC>
     <SC>
-      <key>nav-trigger</key>
+      <key>nav-trigger-control</key>
       <seq>Return</seq>
     </SC>
     <SC>
-      <key>nav-trigger</key>
+      <key>nav-trigger-control</key>
       <seq>Space</seq>
     </SC>
+    <SC>
+      <key>nav-first-control</key>
+      <seq>Home</seq>
+    </SC>
+    <SC>
+      <key>nav-last-control</key>
+      <seq>End</seq>
+    </SC>
+    <SC>
+      <key>nav-nextrow-control</key>
+      <seq>PgDown</seq>
+    </SC>
+    <SC>
+      <key>nav-prevrow-control</key>
+      <seq>PgUp</seq>
+    </SC>
+
 <!-- end Keyboard navigation -->
 
   <SC>

--- a/src/framework/ui/internal/keynavigationcontroller.h
+++ b/src/framework/ui/internal/keynavigationcontroller.h
@@ -35,7 +35,9 @@ public:
     KeyNavigationController() = default;
 
     enum MoveDirection {
-        Right = 0,
+        First = 0,
+        Last,
+        Right,
         Left,
         Up,
         Down
@@ -52,7 +54,12 @@ private:
     void goToNextSubSection();
     void goToPrevSubSection();
 
-    void goToControl(MoveDirection direction, IKeyNavigationSubSection* activeSubSec);
+    void goToFirstControl();
+    void goToLastControl();
+    void goToNextRowControl();
+    void goToPrevRowControl();
+
+    void goToControl(MoveDirection direction, IKeyNavigationSubSection* activeSubSec = nullptr);
 
     void onLeft();
     void onRight();

--- a/src/framework/ui/internal/keynavigationuiactions.cpp
+++ b/src/framework/ui/internal/keynavigationuiactions.cpp
@@ -48,7 +48,19 @@ const UiActionList KeyNavigationUiActions::m_actions = {
     UiAction("nav-down",
              mu::context::UiCtxAny
              ),
-    UiAction("nav-trigger",
+    UiAction("nav-trigger-control",
+             mu::context::UiCtxAny
+             ),
+    UiAction("nav-first-control",
+             mu::context::UiCtxAny
+             ),
+    UiAction("nav-last-control",
+             mu::context::UiCtxAny
+             ),
+    UiAction("nav-nextrow-control",
+             mu::context::UiCtxAny
+             ),
+    UiAction("nav-prevrow-control",
              mu::context::UiCtxAny
              )
 };

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/FlatButton.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/FlatButton.qml
@@ -33,17 +33,8 @@ FocusableControl {
 
     opacity: root.enabled ? 1.0 : ui.theme.itemOpacityDisabled
 
-    onInternalClicked: {
-        root.clicked()
-    }
-
-    onInternalPressAndHold: {
-        root.pressAndHold()
-    }
-
-    onInternalTriggered: {
-        root.clicked()
-    }
+    mouseArea.onClicked: root.clicked()
+    mouseArea.onPressAndHold: root.pressAndHold()
 
     mouseArea.hoverEnabled: true
     mouseArea.onContainsMouseChanged: {
@@ -57,6 +48,8 @@ FocusableControl {
             ui.tooltip.hide(this)
         }
     }
+
+    keynav.onTriggered: root.clicked()
 
     background.color: normalStateColor
     background.opacity: ui.theme.buttonOpacityNormal

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/FocusableControl.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/FocusableControl.qml
@@ -12,13 +12,6 @@ FocusScope {
 
     property alias keynav: keynavItem
 
-    signal internalPressed()
-    signal internalReleased()
-    signal internalClicked()
-    signal internalPressAndHold()
-
-    signal internalTriggered()
-
     function insureActiveFocus() {
         if (!root.activeFocus) {
             root.forceActiveFocus()
@@ -38,10 +31,6 @@ FocusScope {
             if (keynavItem.active) {
                 root.insureActiveFocus()
             }
-        }
-
-        onTriggered: {
-            root.internalTriggered()
         }
     }
 
@@ -64,19 +53,6 @@ FocusScope {
 
         onClicked: {
             root.insureActiveFocus()
-            root.internalClicked()
-        }
-
-        onPressAndHold: {
-            root.internalPressAndHold()
-        }
-
-        onPressed: {
-            root.internalPressed()
-        }
-
-        onReleased: {
-            root.internalReleased()
         }
     }
 }

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/ListItemBlank.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/ListItemBlank.qml
@@ -2,13 +2,13 @@ import QtQuick 2.15
 
 import MuseScore.Ui 1.0
 
-Item {
+FocusableControl {
     id: root
 
     property string hint
 
     property bool isSelected: false
-    property alias radius: background.radius
+    property alias radius: root.background.radius
 
     property color normalStateColor: "transparent"
     property color hoveredStateColor: privateProperties.defaultColor
@@ -24,20 +24,31 @@ Item {
     Accessible.selectable: true
     Accessible.selected: isSelected
 
+    mouseArea.hoverEnabled: root.visible
+    mouseArea.onHoveredChanged: root.hovered(mouseArea.containsMouse, mouseArea.mouseX, mouseArea.mouseY)
+
+    mouseArea.onClicked: root.clicked()
+    mouseArea.onDoubleClicked: root.doubleClicked()
+
+    mouseArea.onContainsMouseChanged: {
+        if (!Boolean(root.hint)) {
+            return
+        }
+
+        if (mouseArea.containsMouse) {
+            ui.tooltip.show(this, root.hint)
+        } else {
+            ui.tooltip.hide(this)
+        }
+    }
+
     QtObject {
         id: privateProperties
 
         property color defaultColor: ui.theme.buttonColor
     }
 
-    Rectangle {
-        id: background
-
-        anchors.fill: parent
-
-        color: normalStateColor
-        opacity: root.enabled ? 1 : ui.theme.itemOpacityDisabled
-    }
+    background.opacity: root.enabled ? 1 : ui.theme.itemOpacityDisabled
 
     states: [
         State {
@@ -45,7 +56,7 @@ Item {
             when: mouseArea.containsMouse && !mouseArea.pressed && !root.isSelected
 
             PropertyChanges {
-                target: background
+                target: root.background
                 opacity: ui.theme.buttonOpacityHover
                 color: hoveredStateColor
             }
@@ -56,7 +67,7 @@ Item {
             when: mouseArea.pressed && !root.isSelected
 
             PropertyChanges {
-                target: background
+                target: root.background
                 opacity: ui.theme.buttonOpacityHit
                 color: pressedStateColor
             }
@@ -67,42 +78,10 @@ Item {
             when: root.isSelected
 
             PropertyChanges {
-                target: background
+                target: root.background
                 opacity: ui.theme.accentOpacityHit
                 color: ui.theme.accentColor
             }
         }
     ]
-
-    MouseArea {
-        id: mouseArea
-
-        anchors.fill: parent
-
-        hoverEnabled: root.visible
-
-        onHoveredChanged: {
-            root.hovered(mouseArea.containsMouse, mouseX, mouseY)
-        }
-
-        onClicked: {
-            root.clicked()
-        }
-
-        onDoubleClicked: {
-            root.doubleClicked()
-        }
-
-        onContainsMouseChanged: {
-            if (!Boolean(root.hint)) {
-                return
-            }
-
-            if (containsMouse) {
-                ui.tooltip.show(this, root.hint)
-            } else {
-                ui.tooltip.hide(this)
-            }
-        }
-    }
 }

--- a/src/instruments/qml/MuseScore/Instruments/InstrumentsPanel.qml
+++ b/src/instruments/qml/MuseScore/Instruments/InstrumentsPanel.qml
@@ -12,6 +12,7 @@ import MuseScore.Instruments 1.0
 import "internal"
 
 Item {
+
     id: root
 
     property KeyNavigationSection keynavSection: null
@@ -37,6 +38,7 @@ Item {
         name: "InstrumentsTree"
         section: root.keynavSection
         direction: KeyNavigationSubSection.Both
+        enabled: root.visible
         order: 3
     }
 
@@ -57,6 +59,7 @@ Item {
             Layout.rightMargin: contentColumn.sideMargin
 
             keynav.section: root.keynavSection
+            keynav.enabled: root.visible
             keynav.order: 2
 
             isMovingUpAvailable: instrumentTreeModel.isMovingUpAvailable

--- a/src/instruments/qml/MuseScore/Instruments/internal/InstrumentsControlPanel.qml
+++ b/src/instruments/qml/MuseScore/Instruments/internal/InstrumentsControlPanel.qml
@@ -31,7 +31,7 @@ RowLayout {
 
     KeyNavigationSubSection {
         id: keynavSub
-        name: "InstrumentsControlPanel"
+        name: "InstrumentsHeader"
     }
 
     FlatButton {

--- a/src/instruments/view/instrumentpaneltreemodel.cpp
+++ b/src/instruments/view/instrumentpaneltreemodel.cpp
@@ -262,6 +262,7 @@ bool InstrumentPanelTreeModel::moveRows(const QModelIndex& sourceParent, int sou
 
 bool InstrumentPanelTreeModel::isSelected(const QModelIndex& rowIndex) const
 {
+    TRACEFUNC;
     if (m_selectionModel->selectedIndexes().isEmpty()) {
         return false;
     }
@@ -345,6 +346,7 @@ int InstrumentPanelTreeModel::columnCount(const QModelIndex&) const
 
 QVariant InstrumentPanelTreeModel::data(const QModelIndex& index, int role) const
 {
+    TRACEFUNC;
     if (!index.isValid() && role != ItemRole) {
         return QVariant();
     }

--- a/src/instruments/view/instrumentpaneltreemodel.cpp
+++ b/src/instruments/view/instrumentpaneltreemodel.cpp
@@ -262,7 +262,6 @@ bool InstrumentPanelTreeModel::moveRows(const QModelIndex& sourceParent, int sou
 
 bool InstrumentPanelTreeModel::isSelected(const QModelIndex& rowIndex) const
 {
-    TRACEFUNC;
     if (m_selectionModel->selectedIndexes().isEmpty()) {
         return false;
     }
@@ -346,7 +345,6 @@ int InstrumentPanelTreeModel::columnCount(const QModelIndex&) const
 
 QVariant InstrumentPanelTreeModel::data(const QModelIndex& index, int role) const
 {
-    TRACEFUNC;
     if (!index.isValid() && role != ItemRole) {
         return QVariant();
     }

--- a/src/notation/qml/MuseScore/NotationScene/NotationToolBar.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NotationToolBar.qml
@@ -8,6 +8,8 @@ Rectangle {
 
     property alias keynav: keynavSub
 
+    signal activeFocusRequested()
+
     Component.onCompleted: {
         toolbarModel.load()
     }
@@ -15,6 +17,12 @@ Rectangle {
     KeyNavigationSubSection {
         id: keynavSub
         name: "NotationToolBar"
+        onActiveChanged: {
+            if (active) {
+                root.activeFocusRequested()
+                root.forceActiveFocus()
+            }
+        }
     }
 
     NotationToolBarModel {

--- a/src/palette/qml/MuseScore/Palette/PalettesWidget.qml
+++ b/src/palette/qml/MuseScore/Palette/PalettesWidget.qml
@@ -17,23 +17,22 @@
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
 
-import QtQuick 2.8
+import QtQuick 2.15
 import QtQuick.Controls 2.1
 import QtQuick.Window 2.2
+import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
 import MuseScore.Palette 1.0
-
-// TODO: make some properties 'property alias`?
-// and `readonly property`?
 
 import "internal"
 
 Rectangle {
+
     id: palettesWidget
 
-    readonly property PaletteWorkspace paletteWorkspace: paletteRootModel.paletteWorkspace
+    property KeyNavigationSection keynavSection: null
 
-    readonly property bool hasFocus: Window.activeFocusItem
+    readonly property PaletteWorkspace paletteWorkspace: paletteRootModel.paletteWorkspace
 
     implicitHeight: 4 * palettesWidgetHeader.implicitHeight
     implicitWidth: paletteTree.implicitWidth
@@ -45,14 +44,6 @@ Rectangle {
     }
 
     color: ui.theme.backgroundPrimaryColor
-
-    FocusableItem {
-        id: focusBreaker
-
-        onActiveFocusChanged: {
-            parent.focus = false
-        }
-    }
 
     PaletteRootModel {
         id: paletteRootModel
@@ -77,6 +68,9 @@ Rectangle {
             rightMargin: 12
         }
 
+        keynav.section: palettesWidget.keynavSection
+        keynav.order: 2
+
         onAddCustomPaletteRequested: paletteTree.insertCustomPalette(0, paletteName);
     }
 
@@ -96,6 +90,11 @@ Rectangle {
         id: paletteTree
         clip: true
         paletteWorkspace: palettesWidget.paletteWorkspace
+        backgroundColor: palettesWidget.color
+
+        keynav.section: palettesWidget.keynavSection
+        keynav.order: 3
+        keynav.enabled: paletteTree.visible
 
         filter: palettesWidgetHeader.searchText
         enableAnimations: !palettesWidgetHeader.searching

--- a/src/palette/qml/MuseScore/Palette/internal/TreePaletteHeader.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/TreePaletteHeader.qml
@@ -37,6 +37,9 @@ Item {
     property PaletteWorkspace paletteWorkspace
     property var modelIndex: null
 
+    property KeyNavigationSubSection keynavSubsection: null
+    property int keynavRow: 0
+
     signal toggleExpandRequested()
     signal enableEditingToggled(bool val)
     signal hideSelectedElementsRequested()
@@ -65,6 +68,11 @@ Item {
         activeFocusOnTab: false // same focus object as parent palette
         icon: paletteHeader.expanded ? IconCode.SMALL_ARROW_DOWN : IconCode.SMALL_ARROW_RIGHT
         normalStateColor: "transparent"
+
+        enabled: paletteExpandArrow.visible
+        keynav.subsection: paletteHeader.keynavSubsection
+        keynav.row: paletteHeader.keynavRow
+        keynav.column: 1
 
         onClicked: paletteHeader.toggleExpandRequested()
     }
@@ -99,8 +107,10 @@ Item {
         activeFocusOnTab: mainPalette.currentItem === paletteTree.currentTreeItem
         normalStateColor: "transparent"
 
-        KeyNavigation.backtab: mainPalette.currentItem
-        KeyNavigation.tab: focusBreaker
+        enabled: deleteButton.visible
+        keynav.subsection: paletteHeader.keynavSubsection
+        keynav.row: paletteHeader.keynavRow
+        keynav.column: 2
 
         onClicked: {
             hideSelectedElementsRequested()
@@ -115,7 +125,10 @@ Item {
 
         visible: paletteHeader.expanded || paletteHeader.hovered || paletteHeaderMenu.visible
 
-        activeFocusOnTab: parent.parent.parent === paletteTree.currentTreeItem
+        enabled: paletteHeaderMenuButton.visible
+        keynav.subsection: paletteHeader.keynavSubsection
+        keynav.row: paletteHeader.keynavRow
+        keynav.column: 3
 
         icon: IconCode.MENU_THREE_DOTS
         normalStateColor: "transparent"


### PR DESCRIPTION
Just prototype 

Navigation pattern

```
     c1   c2        c3      c4
r1   [    [e]       [d]     [m] ]       
r2        [p1]
r3        [p2]
r4        [pn]
r5        [mo]
r6   [    [e]       [d]     [m] ]       
r7        [p1]
r8        [p2]
r9        [pn]
r10       [mo]
r11  [    [e]       [d]     [m] ]    
r12  [    [e]       [d]     [m] ]   
```


https://user-images.githubusercontent.com/3818029/114538190-61164480-9c53-11eb-903a-8d3ca4d2f1a5.mp4

