### PR TITLE
[MU4] Fix #320973: Support .cap and .capx import of (Griffschrift's) X-noteheads

### DIFF
--- a/src/importexport/capella/internal/capella.cpp
+++ b/src/importexport/capella/internal/capella.cpp
@@ -828,6 +828,7 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
 
                 chord->add(note);
                 note->setPitch(pitch);
+                note->setHeadGroup(NoteHead::Group(n.headGroup));
                 // TODO: compute tpc from pitch & line
                 note->setTpcFromPitch();
                 if (o->rightTie) {
@@ -2053,13 +2054,19 @@ void ChordObj::read()
         }
         unsigned char b = cap->readByte();
         n.headType      = b & 7;
+        if (n.headType == 6) {
+            n.headType = 0;
+            n.headGroup = int(NoteHead::Group::HEAD_CROSS);
+        } else {
+            n.headGroup = int(NoteHead::Group::HEAD_NORMAL);
+        }
         n.alteration    = ((b >> 3) & 7) - 2;      // -2 -- +2
         if (b & 0x40) {
             n.explAlteration = 1;
         }
         n.silent = b & 0x80;
-        qDebug("ChordObj::read() note pitch %d explAlt %d head %d alt %d silent %d",
-               n.pitch, n.explAlteration, n.headType, n.alteration, n.silent);
+        qDebug("ChordObj::read() note pitch %d explAlt %d head group %d %d alt %d silent %d",
+               n.pitch, n.explAlteration, n.headType, n.headGroup, n.alteration, n.silent);
         notes.append(n);
     }
 }

--- a/src/importexport/capella/internal/capella.h
+++ b/src/importexport/capella/internal/capella.h
@@ -605,6 +605,7 @@ struct CNote {
     signed char pitch;
     int explAlteration;       // 1 force, 2 suppress
     int headType;
+    int headGroup;
     int alteration;
     int silent;
 };

--- a/src/importexport/capella/internal/capxml.cpp
+++ b/src/importexport/capella/internal/capxml.cpp
@@ -482,6 +482,7 @@ void ChordObj::readCapxNotes(XmlReader& e)
         if (e.name() == "head") {
             QString pitch = e.attribute("pitch");
             QString sstep;
+            QString shape = e.attribute("shape");
             while (e.readNextStartElement()) {
                 const QStringRef& tag(e.name());
                 if (tag == "alter") {
@@ -494,13 +495,18 @@ void ChordObj::readCapxNotes(XmlReader& e)
                     e.unknown();
                 }
             }
-            qDebug("ChordObj::readCapxNotes: pitch '%s' altstep '%s'",
-                   qPrintable(pitch), qPrintable(sstep));
+            qDebug("ChordObj::readCapxNotes: pitch '%s' altstep '%s' shape '%s'",
+                   qPrintable(pitch), qPrintable(sstep), qPrintable(shape));
             int istep = sstep.toInt();
             CNote n;
             n.pitch = pitchStr2Char(pitch);
             n.explAlteration = 0;
             n.headType = 0;
+            if (shape == "none") {
+                n.headGroup = int(NoteHead::Group::HEAD_CROSS);
+            } else {
+                n.headGroup = int(NoteHead::Group::HEAD_NORMAL);
+            }
             n.alteration = istep;
             n.silent = 0;
             notes.append(n);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/320973 and https://musescore.org/de/node/320934, the latter of which the proposed code change comes from.

This is for master what #8071 is for 3.x, as far as I can tell all the imports functionality here isn't working currently.