### PR TITLE
[MU4] Show part name in  instrument form instead of instrument name.

### DIFF
--- a/src/instruments/internal/selectinstrumentscenario.cpp
+++ b/src/instruments/internal/selectinstrumentscenario.cpp
@@ -28,7 +28,7 @@ mu::RetVal<InstrumentList> SelectInstrumentsScenario::selectInstruments(SelectIn
 {
     QStringList params;
     if (mode == SelectInstrumentsMode::ShowCurrentInstruments) {
-        params << "initiallySelectedInstrumentIds=" + partsInstrumentIds().join(",");
+        params << "initiallySelectedPartIds=" + partsIds().join(",");
     }
 
     return selectInstruments(params);
@@ -90,7 +90,7 @@ INotationPartsPtr SelectInstrumentsScenario::notationParts() const
     return notation->parts();
 }
 
-IDList SelectInstrumentsScenario::partsInstrumentIds() const
+IDList SelectInstrumentsScenario::partsIds() const
 {
     auto _notationParts = notationParts();
     if (!_notationParts) {
@@ -101,15 +101,7 @@ IDList SelectInstrumentsScenario::partsInstrumentIds() const
 
     IDList result;
     for (const Part* part: parts) {
-        async::NotifyList<Instrument> selectedInstruments = _notationParts->instrumentList(part->id());
-
-        for (const Instrument& instrument: selectedInstruments) {
-            if (part->isDoublingInstrument(instrument.id)) {
-                continue;
-            }
-
-            result << instrument.id;
-        }
+        result << part->id();
     }
 
     return result;

--- a/src/instruments/internal/selectinstrumentscenario.h
+++ b/src/instruments/internal/selectinstrumentscenario.h
@@ -41,7 +41,7 @@ private:
     RetVal<InstrumentList> selectInstruments(const QStringList& params) const;
 
     notation::INotationPartsPtr notationParts() const;
-    notation::IDList partsInstrumentIds() const;
+    notation::IDList partsIds() const;
 };
 }
 

--- a/src/instruments/qml/MuseScore/Instruments/ChooseInstrumentsPage.qml
+++ b/src/instruments/qml/MuseScore/Instruments/ChooseInstrumentsPage.qml
@@ -31,7 +31,7 @@ import "internal"
 Rectangle {
     id: root
 
-    property string initiallySelectedInstrumentIds: ""
+    property string initiallySelectedPartIds: ""
     property bool hasSelectedInstruments: instrumentsModel.selectedInstruments.length > 0
     property bool canSelectMultipleInstruments: true
     property string currentInstrumentId: ""
@@ -54,7 +54,7 @@ Rectangle {
     }
 
     Component.onCompleted: {
-        instrumentsModel.load(canSelectMultipleInstruments, currentInstrumentId, initiallySelectedInstrumentIds)
+        instrumentsModel.load(canSelectMultipleInstruments, currentInstrumentId, initiallySelectedPartIds)
 
         var groupId = instrumentsModel.selectedGroupId()
         familyView.focusGroup(groupId)

--- a/src/instruments/qml/MuseScore/Instruments/InstrumentsDialog.qml
+++ b/src/instruments/qml/MuseScore/Instruments/InstrumentsDialog.qml
@@ -30,7 +30,7 @@ StyledDialogView {
 
     property bool canSelectMultipleInstruments: true
     property string currentInstrumentId: ""
-    property string initiallySelectedInstrumentIds: ""
+    property string initiallySelectedPartIds: ""
 
     contentHeight: 500
     contentWidth: root.canSelectMultipleInstruments ? 900 : 600
@@ -52,7 +52,7 @@ StyledDialogView {
             anchors.bottom: buttons.top
             anchors.margins: 10
 
-            initiallySelectedInstrumentIds: root.initiallySelectedInstrumentIds
+            initiallySelectedPartIds: root.initiallySelectedPartIds
             canSelectMultipleInstruments: root.canSelectMultipleInstruments
             currentInstrumentId: root.currentInstrumentId
         }

--- a/src/instruments/view/instrumentlistmodel.h
+++ b/src/instruments/view/instrumentlistmodel.h
@@ -35,7 +35,7 @@ class InstrumentListModel : public QObject, public async::Asyncable
     Q_OBJECT
 
     INJECT(instruments, IInstrumentsRepository, repository)
-    INJECT(instruments, context::IGlobalContext, context)
+    INJECT(instruments, context::IGlobalContext, globalContext)
 
     Q_PROPERTY(QVariantList families READ families NOTIFY dataChanged)
     Q_PROPERTY(QVariantList groups READ groups NOTIFY dataChanged)
@@ -45,7 +45,7 @@ class InstrumentListModel : public QObject, public async::Asyncable
 public:
     InstrumentListModel(QObject* parent = nullptr);
 
-    Q_INVOKABLE void load(bool canSelectMultipleInstruments, const QString& currentInstrumentId, const QString& selectedInstrumentIds);
+    Q_INVOKABLE void load(bool canSelectMultipleInstruments, const QString& currentInstrumentId, const QString& selectedPartIds);
 
     QVariantList families() const;
     QVariantList groups() const;
@@ -79,7 +79,8 @@ signals:
     void selectedInstrumentsChanged();
 
 private:
-    void initSelectedInstruments(const notation::IDList& selectedInstrumentIds);
+    void initSelectedInstruments(const notation::IDList& selectedPartIds);
+    notation::INotationPartsPtr notationParts() const;
 
     void sortInstruments(QVariantList& instruments) const;
 
@@ -109,6 +110,8 @@ private:
     struct SelectedInstrumentInfo
     {
         QString id;
+        QString partId;
+        QString partName;
         Transposition transposition;
         Instrument config;
 


### PR DESCRIPTION
If opening `ChooseInstrumentsPage`, display the part name if available and use the instrument names otherwise.

The behavior is now similar as it was in 3.x.

The PR is required for the upcoming score ordering PR which needs part information for the ordering.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
