### PR TITLE
[MU4] Added navigation for instrument settings popups

### DIFF
--- a/src/framework/ui/internal/navigationcontroller.cpp
+++ b/src/framework/ui/internal/navigationcontroller.cpp
@@ -26,6 +26,14 @@
 
 #include "log.h"
 
+//#define NAVIGATION_LOGGING_ENABLED
+
+#ifdef NAVIGATION_LOGGING_ENABLED
+#define MYLOG() LOGI()
+#else
+#define MYLOG() LOGN()
+#endif
+
 using namespace mu::ui;
 
 static const mu::UriQuery DEV_SHOW_CONTROLS_URI("musescore://devtools/keynav/controls?sync=false&modal=false");
@@ -294,7 +302,7 @@ void NavigationController::doActivateSection(INavigationSection* s)
     }
 
     s->setActive(true);
-    LOGD() << "activated section: " << s->name() << ", order: " << s->index().order();
+    MYLOG() << "activated section: " << s->name() << ", order: " << s->index().order();
 
     INavigationPanel* firstSub = firstEnabled(s->panels());
     if (firstSub) {
@@ -326,7 +334,7 @@ void NavigationController::doActivatePanel(INavigationPanel* sub)
     }
 
     sub->setActive(true);
-    LOGD() << "activated subsection: " << sub->name() << ", order: " << sub->index().order();
+    MYLOG() << "activated subsection: " << sub->name() << ", order: " << sub->index().order();
 
     INavigationControl* firstCtr = firstEnabled(sub->controls());
     if (firstCtr) {
@@ -354,7 +362,7 @@ void NavigationController::doActivateControl(INavigationControl* c)
     }
 
     c->setActive(true);
-    LOGD() << "activated control: " << c->name() << ", row: " << c->index().row << ", column: " << c->index().column;
+    MYLOG() << "activated control: " << c->name() << ", row: " << c->index().row << ", column: " << c->index().column;
 }
 
 void NavigationController::doDeactivateControl(INavigationControl* c)
@@ -418,7 +426,7 @@ INavigationControl* NavigationController::activeControl() const
 
 void NavigationController::goToNextSection()
 {
-    LOGI() << "====";
+    MYLOG() << "====";
     if (m_sections.empty()) {
         return;
     }
@@ -441,7 +449,7 @@ void NavigationController::goToNextSection()
 
 void NavigationController::goToPrevSection()
 {
-    LOGI() << "====";
+    MYLOG() << "====";
     if (m_sections.empty()) {
         return;
     }
@@ -464,8 +472,7 @@ void NavigationController::goToPrevSection()
 
 void NavigationController::goToNextPanel()
 {
-    LOGI() << "====";
-
+    MYLOG() << "====";
     INavigationSection* activeSec = activeSection();
     if (!activeSec) {
         doActivateFirst();
@@ -493,7 +500,7 @@ void NavigationController::goToNextPanel()
 
 void NavigationController::goToPrevPanel()
 {
-    LOGI() << "====";
+    MYLOG() << "====";
     INavigationSection* activeSec = activeSection();
     if (!activeSec) {
         doActivateLast();
@@ -661,6 +668,7 @@ void NavigationController::onUp()
 
 void NavigationController::onEscape()
 {
+    MYLOG() << "====";
     INavigationPanel* activeSubSec = activePanel();
     if (!activeSubSec) {
         return;
@@ -680,20 +688,19 @@ void NavigationController::onEscape()
 
 void NavigationController::goToFirstControl()
 {
-    LOGI() << "====";
+    MYLOG() << "====";
     goToControl(MoveDirection::First);
 }
 
 void NavigationController::goToLastControl()
 {
-    LOGI() << "====";
+    MYLOG() << "====";
     goToControl(MoveDirection::Last);
 }
 
 void NavigationController::goToNextRowControl()
 {
-    LOGI() << "====";
-
+    MYLOG() << "====";
     INavigationPanel* activeSubSec = activePanel();
     if (!activeSubSec) {
         return;
@@ -723,8 +730,7 @@ void NavigationController::goToNextRowControl()
 
 void NavigationController::goToPrevRowControl()
 {
-    LOGI() << "====";
-
+    MYLOG() << "====";
     INavigationPanel* activeSubSec = activePanel();
     if (!activeSubSec) {
         return;
@@ -754,8 +760,7 @@ void NavigationController::goToPrevRowControl()
 
 void NavigationController::goToControl(MoveDirection direction, INavigationPanel* activeSubSec)
 {
-    LOGI() << "direction: " << direction;
-
+    MYLOG() << "direction: " << direction;
     if (!activeSubSec) {
         activeSubSec = activePanel();
     }
@@ -766,6 +771,10 @@ void NavigationController::goToControl(MoveDirection direction, INavigationPanel
 
     INavigationControl* activeControl = findActive(activeSubSec->controls());
     if (activeControl) {
+        MYLOG() << "current activated control: " << activeControl->name()
+                << ", row: " << activeControl->index().row
+                << ", column: " << activeControl->index().column;
+
         doDeactivateControl(activeControl);
     }
 
@@ -835,13 +844,13 @@ void NavigationController::goToControl(MoveDirection direction, INavigationPanel
 
 void NavigationController::doTriggerControl()
 {
-    LOGI() << "====";
+    MYLOG() << "====";
     INavigationControl* activeCtrl= activeControl();
     if (!activeCtrl) {
         return;
     }
 
-    LOGD() << "triggered control: " << activeCtrl->name();
+    MYLOG() << "triggered control: " << activeCtrl->name();
     activeCtrl->trigger();
 }
 
@@ -857,7 +866,7 @@ void NavigationController::onForceActiveRequested(INavigationSection* sec, INavi
     }
 
     sec->setActive(true);
-    LOGD() << "activated section: " << sec->name() << ", order: " << sec->index().order();
+    MYLOG() << "activated section: " << sec->name() << ", order: " << sec->index().order();
 
     INavigationPanel* activeSub = findActive(sec->panels());
     if (activeSub && activeSub != sub) {
@@ -865,7 +874,7 @@ void NavigationController::onForceActiveRequested(INavigationSection* sec, INavi
     }
 
     sub->setActive(true);
-    LOGD() << "activated subsection: " << sub->name() << ", order: " << sub->index().order();
+    MYLOG() << "activated subsection: " << sub->name() << ", order: " << sub->index().order();
 
     INavigationControl* activeCtrl = findActive(sub->controls());
     if (activeCtrl && activeCtrl != ctrl) {
@@ -873,5 +882,5 @@ void NavigationController::onForceActiveRequested(INavigationSection* sec, INavi
     }
 
     ctrl->setActive(true);
-    LOGD() << "activated control: " << ctrl->name() << ", row: " << ctrl->index().row << ", column: " << ctrl->index().column;
+    MYLOG() << "activated control: " << ctrl->name() << ", row: " << ctrl->index().row << ", column: " << ctrl->index().column;
 }

--- a/src/framework/ui/qml/MuseScore/Ui/KeyNavDevPanel.qml
+++ b/src/framework/ui/qml/MuseScore/Ui/KeyNavDevPanel.qml
@@ -80,6 +80,12 @@ Rectangle {
             id: item
 
             property var section: modelData
+            property bool active: section.active
+            onActiveChanged: {
+                if (active) {
+                    view.positionViewAtIndex(model.index, ListView.Beginning)
+                }
+            }
 
             width: parent ? parent.width : 0
             height: 48 + subView.height

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/FocusableControl.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/FocusableControl.qml
@@ -33,7 +33,7 @@ FocusScope {
 
     property alias navigation: keynavItem
 
-    function insureActiveFocus() {
+    function ensureActiveFocus() {
         if (!root.activeFocus) {
             root.forceActiveFocus()
         }
@@ -50,7 +50,7 @@ FocusScope {
 
         onActiveChanged: {
             if (keynavItem.active) {
-                root.insureActiveFocus()
+                root.ensureActiveFocus()
             }
         }
     }
@@ -62,19 +62,19 @@ FocusScope {
         border.width: keynavItem.active ? 2 : 0
     }
 
-    Item {
-        id: contentItem
-        objectName: "FocusableControlContent"
-        anchors.fill: focusRectItem
-        anchors.margins: 2 //! NOTE margin needed to show focus border
-    }
-
     MouseArea {
         id: mouseAreaItem
         anchors.fill: parent
 
         onClicked: {
-            root.insureActiveFocus()
+            root.ensureActiveFocus()
         }
+    }
+
+    Item {
+        id: contentItem
+        objectName: "FocusableControlContent"
+        anchors.fill: focusRectItem
+        anchors.margins: 2 //! NOTE margin needed to show focus border
     }
 }

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/IncrementalPropertyControl.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/IncrementalPropertyControl.qml
@@ -130,8 +130,8 @@ Item {
         ValueAdjustControl {
             id: valueAdjustControl
 
-            anchors.verticalCenter: textInputField.verticalCenter
-            anchors.right: textInputField.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.right: parent.right
 
             icon: IconCode.SMALL_ARROW_DOWN
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledComboBox.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledComboBox.qml
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2.9
+import QtQuick 2.15
 import QtQuick.Controls 2.2
 import QtGraphicalEffects 1.0
 import MuseScore.Ui 1.0
@@ -35,7 +35,32 @@ ComboBox {
     property var value
     property var maxVisibleItemCount: 6
 
+    property alias navigation: navCtrl
+
     opacity: root.enabled ? 1 : ui.theme.itemOpacityDisabled
+
+    Keys.onReleased: {
+        //! TODO Conflicted with navigation, needs research
+        if (event.key === Qt.Key_Enter || event.key === Qt.Key_Return) {
+            event.accepted = true
+        }
+    }
+
+    onPressedChanged: {
+        if (root.pressed) {
+            root.ensureActiveFocus()
+        }
+    }
+
+    function ensureActiveFocus() {
+        if (!root.activeFocus) {
+            root.forceActiveFocus()
+        }
+
+        if (!navCtrl.active) {
+            navCtrl.forceActive()
+        }
+    }
 
     function valueFromModel(index, roleName) {
 
@@ -80,6 +105,24 @@ ComboBox {
     implicitHeight: 30
 
     padding: 0
+
+    NavigationControl {
+        id: navCtrl
+        name: root.objectName != "" ? root.objectName : "StyledComboBox"
+        enabled: root.enabled
+        onActiveChanged: {
+            if (!root.activeFocus) {
+                root.forceActiveFocus()
+            }
+        }
+        onTriggered: {
+            if (root.popup.opened) {
+                root.popup.close()
+            } else {
+                root.popup.open()
+            }
+        }
+    }
 
     QtObject {
         id: privateProperties
@@ -126,30 +169,39 @@ ComboBox {
                     name: "TOP_CORNERS_ROUNDED"
                     when: index === 0
 
-                    PropertyChanges { target: delegateBackgroundRect; topLeftRadius: 4
-                                                                      topRightRadius: 4
-                                                                      bottomLeftRadius: 0
-                                                                      bottomRightRadius: 0 }
+                    PropertyChanges {
+                        target: delegateBackgroundRect;
+                        topLeftRadius: 4
+                        topRightRadius: 4
+                        bottomLeftRadius: 0
+                        bottomRightRadius: 0
+                    }
                 },
 
                 State {
                     name: "NO_ROUNDED_CORNERS"
                     when: index !== 0 && index !== count - 1
 
-                    PropertyChanges { target: delegateBackgroundRect; topLeftRadius: 0
-                                                                      topRightRadius: 0
-                                                                      bottomLeftRadius: 0
-                                                                      bottomRightRadius: 0 }
+                    PropertyChanges {
+                        target: delegateBackgroundRect;
+                        topLeftRadius: 0
+                        topRightRadius: 0
+                        bottomLeftRadius: 0
+                        bottomRightRadius: 0
+                    }
                 },
 
                 State {
                     name: "BOTTOM_CORNERS_ROUNDED"
                     when: index === count - 1
 
-                    PropertyChanges { target: delegateBackgroundRect; topLeftRadius: 0
-                                                                      topRightRadius: 0
-                                                                      bottomLeftRadius: 4
-                                                                      bottomRightRadius: 4 }
+                    PropertyChanges {
+                        target: delegateBackgroundRect;
+                        topLeftRadius: 0
+                        topRightRadius: 0
+                        bottomLeftRadius: 4
+                        bottomRightRadius: 4
+                    }
                 }
             ]
         }
@@ -167,31 +219,23 @@ ComboBox {
         horizontalAlignment: Qt.AlignLeft
     }
 
-    background: RoundedRectangle {
-        height: root.implicitHeight
-        width: contentItem.width
-
+    background: Rectangle {
+        height: root.height
+        width: root.width
         color: ui.theme.buttonColor
         opacity: ui.theme.buttonOpacityNormal
 
-        topLeftRadius: 4
-        topRightRadius: 0
-        bottomLeftRadius: 4
-        bottomRightRadius: 0
+        radius: 4
+
+        border.width: navCtrl.active ? 2 : 0
+        border.color: ui.theme.focusColor
     }
 
-    indicator: RoundedRectangle {
+    indicator: Item {
         id: indicatorCanvas
 
         height: root.implicitHeight
         width: height
-
-        topLeftRadius: 0
-        bottomLeftRadius: 0
-        topRightRadius: 4
-        bottomRightRadius: 4
-
-        color: ui.theme.buttonColor
 
         x: root.width - width
         y: root.topPadding + (root.availableHeight - height) / 2

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/TextInputField.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/TextInputField.qml
@@ -19,12 +19,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2.9
-import QtQuick.Controls 2.1
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MuseScore.Ui 1.0
 
-Rectangle {
+FocusableControl {
     id: root
 
     property bool isIndeterminate: false
@@ -45,7 +45,6 @@ Rectangle {
 
     function selectAll() {
         valueInput.selectAll()
-        forceActiveFocus()
     }
 
     function clear() {
@@ -54,20 +53,21 @@ Rectangle {
         textCleared()
     }
 
-    function forceActiveFocus() {
-        valueInput.forceActiveFocus()
+    onActiveFocusChanged: {
+        if (activeFocus) {
+            valueInput.forceActiveFocus()
+        }
     }
 
     implicitHeight: 30
     implicitWidth: parent.width
 
-    color: ui.theme.textFieldColor
-    border.color: ui.theme.strokeColor
-    border.width: 1
+    background.color: ui.theme.textFieldColor
+    background.border.color: navigation.active ? ui.theme.focusColor : ui.theme.strokeColor
+    background.border.width: navigation.active ? 2 : 1
+    background.radius: 4
 
     opacity: root.enabled ? 1.0 : ui.theme.itemOpacityDisabled
-
-    radius: 4
 
     RowLayout {
         anchors.fill: parent
@@ -87,6 +87,8 @@ Rectangle {
 
         TextField {
             id: valueInput
+
+            objectName: "TextField"
 
             Layout.alignment: Qt.AlignVCenter
             Layout.fillWidth: !measureUnitsLabel.visible
@@ -151,7 +153,7 @@ Rectangle {
             icon: IconCode.CLOSE_X_ROUNDED
             visible: root.clearTextButtonVisible
 
-            normalStateColor: root.color
+            normalStateColor: root.background.color
             hoveredStateColor: ui.theme.accentColor
             pressedStateColor: ui.theme.accentColor
 
@@ -168,8 +170,8 @@ Rectangle {
     StyledTextLabel {
         id: undefinedValueLabel
 
-        anchors.verticalCenter: root.verticalCenter
-        anchors.left: root.left
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.left: parent.left
         anchors.leftMargin: 12
 
         text: root.indeterminateText
@@ -183,9 +185,7 @@ Rectangle {
             when: clickableArea.containsMouse && !valueInput.activeFocus
 
             PropertyChanges {
-                target: root
-                border.color: ui.theme.strokeColor
-                border.width: 1
+                target: root.background
                 opacity: 0.6
             }
         },
@@ -195,7 +195,7 @@ Rectangle {
             when: valueInput.activeFocus
 
             PropertyChanges {
-                target: root
+                target: root.background
                 border.color: ui.theme.accentColor
                 border.width: 1
                 opacity: 1
@@ -216,10 +216,8 @@ Rectangle {
         hoverEnabled: true
 
         onPressed: {
-            if (!valueInput.activeFocus) {
-                valueInput.forceActiveFocus()
-            }
-
+            root.ensureActiveFocus()
+            valueInput.forceActiveFocus()
             mouse.accepted = false
         }
     }

--- a/src/framework/uicomponents/view/popupview.h
+++ b/src/framework/uicomponents/view/popupview.h
@@ -24,13 +24,13 @@
 #define MU_UICOMPONENTS_POPUPVIEW_H
 
 #include <QQuickItem>
-#include <QQuickView>
 #include <QQmlParserStatus>
 
 #include "modularity/ioc.h"
 #include "ui/imainwindow.h"
 
 namespace mu::uicomponents {
+class PopupWindow;
 class PopupView : public QObject, public QQmlParserStatus
 {
     Q_OBJECT
@@ -91,7 +91,6 @@ signals:
     void closePolicyChanged(ClosePolicy closePolicy);
 
     void isOpenedChanged();
-
     void opened();
     void closed();
 
@@ -107,7 +106,7 @@ private:
 
     bool isMouseWithinBoundaries(const QPoint& mousePos) const;
 
-    QQuickView* m_view = nullptr;
+    PopupWindow* m_window = nullptr;
     QQuickItem* m_contentItem = nullptr;
 
     QPointF m_localPos;

--- a/src/instruments/qml/MuseScore/Instruments/InstrumentsPanel.qml
+++ b/src/instruments/qml/MuseScore/Instruments/InstrumentsPanel.qml
@@ -55,7 +55,7 @@ Item {
     }
 
     NavigationPanel {
-        id: keynavTreeSub
+        id: navigationTreePanel
         name: "InstrumentsTree"
         section: root.keynavSection
         direction: NavigationPanel.Both
@@ -225,7 +225,7 @@ Item {
                                 isSelected: treeItemDelegateLoader.isSelected
 
                                 keynavRow: model ? model.index : 0
-                                keynavSubSection: keynavTreeSub
+                                navigationPanel: navigationTreePanel
 
                                 isDragAvailable: dropArea.isSelectable
                                 type: treeItemDelegateLoader.delegateType
@@ -270,7 +270,7 @@ Item {
                                 isHighlighted: treeItemDelegateLoader.isSelected
 
                                 keynavRow: model ? model.index : 0
-                                keynavSubSection: keynavTreeSub
+                                navigationPanel: navigationTreePanel
 
                                 onClicked: {
                                     styleData.value.appendNewItem()

--- a/src/instruments/qml/MuseScore/Instruments/internal/InstrumentSettingsPopup.qml
+++ b/src/instruments/qml/MuseScore/Instruments/internal/InstrumentSettingsPopup.qml
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2.9
+import QtQuick 2.15
 
 import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
@@ -30,6 +30,13 @@ StyledPopupView {
 
     contentHeight: contentColumn.childrenRect.height
     contentWidth: 240
+
+    navigation.name: "InstrumentSettingsPopup"
+    navigation.direction: NavigationPanel.Vertical
+
+    onOpened: {
+        instrNameField.ensureActiveFocus()
+    }
 
     function load(instrument) {
         settingsModel.load(instrument)
@@ -50,8 +57,11 @@ StyledPopupView {
         }
 
         TextInputField {
+            id: instrNameField
+            objectName: "InstrNameField"
+            navigation.panel: root.navigation
+            navigation.row: 1
             currentText: settingsModel.instrumentName
-
             onCurrentTextEdited: {
                 settingsModel.instrumentName = newTextValue
             }
@@ -62,8 +72,10 @@ StyledPopupView {
         }
 
         TextInputField {
+            objectName: "AbbreviatureField"
+            navigation.panel: root.navigation
+            navigation.row: 2
             currentText: settingsModel.abbreviature
-
             onCurrentTextEdited: {
                 settingsModel.abbreviature = newTextValue
             }
@@ -74,8 +86,10 @@ StyledPopupView {
         }
 
         TextInputField {
+            objectName: "PartNameField"
+            navigation.panel: root.navigation
+            navigation.row: 3
             currentText: settingsModel.partName
-
             onCurrentTextEdited: {
                 settingsModel.partName = newTextValue
             }
@@ -89,6 +103,7 @@ StyledPopupView {
         FlatButton {
             width: parent.width
             navigation.panel: root.navigation
+            navigation.row: 4
             text: qsTrc("instruments", "Replace instrument")
 
             onClicked: {

--- a/src/instruments/qml/MuseScore/Instruments/internal/InstrumentsTreeItemControl.qml
+++ b/src/instruments/qml/MuseScore/Instruments/internal/InstrumentsTreeItemControl.qml
@@ -31,7 +31,7 @@ Item {
     property bool isHighlighted: false
 
     property int keynavRow: 0
-    property NavigationPanel keynavSubSection: null
+    property NavigationPanel navigationPanel: null
 
     Rectangle {
         anchors.fill: parent
@@ -48,7 +48,7 @@ Item {
     NavigationControl {
         id: keynavItem
         name: "InstrumentsTreeItemControl"
-        panel: root.keynavSubSection
+        panel: root.navigationPanel
         row: root.keynavRow
         column: 0
         enabled: visible
@@ -85,7 +85,7 @@ Item {
                 height: width
 
                 objectName: "InstrumentsAddStaffBtn"
-                navigation.panel: root.keynavSubSection
+                navigation.panel: root.navigationPanel
                 navigation.row: root.keynavRow
                 navigation.column: 1
 

--- a/src/instruments/qml/MuseScore/Instruments/internal/InstrumentsTreeItemDelegate.qml
+++ b/src/instruments/qml/MuseScore/Instruments/internal/InstrumentsTreeItemDelegate.qml
@@ -38,7 +38,7 @@ Item {
     property var type: InstrumentTreeItemType.UNDEFINED
 
     property int keynavRow: 0
-    property NavigationPanel keynavSubSection: null
+    property NavigationPanel navigationPanel: null
 
     property int sideMargin: 0
 
@@ -104,7 +104,7 @@ Item {
     NavigationControl {
         id: keynavItem
         name: "ItemInstrumentsTree"
-        panel: root.keynavSubSection
+        panel: root.navigationPanel
         row: root.keynavRow
         column: 0
         enabled: visible
@@ -230,8 +230,7 @@ Item {
     Component {
         id: instrumentSettingsComp
         InstrumentSettingsPopup {
-            navigation.name: "InstrumentSettingsPopup"
-            navigation.parentControl: keynavItem
+            navigation.parentControl: settingsButton.navigation
             onClosed: {
                 prv.resetOpenedPopup()
                 popupLoader.sourceComponent = null
@@ -242,8 +241,7 @@ Item {
     Component {
         id: staffSettingsComp
         StaffSettingsPopup {
-            navigation.name: "StaffSettingsPopup"
-            navigation.parentControl: keynavItem
+            navigation.parentControl: settingsButton.navigation
             onClosed: {
                 prv.resetOpenedPopup()
                 popupLoader.sourceComponent = null
@@ -263,7 +261,7 @@ Item {
             Layout.preferredWidth: width
 
             objectName: "VisibleBtnInstrument"
-            navigation.panel: root.keynavSubSection
+            navigation.panel: root.navigationPanel
             navigation.row: root.keynavRow
             navigation.column: 1
 
@@ -294,7 +292,7 @@ Item {
 
                 objectName: "ExpandBtnInstrument"
                 enabled: expandButton.visible
-                navigation.panel: root.keynavSubSection
+                navigation.panel: root.navigationPanel
                 navigation.row: root.keynavRow
                 navigation.column: 2
 
@@ -345,7 +343,7 @@ Item {
 
             objectName: "SettingsBtnInstrument"
             enabled: root.visible
-            navigation.panel: root.keynavSubSection
+            navigation.panel: root.navigationPanel
             navigation.row: root.keynavRow
             navigation.column: 3
 

--- a/src/instruments/qml/MuseScore/Instruments/internal/StaffSettingsPopup.qml
+++ b/src/instruments/qml/MuseScore/Instruments/internal/StaffSettingsPopup.qml
@@ -31,8 +31,15 @@ StyledPopupView {
     contentHeight: contentColumn.childrenRect.height
     contentWidth: 240
 
+    navigation.name: "StaffSettingsPopup"
+    navigation.direction: NavigationPanel.Vertical
+
     function load(staff) {
         settingsModel.load(staff)
+    }
+
+    onOpened: {
+        staffTypesComboBox.ensureActiveFocus()
     }
 
     StaffSettingsModel {
@@ -51,7 +58,11 @@ StyledPopupView {
         }
 
         StyledComboBox {
+            id: staffTypesComboBox
             width: parent.width
+
+            navigation.panel: root.navigation
+            navigation.row: 1
 
             textRoleName: "text"
             valueRoleName: "value"
@@ -81,21 +92,24 @@ StyledPopupView {
             text: qsTrc("instruments", "Voices visible in the score")
         }
 
-        ListView {
-            height: contentItem.childrenRect.height
+        Row {
+            height: 40
             width: parent.width
-
             spacing: 26
-            orientation: ListView.Horizontal
+            Repeater {
+                model: settingsModel.voices
+                delegate: CheckBox {
+                    id: item
+                    objectName: "Voice"+modelData.title+"CheckBox"
+                    navigation.panel: root.navigation
+                    navigation.row: model.index + 2 //! NOTE after staffTypesComboBox
+                    text: modelData.title
+                    checked: modelData.visible
 
-            model: settingsModel.voices
-
-            delegate: CheckBox {
-                text: modelData.title
-                checked: modelData.visible
-
-                onClicked: {
-                    settingsModel.setVoiceVisible(model.index, !checked)
+                    onClicked: {
+                        item.checked = !item.checked
+                        settingsModel.setVoiceVisible(model.index, !checked)
+                    }
                 }
             }
         }
@@ -106,10 +120,10 @@ StyledPopupView {
         }
 
         CheckBox {
+            navigation.panel: root.navigation
+            navigation.row: 20 // Should be more than a voices checkbox
             text: qsTrc("instruments", "Small staff")
-
             checked: settingsModel.isSmallStaff
-
             onClicked: {
                 settingsModel.setIsSmallStaff(!checked)
             }
@@ -119,6 +133,9 @@ StyledPopupView {
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.rightMargin: 20
+
+            navigation.panel: root.navigation
+            navigation.row: 21 // after small staff CheckBox
 
             text: qsTrc("instruments", "Hide all measures that do not contain notation (cutaway)")
             wrapMode: Text.WordWrap
@@ -139,6 +156,7 @@ StyledPopupView {
             width: parent.width
 
             navigation.panel: root.navigation
+            navigation.row: 22 // after cutaway CheckBox
 
             text: qsTrc("instruments", "Create a linked staff")
 

--- a/src/instruments/view/staffsettingsmodel.cpp
+++ b/src/instruments/view/staffsettingsmodel.cpp
@@ -106,7 +106,15 @@ void StaffSettingsModel::setVoiceVisible(int voiceIndex, bool visible)
     m_voicesVisibility[voiceIndex] = visible;
     parts()->setVoiceVisible(m_staffId, voiceIndex, visible);
 
-    emit voicesChanged();
+    //! NOTE Do not send a signal to change the list
+    //! This will lead to the re-creation of the controlы (checkboxes),
+    //! and so we will lose the control with active focus,
+    //! and new controls will be created and added.
+    //! None of the controls will be the active focus.
+    //! The checkbox state changes in the view.
+    //! An alternative solution - we need to make a powerful model
+    //! and not recreate elements when their state changes (do not reset it completely)
+    //emit voicesChanged();
 }
 
 bool StaffSettingsModel::isSmallStaff() const

--- a/src/userscores/qml/MuseScore/UserScores/internal/MeasuresSettings.qml
+++ b/src/userscores/qml/MuseScore/UserScores/internal/MeasuresSettings.qml
@@ -36,8 +36,8 @@ FlatButton {
     accentButton: popup.visible
 
     StyledTextLabel {
-        anchors.horizontalCenter: root.horizontalCenter
-        anchors.verticalCenter: root.verticalCenter
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.verticalCenter: parent.verticalCenter
 
         property string pickupMessage: {
             if (withPickupMeasure.checked) {

--- a/src/userscores/qml/MuseScore/UserScores/internal/TimeSignatureSettings.qml
+++ b/src/userscores/qml/MuseScore/UserScores/internal/TimeSignatureSettings.qml
@@ -38,8 +38,8 @@ FlatButton {
     TimeSignatureView {
         id: timeSignatureView
 
-        anchors.horizontalCenter: root.horizontalCenter
-        anchors.verticalCenter: root.verticalCenter
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.verticalCenter: parent.verticalCenter
 
         numerator: root.model.musicSymbolCodes(root.model.timeSignature.numerator)
         denominator: root.model.musicSymbolCodes(root.model.timeSignature.denominator)

--- a/thirdparty/haw_logger/logger/log_base.h
+++ b/thirdparty/haw_logger/logger/log_base.h
@@ -31,6 +31,7 @@
 #define LOGW()      IF_LOGLEVEL(haw::logger::Normal) LOG(haw::logger::Logger::WARN, LOG_TAG)
 #define LOGI()      IF_LOGLEVEL(haw::logger::Normal) LOG(haw::logger::Logger::INFO, LOG_TAG)
 #define LOGD()      IF_LOGLEVEL(haw::logger::Debug) LOG(haw::logger::Logger::DEBG, LOG_TAG)
+#define LOGN()      if (0) LOG(haw::logger::Logger::DEBG, LOG_TAG) // compiling, but no output
 
 //! Helps
 #define DEPRECATED LOGD() << "This function deprecated!!"


### PR DESCRIPTION
I had to work hard to make everything work together - shortcuts, popup active focus, text editing, and mouse events.

Tried different solutions, the path was not winding ...
The current solution is the most stable and works well.

Navigation through the combobox has not yet been fully completed (I will do separately)

https://user-images.githubusercontent.com/3818029/115593986-80594580-a2d5-11eb-8295-ac93dadbcdc9.mp4

