### PR TITLE
[MU4] Fix #8098: Text-only buttons have not the same height as icon b…

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/FlatButton.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/FlatButton.qml
@@ -86,11 +86,12 @@ FocusableControl {
         id: contentWrapper
 
         property int spacing: Boolean(!buttonIcon.isEmpty) && Boolean(textLabel.text) ? 4 : 0
+        property int extraSpacing: buttonIcon.isEmpty && textLabel.text ? 1 : 0 // Required because font is an even-pixel height (10px), #8098
 
         anchors.verticalCenter: parent ? parent.verticalCenter : undefined
         anchors.horizontalCenter: parent ? parent.horizontalCenter : undefined
 
-        height: !prv.isVertical ? Math.max(buttonIcon.height, textLabel.height) : buttonIcon.height + textLabel.height + spacing
+        height: !prv.isVertical ? Math.max(buttonIcon.height, textLabel.height) : buttonIcon.height + textLabel.height + spacing + extraSpacing
         width: prv.isVertical ? Math.max(textLabel.width, buttonIcon.width) : buttonIcon.width + textLabel.width + spacing
 
         StyledIconLabel {


### PR DESCRIPTION
…uttons

    -Text is 10 pixels high (even) while the icons are 15 pixels high (odd).
    As a result we require a one pixel offset for the height of buttons that
    contain only text.

Resolves: https://github.com/musescore/MuseScore/issues/8098

**The Bug**
The text is 10 pixels high (even) while the icons are 15 pixels high (odd). As a result we require a one pixel offset for the height of buttons that contain only text.

**The Fix**
If we have a button with only text, add one pixel to the height of the button to compensate for the even-pixel height of 10.

Alternatively, the text could be increased to 11 pixels and then we would not require this change.

**What the fix looks like**
![palette](https://user-images.githubusercontent.com/25189861/118579820-a7276200-b743-11eb-9024-388062269f71.JPG)
![instrument](https://user-images.githubusercontent.com/25189861/118579824-a989bc00-b743-11eb-9f49-e50ae3c0119b.JPG)
![parts](https://user-images.githubusercontent.com/25189861/118579831-aabae900-b743-11eb-82d5-e020d76c17c4.JPG)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
