### PR TITLE
[MU3] Fix #320620: Crash when filing with slashes

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3200,14 +3200,16 @@ void Score::cmdSlashFill()
                   // insert & turn into slash
                   s = setNoteRest(s, track + voice, nv, f);
                   Chord* c = toChord(s->element(track + voice));
-                  if (c->links()) {
-                        for (ScoreElement* e : *c->links()) {
-                              Chord* lc = toChord(e);
-                              lc->setSlash(true, true);
+                  if (c) {
+                        if (c->links()) {
+                              for (ScoreElement* e : *c->links()) {
+                                    Chord* lc = toChord(e);
+                                    lc->setSlash(true, true);
+                                    }
                               }
+                        else
+                              c->setSlash(true, true);
                         }
-                  else
-                        c->setSlash(true, true);
                   lastSlash = c;
                   if (!firstSlash)
                         firstSlash = c;


### PR DESCRIPTION
on a certain score (see issue or rather forum topic, from an XML Import), multiple measures including the last.

Resolves: https://musescore.org/en/node/320620

PR for master in #8022 