### PR TITLE
[MU4] Fix #303422: Importing colored lyrics from MusicXML

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -5533,7 +5533,8 @@ void MusicXMLParserLyric::parse()
     //qDebug("formatted lyric '%s'", qPrintable(formattedText));
     lyric->setXmlText(formattedText);
     if (lyricColor != QColor::Invalid) {
-        lyric->setColor(lyricColor);
+        lyric->setProperty(Pid::COLOR, lyricColor);
+        lyric->setPropertyFlags(Pid::COLOR, PropertyFlags::UNSTYLED);
     }
 
     const auto l = lyric.release();

--- a/src/importexport/musicxml/tests/data/testLyricColor.xml
+++ b/src/importexport/musicxml/tests/data/testLyricColor.xml
@@ -185,6 +185,10 @@
           <syllabic>single</syllabic>
           <text>blue.</text>
           </lyric>
+        <lyric number="2" color="#9541E8">
+          <syllabic>single</syllabic>
+          <text>purple.</text>
+          </lyric>
         </note>
       <barline location="right">
         <bar-style>light-heavy</bar-style>

--- a/src/libmscore/lyrics.cpp
+++ b/src/libmscore/lyrics.cpp
@@ -278,12 +278,12 @@ void Lyrics::layout()
     }
 
     bool styleDidChange = false;
-    if ((_no & 1) && !_even) {
+    if (isEven() && !_even) {
         initTid(Tid::LYRICS_EVEN, /* preserveDifferent */ true);
         _even             = true;
         styleDidChange    = true;
     }
-    if (!(_no & 1) && _even) {
+    if (!isEven() && _even) {
         initTid(Tid::LYRICS_ODD, /* preserveDifferent */ true);
         _even             = false;
         styleDidChange    = true;
@@ -610,7 +610,7 @@ QVariant Lyrics::propertyDefault(Pid id) const
 {
     switch (id) {
     case Pid::SUB_STYLE:
-        return int((_no & 1) ? Tid::LYRICS_EVEN : Tid::LYRICS_ODD);
+        return int(isEven() ? Tid::LYRICS_EVEN : Tid::LYRICS_ODD);
     case Pid::PLACEMENT:
         return score()->styleV(Sid::lyricsPlacement);
     case Pid::SYLLABIC:


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/303422

Up to 3.5 it worked only for first line (number="1"), in 3.6 and master it stopped working all together

See #6021 which tried to fix this first for 3.x
See also #8034 is for 3.x, as on master MusicXML import can't get tested currently...

