### PR TITLE
[MU3] Fix #320326: Hide piano tool's ToolTips along with the preference setting for "ui/piano/showPitchHelp"

### DIFF
--- a/mscore/pianotools.cpp
+++ b/mscore/pianotools.cpp
@@ -267,9 +267,11 @@ PianoKeyItem::PianoKeyItem(HPiano* _piano, int p)
       _highlighted = false;
       type = -1;
 
-      const char* pitchNames[] = {"C", "C♯", "D", "D♯", "E", "F", "F♯", "G", "G♯", "A", "A♯", "B"}; // keep in sync with `valu` in limbscore/utils.cpp
-      QString text = qApp->translate("utils", pitchNames[_pitch % 12]) + QString::number((_pitch / 12) - 1);
-      setToolTip(text);
+      if (preferences.getBool(PREF_UI_PIANO_SHOWPITCHHELP)) { // changes to that setting take effect only after restarting MuseScore though
+            const char* pitchNames[] = {"C", "C♯", "D", "D♯", "E", "F", "F♯", "G", "G♯", "A", "A♯", "B"}; // keep in sync with `valu` in limbscore/utils.cpp
+            QString text = qApp->translate("utils", pitchNames[_pitch % 12]) + QString::number((_pitch / 12) - 1);
+            setToolTip(text);
+            }
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Fixes a part of https://musescore.org/de/node/320326

Seems an ommission of a057145, the changes for https://musescore.org/en/node/309192

Doesn't seem to apply to master, as that doesn't have a piano keyboard anymore.