### PR TITLE
[MU4] Fixed popups creations for instrument item delegate

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledPopupView.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledPopupView.qml
@@ -135,12 +135,12 @@ PopupView {
             State {
                 name: "CLOSED"
                 when: !root.isOpened
-                PropertyChanges { target: contentContainer; scale: 0.8; opacity: 0.5 }
+                PropertyChanges { target: contentContainer; scale: 0.7; opacity: 0.5 }
             }
         ]
 
         transitions: Transition {
-            NumberAnimation { properties: "scale, opacity"; easing.type: Easing.OutQuint; duration: root.animationEnabled ? 140 : 0 }
+            NumberAnimation { properties: "scale, opacity"; easing.type: Easing.OutQuint; duration: root.animationEnabled ? 300 : 0 }
         }
     }
 }

--- a/src/instruments/qml/MuseScore/Instruments/internal/InstrumentSettingsPopup.qml
+++ b/src/instruments/qml/MuseScore/Instruments/internal/InstrumentSettingsPopup.qml
@@ -8,7 +8,7 @@ StyledPopupView {
     id: root
 
     contentHeight: contentColumn.childrenRect.height
-    contentWidth: parent.width
+    contentWidth: 240
 
     function load(instrument) {
         settingsModel.load(instrument)

--- a/src/instruments/qml/MuseScore/Instruments/internal/StaffSettingsPopup.qml
+++ b/src/instruments/qml/MuseScore/Instruments/internal/StaffSettingsPopup.qml
@@ -8,7 +8,7 @@ StyledPopupView {
     id: root
 
     contentHeight: contentColumn.childrenRect.height
-    contentWidth: parent.width
+    contentWidth: 240
 
     function load(staff) {
         settingsModel.load(staff)


### PR DESCRIPTION
Included https://github.com/musescore/MuseScore/pull/7966

In each item of the list of instruments, including the expanding staves, two popups are created at once when creating a list item.
Each popup contains some content, input fields, checkboxes, buttons, labels, etc.
Popups are shown only when we click on the (settings) button, i.e. they are not needed directly when creating a list item.
And also, for each item, only one popup can be shown, the second one will not be required never.

So, for each item of the list we have two popups, each with 4 controls at least, labels, etc., that is, for example, if we have 4 instruments, then we can create about 80 controls (buttons, checkboxes, input fields) and about 80 labels. Half of which is not needed at the moment, and the second half will never be in demand at all.