### PR TITLE
Concept: Dynamically calculate (minimum) size of NoteInputBar

### DIFF
--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -114,18 +114,27 @@ DockPage {
         id: notationNoteInputBar
         objectName: "notationNoteInputBar"
 
-        minimumWidth: orientation == Qt.Horizontal ? 900 : 96
-        minimumHeight: orientation == Qt.Horizontal ? 48 : 0
+        property int idealWidth: 0
+        property int idealHeight: 0
+
+        minimumWidth: orientation == Qt.Horizontal ? idealWidth : 90
+        minimumHeight: orientation == Qt.Horizontal ? 48 : idealHeight
 
         color: notationPage.color
 
         title: qsTrc("appshell", "Note Input")
 
         content: NoteInputBar {
+            id: notationNoteInputBarContent
             color: notationNoteInputBar.color
             orientation: notationNoteInputBar.orientation
             navigation.section: keynavNoteInputSec
             navigation.order: 1
+
+            Component.onCompleted: {
+                notationNoteInputBar.idealWidth = Qt.binding(() => (notationNoteInputBarContent.idealWidth))
+                notationNoteInputBar.idealHeight = Qt.binding(() => (notationNoteInputBarContent.idealHeight))
+            }
         }
     }
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/GridViewSectional.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/GridViewSectional.qml
@@ -68,6 +68,100 @@ Item {
         }
     }
 
+    property int idealWidth: {
+        if (!isHorizontal) {
+            // TODO: This calculation is incorrect, because `columns` does not represent
+            // the actual number of columns, calculated in GridViewDelegate.qml.
+            return Math.max(cellWidth * columns + columnSpacing * (columns - 1), sectionWidth)
+        }
+
+        let result = 0
+        let lastSection = ""
+        let currentRow = 0
+
+        for (let i = 0; i < root.model.count; i++) {
+            let element = root.model.get(i)
+
+            let section = element[sectionRole]
+            let justAddedSection = false
+
+            if (lastSection !== section) {
+                lastSection = section
+                justAddedSection = true
+                currentRow = 0
+
+                if (i !== 0) {
+                    result += privateProperties.spacingBeforeSection
+                }
+
+                result += sectionWidth
+                result += privateProperties.spacingAfterSection
+            }
+
+            if (currentRow === 0) {
+                if (!justAddedSection) {
+                    result += columnSpacing
+                }
+
+                result += cellWidth
+            }
+
+            currentRow++;
+            if (currentRow === root.rows) {
+                currentRow = 0;
+            }
+        }
+
+        return result
+    }
+
+    property int idealHeight: {
+        if (isHorizontal) {
+            // TODO: This calculation is incorrect, because `rows` does not represent
+            // the actual number of rows, calculated in GridViewDelegate.qml.
+            return Math.max(cellHeight * rows + rowSpacing * (rows - 1), sectionHeight)
+        }
+
+        let result = 0
+        let lastSection = ""
+        let currentColumn = 0
+
+        for (let i = 0; i < root.model.count; i++) {
+            let element = root.model.get(i)
+
+            let section = element[sectionRole]
+            let justAddedSection = false
+
+            if (lastSection !== section) {
+                lastSection = section
+                justAddedSection = true
+                currentColumn = 0
+
+                if (i !== 0) {
+                    result += privateProperties.spacingBeforeSection
+                }
+
+                result += sectionHeight
+                result += privateProperties.spacingAfterSection
+            }
+
+            if (currentColumn === 0) {
+                if (!justAddedSection) {
+                    result += rowSpacing
+                }
+
+                result += cellHeight
+            }
+
+            currentColumn++;
+            if (currentColumn === root.columns) {
+                currentColumn = 0;
+            }
+        }
+
+        return result
+    }
+
     Loader {
         anchors.fill: parent
         sourceComponent: isHorizontal ? horizontalView : verticalView

--- a/src/notation/qml/MuseScore/NotationScene/NoteInputBar.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NoteInputBar.qml
@@ -31,10 +31,26 @@ Rectangle {
 
     property alias orientation: gridView.orientation
 
+    property int idealWidth: {
+        if (!privateProperties.isHorizontal) {
+            return gridView.idealWidth
+        }
+
+        return gridView.idealWidth + 2 * customizeButton.anchors.margins + customizeButton.width
+    }
+
+    property int idealHeight: {
+        if (privateProperties.isHorizontal) {
+            return gridView.idealHeight
+        }
+
+        return gridView.idealHeight + 2 * customizeButton.anchors.margins + customizeButton.height
+    }
+
     property alias navigation: keynavSub
 
     QtObject {
-        id: privatesProperties
+        id: privateProperties
 
         property bool isHorizontal: orientation === Qt.Horizontal
     }
@@ -118,8 +134,7 @@ Rectangle {
             }
 
             Canvas {
-
-                visible: item.showSubitemsByPressAndHoldRole
+                visible: btn.item ? btn.item.showSubitemsByPressAndHoldRole : false
 
                 width: 4
                 height: 4
@@ -149,7 +164,7 @@ Rectangle {
     FlatButton {
         id: customizeButton
 
-        anchors.margins: 8
+        anchors.margins: 6
 
         width: gridView.cellWidth
         height: gridView.cellHeight
@@ -167,7 +182,7 @@ Rectangle {
 
     states: [
         State {
-            when: privatesProperties.isHorizontal
+            when: privateProperties.isHorizontal
             PropertyChanges {
                 target: gridView
                 sectionWidth: 1
@@ -183,7 +198,7 @@ Rectangle {
             }
         },
         State {
-            when: !privatesProperties.isHorizontal
+            when: !privateProperties.isHorizontal
             PropertyChanges {
                 target: gridView
                 sectionWidth: root.width


### PR DESCRIPTION
This PR introduces an algorithm for automatically calculating the minimum width and height of the NoteInputBar. 

<img width="1149" alt="Schermafbeelding 2021-04-25 om 18 31 09" src="https://user-images.githubusercontent.com/48658420/116001358-68930180-a5f4-11eb-981e-93ca5c2ae82e.png">

However, in practice this turns out to be useless:
- When the minimum size of the toolbar is bigger than what fits in the window, it is not possible to re-dock the toolbar;
- Sometimes, when dragging the toolbar around, the app randomly crashes, seemingly by the fault of Qt;
- When moving from the horizontal toolbar area to the vertical one, only the height of the toolbar is recalculated, and the width stays the same, causing it to look like this:
  ![Schermafbeelding 2021-04-25 om 18 39 13 kopie](https://user-images.githubusercontent.com/48658420/116001665-d12eae00-a5f5-11eb-87a8-86186b4df697.jpg)
  Also happens when going from vertical to horizontal. The reason for this is unclear to me, maybe also a Qt thing. Might be related to the second issue. 

I still create the PR, hoping that somebody can still use the algorithm at some point.

A counterpart could be: calculate how many items fit in a given width and how many should be hidden in a '...' menu. 