### PR TITLE
[MU4] Implement some shortcuts

### DIFF
--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -107,6 +107,7 @@ public:
     virtual void deleteSelection() = 0;
     virtual void flipSelection() = 0;
     virtual void addTieToSelection() = 0;
+    virtual void addTiedNoteToChord() = 0;
     virtual void addSlurToSelection() = 0;
     virtual void addOttavaToSelection(OttavaType type) = 0;
     virtual void addHairpinToSelection(HairpinType type) = 0;

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -49,6 +49,7 @@ public:
     virtual Element* hitElement(const QPointF& pos, float width) const = 0;
     virtual int hitStaffIndex(const QPointF& pos) const = 0;
     virtual void addChordToSelection(MoveDirection d) = 0;
+    virtual void moveChordNoteSelection(MoveDirection d) = 0;
     virtual void select(const std::vector<Element*>& elements, SelectType type, int staffIndex = 0) = 0;
     virtual void selectAll() = 0;
     virtual void selectSection() = 0;

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -53,6 +53,8 @@ public:
     virtual void select(const std::vector<Element*>& elements, SelectType type, int staffIndex = 0) = 0;
     virtual void selectAll() = 0;
     virtual void selectSection() = 0;
+    virtual void selectFirstElement() = 0;
+    virtual void selectLastElement() = 0;
     virtual INotationSelectionPtr selection() const = 0;
     virtual void clearSelection() = 0;
     virtual async::Notification selectionChanged() const = 0;

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -112,6 +112,8 @@ public:
     virtual void addOttavaToSelection(OttavaType type) = 0;
     virtual void addHairpinToSelection(HairpinType type) = 0;
     virtual void addAccidentalToSelection(AccidentalType type) = 0;
+    virtual void putRestToSelection() = 0;
+    virtual void putRest(DurationType duration) = 0;
     virtual void addBracketsToSelection(BracketsType type) = 0;
     virtual void changeSelectedNotesArticulation(SymbolId articulationSymbolId) = 0;
     virtual void addGraceNotesToSelectedNotes(GraceNoteType type) = 0;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -94,6 +94,12 @@ void NotationActionController::init()
     dispatcher()->reg(this, "sharp", [this]() { toggleAccidental(AccidentalType::SHARP); });
     dispatcher()->reg(this, "sharp2", [this]() { toggleAccidental(AccidentalType::SHARP2); });
 
+    dispatcher()->reg(this, "rest", this, &NotationActionController::putRestToSelection);
+    dispatcher()->reg(this, "rest-1", [this]() { putRest(DurationType::V_WHOLE); });
+    dispatcher()->reg(this, "rest-2", [this]() { putRest(DurationType::V_HALF); });
+    dispatcher()->reg(this, "rest-4", [this]() { putRest(DurationType::V_QUARTER); });
+    dispatcher()->reg(this, "rest-8", [this]() { putRest(DurationType::V_EIGHTH); });
+
     dispatcher()->reg(this, "add-marcato", [this]() { addArticulation(SymbolId::articMarcatoAbove); });
     dispatcher()->reg(this, "add-sforzato", [this]() { addArticulation(SymbolId::articAccentAbove); });
     dispatcher()->reg(this, "add-tenuto", [this]() { addArticulation(SymbolId::articTenutoAbove); });
@@ -511,6 +517,26 @@ void NotationActionController::toggleAccidental(AccidentalType type)
     } else {
         interaction->addAccidentalToSelection(type);
     }
+}
+
+void NotationActionController::putRestToSelection()
+{
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+
+    interaction->putRestToSelection();
+}
+
+void NotationActionController::putRest(DurationType duration)
+{
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+
+    interaction->putRest(duration);
 }
 
 void NotationActionController::addArticulation(SymbolId articulationSymbolId)

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -131,6 +131,8 @@ void NotationActionController::init()
     dispatcher()->reg(this, "pitch-down", [this](const ActionCode& actionCode) { moveAction(actionCode); });
     dispatcher()->reg(this, "pitch-up-octave", [this](const ActionCode& actionCode) { moveAction(actionCode); });
     dispatcher()->reg(this, "pitch-down-octave", [this](const ActionCode& actionCode) { moveAction(actionCode); });
+    dispatcher()->reg(this, "up-chord", [this]() { moveChord(MoveDirection::Up); });
+    dispatcher()->reg(this, "down-chord", [this]() { moveChord(MoveDirection::Down); });
 
     dispatcher()->reg(this, "cut", this, &NotationActionController::cutSelection);
     dispatcher()->reg(this, "copy", this, &NotationActionController::copySelection);
@@ -659,6 +661,18 @@ void NotationActionController::moveAction(const actions::ActionCode& actionCode)
 
         playSelectedElement();
     }
+}
+
+void NotationActionController::moveChord(MoveDirection direction)
+{
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+
+    interaction->moveChordNoteSelection(direction);
+
+    playSelectedElement(false);
 }
 
 void NotationActionController::moveText(INotationInteractionPtr interaction, const actions::ActionCode& actionCode)
@@ -1439,7 +1453,7 @@ void NotationActionController::toggleScoreConfig(ScoreConfigType configType)
     interaction->setScoreConfig(config);
 }
 
-void NotationActionController::playSelectedElement()
+void NotationActionController::playSelectedElement(bool playChord)
 {
     auto interaction = currentNotationInteraction();
     if (!interaction) {
@@ -1451,7 +1465,7 @@ void NotationActionController::playSelectedElement()
         return;
     }
 
-    if (playbackConfiguration()->playChordWhenEditing()) {
+    if (playChord && playbackConfiguration()->playChordWhenEditing()) {
         element = element->elementBase();
     }
 

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -136,6 +136,7 @@ void NotationActionController::init()
     dispatcher()->reg(this, "delete", this, &NotationActionController::deleteSelection);
     dispatcher()->reg(this, "flip", this, &NotationActionController::flipSelection);
     dispatcher()->reg(this, "tie", this, &NotationActionController::addTie);
+    dispatcher()->reg(this, "chord-tie", this, &NotationActionController::chordTie);
     dispatcher()->reg(this, "add-slur", this, &NotationActionController::addSlur);
 
     dispatcher()->reg(this, UNDO_ACTION_CODE, this, &NotationActionController::undo);
@@ -794,6 +795,25 @@ void NotationActionController::addTie()
         noteInput->addTie();
     } else {
         interaction->addTieToSelection();
+    }
+}
+
+void NotationActionController::chordTie()
+{
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+
+    auto noteInput = interaction->noteInput();
+    if (!noteInput) {
+        return;
+    }
+
+    if (noteInput->isNoteInputMode()) {
+        noteInput->addTie();
+    } else {
+        interaction->addTiedNoteToChord();
     }
 }
 

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -158,6 +158,8 @@ void NotationActionController::init()
     dispatcher()->reg(this, "select-dialog", this, &NotationActionController::openSelectionMoreOptions);
     dispatcher()->reg(this, "select-all", this, &NotationActionController::selectAll);
     dispatcher()->reg(this, "select-section", this, &NotationActionController::selectSection);
+    dispatcher()->reg(this, "first-element", this, &NotationActionController::firstElement);
+    dispatcher()->reg(this, "last-element", this, &NotationActionController::lastElement);
 
     dispatcher()->reg(this, "split-measure", this, &NotationActionController::splitMeasure);
     dispatcher()->reg(this, "join-measures", this, &NotationActionController::joinSelectedMeasures);
@@ -985,6 +987,26 @@ void NotationActionController::selectSection()
     }
 
     interaction->selectSection();
+}
+
+void NotationActionController::firstElement()
+{
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+
+    interaction->selectFirstElement();
+}
+
+void NotationActionController::lastElement()
+{
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+
+    interaction->selectLastElement();
 }
 
 void NotationActionController::openSelectionMoreOptions()

--- a/src/notation/internal/notationactioncontroller.h
+++ b/src/notation/internal/notationactioncontroller.h
@@ -90,6 +90,7 @@ private:
     void swapSelection();
     void flipSelection();
     void addTie();
+    void chordTie();
     void addSlur();
     void addInterval(int interval);
 

--- a/src/notation/internal/notationactioncontroller.h
+++ b/src/notation/internal/notationactioncontroller.h
@@ -72,6 +72,8 @@ private:
     void toggleVisible();
 
     void toggleAccidental(AccidentalType type);
+    void putRestToSelection();
+    void putRest(DurationType duration);
     void addArticulation(SymbolId articulationSymbolId);
 
     void putTuplet(int tupletCount);

--- a/src/notation/internal/notationactioncontroller.h
+++ b/src/notation/internal/notationactioncontroller.h
@@ -81,6 +81,7 @@ private:
     void addBracketsToSelection(BracketsType type);
 
     void moveAction(const actions::ActionCode& actionCode);
+    void moveChord(MoveDirection direction);
     void moveText(INotationInteractionPtr interaction, const actions::ActionCode& actionCode);
 
     void swapVoices(int voiceIndex1, int voiceIndex2);
@@ -156,7 +157,7 @@ private:
     void toggleNavigator();
     void toggleMixer();
 
-    void playSelectedElement();
+    void playSelectedElement(bool playChord = true);
 
     bool isTextEditting() const;
 

--- a/src/notation/internal/notationactioncontroller.h
+++ b/src/notation/internal/notationactioncontroller.h
@@ -107,6 +107,8 @@ private:
     void openSelectionMoreOptions();
     void selectAll();
     void selectSection();
+    void firstElement();
+    void lastElement();
 
     void splitMeasure();
     void joinSelectedMeasures();

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2162,6 +2162,15 @@ void NotationInteraction::addTieToSelection()
     notifyAboutSelectionChanged();
 }
 
+void NotationInteraction::addTiedNoteToChord()
+{
+    startEdit();
+    score()->cmdAddTie(true);
+    apply();
+
+    notifyAboutSelectionChanged();
+}
+
 void NotationInteraction::addSlurToSelection()
 {
     if (selection()->isNone()) {

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -441,6 +441,33 @@ void NotationInteraction::addChordToSelection(MoveDirection d)
     notifyAboutSelectionChanged();
 }
 
+void NotationInteraction::moveChordNoteSelection(MoveDirection d)
+{
+    IF_ASSERT_FAILED(MoveDirection::Up == d || MoveDirection::Down == d) {
+        return;
+    }
+
+    Element* current = selection()->element();
+    if (!current || !(current->isNote() || current->isRest())) {
+        return;
+    }
+
+    Element* chordElem;
+    if (d == MoveDirection::Up) {
+        chordElem = score()->upAlt(current);
+    } else {
+        chordElem = score()->downAlt(current);
+    }
+
+    if (chordElem == current) {
+        return;
+    }
+
+    score()->select(chordElem, SelectType::SINGLE, chordElem->staffIdx());
+
+    notifyAboutSelectionChanged();
+}
+
 void NotationInteraction::select(const std::vector<Element*>& elements, SelectType type, int staffIndex)
 {
     if (needEndTextEditing(elements)) {

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -497,6 +497,22 @@ void NotationInteraction::selectSection()
     notifyAboutSelectionChanged();
 }
 
+void NotationInteraction::selectFirstElement()
+{
+    Element* element = score()->firstElement();
+    score()->select(element, SelectType::SINGLE, element->staffIdx());
+
+    notifyAboutSelectionChanged();
+}
+
+void NotationInteraction::selectLastElement()
+{
+    Element* element = score()->lastElement();
+    score()->select(element, SelectType::SINGLE, element->staffIdx());
+
+    notifyAboutSelectionChanged();
+}
+
 INotationSelectionPtr NotationInteraction::selection() const
 {
     return m_selection;
@@ -2256,8 +2272,9 @@ void NotationInteraction::addAccidentalToSelection(AccidentalType type)
 void NotationInteraction::putRestToSelection()
 {
     Ms::InputState& is = score()->inputState();
-    if (!is.duration().isValid() || is.duration().isZero() || is.duration().isMeasure())
+    if (!is.duration().isValid() || is.duration().isZero() || is.duration().isMeasure()) {
         is.setDuration(DurationType::V_QUARTER);
+    }
     putRest(is.duration().type());
 }
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2226,6 +2226,27 @@ void NotationInteraction::addAccidentalToSelection(AccidentalType type)
     notifyAboutSelectionChanged();
 }
 
+void NotationInteraction::putRestToSelection()
+{
+    Ms::InputState& is = score()->inputState();
+    if (!is.duration().isValid() || is.duration().isZero() || is.duration().isMeasure())
+        is.setDuration(DurationType::V_QUARTER);
+    putRest(is.duration().type());
+}
+
+void NotationInteraction::putRest(DurationType duration)
+{
+    if (selection()->isNone()) {
+        return;
+    }
+
+    startEdit();
+    score()->cmdEnterRest(Duration(duration));
+    apply();
+
+    notifyAboutSelectionChanged();
+}
+
 void NotationInteraction::addBracketsToSelection(BracketsType type)
 {
     if (selection()->isNone()) {

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -67,6 +67,7 @@ public:
     Element* hitElement(const QPointF& pos, float width) const override;
     int hitStaffIndex(const QPointF& pos) const override;
     void addChordToSelection(MoveDirection d) override;
+    void moveChordNoteSelection(MoveDirection d) override;
     void select(const std::vector<Element*>& elements, SelectType type, int staffIndex = 0) override;
     void selectAll() override;
     void selectSection() override;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -124,6 +124,7 @@ public:
     void deleteSelection() override;
     void flipSelection() override;
     void addTieToSelection() override;
+    void addTiedNoteToChord() override;
     void addSlurToSelection() override;
     void addOttavaToSelection(OttavaType type) override;
     void addHairpinToSelection(HairpinType type) override;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -129,6 +129,8 @@ public:
     void addOttavaToSelection(OttavaType type) override;
     void addHairpinToSelection(HairpinType type) override;
     void addAccidentalToSelection(AccidentalType type) override;
+    void putRestToSelection() override;
+    void putRest(DurationType duration) override;
     void addBracketsToSelection(BracketsType type) override;
     void changeSelectedNotesArticulation(SymbolId articulationSymbolId) override;
     void addGraceNotesToSelectedNotes(GraceNoteType type) override;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -71,6 +71,8 @@ public:
     void select(const std::vector<Element*>& elements, SelectType type, int staffIndex = 0) override;
     void selectAll() override;
     void selectSection() override;
+    void selectFirstElement() override;
+    void selectLastElement() override;
     INotationSelectionPtr selection() const override;
     void clearSelection() override;
     async::Notification selectionChanged() const override;

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -81,6 +81,16 @@ const UiActionList NotationUiActions::m_actions = {
              QT_TRANSLATE_NOOP("action", "Down Note in Chord"),
              QT_TRANSLATE_NOOP("action", "Go to lower pitched note in chord")
              ),
+    UiAction("first-element",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "First element"),
+             QT_TRANSLATE_NOOP("action", "Go to first element in score")
+             ),
+    UiAction("last-element",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Last element"),
+             QT_TRANSLATE_NOOP("action", "Go to last element in score")
+             ),
     UiAction("next-track",
              mu::context::UiCtxNotationOpened,
              QT_TRANSLATE_NOOP("action", "Next staff or voice"),

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -71,6 +71,16 @@ const UiActionList NotationUiActions::m_actions = {
              QT_TRANSLATE_NOOP("action", "Previous Measure"),
              QT_TRANSLATE_NOOP("action", "Go to previous measure or move text left")
              ),
+    UiAction("up-chord",
+             mu::context::UiCtxNotationHasSelection,
+             QT_TRANSLATE_NOOP("action", "Up Note in Chord"),
+             QT_TRANSLATE_NOOP("action", "Go to higher pitched note in chord")
+             ),
+    UiAction("down-chord",
+             mu::context::UiCtxNotationHasSelection,
+             QT_TRANSLATE_NOOP("action", "Down Note in Chord"),
+             QT_TRANSLATE_NOOP("action", "Go to lower pitched note in chord")
+             ),
     UiAction("next-track",
              mu::context::UiCtxNotationOpened,
              QT_TRANSLATE_NOOP("action", "Next staff or voice"),

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -684,6 +684,31 @@ const UiActionList NotationUiActions::m_actions = {
              QT_TRANSLATE_NOOP("action", "Insert B"),
              QT_TRANSLATE_NOOP("action", "Insert note B")
              ),
+    UiAction("rest",
+             mu::context::UiCtxNotationHasSelection,
+             QT_TRANSLATE_NOOP("action", "Rest"),
+             QT_TRANSLATE_NOOP("action", "Enter rest")
+             ),
+    UiAction("rest-1",
+             mu::context::UiCtxNotationHasSelection,
+             QT_TRANSLATE_NOOP("action", "Whole Rest"),
+             QT_TRANSLATE_NOOP("action", "Note input: Whole rest")
+             ),
+    UiAction("rest-2",
+             mu::context::UiCtxNotationHasSelection,
+             QT_TRANSLATE_NOOP("action", "Half Rest"),
+             QT_TRANSLATE_NOOP("action", "Note input: Half rest")
+             ),
+    UiAction("rest-4",
+             mu::context::UiCtxNotationHasSelection,
+             QT_TRANSLATE_NOOP("action", "Quarter Rest"),
+             QT_TRANSLATE_NOOP("action", "Note input: Quarter rest")
+             ),
+    UiAction("rest-8",
+             mu::context::UiCtxNotationHasSelection,
+             QT_TRANSLATE_NOOP("action", "Eighth Rest"),
+             QT_TRANSLATE_NOOP("action", "Note input: Eighth rest")
+             ),
     UiAction("add-8va",
              mu::context::UiCtxNotationHasSelection,
              QT_TRANSLATE_NOOP("action", "Ottava 8va alta"),

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -709,6 +709,11 @@ const UiActionList NotationUiActions::m_actions = {
              QT_TRANSLATE_NOOP("action", "Note Anchored Line"),
              QT_TRANSLATE_NOOP("action", "Note anchored line")
              ),
+    UiAction("chord-tie",
+             mu::context::UiCtxNotationHasSelection,
+             QT_TRANSLATE_NOOP("action", "Add Tied Note to Chord"),
+             QT_TRANSLATE_NOOP("action", "Add Tied Note to Chord")
+             ),
     UiAction("title-text",
              mu::context::UiCtxNotationHasSelection,
              QT_TRANSLATE_NOOP("action", "Title"),


### PR DESCRIPTION
Implements shortcuts:
* ```chord-tie```
* ```rest```
* ```rest-1```
* ```rest-2```
* ```rest-4```
* ```rest-8```
* ```up-chord```
* ```down-chord```
* ```first-element```
* ```last-element```

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
