### PR TITLE
[MU3] Fix #321227: Problems with removing empty trailing measures

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2841,7 +2841,6 @@ bool Measure::isEmpty(int staffIdx) const
       {
       int strack;
       int etrack;
-      bool hasStaves = score()->staff(staffIdx)->part()->staves()->size() > 1; 
       if (staffIdx < 0) {
             strack = 0;
             etrack = score()->nstaves() * VOICES;
@@ -2856,6 +2855,7 @@ bool Measure::isEmpty(int staffIdx) const
                   if (e && !e->isRest())
                         return false;
                   // Check for cross-staff chords
+                  bool hasStaves = score()->staff(track / VOICES)->part()->staves()->size() > 1;
                   if (hasStaves) {
                         if (strack >= VOICES) {
                               e = s->element(track - VOICES);
@@ -2870,6 +2870,8 @@ bool Measure::isEmpty(int staffIdx) const
                         }
                   }
             for (Element* a : s->annotations()) {
+                  if (a && staffIdx < 0)
+                        return false;
                   if (!a || a->systemFlag() || !a->visible() || a->isFermata())
                         continue;
                   int atrack = a->track();

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -4275,11 +4275,15 @@ Measure* Score::firstTrailingMeasure(ChordRest** cr)
       Measure* firstMeasure = nullptr;
       auto m = lastMeasure();
 
-      // No active selection: prepare first empty trailing measure of entire score
-      if (!cr)
-            for (; m && m->isFullMeasureRest(); firstMeasure = m, m = m->prevMeasure());
-      // Active selection: select full measure rest of active staff's empty trailing measure
+      if (!cr) {
+            // No active selection: prepare first empty trailing measure of entire score
+            while (m && m->isEmpty(-1)) {
+                  firstMeasure = m;
+                  m = m->prevMeasure();
+                  }
+            }
       else {
+            // Active selection: select full measure rest of active staff's empty trailing measure
             ChordRest* tempCR = *cr;
             while (m && (tempCR = m->first()->nextChordRest(trackZeroVoice((*cr)->track()), false))->isFullMeasureRest()) {
                   *cr = tempCR;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/321227

My approach is instead of `Measure::isFullMeasureRest()` to use `Measure::isEmpty(-1)` which is documented to check a measure accross all staves.
Problem is, that this doesn't work (anymore?), but crashes, so that needed to get fixed too. Also in that special case annotations with the system flag being set, fermatas and invisible annotations should should mean a measure is not empty.

Corresponding PR for master is #8112 (merged already)