### PR TITLE
[MU4] Reimplemented popup view

### DIFF
--- a/src/appshell/qml/DevTools/Gallery/GeneralComponentsGallery.qml
+++ b/src/appshell/qml/DevTools/Gallery/GeneralComponentsGallery.qml
@@ -195,8 +195,13 @@ Rectangle {
                 StyledPopupView {
                     id: popupViewDown
 
+                    contentWidth: layout.childrenRect.width
+                    contentHeight: layout.childrenRect.height
+
                     Column {
+                        id: layout
                         spacing: 12
+                        anchors.fill: parent
 
                         CheckBox {
                             text: "Some checkbox"
@@ -232,6 +237,9 @@ Rectangle {
 
                     Column {
                         spacing: 12
+
+                        width: childrenRect.width
+                        height: childrenRect.height
 
                         CheckBox {
                             text: "Some checkbox"

--- a/src/framework/ui/view/keynavigationcontrol.cpp
+++ b/src/framework/ui/view/keynavigationcontrol.cpp
@@ -106,6 +106,7 @@ void KeyNavigationControl::setSubSection(KeyNavigationSubSection* subsection)
     m_subsection = subsection;
 
     if (m_subsection) {
+        m_subsection->addControl(this);
         connect(m_subsection, &KeyNavigationSubSection::destroyed, this, &KeyNavigationControl::onSubSectionDestroyed);
     }
 
@@ -120,11 +121,4 @@ void KeyNavigationControl::onSubSectionDestroyed()
 KeyNavigationSubSection* KeyNavigationControl::subsection() const
 {
     return m_subsection;
-}
-
-void KeyNavigationControl::componentComplete()
-{
-    if (m_subsection) {
-        m_subsection->addControl(this);
-    }
 }

--- a/src/framework/ui/view/keynavigationcontrol.h
+++ b/src/framework/ui/view/keynavigationcontrol.h
@@ -69,8 +69,6 @@ private slots:
 
 private:
 
-    void componentComplete() override;
-
     KeyNavigationSubSection* m_subsection = nullptr;
     async::Channel<IKeyNavigationControl*> m_forceActiveRequested;
 };

--- a/src/framework/ui/view/keynavigationpopuppanel.cpp
+++ b/src/framework/ui/view/keynavigationpopuppanel.cpp
@@ -39,7 +39,7 @@ void KeyNavigationPopupPanel::setParentControl(KeyNavigationControl* parentContr
     m_parentControl = parentControl;
     emit parentControlChanged(m_parentControl);
 
-    if (m_parentControl) {
+    if (m_parentControl && m_parentControl->subsection()) {
         setSection(m_parentControl->subsection()->section());
     } else {
         setSection(nullptr);

--- a/src/framework/ui/view/keynavigationsection.cpp
+++ b/src/framework/ui/view/keynavigationsection.cpp
@@ -39,8 +39,6 @@ KeyNavigationSection::~KeyNavigationSection()
 void KeyNavigationSection::componentComplete()
 {
     //! NOTE Reg after set properties.
-    LOGD() << "Completed: " << m_name << ", order: " << order();
-
     IF_ASSERT_FAILED(!m_name.isEmpty()) {
         return;
     }

--- a/src/framework/ui/view/keynavigationsubsection.cpp
+++ b/src/framework/ui/view/keynavigationsubsection.cpp
@@ -151,13 +151,6 @@ void KeyNavigationSubSection::onSectionDestroyed()
 
 void KeyNavigationSubSection::componentComplete()
 {
-    IF_ASSERT_FAILED(!m_name.isEmpty()) {
-        return;
-    }
-
-    IF_ASSERT_FAILED(order() > -1) {
-        return;
-    }
 }
 
 void KeyNavigationSubSection::addControl(KeyNavigationControl* control)

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/FocusableControl.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/FocusableControl.qml
@@ -43,6 +43,7 @@ FocusScope {
 
     Item {
         id: contentItem
+        objectName: "FocusableControlContent"
         anchors.fill: focusRectItem
         anchors.margins: 2 //! NOTE margin needed to show focus border
     }

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledMenu.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledMenu.qml
@@ -2,8 +2,8 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
-import MuseScore.UiComponents 1.0
 import MuseScore.Ui 1.0
+import MuseScore.UiComponents 1.0
 
 StyledPopupView {
     id: root
@@ -13,18 +13,35 @@ StyledPopupView {
 
     signal handleAction(string actionCode, int actionIndex)
 
-    arrowVisible: false
-    positionDisplacementX: 0
-    positionDisplacementY: opensUpward ? -view.implicitHeight : parent.height
+    contentWidth: root.itemWidth
+    contentHeight: view.childrenRect.height
     padding: 0
     margins: 0
-    animationEnabled: false
+    x: 0
+    y: opensUpward ? -root.height : parent.height
 
-    height: view.implicitHeight
-    width: itemWidth
+    animationEnabled: false //! NOTE disabled - because trouble with simultaneous opening of submenu
 
     keynav.name: "StyledMenu"
     keynav.direction: KeyNavigationSubSection.Vertical
+
+    function focusOnFirstItem() {
+        var loader = view.itemAtIndex(0)
+        if (loader && loader.item) {
+            loader.item.keynav.forceActive()
+        }
+    }
+
+    function focusOnSelected() {
+        for (var i = 0; i < view.count; ++i) {
+            var loader = view.itemAtIndex(i)
+            if (loader && loader.item && loader.item.isSelected) {
+                loader.item.keynav.forceActive()
+                return true
+            }
+        }
+        return false
+    }
 
     onModelChanged: {
         prv.hasItemsWithIconAndCheckable = false
@@ -53,7 +70,7 @@ StyledPopupView {
         }
     }
 
-    property QtObject prv_prop: QtObject {
+    QtObject {
         id: prv
         property bool hasItemsWithIconAndCheckable: false
         property bool hasItemsWithIconOrCheckable: false
@@ -61,30 +78,9 @@ StyledPopupView {
         property bool hasItemsWithShortcut: false
     }
 
-    function focusOnFirstItem() {
-        var loader = view.itemAtIndex(0)
-        if (loader && loader.item) {
-            loader.item.keynav.forceActive()
-        }
-    }
-
-    function focusOnSelected() {
-        for (var i = 0; i < view.count; ++i) {
-            var loader = view.itemAtIndex(i)
-            if (loader && loader.item && loader.item.isSelected) {
-                loader.item.keynav.forceActive()
-                return true
-            }
-        }
-        return false
-    }
-
     ListView {
         id: view
-
-        implicitHeight: contentHeight
-        implicitWidth: root.itemWidth
-
+        anchors.fill: parent
         spacing: 2
         interactive: false
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledMenuItem.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledMenuItem.qml
@@ -89,8 +89,8 @@ ListItemBlank {
 
             var menuComponent = Qt.createComponent("StyledMenu.qml");
             var menu = menuComponent.createObject(root)
-            menu.positionDisplacementX = root.width
-            menu.positionDisplacementY = 0
+            menu.x = root.width
+            menu.y = 0
 
             menu.keynav.parentControl = root.keynav
             menu.keynav.name = root.keynav.name+"SubMenu"
@@ -190,7 +190,7 @@ ListItemBlank {
         if (isHovered) {
             prv.showSubMenu()
         } else {
-            var mouseOnShowedSubMenu = mapToItem(prv.showedSubMenu, mouseX, mouseY)
+            var mouseOnShowedSubMenu = mapToItem(prv.showedSubMenu.contentItem, mouseX, mouseY)
             var eps = 8
             var subMenuWidth = prv.showedSubMenu.x + prv.showedSubMenu.width
             var subMenuHeight = prv.showedSubMenu.y + prv.showedSubMenu.height

--- a/src/framework/uicomponents/view/popupview.h
+++ b/src/framework/uicomponents/view/popupview.h
@@ -1,4 +1,4 @@
-//=============================================================================
+﻿//=============================================================================
 //  MuseScore
 //  Music Composition & Notation
 //
@@ -22,115 +22,91 @@
 
 #include <QQuickItem>
 #include <QQuickView>
+#include <QQmlParserStatus>
 
-#include "ui/imainwindow.h"
 #include "modularity/ioc.h"
+#include "ui/imainwindow.h"
 
 namespace mu::uicomponents {
-class PopupView : public QQuickItem
+class PopupView : public QObject, public QQmlParserStatus
 {
     Q_OBJECT
-
-    Q_PROPERTY(QQuickItem * backgroundItem READ backgroundItem WRITE setBackgroundItem NOTIFY backgroundItemChanged)
+    Q_PROPERTY(QQuickItem * parent READ parentItem WRITE setParentItem NOTIFY parentItemChanged)
     Q_PROPERTY(QQuickItem * contentItem READ contentItem WRITE setContentItem NOTIFY contentItemChanged)
+
+    //! NOTE Local, related parent
+    Q_PROPERTY(qreal x READ x WRITE setX NOTIFY xChanged)
+    Q_PROPERTY(qreal y READ y WRITE setY NOTIFY yChanged)
+
+    Q_PROPERTY(bool isOpened READ isOpened NOTIFY isOpenedChanged)
     Q_PROPERTY(ClosePolicy closePolicy READ closePolicy WRITE setClosePolicy NOTIFY closePolicyChanged)
-
-    Q_PROPERTY(QPointF globalPos READ globalPos WRITE setGlobalPos NOTIFY globalPosChanged)
-    Q_PROPERTY(qreal positionDisplacementX READ positionDisplacementX WRITE setPositionDisplacementX NOTIFY positionDisplacementXChanged)
-    Q_PROPERTY(qreal positionDisplacementY READ positionDisplacementY WRITE setPositionDisplacementY NOTIFY positionDisplacementYChanged)
-
-    Q_PROPERTY(bool isOpened READ isOpened WRITE setIsOpened NOTIFY isOpenedChanged)
-
-    Q_PROPERTY(qreal padding READ padding WRITE setPadding NOTIFY paddingChanged)
-
-    Q_CLASSINFO("DefaultProperty", "contentItem")
 
     Q_ENUMS(ClosePolicy)
 
     INJECT(uicomponents, ui::IMainWindow, mainWindow)
 
 public:
+
+    explicit PopupView(QQuickItem* parent = nullptr);
+
     enum ClosePolicy {
         NoAutoClose = 0,
         CloseOnPressOutsideParent,
         CloseOnReleaseOutsideParent
     };
 
-    explicit PopupView(QQuickItem* parent = nullptr);
+    QQuickItem* parentItem() const;
+    QQuickItem* contentItem() const;
+
+    qreal x() const;
+    qreal y() const;
+
+    Q_INVOKABLE void forceActiveFocus();
 
     Q_INVOKABLE void open();
     Q_INVOKABLE void close();
     Q_INVOKABLE void toggleOpened();
 
-    QQuickItem* backgroundItem() const;
-    QQuickItem* contentItem() const;
     ClosePolicy closePolicy() const;
 
     bool isOpened() const;
 
-    qreal padding() const;
-
-    QPointF globalPos() const;
-    qreal positionDisplacementX() const;
-    qreal positionDisplacementY() const;
-
 public slots:
-    void setBackgroundItem(QQuickItem* backgroundItem);
-    void setContentItem(QQuickItem* contentItem);
+    void setParentItem(QQuickItem* parent);
+    void setContentItem(QQuickItem* content);
+    void setX(qreal x);
+    void setY(qreal y);
     void setClosePolicy(ClosePolicy closePolicy);
 
-    void setIsOpened(bool isOpened);
-    void setPadding(qreal padding);
-
-    void setGlobalPos(QPointF globalPos);
-    void setPositionDisplacementX(qreal positionDisplacementX);
-    void setPositionDisplacementY(qreal positionDisplacementY);
-
 signals:
-    void backgroundItemChanged(QQuickItem* backgroundItem);
-    void contentItemChanged(QQuickItem* contentItem);
+    void parentItemChanged();
+    void contentItemChanged();
+    void xChanged(qreal x);
+    void yChanged(qreal y);
     void closePolicyChanged(ClosePolicy closePolicy);
 
-    void isOpenedChanged(bool isOpened);
+    void isOpenedChanged();
 
-    void aboutToShow();
-    void aboutToHide();
     void opened();
     void closed();
-
-    void paddingChanged(qreal padding);
-
-    void globalPosChanged(QPointF globalPos);
-    void positionDisplacementXChanged(qreal positionDisplacementX);
-    void positionDisplacementYChanged(qreal positionDisplacementY);
 
 private slots:
     void onApplicationStateChanged(Qt::ApplicationState state);
 
 private:
+    void classBegin() override;
     void componentComplete() override;
     bool eventFilter(QObject* watched, QEvent* event) override;
-    void mousePressEvent(QMouseEvent* event) override;
-    void mouseReleaseEvent(QMouseEvent* event) override;
+    void mousePressEvent(QMouseEvent* event);
+    void mouseReleaseEvent(QMouseEvent* event);
 
     bool isMouseWithinBoundaries(const QPoint& mousePos) const;
 
-    void setupContentComponent(QQmlEngine* engine);
-    void setupContainerView(QQmlEngine* engine);
-    QQuickItem* loadContentItem(QQmlContext* ctx);
-
-    QQmlComponent* m_contentComponent = nullptr;
-    QQuickView* m_containerView = nullptr;
-
-    QQuickItem* m_backgroundItem = nullptr;
+    QQuickView* m_view = nullptr;
     QQuickItem* m_contentItem = nullptr;
 
+    QPointF m_localPos;
     ClosePolicy m_closePolicy = ClosePolicy::CloseOnPressOutsideParent;
-    bool m_isOpened = false;
-    qreal m_padding = 0.0;
-    QPointF m_globalPos;
-    qreal m_positionDisplacementX = 0.0;
-    qreal m_positionDisplacementY = 0.0;
 };
 }
 

--- a/src/instruments/qml/MuseScore/Instruments/internal/InstrumentSettingsPopup.qml
+++ b/src/instruments/qml/MuseScore/Instruments/internal/InstrumentSettingsPopup.qml
@@ -4,13 +4,11 @@ import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
 import MuseScore.Instruments 1.0
 
-StyledPopup {
+StyledPopupView {
     id: root
 
-    height: Math.max(contentColumn.implicitHeight + topPadding + bottomPadding, implicitHeight)
-    width: parent.width
-
-    implicitHeight: 290
+    contentHeight: contentColumn.childrenRect.height
+    contentWidth: parent.width
 
     function load(instrument) {
         settingsModel.load(instrument)
@@ -23,8 +21,7 @@ StyledPopup {
     Column {
         id: contentColumn
 
-        width: parent.width
-
+        anchors.fill: parent
         spacing: 12
 
         StyledTextLabel {
@@ -70,6 +67,7 @@ StyledPopup {
 
         FlatButton {
             width: parent.width
+            keynav.subsection: root.keynav
             text: qsTrc("instruments", "Replace instrument")
 
             onClicked: {

--- a/src/instruments/qml/MuseScore/Instruments/internal/InstrumentsTreeItemDelegate.qml
+++ b/src/instruments/qml/MuseScore/Instruments/internal/InstrumentsTreeItemDelegate.qml
@@ -84,7 +84,7 @@ Item {
 
     KeyNavigationControl {
         id: keynavItem
-        name: "InstrumentsTreeItemDelegate"
+        name: "ItemInstrumentsTree"
         subsection: root.keynavSubSection
         row: root.keynavRow
         column: 0
@@ -203,8 +203,8 @@ Item {
     InstrumentSettingsPopup {
         id: instrumentSettings
 
-        y: settingsButton.y + settingsButton.height + 2
-        arrowX: width - settingsButton.width / 2 - root.sideMargin
+        keynav.name: "InstrumentSettingsPopup"
+        keynav.parentControl: keynavItem
 
         onClosed: privateProperties.resetOpenedPopup()
     }
@@ -212,8 +212,8 @@ Item {
     StaffSettingsPopup {
         id: staffSettings
 
-        y: settingsButton.y + settingsButton.height + 2
-        arrowX: width - settingsButton.width / 2 - root.sideMargin
+        keynav.name: "StaffSettingsPopup"
+        keynav.parentControl: keynavItem
 
         onClosed: privateProperties.resetOpenedPopup()
     }
@@ -229,7 +229,7 @@ Item {
             Layout.alignment: Qt.AlignLeft
             Layout.preferredWidth: width
 
-            objectName: "instrumentVisibleBtn"
+            objectName: "VisibleBtnInstrument"
             keynav.subsection: root.keynavSubSection
             keynav.row: root.keynavRow
             keynav.column: 1
@@ -259,7 +259,7 @@ Item {
 
                 anchors.left: parent.left
 
-                objectName: "instrumentExpandBtn"
+                objectName: "ExpandBtnInstrument"
                 enabled: expandButton.visible
                 keynav.subsection: root.keynavSubSection
                 keynav.row: root.keynavRow
@@ -310,7 +310,7 @@ Item {
             Layout.alignment: Qt.AlignRight
             Layout.preferredWidth: width
 
-            objectName: "instrumentSettingsBtn"
+            objectName: "SettingsBtnInstrument"
             enabled: root.visible
             keynav.subsection: root.keynavSubSection
             keynav.row: root.keynavRow

--- a/src/instruments/qml/MuseScore/Instruments/internal/StaffSettingsPopup.qml
+++ b/src/instruments/qml/MuseScore/Instruments/internal/StaffSettingsPopup.qml
@@ -4,13 +4,11 @@ import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
 import MuseScore.Instruments 1.0
 
-StyledPopup {
+StyledPopupView {
     id: root
 
-    height: Math.max(contentColumn.implicitHeight + topPadding + bottomPadding, implicitHeight)
-    width: parent.width
-
-    implicitHeight: 340
+    contentHeight: contentColumn.childrenRect.height
+    contentWidth: parent.width
 
     function load(staff) {
         settingsModel.load(staff)
@@ -22,7 +20,7 @@ StyledPopup {
 
     Column {
         id: contentColumn
-
+        anchors.fill: parent
         width: parent.width
 
         spacing: 12
@@ -118,6 +116,8 @@ StyledPopup {
 
         FlatButton {
             width: parent.width
+
+            keynav.subsection: root.keynav
 
             text: qsTrc("instruments", "Create a linked staff")
 

--- a/src/palette/qml/MuseScore/Palette/PalettesWidget.qml
+++ b/src/palette/qml/MuseScore/Palette/PalettesWidget.qml
@@ -93,7 +93,7 @@ Rectangle {
         backgroundColor: palettesWidget.color
 
         keynav.section: palettesWidget.keynavSection
-        keynav.order: 3
+        keynav.order: 5
         keynav.enabled: paletteTree.visible
 
         filter: palettesWidgetHeader.searchText

--- a/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
@@ -302,7 +302,7 @@ ListView {
                 visible: !control.Drag.active
                 isSelected: control.selected
 
-                keynav.name: "PaletteTreeItemDelegate"
+                keynav.name: "PaletteTreeItem"
                 keynav.subsection: keynavTree
                 keynav.row: control.keynavRow
                 keynav.column: 0


### PR DESCRIPTION
I had some problems:
1. Intricate sizing system
`PopupView` itself was a `QQuickItem`, which has sizes and coordinates (x and y). But in fact, they do not affect anything on the one hand (because `PopupView` is just a container for the `QQuickView`), on the other hand, it was these sizes that were used to determine that they clicked outside.
There was a situation when the sizes of the `QQuickView`  (what we see), and the sizes of `PopupView` (container) are different, because of this, errors occur.

2. The second problem, the implementation of `PopupView` and `StyledPopupView` requires that there is one `contentItem` at the root - this is not convenient, you have to be sophisticated to get around this require (often we need to put some kind of object, model, items, etc. into the root)

Now:
`PopupView` is only a container for the `QQuickView`, it does not know anything about the implementation of Qml content, this is just a popup and that's it (and does not have sizes or any other properties that are not related to the `QQuickView`)

The sizes of the view itself are determined only by the Qml content, and view sizes are used to test the mouse click.
Implementation of Qml content is all in `StyledPopupView.qml` (internal `Control` is not created or used, as before)

Not implemented:
1. Show the arrow (if we want it)
2. Shadow 
3. Smarter place to show the popup

