### PR TITLE
Use QStyle to make QWidgets look like QML

### DIFF
--- a/src/framework/ui/view/uitheme.cpp
+++ b/src/framework/ui/view/uitheme.cpp
@@ -357,6 +357,9 @@ void UiTheme::setupWidgetTheme()
     QColor fontPrimaryColorDisabled = fontPrimaryColor();
     fontPrimaryColorDisabled.setAlphaF(itemOpacityDisabled());
 
+    QColor linkColorDisabled = linkColor();
+    linkColorDisabled.setAlphaF(itemOpacityDisabled());
+
     QColor backgroundPrimaryColorDisabled = backgroundPrimaryColor();
     backgroundPrimaryColorDisabled.setAlphaF(itemOpacityDisabled());
 
@@ -376,6 +379,9 @@ void UiTheme::setupWidgetTheme()
 
     palette.setColor(QPalette::Text, fontPrimaryColor());
     palette.setColor(QPalette::Disabled, QPalette::Text, fontPrimaryColorDisabled);
+
+    palette.setColor(QPalette::Link, linkColor());
+    palette.setColor(QPalette::Disabled, QPalette::Link, linkColorDisabled);
 
     palette.setColor(QPalette::Button, backgroundSecondaryColor());
     palette.setColor(QPalette::Disabled, QPalette::Button, backgroundSecondaryColorDisabled);

--- a/src/framework/ui/view/uitheme.cpp
+++ b/src/framework/ui/view/uitheme.cpp
@@ -32,7 +32,7 @@
 #include <QVariant>
 
 #include "log.h"
-#include "notation/view/widgets/radiobuttongroupbox.h"
+#include "uicomponents/view/widgets/radiobuttongroupbox.h"
 
 using namespace mu::ui;
 
@@ -534,11 +534,12 @@ QRect UiTheme::subControlRect(QStyle::ComplexControl control, const QStyleOption
             const bool checkable = option->subControls & QStyle::SC_GroupBoxCheckBox;
 
             if (checkable) {
-                auto radioButtonGroupBox = qobject_cast<const notation::RadioButtonGroupBox*>(widget);
+                const bool isRadioButtonGroupBox = qobject_cast<const uicomponents::RadioButtonGroupBox*>(widget);
 
-                indicatorWidth = pixelMetric(radioButtonGroupBox ? PM_ExclusiveIndicatorWidth : PM_IndicatorWidth, option, widget);
-                indicatorHeight = pixelMetric(radioButtonGroupBox ? PM_ExclusiveIndicatorHeight : PM_IndicatorHeight, option, widget);
-                indicatorSpacing = pixelMetric(radioButtonGroupBox ? PM_RadioButtonLabelSpacing : PM_CheckBoxLabelSpacing, option, widget);
+                indicatorWidth = pixelMetric(isRadioButtonGroupBox ? PM_ExclusiveIndicatorWidth : PM_IndicatorWidth, option, widget);
+                indicatorHeight = pixelMetric(isRadioButtonGroupBox ? PM_ExclusiveIndicatorHeight : PM_IndicatorHeight, option, widget);
+                indicatorSpacing
+                    = pixelMetric(isRadioButtonGroupBox ? PM_RadioButtonLabelSpacing : PM_CheckBoxLabelSpacing, option, widget);
             }
 
             if (subControl == SC_GroupBoxFrame) {
@@ -634,9 +635,9 @@ QSize UiTheme::sizeFromContents(QStyle::ContentsType type, const QStyleOption* o
         const bool checkable = groupBox && groupBox->isCheckable();
 
         if (checkable) {
-            const notation::RadioButtonGroupBox* radioButtonGroupBox = qobject_cast<const notation::RadioButtonGroupBox*>(groupBox);
+            const bool isRadioButtonGroupBox = qobject_cast<const uicomponents::RadioButtonGroupBox*>(groupBox);
 
-            int pm = pixelMetric(radioButtonGroupBox ? PM_ExclusiveIndicatorHeight : PM_IndicatorHeight, option, widget);
+            int pm = pixelMetric(isRadioButtonGroupBox ? PM_ExclusiveIndicatorHeight : PM_IndicatorHeight, option, widget);
             return commonStyleSize + QSize(0, std::max(pm, option->fontMetrics.height()));
         }
 

--- a/src/framework/ui/view/uitheme.cpp
+++ b/src/framework/ui/view/uitheme.cpp
@@ -394,9 +394,9 @@ void UiTheme::setupWidgetTheme()
     QApplication::setStyle(this);
     QApplication::setPalette(palette);
 
-    QFont widgetsFont = bodyFont();
-    widgetsFont.setPointSize(configuration()->fontSize(FontSizeType::BODY));
-    QApplication::setFont(widgetsFont);
+    QString styleSheet = QString("* { font: %1px \"%2\" } ")
+                         .arg(QString::number(bodyFont().pixelSize()), bodyFont().family());
+    qApp->setStyleSheet(styleSheet);
 }
 
 void UiTheme::notifyAboutThemeChanged()

--- a/src/framework/ui/view/uitheme.cpp
+++ b/src/framework/ui/view/uitheme.cpp
@@ -22,13 +22,63 @@
 
 #include "uitheme.h"
 
+#include <QAbstractItemView>
 #include <QApplication>
+#include <QMenu>
 #include <QPalette>
+#include <QStyleFactory>
+#include <QStyleOption>
+#include <QToolBar>
 #include <QVariant>
+
+#include "log.h"
+#include "notation/view/widgets/radiobuttongroupbox.h"
 
 using namespace mu::ui;
 
 static const QString SEMIBOLD_STYLE_NAME("SemiBold");
+
+static const QPen NO_BORDER(Qt::transparent, 0);
+static const QBrush NO_FILL(Qt::transparent);
+
+static const int GROUP_BOX_LABEL_SPACING = 2;
+
+//! NOTE In QML, a border is drawn _inside_ a rectangle.
+//!      In C++, a border would normally be drawn half inside the rectangle, half outside.
+//!      In this function, we exactly replicate the behaviour from QML.
+static void drawRoundedRect(QPainter* painter, const QRectF& rect, const qreal radius, const QBrush& brush = NO_FILL,
+                            const QPen& pen = NO_BORDER)
+{
+    IF_ASSERT_FAILED(painter) {
+        return;
+    }
+
+    const qreal bw = pen.width();
+
+    if (bw <= 0 || pen.color().alpha() == 0) {
+        if (brush == NO_FILL) {
+            return;
+        }
+
+        painter->save();
+        painter->setPen(NO_BORDER);
+        painter->setBrush(brush);
+        painter->drawRoundedRect(rect, radius, radius);
+        painter->restore();
+        return;
+    }
+
+    painter->save();
+    painter->setPen(NO_BORDER);
+    painter->setBrush(brush);
+    painter->drawRoundedRect(rect.adjusted(bw, bw, -bw, -bw), radius - bw, radius - bw);
+
+    const qreal corr = 0.5 * bw;
+    painter->setPen(pen);
+    painter->setBrush(NO_FILL);
+    painter->drawRoundedRect(rect.adjusted(corr, corr, -corr, -corr), radius - corr, radius - corr);
+    painter->restore();
+}
 
 struct FontConfig
 {
@@ -36,9 +86,10 @@ struct FontConfig
     FontSizeType sizeType = FontSizeType::BODY;
 };
 
-UiTheme::UiTheme(QObject* parent)
-    : QObject(parent)
+UiTheme::UiTheme(QObject*)
+    : QProxyStyle(QStyleFactory::create("Fusion"))
 {
+    setObjectName("UiTheme");
 }
 
 void UiTheme::init()
@@ -340,6 +391,7 @@ void UiTheme::setupWidgetTheme()
     palette.setColor(QPalette::PlaceholderText, fontPrimaryColor());
     palette.setColor(QPalette::Disabled, QPalette::PlaceholderText, fontPrimaryColorDisabled);
 
+    QApplication::setStyle(this);
     QApplication::setPalette(palette);
 
     QFont widgetsFont = bodyFont();
@@ -350,4 +402,360 @@ void UiTheme::setupWidgetTheme()
 void UiTheme::notifyAboutThemeChanged()
 {
     emit themeChanged();
+}
+
+// ====================================================
+// QStyle
+// ====================================================
+
+void UiTheme::polish(QWidget* widget)
+{
+    QProxyStyle::polish(widget);
+
+    if (qobject_cast<QAbstractItemView*>(widget)
+        || qobject_cast<QGroupBox*>(widget)) {
+        // Make hovering work
+        widget->setMouseTracking(true);
+        widget->setAttribute(Qt::WA_Hover, true);
+    }
+}
+
+void UiTheme::unpolish(QWidget* widget)
+{
+    QProxyStyle::unpolish(widget);
+
+    if (qobject_cast<QAbstractItemView*>(widget)
+        || qobject_cast<QGroupBox*>(widget)) {
+        widget->setMouseTracking(false);
+        widget->setAttribute(Qt::WA_Hover, false);
+    }
+}
+
+void UiTheme::drawPrimitive(QStyle::PrimitiveElement element, const QStyleOption* option, QPainter* painter, const QWidget* widget) const
+{
+    const bool enabled = option->state & State_Enabled;
+    const bool hovered = option->state & State_MouseOver;
+    const bool pressed = option->state & State_Sunken;
+
+    painter->save();
+    painter->setRenderHint(QPainter::Antialiasing, true);
+
+    //! NOTE This drawing code is based on the implementation in QML.
+    switch (element) {
+    case QStyle::PE_PanelButtonCommand: {
+        const QStyleOptionButton* buttonOption = qstyleoption_cast<const QStyleOptionButton*>(option);
+        const bool accentButton = buttonOption && buttonOption->features & QStyleOptionButton::DefaultButton;
+        const bool flat = buttonOption && buttonOption->features & QStyleOptionButton::Flat;
+
+        QColor backgroundColor(accentButton ? accentColor()
+                               : flat ? Qt::transparent
+                               : buttonColor());
+
+        backgroundColor.setAlphaF(!enabled ? buttonOpacityNormal() * itemOpacityDisabled()
+                                  : pressed ? buttonOpacityHit()
+                                  : hovered ? buttonOpacityHover()
+                                  : !flat ? buttonOpacityNormal()
+                                  : 0);
+
+        drawRoundedRect(painter, option->rect, 3, backgroundColor);
+    } break;
+    case QStyle::PE_IndicatorCheckBox: {
+        const bool indeterminate = option->state & State_NoChange;
+        const bool checked = option->state & State_On;
+        const bool inMenu = qobject_cast<const QMenu*>(widget);
+
+        if (!inMenu) {
+            QColor backgroundColor = buttonColor();
+            backgroundColor.setAlphaF(!enabled ? buttonOpacityNormal() * itemOpacityDisabled()
+                                      : pressed ? buttonOpacityHit()
+                                      : hovered ? buttonOpacityHover()
+                                      : buttonOpacityNormal());
+
+            QColor borderColor = enabled && (hovered || pressed) ? strokeColor() : Qt::transparent;
+            borderColor.setAlphaF(enabled && pressed ? buttonOpacityHit()
+                                  : enabled && hovered ? buttonOpacityHover()
+                                  : 0);
+
+            const int borderWidth = enabled && (hovered || pressed) ? 1 : 0;
+            drawRoundedRect(painter, option->rect, 2, backgroundColor, QPen(borderColor, borderWidth));
+        }
+
+        if (checked || indeterminate) {
+            QColor tickColor = fontPrimaryColor();
+            if (!enabled) {
+                tickColor.setAlphaF(itemOpacityDisabled());
+            }
+            painter->setPen(tickColor);
+            painter->setFont(m_iconsFont);
+            painter->drawText(option->rect, Qt::AlignCenter,
+                              iconCodeToChar(indeterminate ? IconCode::Code::MINUS : IconCode::Code::TICK_RIGHT_ANGLE));
+        }
+    } break;
+    case QStyle::PE_IndicatorRadioButton: {
+        bool selected = option->state & State_On;
+
+        QColor borderColor(fontPrimaryColor());
+        QColor backgroundColor(textFieldColor());
+        QColor centerColor(accentColor());
+
+        if (pressed) {
+            backgroundColor.setAlphaF(accentOpacityHit());
+        } else if (selected && !hovered) {
+            backgroundColor.setAlphaF(accentOpacityNormal());
+        } else if (hovered && !selected && !pressed) {
+            backgroundColor.setAlphaF(buttonOpacityHover());
+        } else if (hovered && selected) {
+            backgroundColor.setAlphaF(accentOpacityHover());
+        } else {
+            backgroundColor.setAlphaF(buttonOpacityNormal());
+        }
+
+        borderColor.setAlphaF(backgroundColor.alphaF());
+
+        const int borderWidth = 1;
+        const qreal outerCircleRadius = 10; // diameter = 20
+        const QRect outerCircleRect(option->rect.center() + QPoint(1, 1) - QPoint(outerCircleRadius, outerCircleRadius),
+                                    QSize(outerCircleRadius, outerCircleRadius) * 2);
+        drawRoundedRect(painter, outerCircleRect, outerCircleRadius, backgroundColor, QPen(borderColor, borderWidth));
+
+        if (selected || pressed) {
+            const int innerCircleRadius = 5; // diameter = 10
+            const QRect innerCircleRect(option->rect.center() + QPoint(1, 1) - QPoint(innerCircleRadius, innerCircleRadius),
+                                        QSize(innerCircleRadius, innerCircleRadius) * 2);
+            drawRoundedRect(painter, innerCircleRect, innerCircleRadius, centerColor);
+        }
+    } break;
+    case QStyle::PE_IndicatorSpinUp:
+    case QStyle::PE_IndicatorSpinDown:
+    case QStyle::PE_IndicatorSpinPlus:
+    case QStyle::PE_IndicatorSpinMinus: {
+        QColor color = fontPrimaryColor();
+        if (!enabled) {
+            color.setAlphaF(itemOpacityDisabled());
+        }
+        painter->setPen(color);
+        painter->setFont(m_iconsFont);
+
+        IconCode::Code code;
+        switch (element) {
+        case QStyle::PE_IndicatorSpinPlus:
+            code = IconCode::Code::PLUS;
+            break;
+        case QStyle::PE_IndicatorSpinMinus:
+            code = IconCode::Code::MINUS;
+            break;
+        case QStyle::PE_IndicatorSpinUp:
+            code = IconCode::Code::SMALL_ARROW_UP;
+            break;
+        case QStyle::PE_IndicatorSpinDown:
+            code = IconCode::Code::SMALL_ARROW_DOWN;
+            break;
+        default:
+            code = IconCode::Code::NONE;
+            break;
+        }
+
+        painter->drawText(option->rect, Qt::AlignCenter, iconCodeToChar(code));
+    } break;
+    case QStyle::PE_PanelItemViewItem: {
+        bool selected = option->state & State_Selected;
+
+        QColor backgroundColor(Qt::transparent);
+        if (selected) {
+            backgroundColor = accentColor();
+            backgroundColor.setAlphaF(enabled ? accentOpacityHit() : accentOpacityHit() * itemOpacityDisabled());
+        } else if (enabled && pressed) {
+            backgroundColor = buttonColor();
+            backgroundColor.setAlphaF(buttonOpacityHit());
+        } else if (enabled && hovered) {
+            backgroundColor = buttonColor();
+            backgroundColor.setAlphaF(buttonOpacityHover());
+        }
+
+        painter->fillRect(option->rect, backgroundColor);
+    } break;
+    case QStyle::PE_PanelToolBar: {
+        painter->fillRect(option->rect, backgroundPrimaryColor());
+    } break;
+    case QStyle::PE_IndicatorToolBarHandle: {
+        QColor gripColor(fontPrimaryColor());
+        gripColor.setAlphaF(0.5);
+        painter->setPen(gripColor);
+        painter->setFont(m_iconsFont);
+
+        int rotation = option->state & State_Horizontal ? 0 : 90;
+        QRect rect = option->state & State_Horizontal ? option->rect : QRect(option->rect.topLeft() + QPoint(0, -option->rect.width()),
+                                                                             option->rect.size().transposed());
+        painter->rotate(rotation);
+        painter->drawText(rect, Qt::AlignCenter, iconCodeToChar(IconCode::Code::TOOLBAR_GRIP));
+        painter->rotate(-rotation);
+    } break;
+    case QStyle::PE_FrameGroupBox: {
+        drawRoundedRect(painter, option->rect, 3, QBrush("#03000000"), QPen(strokeColor(), 1));
+    } break;
+    case QStyle::PE_PanelMenu: {
+        drawRoundedRect(painter, option->rect, 3, backgroundPrimaryColor());
+    } break;
+    case QStyle::PE_FrameMenu: {
+        drawRoundedRect(painter, option->rect, 3, NO_FILL, QPen(strokeColor(), 1));
+    } break;
+    default:
+        QProxyStyle::drawPrimitive(element, option, painter, widget);
+        break;
+    }
+
+    painter->restore();
+}
+
+QRect UiTheme::subControlRect(QStyle::ComplexControl control, const QStyleOptionComplex* option, QStyle::SubControl subControl,
+                              const QWidget* widget) const
+{
+    //QRect commonStyleRect = QCommonStyle::subControlRect(control, option, subControl, widget);
+    QRect proxyStyleRect = QProxyStyle::subControlRect(control, option, subControl, widget);
+
+    switch (control) {
+    case QStyle::CC_GroupBox:
+        if (const QStyleOptionGroupBox* optionGroupBox = qstyleoption_cast<const QStyleOptionGroupBox*>(option)) {
+            int indicatorWidth = 0;
+            int indicatorHeight = 0;
+            int indicatorSpacing = 0;
+            const QSize textSize = option->fontMetrics.boundingRect(optionGroupBox->text).size() + QSize(2, 2);
+
+            const bool checkable = option->subControls & QStyle::SC_GroupBoxCheckBox;
+
+            if (checkable) {
+                auto radioButtonGroupBox = qobject_cast<const notation::RadioButtonGroupBox*>(widget);
+
+                indicatorWidth = pixelMetric(radioButtonGroupBox ? PM_ExclusiveIndicatorWidth : PM_IndicatorWidth, option, widget);
+                indicatorHeight = pixelMetric(radioButtonGroupBox ? PM_ExclusiveIndicatorHeight : PM_IndicatorHeight, option, widget);
+                indicatorSpacing = pixelMetric(radioButtonGroupBox ? PM_RadioButtonLabelSpacing : PM_CheckBoxLabelSpacing, option, widget);
+            }
+
+            if (subControl == SC_GroupBoxFrame) {
+                int topMargin = std::max(indicatorHeight, textSize.height()) + GROUP_BOX_LABEL_SPACING;
+                return option->rect.adjusted(0, topMargin, 0, 0);
+            }
+
+            if (subControl == SC_GroupBoxContents) {
+                int margin = 3;
+                int topMargin = margin + std::max(indicatorHeight, textSize.height()) + GROUP_BOX_LABEL_SPACING;
+                return option->rect.adjusted(margin, topMargin, -margin, -margin);
+            }
+
+            const int width = textSize.width() + (checkable ? indicatorWidth + indicatorSpacing : 0);
+            QRect rect;
+
+            if (option->rect.width() > width) {
+                switch (optionGroupBox->textAlignment & Qt::AlignHorizontal_Mask) {
+                case Qt::AlignHCenter:
+                    rect.moveLeft((option->rect.width() - width) / 2);
+                    break;
+                case Qt::AlignRight:
+                    rect.moveLeft(option->rect.width() - width);
+                    break;
+                }
+            }
+
+            if (subControl == SC_GroupBoxCheckBox) {
+                rect.setWidth(indicatorWidth);
+                rect.setHeight(indicatorHeight);
+                rect.moveTop(textSize.height() > indicatorHeight ? (textSize.height() - indicatorHeight) / 2 : 0);
+            } else if (subControl == SC_GroupBoxLabel) {
+                rect.setSize(textSize);
+                if (checkable) {
+                    rect.moveTop(textSize.height() < indicatorHeight ? (indicatorHeight - textSize.height()) / 2 : 0);
+                    rect.translate(indicatorWidth + indicatorSpacing, 0);
+                }
+            }
+
+            return visualRect(option->direction, option->rect, rect);
+        }
+        break;
+    default:
+        break;
+    }
+
+    return proxyStyleRect;
+}
+
+int UiTheme::pixelMetric(QStyle::PixelMetric metric, const QStyleOption* option, const QWidget* widget) const
+{
+    //! NOTE These metrics are based on the implementation in QML.
+    switch (metric) {
+    case PM_IndicatorWidth: // Checkbox
+    case PM_IndicatorHeight:
+        return 20;
+    case PM_CheckBoxLabelSpacing:
+        return 8;
+    case PM_ExclusiveIndicatorWidth: // Radio button
+    case PM_ExclusiveIndicatorHeight:
+        return 20;
+    case PM_RadioButtonLabelSpacing:
+        return 6;
+    case PM_ToolBarHandleExtent: // Toolbars
+        return 32;
+    default:
+        break;
+    }
+
+    return QProxyStyle::pixelMetric(metric, option, widget);
+}
+
+QSize UiTheme::sizeFromContents(QStyle::ContentsType type, const QStyleOption* option, const QSize& contentsSize,
+                                const QWidget* widget) const
+{
+    QSize commonStyleSize = QCommonStyle::sizeFromContents(type, option, contentsSize, widget);
+    QSize proxyStyleSize = QProxyStyle::sizeFromContents(type, option, contentsSize, widget);
+
+    //! NOTE These calculations are based on the implementation in QML.
+    switch (type) {
+    case CT_PushButton:
+        return QSize(std::max(contentsSize.width() + 32, 132),
+                     contentsSize.height() + 14);
+    case CT_ToolButton:
+        return contentsSize.expandedTo(QSize(30, 30));
+    case CT_ComboBox:
+    case CT_LineEdit:
+        return proxyStyleSize.expandedTo(QSize(30, 30));
+    case CT_SpinBox:
+        return QSize(proxyStyleSize.width(), 32); // results in the height begin 30
+    case CT_GroupBox: {
+        const QGroupBox* groupBox = qobject_cast<const QGroupBox*>(widget);
+        const bool checkable = groupBox && groupBox->isCheckable();
+
+        if (checkable) {
+            const notation::RadioButtonGroupBox* radioButtonGroupBox = qobject_cast<const notation::RadioButtonGroupBox*>(groupBox);
+
+            int pm = pixelMetric(radioButtonGroupBox ? PM_ExclusiveIndicatorHeight : PM_IndicatorHeight, option, widget);
+            return commonStyleSize + QSize(0, std::max(pm, option->fontMetrics.height()));
+        }
+
+        return commonStyleSize + QSize(0, option->fontMetrics.height());
+    } break;
+    case CT_ItemViewItem:
+        return commonStyleSize.expandedTo(QSize(20, 20));
+    case CT_MenuItem:
+        if (const QStyleOptionMenuItem* optionMenuItem = qstyleoption_cast<const QStyleOptionMenuItem*>(option)) {
+            if (optionMenuItem->menuItemType == QStyleOptionMenuItem::Separator) {
+                return proxyStyleSize;
+            }
+        }
+        return proxyStyleSize.expandedTo(QSize(30, 30));
+    default:
+        break;
+    }
+
+    return proxyStyleSize;
+}
+
+int UiTheme::styleHint(QStyle::StyleHint hint, const QStyleOption* option, const QWidget* widget, QStyleHintReturn* returnData) const
+{
+    switch (hint) {
+    case SH_ItemView_ScrollMode:
+        return QAbstractItemView::ScrollPerPixel;
+    default:
+        break;
+    }
+
+    return QProxyStyle::styleHint(hint, option, widget, returnData);
 }

--- a/src/framework/ui/view/uitheme.cpp
+++ b/src/framework/ui/view/uitheme.cpp
@@ -24,6 +24,7 @@
 
 #include <QAbstractItemView>
 #include <QApplication>
+#include <QGroupBox>
 #include <QMenu>
 #include <QPalette>
 #include <QStyleFactory>
@@ -32,7 +33,6 @@
 #include <QVariant>
 
 #include "log.h"
-#include "uicomponents/view/widgets/radiobuttongroupbox.h"
 
 using namespace mu::ui;
 
@@ -534,7 +534,8 @@ QRect UiTheme::subControlRect(QStyle::ComplexControl control, const QStyleOption
             const bool checkable = option->subControls & QStyle::SC_GroupBoxCheckBox;
 
             if (checkable) {
-                const bool isRadioButtonGroupBox = qobject_cast<const uicomponents::RadioButtonGroupBox*>(widget);
+                const bool isRadioButtonGroupBox
+                    =widget && strcmp(widget->metaObject()->className(), "mu::uicomponents::RadioButtonGroupBox") == 0;
 
                 indicatorWidth = pixelMetric(isRadioButtonGroupBox ? PM_ExclusiveIndicatorWidth : PM_IndicatorWidth, option, widget);
                 indicatorHeight = pixelMetric(isRadioButtonGroupBox ? PM_ExclusiveIndicatorHeight : PM_IndicatorHeight, option, widget);
@@ -635,7 +636,8 @@ QSize UiTheme::sizeFromContents(QStyle::ContentsType type, const QStyleOption* o
         const bool checkable = groupBox && groupBox->isCheckable();
 
         if (checkable) {
-            const bool isRadioButtonGroupBox = qobject_cast<const uicomponents::RadioButtonGroupBox*>(groupBox);
+            const bool isRadioButtonGroupBox
+                =widget && strcmp(widget->metaObject()->className(), "mu::uicomponents::RadioButtonGroupBox") == 0;
 
             int pm = pixelMetric(isRadioButtonGroupBox ? PM_ExclusiveIndicatorHeight : PM_IndicatorHeight, option, widget);
             return commonStyleSize + QSize(0, std::max(pm, option->fontMetrics.height()));
@@ -662,6 +664,9 @@ QSize UiTheme::sizeFromContents(QStyle::ContentsType type, const QStyleOption* o
 int UiTheme::styleHint(QStyle::StyleHint hint, const QStyleOption* option, const QWidget* widget, QStyleHintReturn* returnData) const
 {
     switch (hint) {
+    case SH_DitherDisabledText:
+    case SH_EtchDisabledText:
+        return false;
     case SH_ItemView_ScrollMode:
         return QAbstractItemView::ScrollPerPixel;
     default:

--- a/src/framework/ui/view/uitheme.h
+++ b/src/framework/ui/view/uitheme.h
@@ -23,15 +23,15 @@
 #ifndef MU_UI_UITHEME_H
 #define MU_UI_UITHEME_H
 
-#include <QObject>
 #include <QFont>
+#include <QProxyStyle>
 
 #include "modularity/ioc.h"
 #include "ui/iuiconfiguration.h"
 #include "async/asyncable.h"
 
 namespace mu::ui {
-class UiTheme : public QObject, public async::Asyncable
+class UiTheme : public QProxyStyle, public async::Asyncable
 {
     Q_OBJECT
 
@@ -115,6 +115,18 @@ public:
     qreal buttonOpacityHit() const;
 
     qreal itemOpacityDisabled() const;
+
+    void polish(QWidget* widget) override;
+    void unpolish(QWidget* widget) override;
+
+    void drawPrimitive(PrimitiveElement element, const QStyleOption* option, QPainter* painter, const QWidget* widget) const override;
+    QRect subControlRect(QStyle::ComplexControl control, const QStyleOptionComplex* option, QStyle::SubControl subControl,
+                         const QWidget* widget = nullptr) const override;
+    int pixelMetric(PixelMetric metric, const QStyleOption* option, const QWidget* widget) const override;
+    QSize sizeFromContents(ContentsType type, const QStyleOption* option, const QSize& contentsSize,
+                           const QWidget* widget = nullptr) const override;
+    int styleHint(StyleHint hint, const QStyleOption* option = nullptr, const QWidget* widget = nullptr,
+                  QStyleHintReturn* returnData = nullptr) const override;
 
 signals:
     void themeChanged();

--- a/src/framework/ui/view/uitheme.h
+++ b/src/framework/ui/view/uitheme.h
@@ -148,6 +148,15 @@ private:
 
     void notifyAboutThemeChanged();
 
+    void drawButtonBackground(QPainter* painter, const QRect& rect, bool enabled, bool hovered, bool pressed, bool accentButton,
+                              bool flat) const;
+    void drawCheckboxIndicator(QPainter* painter, const QRect& rect, bool enabled, bool hovered, bool pressed, bool checked,
+                               bool indeterminate, bool inMenu) const;
+    void drawRadioButtonIndicator(QPainter* painter, const QRect& rect, bool enabled, bool hovered, bool pressed, bool selected) const;
+    void drawIndicatorIcon(QPainter* painter, const QRect& rect, bool enabled, QStyle::PrimitiveElement element) const;
+    void drawListViewItemBackground(QPainter* painter, const QRect& rect, bool enabled, bool hovered, bool pressed, bool selected) const;
+    void drawToolbarGrip(QPainter* painter, const QRect& rect, bool horizontal) const;
+
     QFont m_bodyFont;
     QFont m_bodyBoldFont;
     QFont m_largeBodyFont;

--- a/src/framework/uicomponents/CMakeLists.txt
+++ b/src/framework/uicomponents/CMakeLists.txt
@@ -54,6 +54,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/dialogview.h
     ${CMAKE_CURRENT_LIST_DIR}/view/filepickermodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/filepickermodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/widgets/radiobuttongroupbox.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/widgets/radiobuttongroupbox.h
     )
 
 include(${PROJECT_SOURCE_DIR}/build/module.cmake)

--- a/src/framework/uicomponents/view/widgets/radiobuttongroupbox.cpp
+++ b/src/framework/uicomponents/view/widgets/radiobuttongroupbox.cpp
@@ -26,7 +26,7 @@
 #include <QStyleOption>
 #include <QStylePainter>
 
-using namespace mu::notation;
+using namespace mu::uicomponents;
 
 RadioButtonGroupBox::RadioButtonGroupBox(QWidget* parent)
     : QGroupBox(parent)

--- a/src/framework/uicomponents/view/widgets/radiobuttongroupbox.h
+++ b/src/framework/uicomponents/view/widgets/radiobuttongroupbox.h
@@ -25,7 +25,7 @@
 
 #include <QGroupBox>
 
-namespace mu::notation {
+namespace mu::uicomponents {
 class RadioButtonGroupBox : public QGroupBox
 {
     Q_OBJECT

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -1345,12 +1345,12 @@ QVariant EditStyle::getValue(StyleId idx)
             QTextEdit* te = qobject_cast<QTextEdit*>(sw.widget);
             return te->toPlainText();
         }
-    } else if (!strcmp("QPointF", type)) {
+    } else if (!strcmp("mu::PointF", type)) {
         OffsetSelect* cb = qobject_cast<OffsetSelect*>(sw.widget);
         if (cb) {
-            return cb->offset();
+            return mu::PointF::fromQPointF(cb->offset());
         } else {
-            qFatal("unhandled QPointF");
+            qFatal("unhandled mu::PointF");
         }
     } else if (!strcmp("Ms::Direction", type)) {
         QComboBox* cb = qobject_cast<QComboBox*>(sw.widget);
@@ -1454,10 +1454,10 @@ void EditStyle::setValues()
         } else if (!strcmp("Ms::Align", type)) {
             AlignSelect* as = qobject_cast<AlignSelect*>(sw.widget);
             as->setAlign(val.value<Ms::Align>());
-        } else if (!strcmp("QPointF", type)) {
+        } else if (!strcmp("mu::PointF", type)) {
             OffsetSelect* as = qobject_cast<OffsetSelect*>(sw.widget);
             if (as) {
-                as->setOffset(val.value<QPointF>());
+                as->setOffset(val.value<mu::PointF>().toQPointF());
             }
         } else {
             unhandledType(sw);

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -1987,7 +1987,91 @@
            <string>Sizes</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_27">
-           <item row="1" column="1" colspan="2">
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_38">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Small staff size:</string>
+             </property>
+             <property name="buddy">
+              <cstring>smallStaffSize</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="smallStaffSize">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="suffix">
+              <string notr="true">%</string>
+             </property>
+             <property name="minimum">
+              <number>10</number>
+             </property>
+             <property name="maximum">
+              <number>200</number>
+             </property>
+             <property name="value">
+              <number>70</number>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="QToolButton" name="resetSmallStaffSize">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Small staff size' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset>
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="3">
+            <spacer name="horizontalSpacer_24">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_44">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Small note size:</string>
+             </property>
+             <property name="buddy">
+              <cstring>smallNoteSize</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
             <widget class="QSpinBox" name="smallNoteSize">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -2009,101 +2093,7 @@
              </property>
             </widget>
            </item>
-           <item row="3" column="1" rowspan="2" colspan="2">
-            <widget class="QSpinBox" name="smallClefSize">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="suffix">
-              <string notr="true">%</string>
-             </property>
-             <property name="minimum">
-              <number>10</number>
-             </property>
-             <property name="maximum">
-              <number>200</number>
-             </property>
-             <property name="value">
-              <number>70</number>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="3" colspan="2">
-            <widget class="QToolButton" name="resetGraceNoteSize">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Grace note size' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset>
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="3">
-            <widget class="QToolButton" name="resetSmallClefSize">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Small clef size' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset>
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1" colspan="2">
-            <widget class="QSpinBox" name="graceNoteSize">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="suffix">
-              <string notr="true">%</string>
-             </property>
-             <property name="minimum">
-              <number>10</number>
-             </property>
-             <property name="maximum">
-              <number>200</number>
-             </property>
-             <property name="value">
-              <number>70</number>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="label_44">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Small note size:</string>
-             </property>
-             <property name="buddy">
-              <cstring>smallNoteSize</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="3" colspan="2">
+           <item row="1" column="2">
             <widget class="QToolButton" name="resetSmallNoteSize">
              <property name="toolTip">
               <string>Reset to default</string>
@@ -2136,70 +2126,8 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="5">
-            <spacer name="horizontalSpacer_24">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_38">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Small staff size:</string>
-             </property>
-             <property name="buddy">
-              <cstring>smallStaffSize</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="3" colspan="2">
-            <widget class="QToolButton" name="resetSmallStaffSize">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Small staff size' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset>
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="0" rowspan="2">
-            <widget class="QLabel" name="label_45">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Small clef size:</string>
-             </property>
-             <property name="buddy">
-              <cstring>smallClefSize</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1" colspan="2">
-            <widget class="QSpinBox" name="smallStaffSize">
+           <item row="2" column="1">
+            <widget class="QSpinBox" name="graceNoteSize">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -2217,6 +2145,78 @@
              </property>
              <property name="value">
               <number>70</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="2">
+            <widget class="QToolButton" name="resetGraceNoteSize">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Grace note size' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset>
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_45">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Small clef size:</string>
+             </property>
+             <property name="buddy">
+              <cstring>smallClefSize</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QSpinBox" name="smallClefSize">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="suffix">
+              <string notr="true">%</string>
+             </property>
+             <property name="minimum">
+              <number>10</number>
+             </property>
+             <property name="maximum">
+              <number>200</number>
+             </property>
+             <property name="value">
+              <number>70</number>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="2">
+            <widget class="QToolButton" name="resetSmallClefSize">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Small clef size' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset>
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
              </property>
             </widget>
            </item>
@@ -3274,9 +3274,6 @@
       </widget>
       <widget class="QWidget" name="PageSystem">
        <layout class="QVBoxLayout" name="verticalLayout_3">
-        <property name="spacing">
-         <number>0</number>
-        </property>
         <item>
          <widget class="QGroupBox" name="groupBox_systemBrackets">
           <property name="title">
@@ -3715,9 +3712,6 @@
       </widget>
       <widget class="QWidget" name="PageAccidentals">
        <layout class="QVBoxLayout" name="verticalLayout_30">
-        <property name="spacing">
-         <number>0</number>
-        </property>
         <item>
          <widget class="QGroupBox" name="groupBox_accidentals">
           <property name="title">
@@ -13096,6 +13090,7 @@ By default, they will be placed such as that their right end are at the same lev
   <tabstop>resetFourMeasureRepeatShowExtenders</tabstop>
   <tabstop>mrNumberSeries</tabstop>
   <tabstop>mrNumberEveryXMeasures</tabstop>
+  <tabstop>resetMRNumberEveryXMeasures</tabstop>
   <tabstop>mrNumberSeriesWithParentheses</tabstop>
   <tabstop>resetMRNumberSeriesWithParentheses</tabstop>
   <tabstop>beamWidth</tabstop>

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -1204,7 +1204,7 @@
                 </widget>
                </item>
                <item row="2" column="0" colspan="9">
-                <widget class="mu::notation::RadioButtonGroupBox" name="enableVerticalSpread">
+                <widget class="mu::uicomponents::RadioButtonGroupBox" name="enableVerticalSpread">
                  <property name="title">
                   <string>Enable vertical justification of staves</string>
                  </property>
@@ -1681,7 +1681,7 @@
                 </widget>
                </item>
                <item row="3" column="0" colspan="9">
-                <widget class="mu::notation::RadioButtonGroupBox" name="disableVerticalSpread">
+                <widget class="mu::uicomponents::RadioButtonGroupBox" name="disableVerticalSpread">
                  <property name="title">
                   <string>Disable vertical justification of staves</string>
                  </property>
@@ -12846,9 +12846,9 @@ By default, they will be placed such as that their right end are at the same lev
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>mu::notation::RadioButtonGroupBox</class>
+   <class>mu::uicomponents::RadioButtonGroupBox</class>
    <extends>QGroupBox</extends>
-   <header>notation/view/widgets/radiobuttongroupbox.h</header>
+   <header>uicomponents/view/widgets/radiobuttongroupbox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/notation/view/widgets/transposedialog.ui
+++ b/src/notation/view/widgets/transposedialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>500</width>
-    <height>483</height>
+    <height>517</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,7 +18,7 @@
     <widget class="QWidget" name="widget" native="true">
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QGroupBox" name="chromaticBox">
+       <widget class="mu::notation::RadioButtonGroupBox" name="chromaticBox">
         <property name="title">
          <string>Transpose Chromatically</string>
         </property>
@@ -27,7 +27,7 @@
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_3">
          <item>
-          <widget class="QGroupBox" name="transposeByKey">
+          <widget class="mu::notation::RadioButtonGroupBox" name="transposeByKey">
            <property name="toolTip">
             <string>Transpose to key (specified at concert pitch)</string>
            </property>
@@ -157,7 +157,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QGroupBox" name="transposeByInterval">
+          <widget class="mu::notation::RadioButtonGroupBox" name="transposeByInterval">
            <property name="title">
             <string>By Interval</string>
            </property>
@@ -345,7 +345,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QGroupBox" name="diatonicBox">
+       <widget class="mu::notation::RadioButtonGroupBox" name="diatonicBox">
         <property name="title">
          <string>Transpose Diatonically</string>
         </property>
@@ -486,6 +486,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>mu::notation::RadioButtonGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>notation/view/widgets/radiobuttongroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>chromaticBox</tabstop>
   <tabstop>transposeByKey</tabstop>

--- a/src/notation/view/widgets/transposedialog.ui
+++ b/src/notation/view/widgets/transposedialog.ui
@@ -18,7 +18,7 @@
     <widget class="QWidget" name="widget" native="true">
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="mu::notation::RadioButtonGroupBox" name="chromaticBox">
+       <widget class="mu::uicomponents::RadioButtonGroupBox" name="chromaticBox">
         <property name="title">
          <string>Transpose Chromatically</string>
         </property>
@@ -27,7 +27,7 @@
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_3">
          <item>
-          <widget class="mu::notation::RadioButtonGroupBox" name="transposeByKey">
+          <widget class="mu::uicomponents::RadioButtonGroupBox" name="transposeByKey">
            <property name="toolTip">
             <string>Transpose to key (specified at concert pitch)</string>
            </property>
@@ -157,7 +157,7 @@
           </widget>
          </item>
          <item>
-          <widget class="mu::notation::RadioButtonGroupBox" name="transposeByInterval">
+          <widget class="mu::uicomponents::RadioButtonGroupBox" name="transposeByInterval">
            <property name="title">
             <string>By Interval</string>
            </property>
@@ -345,7 +345,7 @@
        </widget>
       </item>
       <item>
-       <widget class="mu::notation::RadioButtonGroupBox" name="diatonicBox">
+       <widget class="mu::uicomponents::RadioButtonGroupBox" name="diatonicBox">
         <property name="title">
          <string>Transpose Diatonically</string>
         </property>
@@ -488,9 +488,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>mu::notation::RadioButtonGroupBox</class>
+   <class>mu::uicomponents::RadioButtonGroupBox</class>
    <extends>QGroupBox</extends>
-   <header>notation/view/widgets/radiobuttongroupbox.h</header>
+   <header>uicomponents/view/widgets/radiobuttongroupbox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/notation/view/widgets/widgets.cmake
+++ b/src/notation/view/widgets/widgets.cmake
@@ -44,8 +44,6 @@ set(WIDGETS_SRC
     ${CMAKE_CURRENT_LIST_DIR}/breaksdialog.h
     ${CMAKE_CURRENT_LIST_DIR}/pagesettings.cpp
     ${CMAKE_CURRENT_LIST_DIR}/pagesettings.h
-    ${CMAKE_CURRENT_LIST_DIR}/radiobuttongroupbox.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/radiobuttongroupbox.h
     ${CMAKE_CURRENT_LIST_DIR}/scoreproperties.cpp
     ${CMAKE_CURRENT_LIST_DIR}/scoreproperties.h
     ${CMAKE_CURRENT_LIST_DIR}/transposedialog.cpp


### PR DESCRIPTION
Use QStyle to make QWidgets look like QML. 

I made UiTheme a subclass of QProxyStyle, override some methods to make QWidgets look like our QML components, and set it as the style for the app.

Why using UiTheme for this? This turned out to be very convenient because of the easy access to colors and theme information. 

I did not style _all_ widgets, just the most used ones, because this is of course just a temporary solution until we have time to rewrite all those dialogs. Of course anyone may feel free to style the remaining controls. 

QStyle could be interesting for some other things too; for example in docktoolbar.cpp I replaced most of the usage of stylesheets with QStyle. I think this solution is much better than those hardcoded SVGs for the grip icons. However, for an unclear reason, making the grips hoverable still won't work, even after setting `WA_Hover` or `mouseTracking`.

(There is still other work to do with the look of dialogs... they deserve some tidying.)

Here are two screenshots:
<img width="1436" alt="Style dialog and Breaks dialog" src="https://user-images.githubusercontent.com/48658420/115786319-ee2e6b80-a3c0-11eb-954a-f938f8c6b53e.png">
<img width="1436" alt="Toolbars and menus" src="https://user-images.githubusercontent.com/48658420/115786329-f1295c00-a3c0-11eb-90fe-a97b86adab90.png">

Status:
- [x] Tested on macOS
- [x] Tested on Windows
- [x] Tested on Linux (Ubuntu)