### PR TITLE
Fix #320126: Grace note slash in tablature

### DIFF
--- a/src/libmscore/chord.cpp
+++ b/src/libmscore/chord.cpp
@@ -2322,6 +2322,9 @@ void Chord::layoutTablature()
                 QPointF p(_stem->hookPos());
                 p.rx() -= _stem->width();
                 _hook->setPos(p);
+                if (_stemSlash) {
+                    _stemSlash->layout();
+                }
             }
         }
     }


### PR DESCRIPTION
This will fix 2 bugs - grace notes slashes will now show up in TAB-COMMON and the slashes will no longer be stranded above the staff when switching between TAB-COMMON and TAB-FULL.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://musescore.org/en/cla)
- [x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x ] I made sure the code compiles on my machine
- [x ] I made sure there are no unnecessary changes in the code
- [x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
