### PR TITLE
[MU3 Backend] ENG-18: Fretboard Diagrams

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -4906,70 +4906,19 @@ FretDiagram* MusicXMLParserPass2::frame()
 
       FretDiagram* fd = new FretDiagram(_score);
 
+      int fretOffset = 0;
+
       // Format: fret: string
       std::map<int, int> bStarts;
       std::map<int, int> bEnds;
 
       while (_e.readNextStartElement()) {
-            if (_e.name() == "first-fret") {
-                  bool ok {};
-                  int val = _e.readElementText().toInt(&ok);
-                  if (ok && val > 0)
-                        fd->setFretOffset(val - 1);
-                  else
-                        _logger->logError(QString("FretDiagram::readMusicXML: illegal first-fret %1").arg(val), &_e);
-                  }
-            else if (_e.name() == "frame-frets") {
-                  int val = _e.readElementText().toInt();
-                  if (val > 0) {
-                        fd->setProperty(Pid::FRET_FRETS, val);
-                        fd->setPropertyFlags(Pid::FRET_FRETS, PropertyFlags::UNSTYLED);
-                        }
-                  else
-                        _logger->logError(QString("FretDiagram::readMusicXML: illegal frame-fret %1").arg(val), &_e);
-                  }
-            else if (_e.name() == "frame-note") {
-                  int fret   = -1;
-                  int string = -1;
-                  int actualString = -1;
-                  while (_e.readNextStartElement()) {
-                        if (_e.name() == "fret")
-                              fret = _e.readElementText().toInt();
-                        else if (_e.name() == "string") {
-                              string = _e.readElementText().toInt();
-                              actualString = fd->strings() - string;
-                              }
-                        else if (_e.name() == "barre") {
-                              // Keep barres to be added later
-                              QString t = _e.attributes().value("type").toString();
-                              if (t == "start")
-                                    bStarts[fret] = actualString;
-                              else if (t == "stop")
-                                    bEnds[fret] = actualString;
-                              else
-                                    _logger->logError(QString("FretDiagram::readMusicXML: illegal frame-note barre type %1").arg(t), &_e);
-                              skipLogCurrElem();
-                              }
-                        else
-                              skipLogCurrElem();
-                        }
-                  _logger->logDebugInfo(QString("FretDiagram::readMusicXML string %1 fret %2").arg(string).arg(fret), &_e);
-
-                  if (string > 0) {
-                        if (fret == 0)
-                              fd->setMarker(actualString, FretMarkerType::CIRCLE);
-                        else if (fret > 0) {
-                              if (fd->marker(actualString).mtype == FretMarkerType::CROSS)
-                                    fd->setMarker(actualString, FretMarkerType::NONE);
-                              fd->setDot(actualString, fret - fd->fretOffset(), true);
-                              }
-                  else
-                        _logger->logError(QString("FretDiagram::readMusicXML: illegal frame-note string %1").arg(string), &_e);
-                  }
-            else if (_e.name() == "frame-strings") {
+            // xs:sequence (elements will appear in this order, as enforced by XML schema)
+            if (_e.name() == "frame-strings") {
                   int val = _e.readElementText().toInt();
                   if (val > 0) {
                         fd->setStrings(val);
+                        fd->setPropertyFlags(Pid::FRET_STRINGS, PropertyFlags::UNSTYLED); // Prevent style overwrite
                         for (int i = 0; i < val; ++i) {
                               // MXML Spec: any string without a dot or other marker has a closed string
                               // cross marker above it.
@@ -4979,20 +4928,89 @@ FretDiagram* MusicXMLParserPass2::frame()
                   else
                         _logger->logError(QString("FretDiagram::readMusicXML: illegal frame-strings %1").arg(val), &_e);
                   }
+            else if (_e.name() == "frame-frets") {
+                  int val = _e.readElementText().toInt();
+                  if (val > 0) {
+                        fd->setFrets(val);
+                        fd->setPropertyFlags(Pid::FRET_FRETS, PropertyFlags::UNSTYLED); // Prevent style overwrite
+                        }
+                  else
+                        _logger->logError(QString("FretDiagram::readMusicXML: illegal frame-fret %1").arg(val), &_e);
+                  }
+            else if (_e.name() == "first-fret") {
+                  int firstFret = _e.readElementText().toInt();   // MusicXML (1-indexed)
+                  fretOffset = firstFret - 1;                     // MuseScore (0-indexed)
+                  if (fretOffset >= 0)
+                        fd->setFretOffset(fretOffset);
+                  else
+                        _logger->logError(QString("FretDiagram::readMusicXML: illegal first-fret %1").arg(firstFret), &_e);
+
+                  }
+            else if (_e.name() == "frame-note") {
+                  // Handle differences in how MusicXML and MuseScore store fret and string information
+                  int mxmlString = -1;    // MusicXML (1 = rightmost)
+                  int msString = -1;      // MuseScore (0 = leftmost)
+                  int mxmlFret = -1;      // MusicXML (absolute)
+                  int msFret = -1;        // MuseScore (relative to offset)
+                  bool barre = false;     // Flag to prevent barres being duplicated as dots
+                  while (_e.readNextStartElement()) {
+                        // xs:sequence  (elements will appear in this order, as enforced by XML schema)
+                        if (_e.name() == "string") {
+                              mxmlString = _e.readElementText().toInt();
+                              msString = fd->strings() - mxmlString;
+                              }
+                        else if (_e.name() == "fret") {
+                              mxmlFret = _e.readElementText().toInt();
+                              msFret = mxmlFret - fretOffset;
+                              }
+                        else if (_e.name() == "barre") {
+                              // Keep barres to be added later
+                              barre = true;
+                              QString t = _e.attributes().value("type").toString();
+                              if (t == "start")
+                                    bStarts[msFret] = msString;
+                              else if (t == "stop")
+                                    bEnds[msFret] = msString;
+                              else
+                                    _logger->logError(QString("FretDiagram::readMusicXML: illegal frame-note barre type %1").arg(t), &_e);
+                              skipLogCurrElem();
+                              }
+                        else
+                              skipLogCurrElem();
+                        }
+                  _logger->logDebugInfo(QString("FretDiagram::readMusicXML string %1 fret %2").arg(mxmlString).arg(mxmlFret), &_e);
+
+                  if (mxmlString > 0) {
+                        if (mxmlFret == 0)
+                              fd->setMarker(msString, FretMarkerType::CIRCLE);
+                        else if (msFret > 0 && !barre) {
+                              fd->setDot(msString, msFret, true);
+                              fd->setMarker(msString, FretMarkerType::NONE);
+                              }
+                        }
+                  else
+                        _logger->logError(QString("FretDiagram::readMusicXML: illegal frame-note string %1").arg(mxmlString), &_e);
+                  }
             else
                   skipLogCurrElem();
             }
 
       // Finally add barres
       for (auto const& i : bStarts) {
-            int fret = i.first;
+            int fret = i.first;  // Already in MuseScore format
             int startString = i.second;
 
+            // If end is missing, skip this one
             if (bEnds.find(fret) == bEnds.end())
                   continue;
 
             int endString = bEnds[fret];
-            fd->setBarre(startString, endString, fret - fd->fretOffset());
+            fd->setBarre(startString, endString, fret);
+
+            // Reset fret marker of all strings covered by barre
+            for (int string = startString; string <= endString; ++string) {
+                  fd->setMarker(string, FretMarkerType::NONE);
+                  }
             }
 
       return fd;
@@ -5169,12 +5187,6 @@ void MusicXMLParserPass2::harmony(const QString& partId, Measure* measure, const
                   skipLogCurrElem();
             }
 
-      if (fd) {
-            fd->setTrack(track);
-            Segment* s = measure->getSegment(SegmentType::ChordRest, sTime + offset);
-            s->add(fd);
-            }
-
       const ChordDescription* d = 0;
       if (ha->rootTpc() != Tpc::TPC_INVALID)
             d = ha->fromXml(kind, kindText, symbols, parens, degreeList);
@@ -5195,7 +5207,16 @@ void MusicXMLParserPass2::harmony(const QString& partId, Measure* measure, const
       // harmony = ha;
       ha->setTrack(track);
       Segment* s = measure->getSegment(SegmentType::ChordRest, sTime + offset);
-      s->add(ha);
+
+      // Add harmony to FretDiagram if present, otherwise add directly to Segment
+      if (fd) {
+            fd->setTrack(track);
+            s->add(fd);
+            fd->add(ha);
+            }
+      else {
+            s->add(ha);
+            }
       }
 
 //---------------------------------------------------------

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -4943,8 +4943,11 @@ FretDiagram* MusicXMLParserPass2::frame()
                   if (string > 0) {
                         if (fret == 0)
                               fd->setMarker(actualString, FretMarkerType::CIRCLE);
-                        else if (fret > 0)
+                        else if (fret > 0) {
+                              if (fd->marker(actualString).mtype == FretMarkerType::CROSS)
+                                    fd->setMarker(actualString, FretMarkerType::NONE);
                               fd->setDot(actualString, fret, true);
+                              }
                         }
                   else
                         _logger->logError(QString("FretDiagram::readMusicXML: illegal frame-note string %1").arg(string), &_e);

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -4921,8 +4921,10 @@ FretDiagram* MusicXMLParserPass2::frame()
                   }
             else if (_e.name() == "frame-frets") {
                   int val = _e.readElementText().toInt();
-                  if (val > 0)
-                        fd->setFrets(val);
+                  if (val > 0) {
+                        fd->setProperty(Pid::FRET_FRETS, val);
+                        fd->setPropertyFlags(Pid::FRET_FRETS, PropertyFlags::UNSTYLED);
+                        }
                   else
                         _logger->logError(QString("FretDiagram::readMusicXML: illegal frame-fret %1").arg(val), &_e);
                   }

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -4893,6 +4893,11 @@ FiguredBass* MusicXMLParserPass2::figuredBass()
 /**
  Parse the /score-partwise/part/measure/harmony/frame node.
  Return the result as a FretDiagram.
+ Notes:
+ - MusicXML's first-fret is a positive integer equivalent to MuseScore's FretDiagram::_fretOffset
+ - it is one-based in MusicXML and zero-based in MuseScore
+ - in MusicXML fret numbers are absolute, in MuseScore they are relative to the fretOffset,
+   which affects both single strings and barres
  */
 
 FretDiagram* MusicXMLParserPass2::frame()
@@ -4906,7 +4911,15 @@ FretDiagram* MusicXMLParserPass2::frame()
       std::map<int, int> bEnds;
 
       while (_e.readNextStartElement()) {
-            if (_e.name() == "frame-frets") {
+            if (_e.name() == "first-fret") {
+                  bool ok {};
+                  int val = _e.readElementText().toInt(&ok);
+                  if (ok && val > 0)
+                        fd->setFretOffset(val - 1);
+                  else
+                        _logger->logError(QString("FretDiagram::readMusicXML: illegal first-fret %1").arg(val), &_e);
+                  }
+            else if (_e.name() == "frame-frets") {
                   int val = _e.readElementText().toInt();
                   if (val > 0)
                         fd->setFrets(val);
@@ -4946,9 +4959,8 @@ FretDiagram* MusicXMLParserPass2::frame()
                         else if (fret > 0) {
                               if (fd->marker(actualString).mtype == FretMarkerType::CROSS)
                                     fd->setMarker(actualString, FretMarkerType::NONE);
-                              fd->setDot(actualString, fret, true);
+                              fd->setDot(actualString, fret - fd->fretOffset(), true);
                               }
-                        }
                   else
                         _logger->logError(QString("FretDiagram::readMusicXML: illegal frame-note string %1").arg(string), &_e);
                   }
@@ -4978,7 +4990,7 @@ FretDiagram* MusicXMLParserPass2::frame()
                   continue;
 
             int endString = bEnds[fret];
-            fd->setBarre(startString, endString, fret);
+            fd->setBarre(startString, endString, fret - fd->fretOffset());
             }
 
       return fd;

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -273,7 +273,7 @@ void FretDiagram::init(StringData* stringData, Chord* chord)
                   if (stringData->convertPitch(note->pitch(), chord->staff(), chord->segment()->tick(), &string, &fret))
                         setDot(string, fret);
                   }
-            _maxFrets = stringData->frets();
+            _frets = stringData->frets();
             }
       else
             _maxFrets = 6;
@@ -1290,27 +1290,27 @@ void FretDiagram::writeMusicXML(XmlWriter& xml) const
                   xml.tag("fret", "0");
                   xml.etag();
                   }
-            else {
-                  // Write dots
-                  for (auto const& d : dot(i)) {
-                        if (!d.exists())
-                              continue;
-                        xml.stag("frame-note");
-                        xml.tag("string", mxmlString);
-                        xml.tag("fret", d.fret);
-                        // TODO: write fingerings
 
-                        // Also write barre if it starts at this dot
-                        if (std::find(bStarts.begin(), bStarts.end(), d.fret) != bStarts.end()) {
-                              xml.tagE("barre type=\"start\"");
-                              bStarts.erase(std::remove(bStarts.begin(), bStarts.end(), d.fret), bStarts.end());
-                              }
-                        if (std::find(bEnds.begin(), bEnds.end(), d.fret) != bEnds.end()) {
-                              xml.tagE("barre type=\"stop\"");
-                              bEnds.erase(std::remove(bEnds.begin(), bEnds.end(), d.fret), bEnds.end());
-                              }
-                        xml.etag();
+            // Markers may exists alongside with dots
+            // Write dots
+            for (auto const& d : dot(i)) {
+                  if (!d.exists())
+                        continue;
+                  xml.stag("frame-note");
+                  xml.tag("string", mxmlString);
+                  xml.tag("fret", d.fret);
+                  // TODO: write fingerings
+
+                  // Also write barre if it starts at this dot
+                  if (std::find(bStarts.begin(), bStarts.end(), d.fret) != bStarts.end()) {
+                        xml.tagE("barre type=\"start\"");
+                        bStarts.erase(std::remove(bStarts.begin(), bStarts.end(), d.fret), bStarts.end());
                         }
+                  if (std::find(bEnds.begin(), bEnds.end(), d.fret) != bEnds.end()) {
+                        xml.tagE("barre type=\"stop\"");
+                        bEnds.erase(std::remove(bEnds.begin(), bEnds.end(), d.fret), bEnds.end());
+                        }
+                  xml.etag();
                   }
 
             // Write unwritten barres

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -1266,6 +1266,9 @@ void FretDiagram::writeMusicXML(XmlWriter& xml) const
       xml.stag("frame");
       xml.tag("frame-strings", _strings);
       xml.tag("frame-frets", frets());
+      if (fretOffset() > 0)
+            xml.tag("first-fret", fretOffset() + 1);
+
 
       for (int i = 0; i < _strings; ++i) {
             int mxmlString = _strings - i;
@@ -1290,25 +1293,26 @@ void FretDiagram::writeMusicXML(XmlWriter& xml) const
                   xml.tag("fret", "0");
                   xml.etag();
                   }
+            else {
+                  // Write dots
+                  for (auto const& d : dot(i)) {
+                        if (!d.exists())
+                              continue;
+                        xml.stag("frame-note");
+                        xml.tag("string", mxmlString);
+                        xml.tag("fret", d.fret + fretOffset());
+                        // TODO: write fingerings
 
-            // Markers may exists alongside with dots
-            // Write dots
-            for (auto const& d : dot(i)) {
-                  if (!d.exists())
-                        continue;
-                  xml.stag("frame-note");
-                  xml.tag("string", mxmlString);
-                  xml.tag("fret", d.fret);
-                  // TODO: write fingerings
-
-                  // Also write barre if it starts at this dot
-                  if (std::find(bStarts.begin(), bStarts.end(), d.fret) != bStarts.end()) {
-                        xml.tagE("barre type=\"start\"");
-                        bStarts.erase(std::remove(bStarts.begin(), bStarts.end(), d.fret), bStarts.end());
-                        }
-                  if (std::find(bEnds.begin(), bEnds.end(), d.fret) != bEnds.end()) {
-                        xml.tagE("barre type=\"stop\"");
-                        bEnds.erase(std::remove(bEnds.begin(), bEnds.end(), d.fret), bEnds.end());
+                        // Also write barre if it starts at this dot
+                        if (std::find(bStarts.begin(), bStarts.end(), d.fret) != bStarts.end()) {
+                              xml.tagE("barre type=\"start\"");
+                              bStarts.erase(std::remove(bStarts.begin(), bStarts.end(), d.fret), bStarts.end());
+                              }
+                        if (std::find(bEnds.begin(), bEnds.end(), d.fret) != bEnds.end()) {
+                              xml.tagE("barre type=\"stop\"");
+                              bEnds.erase(std::remove(bEnds.begin(), bEnds.end(), d.fret), bEnds.end());
+                              }
+                        xml.etag();
                         }
                   xml.etag();
                   }

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -1269,7 +1269,6 @@ void FretDiagram::writeMusicXML(XmlWriter& xml) const
       if (fretOffset() > 0)
             xml.tag("first-fret", fretOffset() + 1);
 
-
       for (int i = 0; i < _strings; ++i) {
             int mxmlString = _strings - i;
 
@@ -1278,13 +1277,14 @@ void FretDiagram::writeMusicXML(XmlWriter& xml) const
             for (auto const& j : _barres) {
                   FretItem::Barre b = j.second;
                   int fret = j.first;
+                  int mxmlFret = fret + fretOffset();
                   if (!b.exists())
                         continue;
 
                   if (b.startString == i)
-                        bStarts.push_back(fret);
+                        bStarts.push_back(mxmlFret);
                   else if (b.endString == i || (b.endString == -1 && mxmlString == 1))
-                        bEnds.push_back(fret);
+                        bEnds.push_back(mxmlFret);
                   }
 
             if (marker(i).exists() && marker(i).mtype == FretMarkerType::CIRCLE) {
@@ -1293,26 +1293,25 @@ void FretDiagram::writeMusicXML(XmlWriter& xml) const
                   xml.tag("fret", "0");
                   xml.etag();
                   }
-            else {
-                  // Write dots
-                  for (auto const& d : dot(i)) {
-                        if (!d.exists())
-                              continue;
-                        xml.stag("frame-note");
-                        xml.tag("string", mxmlString);
-                        xml.tag("fret", d.fret + fretOffset());
-                        // TODO: write fingerings
 
-                        // Also write barre if it starts at this dot
-                        if (std::find(bStarts.begin(), bStarts.end(), d.fret) != bStarts.end()) {
-                              xml.tagE("barre type=\"start\"");
-                              bStarts.erase(std::remove(bStarts.begin(), bStarts.end(), d.fret), bStarts.end());
-                              }
-                        if (std::find(bEnds.begin(), bEnds.end(), d.fret) != bEnds.end()) {
-                              xml.tagE("barre type=\"stop\"");
-                              bEnds.erase(std::remove(bEnds.begin(), bEnds.end(), d.fret), bEnds.end());
-                              }
-                        xml.etag();
+            // Markers may exists alongside with dots
+            // Write dots
+            for (auto const& d : dot(i)) {
+                  if (!d.exists())
+                        continue;
+                  xml.stag("frame-note");
+                  xml.tag("string", mxmlString);
+                  xml.tag("fret", d.fret + fretOffset());
+                  // TODO: write fingerings
+
+                  // Also write barre if it starts at this dot
+                  if (std::find(bStarts.begin(), bStarts.end(), d.fret) != bStarts.end()) {
+                        xml.tagE("barre type=\"start\"");
+                        bStarts.erase(std::remove(bStarts.begin(), bStarts.end(), d.fret), bStarts.end());
+                        }
+                  if (std::find(bEnds.begin(), bEnds.end(), d.fret) != bEnds.end()) {
+                        xml.tagE("barre type=\"stop\"");
+                        bEnds.erase(std::remove(bEnds.begin(), bEnds.end(), d.fret), bEnds.end());
                         }
                   xml.etag();
                   }

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -2628,6 +2628,10 @@ const std::vector<Tid>& primaryTextStyles()
       return _primaryTextStyles;
       }
 
+//---------------------------------------------------------
+//   pageStyles
+//---------------------------------------------------------
+
 QSet<Sid> pageStyles()
 {
     static const QSet<Sid> styles {
@@ -2642,6 +2646,22 @@ QSet<Sid> pageStyles()
         Sid::pageOddLeftMargin,
         Sid::pageTwosided,
         Sid::spatium
+    };
+
+    return styles;
+}
+
+//---------------------------------------------------------
+//   fretStyles
+//---------------------------------------------------------
+
+QSet<Sid> fretStyles()
+{
+      static const QSet<Sid> styles {
+            Sid::fretPlacement,
+            Sid::fretStrings,
+            Sid::fretFrets,
+            Sid::fretOrientation,
     };
 
     return styles;

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -1516,6 +1516,7 @@ const std::vector<Tid>& allTextStyles();
 const std::vector<Tid>& primaryTextStyles();
 
 QSet<Sid> pageStyles();
+QSet<Sid> fretStyles();
 
 #ifndef NDEBUG
 extern void checkStyles();

--- a/mtest/musicxml/io/testChordDiagrams1.xml
+++ b/mtest/musicxml/io/testChordDiagrams1.xml
@@ -76,7 +76,7 @@
         <kind>major</kind>
         <frame>
           <frame-strings>6</frame-strings>
-          <frame-frets>5</frame-frets>
+          <frame-frets>3</frame-frets>
           <frame-note>
             <string>5</string>
             <fret>3</fret>

--- a/mtest/musicxml/io/testChordDiagrams1.xml
+++ b/mtest/musicxml/io/testChordDiagrams1.xml
@@ -157,6 +157,201 @@
           <text>Chord plus frame</text>
           </lyric>
         </note>
+      </measure>
+    <measure number="4">
+      <print new-system="yes"/>
+      <harmony print-frame="no">
+        <root>
+          <root-step>G</root-step>
+          </root>
+        <kind>major</kind>
+        <frame>
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+          <frame-note>
+            <string>6</string>
+            <fret>3</fret>
+            </frame-note>
+          <frame-note>
+            <string>5</string>
+            <fret>2</fret>
+            </frame-note>
+          <frame-note>
+            <string>4</string>
+            <fret>0</fret>
+            </frame-note>
+          <frame-note>
+            <string>3</string>
+            <fret>0</fret>
+            </frame-note>
+          <frame-note>
+            <string>2</string>
+            <fret>0</fret>
+            </frame-note>
+          <frame-note>
+            <string>1</string>
+            <fret>3</fret>
+            </frame-note>
+          </frame>
+        </harmony>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <lyric number="1">
+          <syllabic>single</syllabic>
+          <text>Frame</text>
+          </lyric>
+        </note>
+      </measure>
+    <measure number="5">
+      <harmony print-frame="no">
+        <root>
+          <root-step>G</root-step>
+          </root>
+        <kind>major</kind>
+        <frame>
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+          <first-fret>2</first-fret>
+          <frame-note>
+            <string>6</string>
+            <fret>3</fret>
+            </frame-note>
+          <frame-note>
+            <string>5</string>
+            <fret>2</fret>
+            </frame-note>
+          <frame-note>
+            <string>4</string>
+            <fret>0</fret>
+            </frame-note>
+          <frame-note>
+            <string>3</string>
+            <fret>0</fret>
+            </frame-note>
+          <frame-note>
+            <string>2</string>
+            <fret>0</fret>
+            </frame-note>
+          <frame-note>
+            <string>1</string>
+            <fret>3</fret>
+            </frame-note>
+          </frame>
+        </harmony>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <lyric number="1">
+          <syllabic>single</syllabic>
+          <text>Frame with first-fret 2</text>
+          </lyric>
+        </note>
+      </measure>
+    <measure number="6">
+      <harmony print-frame="no">
+        <root>
+          <root-step>A</root-step>
+          </root>
+        <kind>major</kind>
+        <frame>
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+          <frame-note>
+            <string>5</string>
+            <fret>0</fret>
+            </frame-note>
+          <frame-note>
+            <string>4</string>
+            <fret>2</fret>
+            </frame-note>
+          <frame-note>
+            <string>3</string>
+            <fret>2</fret>
+            </frame-note>
+          <frame-note>
+            <string>2</string>
+            <fret>2</fret>
+            </frame-note>
+          <frame-note>
+            <string>1</string>
+            <fret>0</fret>
+            </frame-note>
+          </frame>
+        </harmony>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <lyric number="1">
+          <syllabic>single</syllabic>
+          <text>Frame</text>
+          </lyric>
+        </note>
+      </measure>
+    <measure number="7">
+      <harmony print-frame="no">
+        <root>
+          <root-step>A</root-step>
+          </root>
+        <kind>major</kind>
+        <frame>
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+          <first-fret>12</first-fret>
+          <frame-note>
+            <string>5</string>
+            <fret>12</fret>
+            <barre type="start"/>
+            </frame-note>
+          <frame-note>
+            <string>4</string>
+            <fret>14</fret>
+            <barre type="start"/>
+            </frame-note>
+          <frame-note>
+            <string>3</string>
+            <fret>14</fret>
+            </frame-note>
+          <frame-note>
+            <string>2</string>
+            <fret>14</fret>
+            <barre type="stop"/>
+            </frame-note>
+          <frame-note>
+            <string>1</string>
+            <fret>12</fret>
+            <barre type="stop"/>
+            </frame-note>
+          </frame>
+        </harmony>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <lyric number="1">
+          <syllabic>single</syllabic>
+          <text>Frame with first-fret 12 and barres</text>
+          </lyric>
+        </note>
       <barline location="right">
         <bar-style>light-heavy</bar-style>
         </barline>

--- a/mtest/musicxml/io/testFretboardDiagrams.xml
+++ b/mtest/musicxml/io/testFretboardDiagrams.xml
@@ -1,0 +1,618 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-number>MuseScore testfile</work-number>
+    <work-title>Fretboard Diagrams</work-title>
+    </work>
+  <movement-number>MuseScore testfile</movement-number>
+  <movement-title>Fretboard Diagrams</movement-title>
+  <identification>
+    <creator type="composer">Henry Ives</creator>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>6.99912</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1697.36</page-height>
+      <page-width>1200.15</page-width>
+      <page-margins type="even">
+        <left-margin>85.7251</left-margin>
+        <right-margin>85.7251</right-margin>
+        <top-margin>85.7251</top-margin>
+        <bottom-margin>85.7251</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>85.7251</left-margin>
+        <right-margin>85.7251</right-margin>
+        <top-margin>85.7251</top-margin>
+        <bottom-margin>85.7251</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <word-font font-family="Edwin" font-size="10"/>
+    <lyric-font font-family="Edwin" font-size="10"/>
+    </defaults>
+  <credit page="1">
+    <credit-type>title</credit-type>
+    <credit-words default-x="600.075" default-y="1612.26" justify="center" valign="top" font-size="22">Fretboard Diagrams</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-type>subtitle</credit-type>
+    <credit-words default-x="600.075" default-y="1555.11" justify="center" valign="top" font-size="16">MuseScore testfile</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-type>composer</credit-type>
+    <credit-words default-x="1114.42" default-y="1512.26" justify="right" valign="top">Henry Ives</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <score-instrument id="P1-I1">
+        <instrument-name>Staff 1</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="344.53">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50.00</left-margin>
+            <right-margin>0.00</right-margin>
+            </system-margins>
+          <top-system-distance>189.55</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>2</divisions>
+        <key>
+          <fifths>5</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <harmony print-frame="no">
+        <root>
+          <root-step>B</root-step>
+          </root>
+        <kind text="maj7">major-seventh</kind>
+        <frame>
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+          <frame-note>
+            <string>5</string>
+            <fret>2</fret>
+            <barre type="start"/>
+            </frame-note>
+          <frame-note>
+            <string>4</string>
+            <fret>4</fret>
+            </frame-note>
+          <frame-note>
+            <string>3</string>
+            <fret>3</fret>
+            </frame-note>
+          <frame-note>
+            <string>2</string>
+            <fret>4</fret>
+            </frame-note>
+          <frame-note>
+            <string>1</string>
+            <fret>2</fret>
+            <barre type="stop"/>
+            </frame-note>
+          </frame>
+        </harmony>
+      <note default-x="133.48" default-y="-10.00">
+        <pitch>
+          <step>D</step>
+          <alter>1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <harmony print-frame="no">
+        <root>
+          <root-step>D</root-step>
+          </root>
+        <kind text="7">dominant</kind>
+        <frame>
+          <frame-strings>6</frame-strings>
+          <frame-frets>3</frame-frets>
+          <first-fret>3</first-fret>
+          <frame-note>
+            <string>5</string>
+            <fret>5</fret>
+            </frame-note>
+          <frame-note>
+            <string>4</string>
+            <fret>4</fret>
+            </frame-note>
+          <frame-note>
+            <string>3</string>
+            <fret>5</fret>
+            </frame-note>
+          <frame-note>
+            <string>2</string>
+            <fret>3</fret>
+            </frame-note>
+          <frame-note>
+            <string>1</string>
+            <fret>0</fret>
+            </frame-note>
+          </frame>
+        </harmony>
+      <note default-x="185.79" default-y="-10.00">
+        <pitch>
+          <step>D</step>
+          <alter>1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <harmony print-frame="no">
+        <root>
+          <root-step>G</root-step>
+          </root>
+        <kind text="maj7">major-seventh</kind>
+        <frame>
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+          <frame-note>
+            <string>6</string>
+            <fret>3</fret>
+            </frame-note>
+          <frame-note>
+            <string>4</string>
+            <fret>4</fret>
+            </frame-note>
+          <frame-note>
+            <string>3</string>
+            <fret>4</fret>
+            </frame-note>
+          <frame-note>
+            <string>2</string>
+            <fret>3</fret>
+            </frame-note>
+          <frame-note>
+            <string>1</string>
+            <fret>0</fret>
+            </frame-note>
+          </frame>
+        </harmony>
+      <note default-x="238.10" default-y="-10.00">
+        <pitch>
+          <step>D</step>
+          <alter>1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <tie type="start"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <tied type="start"/>
+          </notations>
+        </note>
+      <harmony print-frame="no">
+        <root>
+          <root-step>B</root-step>
+          <root-alter>-1</root-alter>
+          </root>
+        <kind text="7">dominant</kind>
+        <frame>
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+          <frame-note>
+            <string>5</string>
+            <fret>1</fret>
+            <barre type="start"/>
+            </frame-note>
+          <frame-note>
+            <string>4</string>
+            <fret>3</fret>
+            </frame-note>
+          <frame-note>
+            <string>2</string>
+            <fret>3</fret>
+            </frame-note>
+          <frame-note>
+            <string>1</string>
+            <fret>1</fret>
+            <barre type="stop"/>
+            </frame-note>
+          </frame>
+        </harmony>
+      <note default-x="290.42" default-y="-10.00">
+        <pitch>
+          <step>D</step>
+          <alter>1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <tie type="stop"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <tied type="stop"/>
+          </notations>
+        </note>
+      </measure>
+    <measure number="2" width="224.05">
+      <harmony print-frame="no">
+        <root>
+          <root-step>E</root-step>
+          <root-alter>-1</root-alter>
+          </root>
+        <kind text="maj7">major-seventh</kind>
+        <frame>
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+          <frame-note>
+            <string>4</string>
+            <fret>1</fret>
+            </frame-note>
+          <frame-note>
+            <string>3</string>
+            <fret>3</fret>
+            <barre type="start"/>
+            </frame-note>
+          <frame-note>
+            <string>1</string>
+            <fret>3</fret>
+            <barre type="stop"/>
+            </frame-note>
+          </frame>
+        </harmony>
+      <note default-x="13.00" default-y="-10.00">
+        <pitch>
+          <step>D</step>
+          <alter>1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="65.31" default-y="-10.00">
+        <pitch>
+          <step>D</step>
+          <alter>1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <harmony print-frame="no">
+        <root>
+          <root-step>A</root-step>
+          </root>
+        <kind text="m7">minor-seventh</kind>
+        <frame>
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+          <first-fret>5</first-fret>
+          <frame-note>
+            <string>6</string>
+            <fret>5</fret>
+            </frame-note>
+          <frame-note>
+            <string>4</string>
+            <fret>5</fret>
+            </frame-note>
+          <frame-note>
+            <string>3</string>
+            <fret>5</fret>
+            </frame-note>
+          <frame-note>
+            <string>2</string>
+            <fret>5</fret>
+            </frame-note>
+          <frame-note>
+            <string>1</string>
+            <fret>0</fret>
+            </frame-note>
+          </frame>
+        </harmony>
+      <note default-x="117.62" default-y="-10.00">
+        <pitch>
+          <step>D</step>
+          <alter>1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <tie type="start"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <tied type="start"/>
+          </notations>
+        </note>
+      <harmony print-frame="no">
+        <root>
+          <root-step>D</root-step>
+          </root>
+        <kind text="7">dominant</kind>
+        <frame>
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+          <first-fret>3</first-fret>
+          <frame-note>
+            <string>5</string>
+            <fret>5</fret>
+            </frame-note>
+          <frame-note>
+            <string>4</string>
+            <fret>4</fret>
+            </frame-note>
+          <frame-note>
+            <string>3</string>
+            <fret>5</fret>
+            </frame-note>
+          <frame-note>
+            <string>2</string>
+            <fret>3</fret>
+            </frame-note>
+          <frame-note>
+            <string>1</string>
+            <fret>0</fret>
+            </frame-note>
+          </frame>
+        </harmony>
+      <note default-x="169.93" default-y="-10.00">
+        <pitch>
+          <step>D</step>
+          <alter>1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <tie type="stop"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <tied type="stop"/>
+          </notations>
+        </note>
+      </measure>
+    <measure number="3" width="233.76">
+      <harmony print-frame="no">
+        <root>
+          <root-step>G</root-step>
+          </root>
+        <kind text="maj7">major-seventh</kind>
+        <frame>
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+          <frame-note>
+            <string>6</string>
+            <fret>3</fret>
+            </frame-note>
+          <frame-note>
+            <string>4</string>
+            <fret>4</fret>
+            </frame-note>
+          <frame-note>
+            <string>3</string>
+            <fret>4</fret>
+            </frame-note>
+          <frame-note>
+            <string>2</string>
+            <fret>3</fret>
+            </frame-note>
+          <frame-note>
+            <string>1</string>
+            <fret>0</fret>
+            </frame-note>
+          </frame>
+        </harmony>
+      <note default-x="13.00" default-y="-10.00">
+        <pitch>
+          <step>D</step>
+          <alter>1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <harmony print-frame="no">
+        <root>
+          <root-step>B</root-step>
+          <root-alter>-1</root-alter>
+          </root>
+        <kind text="7">dominant</kind>
+        <frame>
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+          <frame-note>
+            <string>5</string>
+            <fret>1</fret>
+            <barre type="start"/>
+            </frame-note>
+          <frame-note>
+            <string>4</string>
+            <fret>3</fret>
+            </frame-note>
+          <frame-note>
+            <string>2</string>
+            <fret>3</fret>
+            </frame-note>
+          <frame-note>
+            <string>1</string>
+            <fret>1</fret>
+            <barre type="stop"/>
+            </frame-note>
+          </frame>
+        </harmony>
+      <note default-x="69.96" default-y="0.00">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <harmony print-frame="no">
+        <root>
+          <root-step>E</root-step>
+          <root-alter>-1</root-alter>
+          </root>
+        <kind text="maj7">major-seventh</kind>
+        <frame>
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+          <frame-note>
+            <string>4</string>
+            <fret>1</fret>
+            </frame-note>
+          <frame-note>
+            <string>3</string>
+            <fret>3</fret>
+            <barre type="start"/>
+            </frame-note>
+          <frame-note>
+            <string>2</string>
+            <fret>3</fret>
+            <barre type="stop"/>
+            </frame-note>
+          </frame>
+        </harmony>
+      <note default-x="126.91" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <dot/>
+        <stem>down</stem>
+        </note>
+      <harmony print-frame="no">
+        <root>
+          <root-step>F</root-step>
+          <root-alter>1</root-alter>
+          </root>
+        <kind text="7">dominant</kind>
+        <frame>
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+          <frame-note>
+            <string>6</string>
+            <fret>2</fret>
+            <barre type="start"/>
+            </frame-note>
+          <frame-note>
+            <string>5</string>
+            <fret>4</fret>
+            </frame-note>
+          <frame-note>
+            <string>3</string>
+            <fret>3</fret>
+            </frame-note>
+          <frame-note>
+            <string>1</string>
+            <fret>2</fret>
+            <barre type="stop"/>
+            </frame-note>
+          </frame>
+        </harmony>
+      <note default-x="196.36" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        </note>
+      </measure>
+    <measure number="4" width="176.37">
+      <harmony print-frame="no">
+        <root>
+          <root-step>B</root-step>
+          </root>
+        <kind text="maj7">major-seventh</kind>
+        <frame>
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+          <frame-note>
+            <string>5</string>
+            <fret>2</fret>
+            <barre type="start"/>
+            </frame-note>
+          <frame-note>
+            <string>4</string>
+            <fret>4</fret>
+            </frame-note>
+          <frame-note>
+            <string>3</string>
+            <fret>3</fret>
+            </frame-note>
+          <frame-note>
+            <string>2</string>
+            <fret>4</fret>
+            </frame-note>
+          <frame-note>
+            <string>1</string>
+            <fret>2</fret>
+            <barre type="stop"/>
+            </frame-note>
+          </frame>
+        </harmony>
+      <note default-x="13.96" default-y="-10.00">
+        <pitch>
+          <step>D</step>
+          <alter>1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>8</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      </measure>
+    </part>
+  </score-partwise>

--- a/mtest/musicxml/io/testFretboardDiagrams_ref.mscx
+++ b/mtest/musicxml/io/testFretboardDiagrams_ref.mscx
@@ -1,0 +1,754 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.02">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.26771</pageWidth>
+      <pageHeight>11.6929</pageHeight>
+      <pagePrintableWidth>7.08661</pagePrintableWidth>
+      <pageEvenLeftMargin>0.590551</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.590551</pageOddLeftMargin>
+      <pageEvenTopMargin>0.590551</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
+      <pageOddTopMargin>0.590551</pageOddTopMargin>
+      <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <chordSymbolAFontSize>10</chordSymbolAFontSize>
+      <chordSymbolBFontSize>10</chordSymbolBFontSize>
+      <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
+      <tupletFontSize>10</tupletFontSize>
+      <fingeringFontSize>10</fingeringFontSize>
+      <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
+      <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
+      <stringNumberFontSize>10</stringNumberFontSize>
+      <partInstrumentFontSize>10</partInstrumentFontSize>
+      <dynamicsFontSize>10</dynamicsFontSize>
+      <tempoFontSize>10</tempoFontSize>
+      <metronomeFontSize>10</metronomeFontSize>
+      <measureNumberFontSize>10</measureNumberFontSize>
+      <mmRestRangeFontSize>10</mmRestRangeFontSize>
+      <rehearsalMarkFontSize>10</rehearsalMarkFontSize>
+      <repeatLeftFontSize>10</repeatLeftFontSize>
+      <repeatRightFontSize>10</repeatRightFontSize>
+      <glissandoFontSize>10</glissandoFontSize>
+      <bendFontSize>10</bendFontSize>
+      <headerFontSize>10</headerFontSize>
+      <footerFontSize>10</footerFontSize>
+      <Spatium>1.74978</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer">Henry Ives</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber">MuseScore testfile</metaTag>
+    <metaTag name="movementTitle">Fretboard Diagrams</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber">MuseScore testfile</metaTag>
+    <metaTag name="workTitle">Fretboard Diagrams</metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument id="piano">
+        <longName>Piano</longName>
+        <trackName>Staff 1</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <singleNoteDynamics>0</singleNoteDynamics>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <controller ctrl="10" value="63"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>12.5</height>
+        <Text>
+          <style>Title</style>
+          <offset x="0" y="-0.0454943"/>
+          <text><font size="22"/>Fretboard Diagrams</text>
+          </Text>
+        <Text>
+          <style>Subtitle</style>
+          <offset x="0" y="9.9545"/>
+          <text><font size="16"/>MuseScore testfile</text>
+          </Text>
+        <Text>
+          <style>Composer</style>
+          <align>right,top</align>
+          <offset x="0" y="17.4523"/>
+          <text>Henry Ives</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            </Clef>
+          <KeySig>
+            <accidental>5</accidental>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <FretDiagram>
+            <frets>4</frets>
+            <Harmony>
+              <root>19</root>
+              <name>maj7</name>
+              <align>center,top</align>
+              </Harmony>
+            <fretDiagram>
+              <string no="0">
+                <marker>cross</marker>
+                </string>
+              <string no="2">
+                <dot fret="4">normal</dot>
+                </string>
+              <string no="3">
+                <dot fret="3">normal</dot>
+                </string>
+              <string no="4">
+                <dot fret="4">normal</dot>
+                </string>
+              <barre start="1" end="5">2</barre>
+              </fretDiagram>
+            <string no="0">
+              <marker>88</marker>
+              </string>
+            <string no="2">
+              <dot>4</dot>
+              </string>
+            <string no="3">
+              <dot>3</dot>
+              </string>
+            <string no="4">
+              <dot>4</dot>
+              </string>
+            </FretDiagram>
+          <Chord>
+            <durationType>quarter</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <pitch>75</pitch>
+              <tpc>23</tpc>
+              </Note>
+            </Chord>
+          <FretDiagram>
+            <fretOffset>2</fretOffset>
+            <frets>3</frets>
+            <Harmony>
+              <root>16</root>
+              <name>7</name>
+              <align>center,top</align>
+              </Harmony>
+            <fretDiagram>
+              <string no="0">
+                <marker>cross</marker>
+                </string>
+              <string no="1">
+                <dot fret="3">normal</dot>
+                </string>
+              <string no="2">
+                <dot fret="2">normal</dot>
+                </string>
+              <string no="3">
+                <dot fret="3">normal</dot>
+                </string>
+              <string no="4">
+                <dot fret="1">normal</dot>
+                </string>
+              <string no="5">
+                <marker>circle</marker>
+                </string>
+              </fretDiagram>
+            <string no="0">
+              <marker>88</marker>
+              </string>
+            <string no="1">
+              <dot>3</dot>
+              </string>
+            <string no="2">
+              <dot>2</dot>
+              </string>
+            <string no="3">
+              <dot>3</dot>
+              </string>
+            <string no="4">
+              <dot>1</dot>
+              </string>
+            <string no="5">
+              <marker>79</marker>
+              </string>
+            </FretDiagram>
+          <Chord>
+            <durationType>quarter</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <pitch>75</pitch>
+              <tpc>23</tpc>
+              </Note>
+            </Chord>
+          <FretDiagram>
+            <frets>4</frets>
+            <Harmony>
+              <root>15</root>
+              <name>maj7</name>
+              <align>center,top</align>
+              </Harmony>
+            <fretDiagram>
+              <string no="0">
+                <dot fret="3">normal</dot>
+                </string>
+              <string no="1">
+                <marker>cross</marker>
+                </string>
+              <string no="2">
+                <dot fret="4">normal</dot>
+                </string>
+              <string no="3">
+                <dot fret="4">normal</dot>
+                </string>
+              <string no="4">
+                <dot fret="3">normal</dot>
+                </string>
+              <string no="5">
+                <marker>circle</marker>
+                </string>
+              </fretDiagram>
+            <string no="0">
+              <dot>3</dot>
+              </string>
+            <string no="1">
+              <marker>88</marker>
+              </string>
+            <string no="2">
+              <dot>4</dot>
+              </string>
+            <string no="3">
+              <dot>4</dot>
+              </string>
+            <string no="4">
+              <dot>3</dot>
+              </string>
+            <string no="5">
+              <marker>79</marker>
+              </string>
+            </FretDiagram>
+          <Chord>
+            <durationType>quarter</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <Spanner type="Tie">
+                <Tie>
+                  </Tie>
+                <next>
+                  <location>
+                    <fractions>1/4</fractions>
+                    </location>
+                  </next>
+                </Spanner>
+              <pitch>75</pitch>
+              <tpc>23</tpc>
+              </Note>
+            </Chord>
+          <FretDiagram>
+            <frets>4</frets>
+            <Harmony>
+              <root>12</root>
+              <name>7</name>
+              <align>center,top</align>
+              </Harmony>
+            <fretDiagram>
+              <string no="0">
+                <marker>cross</marker>
+                </string>
+              <string no="2">
+                <dot fret="3">normal</dot>
+                </string>
+              <string no="4">
+                <dot fret="3">normal</dot>
+                </string>
+              <barre start="1" end="5">1</barre>
+              </fretDiagram>
+            <string no="0">
+              <marker>88</marker>
+              </string>
+            <string no="2">
+              <dot>3</dot>
+              </string>
+            <string no="4">
+              <dot>3</dot>
+              </string>
+            </FretDiagram>
+          <Chord>
+            <durationType>quarter</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <fractions>-1/4</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
+              <pitch>75</pitch>
+              <tpc>23</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <FretDiagram>
+            <frets>4</frets>
+            <Harmony>
+              <root>11</root>
+              <name>maj7</name>
+              <align>center,top</align>
+              </Harmony>
+            <fretDiagram>
+              <string no="0">
+                <marker>cross</marker>
+                </string>
+              <string no="1">
+                <marker>cross</marker>
+                </string>
+              <string no="2">
+                <dot fret="1">normal</dot>
+                </string>
+              <barre start="3" end="5">3</barre>
+              </fretDiagram>
+            <string no="0">
+              <marker>88</marker>
+              </string>
+            <string no="1">
+              <marker>88</marker>
+              </string>
+            <string no="2">
+              <dot>1</dot>
+              </string>
+            </FretDiagram>
+          <Chord>
+            <durationType>quarter</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <pitch>75</pitch>
+              <tpc>23</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <pitch>75</pitch>
+              <tpc>23</tpc>
+              </Note>
+            </Chord>
+          <FretDiagram>
+            <fretOffset>4</fretOffset>
+            <frets>4</frets>
+            <Harmony>
+              <root>17</root>
+              <name>m7</name>
+              <align>center,top</align>
+              </Harmony>
+            <fretDiagram>
+              <string no="0">
+                <dot fret="1">normal</dot>
+                </string>
+              <string no="1">
+                <marker>cross</marker>
+                </string>
+              <string no="2">
+                <dot fret="1">normal</dot>
+                </string>
+              <string no="3">
+                <dot fret="1">normal</dot>
+                </string>
+              <string no="4">
+                <dot fret="1">normal</dot>
+                </string>
+              <string no="5">
+                <marker>circle</marker>
+                </string>
+              </fretDiagram>
+            <string no="0">
+              <dot>1</dot>
+              </string>
+            <string no="1">
+              <marker>88</marker>
+              </string>
+            <string no="2">
+              <dot>1</dot>
+              </string>
+            <string no="3">
+              <dot>1</dot>
+              </string>
+            <string no="4">
+              <dot>1</dot>
+              </string>
+            <string no="5">
+              <marker>79</marker>
+              </string>
+            </FretDiagram>
+          <Chord>
+            <durationType>quarter</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <Spanner type="Tie">
+                <Tie>
+                  </Tie>
+                <next>
+                  <location>
+                    <fractions>1/4</fractions>
+                    </location>
+                  </next>
+                </Spanner>
+              <pitch>75</pitch>
+              <tpc>23</tpc>
+              </Note>
+            </Chord>
+          <FretDiagram>
+            <fretOffset>2</fretOffset>
+            <frets>4</frets>
+            <Harmony>
+              <root>16</root>
+              <name>7</name>
+              <align>center,top</align>
+              </Harmony>
+            <fretDiagram>
+              <string no="0">
+                <marker>cross</marker>
+                </string>
+              <string no="1">
+                <dot fret="3">normal</dot>
+                </string>
+              <string no="2">
+                <dot fret="2">normal</dot>
+                </string>
+              <string no="3">
+                <dot fret="3">normal</dot>
+                </string>
+              <string no="4">
+                <dot fret="1">normal</dot>
+                </string>
+              <string no="5">
+                <marker>circle</marker>
+                </string>
+              </fretDiagram>
+            <string no="0">
+              <marker>88</marker>
+              </string>
+            <string no="1">
+              <dot>3</dot>
+              </string>
+            <string no="2">
+              <dot>2</dot>
+              </string>
+            <string no="3">
+              <dot>3</dot>
+              </string>
+            <string no="4">
+              <dot>1</dot>
+              </string>
+            <string no="5">
+              <marker>79</marker>
+              </string>
+            </FretDiagram>
+          <Chord>
+            <durationType>quarter</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <fractions>-1/4</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
+              <pitch>75</pitch>
+              <tpc>23</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <FretDiagram>
+            <frets>4</frets>
+            <Harmony>
+              <root>15</root>
+              <name>maj7</name>
+              <align>center,top</align>
+              </Harmony>
+            <fretDiagram>
+              <string no="0">
+                <dot fret="3">normal</dot>
+                </string>
+              <string no="1">
+                <marker>cross</marker>
+                </string>
+              <string no="2">
+                <dot fret="4">normal</dot>
+                </string>
+              <string no="3">
+                <dot fret="4">normal</dot>
+                </string>
+              <string no="4">
+                <dot fret="3">normal</dot>
+                </string>
+              <string no="5">
+                <marker>circle</marker>
+                </string>
+              </fretDiagram>
+            <string no="0">
+              <dot>3</dot>
+              </string>
+            <string no="1">
+              <marker>88</marker>
+              </string>
+            <string no="2">
+              <dot>4</dot>
+              </string>
+            <string no="3">
+              <dot>4</dot>
+              </string>
+            <string no="4">
+              <dot>3</dot>
+              </string>
+            <string no="5">
+              <marker>79</marker>
+              </string>
+            </FretDiagram>
+          <Chord>
+            <durationType>quarter</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <pitch>75</pitch>
+              <tpc>23</tpc>
+              </Note>
+            </Chord>
+          <FretDiagram>
+            <frets>4</frets>
+            <Harmony>
+              <root>12</root>
+              <name>7</name>
+              <align>center,top</align>
+              </Harmony>
+            <fretDiagram>
+              <string no="0">
+                <marker>cross</marker>
+                </string>
+              <string no="2">
+                <dot fret="3">normal</dot>
+                </string>
+              <string no="4">
+                <dot fret="3">normal</dot>
+                </string>
+              <barre start="1" end="5">1</barre>
+              </fretDiagram>
+            <string no="0">
+              <marker>88</marker>
+              </string>
+            <string no="2">
+              <dot>3</dot>
+              </string>
+            <string no="4">
+              <dot>3</dot>
+              </string>
+            </FretDiagram>
+          <Chord>
+            <durationType>quarter</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <pitch>78</pitch>
+              <tpc>20</tpc>
+              </Note>
+            </Chord>
+          <FretDiagram>
+            <frets>4</frets>
+            <Harmony>
+              <root>11</root>
+              <name>maj7</name>
+              <align>center,top</align>
+              </Harmony>
+            <fretDiagram>
+              <string no="0">
+                <marker>cross</marker>
+                </string>
+              <string no="1">
+                <marker>cross</marker>
+                </string>
+              <string no="2">
+                <dot fret="1">normal</dot>
+                </string>
+              <string no="5">
+                <marker>cross</marker>
+                </string>
+              <barre start="3" end="4">3</barre>
+              </fretDiagram>
+            <string no="0">
+              <marker>88</marker>
+              </string>
+            <string no="1">
+              <marker>88</marker>
+              </string>
+            <string no="2">
+              <dot>1</dot>
+              </string>
+            <string no="5">
+              <marker>88</marker>
+              </string>
+            </FretDiagram>
+          <Chord>
+            <dots>1</dots>
+            <durationType>quarter</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          <FretDiagram>
+            <frets>4</frets>
+            <Harmony>
+              <root>20</root>
+              <name>7</name>
+              <align>center,top</align>
+              </Harmony>
+            <fretDiagram>
+              <string no="1">
+                <dot fret="4">normal</dot>
+                </string>
+              <string no="3">
+                <dot fret="3">normal</dot>
+                </string>
+              <barre start="0" end="5">2</barre>
+              </fretDiagram>
+            <string no="1">
+              <dot>4</dot>
+              </string>
+            <string no="3">
+              <dot>3</dot>
+              </string>
+            </FretDiagram>
+          <Chord>
+            <BeamMode>no</BeamMode>
+            <durationType>eighth</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <pitch>73</pitch>
+              <tpc>21</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <FretDiagram>
+            <frets>4</frets>
+            <Harmony>
+              <root>19</root>
+              <name>maj7</name>
+              <align>center,top</align>
+              </Harmony>
+            <fretDiagram>
+              <string no="0">
+                <marker>cross</marker>
+                </string>
+              <string no="2">
+                <dot fret="4">normal</dot>
+                </string>
+              <string no="3">
+                <dot fret="3">normal</dot>
+                </string>
+              <string no="4">
+                <dot fret="4">normal</dot>
+                </string>
+              <barre start="1" end="5">2</barre>
+              </fretDiagram>
+            <string no="0">
+              <marker>88</marker>
+              </string>
+            <string no="2">
+              <dot>4</dot>
+              </string>
+            <string no="3">
+              <dot>3</dot>
+              </string>
+            <string no="4">
+              <dot>4</dot>
+              </string>
+            </FretDiagram>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>75</pitch>
+              <tpc>23</tpc>
+              </Note>
+            </Chord>
+          <BarLine>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/musicxml/io/tst_mxml_io.cpp
+++ b/mtest/musicxml/io/tst_mxml_io.cpp
@@ -106,6 +106,7 @@ private slots:
       void fractionMinus() { mxmlIoTestRef("testFractionMinus"); }
       void fractionPlus() { mxmlIoTestRef("testFractionPlus"); }
       void fractionTicks() { mxmlIoTestRef("testFractionTicks"); }
+      void fretboardDiagrams() { mxmlImportTestRef("testFretboardDiagrams"); }
       void grace1() { mxmlIoTest("testGrace1"); }
       void grace2() { mxmlIoTest("testGrace2"); }
       void hairpinDynamics() { mxmlMscxExportTestRef("testHairpinDynamics"); }


### PR DESCRIPTION
Resolves: [ENG-18](https://mu--se.atlassian.net/jira/software/projects/ENG/boards/21?selectedIssue=ENG-18): Fretboard diagrams need much improvement

This commit includes several bugfixes and improvements regarding
fretboard diagrams imported from MusicXML. These include:
- Implementation of the \<first-fret\> tag on import and export, handling
conversion to and from the internal fretOffset field.
- Prevention of the \<frame-frets\> from being overwritten by styling.
- A remedy to an issue where all non-"o" strings had "x" markings.
- A fix to attach Harmonies to their respective FretDiagrams (rather
than to the Segment) where applicable, fixing a horizontal alignment
issue.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://musescore.org/en/cla)
- [X] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [X] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [X] I created the test (mtest, vtest, script test) to verify the changes I made
