### PR TITLE
Export dialog: code review fixes part 3

### DIFF
--- a/src/converter/internal/convertercontroller.cpp
+++ b/src/converter/internal/convertercontroller.cpp
@@ -79,7 +79,7 @@ mu::Ret ConverterController::fileConvert(const io::path& in, const io::path& out
         return make_ret(Err::OutFileFailedOpen);
     }
 
-    ret = writer->write({ masterNotation->notation() }, file);
+    ret = writer->write(masterNotation->notation(), file);
     if (!ret) {
         LOGE() << "failed write, err: " << ret.toString() << ", path: " << out;
         return make_ret(Err::OutFileFailedWrite);

--- a/src/importexport/audioexport/internal/flacwriter.cpp
+++ b/src/importexport/audioexport/internal/flacwriter.cpp
@@ -27,9 +27,9 @@
 using namespace mu::iex::audioexport;
 using namespace mu::system;
 
-mu::Ret FlacWriter::write(const notation::INotationPtrList& notations, IODevice& destinationDevice, const Options& options)
+mu::Ret FlacWriter::write(notation::INotationPtr notation, IODevice& destinationDevice, const Options& options)
 {
-    UNUSED(notations)
+    UNUSED(notation)
     UNUSED(destinationDevice)
     UNUSED(options)
 

--- a/src/importexport/audioexport/internal/flacwriter.h
+++ b/src/importexport/audioexport/internal/flacwriter.h
@@ -29,8 +29,7 @@ namespace mu::iex::audioexport {
 class FlacWriter : public notation::AbstractNotationWriter
 {
 public:
-    Ret write(const notation::INotationPtrList& notations, system::IODevice& destinationDevice,
-              const Options& options = Options()) override;
+    Ret write(notation::INotationPtr notation, system::IODevice& destinationDevice, const Options& options = Options()) override;
 };
 }
 

--- a/src/importexport/audioexport/internal/mp3writer.cpp
+++ b/src/importexport/audioexport/internal/mp3writer.cpp
@@ -27,9 +27,9 @@
 using namespace mu::iex::audioexport;
 using namespace mu::framework;
 
-mu::Ret Mp3Writer::write(const notation::INotationPtrList& notations, system::IODevice& destinationDevice, const Options& options)
+mu::Ret Mp3Writer::write(notation::INotationPtr notation, system::IODevice& destinationDevice, const Options& options)
 {
-    UNUSED(notations)
+    UNUSED(notation)
     UNUSED(destinationDevice)
     UNUSED(options)
 

--- a/src/importexport/audioexport/internal/mp3writer.h
+++ b/src/importexport/audioexport/internal/mp3writer.h
@@ -29,8 +29,7 @@ namespace mu::iex::audioexport {
 class Mp3Writer : public notation::AbstractNotationWriter
 {
 public:
-    Ret write(const notation::INotationPtrList& notations, system::IODevice& destinationDevice,
-              const Options& options = Options()) override;
+    Ret write(notation::INotationPtr notation, system::IODevice& destinationDevice, const Options& options = Options()) override;
 };
 }
 

--- a/src/importexport/audioexport/internal/oggwriter.cpp
+++ b/src/importexport/audioexport/internal/oggwriter.cpp
@@ -27,9 +27,9 @@
 using namespace mu::iex::audioexport;
 using namespace mu::system;
 
-mu::Ret OggWriter::write(const notation::INotationPtrList& notations, IODevice& destinationDevice, const Options& options)
+mu::Ret OggWriter::write(notation::INotationPtr notation, IODevice& destinationDevice, const Options& options)
 {
-    UNUSED(notations)
+    UNUSED(notation)
     UNUSED(destinationDevice)
     UNUSED(options)
 

--- a/src/importexport/audioexport/internal/oggwriter.h
+++ b/src/importexport/audioexport/internal/oggwriter.h
@@ -29,8 +29,7 @@ namespace mu::iex::audioexport {
 class OggWriter : public notation::AbstractNotationWriter
 {
 public:
-    Ret write(const notation::INotationPtrList& notations, system::IODevice& destinationDevice,
-              const Options& options = Options()) override;
+    Ret write(notation::INotationPtr notation, system::IODevice& destinationDevice, const Options& options = Options()) override;
 };
 }
 

--- a/src/importexport/audioexport/internal/wavewriter.cpp
+++ b/src/importexport/audioexport/internal/wavewriter.cpp
@@ -27,9 +27,9 @@
 using namespace mu::iex::audioexport;
 using namespace mu::framework;
 
-mu::Ret WaveWriter::write(const notation::INotationPtrList& notations, system::IODevice& destinationDevice, const Options& options)
+mu::Ret WaveWriter::write(notation::INotationPtr notation, system::IODevice& destinationDevice, const Options& options)
 {
-    UNUSED(notations)
+    UNUSED(notation)
     UNUSED(destinationDevice)
     UNUSED(options)
 

--- a/src/importexport/audioexport/internal/wavewriter.h
+++ b/src/importexport/audioexport/internal/wavewriter.h
@@ -29,8 +29,7 @@ namespace mu::iex::audioexport {
 class WaveWriter : public notation::AbstractNotationWriter
 {
 public:
-    Ret write(const notation::INotationPtrList& notations, system::IODevice& destinationDevice,
-              const Options& options = Options()) override;
+    Ret write(notation::INotationPtr notation, system::IODevice& destinationDevice, const Options& options = Options()) override;
 };
 }
 

--- a/src/importexport/imagesexport/internal/pdfwriter.h
+++ b/src/importexport/imagesexport/internal/pdfwriter.h
@@ -28,18 +28,23 @@
 #include "../iimagesexportconfiguration.h"
 #include "modularity/ioc.h"
 
+class QPdfWriter;
+
 namespace mu::iex::imagesexport {
 class PdfWriter : public notation::AbstractNotationWriter
 {
     INJECT(iex_imagesexport, IImagesExportConfiguration, configuration)
 
 public:
-    std::vector<notation::WriterUnitType> supportedUnitTypes() const override;
-    Ret write(const notation::INotationPtrList& notations, system::IODevice& destinationDevice,
-              const Options& options = Options()) override;
+    std::vector<notation::INotationWriter::UnitType> supportedUnitTypes() const override;
+    Ret write(notation::INotationPtr notation, system::IODevice& destinationDevice, const Options& options = Options()) override;
+    Ret writeList(const notation::INotationPtrList& notations, system::IODevice& destinationDevice,
+                  const Options& options = Options()) override;
 
 private:
     QString documentTitle(const Ms::Score& score) const;
+    void preparePdfWriter(QPdfWriter& pdfWriter, const QString& title) const;
+    void doWrite(QPdfWriter& pdfWriter, mu::draw::Painter& painter, Ms::Score* score) const;
 };
 }
 

--- a/src/importexport/imagesexport/internal/pngwriter.cpp
+++ b/src/importexport/imagesexport/internal/pngwriter.cpp
@@ -37,21 +37,17 @@ using namespace mu::iex::imagesexport;
 using namespace mu::notation;
 using namespace mu::system;
 
-std::vector<WriterUnitType> PngWriter::supportedUnitTypes() const
+std::vector<INotationWriter::UnitType> PngWriter::supportedUnitTypes() const
 {
-    return { WriterUnitType::PER_PAGE };
+    return { UnitType::PER_PAGE };
 }
 
-mu::Ret PngWriter::write(const INotationPtrList& notations, IODevice& destinationDevice, const Options& options)
+mu::Ret PngWriter::write(INotationPtr notation, IODevice& destinationDevice, const Options& options)
 {
-    IF_ASSERT_FAILED(!notations.empty()) {
-        return make_ret(Ret::Code::UnknownError);
-    }
-
-    INotationPtr notation = notations.front();
     IF_ASSERT_FAILED(notation) {
         return make_ret(Ret::Code::UnknownError);
     }
+
     Ms::Score* score = notation->elements()->msScore();
     IF_ASSERT_FAILED(score) {
         return make_ret(Ret::Code::UnknownError);

--- a/src/importexport/imagesexport/internal/pngwriter.h
+++ b/src/importexport/imagesexport/internal/pngwriter.h
@@ -34,9 +34,8 @@ class PngWriter : public notation::AbstractNotationWriter
     INJECT(iex_imagesexport, IImagesExportConfiguration, configuration)
 
 public:
-    std::vector<notation::WriterUnitType> supportedUnitTypes() const override;
-    Ret write(const notation::INotationPtrList& notations, system::IODevice& destinationDevice,
-              const Options& options = Options()) override;
+    std::vector<notation::INotationWriter::UnitType> supportedUnitTypes() const override;
+    Ret write(notation::INotationPtr notation, system::IODevice& destinationDevice, const Options& options = Options()) override;
 };
 }
 

--- a/src/importexport/imagesexport/internal/svgwriter.cpp
+++ b/src/importexport/imagesexport/internal/svgwriter.cpp
@@ -39,21 +39,17 @@ using namespace mu::iex::imagesexport;
 using namespace mu::notation;
 using namespace mu::system;
 
-std::vector<WriterUnitType> SvgWriter::supportedUnitTypes() const
+std::vector<INotationWriter::UnitType> SvgWriter::supportedUnitTypes() const
 {
-    return { WriterUnitType::PER_PAGE };
+    return { UnitType::PER_PAGE };
 }
 
-mu::Ret SvgWriter::write(const INotationPtrList& notations, IODevice& destinationDevice, const Options& options)
+mu::Ret SvgWriter::write(INotationPtr notation, IODevice& destinationDevice, const Options& options)
 {
-    IF_ASSERT_FAILED(!notations.empty()) {
-        return make_ret(Ret::Code::UnknownError);
-    }
-
-    INotationPtr notation = notations.front();
     IF_ASSERT_FAILED(notation) {
         return make_ret(Ret::Code::UnknownError);
     }
+
     Ms::Score* score = notation->elements()->msScore();
     IF_ASSERT_FAILED(score) {
         return make_ret(Ret::Code::UnknownError);

--- a/src/importexport/imagesexport/internal/svgwriter.h
+++ b/src/importexport/imagesexport/internal/svgwriter.h
@@ -29,9 +29,8 @@ namespace mu::iex::imagesexport {
 class SvgWriter : public notation::AbstractNotationWriter
 {
 public:
-    std::vector<notation::WriterUnitType> supportedUnitTypes() const override;
-    Ret write(const notation::INotationPtrList& notations, system::IODevice& destinationDevice,
-              const Options& options = Options()) override;
+    std::vector<notation::INotationWriter::UnitType> supportedUnitTypes() const override;
+    Ret write(notation::INotationPtr notation, system::IODevice& destinationDevice, const Options& options = Options()) override;
 
 private:
     using NotesColors = QHash<int /* noteIndex */, QColor>;

--- a/src/importexport/midiimport/internal/notationmidiwriter.cpp
+++ b/src/importexport/midiimport/internal/notationmidiwriter.cpp
@@ -27,9 +27,9 @@
 using namespace mu::iex::midiimport;
 using namespace mu::system;
 
-mu::Ret NotationMidiWriter::write(const notation::INotationPtrList& notations, IODevice& destinationDevice, const Options& options)
+mu::Ret NotationMidiWriter::write(notation::INotationPtr notation, IODevice& destinationDevice, const Options& options)
 {
-    UNUSED(notations)
+    UNUSED(notation)
     UNUSED(destinationDevice)
     UNUSED(options)
 

--- a/src/importexport/midiimport/internal/notationmidiwriter.h
+++ b/src/importexport/midiimport/internal/notationmidiwriter.h
@@ -29,8 +29,7 @@ namespace mu::iex::midiimport {
 class NotationMidiWriter : public notation::AbstractNotationWriter
 {
 public:
-    Ret write(const notation::INotationPtrList& notations, system::IODevice& destinationDevice,
-              const Options& options = Options()) override;
+    Ret write(notation::INotationPtr notation, system::IODevice& destinationDevice, const Options& options = Options()) override;
 };
 }
 

--- a/src/importexport/musicxml/internal/musicxmlwriter.cpp
+++ b/src/importexport/musicxml/internal/musicxmlwriter.cpp
@@ -30,13 +30,8 @@
 using namespace mu::iex::musicxml;
 using namespace mu::system;
 
-mu::Ret MusicXmlWriter::write(const notation::INotationPtrList& notations, IODevice& destinationDevice, const Options&)
+mu::Ret MusicXmlWriter::write(notation::INotationPtr notation, IODevice& destinationDevice, const Options&)
 {
-    IF_ASSERT_FAILED(!notations.empty()) {
-        return make_ret(Ret::Code::UnknownError);
-    }
-
-    INotationPtr notation = notations.front();
     IF_ASSERT_FAILED(notation) {
         return make_ret(Ret::Code::UnknownError);
     }

--- a/src/importexport/musicxml/internal/musicxmlwriter.h
+++ b/src/importexport/musicxml/internal/musicxmlwriter.h
@@ -29,8 +29,7 @@ namespace mu::iex::musicxml {
 class MusicXmlWriter : public notation::AbstractNotationWriter
 {
 public:
-    Ret write(const notation::INotationPtrList& notations, system::IODevice& destinationDevice,
-              const Options& options = Options()) override;
+    Ret write(notation::INotationPtr notation, system::IODevice& destinationDevice, const Options& options = Options()) override;
 };
 }
 

--- a/src/importexport/musicxml/internal/mxlwriter.cpp
+++ b/src/importexport/musicxml/internal/mxlwriter.cpp
@@ -29,17 +29,13 @@
 using namespace mu::iex::musicxml;
 using namespace mu::system;
 
-mu::Ret MxlWriter::write(const notation::INotationPtrList& notations, IODevice& destinationDevice, const Options&)
+mu::Ret MxlWriter::write(notation::INotationPtr notation, system::IODevice& destinationDevice, const Options&)
 {
-    IF_ASSERT_FAILED(!notations.empty()) {
-        return make_ret(Ret::Code::UnknownError);
-    }
-
-    INotationPtr notation = notations.front();
     IF_ASSERT_FAILED(notation) {
         return make_ret(Ret::Code::UnknownError);
     }
     Ms::Score* score = notation->elements()->msScore();
+
     IF_ASSERT_FAILED(score) {
         return make_ret(Ret::Code::UnknownError);
     }

--- a/src/importexport/musicxml/internal/mxlwriter.h
+++ b/src/importexport/musicxml/internal/mxlwriter.h
@@ -29,8 +29,7 @@ namespace mu::iex::musicxml {
 class MxlWriter : public notation::AbstractNotationWriter
 {
 public:
-    Ret write(const notation::INotationPtrList& notations, system::IODevice& destinationDevice,
-              const Options& options = Options()) override;
+    Ret write(notation::INotationPtr notation, system::IODevice& destinationDevice, const Options& options = Options()) override;
 };
 }
 

--- a/src/notation/abstractnotationwriter.h
+++ b/src/notation/abstractnotationwriter.h
@@ -29,16 +29,18 @@ namespace mu::notation {
 class AbstractNotationWriter : public INotationWriter
 {
 public:
-    std::vector<WriterUnitType> supportedUnitTypes() const override;
-    bool supportsUnitType(WriterUnitType unitType) const override;
+    std::vector<UnitType> supportedUnitTypes() const override;
+    bool supportsUnitType(UnitType unitType) const override;
 
-    virtual Ret write(const INotationPtrList& notations, system::IODevice& destinationDevice, const Options& options = Options()) override;
+    virtual Ret write(INotationPtr notation, system::IODevice& destinationDevice, const Options& options = Options()) override;
+    virtual Ret writeList(const INotationPtrList& notations, system::IODevice& destinationDevice,
+                          const Options& options = Options()) override;
 
     void abort() override;
     framework::ProgressChannel progress() const override;
 
 protected:
-    WriterUnitType unitTypeFromOptions(const Options& options) const;
+    UnitType unitTypeFromOptions(const Options& options) const;
     framework::ProgressChannel m_progress;
 };
 }

--- a/src/notation/inotationwriter.h
+++ b/src/notation/inotationwriter.h
@@ -35,8 +35,14 @@ namespace mu::notation {
 class INotationWriter
 {
 public:
-    virtual std::vector<WriterUnitType> supportedUnitTypes() const = 0;
-    virtual bool supportsUnitType(WriterUnitType unitType) const = 0;
+    enum class UnitType {
+        PER_PAGE,
+        PER_PART,
+        MULTI_PART
+    };
+
+    virtual std::vector<UnitType> supportedUnitTypes() const = 0;
+    virtual bool supportsUnitType(UnitType unitType) const = 0;
 
     enum class OptionKey {
         UNIT_TYPE,
@@ -50,7 +56,8 @@ public:
 
     virtual ~INotationWriter() = default;
 
-    virtual Ret write(const INotationPtrList& notations, system::IODevice& destinationDevice, const Options& options = Options()) = 0;
+    virtual Ret write(INotationPtr notation, system::IODevice& destinationDevice, const Options& options = Options()) = 0;
+    virtual Ret writeList(const INotationPtrList& notations, system::IODevice& destinationDevice, const Options& options = Options()) = 0;
     virtual void abort() = 0;
     virtual framework::ProgressChannel progress() const = 0;
 };

--- a/src/notation/internal/abstractnotationwriter.cpp
+++ b/src/notation/internal/abstractnotationwriter.cpp
@@ -27,20 +27,39 @@
 using namespace mu::notation;
 using namespace mu::framework;
 
-std::vector<WriterUnitType> AbstractNotationWriter::supportedUnitTypes() const
+std::vector<INotationWriter::UnitType> AbstractNotationWriter::supportedUnitTypes() const
 {
-    return { WriterUnitType::PER_PART };
+    return { UnitType::PER_PART };
 }
 
-bool AbstractNotationWriter::supportsUnitType(WriterUnitType unitType) const
+bool AbstractNotationWriter::supportsUnitType(UnitType unitType) const
 {
-    std::vector<WriterUnitType> unitTypes = supportedUnitTypes();
+    std::vector<UnitType> unitTypes = supportedUnitTypes();
     return std::find(unitTypes.cbegin(), unitTypes.cend(), unitType) != unitTypes.cend();
 }
 
-mu::Ret AbstractNotationWriter::write(const INotationPtrList&, system::IODevice&, const Options& options)
+mu::Ret AbstractNotationWriter::write(INotationPtr, system::IODevice&, const Options& options)
 {
-    if (supportsUnitType(static_cast<WriterUnitType>(options.value(OptionKey::UNIT_TYPE, Val(0)).toInt()))) {
+    IF_ASSERT_FAILED(unitTypeFromOptions(options) != UnitType::MULTI_PART) {
+        return Ret(Ret::Code::NotSupported);
+    }
+
+    if (supportsUnitType(static_cast<UnitType>(options.value(OptionKey::UNIT_TYPE, Val(0)).toInt()))) {
+        NOT_IMPLEMENTED;
+        return Ret(Ret::Code::NotImplemented);
+    }
+
+    NOT_SUPPORTED;
+    return Ret(Ret::Code::NotSupported);
+}
+
+mu::Ret AbstractNotationWriter::writeList(const INotationPtrList&, system::IODevice&, const Options& options)
+{
+    IF_ASSERT_FAILED(unitTypeFromOptions(options) == UnitType::MULTI_PART) {
+        return Ret(Ret::Code::NotSupported);
+    }
+
+    if (supportsUnitType(static_cast<UnitType>(options.value(OptionKey::UNIT_TYPE, Val(0)).toInt()))) {
         NOT_IMPLEMENTED;
         return Ret(Ret::Code::NotImplemented);
     }
@@ -59,16 +78,15 @@ ProgressChannel AbstractNotationWriter::progress() const
     return m_progress;
 }
 
-WriterUnitType AbstractNotationWriter::unitTypeFromOptions(const Options& options) const
+INotationWriter::UnitType AbstractNotationWriter::unitTypeFromOptions(const Options& options) const
 {
-    std::vector<WriterUnitType> supported = supportedUnitTypes();
+    std::vector<UnitType> supported = supportedUnitTypes();
     IF_ASSERT_FAILED(!supported.empty()) {
-        return WriterUnitType::PER_PART;
+        return UnitType::PER_PART;
     }
 
-    WriterUnitType defaultUnitType = supported.front();
-    WriterUnitType unitType = static_cast<WriterUnitType>(options.value(OptionKey::UNIT_TYPE, Val(
-                                                                            static_cast<int>(defaultUnitType))).toInt());
+    UnitType defaultUnitType = supported.front();
+    UnitType unitType = static_cast<UnitType>(options.value(OptionKey::UNIT_TYPE, Val(static_cast<int>(defaultUnitType))).toInt());
     if (!supportsUnitType(unitType)) {
         return defaultUnitType;
     }

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -539,7 +539,7 @@ mu::Ret MasterNotation::exportScore(const io::path& path, const std::string& suf
         return false;
     }
 
-    Ret ret = writer->write({ shared_from_this() }, file);
+    Ret ret = writer->write(shared_from_this(), file);
     file.close();
 
     return ret;

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -166,12 +166,6 @@ enum class SaveMode
     SaveOnline
 };
 
-enum class WriterUnitType {
-    PER_PAGE,
-    PER_PART,
-    MULTI_PART
-};
-
 enum class ResettableValueType
 {
     Stretch,

--- a/src/userscores/iexportscorescenario.h
+++ b/src/userscores/iexportscorescenario.h
@@ -24,6 +24,7 @@
 
 #include "modularity/imoduleexport.h"
 #include "notation/inotation.h"
+#include "notation/inotationwriter.h"
 #include "internal/exporttype.h"
 
 namespace mu::userscores {
@@ -32,10 +33,10 @@ class IExportScoreScenario : MODULE_EXPORT_INTERFACE
     INTERFACE_ID(IExportScoreScenario)
 
 public:
-    virtual std::vector<notation::WriterUnitType> supportedUnitTypes(const ExportType& exportType) const = 0;
+    virtual std::vector<notation::INotationWriter::UnitType> supportedUnitTypes(const ExportType& exportType) const = 0;
 
     virtual bool exportScores(const notation::INotationPtrList& notations, const ExportType& exportType,
-                              notation::WriterUnitType unitType) const = 0;
+                              notation::INotationWriter::UnitType unitType) const = 0;
 };
 }
 

--- a/src/userscores/internal/exportscorescenario.h
+++ b/src/userscores/internal/exportscorescenario.h
@@ -43,10 +43,10 @@ class ExportScoreScenario : public IExportScoreScenario
     INJECT(userscores, system::IFileSystem, fileSystem)
 
 public:
-    std::vector<notation::WriterUnitType> supportedUnitTypes(const ExportType& exportType) const override;
+    std::vector<notation::INotationWriter::UnitType> supportedUnitTypes(const ExportType& exportType) const override;
 
     bool exportScores(const notation::INotationPtrList& notations, const ExportType& exportType,
-                      notation::WriterUnitType unitType) const override;
+                      notation::INotationWriter::UnitType unitType) const override;
 
 private:
     enum class FileConflictPolicy {
@@ -55,15 +55,18 @@ private:
         ReplaceAll
     };
 
-    bool isCreatingOnlyOneFile(const notation::INotationPtrList& notations, notation::WriterUnitType unitType) const;
+    bool isCreatingOnlyOneFile(const notation::INotationPtrList& notations, notation::INotationWriter::UnitType unitType) const;
 
     bool isMainNotation(notation::INotationPtr notation) const;
+
+    io::path askExportPath(const notation::INotationPtrList& notations, const ExportType& exportType,
+                           notation::INotationWriter::UnitType unitType) const;
+    io::path completeExportPath(const io::path& basePath, notation::INotationPtr notation, bool isMain, int pageIndex = -1) const;
 
     bool shouldReplaceFile(const QString& filename) const;
     bool askForRetry(const QString& filename) const;
 
-    bool doExport(notation::INotationWriterPtr writer, const notation::INotationPtrList& notations, const io::path& path,
-                  const notation::INotationWriter::Options& options) const;
+    bool doExportLoop(const io::path& path, std::function<bool(system::IODevice&)> exportFunction) const;
 
     mutable FileConflictPolicy m_fileConflictPolicy;
 };

--- a/src/userscores/internal/userscoresconfiguration.cpp
+++ b/src/userscores/internal/userscoresconfiguration.cpp
@@ -193,23 +193,6 @@ io::path UserScoresConfiguration::defaultSavingFilePath(const io::path& fileName
     return scoresPath().val + "/" + fileName + DEFAULT_FILE_SUFFIX;
 }
 
-io::path UserScoresConfiguration::completeExportPath(const io::path& basePath, INotationPtr notation, bool isMain, int pageIndex) const
-{
-    io::path result = io::dirpath(basePath) + "/" + io::basename(basePath);
-
-    if (!isMain) {
-        result += "-" + io::escapeFileName(notation->metaInfo().title).toStdString();
-    }
-
-    if (pageIndex > -1) {
-        result += "-" + std::to_string(pageIndex + 1);
-    }
-
-    result += "." + io::syffix(basePath);
-
-    return result;
-}
-
 QColor UserScoresConfiguration::templatePreviewBackgroundColor() const
 {
     return notationConfiguration()->backgroundColor();

--- a/src/userscores/internal/userscoresconfiguration.h
+++ b/src/userscores/internal/userscoresconfiguration.h
@@ -58,7 +58,6 @@ public:
     void setScoresPath(const io::path& path) override;
 
     io::path defaultSavingFilePath(const io::path& fileName) const override;
-    io::path completeExportPath(const io::path& basePath, notation::INotationPtr notation, bool isMain, int pageIndex = -1) const override;
 
     QColor templatePreviewBackgroundColor() const override;
     async::Notification templatePreviewBackgroundChanged() const override;

--- a/src/userscores/iuserscoresconfiguration.h
+++ b/src/userscores/iuserscoresconfiguration.h
@@ -53,8 +53,6 @@ public:
     virtual void setScoresPath(const io::path& path) = 0;
 
     virtual io::path defaultSavingFilePath(const io::path& fileName) const = 0;
-    virtual io::path completeExportPath(const io::path& basePath, notation::INotationPtr notation, bool isMain,
-                                        int pageIndex = -1) const = 0;
 
     virtual QColor templatePreviewBackgroundColor() const = 0;
     virtual async::Notification templatePreviewBackgroundChanged() const = 0;

--- a/src/userscores/tests/mocks/userscoresconfigurationmock.h
+++ b/src/userscores/tests/mocks/userscoresconfigurationmock.h
@@ -44,7 +44,6 @@ public:
     MOCK_METHOD(void, setScoresPath, (const io::path&), (override));
 
     MOCK_METHOD(io::path, defaultSavingFilePath, (const io::path&), (const, override));
-    MOCK_METHOD(io::path, completeExportPath, (const io::path&, notation::INotationPtr, bool, int), (const, override));
 
     MOCK_METHOD(QColor, templatePreviewBackgroundColor, (), (const, override));
     MOCK_METHOD(async::Notification, templatePreviewBackgroundChanged, (), (const, override));

--- a/src/userscores/view/exportdialogmodel.cpp
+++ b/src/userscores/view/exportdialogmodel.cpp
@@ -28,7 +28,9 @@ using namespace mu::userscores;
 using namespace mu::notation;
 using namespace mu::iex::musicxml;
 
-static const WriterUnitType DEFAULT_EXPORT_UNITTYPE = WriterUnitType::PER_PART;
+using UnitType = INotationWriter::UnitType;
+
+static const UnitType DEFAULT_EXPORT_UNITTYPE = UnitType::PER_PART;
 
 ExportDialogModel::ExportDialogModel(QObject* parent)
     : QAbstractListModel(parent)
@@ -218,7 +220,7 @@ void ExportDialogModel::setExportType(const ExportType& type)
     m_selectedExportType = type;
     emit selectedExportTypeChanged(type.toMap());
 
-    std::vector<WriterUnitType> unitTypes = exportScoreScenario()->supportedUnitTypes(type);
+    std::vector<UnitType> unitTypes = exportScoreScenario()->supportedUnitTypes(type);
 
     IF_ASSERT_FAILED(!unitTypes.empty()) {
         return;
@@ -254,15 +256,15 @@ void ExportDialogModel::selectExportTypeById(const QString& id)
 
 QVariantList ExportDialogModel::availableUnitTypes() const
 {
-    QMap<WriterUnitType, QString> unitTypeNames {
-        { WriterUnitType::PER_PAGE, qtrc("userscores", "Each page to a separate file") },
-        { WriterUnitType::PER_PART, qtrc("userscores", "Each part to a separate file") },
-        { WriterUnitType::MULTI_PART, qtrc("userscores", "All parts combined in one file") },
+    QMap<UnitType, QString> unitTypeNames {
+        { UnitType::PER_PAGE, qtrc("userscores", "Each page to a separate file") },
+        { UnitType::PER_PART, qtrc("userscores", "Each part to a separate file") },
+        { UnitType::MULTI_PART, qtrc("userscores", "All parts combined in one file") },
     };
 
     QVariantList result;
 
-    for (WriterUnitType type : exportScoreScenario()->supportedUnitTypes(m_selectedExportType)) {
+    for (UnitType type : exportScoreScenario()->supportedUnitTypes(m_selectedExportType)) {
         QVariantMap obj;
         obj["text"] = unitTypeNames[type];
         obj["value"] = static_cast<int>(type);
@@ -279,10 +281,10 @@ int ExportDialogModel::selectedUnitType() const
 
 void ExportDialogModel::setUnitType(int unitType)
 {
-    setUnitType(static_cast<WriterUnitType>(unitType));
+    setUnitType(static_cast<UnitType>(unitType));
 }
 
-void ExportDialogModel::setUnitType(WriterUnitType unitType)
+void ExportDialogModel::setUnitType(UnitType unitType)
 {
     if (m_selectedUnitType == unitType) {
         return;

--- a/src/userscores/view/exportdialogmodel.h
+++ b/src/userscores/view/exportdialogmodel.h
@@ -92,7 +92,7 @@ public:
     QVariantList availableUnitTypes() const;
     int selectedUnitType() const;
     void setUnitType(int unitType);
-    void setUnitType(notation::WriterUnitType unitType);
+    void setUnitType(notation::INotationWriter::UnitType unitType);
 
     Q_INVOKABLE bool exportScores();
 
@@ -138,7 +138,7 @@ signals:
     void selectionChanged();
 
     void selectedExportTypeChanged(QVariantMap newExportType);
-    void selectedUnitTypeChanged(notation::WriterUnitType newUnitType);
+    void selectedUnitTypeChanged(notation::INotationWriter::UnitType newUnitType);
 
     void pdfResolutionChanged(int resolution);
     void pngResolutionChanged(int resolution);
@@ -167,12 +167,12 @@ private:
     bool isMainNotation(notation::INotationPtr notation) const;
     notation::IMasterNotationPtr masterNotation() const;
 
-    QList<notation::INotationPtr> m_notations;
-    QItemSelectionModel* m_selectionModel;
+    QList<notation::INotationPtr> m_notations {};
+    QItemSelectionModel* m_selectionModel = nullptr;
 
-    ExportTypeList m_exportTypeList;
-    ExportType m_selectedExportType;
-    notation::WriterUnitType m_selectedUnitType;
+    ExportTypeList m_exportTypeList {};
+    ExportType m_selectedExportType = ExportType();
+    notation::INotationWriter::UnitType m_selectedUnitType = notation::INotationWriter::UnitType::PER_PART;
 };
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/pull/7814#pullrequestreview-645640616

- Moved WriterUnitType to INotationWriter::UnitType
- Brought back method for simply exporting one score
- Small refactor in ExportScoreScenario regarding export path