### PR TITLE
[MU4] Preparation ScoreOrdering: part names in instruments form

### DIFF
--- a/src/engraving/libmscore/instrument.h
+++ b/src/engraving/libmscore/instrument.h
@@ -324,6 +324,7 @@ public:
     bool isDifferentInstrument(const Instrument& i) const;
 
     QString getId() const { return _id; }
+    void setId(const QString& id) { _id = id; }
     void setMinPitchP(int v) { _minPitchP = v; }
     void setMaxPitchP(int v) { _maxPitchP = v; }
     void setMinPitchA(int v) { _minPitchA = v; }

--- a/src/engraving/libmscore/part.cpp
+++ b/src/engraving/libmscore/part.cpp
@@ -400,7 +400,7 @@ const InstrumentList* Part::instruments() const
 
 bool Part::isDoublingInstrument(const QString& instrumentId) const
 {
-    return instrument()->instrumentId() != instrumentId;
+    return instrument()->getId() != instrumentId;
 }
 
 //---------------------------------------------------------
@@ -409,7 +409,7 @@ bool Part::isDoublingInstrument(const QString& instrumentId) const
 
 QString Part::instrumentId(const Fraction& tick) const
 {
-    return instrument(tick)->instrumentId();
+    return instrument(tick)->getId();
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/undo.cpp
+++ b/src/engraving/libmscore/undo.cpp
@@ -1030,6 +1030,26 @@ void RemovePart::redo(EditData*)
 }
 
 //---------------------------------------------------------
+//   SetSoloist
+//---------------------------------------------------------
+
+SetSoloist::SetSoloist(Part* p, bool b)
+{
+    part = p;
+    soloist  = b;
+}
+
+void SetSoloist::undo(EditData*)
+{
+    part->setSoloist(!soloist);
+}
+
+void SetSoloist::redo(EditData*)
+{
+    part->setSoloist(soloist);
+}
+
+//---------------------------------------------------------
 //   InsertStaff
 //---------------------------------------------------------
 

--- a/src/engraving/libmscore/undo.h
+++ b/src/engraving/libmscore/undo.h
@@ -257,6 +257,22 @@ public:
 };
 
 //---------------------------------------------------------
+//   SetSoloist
+//---------------------------------------------------------
+
+class SetSoloist : public UndoCommand
+{
+    Part* part = nullptr;
+    bool soloist = false;
+
+public:
+    SetSoloist(Part* p, bool b);
+    void undo(EditData*) override;
+    void redo(EditData*) override;
+    UNDO_NAME("SetSoloist")
+};
+
+//---------------------------------------------------------
 //   InsertStaff
 //---------------------------------------------------------
 

--- a/src/instruments/instrumentstypes.h
+++ b/src/instruments/instrumentstypes.h
@@ -162,7 +162,14 @@ struct Instrument
     QString abbreviature() const { return !shortNames.isEmpty() ? shortNames.first().name() : QString(); }
 };
 
-using InstrumentList = QList<Instrument>;
+struct PartInstrument {
+    bool part;
+    bool soloist;
+    QString partId;
+    Instrument instrument;
+};
+
+using PartInstrumentList = QList<PartInstrument>;
 
 struct InstrumentTemplate
 {

--- a/src/instruments/instrumentstypes.h
+++ b/src/instruments/instrumentstypes.h
@@ -163,8 +163,8 @@ struct Instrument
 };
 
 struct PartInstrument {
-    bool part;
-    bool soloist;
+    bool isExistingPart;
+    bool isSoloist;
     QString partId;
     Instrument instrument;
 };

--- a/src/instruments/instrumentstypes.h
+++ b/src/instruments/instrumentstypes.h
@@ -122,6 +122,7 @@ struct Instrument
     StaffNameList longNames;
     StaffNameList shortNames;
     QString name;
+    QString musicXMLid;
     QString description;
 
     bool extended = false;

--- a/src/instruments/internal/instrumentsreader.cpp
+++ b/src/instruments/internal/instrumentsreader.cpp
@@ -155,7 +155,8 @@ InstrumentTemplate InstrumentsReader::readInstrumentTemplate(Ms::XmlReader& read
     InstrumentTemplate instrumentTemplate;
     Instrument& instrument = instrumentTemplate.instrument;
 
-    instrumentTemplate.id = reader.attributes().value("id").toString();
+    instrument.id = reader.attributes().value("id").toString();
+    instrumentTemplate.id = instrument.id;
 
     bool customDrumset = false;
 
@@ -242,7 +243,7 @@ InstrumentTemplate InstrumentsReader::readInstrumentTemplate(Ms::XmlReader& read
         } else if (reader.name() == "transposeDiatonic") {
             instrument.transpose.diatonic = reader.readElementText().toInt();
         } else if (reader.name() == "instrumentId") {
-            instrument.id = reader.readElementText();
+            instrument.musicXMLid = reader.readElementText();
         } else if (reader.name() == "StringData") {
             instrument.stringData = readStringData(reader);
         } else if (reader.name() == "useDrumset") {
@@ -296,7 +297,7 @@ InstrumentTemplate InstrumentsReader::readInstrumentTemplate(Ms::XmlReader& read
             QString templateId = reader.readElementText();
             initInstrument(instrument, generalMeta.instrumentTemplates[templateId].instrument);
         } else if (reader.name() == "musicXMLid") {
-            instrument.id = reader.readElementText();
+            instrument.musicXMLid = reader.readElementText();
         } else if (reader.name() == "genre") {
             instrument.genreIds << reader.readElementText();
         } else if (reader.name() == "singleNoteDynamics") {
@@ -417,6 +418,7 @@ void InstrumentsReader::fillByDefault(Instrument& instrument) const
 void InstrumentsReader::initInstrument(Instrument& sourceInstrument, const Instrument& destinationInstrument) const
 {
     sourceInstrument.id = destinationInstrument.id;
+    sourceInstrument.musicXMLid = destinationInstrument.musicXMLid;
     sourceInstrument.longNames = destinationInstrument.longNames;
     sourceInstrument.shortNames = destinationInstrument.shortNames;
     sourceInstrument.staves = destinationInstrument.staves;

--- a/src/instruments/internal/instrumentsreader.cpp
+++ b/src/instruments/internal/instrumentsreader.cpp
@@ -306,7 +306,7 @@ InstrumentTemplate InstrumentsReader::readInstrumentTemplate(Ms::XmlReader& read
         }
     }
 
-    fillByDeffault(instrument);
+    fillByDefault(instrument);
 
     return instrumentTemplate;
 }
@@ -385,7 +385,7 @@ StringData InstrumentsReader::readStringData(Ms::XmlReader& reader) const
     return StringData(frets, strings);
 }
 
-void InstrumentsReader::fillByDeffault(Instrument& instrument) const
+void InstrumentsReader::fillByDefault(Instrument& instrument) const
 {
     if (instrument.channels.empty()) {
         Channel a;

--- a/src/instruments/internal/instrumentsreader.h
+++ b/src/instruments/internal/instrumentsreader.h
@@ -58,7 +58,7 @@ private:
     MidiAction readMidiAction(Ms::XmlReader& reader) const;
     StringData readStringData(Ms::XmlReader& reader) const;
 
-    void fillByDeffault(Instrument& instrument) const;
+    void fillByDefault(Instrument& instrument) const;
     void initInstrument(Instrument& sourceInstrument, const Instrument& destinationInstrument) const;
 };
 }

--- a/src/instruments/internal/selectinstrumentscenario.cpp
+++ b/src/instruments/internal/selectinstrumentscenario.cpp
@@ -28,7 +28,7 @@ mu::RetVal<InstrumentList> SelectInstrumentsScenario::selectInstruments(SelectIn
 {
     QStringList params;
     if (mode == SelectInstrumentsMode::ShowCurrentInstruments) {
-        params << "initiallySelectedInstrumentIds=" + partsInstrumentIds().join(",");
+        params << "initiallySelectedPartIds=" + partsIds().join(",");
     }
 
     return selectInstruments(params);
@@ -90,7 +90,7 @@ INotationPartsPtr SelectInstrumentsScenario::notationParts() const
     return notation->parts();
 }
 
-IDList SelectInstrumentsScenario::partsInstrumentIds() const
+IDList SelectInstrumentsScenario::partsIds() const
 {
     auto _notationParts = notationParts();
     if (!_notationParts) {
@@ -101,15 +101,7 @@ IDList SelectInstrumentsScenario::partsInstrumentIds() const
 
     IDList result;
     for (const Part* part: parts) {
-        async::NotifyList<Instrument> selectedInstruments = _notationParts->instrumentList(part->id());
-
-        for (const Instrument& instrument: selectedInstruments) {
-            if (part->isDoublingInstrument(instrument.id)) {
-                continue;
-            }
-
-            result << instrument.id;
-        }
+        result << part->id();
     }
 
     return result;

--- a/src/instruments/internal/selectinstrumentscenario.cpp
+++ b/src/instruments/internal/selectinstrumentscenario.cpp
@@ -77,8 +77,8 @@ mu::RetVal<PartInstrumentList> SelectInstrumentsScenario::selectInstruments(cons
         QVariantMap map = obj.toMap();
         PartInstrument pi;
 
-        pi.part = map["part"].toBool();
-        pi.soloist = map["soloist"].toBool();
+        pi.isExistingPart = map["isExistingPart"].toBool();
+        pi.isSoloist = map["isSoloist"].toBool();
         pi.partId = map["id"].toString();
         pi.instrument = map["instrument"].value<Instrument>();
 

--- a/src/instruments/internal/selectinstrumentscenario.h
+++ b/src/instruments/internal/selectinstrumentscenario.h
@@ -41,7 +41,7 @@ private:
     RetVal<InstrumentList> selectInstruments(const QStringList& params) const;
 
     notation::INotationPartsPtr notationParts() const;
-    notation::IDList partsInstrumentIds() const;
+    notation::IDList partsIds() const;
 };
 }
 

--- a/src/instruments/internal/selectinstrumentscenario.h
+++ b/src/instruments/internal/selectinstrumentscenario.h
@@ -34,11 +34,11 @@ class SelectInstrumentsScenario : public ISelectInstrumentsScenario
     INJECT(instruments, framework::IInteractive, interactive)
 
 public:
-    RetVal<InstrumentList> selectInstruments(SelectInstrumentsMode mode = SelectInstrumentsMode::None) const override;
+    RetVal<PartInstrumentList> selectInstruments(SelectInstrumentsMode mode = SelectInstrumentsMode::None) const override;
     RetVal<Instrument> selectInstrument(const std::string& currentInstrumentId = "") const override;
 
 private:
-    RetVal<InstrumentList> selectInstruments(const QStringList& params) const;
+    RetVal<PartInstrumentList> selectInstruments(const QStringList& params) const;
 
     notation::INotationPartsPtr notationParts() const;
     notation::IDList partsIds() const;

--- a/src/instruments/iselectinstrumentscenario.h
+++ b/src/instruments/iselectinstrumentscenario.h
@@ -39,7 +39,7 @@ public:
         ShowCurrentInstruments
     };
 
-    virtual RetVal<InstrumentList> selectInstruments(SelectInstrumentsMode mode = SelectInstrumentsMode::None) const = 0;
+    virtual RetVal<PartInstrumentList> selectInstruments(SelectInstrumentsMode mode = SelectInstrumentsMode::None) const = 0;
     virtual RetVal<Instrument> selectInstrument(const std::string& currentInstrumentId = "") const = 0;
 };
 }

--- a/src/instruments/qml/MuseScore/Instruments/ChooseInstrumentsPage.qml
+++ b/src/instruments/qml/MuseScore/Instruments/ChooseInstrumentsPage.qml
@@ -31,7 +31,7 @@ import "internal"
 Rectangle {
     id: root
 
-    property string initiallySelectedInstrumentIds: ""
+    property string initiallySelectedPartIds: ""
     property bool hasSelectedInstruments: instrumentsModel.selectedInstruments.length > 0
     property bool canSelectMultipleInstruments: true
     property string currentInstrumentId: ""
@@ -56,7 +56,7 @@ Rectangle {
     }
 
     Component.onCompleted: {
-        instrumentsModel.load(canSelectMultipleInstruments, currentInstrumentId, initiallySelectedInstrumentIds)
+        instrumentsModel.load(canSelectMultipleInstruments, currentInstrumentId, initiallySelectedPartIds)
 
         var groupId = instrumentsModel.selectedGroupId()
         familyView.focusGroup(groupId)

--- a/src/instruments/qml/MuseScore/Instruments/ChooseInstrumentsPage.qml
+++ b/src/instruments/qml/MuseScore/Instruments/ChooseInstrumentsPage.qml
@@ -44,10 +44,10 @@ Rectangle {
 
         for (var i = 0; i < instruments.length; ++i) {
             var obj = {}
-            obj["part"] = instruments[i].part
+            obj["isExistingPart"] = instruments[i].isExistingPart
             obj["id"] = instruments[i].id
             obj["name"] = instruments[i].name
-            obj["soloist"] = instruments[i].soloist
+            obj["isSoloist"] = instruments[i].isSoloist
             obj["instrument"] = instruments[i].config
 
             result.push(obj)
@@ -219,6 +219,10 @@ Rectangle {
 
             onOrderChanged: {
                 instrumentsModel.selectOrderType(id)
+            }
+
+            onSoloistChanged: {
+                instrumentsModel.toggleSoloist(id)
             }
         }
 

--- a/src/instruments/qml/MuseScore/Instruments/ChooseInstrumentsPage.qml
+++ b/src/instruments/qml/MuseScore/Instruments/ChooseInstrumentsPage.qml
@@ -43,7 +43,14 @@ Rectangle {
         var result = []
 
         for (var i = 0; i < instruments.length; ++i) {
-            result.push(instruments[i].config)
+            var obj = {}
+            obj["part"] = instruments[i].part
+            obj["id"] = instruments[i].id
+            obj["name"] = instruments[i].name
+            obj["soloist"] = instruments[i].soloist
+            obj["instrument"] = instruments[i].config
+
+            result.push(obj)
         }
 
         return result

--- a/src/instruments/qml/MuseScore/Instruments/InstrumentsDialog.qml
+++ b/src/instruments/qml/MuseScore/Instruments/InstrumentsDialog.qml
@@ -31,7 +31,7 @@ StyledDialogView {
 
     property bool canSelectMultipleInstruments: true
     property string currentInstrumentId: ""
-    property string initiallySelectedInstrumentIds: ""
+    property string initiallySelectedPartIds: ""
 
     contentHeight: 500
     contentWidth: root.canSelectMultipleInstruments ? 900 : 600
@@ -48,7 +48,7 @@ StyledDialogView {
 
             Layout.fillWidth: true
             Layout.fillHeight: true
-            initiallySelectedInstrumentIds: root.initiallySelectedInstrumentIds
+            initiallySelectedPartIds: root.initiallySelectedPartIds
             canSelectMultipleInstruments: root.canSelectMultipleInstruments
             currentInstrumentId: root.currentInstrumentId
         }

--- a/src/instruments/qml/MuseScore/Instruments/internal/SelectedInstrumentsView.qml
+++ b/src/instruments/qml/MuseScore/Instruments/internal/SelectedInstrumentsView.qml
@@ -43,9 +43,22 @@ Item {
 
     signal unselectInstrumentRequested(string id)
     signal orderChanged(string id)
+    signal soloistChanged(string id)
 
     function scrollViewToEnd() {
         instrumentsView.positionViewAtEnd()
+    }
+
+    function soloistsButtonText(soloist) {
+        return soloist ? qsTrc("instruments", "Undo soloist") : qsTrc("instruments", "Make soloist")
+    }
+
+    function instrumentName(data) {
+        var name = data.name
+        if (data.isSoloist) {
+            name = qsTrc("instruments", "Soloist: ") + name
+        }
+        return name
     }
 
     NavigationPanel {
@@ -102,17 +115,6 @@ Item {
         FlatButton {
             Layout.preferredWidth: width
 
-            navigation.name: "Make soloist"
-            navigation.panel: navPanel
-            navigation.row: 2
-
-            enabled: root.isInstrumentSelected
-            text: qsTrc("instruments", "Make soloist")
-        }
-
-        FlatButton {
-            Layout.preferredWidth: width
-
             navigation.name: "Delete"
             navigation.panel: navPanel
             navigation.row: 3
@@ -163,8 +165,23 @@ Item {
                 anchors.verticalCenter: parent.verticalCenter
 
                 horizontalAlignment: Text.AlignLeft
-                text: modelData.name
+                text: instrumentName(modelData)
                 font: ui.theme.bodyBoldFont
+            }
+
+            FlatButton {
+                anchors.right: parent.right
+                anchors.leftMargin: 4
+                anchors.rightMargin: 4
+                anchors.verticalCenter: parent.verticalCenter
+
+                visible: root.currentInstrumentIndex === index
+
+                text: soloistsButtonText(modelData.isSoloist)
+
+                onClicked: {
+                    soloistChanged(modelData.id)
+                }
             }
 
             onClicked: {

--- a/src/instruments/view/instrumentlistmodel.cpp
+++ b/src/instruments/view/instrumentlistmodel.cpp
@@ -74,30 +74,27 @@ void InstrumentListModel::initSelectedInstruments(const IDList& selectedPartIds)
         return;
     }
 
-    QMap<QString, const Part*> partMap;
-    for (const Part* part: _notationParts->partList()) {
-        if (selectedPartIds.contains(part->id())) {
-            partMap.insert(part->id(), part);
-        }
-    }
 
+    auto parts = _notationParts->partList();
     for (const ID& partId: selectedPartIds) {
-        if (!partMap.contains(partId)) {
+        auto compareId = [partId](auto p) {
+            return p->id() == partId;
+        };
+        const Part* part = *find_if(begin(parts), end(parts), compareId);
+
+        if (!part) {
             continue;
         }
-        for (auto instrument: _notationParts->instrumentList(partId)) {
-            if (partMap[partId]->isDoublingInstrument(instrument.id)) {
-                continue;
-            }
-            InstrumentTemplate templ = instrumentTemplate(instrument.id);
 
-            SelectedInstrumentInfo info;
-            info.id = templ.id;
-            info.partId = partId;
-            info.partName = partMap[partId]->partName();
-            info.config = templ.instrument;
-            m_selectedInstruments << info;
-        }
+        SelectedInstrumentInfo info;
+
+        info.partId = partId;
+        info.partName = part->partName();
+
+        info.id = QString();
+        info.config = Instrument();
+
+        m_selectedInstruments << info;
     }
 
     emit selectedInstrumentsChanged();

--- a/src/instruments/view/instrumentlistmodel.cpp
+++ b/src/instruments/view/instrumentlistmodel.cpp
@@ -80,11 +80,13 @@ void InstrumentListModel::initSelectedInstruments(const IDList& selectedPartIds)
         auto compareId = [partId](auto p) {
             return p->id() == partId;
         };
-        const Part* part = *find_if(begin(parts), end(parts), compareId);
 
-        if (!part) {
+        auto pi = find_if(begin(parts), end(parts), compareId);
+        if ((pi == end(parts)) || !(*pi)) {
             continue;
         }
+
+        const Part* part = *pi;
 
         SelectedInstrumentInfo info;
 
@@ -272,6 +274,7 @@ void InstrumentListModel::selectInstrument(const QString& instrumentId, const QS
     }
 
     SelectedInstrumentInfo info;
+    info.part = false;
     info.id = codeKey;
     info.partId = QString();
     info.partName = QString();

--- a/src/instruments/view/instrumentlistmodel.h
+++ b/src/instruments/view/instrumentlistmodel.h
@@ -35,7 +35,7 @@ class InstrumentListModel : public QObject, public async::Asyncable
     Q_OBJECT
 
     INJECT(instruments, IInstrumentsRepository, repository)
-    INJECT(instruments, context::IGlobalContext, context)
+    INJECT(instruments, context::IGlobalContext, globalContext)
 
     Q_PROPERTY(QVariantList families READ families NOTIFY dataChanged)
     Q_PROPERTY(QVariantList groups READ groups NOTIFY dataChanged)
@@ -45,7 +45,7 @@ class InstrumentListModel : public QObject, public async::Asyncable
 public:
     InstrumentListModel(QObject* parent = nullptr);
 
-    Q_INVOKABLE void load(bool canSelectMultipleInstruments, const QString& currentInstrumentId, const QString& selectedInstrumentIds);
+    Q_INVOKABLE void load(bool canSelectMultipleInstruments, const QString& currentInstrumentId, const QString& selectedPartIds);
 
     QVariantList families() const;
     QVariantList groups() const;
@@ -79,7 +79,8 @@ signals:
     void selectedInstrumentsChanged();
 
 private:
-    void initSelectedInstruments(const notation::IDList& selectedInstrumentIds);
+    void initSelectedInstruments(const notation::IDList& selectedPartIds);
+    notation::INotationPartsPtr notationParts() const;
 
     void sortInstruments(QVariantList& instruments) const;
 
@@ -109,6 +110,8 @@ private:
     struct SelectedInstrumentInfo
     {
         QString id;
+        QString partId;
+        QString partName;
         Transposition transposition;
         Instrument config;
 

--- a/src/instruments/view/instrumentlistmodel.h
+++ b/src/instruments/view/instrumentlistmodel.h
@@ -60,7 +60,7 @@ public:
     Q_INVOKABLE void selectInstrument(const QString& instrumentId, const QString& transpositionId = QString());
     Q_INVOKABLE void unselectInstrument(const QString& instrumentId);
     Q_INVOKABLE void swapSelectedInstruments(int firstIndex, int secondIndex);
-    Q_INVOKABLE void makeSoloist(const QString& instrumentId);
+    Q_INVOKABLE void toggleSoloist(const QString& instrumentId);
 
     Q_INVOKABLE void setSearchText(const QString& text);
 
@@ -83,6 +83,8 @@ private:
     notation::INotationPartsPtr notationParts() const;
 
     void sortInstruments(QVariantList& instruments) const;
+
+    int findInstrumentIndex(const QString& instrumentId) const;
 
     bool isSearching() const;
 
@@ -110,8 +112,9 @@ private:
     struct SelectedInstrumentInfo
     {
         QString id;
-        QString partId;
-        QString partName;
+        QString name;
+        bool isSoloist;
+        bool isExistingPart;
         Transposition transposition;
         Instrument config;
 

--- a/src/instruments/view/instrumentspaneltreemodel.cpp
+++ b/src/instruments/view/instrumentspaneltreemodel.cpp
@@ -151,13 +151,13 @@ void InstrumentsPanelTreeModel::selectRow(const QModelIndex& rowIndex)
 void InstrumentsPanelTreeModel::addInstruments()
 {
     auto mode = ISelectInstrumentsScenario::SelectInstrumentsMode::ShowCurrentInstruments;
-    RetVal<InstrumentList> selectedInstruments = selectInstrumentsScenario()->selectInstruments(mode);
+    RetVal<PartInstrumentList> selectedInstruments = selectInstrumentsScenario()->selectInstruments(mode);
     if (!selectedInstruments.ret) {
         LOGE() << selectedInstruments.ret.toString();
         return;
     }
 
-    m_masterNotationParts->setInstruments(selectedInstruments.val);
+    m_masterNotationParts->setParts(selectedInstruments.val);
 
     emit isEmptyChanged();
 }

--- a/src/notation/inotationparts.h
+++ b/src/notation/inotationparts.h
@@ -45,7 +45,7 @@ public:
     virtual ValCh<bool> canChangeInstrumentVisibility(const ID& instrumentId, const ID& fromPartId) const = 0;
     virtual bool voiceVisible(int voiceIndex) const = 0;
 
-    virtual void setInstruments(const instruments::InstrumentList& instruments) = 0;
+    virtual void setParts(const instruments::PartInstrumentList& instruments) = 0;
     virtual void setPartVisible(const ID& partId, bool visible) = 0;
     virtual void setInstrumentVisible(const ID& instrumentId, const ID& fromPartId, bool visible) = 0;
     virtual void setStaffVisible(const ID& staffId, bool visible) = 0;

--- a/src/notation/internal/instrumentsconverter.cpp
+++ b/src/notation/internal/instrumentsconverter.cpp
@@ -43,7 +43,8 @@ Ms::Instrument InstrumentsConverter::convertInstrument(const mu::instruments::In
 
     result.setTrackName(instrument.name);
     result.setTranspose(instrument.transpose);
-    result.setInstrumentId(instrument.id);
+    result.setId(instrument.id);
+    result.setInstrumentId(instrument.musicXMLid);
 
     if (instrument.useDrumset) {
         result.setDrumset(instrument.drumset ? instrument.drumset : Ms::smDrumset);
@@ -82,7 +83,8 @@ mu::instruments::Instrument InstrumentsConverter::convertInstrument(const Ms::In
 
     result.name = instrument.trackName();
     result.transpose = instrument.transpose();
-    result.id = instrument.instrumentId();
+    result.id = instrument.getId();
+    result.musicXMLid = instrument.instrumentId();
     result.useDrumset = instrument.useDrumset();
     result.drumset = instrument.drumset();
 

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -254,7 +254,7 @@ mu::Ret MasterNotation::createNew(const ScoreCreateOptions& scoreOptions)
     setScore(score);
 
     if (templatePath.empty()) {
-        parts()->setInstruments(scoreOptions.instruments);
+        parts()->setParts(scoreOptions.parts);
     }
 
     score->style().checkChordList();

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -45,10 +45,10 @@ void MasterNotationParts::apply()
     partsChanged().notify();
 }
 
-void MasterNotationParts::setInstruments(const instruments::InstrumentList& instruments)
+void MasterNotationParts::setParts(const instruments::PartInstrumentList& instruments)
 {
     startEdit();
-    NotationParts::setInstruments(instruments);
+    NotationParts::setParts(instruments);
     apply();
 }
 

--- a/src/notation/internal/masternotationparts.h
+++ b/src/notation/internal/masternotationparts.h
@@ -34,7 +34,7 @@ public:
 
     void setExcerpts(ExcerptNotationList excerpts);
 
-    void setInstruments(const instruments::InstrumentList& instruments) override;
+    void setParts(const instruments::PartInstrumentList& instruments) override;
     void setInstrumentName(const ID& instrumentId, const ID& fromPartId, const QString& name) override;
     void setPartName(const ID& partId, const QString& name) override;
     void setPartSharpFlat(const ID& partId, const SharpFlat& sharpFlat) override;

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -1256,17 +1256,17 @@ void NotationParts::appendNewInstruments(const InstrumentList& instruments)
     }
 
     IDList existedInstrumentIds = allInstrumentsIds();
-    IDList newInstruentIds = instrumentIds;
+    IDList newInstrumentIds = instrumentIds;
     for (const ID& instrumentId: existedInstrumentIds) {
-        newInstruentIds.removeOne(instrumentId);
+        newInstrumentIds.removeOne(instrumentId);
     }
 
     for (const mu::instruments::Instrument& instrument: instruments) {
-        if (!newInstruentIds.contains(instrument.id)) {
+        if (!newInstrumentIds.contains(instrument.id)) {
             continue;
         }
 
-        newInstruentIds.removeOne(instrument.id);
+        newInstrumentIds.removeOne(instrument.id);
 
         Part* part = new Part(score());
 

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -290,7 +290,7 @@ bool NotationParts::needAssignInstrumentToChord(const ID& instrumentId, const ID
     QMap<Ms::Fraction, Ms::InstrumentChange*> instrumentChangeElements = this->instrumentChangeElements(fromPartId);
 
     for (const Ms::InstrumentChange* instrumentChange: instrumentChangeElements.values()) {
-        if (instrumentChange->instrument()->instrumentId() == instrumentId) {
+        if (instrumentChange->instrument()->getId() == instrumentId) {
             return false;
         }
     }
@@ -306,7 +306,7 @@ void NotationParts::assignIstrumentToSelectedChord(Ms::Instrument* instrument)
     }
 
     Part* part = chord->part();
-    part->removeInstrument(instrument->instrumentId());
+    part->removeInstrument(instrument->getId());
     part->setInstrument(instrument, chord->segment()->tick());
 
     auto instrumentChange = new Ms::InstrumentChange(*instrument, score());
@@ -656,7 +656,7 @@ void NotationParts::appendStaff(Staff* staff, const ID& destinationPartId)
     Ms::Instrument* instrument = instrumentInfo.instrument;
     instrument->setClefType(staffIndex, staff->defaultClefType());
 
-    ChangedNotifier<const Staff*>* notifier = instrumentNotifier(instrument->instrumentId(), destinationPartId);
+    ChangedNotifier<const Staff*>* notifier = instrumentNotifier(instrument->getId(), destinationPartId);
     notifier->itemAdded(staff);
 }
 
@@ -889,7 +889,7 @@ QMap<Ms::Fraction, Ms::Instrument*> NotationParts::instruments(const Part* fromP
         Ms::Fraction fraction = Ms::Fraction::fromTicks(it->first);
         Ms::Instrument* instrument = it->second;
 
-        bool acceptedByFilter = !filterInstrumentsIds.isEmpty() ? filterInstrumentsIds.contains(instrument->instrumentId()) : true;
+        bool acceptedByFilter = !filterInstrumentsIds.isEmpty() ? filterInstrumentsIds.contains(instrument->getId()) : true;
         if (acceptedByFilter) {
             result.insert(fraction, instrument);
         }
@@ -913,7 +913,7 @@ void NotationParts::doInsertInstruments(const QMap<Ms::Fraction, Ms::Instrument*
 
     int destinationIndex = 0;
     for (int i = 0; i < partInstruments.size(); i++) {
-        if (partInstruments[i]->instrumentId() == destinationInstrumentId) {
+        if (partInstruments[i]->getId() == destinationInstrumentId) {
             destinationIndex = i;
             break;
         }
@@ -1080,7 +1080,7 @@ NotationParts::InstrumentInfo NotationParts::instrumentInfo(const ID& instrument
 
     for (const Ms::Fraction& fraction: partInstruments.keys()) {
         Ms::Instrument* instrument = partInstruments.value(fraction);
-        if (instrument->instrumentId() == instrumentId) {
+        if (instrument->getId() == instrumentId) {
             return InstrumentInfo(fraction, instrument);
         }
     }
@@ -1232,8 +1232,8 @@ void NotationParts::removeMissingInstruments(const InstrumentList& instruments)
         IDList instrumentsToRemove;
 
         for (const Ms::Instrument* instrument: partInstruments.values()) {
-            if (!instrumentIds.contains(instrument->instrumentId())) {
-                instrumentsToRemove << instrument->instrumentId();
+            if (!instrumentIds.contains(instrument->getId())) {
+                instrumentsToRemove << instrument->getId();
             }
         }
 
@@ -1283,7 +1283,7 @@ void NotationParts::sortParts(const InstrumentList& instruments)
     Q_ASSERT(score()->parts().size() == static_cast<int>(instruments.size()));
 
     auto mainInstrumentId = [](const Part* part) {
-        return part->instrument()->instrumentId();
+        return part->instrument()->getId();
     };
 
     for (int i = 0; i < instruments.size(); ++i) {
@@ -1312,7 +1312,7 @@ IDList NotationParts::allInstrumentsIds() const
         auto partInstruments = instruments(part);
 
         for (const Ms::Instrument* instrument: partInstruments.values()) {
-            result << instrument->instrumentId();
+            result << instrument->getId();
         }
     }
 
@@ -1351,7 +1351,7 @@ void NotationParts::notifyAboutStaffChanged(const ID& staffId) const
     }
 
     InstrumentInfo instrumentInfo = this->instrumentInfo(staff);
-    ChangedNotifier<const Staff*>* notifier = instrumentNotifier(instrumentInfo.instrument->instrumentId(), staff->part()->id());
+    ChangedNotifier<const Staff*>* notifier = instrumentNotifier(instrumentInfo.instrument->getId(), staff->part()->id());
     notifier->itemChanged(staff);
 }
 

--- a/src/notation/internal/notationparts.h
+++ b/src/notation/internal/notationparts.h
@@ -42,7 +42,7 @@ public:
     ValCh<bool> canChangeInstrumentVisibility(const ID& instrumentId, const ID& fromPartId) const override;
     bool voiceVisible(int voiceIndex) const override;
 
-    void setInstruments(const instruments::InstrumentList& instruments) override;
+    void setParts(const instruments::PartInstrumentList& parts) override;
     void setPartVisible(const ID& partId, bool visible) override;
     void setInstrumentVisible(const ID& instrumentId, const ID& fromPartId, bool visible) override;
     void setStaffVisible(const ID& staffId, bool visible) override;
@@ -149,9 +149,9 @@ private:
 
     void appendStaves(Part* part, const instruments::Instrument& instrument);
 
-    void removeMissingInstruments(const instruments::InstrumentList& instruments);
-    void appendNewInstruments(const instruments::InstrumentList& instruments);
-    void sortParts(const instruments::InstrumentList& instruments);
+    void removeMissingParts(const instruments::PartInstrumentList& parts);
+    void appendNewParts(const instruments::PartInstrumentList& parts);
+    void sortParts(const instruments::PartInstrumentList& parts);
 
     IDList allInstrumentsIds() const;
     int lastStaffIndex() const;

--- a/src/notation/internal/notationparts.h
+++ b/src/notation/internal/notationparts.h
@@ -151,6 +151,7 @@ private:
 
     void removeMissingParts(const instruments::PartInstrumentList& parts);
     void appendNewParts(const instruments::PartInstrumentList& parts);
+    void updateSoloist(const instruments::PartInstrumentList& parts);
     void sortParts(const instruments::PartInstrumentList& parts);
 
     IDList allInstrumentsIds() const;

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -300,7 +300,8 @@ struct ScoreCreateOptions
     int measureTimesigDenominator = 0;
 
     io::path templatePath;
-    instruments::InstrumentList instruments;
+
+    instruments::PartInstrumentList parts;
 };
 
 struct SearchCommand

--- a/src/plugins/api/instrument.h
+++ b/src/plugins/api/instrument.h
@@ -250,7 +250,7 @@ public:
 
     Ms::Part* part() { return _part; }
 
-    QString instrumentId() const { return instrument()->instrumentId(); }
+    QString instrumentId() const { return instrument()->getId(); }
     QString longName() const;
     QString shortName() const;
 

--- a/src/plugins/api/part.h
+++ b/src/plugins/api/part.h
@@ -111,7 +111,7 @@ public:
 
     int startTrack() const { return part()->startTrack(); }
     int endTrack()   const { return part()->endTrack(); }
-    QString instrumentId() const { return part()->instrument()->instrumentId(); }
+    QString instrumentId() const { return part()->instrument()->getId(); }
     int harmonyCount() const { return part()->harmonyCount(); }
     bool hasPitchedStaff() const { return part()->hasPitchedStaff(); }
     bool hasTabStaff() const { return part()->hasTabStaff(); }

--- a/src/stubs/instruments/qml/MuseScore/Instruments/ChooseInstrumentsPage.qml
+++ b/src/stubs/instruments/qml/MuseScore/Instruments/ChooseInstrumentsPage.qml
@@ -26,7 +26,7 @@ import MuseScore.UiComponents 1.0
 Rectangle {
     id: root
 
-    property string initiallySelectedInstrumentIds: ""
+    property string initiallySelectedPartIds: ""
     property bool hasSelectedInstruments: false
     property bool canSelectMultipleInstruments: false
     property string currentInstrumentId: ""

--- a/src/stubs/instruments/qml/MuseScore/Instruments/InstrumentsDialog.qml
+++ b/src/stubs/instruments/qml/MuseScore/Instruments/InstrumentsDialog.qml
@@ -29,7 +29,7 @@ QmlDialog {
 
     property bool canSelectMultipleInstruments: false
     property string currentInstrumentId: ""
-    property string initiallySelectedInstrumentIds: ""
+    property string initiallySelectedPartIds: ""
 
     height: 500
     width: 900

--- a/src/stubs/instruments/selectinstrumentscenariostub.cpp
+++ b/src/stubs/instruments/selectinstrumentscenariostub.cpp
@@ -23,9 +23,9 @@
 
 using namespace mu::instruments;
 
-mu::RetVal<InstrumentList> SelectInstrumentsScenario::selectInstruments(ISelectInstrumentsScenario::SelectInstrumentsMode) const
+mu::RetVal<PartInstrumentList> SelectInstrumentsScenario::selectInstruments(ISelectInstrumentsScenario::SelectInstrumentsMode) const
 {
-    mu::RetVal<InstrumentList> result;
+    mu::RetVal<PartInstrumentList> result;
     result.ret = make_ret(Ret::Code::NotSupported);
     return result;
 }

--- a/src/stubs/instruments/selectinstrumentscenariostub.h
+++ b/src/stubs/instruments/selectinstrumentscenariostub.h
@@ -28,7 +28,7 @@ namespace mu::instruments {
 class SelectInstrumentsScenario : public ISelectInstrumentsScenario
 {
 public:
-    RetVal<InstrumentList> selectInstruments(SelectInstrumentsMode mode = SelectInstrumentsMode::None) const override;
+    RetVal<PartInstrumentList> selectInstruments(SelectInstrumentsMode mode = SelectInstrumentsMode::None) const override;
     RetVal<Instrument> selectInstrument(const std::string& currentInstrumentId = "") const override;
 };
 }

--- a/src/userscores/qml/MuseScore/UserScores/internal/ChooseInstrumentsAndTemplatesPage.qml
+++ b/src/userscores/qml/MuseScore/UserScores/internal/ChooseInstrumentsAndTemplatesPage.qml
@@ -49,7 +49,9 @@ Item {
         var result = {}
 
         if (pagesStack.currentIndex === 0) {
-            result["instruments"] = instrumentsPage.selectedInstruments()
+            var parts = {}
+            parts["instruments"] = instrumentsPage.selectedInstruments()
+            result["parts"] = parts
         } else if (pagesStack.currentIndex === 1) {
             result["templatePath"] = templatePage.selectedTemplatePath
         }

--- a/src/userscores/view/newscoremodel.cpp
+++ b/src/userscores/view/newscoremodel.cpp
@@ -108,12 +108,12 @@ ScoreCreateOptions NewScoreModel::parseOptions(const QVariantMap& info) const
     QVariantMap partMap = info["parts"].toMap();
     for (const QVariant& obj: partMap["instruments"].toList()) {
         QVariantMap objMap = obj.toMap();
-        Q_ASSERT(!objMap["part"].toBool());
+        Q_ASSERT(!objMap["isExistingPart"].toBool());
 
         PartInstrument pi;
 
-        pi.part = false;
-        pi.soloist = false;
+        pi.isExistingPart = false;
+        pi.isSoloist = false;
         pi.partId = QString();
         pi.instrument = objMap["instrument"].value<Instrument>();
 

--- a/src/userscores/view/newscoremodel.cpp
+++ b/src/userscores/view/newscoremodel.cpp
@@ -105,8 +105,19 @@ ScoreCreateOptions NewScoreModel::parseOptions(const QVariantMap& info) const
 
     options.templatePath = info["templatePath"].toString();
 
-    for (const QVariant& obj: info["instruments"].toList()) {
-        options.instruments << obj.value<Instrument>();
+    QVariantMap partMap = info["parts"].toMap();
+    for (const QVariant& obj: partMap["instruments"].toList()) {
+        QVariantMap objMap = obj.toMap();
+        Q_ASSERT(!objMap["part"].toBool());
+
+        PartInstrument pi;
+
+        pi.part = false;
+        pi.soloist = false;
+        pi.partId = QString();
+        pi.instrument = objMap["instrument"].value<Instrument>();
+
+        options.parts << pi;
     }
 
     return options;


### PR DESCRIPTION
This PR is the first of a number of PR's required to
- implement score ordering.
- solve several issues with `Parts` and `Excerpts` 
- independent sorting of staves/parts in both main score and excepts.

The changes in this PR are:

-1 Replace *MusicXMLid* as an instrument id by the `id` as given in `instruments.xml`
This solves the issue an *Oboe* suddenly becomes a *Baroque Oboe* when the instruments form is opened again. The reason for this name change is *MusicxXMLid* isn't unique, several instrument share the same *MusicXMLid*. Both *Oboe* and *Baroque Oboe* share the same *MusicXMLid*, *wind.reed.oboe* but there also 3 *Cornet*s, 4 *Bariton Horn*s and even 10 *Horn*s share the same id. This similar to PR #7995 but since it was required here too it is include in this PR and PR #7995 is closed.

-2 *Your score* in instrument form now shows `Parts` rather than `Instruments`
In the list under *Your score*, "Instruments" should refer to `Parts`, not `Instruments`. Please note `Part` is a class as used internally, not "Part" as seen on the UI, which is actually an `Excerpt`. And to complicate things even more, the word "Instrument" on the UI sometimes refers to a `Part`-class, sometime to an `Instrument`-class. The column *Your score* actually show the `Parts` for an `Instrument`. 
By this change 2 issues are solved
  - When changing the part name *Your score* now shows this part name.
  - Without this PR, deleting in instrument in a part with an instrument change removes the wrong instruments. E.g. in a part starting with an *Alto Saxophone*, switching to *Clarinet*, switching to *Tenor Saxophone* and back to *Alto Saxophone*, removes all instrument changes!
With this PR the `Part` is removed, what actually is supposed to happen. PR #8048 is partly doing the same but this PR is more elaborated and replaces PR #8048.

-3 *Soloist* function implemented
When a part is made *Soloist* the part is made soloists. The form now also reflect the actual status of the part, soloist not no soloist. This is first step to implementing score ordering.

-4 `Make soloist` button moved
Original the *Make soloist* button was in the header of the part list under *Your score*. To make more space for the score order name is was decided to move this button to the instrument line. For the discussion, see the discussion with @Tantacrul on Discord (`design` channel, April 15th, 2021).

-5 Some minor typos corrected.
When encountered some minor typos are corrected.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
