### PR TITLE
Improved scroll gradient visibility in Add-ons->Languages

### DIFF
--- a/src/languages/qml/MuseScore/Languages/LanguagesPage.qml
+++ b/src/languages/qml/MuseScore/Languages/LanguagesPage.qml
@@ -77,7 +77,7 @@ Item {
         anchors.right: parent.right
         anchors.rightMargin: privateProperties.sideMargin
 
-        height: 48
+        height: 40
 
         StyledTextLabel {
             width: header.itemWidth
@@ -103,7 +103,7 @@ Item {
         anchors.right: parent.right
         anchors.top: view.top
 
-        height: 8
+        height: 56
         z: 1
 
         gradient: Gradient {
@@ -125,6 +125,14 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: panel.visible ? panel.top : parent.bottom
+
+        header: Rectangle {
+            height: 24
+        }
+
+        footer: Rectangle {
+            height: 32
+        }
 
         model: filterModel
 
@@ -170,7 +178,7 @@ Item {
         anchors.right: parent.right
         anchors.bottom: view.bottom
 
-        height: 8
+        height: 56
         z: 1
 
         gradient: Gradient {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/7929

The scroll gradient in Add-ons, Languages page isn't obvious enough. While the issue required the gradient at the bottom to be prominent, the following modifications also improve gradient visibility at the top of the list.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made

![Screenshot](https://user-images.githubusercontent.com/53314035/115337579-e1422a00-a1be-11eb-977c-d7abe8006062.png)