### PR TITLE
[MU4] Update .git-blame-ignore-revs to include one more rev to ignore

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
 # Conversion to new code style
 45b9887603f08523f9a663b164bd9f10b85f8b25
 9114d609168b327f00ef47b9891733cdb119b512
+# Change of code style
+4a0c9722961b0c1ad0c185955cb31b52e3ff5d85


### PR DESCRIPTION
Namely:

* 4a0c9722961b0c1ad0c185955cb31b52e3ff5d85
