### PR TITLE
[MU4] Disabled notarize for MacOS on CI

### DIFF
--- a/.github/workflows/ci_macos_mu4.yml
+++ b/.github/workflows/ci_macos_mu4.yml
@@ -95,6 +95,9 @@ jobs:
           DO_UPLOAD_SYMBOLS='false'
           DO_PUBLISH='false'
         fi
+
+        # Temporary off, until the problem with the Apple account, is resolved
+        DO_NOTARIZE='false'
         
         echo "github.repository: ${{ github.repository }}"
         echo "BUILD_MODE=$BUILD_MODE" >> $GITHUB_ENV


### PR DESCRIPTION
Temporary off, until the problem with the Apple account, is resolved