### PR TITLE
Fix: [MU4 Issue] Rename 'Delete Score' to 'Delete Part' in Parts dialog

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/internal/PartDelegate.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PartDelegate.qml
@@ -171,7 +171,7 @@ ListItemBlank {
         StyledContextMenuItem {
             id: deleteItem
 
-            text: qsTrc("notation", "Delete part")
+            text: qsTrc("notation", "Delete")
 
             onTriggered: {
                 root.removePartRequested()

--- a/src/notation/qml/MuseScore/NotationScene/internal/PartDelegate.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PartDelegate.qml
@@ -171,7 +171,7 @@ ListItemBlank {
         StyledContextMenuItem {
             id: deleteItem
 
-            text: qsTrc("notation", "Delete score")
+            text: qsTrc("notation", "Delete part")
 
             onTriggered: {
                 root.removePartRequested()


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8032

Fix typo, changing "Delete score" to "Delete part"

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
