### PR TITLE
[MU4] Fix #7931: Modified Value of Text-Icon Spacing to desired value (18 pixels)

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/internal/ValueListItem.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/internal/ValueListItem.qml
@@ -62,7 +62,7 @@ ListItemBlank {
             Layout.fillWidth: true
             Layout.leftMargin: root.sideMargin
 
-            spacing: 8
+            spacing: 18
 
             StyledIconLabel {
                 iconCode: Boolean(root.item[iconRoleName]) ? root.item[iconRoleName] : IconCode.NONE


### PR DESCRIPTION
Resolves: #7931 

As mentioned in the Issue Post, The distance between the Icon and Text for each Entry was less than what is expected:

Original value: 8px
Expected/Edited Value: 18px

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
