### PR TITLE
[MU4] Fix #8040: choose quarter note as default duration

### DIFF
--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -112,13 +112,13 @@ void NotationNoteInput::startNoteInput()
     }
     //! ---
 
+    m_interaction->select({ el }, SelectType::SINGLE, 0);
+
     Duration d(is.duration());
     if (!d.isValid() || d.isZero() || d.type() == Duration::DurationType::V_MEASURE) {
         is.setDuration(Duration(Duration::DurationType::V_QUARTER));
     }
     is.setAccidentalType(Ms::AccidentalType::NONE);
-
-    m_interaction->select({ el }, SelectType::SINGLE, 0);
 
     is.setRest(false);
     is.setNoteEntryMode(true);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8040

Moved the line which updates current selection before the code that deals with default note durations.

In the original code, when current selection gets updated after the default note duration is selected, the note duration is reverted to `V_MEASURE`, which could cause a `Q_ASSERT` to fail for debug builds. 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
