### PR TITLE
Unify window title bar on macOS with rest of window when using KDAB Docking system

### DIFF
--- a/src/appshell/qml/kdab/MainMacOS.qml
+++ b/src/appshell/qml/kdab/MainMacOS.qml
@@ -23,9 +23,15 @@ import QtQuick 2.15
 import Qt.labs.platform 1.1 as PLATFORM
 
 import MuseScore.AppShell 1.0
+import MuseScore.Dock 1.0
 
 AppWindow {
     id: root
+
+    AppWindowStyler {
+        id: appWindowStyler
+        targetWindow: root
+    }
 
     PLATFORM.MenuBar {
         id: menuBar
@@ -36,6 +42,7 @@ AppWindow {
     }
 
     Component.onCompleted: {
+        appWindowStyler.init()
         menuModel.load()
 
         for (var i in menuModel.items) {

--- a/src/appshell/view/dockwindow/dockwindow.cpp
+++ b/src/appshell/view/dockwindow/dockwindow.cpp
@@ -114,7 +114,7 @@ void DockWindow::onMainWindowEvent(QEvent* event)
 {
     switch (event->type()) {
     case QEvent::Paint: {
-        configuration()->applyPlatformStyle(m_window);
+        configuration()->applyPlatformStyle(qWindow());
     } break;
     case QEvent::Resize: {
         QResizeEvent* resizeEvent = static_cast<QResizeEvent*>(event);
@@ -302,7 +302,6 @@ void DockWindow::updateStyle()
 {
     m_window->setStyleSheet(WINDOW_QSS.arg(m_color.name()).arg(m_borderColor.name()));
     m_statusbar->setStyleSheet(STATUS_QSS.arg(m_color.name()).arg(m_borderColor.name()));
-    configuration()->applyPlatformStyle(m_window);
 }
 
 void DockWindow::onMenusChanged(const QList<QMenu*>& menus)

--- a/src/appshell/view/dockwindow_kdab/docksetup.cpp
+++ b/src/appshell/view/dockwindow_kdab/docksetup.cpp
@@ -35,6 +35,10 @@
 
 #include "mainwindowprovider.h"
 
+#ifdef Q_OS_MAC
+#include "view/dockwindow_kdab/internal/platform/macos/appwindowstyler.h"
+#endif
+
 #include "modularity/ioc.h"
 
 #include "thirdparty/KDDockWidgets/src/Config.h"
@@ -86,6 +90,10 @@ void DockSetup::registerQmlTypes()
     qmlRegisterType<DockCentral>("MuseScore.Dock", 1, 0, "DockCentral");
     qmlRegisterType<DockPage>("MuseScore.Dock", 1, 0, "DockPage");
     qmlRegisterType<DockFrameModel>("MuseScore.Dock", 1, 0, "DockFrameModel");
+
+#ifdef Q_OS_MAC
+    qmlRegisterType<AppWindowStyler>("MuseScore.Dock", 1, 0, "AppWindowStyler");
+#endif
 
     qRegisterMetaType<DropIndicators*>();
 }

--- a/src/appshell/view/dockwindow_kdab/dockwindow.cmake
+++ b/src/appshell/view/dockwindow_kdab/dockwindow.cmake
@@ -22,6 +22,15 @@ set (DOCK_LIBS
     kddockwidgets
 )
 
+if (OS_IS_MAC)
+    set (DOCKWINDOW_PLATFORM_SRC
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/appwindowstyler.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/appwindowstyler.h
+        )
+else()
+    set (DOCKWINDOW_PLATFORM_SRC )
+endif()
+
 set (DOCKWINDOW_SRC
     ${CMAKE_CURRENT_LIST_DIR}/docksetup.cpp
     ${CMAKE_CURRENT_LIST_DIR}/docksetup.h
@@ -50,5 +59,6 @@ set (DOCKWINDOW_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/dockseparator.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/dockframemodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/dockframemodel.h
+    ${DOCKWINDOW_PLATFORM_SRC}
 )
 

--- a/src/appshell/view/dockwindow_kdab/internal/platform/macos/appwindowstyler.cpp
+++ b/src/appshell/view/dockwindow_kdab/internal/platform/macos/appwindowstyler.cpp
@@ -19,33 +19,38 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+#include "appwindowstyler.h"
 
-#ifndef MU_UI_MACOSPLATFORMTHEME_H
-#define MU_UI_MACOSPLATFORMTHEME_H
+#include <QObject>
+#include <QWindow>
 
-#include "internal/iplatformtheme.h"
+using namespace mu::appshell;
 
-namespace mu::ui {
-class MacOSPlatformTheme : public IPlatformTheme
+AppWindowStyler::AppWindowStyler(QObject* parent)
+    : QObject(parent), m_targetWindow(nullptr)
 {
-public:
-    void startListening() override;
-    void stopListening() override;
-
-    bool isFollowSystemThemeAvailable() const override;
-
-    ThemeCode themeCode() const override;
-    async::Channel<ThemeCode> themeCodeChanged() const override;
-
-    void applyPlatformStyleOnAppForTheme(ThemeCode themeCode) override;
-    void applyPlatformStyleOnWindowForTheme(QWindow* window, ThemeCode themeCode) override;
-
-private:
-    bool isSystemDarkMode() const;
-    bool isSystemHighContrast() const;
-
-    async::Channel<ThemeCode> m_channel;
-};
 }
 
-#endif // MU_UI_MACOSPLATFORMTHEME_H
+void AppWindowStyler::init()
+{
+    uiConfiguration()->currentThemeChanged().onNotify(this, [this]() {
+        uiConfiguration()->applyPlatformStyle(m_targetWindow);
+    });
+}
+
+QWindow* AppWindowStyler::targetWindow() const
+{
+    return m_targetWindow;
+}
+
+void AppWindowStyler::setTargetWindow(QWindow* window)
+{
+    if (m_targetWindow == window) {
+        return;
+    }
+
+    m_targetWindow = window;
+    emit targetWindowChanged();
+
+    uiConfiguration()->applyPlatformStyle(m_targetWindow);
+}

--- a/src/appshell/view/dockwindow_kdab/internal/platform/macos/appwindowstyler.h
+++ b/src/appshell/view/dockwindow_kdab/internal/platform/macos/appwindowstyler.h
@@ -19,33 +19,40 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+#ifndef MU_APPSHELL_APPWINDOWSTYLER_H
+#define MU_APPSHELL_APPWINDOWSTYLER_H
 
-#ifndef MU_UI_MACOSPLATFORMTHEME_H
-#define MU_UI_MACOSPLATFORMTHEME_H
+#include "async/asyncable.h"
+#include "modularity/ioc.h"
+#include "ui/iuiconfiguration.h"
 
-#include "internal/iplatformtheme.h"
+#include <QObject>
 
-namespace mu::ui {
-class MacOSPlatformTheme : public IPlatformTheme
+class QWindow;
+
+namespace mu::appshell {
+class AppWindowStyler : public QObject, public async::Asyncable
 {
+    Q_OBJECT
+
+    INJECT(appshell, ui::IUiConfiguration, uiConfiguration)
+
+    Q_PROPERTY(QWindow * targetWindow READ targetWindow WRITE setTargetWindow NOTIFY targetWindowChanged)
+
 public:
-    void startListening() override;
-    void stopListening() override;
+    explicit AppWindowStyler(QObject* parent = nullptr);
 
-    bool isFollowSystemThemeAvailable() const override;
+    Q_INVOKABLE void init();
 
-    ThemeCode themeCode() const override;
-    async::Channel<ThemeCode> themeCodeChanged() const override;
+    QWindow* targetWindow() const;
+    void setTargetWindow(QWindow* window);
 
-    void applyPlatformStyleOnAppForTheme(ThemeCode themeCode) override;
-    void applyPlatformStyleOnWindowForTheme(QWindow* window, ThemeCode themeCode) override;
+signals:
+    void targetWindowChanged();
 
 private:
-    bool isSystemDarkMode() const;
-    bool isSystemHighContrast() const;
-
-    async::Channel<ThemeCode> m_channel;
+    QWindow* m_targetWindow;
 };
 }
 
-#endif // MU_UI_MACOSPLATFORMTHEME_H
+#endif // MU_APPSHELL_APPWINDOWSTYLER_H

--- a/src/framework/ui/internal/iplatformtheme.h
+++ b/src/framework/ui/internal/iplatformtheme.h
@@ -27,7 +27,7 @@
 #include "async/channel.h"
 #include "uitypes.h"
 
-class QWidget;
+class QWindow;
 
 namespace mu::ui {
 class IPlatformTheme : MODULE_EXPORT_INTERFACE
@@ -46,7 +46,7 @@ public:
     virtual async::Channel<ThemeCode> themeCodeChanged() const = 0;
 
     virtual void applyPlatformStyleOnAppForTheme(ThemeCode themeCode) = 0;
-    virtual void applyPlatformStyleOnWindowForTheme(QWidget* window, ThemeCode themeCode) = 0;
+    virtual void applyPlatformStyleOnWindowForTheme(QWindow* window, ThemeCode themeCode) = 0;
 };
 }
 

--- a/src/framework/ui/internal/platform/macos/macosplatformtheme.mm
+++ b/src/framework/ui/internal/platform/macos/macosplatformtheme.mm
@@ -21,7 +21,9 @@
 #include "log.h"
 
 #include <Cocoa/Cocoa.h>
-#include <QWidget>
+#include <QApplication>
+#include <QPalette>
+#include <QWindow>
 
 using namespace mu::ui;
 using namespace mu::async;
@@ -112,10 +114,14 @@ void MacOSPlatformTheme::applyPlatformStyleOnAppForTheme(ThemeCode themeCode)
     }
 }
 
-void MacOSPlatformTheme::applyPlatformStyleOnWindowForTheme(QWidget* widget, ThemeCode)
+void MacOSPlatformTheme::applyPlatformStyleOnWindowForTheme(QWindow* window, ThemeCode)
 {
-    QColor backgroundColor = widget->palette().window().color();
-    NSView* nsView = (__bridge NSView*)reinterpret_cast<void*>(widget->winId());
+    if (!window) {
+        return;
+    }
+
+    QColor backgroundColor = QApplication::palette().window().color();
+    NSView* nsView = (__bridge NSView*)reinterpret_cast<void*>(window->winId());
     NSWindow* nsWindow = [nsView window];
     if (nsWindow) {
         [nsWindow setTitlebarAppearsTransparent:YES];

--- a/src/framework/ui/internal/platform/stub/stubplatformtheme.cpp
+++ b/src/framework/ui/internal/platform/stub/stubplatformtheme.cpp
@@ -52,6 +52,6 @@ void StubPlatformTheme::applyPlatformStyleOnAppForTheme(ThemeCode)
 {
 }
 
-void StubPlatformTheme::applyPlatformStyleOnWindowForTheme(QWidget*, ThemeCode)
+void StubPlatformTheme::applyPlatformStyleOnWindowForTheme(QWindow*, ThemeCode)
 {
 }

--- a/src/framework/ui/internal/platform/stub/stubplatformtheme.h
+++ b/src/framework/ui/internal/platform/stub/stubplatformtheme.h
@@ -38,7 +38,7 @@ public:
     async::Channel<ThemeCode> themeCodeChanged() const override;
 
     void applyPlatformStyleOnAppForTheme(ThemeCode themeCode) override;
-    void applyPlatformStyleOnWindowForTheme(QWidget* window, ThemeCode themeCode) override;
+    void applyPlatformStyleOnWindowForTheme(QWindow* window, ThemeCode themeCode) override;
 
 private:
     async::Channel<ThemeCode> m_channel;

--- a/src/framework/ui/internal/platform/windows/windowsplatformtheme.cpp
+++ b/src/framework/ui/internal/platform/windows/windowsplatformtheme.cpp
@@ -159,6 +159,6 @@ void WindowsPlatformTheme::applyPlatformStyleOnAppForTheme(ThemeCode)
 {
 }
 
-void WindowsPlatformTheme::applyPlatformStyleOnWindowForTheme(QWidget*, ThemeCode)
+void WindowsPlatformTheme::applyPlatformStyleOnWindowForTheme(QWindow*, ThemeCode)
 {
 }

--- a/src/framework/ui/internal/platform/windows/windowsplatformtheme.h
+++ b/src/framework/ui/internal/platform/windows/windowsplatformtheme.h
@@ -40,7 +40,7 @@ public:
     async::Channel<ThemeCode> themeCodeChanged() const override;
 
     void applyPlatformStyleOnAppForTheme(ThemeCode themeCode) override;
-    void applyPlatformStyleOnWindowForTheme(QWidget* window, ThemeCode themeCode) override;
+    void applyPlatformStyleOnWindowForTheme(QWindow* window, ThemeCode themeCode) override;
 
 private:
     int m_buildNumber = 0;

--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -518,7 +518,7 @@ Notification UiConfiguration::pageStateChanged() const
     return m_pageStateChanged;
 }
 
-void UiConfiguration::applyPlatformStyle(QWidget* window)
+void UiConfiguration::applyPlatformStyle(QWindow* window)
 {
     platformTheme()->applyPlatformStyleOnWindowForTheme(window, currentThemeCodeKey());
 }

--- a/src/framework/ui/internal/uiconfiguration.h
+++ b/src/framework/ui/internal/uiconfiguration.h
@@ -74,7 +74,7 @@ public:
     void setPageState(const std::string& pageName, const QByteArray& state) override;
     async::Notification pageStateChanged() const override;
 
-    void applyPlatformStyle(QWidget* window) override;
+    void applyPlatformStyle(QWindow* window) override;
 
 private:
     bool needFollowSystemTheme() const;

--- a/src/framework/ui/iuiconfiguration.h
+++ b/src/framework/ui/iuiconfiguration.h
@@ -31,6 +31,7 @@
 #include "uitypes.h"
 
 class QByteArray;
+class QWindow;
 
 namespace mu::ui {
 class IUiConfiguration : MODULE_EXPORT_INTERFACE
@@ -73,7 +74,7 @@ public:
     virtual void setPageState(const std::string& pageName, const QByteArray& state) = 0;
     virtual async::Notification pageStateChanged() const = 0;
 
-    virtual void applyPlatformStyle(QWidget* window) = 0;
+    virtual void applyPlatformStyle(QWindow* window) = 0;
 };
 }
 


### PR DESCRIPTION
<img width="1195" alt="Schermafbeelding 2021-05-08 om 00 00 21" src="https://user-images.githubusercontent.com/48658420/117512683-62a40580-af90-11eb-8844-2508807472e6.png">
Makes the title bar of the main window use the color from our theme, and removes the border between the title bar and the rest. 