### PR TITLE
[MU4] Move focus to notation view on note input

### DIFF
--- a/src/framework/ui/inavigationcontroller.h
+++ b/src/framework/ui/inavigationcontroller.h
@@ -39,6 +39,8 @@ public:
 
     virtual const std::set<INavigationSection*>& sections() const = 0;
 
+    virtual bool activateByName(const std::string& section, const std::string& panel, const std::string& control) = 0;
+
     virtual INavigationSection* activeSection() const = 0;
     virtual INavigationPanel* activePanel() const = 0;
     virtual INavigationControl* activeControl() const = 0;

--- a/src/framework/ui/internal/navigationcontroller.cpp
+++ b/src/framework/ui/internal/navigationcontroller.cpp
@@ -1081,6 +1081,30 @@ void NavigationController::doTriggerControl()
     activeCtrl->trigger();
 }
 
+bool NavigationController::activateByName(const std::string& sectName, const std::string& panelName, const std::string& controlName)
+{
+    INavigationSection* section = findByName(m_sections, QString::fromStdString(sectName));
+    if (section) {
+        LOGE() << "not found section with name: " << sectName;
+        return false;
+    }
+
+    INavigationPanel* panel = findByName(section->panels(), QString::fromStdString(panelName));
+    if (!panel) {
+        LOGE() << "not found panel with name: " << panelName << ", section: " << sectName;
+        return false;
+    }
+
+    INavigationControl* control = findByName(panel->controls(), QString::fromStdString(controlName));
+    if (!panel) {
+        LOGE() << "not found control with name: " << controlName << ", panel: " << panelName << ", section: " << sectName;
+        return false;
+    }
+
+    onForceActiveRequested(section, panel, control);
+    return true;
+}
+
 void NavigationController::onForceActiveRequested(INavigationSection* sect, INavigationPanel* panel, INavigationControl* ctrl)
 {
     TRACEFUNC;

--- a/src/framework/ui/internal/navigationcontroller.h
+++ b/src/framework/ui/internal/navigationcontroller.h
@@ -55,6 +55,8 @@ public:
 
     const std::set<INavigationSection*>& sections() const override;
 
+    bool activateByName(const std::string& section, const std::string& panel, const std::string& control) override;
+
     INavigationSection* activeSection() const override;
     INavigationPanel* activePanel() const override;
     INavigationControl* activeControl() const override;

--- a/src/notation/qml/MuseScore/NotationScene/NotationView.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NotationView.qml
@@ -77,7 +77,7 @@ FocusScope {
                 SplitView.fillWidth: true
                 SplitView.fillHeight: true
 
-                onMousePressed: {
+                onActiveFocusRequested: {
                     tabPanel.ensureActive()
                 }
 

--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -297,6 +297,7 @@ void NotationPaintView::onNoteInputChanged()
         setAcceptHoverEvents(true);
         QRectF cursorRect = notationNoteInput()->cursorRect();
         adjustCanvasPosition(cursorRect);
+        emit activeFocusRequested();
     } else {
         setAcceptHoverEvents(false);
     }
@@ -647,9 +648,8 @@ void NotationPaintView::wheelEvent(QWheelEvent* event)
 
 void NotationPaintView::mousePressEvent(QMouseEvent* event)
 {
-    emit mousePressed();
-
     setFocus(true);
+    emit activeFocusRequested();
 
     if (isInited()) {
         m_inputController->mousePressEvent(event);

--- a/src/notation/view/notationpaintview.h
+++ b/src/notation/view/notationpaintview.h
@@ -109,7 +109,7 @@ signals:
     void backgroundColorChanged(QColor color);
     void viewportChanged(QRect viewport);
 
-    void mousePressed();
+    void activeFocusRequested();
 
 protected:
     void setNotation(INotationPtr notation);


### PR DESCRIPTION
At the moment, the method` UINavigationController::activateByName` not necessary, but I decided to keep it, I think it will help in the future. 