### PR TITLE
[MU4] Fix #318860: Restore rest offset with slash notation in voices 3 and 4

### DIFF
--- a/src/libmscore/rest.cpp
+++ b/src/libmscore/rest.cpp
@@ -454,8 +454,9 @@ int Rest::computeLineOffset(int lines)
         }
     }
 
-    if (offsetVoices) {
-        // if the staff contains slash notation then don't offset voices
+    if (offsetVoices && voice() < 2) {
+        // in slash notation voices 1 and 2 are not offset outside the staff
+        // if the staff contains slash notation then only offset rests in voices 3 and 4
         int baseTrack = staffIdx() * VOICES;
         for (int v = 0; v < VOICES; ++v) {
             Element* e = s->element(baseTrack + v);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/318800#comment-1074094

This is porting #7952 to master