### PR TITLE
[MU4] Notenames plugins: For hidden notes skip notenames

### DIFF
--- a/share/plugins/notenames-interactive.qml
+++ b/share/plugins/notenames-interactive.qml
@@ -25,7 +25,7 @@ import QtQuick.Controls 2.0
 import MuseScore 3.0
 
 MuseScore {
-    version: "3.4"
+    version: "3.5"
     description: qsTr("This plugin names notes as per your language setting")
     menuPath: "Plugins.Notes." + qsTr("Note Names (Interactive)")
     pluginType: "dock"
@@ -64,9 +64,11 @@ MuseScore {
     function getChordName(chord) {
         var text = "";
         var notes = chord.notes;
+        var sep = "\n";   // change to "," if you want them horizontally (anybody?)
         for (var i = 0; i < notes.length; i++) {
-            var sep = "\n";   // change to "," if you want them horizontally (anybody?)
-            if ( i > 0 )
+            if (!notes[i].visible)
+                continue // skip notes a that are not selected or invisible
+            if (text) // only if text isn't empty
                 text = sep + text; // any but top note
             if (typeof notes[i].tpc === "undefined") // like for grace notes ?!?
                 return;

--- a/share/plugins/notenames-interactive.qml
+++ b/share/plugins/notenames-interactive.qml
@@ -66,7 +66,7 @@ MuseScore {
         var notes = chord.notes;
         var sep = "\n";   // change to "," if you want them horizontally (anybody?)
         for (var i = 0; i < notes.length; i++) {
-            if (!notes[i].visible)
+            if ((curScore.selection.elements.length && !notes[i].selected) || !notes[i].visible)
                 continue // skip notes a that are not selected or invisible
             if (text) // only if text isn't empty
                 text = sep + text; // any but top note

--- a/share/plugins/notenames.qml
+++ b/share/plugins/notenames.qml
@@ -24,7 +24,7 @@ import QtQuick 2.2
 import MuseScore 3.0
 
 MuseScore {
-   version: "3.4.2.1"
+   version: "3.5"
    description: qsTr("This plugin names notes as per your language setting")
    menuPath: "Plugins.Notes." + qsTr("Note Names")
 
@@ -32,10 +32,12 @@ MuseScore {
    property var fontSizeMini: 0.7;
 
    function nameChord (notes, text, small) {
+      var sep = "\n";   // change to "," if you want them horizontally (anybody?)
       for (var i = 0; i < notes.length; i++) {
-         var sep = "\n";   // change to "," if you want them horizontally (anybody?)
-         if ( i > 0 )
-            text.text = sep + text.text; // any but top note
+         if (!notes[i].visible)
+            continue // skip notes that are not selected or invisible
+         if (text.text) // only if text isn't empty
+            text.text = sep + text.text;
          if (small)
              text.fontSize *= fontSizeMini
          if (typeof notes[i].tpc === "undefined") // like for grace notes ?!?
@@ -135,7 +137,8 @@ MuseScore {
             var chord = list[chordNum];
             // Set note text, grace notes are shown a bit smaller
             nameChord(chord.notes, text, small)
-            cursor.add(text)
+            if (text.text)
+               cursor.add(text)
             // X position the note name over the grace chord
             text.offsetX = chord.posX
             switch (cursor.voice) {
@@ -143,7 +146,8 @@ MuseScore {
             }
 
             // If we consume a STAFF_TEXT we must manufacture a new one.
-            text = newElement(Element.STAFF_TEXT);    // Make another STAFF_TEXT
+            if (text.text)
+               text = newElement(Element.STAFF_TEXT);    // Make another STAFF_TEXT
          }
       }
       return text
@@ -212,13 +216,15 @@ MuseScore {
                   // Now handle the note names on the main chord...
                   var notes = cursor.element.notes;
                   nameChord(notes, text, false);
-                  cursor.add(text);
+                  if (text.text)
+                     cursor.add(text);
 
                   switch (cursor.voice) {
                      case 1: case 3: text.placement = Placement.BELOW; break;
                   }
 
-                  text = newElement(Element.STAFF_TEXT) // Make another STAFF_TEXT object
+                  if (text.text)
+                     text = newElement(Element.STAFF_TEXT) // Make another STAFF_TEXT object
 
                   // Finally process trailing grace notes if they exist...
                   text = renderGraceNoteNames(cursor, trailingFifo, text, true)

--- a/share/plugins/notenames.qml
+++ b/share/plugins/notenames.qml
@@ -34,7 +34,7 @@ MuseScore {
    function nameChord (notes, text, small) {
       var sep = "\n";   // change to "," if you want them horizontally (anybody?)
       for (var i = 0; i < notes.length; i++) {
-         if (!notes[i].visible)
+         if ((curScore.selection.elements.length && !notes[i].selected) || !notes[i].visible)
             continue // skip notes that are not selected or invisible
          if (text.text) // only if text isn't empty
             text.text = sep + text.text;


### PR DESCRIPTION
This PR fixes:

* If a note(head) is invisble, the notenames plugins still put a visible name to it. 
* If there's a list selection, only the 1st note of that gets named.