### PR TITLE
[MU4] Change instrument id from musicXMLid to an unique instrument id

### DIFF
--- a/src/instruments/instrumentstypes.h
+++ b/src/instruments/instrumentstypes.h
@@ -122,6 +122,7 @@ struct Instrument
     StaffNameList longNames;
     StaffNameList shortNames;
     QString name;
+    QString musicXMLid;
     QString description;
 
     bool extended = false;

--- a/src/instruments/internal/instrumentsreader.cpp
+++ b/src/instruments/internal/instrumentsreader.cpp
@@ -155,7 +155,8 @@ InstrumentTemplate InstrumentsReader::readInstrumentTemplate(Ms::XmlReader& read
     InstrumentTemplate instrumentTemplate;
     Instrument& instrument = instrumentTemplate.instrument;
 
-    instrumentTemplate.id = reader.attributes().value("id").toString();
+    instrument.id = reader.attributes().value("id").toString();
+    instrumentTemplate.id = instrument.id;
 
     bool customDrumset = false;
 
@@ -242,7 +243,7 @@ InstrumentTemplate InstrumentsReader::readInstrumentTemplate(Ms::XmlReader& read
         } else if (reader.name() == "transposeDiatonic") {
             instrument.transpose.diatonic = reader.readElementText().toInt();
         } else if (reader.name() == "instrumentId") {
-            instrument.id = reader.readElementText();
+            instrument.musicXMLid = reader.readElementText();
         } else if (reader.name() == "StringData") {
             instrument.stringData = readStringData(reader);
         } else if (reader.name() == "useDrumset") {
@@ -296,7 +297,7 @@ InstrumentTemplate InstrumentsReader::readInstrumentTemplate(Ms::XmlReader& read
             QString templateId = reader.readElementText();
             initInstrument(instrument, generalMeta.instrumentTemplates[templateId].instrument);
         } else if (reader.name() == "musicXMLid") {
-            instrument.id = reader.readElementText();
+            instrument.musicXMLid = reader.readElementText();
         } else if (reader.name() == "genre") {
             instrument.genreIds << reader.readElementText();
         } else if (reader.name() == "singleNoteDynamics") {
@@ -417,6 +418,7 @@ void InstrumentsReader::fillByDefault(Instrument& instrument) const
 void InstrumentsReader::initInstrument(Instrument& sourceInstrument, const Instrument& destinationInstrument) const
 {
     sourceInstrument.id = destinationInstrument.id;
+    sourceInstrument.musicXMLid = destinationInstrument.musicXMLid;
     sourceInstrument.longNames = destinationInstrument.longNames;
     sourceInstrument.shortNames = destinationInstrument.shortNames;
     sourceInstrument.staves = destinationInstrument.staves;

--- a/src/instruments/internal/instrumentsreader.cpp
+++ b/src/instruments/internal/instrumentsreader.cpp
@@ -306,7 +306,7 @@ InstrumentTemplate InstrumentsReader::readInstrumentTemplate(Ms::XmlReader& read
         }
     }
 
-    fillByDeffault(instrument);
+    fillByDefault(instrument);
 
     return instrumentTemplate;
 }
@@ -385,7 +385,7 @@ StringData InstrumentsReader::readStringData(Ms::XmlReader& reader) const
     return StringData(frets, strings);
 }
 
-void InstrumentsReader::fillByDeffault(Instrument& instrument) const
+void InstrumentsReader::fillByDefault(Instrument& instrument) const
 {
     if (instrument.channels.empty()) {
         Channel a;

--- a/src/instruments/internal/instrumentsreader.h
+++ b/src/instruments/internal/instrumentsreader.h
@@ -58,7 +58,7 @@ private:
     MidiAction readMidiAction(Ms::XmlReader& reader) const;
     StringData readStringData(Ms::XmlReader& reader) const;
 
-    void fillByDeffault(Instrument& instrument) const;
+    void fillByDefault(Instrument& instrument) const;
     void initInstrument(Instrument& sourceInstrument, const Instrument& destinationInstrument) const;
 };
 }

--- a/src/libmscore/instrument.h
+++ b/src/libmscore/instrument.h
@@ -324,6 +324,7 @@ public:
     bool isDifferentInstrument(const Instrument& i) const;
 
     QString getId() const { return _id; }
+    void setId(const QString& id) { _id = id; }
     void setMinPitchP(int v) { _minPitchP = v; }
     void setMaxPitchP(int v) { _maxPitchP = v; }
     void setMinPitchA(int v) { _minPitchA = v; }

--- a/src/libmscore/part.cpp
+++ b/src/libmscore/part.cpp
@@ -400,7 +400,7 @@ const InstrumentList* Part::instruments() const
 
 bool Part::isDoublingInstrument(const QString& instrumentId) const
 {
-    return instrument()->instrumentId() != instrumentId;
+    return instrument()->getId() != instrumentId;
 }
 
 //---------------------------------------------------------
@@ -409,7 +409,7 @@ bool Part::isDoublingInstrument(const QString& instrumentId) const
 
 QString Part::instrumentId(const Fraction& tick) const
 {
-    return instrument(tick)->instrumentId();
+    return instrument(tick)->getId();
 }
 
 //---------------------------------------------------------

--- a/src/notation/internal/instrumentsconverter.cpp
+++ b/src/notation/internal/instrumentsconverter.cpp
@@ -43,7 +43,8 @@ Ms::Instrument InstrumentsConverter::convertInstrument(const mu::instruments::In
 
     result.setTrackName(instrument.name);
     result.setTranspose(instrument.transpose);
-    result.setInstrumentId(instrument.id);
+    result.setId(instrument.id);
+    result.setInstrumentId(instrument.musicXMLid);
 
     if (instrument.useDrumset) {
         result.setDrumset(instrument.drumset ? instrument.drumset : Ms::smDrumset);
@@ -82,7 +83,8 @@ mu::instruments::Instrument InstrumentsConverter::convertInstrument(const Ms::In
 
     result.name = instrument.trackName();
     result.transpose = instrument.transpose();
-    result.id = instrument.instrumentId();
+    result.id = instrument.getId();
+    result.musicXMLid = instrument.instrumentId();
     result.useDrumset = instrument.useDrumset();
     result.drumset = instrument.drumset();
 

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -290,7 +290,7 @@ bool NotationParts::needAssignInstrumentToChord(const ID& instrumentId, const ID
     QMap<Ms::Fraction, Ms::InstrumentChange*> instrumentChangeElements = this->instrumentChangeElements(fromPartId);
 
     for (const Ms::InstrumentChange* instrumentChange: instrumentChangeElements.values()) {
-        if (instrumentChange->instrument()->instrumentId() == instrumentId) {
+        if (instrumentChange->instrument()->getId() == instrumentId) {
             return false;
         }
     }
@@ -306,7 +306,7 @@ void NotationParts::assignIstrumentToSelectedChord(Ms::Instrument* instrument)
     }
 
     Part* part = chord->part();
-    part->removeInstrument(instrument->instrumentId());
+    part->removeInstrument(instrument->getId());
     part->setInstrument(instrument, chord->segment()->tick());
 
     auto instrumentChange = new Ms::InstrumentChange(*instrument, score());
@@ -656,7 +656,7 @@ void NotationParts::appendStaff(Staff* staff, const ID& destinationPartId)
     Ms::Instrument* instrument = instrumentInfo.instrument;
     instrument->setClefType(staffIndex, staff->defaultClefType());
 
-    ChangedNotifier<const Staff*>* notifier = instrumentNotifier(instrument->instrumentId(), destinationPartId);
+    ChangedNotifier<const Staff*>* notifier = instrumentNotifier(instrument->getId(), destinationPartId);
     notifier->itemAdded(staff);
 }
 
@@ -889,7 +889,7 @@ QMap<Ms::Fraction, Ms::Instrument*> NotationParts::instruments(const Part* fromP
         Ms::Fraction fraction = Ms::Fraction::fromTicks(it->first);
         Ms::Instrument* instrument = it->second;
 
-        bool acceptedByFilter = !filterInstrumentsIds.isEmpty() ? filterInstrumentsIds.contains(instrument->instrumentId()) : true;
+        bool acceptedByFilter = !filterInstrumentsIds.isEmpty() ? filterInstrumentsIds.contains(instrument->getId()) : true;
         if (acceptedByFilter) {
             result.insert(fraction, instrument);
         }
@@ -913,7 +913,7 @@ void NotationParts::doInsertInstruments(const QMap<Ms::Fraction, Ms::Instrument*
 
     int destinationIndex = 0;
     for (int i = 0; i < partInstruments.size(); i++) {
-        if (partInstruments[i]->instrumentId() == destinationInstrumentId) {
+        if (partInstruments[i]->getId() == destinationInstrumentId) {
             destinationIndex = i;
             break;
         }
@@ -1080,7 +1080,7 @@ NotationParts::InstrumentInfo NotationParts::instrumentInfo(const ID& instrument
 
     for (const Ms::Fraction& fraction: partInstruments.keys()) {
         Ms::Instrument* instrument = partInstruments.value(fraction);
-        if (instrument->instrumentId() == instrumentId) {
+        if (instrument->getId() == instrumentId) {
             return InstrumentInfo(fraction, instrument);
         }
     }
@@ -1232,8 +1232,8 @@ void NotationParts::removeMissingInstruments(const InstrumentList& instruments)
         IDList instrumentsToRemove;
 
         for (const Ms::Instrument* instrument: partInstruments.values()) {
-            if (!instrumentIds.contains(instrument->instrumentId())) {
-                instrumentsToRemove << instrument->instrumentId();
+            if (!instrumentIds.contains(instrument->getId())) {
+                instrumentsToRemove << instrument->getId();
             }
         }
 
@@ -1283,7 +1283,7 @@ void NotationParts::sortParts(const InstrumentList& instruments)
     Q_ASSERT(score()->parts().size() == static_cast<int>(instruments.size()));
 
     auto mainInstrumentId = [](const Part* part) {
-        return part->instrument()->instrumentId();
+        return part->instrument()->getId();
     };
 
     for (int i = 0; i < instruments.size(); ++i) {
@@ -1312,7 +1312,7 @@ IDList NotationParts::allInstrumentsIds() const
         auto partInstruments = instruments(part);
 
         for (const Ms::Instrument* instrument: partInstruments.values()) {
-            result << instrument->instrumentId();
+            result << instrument->getId();
         }
     }
 
@@ -1351,7 +1351,7 @@ void NotationParts::notifyAboutStaffChanged(const ID& staffId) const
     }
 
     InstrumentInfo instrumentInfo = this->instrumentInfo(staff);
-    ChangedNotifier<const Staff*>* notifier = instrumentNotifier(instrumentInfo.instrument->instrumentId(), staff->part()->id());
+    ChangedNotifier<const Staff*>* notifier = instrumentNotifier(instrumentInfo.instrument->getId(), staff->part()->id());
     notifier->itemChanged(staff);
 }
 

--- a/src/plugins/api/instrument.h
+++ b/src/plugins/api/instrument.h
@@ -250,7 +250,7 @@ public:
 
     Ms::Part* part() { return _part; }
 
-    QString instrumentId() const { return instrument()->instrumentId(); }
+    QString instrumentId() const { return instrument()->getId(); }
     QString longName() const;
     QString shortName() const;
 

--- a/src/plugins/api/part.h
+++ b/src/plugins/api/part.h
@@ -111,7 +111,7 @@ public:
 
     int startTrack() const { return part()->startTrack(); }
     int endTrack()   const { return part()->endTrack(); }
-    QString instrumentId() const { return part()->instrument()->instrumentId(); }
+    QString instrumentId() const { return part()->instrument()->getId(); }
     int harmonyCount() const { return part()->harmonyCount(); }
     bool hasPitchedStaff() const { return part()->hasPitchedStaff(); }
     bool hasTabStaff() const { return part()->hasTabStaff(); }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/320404

Change instrument id from `musicXMLid` to an unique instrument id as defined by the `id` attribute of the `instrument` tag in `instruments.xml`.

Main reason for this change are `musicXMLid` isn't unique for instruments. Also not all instruments have a `musicXMLid` defined.

A small check of the existing `instruments.xml`:
1) 584 instruments defined.
2) 561 instruments don't have an `musicXMLid`.
3) There are only 335 unique  `musicXMLid`'s defined.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
