### PR TITLE
Update colornotes.qml to use Score.elements.selection

### DIFF
--- a/share/plugins/colornotes.qml
+++ b/share/plugins/colornotes.qml
@@ -24,7 +24,7 @@ import QtQuick 2.2
 import MuseScore 3.0
 
 MuseScore {
-      version:  "3.0"
+      version:  "3.5"
       description: qsTr("This plugin colors notes in the selection depending on their pitch as per the Boomwhackers convention")
       menuPath: "Plugins.Notes.Color Notes"
 
@@ -44,62 +44,21 @@ MuseScore {
                ]
       property string black : "#000000"
 
-      // Apply the given function to all notes in selection
+      // Apply the given function to all notes (elements with pitch) in selection
       // or, if nothing is selected, in the entire score
 
       function applyToNotesInSelection(func) {
-            var cursor = curScore.newCursor();
-            cursor.rewind(1);
-            var startStaff;
-            var endStaff;
-            var endTick;
-            var fullScore = false;
-            if (!cursor.segment) { // no selection
-                  fullScore = true;
-                  startStaff = 0; // start with 1st staff
-                  endStaff = curScore.nstaves - 1; // and end with last
-            } else {
-                  startStaff = cursor.staffIdx;
-                  cursor.rewind(2);
-                  if (cursor.tick === 0) {
-                        // this happens when the selection includes
-                        // the last measure of the score.
-                        // rewind(2) goes behind the last segment (where
-                        // there's none) and sets tick=0
-                        endTick = curScore.lastSegment.tick + 1;
-                  } else {
-                        endTick = cursor.tick;
-                  }
-                  endStaff = cursor.staffIdx;
+            var fullScore = !curScore.selection.elements.length
+            if (fullScore) {
+                  cmd("select-all")
+                  curScore.startCmd()
             }
-            console.log(startStaff + " - " + endStaff + " - " + endTick)
-            for (var staff = startStaff; staff <= endStaff; staff++) {
-                  for (var voice = 0; voice < 4; voice++) {
-                        cursor.rewind(1); // sets voice to 0
-                        cursor.voice = voice; //voice has to be set after goTo
-                        cursor.staffIdx = staff;
-
-                        if (fullScore)
-                              cursor.rewind(0) // if no selection, beginning of score
-
-                        while (cursor.segment && (fullScore || cursor.tick < endTick)) {
-                              if (cursor.element && cursor.element.type === Element.CHORD) {
-                                    var graceChords = cursor.element.graceNotes;
-                                    for (var i = 0; i < graceChords.length; i++) {
-                                          // iterate through all grace chords
-                                          var graceNotes = graceChords[i].notes;
-                                          for (var j = 0; j < graceNotes.length; j++)
-                                                func(graceNotes[j]);
-                                    }
-                                    var notes = cursor.element.notes;
-                                    for (var k = 0; k < notes.length; k++) {
-                                          var note = notes[k];
-                                          func(note);
-                                    }
-                              }
-                              cursor.next();
-                        }
-                  }
+            for (var i in curScore.selection.elements)
+                  if (curScore.selection.elements[i].pitch)
+                        func(curScore.selection.elements[i])
+            if (fullScore) {
+                  curScore.endCmd()
+                  cmd("escape")
             }
       }
 
@@ -114,17 +73,19 @@ MuseScore {
                         note.accidental.color = colors[note.pitch % 12];
                   else
                         note.accidental.color = black;
-                  }
+            }
 
-            for (var i = 0; i < note.dots.length; i++) {
-                  if (note.dots[i]) {
-                        if (note.dots[i].color == black)
-                              note.dots[i].color = colors[note.pitch % 12];
-                        else
-                              note.dots[i].color = black;
+            if (note.dots) {
+                  for (var i = 0; i < note.dots.length; i++) {
+                        if (note.dots[i]) {
+                              if (note.dots[i].color == black)
+                                    note.dots[i].color = colors[note.pitch % 12];
+                              else
+                                    note.dots[i].color = black;
                         }
                   }
-         }
+            }
+      }
 
       onRun: {
             console.log("hello colornotes");
@@ -132,5 +93,5 @@ MuseScore {
             applyToNotesInSelection(colorNote)
 
             Qt.quit();
-         }
+      }
 }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/321398

Fixes the bug in the ColorNotes sample plugin that causes it to apply to notes not currently selected if a distinct selection (not a range) is used, and simplifies the code.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
