### PR TITLE
[MU4] Implement copy, paste, cut in TextBase; fix escape in TextBase

### DIFF
--- a/src/context/internal/uicontextresolver.cpp
+++ b/src/context/internal/uicontextresolver.cpp
@@ -99,8 +99,12 @@ UiContext UiContextResolver::currentUiContext() const
 
 bool UiContextResolver::match(const ui::UiContext& currentCtx, const ui::UiContext& actCtx) const
 {
-    //! NOTE If now editing the notation text, then we allow actions only with the context `UiCtxNotationTextEditing`,
-    //! all others, even `UiCtxAny`, are forbidden
+    //! NOTE For actions that need to run when editing text and everywhere else
+    if (actCtx == context::UiCtxAnyOrTextEditing) {
+        return true;
+    }
+
+    //! NOTE For actions that need to run ONLY when text editing
     if (currentCtx == context::UiCtxNotationTextEditing) {
         return actCtx == context::UiCtxNotationTextEditing;
     }

--- a/src/context/uicontext.h
+++ b/src/context/uicontext.h
@@ -38,6 +38,9 @@ static constexpr ui::UiContext UiCtxHomeOpened = "UiCtxHomeOpened";
 // notation detail
 static constexpr ui::UiContext UiCtxNotationFocused = "UiCtxNotationFocused";
 static constexpr ui::UiContext UiCtxNotationTextEditing = "UiCtxNotationTextEditing";
+
+// for actions that need to be always available, even when editing text
+static constexpr ui::UiContext UiCtxAnyOrTextEditing = "UiCtxAnyOrTextEditing";
 }
 
 #endif // MU_CONTEXT_UICONTEXT_H

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -292,11 +292,6 @@ bool NotationActionController::canReceiveAction(const actions::ActionCode& code)
         return false;
     }
 
-    //! NOTE At the moment, if we are in the text editing mode, we can only process the escape
-    if (isTextEditting()) {
-        return code == ESCAPE_ACTION_CODE;
-    }
-
     if (code == UNDO_ACTION_CODE) {
         return canUndo();
     }
@@ -405,6 +400,7 @@ void NotationActionController::resetState()
 
     if (interaction->isTextEditingStarted()) {
         interaction->endEditText();
+        interaction->clearSelection();
         return;
     }
 

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -37,7 +37,7 @@ static const ActionCode SHOW_IRREGULAR_CODE("mark-irregular");
 
 const UiActionList NotationUiActions::m_actions = {
     UiAction("escape",
-             mu::context::UiCtxNotationFocused,
+             mu::context::UiCtxAnyOrTextEditing,
              QT_TRANSLATE_NOOP("action", "Esc")
              ),
     UiAction("put-note", // args: QPoint pos, bool replace, bool insert
@@ -135,15 +135,15 @@ const UiActionList NotationUiActions::m_actions = {
              QT_TRANSLATE_NOOP("action", "Pitch up by an octave or move text or articulation up")
              ),
     UiAction("cut",
-             mu::context::UiCtxNotationFocused,
+             mu::context::UiCtxAnyOrTextEditing,
              QT_TRANSLATE_NOOP("action", "Cut")
              ),
     UiAction("copy",
-             mu::context::UiCtxNotationFocused,
+             mu::context::UiCtxAnyOrTextEditing,
              QT_TRANSLATE_NOOP("action", "Copy")
              ),
     UiAction("paste",
-             mu::context::UiCtxNotationFocused,
+             mu::context::UiCtxAnyOrTextEditing,
              QT_TRANSLATE_NOOP("action", "Paste")
              ),
     UiAction("paste-half",


### PR DESCRIPTION
Resolves: #7881 

Implements copy, paste and cut in text boxes. Esc now should also work as intended in text boxes.
