### PR TITLE
[MU4] Fix #321227: Problems with removing empty trailing measures

### DIFF
--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -2911,7 +2911,6 @@ bool Measure::isEmpty(int staffIdx) const
 {
     int strack;
     int etrack;
-    bool hasStaves = score()->staff(staffIdx)->part()->staves()->size() > 1;
     if (staffIdx < 0) {
         strack = 0;
         etrack = score()->nstaves() * VOICES;
@@ -2926,6 +2925,7 @@ bool Measure::isEmpty(int staffIdx) const
                 return false;
             }
             // Check for cross-staff chords
+            bool hasStaves = score()->staff(track / VOICES)->part()->staves()->size() > 1;
             if (hasStaves) {
                 if (strack >= VOICES) {
                     e = s->element(track - VOICES);
@@ -2942,6 +2942,9 @@ bool Measure::isEmpty(int staffIdx) const
             }
         }
         for (Element* a : s->annotations()) {
+            if (a && staffIdx < 0) {
+                return false;
+            }
             if (!a || a->systemFlag() || !a->visible() || a->isFermata()) {
                 continue;
             }

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -4542,7 +4542,9 @@ Measure* Score::firstTrailingMeasure(ChordRest** cr)
 
     if (!cr) {
         // No active selection: prepare first empty trailing measure of entire score
-        for (; m && m->isFullMeasureRest(); firstMeasure = m, m = m->prevMeasure()) {
+        while (m && m->isEmpty(-1)) {
+            firstMeasure = m;
+            m = m->prevMeasure();
         }
     } else {
         // Active selection: select full measure rest of active staff's empty trailing measure


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/321227

My approach is instead of `Measure::isFullMeasureRest()` to use `Measure::isEmpty(-1)` which is documented to check a measure accross all staves.
Problem is, that this doesn't work (anymore?), but crashes, so that needed to get fixed too. Also in that special case annotations with the system flag being set, fermatas and invisible annotations should should mean a measure is not empty.

Counterpart of #8111, but for master