### PR TITLE
[MU3] Fix #320573: [MusicXML import] fretboard frets property not saved in MuseScore format

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -4903,8 +4903,10 @@ FretDiagram* MusicXMLParserPass2::frame()
       while (_e.readNextStartElement()) {
             if (_e.name() == "frame-frets") {
                   int val = _e.readElementText().toInt();
-                  if (val > 0)
-                        fd->setFrets(val);
+                  if (val > 0) {
+                        fd->setProperty(Pid::FRET_FRETS, val);
+                        fd->setPropertyFlags(Pid::FRET_FRETS, PropertyFlags::UNSTYLED);
+                        }
                   else
                         _logger->logError(QString("FretDiagram::readMusicXML: illegal frame-fret %1").arg(val), &_e);
                   }

--- a/mtest/musicxml/io/testChordDiagrams1.xml
+++ b/mtest/musicxml/io/testChordDiagrams1.xml
@@ -76,7 +76,7 @@
         <kind>major</kind>
         <frame>
           <frame-strings>6</frame-strings>
-          <frame-frets>5</frame-frets>
+          <frame-frets>3</frame-frets>
           <frame-note>
             <string>5</string>
             <fret>3</fret>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/320573

PR for master in #8037 (but there MusicXML import is currently not working)