### PR TITLE
[MU4] Fix next\previous chord action in multiple element selection

### DIFF
--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -578,11 +578,12 @@ void NotationActionController::moveAction(const actions::ActionCode& actionCode)
         return;
     }
 
-    Element* element = interaction->selection()->element();
-    if (!element) {
+    std::vector<Element*> selectionElements = interaction->selection()->elements();
+    if (selectionElements.empty()) {
         LOGW() << "no selection element";
         return;
     }
+    Element* element = selectionElements.back();
 
     if (element->isLyrics()) {
         NOT_IMPLEMENTED;


### PR DESCRIPTION
Before, when there was a multiple element selection, actions ```next-chord``` and ```prev-chord``` would not work.

A simple 1 line fix.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
