### PR TITLE
[MU4] Fix #320620: Crash when filing with slashes

### DIFF
--- a/src/libmscore/cmd.cpp
+++ b/src/libmscore/cmd.cpp
@@ -3454,13 +3454,15 @@ void Score::cmdSlashFill()
             // insert & turn into slash
             s = setNoteRest(s, track + voice, nv, f);
             Chord* c = toChord(s->element(track + voice));
-            if (c->links()) {
-                for (ScoreElement* e : *c->links()) {
-                    Chord* lc = toChord(e);
-                    lc->setSlash(true, true);
+            if (c) {
+                if (c->links()) {
+                    for (ScoreElement* e : *c->links()) {
+                        Chord* lc = toChord(e);
+                        lc->setSlash(true, true);
+                    }
+                } else {
+                    c->setSlash(true, true);
                 }
-            } else {
-                c->setSlash(true, true);
             }
             lastSlash = c;
             if (!firstSlash) {


### PR DESCRIPTION
on a certain score (see issue resp. forum topic, from an XML Import), multiple measures including the last.

Resolves: https://musescore.org/en/node/320620

Like #8021 but for master