### PR TITLE
[MU3] Fix #303422: Importing colored lyrics from MusicXML

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -5353,8 +5353,10 @@ void MusicXMLParserLyric::parse()
 
       //qDebug("formatted lyric '%s'", qPrintable(formattedText));
       lyric->setXmlText(formattedText);
-      if (lyricColor != QColor::Invalid)
-            lyric->setColor(lyricColor);
+      if (lyricColor != QColor::Invalid) {
+            lyric->setProperty(Pid::COLOR, lyricColor);
+            lyric->setPropertyFlags(Pid::COLOR, PropertyFlags::UNSTYLED);
+            }
 
       const auto l = lyric.release();
       _numberedLyrics[lyricNo] = l;

--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -272,12 +272,12 @@ void Lyrics::layout()
             }
 
       bool styleDidChange = false;
-      if ((_no & 1) && !_even) {
+      if (isEven() && !_even) {
             initTid(Tid::LYRICS_EVEN, /* preserveDifferent */ true);
             _even             = true;
             styleDidChange    = true;
             }
-      if (!(_no & 1) && _even) {
+      if (!isEven() && _even) {
             initTid(Tid::LYRICS_ODD, /* preserveDifferent */ true);
             _even             = false;
             styleDidChange    = true;
@@ -600,7 +600,7 @@ QVariant Lyrics::propertyDefault(Pid id) const
       {
       switch (id) {
             case Pid::SUB_STYLE:
-                  return int((_no & 1) ? Tid::LYRICS_EVEN : Tid::LYRICS_ODD);
+                  return int(isEven() ? Tid::LYRICS_EVEN : Tid::LYRICS_ODD);
             case Pid::PLACEMENT:
                   return score()->styleV(Sid::lyricsPlacement);
             case Pid::SYLLABIC:

--- a/mtest/musicxml/io/testLyricColor.xml
+++ b/mtest/musicxml/io/testLyricColor.xml
@@ -185,6 +185,10 @@
           <syllabic>single</syllabic>
           <text>blue.</text>
           </lyric>
+        <lyric number="2" color="#9541E8">
+          <syllabic>single</syllabic>
+          <text>purple.</text>
+          </lyric>
         </note>
       <barline location="right">
         <bar-style>light-heavy</bar-style>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/303422

Up to 3.5 it worked only for first line (number="1"), in 3.6 and master it stopped working all together

This is for 3.x what #8033 is for master, as on master MusicXML import can't get tested currently...

Image of importing the test file, `mtest/musicxml/io/testLyricColor.xml`:
![image](https://user-images.githubusercontent.com/1786669/116704492-c2684280-a9cb-11eb-97b1-8075c56640e2.png)
