### PR TITLE
[MU4] Fix #318631: Tablature fingering order not always correct

### DIFF
--- a/src/libmscore/chord.cpp
+++ b/src/libmscore/chord.cpp
@@ -560,21 +560,30 @@ void Chord::add(Element* e)
     case ElementType::NOTE:
     {
         Note* note = toNote(e);
+        bool tab = staff() && staff()->isTabStaff(tick());
         bool found = false;
 
-        // _notes should be sorted by line position,
-        // but it's often not yet possible since line is unknown
-        // use pitch instead, and line as a second sort criteria.
-
         for (unsigned idx = 0; idx < _notes.size(); ++idx) {
-            if (note->pitch() <= _notes[idx]->pitch()) {
-                if (note->pitch() == _notes[idx]->pitch() && note->line() >= _notes[idx]->line()) {
-                    _notes.insert(_notes.begin() + idx + 1, note);
-                } else {
+            if (tab) {
+                // _notes should be sorted by string
+                if (note->string() > _notes[idx]->string()) {
                     _notes.insert(_notes.begin() + idx, note);
+                    found = true;
+                    break;
                 }
-                found = true;
-                break;
+            } else {
+                // _notes should be sorted by line position,
+                // but it's often not yet possible since line is unknown
+                // use pitch instead, and line as a second sort criteria.
+                if (note->pitch() <= _notes[idx]->pitch()) {
+                    if (note->pitch() == _notes[idx]->pitch() && note->line() >= _notes[idx]->line()) {
+                        _notes.insert(_notes.begin() + idx + 1, note);
+                    } else {
+                        _notes.insert(_notes.begin() + idx, note);
+                    }
+                    found = true;
+                    break;
+                }
             }
         }
         if (!found) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/318631

Shamelessly stolen from https://github.com/mattmcclinch/MuseScore/commit/8641a0d32d8286f839a34c5510d93ee0ed0eb816 and ported to master