### PR TITLE
[MU4] Accessibility concept implementation  

### DIFF
--- a/src/appshell/appshell.qrc
+++ b/src/appshell/appshell.qrc
@@ -84,5 +84,6 @@
         <file>qml/kdab/MainMacOS.qml</file>
         <file>qml/kdab/WindowContent.qml</file>
         <file>qml/kdab/AppMenuBar.qml</file>
+        <file>qml/DevTools/Accessibility/AccessibilityTest.qml</file>
     </qresource>
 </RCC>

--- a/src/appshell/qml/DevTools/Accessibility/AccessibilityTest.qml
+++ b/src/appshell/qml/DevTools/Accessibility/AccessibilityTest.qml
@@ -1,0 +1,67 @@
+import QtQuick 2.15
+
+import MuseScore.UiComponents 1.0
+
+Rectangle {
+    id: root
+
+    Row {
+        anchors.fill: parent
+        anchors.margins: 16
+        spacing: 8
+
+        Rectangle {
+            id: item1
+
+            width: 32
+            height: 32
+            color: "#eeeeee"
+
+            Accessible.role: Accessible.Button
+            Accessible.name: "Item 1"
+            Accessible.onPressAction: {
+                // do a button click
+            }
+
+
+            StyledTextLabel {
+                anchors.fill: parent
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                text: "Item 1"
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                onClicked: parent.forceActiveFocus()
+            }
+        }
+
+        Rectangle {
+            id: item2
+
+            width: 32
+            height: 32
+            color: "#eeeeee"
+
+            Accessible.role: Accessible.Button
+            Accessible.name: "Item 2"
+            Accessible.onPressAction: {
+                // do a button click
+            }
+
+
+            StyledTextLabel {
+                anchors.fill: parent
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                text: "Item 2"
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                onClicked: parent.forceActiveFocus()
+            }
+        }
+    }
+}

--- a/src/appshell/qml/DevTools/DevToolsPage.qml
+++ b/src/appshell/qml/DevTools/DevToolsPage.qml
@@ -34,6 +34,7 @@ import "./NotationDialogs"
 import "./Telemetry"
 import "./VST"
 import "./KeyNav"
+import "./Accessibility"
 
 DockPage {
     id: homePage
@@ -71,7 +72,8 @@ DockPage {
                         { "name": "vst", "title": "VST" },
                         { "name": "plugins", "title": "Plugins" },
                         { "name": "autobot", "title": "Autobot" },
-                        { "name": "navigation", "title": "KeyNav" }
+                        { "name": "navigation", "title": "KeyNav" },
+                        { "name": "accessibility", "title": "Accessibility" }
                     ]
 
                     onSelected: {
@@ -103,7 +105,10 @@ DockPage {
             case "plugins": currentComp = pluginsComp; break
             case "autobot": currentComp = autobotComp; break
             case "navigation": currentComp = keynavComp; break
+            case "accessibility": currentComp = accessibilityComp; break
             }
+
+            devtoolsCentral.forceActiveFocus()
         }
 
         Rectangle {
@@ -183,6 +188,14 @@ DockPage {
             onActiveFocusRequested: {
                 devtoolsCentral.forceActiveFocus()
             }
+        }
+    }
+
+    Component {
+        id: accessibilityComp
+
+        AccessibilityTest {
+
         }
     }
 

--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -23,6 +23,7 @@ add_subdirectory(ui)
 add_subdirectory(uicomponents)
 add_subdirectory(fonts)
 add_subdirectory(actions)
+add_subdirectory(accessibility)
 
 if (BUILD_SHORTCUTS_MODULE)
     add_subdirectory(shortcuts)

--- a/src/framework/accessibility/CMakeLists.txt
+++ b/src/framework/accessibility/CMakeLists.txt
@@ -25,6 +25,17 @@ set(MODULE_QML_IMPORT ${CMAKE_CURRENT_LIST_DIR}/qml)
 set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/accessibilitymodule.cpp
     ${CMAKE_CURRENT_LIST_DIR}/accessibilitymodule.h
+    ${CMAKE_CURRENT_LIST_DIR}/iaccessibility.h
+    ${CMAKE_CURRENT_LIST_DIR}/iaccessibilitycontroller.h
+
+    ${CMAKE_CURRENT_LIST_DIR}/internal/accessibilitycontroller.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/accessibilitycontroller.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/accessibleobject.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/accessibleobject.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/accessiblecontrollerinterface.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/accessiblecontrollerinterface.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/accessibleiteminterface.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/accessibleiteminterface.h
     )
 
 include(${PROJECT_SOURCE_DIR}/build/module.cmake)

--- a/src/framework/accessibility/CMakeLists.txt
+++ b/src/framework/accessibility/CMakeLists.txt
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-3.0-only
+# MuseScore-CLA-applies
+#
+# MuseScore
+# Music Composition & Notation
+#
+# Copyright (C) 2021 MuseScore BVBA and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+set(MODULE accessibility)
+
+set(MODULE_QML_IMPORT ${CMAKE_CURRENT_LIST_DIR}/qml)
+
+set(MODULE_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/accessibilitymodule.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/accessibilitymodule.h
+    )
+
+include(${PROJECT_SOURCE_DIR}/build/module.cmake)

--- a/src/framework/accessibility/accessibilitymodule.cpp
+++ b/src/framework/accessibility/accessibilitymodule.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-License-Identifier: GPL-3.0-only
  * MuseScore-CLA-applies
  *
@@ -22,34 +22,20 @@
 #include "accessibilitymodule.h"
 
 #include <QtQml>
-#include <QAccessible>
 
 #include "modularity/ioc.h"
 #include "log.h"
 
+#include "internal/accessibilitycontroller.h"
+
 using namespace mu::accessibility;
 using namespace mu::framework;
+
+static std::shared_ptr<AccessibilityController> s_accessibilityController = std::make_shared<AccessibilityController>();
 
 static void accessibility_init_qrc()
 {
     //Q_INIT_RESOURCE(accessibility);
-}
-
-static QAccessibleInterface* muAccessibleFactory(const QString& classname, QObject* object)
-{
-    LOGI() << "classname: " << classname;
-//    if (classname == QLatin1String("QQuickWindow")) {
-//        return new QAccessibleQuickWindow(qobject_cast<QQuickWindow*>(object));
-//    } else if (classname == QLatin1String("QQuickItem")) {
-//        QQuickItem* item = qobject_cast<QQuickItem*>(object);
-//        Q_ASSERT(item);
-//        QQuickItemPrivate* itemPrivate = QQuickItemPrivate::get(item);
-//        if (!itemPrivate->isAccessible) {
-//            return nullptr;
-//        }
-//        return new QAccessibleQuickItem(item);
-//    }
-    return nullptr;
 }
 
 std::string AccessibilityModule::moduleName() const
@@ -59,6 +45,7 @@ std::string AccessibilityModule::moduleName() const
 
 void AccessibilityModule::registerExports()
 {
+    ioc()->registerExport<IAccessibilityController>(moduleName(), s_accessibilityController);
 }
 
 void AccessibilityModule::resolveImports()
@@ -74,11 +61,11 @@ void AccessibilityModule::registerUiTypes()
 {
 }
 
-void AccessibilityModule::onInit(const IApplication::RunMode&)
+void AccessibilityModule::onInit(const framework::IApplication::RunMode& mode)
 {
-    QAccessible::installFactory(muAccessibleFactory);
-}
+    if (mode != framework::IApplication::RunMode::Editor) {
+        return;
+    }
 
-void AccessibilityModule::onDeinit()
-{
+    s_accessibilityController->init();
 }

--- a/src/framework/accessibility/accessibilitymodule.cpp
+++ b/src/framework/accessibility/accessibilitymodule.cpp
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "accessibilitymodule.h"
+
+#include <QtQml>
+#include <QAccessible>
+
+#include "modularity/ioc.h"
+#include "log.h"
+
+using namespace mu::accessibility;
+using namespace mu::framework;
+
+static void accessibility_init_qrc()
+{
+    //Q_INIT_RESOURCE(accessibility);
+}
+
+static QAccessibleInterface* muAccessibleFactory(const QString& classname, QObject* object)
+{
+    LOGI() << "classname: " << classname;
+//    if (classname == QLatin1String("QQuickWindow")) {
+//        return new QAccessibleQuickWindow(qobject_cast<QQuickWindow*>(object));
+//    } else if (classname == QLatin1String("QQuickItem")) {
+//        QQuickItem* item = qobject_cast<QQuickItem*>(object);
+//        Q_ASSERT(item);
+//        QQuickItemPrivate* itemPrivate = QQuickItemPrivate::get(item);
+//        if (!itemPrivate->isAccessible) {
+//            return nullptr;
+//        }
+//        return new QAccessibleQuickItem(item);
+//    }
+    return nullptr;
+}
+
+std::string AccessibilityModule::moduleName() const
+{
+    return "accessibility";
+}
+
+void AccessibilityModule::registerExports()
+{
+}
+
+void AccessibilityModule::resolveImports()
+{
+}
+
+void AccessibilityModule::registerResources()
+{
+    accessibility_init_qrc();
+}
+
+void AccessibilityModule::registerUiTypes()
+{
+}
+
+void AccessibilityModule::onInit(const IApplication::RunMode&)
+{
+    QAccessible::installFactory(muAccessibleFactory);
+}
+
+void AccessibilityModule::onDeinit()
+{
+}

--- a/src/framework/accessibility/accessibilitymodule.h
+++ b/src/framework/accessibility/accessibilitymodule.h
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_ACCESSIBILITY_ACCESSIBILITYMODULE_H
+#define MU_ACCESSIBILITY_ACCESSIBILITYMODULE_H
+
+#include "framework/global/modularity/imodulesetup.h"
+
+namespace mu::accessibility {
+class AccessibilityModule : public framework::IModuleSetup
+{
+public:
+    std::string moduleName() const override;
+
+    void registerExports() override;
+    void resolveImports() override;
+    void registerResources() override;
+    void registerUiTypes() override;
+    void onInit(const framework::IApplication::RunMode& mode) override;
+    void onDeinit() override;
+};
+}
+
+#endif // MU_ACCESSIBILITY_ACCESSIBILITYMODULE_H

--- a/src/framework/accessibility/iaccessibility.h
+++ b/src/framework/accessibility/iaccessibility.h
@@ -19,24 +19,32 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+#ifndef MU_ACCESSIBILITY_IACCESSIBILITY_H
+#define MU_ACCESSIBILITY_IACCESSIBILITY_H
 
-#ifndef MU_ACCESSIBILITY_ACCESSIBILITYMODULE_H
-#define MU_ACCESSIBILITY_ACCESSIBILITYMODULE_H
-
-#include "framework/global/modularity/imodulesetup.h"
+#include <QString>
 
 namespace mu::accessibility {
-class AccessibilityModule : public framework::IModuleSetup
+class IAccessibility
 {
 public:
-    std::string moduleName() const override;
+    enum class Role {
+        NoRole = 0,
+        Panel,
+        Button
+    };
 
-    void registerExports() override;
-    void resolveImports() override;
-    void registerResources() override;
-    void registerUiTypes() override;
-    void onInit(const framework::IApplication::RunMode& mode) override;
+    enum class State {
+        Undefined = 0,
+        Disabled,
+        Active,
+        Focused
+    };
+
+    virtual Role accessibleRole() const = 0;
+    virtual QString accessibleName() const = 0;
+    virtual bool accessibleState(State st) const = 0;
 };
 }
 
-#endif // MU_ACCESSIBILITY_ACCESSIBILITYMODULE_H
+#endif // MU_ACCESSIBILITY_IACCESSIBILITY_H

--- a/src/framework/accessibility/iaccessibilitycontroller.h
+++ b/src/framework/accessibility/iaccessibilitycontroller.h
@@ -20,23 +20,24 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MU_ACCESSIBILITY_ACCESSIBILITYMODULE_H
-#define MU_ACCESSIBILITY_ACCESSIBILITYMODULE_H
+#ifndef MU_ACCESSIBILITY_IACCESSIBILITYCONTROLLER_H
+#define MU_ACCESSIBILITY_IACCESSIBILITYCONTROLLER_H
 
-#include "framework/global/modularity/imodulesetup.h"
+#include "modularity/imoduleexport.h"
+#include "iaccessibility.h"
 
 namespace mu::accessibility {
-class AccessibilityModule : public framework::IModuleSetup
+class IAccessibilityController : MODULE_EXPORT_INTERFACE
 {
+    INTERFACE_ID(IAccessibilityController)
 public:
-    std::string moduleName() const override;
+    virtual ~IAccessibilityController() = default;
 
-    void registerExports() override;
-    void resolveImports() override;
-    void registerResources() override;
-    void registerUiTypes() override;
-    void onInit(const framework::IApplication::RunMode& mode) override;
+    virtual void created(IAccessibility* parent, IAccessibility* item) = 0;
+    virtual void destroyed(IAccessibility* item) = 0;
+    virtual void actived(IAccessibility* item, bool isActive) = 0;
+    virtual void focused(IAccessibility* item) = 0;
 };
 }
 
-#endif // MU_ACCESSIBILITY_ACCESSIBILITYMODULE_H
+#endif // MU_ACCESSIBILITY_IACCESSIBILITYCONTROLLER_H

--- a/src/framework/accessibility/internal/accessibilitycontroller.cpp
+++ b/src/framework/accessibility/internal/accessibilitycontroller.cpp
@@ -1,0 +1,205 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "accessibilitycontroller.h"
+
+#include <QGuiApplication>
+#include <QAccessible>
+
+#include "accessibleobject.h"
+#include "accessiblecontrollerinterface.h"
+#include "accessibleiteminterface.h"
+
+#include "async/async.h"
+#include "log.h"
+
+using namespace mu::accessibility;
+
+AccessibilityController::~AccessibilityController()
+{
+}
+
+static QAccessibleInterface* muAccessibleFactory(const QString& classname, QObject* object)
+{
+    if (classname == QLatin1String("mu::accessibility::AccessibleObject")) {
+        return static_cast<QAccessibleInterface*>(new AccessibleItemInterface(object));
+    }
+
+    if (classname == QLatin1String("mu::accessibility::AccessibilityController")) {
+        return static_cast<QAccessibleInterface*>(new AccessibleControllerInterface(object));
+    }
+
+    return nullptr;
+}
+
+static void updateHandlerNoop(QAccessibleEvent*)
+{
+}
+
+void AccessibilityController::init()
+{
+    setObjectName("AccessibilityController");
+
+    QAccessible::installFactory(muAccessibleFactory);
+
+    QAccessible::setRootObject(this);
+    QAccessible::installRootObjectHandler([](QObject*) {});
+
+    //! NOTE Disabled any events from Qt
+    QAccessible::installUpdateHandler(updateHandlerNoop);
+}
+
+void AccessibilityController::created(IAccessibility* parent, IAccessibility* item)
+{
+    //! TODO Not working yet
+    parent = nullptr;
+
+    QObject* prnObj = nullptr;
+    if (parent) {
+        prnObj = findItem(parent).object;
+    } else {
+        prnObj = this;
+    }
+
+    Item it;
+    it.parent = parent;
+    it.item = item;
+    it.object = new AccessibleObject(item, prnObj);
+    it.object->setController(shared_from_this());
+    it.iface = QAccessible::queryAccessibleInterface(it.object);
+
+    m_items.append(it);
+
+    LOGI() << "parent: " << (parent ? parent->accessibleName() : "") << ", item: " << item->accessibleName();
+
+    QAccessibleEvent ev(it.object, QAccessible::ObjectCreated);
+    sendEvent(&ev);
+}
+
+void AccessibilityController::destroyed(IAccessibility* aitem)
+{
+    LOGI() << aitem->accessibleName();
+    int idx = indexBy(aitem);
+    IF_ASSERT_FAILED(idx >= 0) {
+        return;
+    }
+    Item item = m_items.takeAt(idx);
+    QAccessibleEvent ev(item.object, QAccessible::ObjectDestroyed);
+    sendEvent(&ev);
+
+    delete item.object;
+}
+
+void AccessibilityController::actived(IAccessibility* aitem, bool isActive)
+{
+    LOGI() << aitem->accessibleName() << " " << isActive;
+    const Item& item = findItem(aitem);
+    IF_ASSERT_FAILED(item.isValid()) {
+        return;
+    }
+
+    QAccessible::State state;
+    state.active = isActive;
+    QAccessibleStateChangeEvent ev(item.object, state);
+    sendEvent(&ev);
+}
+
+void AccessibilityController::focused(IAccessibility* aitem)
+{
+    LOGI() << aitem->accessibleName();
+    const Item& item = findItem(aitem);
+    IF_ASSERT_FAILED(item.isValid()) {
+        return;
+    }
+
+    QAccessibleEvent ev(item.object, QAccessible::Focus);
+    sendEvent(&ev);
+}
+
+void AccessibilityController::sendEvent(QAccessibleEvent* ev)
+{
+    QAccessible::installUpdateHandler(0);
+    QAccessible::updateAccessibility(ev);
+    //! NOTE Disabled any events from Qt
+    QAccessible::installUpdateHandler(updateHandlerNoop);
+}
+
+const AccessibilityController::Item& AccessibilityController::findItem(IAccessibility* aitem) const
+{
+    for (int i = 0; i < m_items.count(); ++i) {
+        if (m_items.at(i).item == aitem) {
+            return m_items.at(i);
+        }
+    }
+
+    static AccessibilityController::Item null;
+    return null;
+}
+
+int AccessibilityController::indexBy(IAccessibility* aitem) const
+{
+    for (int i = 0; i < m_items.count(); ++i) {
+        if (m_items.at(i).item == aitem) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+int AccessibilityController::childCount(const IAccessibility* aitem) const
+{
+    int count = 0;
+    for (const Item& item: m_items) {
+        if (item.parent == aitem) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+QAccessibleInterface* AccessibilityController::child(const IAccessibility* aitem, int i) const
+{
+    int idx = -1;
+    for (const Item& item: m_items) {
+        if (item.parent == aitem) {
+            ++idx;
+            if (idx == i) {
+                return item.iface;
+            }
+        }
+    }
+    return nullptr;
+}
+
+int AccessibilityController::indexOfChild(const IAccessibility* aitem, const QAccessibleInterface* iface) const
+{
+    int idx = -1;
+    for (const Item& item: m_items) {
+        if (item.parent == aitem) {
+            ++idx;
+            if (item.iface == iface) {
+                return idx;
+            }
+        }
+    }
+
+    return -1;
+}

--- a/src/framework/accessibility/internal/accessibilitycontroller.h
+++ b/src/framework/accessibility/internal/accessibilitycontroller.h
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_ACCESSIBILITY_ACCESSIBILITYCONTROLLER_H
+#define MU_ACCESSIBILITY_ACCESSIBILITYCONTROLLER_H
+
+#include <memory>
+#include <QObject>
+#include <QList>
+
+#include "../iaccessibilitycontroller.h"
+#include "accessibleobject.h"
+
+class QAccessibleInterface;
+class QAccessibleEvent;
+
+namespace mu::accessibility {
+class AccessibilityController : public QObject, public IAccessibilityController,
+    public std::enable_shared_from_this<AccessibilityController>
+{
+    Q_OBJECT
+public:
+    AccessibilityController() = default;
+    ~AccessibilityController();
+
+    void init();
+
+    void created(IAccessibility* parent, IAccessibility* item) override;
+    void destroyed(IAccessibility* item) override;
+    void actived(IAccessibility* item, bool isActive) override;
+    void focused(IAccessibility* item) override;
+
+    int childCount(const IAccessibility* item) const;
+    QAccessibleInterface* child(const IAccessibility* item, int i) const;
+    int indexOfChild(const IAccessibility* item, const QAccessibleInterface* iface) const;
+
+private:
+
+    struct Item
+    {
+        IAccessibility* parent = nullptr;
+        IAccessibility* item = nullptr;
+        AccessibleObject* object = nullptr;
+        QAccessibleInterface* iface = nullptr;
+
+        bool isValid() const { return item != nullptr; }
+    };
+
+    const Item& findItem(IAccessibility* aitem) const;
+    int indexBy(IAccessibility* aitem) const;
+
+    void sendEvent(QAccessibleEvent* ev);
+
+    QList<Item> m_items;
+};
+}
+
+#endif // MU_ACCESSIBILITY_ACCESSIBILITYCONTROLLER_H

--- a/src/framework/accessibility/internal/accessiblecontrollerinterface.cpp
+++ b/src/framework/accessibility/internal/accessiblecontrollerinterface.cpp
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "accessiblecontrollerinterface.h"
+
+#include "accessibilitycontroller.h"
+
+#include "log.h"
+
+using namespace mu::accessibility;
+
+AccessibleControllerInterface::AccessibleControllerInterface(QObject* o)
+{
+    m_controller = qobject_cast<AccessibilityController*>(o);
+}
+
+bool AccessibleControllerInterface::isValid() const
+{
+    return m_controller != nullptr;
+}
+
+QObject* AccessibleControllerInterface::object() const
+{
+    return m_controller;
+}
+
+QWindow* AccessibleControllerInterface::window() const
+{
+    return nullptr;
+}
+
+QRect AccessibleControllerInterface::rect() const
+{
+    return QRect();
+}
+
+QAccessibleInterface* AccessibleControllerInterface::parent() const
+{
+    return nullptr;
+}
+
+int AccessibleControllerInterface::childCount() const
+{
+    return m_controller->childCount(nullptr);
+}
+
+QAccessibleInterface* AccessibleControllerInterface::child(int i) const
+{
+    return m_controller->child(nullptr, i);
+}
+
+QAccessibleInterface* AccessibleControllerInterface::childAt(int, int) const
+{
+    NOT_IMPLEMENTED;
+    return nullptr;
+}
+
+int AccessibleControllerInterface::indexOfChild(const QAccessibleInterface* iface) const
+{
+    return m_controller->indexOfChild(nullptr, iface);
+}
+
+QAccessible::Role AccessibleControllerInterface::role() const
+{
+    return QAccessible::Application;
+}
+
+QAccessible::State AccessibleControllerInterface::state() const
+{
+    QAccessible::State state;
+    state.active = 1;
+    return state;
+}
+
+QString AccessibleControllerInterface::text(QAccessible::Text) const
+{
+    return QString();
+}
+
+void AccessibleControllerInterface::setText(QAccessible::Text, const QString&)
+{
+    NOT_IMPLEMENTED;
+}

--- a/src/framework/accessibility/internal/accessiblecontrollerinterface.h
+++ b/src/framework/accessibility/internal/accessiblecontrollerinterface.h
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef CONTROLLERACCESSIBLEINTERFACE_H
+#define CONTROLLERACCESSIBLEINTERFACE_H
+
+#include <QAccessibleInterface>
+
+namespace mu::accessibility {
+class AccessibilityController;
+class AccessibleControllerInterface : public QAccessibleInterface
+{
+public:
+    AccessibleControllerInterface(QObject* o);
+
+    bool isValid() const override;
+    QObject* object() const override;
+    QWindow* window() const override;
+    QRect rect() const override;
+
+    QAccessibleInterface* parent() const override;
+    int childCount() const override;
+    QAccessibleInterface* child(int i) const override;
+    QAccessibleInterface* childAt(int x, int y) const override;
+    int indexOfChild(const QAccessibleInterface* iface) const override;
+
+    QAccessible::Role role() const override;
+    QAccessible::State state() const override;
+
+    QString text(QAccessible::Text) const override;
+    void setText(QAccessible::Text t, const QString& text) override;
+
+private:
+
+    AccessibilityController* m_controller = nullptr;
+};
+}
+
+#endif // CONTROLLERACCESSIBLEINTERFACE_H

--- a/src/framework/accessibility/internal/accessibleiteminterface.cpp
+++ b/src/framework/accessibility/internal/accessibleiteminterface.cpp
@@ -1,0 +1,146 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "accessibleiteminterface.h"
+
+#include <QWindow>
+
+#include "accessibilitycontroller.h"
+
+#include "log.h"
+
+using namespace mu::accessibility;
+
+AccessibleItemInterface::AccessibleItemInterface(QObject* object)
+{
+    m_object = qobject_cast<AccessibleObject*>(object);
+}
+
+bool AccessibleItemInterface::isValid() const
+{
+    return m_object != nullptr;
+}
+
+QObject* AccessibleItemInterface::object() const
+{
+    return m_object;
+}
+
+QWindow* AccessibleItemInterface::window() const
+{
+    //! TODO Need to add a current window
+    return mainWindow()->qWindow();
+}
+
+QRect AccessibleItemInterface::rect() const
+{
+    NOT_IMPLEMENTED;
+    return QRect();
+}
+
+QAccessibleInterface* AccessibleItemInterface::parent() const
+{
+    return QAccessible::queryAccessibleInterface(m_object->parent());
+}
+
+int AccessibleItemInterface::childCount() const
+{
+    return m_object->controller()->childCount(m_object->item());
+}
+
+QAccessibleInterface* AccessibleItemInterface::child(int index) const
+{
+    return m_object->controller()->child(m_object->item(), index);
+}
+
+int AccessibleItemInterface::indexOfChild(const QAccessibleInterface* iface) const
+{
+    return m_object->controller()->indexOfChild(m_object->item(), iface);
+}
+
+QAccessibleInterface* AccessibleItemInterface::childAt(int, int) const
+{
+    NOT_IMPLEMENTED;
+    return nullptr;
+}
+
+QAccessibleInterface* AccessibleItemInterface::focusChild() const
+{
+    NOT_IMPLEMENTED;
+    return nullptr;
+}
+
+QAccessible::State AccessibleItemInterface::state() const
+{
+    IAccessibility* item = m_object->item();
+    QAccessible::State state;
+    state.invisible = false;
+    state.invalid = false;
+    state.disabled = item->accessibleState(IAccessibility::State::Disabled);
+
+    IAccessibility::Role r = m_object->item()->accessibleRole();
+    switch (r) {
+    case IAccessibility::Role::NoRole: break;
+    case IAccessibility::Role::Panel: {
+        state.active = item->accessibleState(IAccessibility::State::Active);
+    } break;
+    case IAccessibility::Role::Button: {
+        state.focusable = true;
+        state.focused = item->accessibleState(IAccessibility::State::Focused);
+    } break;
+    }
+
+    return state;
+}
+
+QAccessible::Role AccessibleItemInterface::role() const
+{
+    IAccessibility::Role r = m_object->item()->accessibleRole();
+    switch (r) {
+    case IAccessibility::Role::NoRole: return QAccessible::NoRole;
+    case IAccessibility::Role::Panel: return QAccessible::Pane;
+    case IAccessibility::Role::Button: return QAccessible::Button;
+    }
+    return QAccessible::NoRole;
+}
+
+QString AccessibleItemInterface::text(QAccessible::Text textType) const
+{
+    return m_object->item()->accessibleName();
+
+    switch (textType) {
+    case QAccessible::Name: return m_object->item()->accessibleName();
+    default: break;
+    }
+
+    return QString();
+}
+
+void AccessibleItemInterface::setText(QAccessible::Text, const QString&)
+{
+    NOT_IMPLEMENTED;
+}
+
+void* AccessibleItemInterface::interface_cast(QAccessible::InterfaceType)
+{
+    //! NOTE Not implemented
+    return nullptr;
+}

--- a/src/framework/accessibility/internal/accessibleiteminterface.h
+++ b/src/framework/accessibility/internal/accessibleiteminterface.h
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_ACCESSIBILITY_ACCESSIBLEITEMINTERFACE_H
+#define MU_ACCESSIBILITY_ACCESSIBLEITEMINTERFACE_H
+
+#include <QAccessibleInterface>
+
+#include "accessibleobject.h"
+
+#include "modularity/ioc.h"
+#include "ui/imainwindow.h"
+
+namespace mu::accessibility {
+class AccessibleItemInterface : public QAccessibleInterface
+{
+    INJECT(accessibility, ui::IMainWindow, mainWindow)
+
+public:
+    AccessibleItemInterface(QObject* object);
+
+    bool isValid() const override;
+    QObject* object() const override;
+    QWindow* window() const override;
+    QRect rect() const override;
+
+    QAccessibleInterface* focusChild() const override;
+    QAccessibleInterface* childAt(int x, int y) const override;
+
+    QAccessibleInterface* parent() const override;
+    QAccessibleInterface* child(int index) const override;
+    int childCount() const override;
+    int indexOfChild(const QAccessibleInterface* iface) const override;
+
+    QAccessible::State state() const override;
+    QAccessible::Role role() const override;
+    QString text(QAccessible::Text) const override;
+    void setText(QAccessible::Text, const QString& text) override;
+
+protected:
+    void* interface_cast(QAccessible::InterfaceType t) override;
+
+private:
+
+    AccessibleObject* m_object = nullptr;
+};
+}
+
+#endif // MU_ACCESSIBILITY_ACCESSIBLEITEMINTERFACE_H

--- a/src/framework/accessibility/internal/accessibleobject.cpp
+++ b/src/framework/accessibility/internal/accessibleobject.cpp
@@ -19,24 +19,30 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+#include "accessibleobject.h"
 
-#ifndef MU_ACCESSIBILITY_ACCESSIBILITYMODULE_H
-#define MU_ACCESSIBILITY_ACCESSIBILITYMODULE_H
+#include "accessibilitycontroller.h"
 
-#include "framework/global/modularity/imodulesetup.h"
+using namespace mu::accessibility;
 
-namespace mu::accessibility {
-class AccessibilityModule : public framework::IModuleSetup
+AccessibleObject::AccessibleObject(IAccessibility* item, QObject* parent)
+    : QObject(parent)
 {
-public:
-    std::string moduleName() const override;
-
-    void registerExports() override;
-    void resolveImports() override;
-    void registerResources() override;
-    void registerUiTypes() override;
-    void onInit(const framework::IApplication::RunMode& mode) override;
-};
+    setObjectName("AccessibleObject");
+    m_item = item;
 }
 
-#endif // MU_ACCESSIBILITY_ACCESSIBILITYMODULE_H
+void AccessibleObject::setController(std::shared_ptr<AccessibilityController> controller)
+{
+    m_controller = controller;
+}
+
+const std::shared_ptr<AccessibilityController>& AccessibleObject::controller() const
+{
+    return m_controller;
+}
+
+IAccessibility* AccessibleObject::item() const
+{
+    return m_item;
+}

--- a/src/framework/accessibility/internal/accessibleobject.h
+++ b/src/framework/accessibility/internal/accessibleobject.h
@@ -19,24 +19,29 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+#ifndef MU_ACCESSIBILITY_ACCESSIBLEOBJECT_H
+#define MU_ACCESSIBILITY_ACCESSIBLEOBJECT_H
 
-#ifndef MU_ACCESSIBILITY_ACCESSIBILITYMODULE_H
-#define MU_ACCESSIBILITY_ACCESSIBILITYMODULE_H
-
-#include "framework/global/modularity/imodulesetup.h"
+#include <QObject>
+#include "../iaccessibility.h"
 
 namespace mu::accessibility {
-class AccessibilityModule : public framework::IModuleSetup
+class AccessibilityController;
+class AccessibleObject : public QObject
 {
+    Q_OBJECT
 public:
-    std::string moduleName() const override;
+    explicit AccessibleObject(IAccessibility* item, QObject* parent);
 
-    void registerExports() override;
-    void resolveImports() override;
-    void registerResources() override;
-    void registerUiTypes() override;
-    void onInit(const framework::IApplication::RunMode& mode) override;
+    void setController(std::shared_ptr<AccessibilityController> controller);
+    const std::shared_ptr<AccessibilityController>& controller() const;
+
+    IAccessibility* item() const;
+
+private:
+    IAccessibility* m_item = nullptr;
+    std::shared_ptr<AccessibilityController> m_controller;
 };
 }
 
-#endif // MU_ACCESSIBILITY_ACCESSIBILITYMODULE_H
+#endif // MU_ACCESSIBILITY_ACCESSIBLEOBJECT_H

--- a/src/framework/ui/dev/interactivetestsmodel.cpp
+++ b/src/framework/ui/dev/interactivetestsmodel.cpp
@@ -27,6 +27,8 @@
 
 #include "async/async.h"
 
+#include <QAccessible>
+
 using namespace mu::ui;
 using namespace mu::framework;
 
@@ -42,6 +44,9 @@ InteractiveTestsModel::InteractiveTestsModel(QObject* parent)
 
 void InteractiveTestsModel::openSampleDialog()
 {
+    QAccessibleInterface* iface = QAccessible::queryAccessibleInterface(this);
+    int k = 1;
+
     LOGI() << "cpp: before open";
     RetVal<Val> rv = interactive()->open("musescore://devtools/interactive/sample?color=#474747");
     LOGI() << "cpp: after open ret: " << rv.ret.toString() << ", val: " << rv.val.toString();

--- a/src/framework/ui/inavigation.h
+++ b/src/framework/ui/inavigation.h
@@ -31,6 +31,8 @@
 #include "async/channel.h"
 #include "async/notification.h"
 
+class QWindow;
+
 namespace mu::ui {
 class INavigationSection;
 class INavigationPanel;
@@ -144,6 +146,7 @@ public:
         Exclusive
     };
 
+    virtual QWindow* qWindow() const = 0;
     virtual Type type() const = 0;
     virtual const std::set<INavigationPanel*>& panels() const = 0;
     virtual async::Notification panelsListChanged() const = 0;

--- a/src/framework/ui/tests/mocks/navigationmocks.h
+++ b/src/framework/ui/tests/mocks/navigationmocks.h
@@ -31,6 +31,7 @@ class NavigationSectionMock : public INavigationSection
 {
 public:
 
+    MOCK_METHOD(QWindow*, qWindow, (), (const, override));
     MOCK_METHOD(Type, type, (), (const, override));
     MOCK_METHOD(QString, name, (), (const, override));
 

--- a/src/framework/ui/view/navigationcontrol.cpp
+++ b/src/framework/ui/view/navigationcontrol.cpp
@@ -25,6 +25,7 @@
 #include "log.h"
 
 using namespace mu::ui;
+using namespace mu::accessibility;
 
 NavigationControl::NavigationControl(QObject* parent)
     : AbstractNavigation(parent)
@@ -36,6 +37,13 @@ NavigationControl::~NavigationControl()
     if (m_panel) {
         m_panel->removeControl(this);
     }
+    accessibilityController()->destroyed(this);
+}
+
+void NavigationControl::componentComplete()
+{
+    AbstractNavigation::componentComplete();
+    accessibilityController()->created(m_panel, this);
 }
 
 QString NavigationControl::name() const
@@ -71,6 +79,9 @@ bool NavigationControl::active() const
 void NavigationControl::setActive(bool arg)
 {
     AbstractNavigation::setActive(arg);
+    if (arg) {
+        accessibilityController()->focused(this);
+    }
 }
 
 mu::async::Channel<bool> NavigationControl::activeChanged() const
@@ -133,4 +144,29 @@ NavigationPanel* NavigationControl::panel_property() const
 INavigationPanel* NavigationControl::panel() const
 {
     return m_panel;
+}
+
+IAccessibility::Role NavigationControl::accessibleRole() const
+{
+    return IAccessibility::Role::Button;
+}
+
+QString NavigationControl::accessibleName() const
+{
+    return name();
+}
+
+bool NavigationControl::accessibleState(State st) const
+{
+    switch (st) {
+    case State::Undefined: return false;
+    case State::Disabled: return !enabled();
+    case State::Active: return active();
+    case State::Focused: return active();
+    default: {
+        LOGW() << "not handled state: " << static_cast<int>(st);
+    }
+    }
+
+    return false;
 }

--- a/src/framework/ui/view/navigationcontrol.h
+++ b/src/framework/ui/view/navigationcontrol.h
@@ -27,12 +27,18 @@
 #include "abstractnavigation.h"
 #include "async/asyncable.h"
 
+#include "modularity/ioc.h"
+#include "accessibility/iaccessibilitycontroller.h"
+
 namespace mu::ui {
 class NavigationPanel;
-class NavigationControl : public AbstractNavigation, public INavigationControl, public async::Asyncable
+class NavigationControl : public AbstractNavigation, public INavigationControl, public accessibility::IAccessibility,
+    public async::Asyncable
 {
     Q_OBJECT
     Q_PROPERTY(mu::ui::NavigationPanel* panel READ panel_property WRITE setPanel NOTIFY panelChanged)
+
+    INJECT(ui, accessibility::IAccessibilityController, accessibilityController)
 
 public:
     explicit NavigationControl(QObject* parent = nullptr);
@@ -59,6 +65,13 @@ public:
     async::Channel<INavigationControl*> activeRequested() const override;
 
     Q_INVOKABLE void requestActive();
+
+    void componentComplete() override;
+
+    // IAccessibility
+    IAccessibility::Role accessibleRole() const override;
+    QString accessibleName() const override;
+    bool accessibleState(State st) const override;
 
 public slots:
     void setPanel(NavigationPanel* panel);

--- a/src/framework/ui/view/navigationpanel.cpp
+++ b/src/framework/ui/view/navigationpanel.cpp
@@ -27,6 +27,7 @@
 #include "log.h"
 
 using namespace mu::ui;
+using namespace mu::accessibility;
 
 NavigationPanel::NavigationPanel(QObject* parent)
     : AbstractNavigation(parent)
@@ -38,6 +39,8 @@ NavigationPanel::~NavigationPanel()
     if (m_section) {
         m_section->removePanel(this);
     }
+
+    accessibilityController()->destroyed(this);
 }
 
 QString NavigationPanel::name() const
@@ -84,6 +87,7 @@ bool NavigationPanel::active() const
 void NavigationPanel::setActive(bool arg)
 {
     AbstractNavigation::setActive(arg);
+    accessibilityController()->actived(this, arg);
 }
 
 mu::async::Channel<bool> NavigationPanel::activeChanged() const
@@ -175,6 +179,7 @@ void NavigationPanel::onSectionDestroyed()
 
 void NavigationPanel::componentComplete()
 {
+    accessibilityController()->created(nullptr, this);
 }
 
 void NavigationPanel::addControl(NavigationControl* control)
@@ -208,4 +213,29 @@ void NavigationPanel::removeControl(NavigationControl* control)
     if (m_controlsListChanged.isConnected()) {
         m_controlsListChanged.notify();
     }
+}
+
+IAccessibility::Role NavigationPanel::accessibleRole() const
+{
+    return IAccessibility::Role::Panel;
+}
+
+QString NavigationPanel::accessibleName() const
+{
+    return name();
+}
+
+bool NavigationPanel::accessibleState(State st) const
+{
+    switch (st) {
+    case State::Undefined: return false;
+    case State::Disabled: return !enabled();
+    case State::Active: return active();
+    case State::Focused: return active();
+    default: {
+        LOGW() << "not handled state: " << static_cast<int>(st);
+    }
+    }
+
+    return false;
 }

--- a/src/framework/ui/view/navigationpanel.h
+++ b/src/framework/ui/view/navigationpanel.h
@@ -27,15 +27,21 @@
 
 #include "abstractnavigation.h"
 #include "navigationcontrol.h"
+#include "accessibility/iaccessibility.h"
 #include "async/asyncable.h"
+
+#include "modularity/ioc.h"
+#include "accessibility/iaccessibilitycontroller.h"
 
 namespace mu::ui {
 class NavigationSection;
-class NavigationPanel : public AbstractNavigation, public INavigationPanel, public async::Asyncable
+class NavigationPanel : public AbstractNavigation, public INavigationPanel, public accessibility::IAccessibility, public async::Asyncable
 {
     Q_OBJECT
     Q_PROPERTY(mu::ui::NavigationSection* section READ section_property WRITE setSection_property NOTIFY sectionChanged)
     Q_PROPERTY(QmlDirection direction READ direction_property WRITE setDirection NOTIFY directionChanged)
+
+    INJECT(ui, accessibility::IAccessibilityController, accessibilityController)
 
 public:
     explicit NavigationPanel(QObject* parent = nullptr);
@@ -78,6 +84,11 @@ public:
 
     void addControl(NavigationControl* control);
     void removeControl(NavigationControl* control);
+
+    // IAccessibility
+    Role accessibleRole() const override;
+    QString accessibleName() const override;
+    bool accessibleState(State st) const override;
 
 public slots:
     void setSection_property(NavigationSection* section);

--- a/src/framework/ui/view/navigationsection.cpp
+++ b/src/framework/ui/view/navigationsection.cpp
@@ -145,6 +145,11 @@ void NavigationSection::removePanel(NavigationPanel* panel)
     }
 }
 
+QWindow* NavigationSection::qWindow() const
+{
+    return nullptr;
+}
+
 INavigationSection::Type NavigationSection::type() const
 {
     return static_cast<INavigationSection::Type>(m_type);

--- a/src/framework/ui/view/navigationsection.h
+++ b/src/framework/ui/view/navigationsection.h
@@ -51,6 +51,8 @@ public:
     };
     Q_ENUM(QmlType)
 
+    QWindow* qWindow() const override;
+
     QmlType type_property() const;
     INavigationSection::Type type() const override;
     QString name() const override;

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/FlatButton.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/FlatButton.qml
@@ -44,6 +44,12 @@ FocusableControl {
     signal clicked()
     signal pressAndHold()
 
+    Accessible.role: Accessible.Button
+    Accessible.name: root.text
+    Accessible.onPressAction: {
+        // do a button click
+    }
+
     QtObject {
         id: prv
 

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -143,6 +143,7 @@ endif(BUILD_TELEMETRY_MODULE)
 set(LINK_LIB ${LINK_LIB}
     libmscore
     actions
+    accessibility
     appshell
     context
     shortcuts

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -33,6 +33,7 @@
 #include "framework/uicomponents/uicomponentsmodule.h"
 #include "framework/fonts/fontsmodule.h"
 #include "framework/actions/actionsmodule.h"
+#include "framework/accessibility/accessibilitymodule.h"
 #ifdef BUILD_SHORTCUTS_MODULE
 #include "framework/shortcuts/shortcutsmodule.h"
 #else
@@ -178,6 +179,7 @@ int main(int argc, char** argv)
 #endif
 
     app.addModule(new mu::actions::ActionsModule());
+    app.addModule(new mu::accessibility::AccessibilityModule());
     app.addModule(new mu::appshell::AppShellModule());
 
     app.addModule(new mu::context::ContextModule());


### PR DESCRIPTION
Qt has a low-level cross-platform interface for implementing accessibility on different platforms (Windows, macOS, and Linux), as well as a high-level one for QWidget and QQuick.

We want to implement accessibility for the notation (libmscore) as well, but we will not be able to use high-level interfaces QWidget or QQuick there is.

I also believe that if we use the high-level interface in QQuick, then this is a quick start, but in the long term, it will cause more problems when we want to implement our behaviors, comply with the navigation system, etc.

For these reasons, I decided to use only the low-level Qt Accessibility interface. And will develop your own high-level interface, which can be applied anywhere in the application, including the notation (libmscore)

This is a prototype solution.
Not everything is done yet, but something is already working :)



https://user-images.githubusercontent.com/3818029/118850866-7d03aa80-b8d1-11eb-8eec-bebe6439ac06.mp4






