### PR TITLE
[MU4] Fixed navigation by tab

### DIFF
--- a/src/framework/ui/internal/navigationcontroller.h
+++ b/src/framework/ui/internal/navigationcontroller.h
@@ -61,7 +61,7 @@ private:
     void devShowControls();
 
     void goToNextSection();
-    void goToPrevSection();
+    void goToPrevSection(bool isActivateLastPanel = false);
     void goToNextPanel();
     void goToPrevPanel();
 
@@ -81,7 +81,7 @@ private:
     void doTriggerControl();
     void onForceActiveRequested(INavigationSection* sec, INavigationPanel* sub, INavigationControl* ctrl);
 
-    void doActivateSection(INavigationSection* s);
+    void doActivateSection(INavigationSection* s, bool isActivateLastPanel = false);
     void doDeactivateSection(INavigationSection* s);
     void doActivatePanel(INavigationPanel* s);
     void doDeactivatePanel(INavigationPanel* s);


### PR DESCRIPTION
it's just Tab that needs fixing. Basically the desired behaviour is:

F6: Navigates sections
Tab: Navigates sections and subsections
Arrow keys: Navigate controls within a subsection

Using Tab for both sections and subsections should help people who don't know about the F6 shortcut.

@shoogle FYI