### PR TITLE
[MU4] Fix #7971: Help > MusicXML Links to contributor licenses rather than end-user licenses

### DIFF
--- a/src/appshell/internal/appshellconfiguration.cpp
+++ b/src/appshell/internal/appshellconfiguration.cpp
@@ -33,8 +33,8 @@ static const std::string ASK_FOR_HELP_URL("https://musescore.org/redirect/post/q
 static const std::string BUG_REPORT_URL("https://musescore.org/redirect/post/bug-report?locale=");
 static const std::string LEAVE_FEEDBACK_URL("https://musescore.com/content/editor-feedback?");
 static const std::string MUSESCORE_URL("http://www.musescore.org/");
-static const std::string MUSICXML_LICENSE_URL("https://www.w3.org/community/about/agreements/cla/");
-static const std::string MUSICXML_LICENSE_DEED_URL("https://www.w3.org/community/about/agreements/cla-deed/");
+static const std::string MUSICXML_LICENSE_URL("https://www.w3.org/community/about/process/final/");
+static const std::string MUSICXML_LICENSE_DEED_URL("https://www.w3.org/community/about/process/fsa-deed/");
 
 static const std::string UTM_MEDIUM_MENU("menu");
 

--- a/src/appshell/qml/AboutMusicXMLDialog.qml
+++ b/src/appshell/qml/AboutMusicXMLDialog.qml
@@ -50,7 +50,7 @@ QmlDialog {
                     StyledTextLabel {
                         width: parent.width
 
-                        text: qsTrc("appshell", "Copyright 2004 - 2017 the Contributors to the MusicXML Specification, published by the W3C Music Notation Community Group under the W3C Community Contributor License Agreement (CLA):")
+                        text: qsTrc("appshell", "Copyright 2004 - 2017 the Contributors to the MusicXML Specification, published by the W3C Music Notation Community Group under the W3C Community Final Specification Agreement:")
                         wrapMode: Text.WordWrap
                         maximumLineCount: 3
                     }


### PR DESCRIPTION
Fixes #7971

See #7979 for a 3.x backport.