### PR TITLE
[MU4] Fix #270988: [MusicXML] first-fret tag not supported for fretboard diagrams

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -5073,6 +5073,11 @@ FiguredBass* MusicXMLParserPass2::figuredBass()
 /**
  Parse the /score-partwise/part/measure/harmony/frame node.
  Return the result as a FretDiagram.
+  Notes:
+ - MusicXML's first-fret is a positive integer equivalent to MuseScore's FretDiagram::_fretOffset
+ - it is one-based in MusicXML and zero-based in MuseScore
+ - in MusicXML fret numbers are absolute, in MuseScore they are relative to the fretOffset,
+   which affects both single strings and barres
  */
 
 FretDiagram* MusicXMLParserPass2::frame()
@@ -5086,7 +5091,15 @@ FretDiagram* MusicXMLParserPass2::frame()
     std::map<int, int> bEnds;
 
     while (_e.readNextStartElement()) {
-        if (_e.name() == "frame-frets") {
+        if (_e.name() == "first-fret") {
+            bool ok{};
+            int val = _e.readElementText().toInt(&ok);
+            if (ok && val > 0) {
+                fd->setFretOffset(val - 1);
+            } else {
+                _logger->logError(QString("FretDiagram::readMusicXML: illegal first-fret %1").arg(val), &_e);
+            }
+        } else if (_e.name() == "frame-frets") {
             int val = _e.readElementText().toInt();
             if (val > 0) {
                 fd->setProperty(Pid::FRET_FRETS, val);
@@ -5128,7 +5141,7 @@ FretDiagram* MusicXMLParserPass2::frame()
                     if (fd->marker(actualString).mtype == FretMarkerType::CROSS) {
                         fd->setMarker(actualString, FretMarkerType::NONE);
                     }
-                    fd->setDot(actualString, fret, true);
+                    fd->setDot(actualString, fret - fd->fretOffset(), true);
                 }
             } else {
                 _logger->logError(QString("FretDiagram::readMusicXML: illegal frame-note string %1").arg(string), &_e);
@@ -5160,7 +5173,7 @@ FretDiagram* MusicXMLParserPass2::frame()
         }
 
         int endString = bEnds[fret];
-        fd->setBarre(startString, endString, fret);
+        fd->setBarre(startString, endString, fret - fd->fretOffset());
     }
 
     return fd;

--- a/src/importexport/musicxml/tests/data/testChordDiagrams1.xml
+++ b/src/importexport/musicxml/tests/data/testChordDiagrams1.xml
@@ -157,6 +157,201 @@
           <text>Chord plus frame</text>
           </lyric>
         </note>
+      </measure>
+    <measure number="4">
+      <print new-system="yes"/>
+      <harmony print-frame="no">
+        <root>
+          <root-step>G</root-step>
+          </root>
+        <kind>major</kind>
+        <frame>
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+          <frame-note>
+            <string>6</string>
+            <fret>3</fret>
+            </frame-note>
+          <frame-note>
+            <string>5</string>
+            <fret>2</fret>
+            </frame-note>
+          <frame-note>
+            <string>4</string>
+            <fret>0</fret>
+            </frame-note>
+          <frame-note>
+            <string>3</string>
+            <fret>0</fret>
+            </frame-note>
+          <frame-note>
+            <string>2</string>
+            <fret>0</fret>
+            </frame-note>
+          <frame-note>
+            <string>1</string>
+            <fret>3</fret>
+            </frame-note>
+          </frame>
+        </harmony>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <lyric number="1">
+          <syllabic>single</syllabic>
+          <text>Frame</text>
+          </lyric>
+        </note>
+      </measure>
+    <measure number="5">
+      <harmony print-frame="no">
+        <root>
+          <root-step>G</root-step>
+          </root>
+        <kind>major</kind>
+        <frame>
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+          <first-fret>2</first-fret>
+          <frame-note>
+            <string>6</string>
+            <fret>3</fret>
+            </frame-note>
+          <frame-note>
+            <string>5</string>
+            <fret>2</fret>
+            </frame-note>
+          <frame-note>
+            <string>4</string>
+            <fret>0</fret>
+            </frame-note>
+          <frame-note>
+            <string>3</string>
+            <fret>0</fret>
+            </frame-note>
+          <frame-note>
+            <string>2</string>
+            <fret>0</fret>
+            </frame-note>
+          <frame-note>
+            <string>1</string>
+            <fret>3</fret>
+            </frame-note>
+          </frame>
+        </harmony>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <lyric number="1">
+          <syllabic>single</syllabic>
+          <text>Frame with first-fret 2</text>
+          </lyric>
+        </note>
+      </measure>
+    <measure number="6">
+      <harmony print-frame="no">
+        <root>
+          <root-step>A</root-step>
+          </root>
+        <kind>major</kind>
+        <frame>
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+          <frame-note>
+            <string>5</string>
+            <fret>0</fret>
+            </frame-note>
+          <frame-note>
+            <string>4</string>
+            <fret>2</fret>
+            </frame-note>
+          <frame-note>
+            <string>3</string>
+            <fret>2</fret>
+            </frame-note>
+          <frame-note>
+            <string>2</string>
+            <fret>2</fret>
+            </frame-note>
+          <frame-note>
+            <string>1</string>
+            <fret>0</fret>
+            </frame-note>
+          </frame>
+        </harmony>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <lyric number="1">
+          <syllabic>single</syllabic>
+          <text>Frame</text>
+          </lyric>
+        </note>
+      </measure>
+    <measure number="7">
+      <harmony print-frame="no">
+        <root>
+          <root-step>A</root-step>
+          </root>
+        <kind>major</kind>
+        <frame>
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+          <first-fret>12</first-fret>
+          <frame-note>
+            <string>5</string>
+            <fret>12</fret>
+            <barre type="start"/>
+            </frame-note>
+          <frame-note>
+            <string>4</string>
+            <fret>14</fret>
+            <barre type="start"/>
+            </frame-note>
+          <frame-note>
+            <string>3</string>
+            <fret>14</fret>
+            </frame-note>
+          <frame-note>
+            <string>2</string>
+            <fret>14</fret>
+            <barre type="stop"/>
+            </frame-note>
+          <frame-note>
+            <string>1</string>
+            <fret>12</fret>
+            <barre type="stop"/>
+            </frame-note>
+          </frame>
+        </harmony>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <lyric number="1">
+          <syllabic>single</syllabic>
+          <text>Frame with first-fret 12 and barres</text>
+          </lyric>
+        </note>
       <barline location="right">
         <bar-style>light-heavy</bar-style>
         </barline>

--- a/src/libmscore/fret.cpp
+++ b/src/libmscore/fret.cpp
@@ -1307,6 +1307,9 @@ void FretDiagram::writeMusicXML(XmlWriter& xml) const
     xml.stag("frame");
     xml.tag("frame-strings", _strings);
     xml.tag("frame-frets", frets());
+    if (fretOffset() > 0) {
+        xml.tag("first-fret", fretOffset() + 1);
+    }
 
     for (int i = 0; i < _strings; ++i) {
         int mxmlString = _strings - i;
@@ -1341,7 +1344,7 @@ void FretDiagram::writeMusicXML(XmlWriter& xml) const
             }
             xml.stag("frame-note");
             xml.tag("string", mxmlString);
-            xml.tag("fret", d.fret);
+            xml.tag("fret", d.fret + fretOffset());
             // TODO: write fingerings
 
             // Also write barre if it starts at this dot


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/270988

Support first-fret tag on both import and export.

This is for master what #8059 is for 3.x