### PR TITLE
Restore "-nightly" suffix to AppImage builds

### DIFF
--- a/build/Linux+BSD/portable/Recipe
+++ b/build/Linux+BSD/portable/Recipe
@@ -53,7 +53,6 @@ apt_packages_runtime=(
   libegl1-mesa-dev
   libodbc1
   libpq-dev
-  libssl1.0.0
   libxcomposite-dev
   libxcursor-dev
   libxi-dev
@@ -276,8 +275,7 @@ additional_qt_components=(
 # linuxdeploy may have missed some libraries that we need
 # Report new additions at https://github.com/linuxdeploy/linuxdeploy/issues
 additional_libraries=(
-  libssl.so.1.0.0    # OpenSSL (for Save Online)
-  libcrypto.so.1.0.0 # OpenSSL (for Save Online)
+  # none
 )
 
 # FALLBACK LIBRARIES

--- a/build/ci/linux/build.sh
+++ b/build/ci/linux/build.sh
@@ -56,10 +56,6 @@ case "${BUILD_MODE}" in
 "mtests")        MUSESCORE_BUILD_CONFIG=dev; BUILDTYPE=installdebug; OPTIONS="USE_SYSTEM_FREETYPE=ON UPDATE_CACHE=FALSE PREFIX=$ARTIFACTS_DIR/software";;
 esac
 
-if [ "${BUILDTYPE}" == "portable" ]; then
-  SUFFIX="-portable${SUFFIX}" # special value needed for CMakeLists.txt
-fi
-
 echo "MUSESCORE_BUILD_CONFIG: $MUSESCORE_BUILD_CONFIG"
 echo "BUILD_NUMBER: $BUILD_NUMBER"
 echo "TELEMETRY_TRACK_ID: $TELEMETRY_TRACK_ID"

--- a/build/ci/linux/dumpsyms.sh
+++ b/build/ci/linux/dumpsyms.sh
@@ -27,7 +27,7 @@ GEN_SCRIPT=tools/crashdump/generate_syms.sh
 ARTIFACTS_DIR=build.artifacts
 BUILD_DIR=build.release
 SYMBOLS_DIR=$ARTIFACTS_DIR/symbols
-MSCORE_BIN=$BUILD_DIR/src/main/mscore-portable
+MSCORE_BIN=$BUILD_DIR/src/main/mscore-portable*
 
 
 echo "GEN_SCRIPT: $GEN_SCRIPT"

--- a/build/ci/linux/setup.sh
+++ b/build/ci/linux/setup.sh
@@ -79,7 +79,6 @@ apt_packages_runtime=(
   libegl1-mesa-dev
   libodbc1
   libpq-dev
-  libssl1.0.0
   libxcomposite-dev
   libxcursor-dev
   libxi-dev

--- a/build/ci/linux/tools/make_appimage.sh
+++ b/build/ci/linux/tools/make_appimage.sh
@@ -152,8 +152,7 @@ additional_qt_components=(
 # linuxdeploy may have missed some libraries that we need
 # Report new additions at https://github.com/linuxdeploy/linuxdeploy/issues
 additional_libraries=(
-  libssl.so.1.0.0    # OpenSSL (for Save Online)
-  libcrypto.so.1.0.0 # OpenSSL (for Save Online)
+  # none
 )
 
 # FALLBACK LIBRARIES

--- a/ninja_build.sh
+++ b/ninja_build.sh
@@ -133,7 +133,7 @@ case $TARGET in
 
     appimage)
         MUSESCORE_INSTALL_DIR=MuseScore 
-        MUSESCORE_INSTALL_SUFFIX=-portable 
+        MUSESCORE_INSTALL_SUFFIX="-portable${MUSESCORE_INSTALL_SUFFIX}" # e.g. "-portable" or "-portable-nightly"
         MUSESCORE_LABEL="Portable AppImage" 
         MUSESCORE_NO_RPATH=ON 
 
@@ -146,7 +146,8 @@ case $TARGET in
         install_dir="$(cat $build_dir/PREFIX.txt)" 
         cd $install_dir
 
-        [ -L usr ] || ln -s . usr && mscore="mscore-portable" 
+        ln -sf . usr # we installed into the root of our AppImage but some tools expect a "usr" subdirectory
+        mscore="mscore${MUSESCORE_INSTALL_SUFFIX}"
         dsktp="${mscore}.desktop" 
         icon="${mscore}.svg" 
         mani="install_manifest.txt" 


### PR DESCRIPTION
The suffix is necessary to allow nightly builds to be installed alongside release builds without conflicts. For example, it is necessary for both builds to appear in:

- The system's application launcher menu.
- The file manager's right-click "Open with..." menu.
- The user's `$PATH` for command line usage.