### PR TITLE
[MU4] Fixed show menu popups for toolbars

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledMenuLoader.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledMenuLoader.qml
@@ -1,0 +1,41 @@
+import QtQuick 2.15
+
+Loader {
+
+    id: loader
+
+    signal handleAction(string actionCode, int actionIndex)
+
+    property alias menu: loader.item
+
+    function isMenuOpened() {
+        return loader.menu && loader.menu.isOpened
+    }
+
+    function toggleOpened(model) {
+        if (!loader.sourceComponent) {
+            loader.sourceComponent = itemMenuComp
+        }
+
+        var menu = loader.menu
+        if (menu.isOpened) {
+            menu.close()
+            return
+        }
+
+        menu.parent = loader.parent
+        menu.model = model
+        menu.open()
+    }
+
+    Component {
+        id: itemMenuComp
+        StyledMenu {
+            id: itemMenu
+            onHandleAction: {
+                Qt.callLater(loader.handleAction, actionCode, actionIndex)
+                itemMenu.close()
+            }
+        }
+    }
+}

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/qmldir
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/qmldir
@@ -39,5 +39,6 @@ TimeInputField 1.0 TimeInputField.qml
 StyledPopupView 1.0 StyledPopupView.qml
 StyledMenu 1.0 StyledMenu.qml
 StyledMenuItem 1.0 StyledMenuItem.qml
+StyledMenuLoader 1.0 StyledMenuLoader.qml
 FilePicker 1.0 FilePicker.qml
 ValueList 1.0 ValueList.qml

--- a/src/framework/uicomponents/uicomponents.qrc
+++ b/src/framework/uicomponents/uicomponents.qrc
@@ -47,5 +47,6 @@
         <file>qml/MuseScore/UiComponents/internal/ValueListHeaderItem.qml</file>
         <file>qml/MuseScore/UiComponents/internal/ValueListItem.qml</file>
         <file>qml/MuseScore/UiComponents/FocusableControl.qml</file>
+        <file>qml/MuseScore/UiComponents/StyledMenuLoader.qml</file>
     </qresource>
 </RCC>

--- a/src/notation/qml/MuseScore/NotationScene/NoteInputBar.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NoteInputBar.qml
@@ -87,31 +87,6 @@ Rectangle {
                 menuLoader.toggleOpened(item.subitemsRole)
             }
 
-            Loader {
-                id: menuLoader
-                anchors.fill: parent
-
-                property var menu: menuLoader.item
-
-                function isMenuOpened() {
-                    return menuLoader.menu && menuLoader.menu.isOpened
-                }
-
-                function toggleOpened(items) {
-                    if (!menuLoader.sourceComponent) {
-                        menuLoader.sourceComponent = itemMenuComp
-                    }
-
-                    if (menuLoader.menu.isOpened) {
-                        menuLoader.menu.close()
-                        return
-                    }
-
-                    menuLoader.menu.model = items
-                    menuLoader.menu.open()
-                }
-            }
-
             Canvas {
                 visible: item.showSubitemsByPressAndHoldRole
 
@@ -132,18 +107,10 @@ Rectangle {
                     ctx.fill();
                 }
             }
-        }
-    }
 
-    Component {
-        id: itemMenuComp
-
-        StyledMenu {
-            id: itemMenu
-
-            onHandleAction: {
-                Qt.callLater(noteInputModel.handleAction, actionCode, actionIndex)
-                itemMenu.close()
+            StyledMenuLoader {
+                id: menuLoader
+                onHandleAction: noteInputModel.handleAction(actionCode, actionIndex)
             }
         }
     }

--- a/src/playback/qml/MuseScore/Playback/PlaybackToolBar.qml
+++ b/src/playback/qml/MuseScore/Playback/PlaybackToolBar.qml
@@ -94,29 +94,9 @@ Rectangle {
                                 Qt.callLater(playbackModel.handleAction, modelData.code)
                             }
 
-                            Loader {
+                            StyledMenuLoader {
                                 id: menuLoader
-                                anchors.fill: parent
-
-                                property alias menu: menuLoader.item
-
-                                function isMenuOpened() {
-                                    return menuLoader.menu && menuLoader.menu.isOpened
-                                }
-
-                                function toggleOpened(items) {
-                                    if (!menuLoader.sourceComponent) {
-                                        menuLoader.sourceComponent = itemMenuComp
-                                    }
-
-                                    if (menuLoader.menu.isOpened) {
-                                        menuLoader.menu.close()
-                                        return
-                                    }
-
-                                    menuLoader.menu.model = items
-                                    menuLoader.menu.open()
-                                }
+                                onHandleAction: playbackModel.handleAction(actionCode)
                             }
                         }
                     }
@@ -126,21 +106,7 @@ Rectangle {
 
                         SeparatorLine {
                             property var modelData
-
                             orientation: Qt.Vertical
-                        }
-                    }
-                }
-
-                Component {
-                    id: itemMenuComp
-
-                    StyledMenu {
-                        id: itemMenu
-
-                        onHandleAction: {
-                            Qt.callLater(playbackModel.handleAction, actionCode)
-                            itemMenu.close()
                         }
                     }
                 }


### PR DESCRIPTION
StyledPopupView has a rather convoluted sizing system
And it became even more confusing when using a loader

The order of changing the size of the popup:

1. The dimensions specified in the properties of the height and width are set by default.
2. After creating the component, the sizes of the popup are set equal to the sizes of the content (namely implicitHeight and implicitWidth)
- i.e. the size of the popup becomes equal to the size of the content - this is good

3. If the popup is loaded by the loader, the loader has the specified sizes, then the loader sets its own sizes to the loaded element, i.e. in this case, the popup.
- But the changed sizes of the popup do not affect the content in any way, they only affect the check of the coordinates of the mouse click, that is, we see one thing on the screen, but in fact the other is checked - this is bad

4. If the component has popup sizes to the content size, then it also works
StyledMenu.qml
```
    height: view.implicitHeight   // binding
    width: itemWidth                  // constant
```

As a result, the sizes of the pop-up used to check for a mouse click hit may not be expected and do not correspond at all to what we see on the screen :(
