### PR TITLE
Allow users to reorder Format-Style menu

### DIFF
--- a/src/notation/view/widgets/editstyle.h
+++ b/src/notation/view/widgets/editstyle.h
@@ -91,6 +91,10 @@ class EditStyle : public QDialog, private Ui::EditStyleBase
 
     static EditStylePage pageForElement(Element*);
 
+private:
+    int numberOfPage;
+    int pageListMap[50];
+
 private slots:
     void selectChordDescriptionFile();
     void setChordStyle(bool);
@@ -117,6 +121,12 @@ private slots:
     void editUserStyleName();
     void endEditUserStyleName();
     void resetUserStyleName();
+    void pageListRowChanged(int);
+    void pageListResetOrder();
+    void pageListMoved(QModelIndex, int, int, QModelIndex, int);
+    void stringToArray(std::string, int*);
+    std::string arrayToString(int*);
+    std::string ConsecutiveStr(int);
 
 public:
     EditStyle(QWidget* = nullptr);

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -32,6 +32,15 @@
         <height>0</height>
        </size>
       </property>
+      <property name="dragEnabled">
+       <bool>true</bool>
+      </property>
+      <property name="dragDropMode">
+       <enum>QAbstractItemView::DragDrop</enum>
+      </property>
+      <property name="defaultDropAction">
+       <enum>Qt::MoveAction</enum>
+      </property>
       <property name="alternatingRowColors">
        <bool>true</bool>
       </property>
@@ -13350,22 +13359,4 @@ By default, they will be placed such as that their right end are at the same lev
  <resources>
   <include location="../../notationscene.qrc"/>
  </resources>
- <connections>
-  <connection>
-   <sender>pageList</sender>
-   <signal>currentRowChanged(int)</signal>
-   <receiver>pageStack</receiver>
-   <slot>setCurrentIndex(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>42</x>
-     <y>22</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>395</x>
-     <y>16</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
 </ui>


### PR DESCRIPTION
Resolves: *https://musescore.org/en/node/272277*

*Format-Style menu is currently 37 item long, and finding an item is quite difficult.
Changing into alphabetical order may not be ideal for all users.
This PR allows users to customize the ordering of the menu*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
