### PR TITLE
[MU4] Fixed PopupView on Windows

### DIFF
--- a/src/appshell/appshell.cpp
+++ b/src/appshell/appshell.cpp
@@ -186,7 +186,7 @@ int AppShell::run(int argc, char** argv)
 
         //! Needs to be set because we use transparent windows for PopupView.
         //! Needs to be called before any QQuickWindows are shown.
-        QQuickWindow::setDefaultAlphaBuffer(true);
+        // QQuickWindow::setDefaultAlphaBuffer(true);
 
         engine->load(url);
     }

--- a/src/framework/ui/internal/uiactionsregister.cpp
+++ b/src/framework/ui/internal/uiactionsregister.cpp
@@ -159,7 +159,6 @@ void UiActionsRegister::updateEnabledAll()
     ActionCodeList changedList;
     auto ctxResolver = uicontextResolver();
     ui::UiContext currentCtx = ctxResolver->currentUiContext();
-    LOGD() << "currentCtx: " << currentCtx.toString();
     for (auto it = m_actions.begin(); it != m_actions.end(); ++it) {
         Info& inf = it->second;
         doUpdateEnabled(inf, ctxResolver, currentCtx, changedList);

--- a/src/framework/uicomponents/CMakeLists.txt
+++ b/src/framework/uicomponents/CMakeLists.txt
@@ -47,6 +47,9 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/qmllistproperty.h
     ${CMAKE_CURRENT_LIST_DIR}/view/popupview.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/popupview.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/popupwindow/ipopupwindow.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/popupwindow/popupwindow_qquickview.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/popupwindow/popupwindow_qquickview.h
     ${CMAKE_CURRENT_LIST_DIR}/view/dialogview.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/dialogview.h
     ${CMAKE_CURRENT_LIST_DIR}/view/filepickermodel.cpp

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledMenu.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledMenu.qml
@@ -40,6 +40,7 @@ StyledPopupView {
     margins: 0
     x: 0
     y: opensUpward ? -root.height : parent.height
+    showArrow: false
 
     animationEnabled: false //! NOTE disabled - because trouble with simultaneous opening of submenu
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledMenuLoader.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledMenuLoader.qml
@@ -57,6 +57,10 @@ Loader {
         }
     }
 
+    function unloadMenu() {
+        loader.sourceComponent = null
+    }
+
     Component {
         id: itemMenuComp
         StyledMenu {
@@ -64,6 +68,10 @@ Loader {
             onHandleAction: {
                 Qt.callLater(loader.handleAction, actionCode, actionIndex)
                 itemMenu.close()
+            }
+
+            onClosed: {
+                Qt.callLater(loader.unloadMenu)
             }
         }
     }

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledPopupView.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledPopupView.qml
@@ -42,9 +42,10 @@ PopupView {
     property int contentHeight: contentBody.childrenRect.height
 
     property bool opensUpward: false
-    property var arrowX: root.width / 2
+    property int arrowX: root.width / 2
+    property bool showArrow: true
 
-    property bool animationEnabled: true
+    property bool animationEnabled: false
 
     property alias navigation: keynavPanel
     property bool isDoActiveParentOnClose: true
@@ -106,6 +107,8 @@ PopupView {
         implicitWidth: contentContainer.implicitWidth + root.padding * 2
         implicitHeight: contentContainer.implicitHeight + root.padding * 2
 
+        focus: true
+
         Item {
             id: contentContainer
             x: root.padding
@@ -116,8 +119,8 @@ PopupView {
             implicitWidth: contentBody.implicitWidth + root.margins * 2
             implicitHeight: contentBody.implicitHeight + root.margins * 2
 
-            scale: 0.7
-            opacity: 0.5
+            scale: root.animationEnabled ? 0.7 : 1.0
+            opacity: root.animationEnabled ? 0.5 : 1.0
             transformOrigin: Item.Center
 
             Rectangle {
@@ -141,7 +144,8 @@ PopupView {
                 anchors.bottomMargin: root.opensUpward ? (-arrow.height + contentBackground.border.width) : 0
                 height: root.padding
                 width: root.padding * 2
-                visible: arrow.height > 0
+                visible: root.showArrow && arrow.height > 0
+                enabled: root.showArrow
                 x: root.arrowX - arrow.width / 2 - root.padding
 
                 onPaint: {
@@ -188,7 +192,7 @@ PopupView {
             State {
                 name: "CLOSED"
                 when: !root.isOpened
-                PropertyChanges { target: contentContainer; scale: 0.7; opacity: 0.5 }
+                PropertyChanges { target: contentContainer; scale: root.animationEnabled ? 0.7 : 1.0; opacity: root.animationEnabled ? 0.5 : 1.0 }
             }
         ]
 

--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -87,7 +87,7 @@ void PopupView::componentComplete()
         return;
     }
 
-    m_window = new PopupWindow_QQuickView();  //new PopupWindow(engine, uiConfiguration(), isDialog());
+    m_window = new PopupWindow_QQuickView();
     m_window->init(engine, uiConfiguration(), isDialog());
     m_window->setOnHidden([this]() { onHidden(); });
     m_window->setContent(m_contentItem);
@@ -132,11 +132,12 @@ void PopupView::open()
         IF_ASSERT_FAILED(prn) {
             return;
         }
-
         m_globalPos = prn->mapToGlobal(m_localPos);
     }
 
     m_window->show(m_globalPos.toPoint());
+
+    m_globalPos = QPointF(); // invalidate
 
     if (isDialog()) {
         QWindow* qWindow = m_window->qWindow();
@@ -146,7 +147,7 @@ void PopupView::open()
         qWindow->setTitle(m_title);
         qWindow->setModality(m_modal ? Qt::ApplicationModal : Qt::NonModal);
 
-        const QRect& winRect = m_window->geometry();
+        QRect winRect = m_window->geometry();
         qWindow->setMinimumSize(winRect.size());
         if (!m_resizable) {
             qWindow->setMaximumSize(winRect.size());

--- a/src/framework/uicomponents/view/popupview.h
+++ b/src/framework/uicomponents/view/popupview.h
@@ -32,9 +32,9 @@
 #include "ui/iuiconfiguration.h"
 #include "ui/inavigationcontroller.h"
 #include "ui/view/navigationcontrol.h"
+#include "popupwindow/ipopupwindow.h"
 
 namespace mu::uicomponents {
-class PopupWindow;
 class PopupView : public QObject, public QQmlParserStatus
 {
     Q_OBJECT
@@ -88,7 +88,7 @@ public:
 
     qreal localX() const;
     qreal localY() const;
-    const QRect& geometry() const;
+    QRect geometry() const;
 
     Q_INVOKABLE void forceActiveFocus();
 
@@ -156,7 +156,7 @@ protected:
 
     void setErrCode(Ret::Code code);
 
-    PopupWindow* m_window = nullptr;
+    IPopupWindow* m_window = nullptr;
     QQuickItem* m_contentItem = nullptr;
 
     QPointF m_localPos;

--- a/src/framework/uicomponents/view/popupwindow/ipopupwindow.h
+++ b/src/framework/uicomponents/view/popupwindow/ipopupwindow.h
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_UICOMPONENTS_IPOPUPWINDOW_H
+#define MU_UICOMPONENTS_IPOPUPWINDOW_H
+
+#include <memory>
+#include <QQmlEngine>
+#include <QQuickItem>
+#include "ui/iuiconfiguration.h"
+
+namespace mu::uicomponents {
+class IPopupWindow
+{
+public:
+    virtual ~IPopupWindow() = default;
+
+    virtual void init(QQmlEngine* engine, std::shared_ptr<ui::IUiConfiguration> uiConfiguration, bool isDialogMode) = 0;
+
+    virtual void setContent(QQuickItem* item) = 0;
+
+    virtual void show(QPoint p) = 0;
+    virtual void hide() = 0;
+
+    virtual QWindow* qWindow() const = 0;
+    virtual bool isVisible() const = 0;
+    virtual QRect geometry() const = 0;
+
+    virtual void forceActiveFocus() = 0;
+
+    virtual void setOnHidden(const std::function<void()>& callback) = 0;
+};
+}
+#endif // MU_UICOMPONENTS_IPOPUPWINDOW_H

--- a/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
+++ b/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
@@ -41,13 +41,10 @@ void PopupWindow_QQuickView::init(QQmlEngine* engine, std::shared_ptr<ui::IUiCon
 {
     //! NOTE Without a parent on MacOS with FullScreen, the popup is shown on another virtual Desktop.
     //! With parent on WinOS not work transparent background.
-#ifdef Q_OS_MAC
-    m_view = new QQuickView(engine, mainWindow()->qWindow());
-#else
-    m_view = new QQuickView(engine, nullptr);
-#endif
 
-    m_view->setObjectName("PopupQQuickViewWindow");
+    m_view = new QQuickView(engine, nullptr);
+    m_view->setObjectName("PopupWindow_QQuickView");
+
     m_view->setResizeMode(QQuickView::SizeRootObjectToView);
 
     // dialog
@@ -103,6 +100,7 @@ void PopupWindow_QQuickView::forceActiveFocus()
 void PopupWindow_QQuickView::show(QPoint p)
 {
     m_view->setPosition(p);
+    m_view->setTransientParent(mainWindow()->qWindow());
     m_view->show();
 
     m_view->requestActivate();

--- a/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
+++ b/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
@@ -1,0 +1,182 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "popupwindow_qquickview.h"
+
+#include <QTimer>
+#include "log.h"
+
+using namespace mu::uicomponents;
+
+PopupWindow_QQuickView::PopupWindow_QQuickView(QObject* parent)
+    : QObject(parent)
+{
+    setObjectName("PopupWindow");
+}
+
+PopupWindow_QQuickView::~PopupWindow_QQuickView()
+{
+    delete m_view;
+}
+
+void PopupWindow_QQuickView::init(QQmlEngine* engine, std::shared_ptr<ui::IUiConfiguration> uiConfiguration, bool isDialogMode)
+{
+    //! NOTE Without a parent on MacOS with FullScreen, the popup is shown on another virtual Desktop.
+    //! With parent on WinOS not work transparent background.
+#ifdef Q_OS_MAC
+    m_view = new QQuickView(engine, mainWindow()->qWindow());
+#else
+    m_view = new QQuickView(engine, nullptr);
+#endif
+
+    m_view->setObjectName("PopupQQuickViewWindow");
+    m_view->setResizeMode(QQuickView::SizeRootObjectToView);
+
+    // dialog
+    if (isDialogMode) {
+        m_view->setFlags(Qt::Dialog);
+        QString bgColorStr = uiConfiguration->currentTheme().values.value(ui::BACKGROUND_PRIMARY_COLOR).toString();
+        m_view->setColor(QColor(bgColorStr));
+    }
+    // popup
+    else {
+        m_view->setFlags(Qt::Dialog                             // The most appropriate behavior for us on all platforms
+                         | Qt::FramelessWindowHint              // Without border
+                         | Qt::NoDropShadowWindowHint           // Without system shadow
+                         | Qt::BypassWindowManagerHint          // Otherwise, it does not work correctly on Gnome (Linux) when resizing)
+                         );
+
+        m_view->setColor(QColor(Qt::transparent));
+    }
+
+    m_view->installEventFilter(this);
+}
+
+void PopupWindow_QQuickView::setContent(QQuickItem* item)
+{
+    m_view->setContent(QUrl(), nullptr, item);
+
+    connect(item, &QQuickItem::implicitWidthChanged, [this, item]() {
+        if (!m_view->isVisible()) {
+            return;
+        }
+        if (item->implicitWidth() != m_view->width()) {
+            m_view->resize(item->implicitWidth(), item->implicitHeight());
+        }
+    });
+
+    connect(item, &QQuickItem::implicitHeightChanged, [this, item]() {
+        if (!m_view->isVisible()) {
+            return;
+        }
+        if (item->implicitHeight() != m_view->height()) {
+            m_view->resize(item->implicitWidth(), item->implicitHeight());
+        }
+    });
+}
+
+void PopupWindow_QQuickView::forceActiveFocus()
+{
+    if (!m_view->rootObject()->hasActiveFocus()) {
+        m_view->rootObject()->forceActiveFocus();
+    }
+}
+
+void PopupWindow_QQuickView::show(QPoint p)
+{
+    m_view->setPosition(p);
+    m_view->show();
+
+    m_view->requestActivate();
+
+    QQuickItem* item = m_view->rootObject();
+    m_view->resize(item->implicitWidth(), item->implicitHeight());
+
+    QTimer::singleShot(0, [this]() {
+        forceActiveFocus();
+    });
+}
+
+void PopupWindow_QQuickView::hide()
+{
+    m_view->hide();
+}
+
+QWindow* PopupWindow_QQuickView::qWindow() const
+{
+    return m_view;
+}
+
+bool PopupWindow_QQuickView::isVisible() const
+{
+    return m_view->isVisible();
+}
+
+QRect PopupWindow_QQuickView::geometry() const
+{
+    return m_view->geometry();
+}
+
+void PopupWindow_QQuickView::setOnHidden(const std::function<void()>& callback)
+{
+    m_onHidden = callback;
+}
+
+bool PopupWindow_QQuickView::eventFilter(QObject* watched, QEvent* event)
+{
+// Please, don't remove
+//#define POPUPWINDOW_DEBUG_EVENTS_ENABLED
+#ifdef POPUPWINDOW_DEBUG_EVENTS_ENABLED
+    static QMetaEnum typeEnum = QMetaEnum::fromType<QEvent::Type>();
+    static QList<QEvent::Type> excludeLoggingTypes = { QEvent::MouseMove };
+    const char* typeStr = typeEnum.key(event->type());
+    if (!excludeLoggingTypes.contains(event->type())) {
+        LOGI() << (watched ? watched->objectName() : "null") << " event: " << (typeStr ? typeStr : "unknown");
+    }
+
+    static QList<QEvent::Type> trackEvents = { QEvent::Hide, QEvent::Show };
+    if (trackEvents.contains(event->type())) {
+        int k = 1;
+    }
+
+    if (QString(typeStr) == "WindowDeactivate") {
+        int k = 1;
+    }
+#endif
+
+    if (watched == m_view) {
+        if (event->type() == QEvent::Hide) {
+            if (m_onHidden) {
+                m_onHidden();
+            }
+        }
+
+        if (event->type() == QEvent::FocusIn) {
+            m_view->rootObject()->forceActiveFocus();
+        }
+
+        if (event->type() == QEvent::MouseButtonPress) {
+            forceActiveFocus();
+        }
+    }
+
+    return QObject::eventFilter(watched, event);
+}

--- a/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.h
+++ b/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.h
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_UICOMPONENTS_POPUPWINDOW_QQUICKVIEW_H
+#define MU_UICOMPONENTS_POPUPWINDOW_QQUICKVIEW_H
+
+#include <QObject>
+#include <QQuickView>
+#include "ipopupwindow.h"
+
+#include "modularity/ioc.h"
+#include "ui/imainwindow.h"
+
+namespace mu::uicomponents {
+class PopupWindow_QQuickView : public QObject, public IPopupWindow
+{
+    Q_OBJECT
+
+    INJECT(uicomponents, ui::IMainWindow, mainWindow)
+
+public:
+    explicit PopupWindow_QQuickView(QObject* parent = nullptr);
+    ~PopupWindow_QQuickView();
+
+    void init(QQmlEngine* engine, std::shared_ptr<ui::IUiConfiguration> uiConfiguration, bool isDialogMode) override;
+
+    void setContent(QQuickItem* item) override;
+
+    void show(QPoint p) override;
+    void hide() override;
+
+    QWindow* qWindow() const override;
+    bool isVisible() const override;
+    QRect geometry() const override;
+
+    void forceActiveFocus() override;
+
+    void setOnHidden(const std::function<void()>& callback) override;
+
+private:
+
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
+    QQuickView* m_view = nullptr;
+    std::function<void()> m_onHidden;
+};
+}
+#endif // POPUPWINDOW_QQUICKVIEW_H


### PR DESCRIPTION
I reimplemented PopupView again.. 
On Windows not shown popups 
I can fix it with the old implementation, but! 
I found, what on Windows impossible do transparent background for QQuickView (not top-level), so our popup with the arrow shown with black frame. 
Now used another implementation work with Qml View

I tested on Windows and Linux, I can't test on MacOS at the momemt. 

I believe that we must re-implement PopupMenu, which needs to make that the submenus do not create new windows, but everything is in one window.
