### PR TITLE
[MU4] Fix #320573: [MusicXML import] fretboard frets property not saved in MuseScore format

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -5089,7 +5089,8 @@ FretDiagram* MusicXMLParserPass2::frame()
         if (_e.name() == "frame-frets") {
             int val = _e.readElementText().toInt();
             if (val > 0) {
-                fd->setFrets(val);
+                fd->setProperty(Pid::FRET_FRETS, val);
+                fd->setPropertyFlags(Pid::FRET_FRETS, PropertyFlags::UNSTYLED);
             } else {
                 _logger->logError(QString("FretDiagram::readMusicXML: illegal frame-fret %1").arg(val), &_e);
             }

--- a/src/importexport/musicxml/tests/data/testChordDiagrams1.xml
+++ b/src/importexport/musicxml/tests/data/testChordDiagrams1.xml
@@ -76,7 +76,7 @@
         <kind>major</kind>
         <frame>
           <frame-strings>6</frame-strings>
-          <frame-frets>5</frame-frets>
+          <frame-frets>3</frame-frets>
           <frame-note>
             <string>5</string>
             <fret>3</fret>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/320573

PR for 3.x in #8036, as MusicXML import is currently not working in master