### PR TITLE
290694 import xml barline span

### DIFF
--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -3927,6 +3927,11 @@ void Measure::setEndBarLineType(BarLineType val, int track, bool visible, QColor
         bl = new BarLine(score());
         bl->setParent(seg);
         bl->setTrack(track);
+        Part* part = score()->staff(track / VOICES)->part();
+        // by default, barlines for multi-staff parts should span across staves
+        if (part && part->nstaves() > 1) {
+            bl->setSpanStaff(true);
+        }
         score()->addElement(bl);
     }
     bl->setGenerated(false);

--- a/src/importexport/musicxml/tests/data/testSystemBrackets3_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSystemBrackets3_ref.mscx
@@ -32,56 +32,11 @@
         </Staff>
       <trackName>Backing
 Vocals</trackName>
-      <Instrument id="voice">
+      <Instrument>
         <longName>Backing
 Vocals</longName>
         <shortName>B. Vx.</shortName>
         <trackName>Voice</trackName>
-        <minPitchP>38</minPitchP>
-        <maxPitchP>84</maxPitchP>
-        <minPitchA>41</minPitchA>
-        <maxPitchA>79</maxPitchA>
-        <instrumentId>voice.vocals</instrumentId>
-        <Articulation>
-          <velocity>100</velocity>
-          <gateTime>100</gateTime>
-          </Articulation>
-        <Articulation name="staccatissimo">
-          <velocity>100</velocity>
-          <gateTime>33</gateTime>
-          </Articulation>
-        <Articulation name="staccato">
-          <velocity>100</velocity>
-          <gateTime>50</gateTime>
-          </Articulation>
-        <Articulation name="portato">
-          <velocity>100</velocity>
-          <gateTime>67</gateTime>
-          </Articulation>
-        <Articulation name="tenuto">
-          <velocity>100</velocity>
-          <gateTime>100</gateTime>
-          </Articulation>
-        <Articulation name="marcato">
-          <velocity>120</velocity>
-          <gateTime>67</gateTime>
-          </Articulation>
-        <Articulation name="sforzato">
-          <velocity>150</velocity>
-          <gateTime>100</gateTime>
-          </Articulation>
-        <Articulation name="sforzatoStaccato">
-          <velocity>150</velocity>
-          <gateTime>50</gateTime>
-          </Articulation>
-        <Articulation name="marcatoStaccato">
-          <velocity>120</velocity>
-          <gateTime>50</gateTime>
-          </Articulation>
-        <Articulation name="marcatoTenuto">
-          <velocity>120</velocity>
-          <gateTime>100</gateTime>
-          </Articulation>
         <Channel>
           <program value="52"/>
           <controller ctrl="10" value="63"/>
@@ -124,20 +79,14 @@ Vocals</longName>
         </Staff>
       <trackName>Electric
 Guitar 1</trackName>
-      <Instrument id="electric-guitar">
+      <Instrument>
         <longName>Electric
 Guitar 1</longName>
         <shortName>Elec.
 Gtr. 1</shortName>
         <trackName>Electric Guitar</trackName>
-        <minPitchP>40</minPitchP>
-        <maxPitchP>88</maxPitchP>
-        <minPitchA>40</minPitchA>
-        <maxPitchA>86</maxPitchA>
-        <instrumentId>pluck.guitar.electric</instrumentId>
-        <clef>G8vb</clef>
         <StringData>
-          <frets>24</frets>
+          <frets>25</frets>
           <string>40</string>
           <string>45</string>
           <string>50</string>
@@ -145,76 +94,11 @@ Gtr. 1</shortName>
           <string>59</string>
           <string>64</string>
           </StringData>
-        <Articulation>
-          <velocity>100</velocity>
-          <gateTime>100</gateTime>
-          </Articulation>
-        <Articulation name="staccatissimo">
-          <velocity>100</velocity>
-          <gateTime>33</gateTime>
-          </Articulation>
-        <Articulation name="staccato">
-          <velocity>100</velocity>
-          <gateTime>50</gateTime>
-          </Articulation>
-        <Articulation name="portato">
-          <velocity>100</velocity>
-          <gateTime>67</gateTime>
-          </Articulation>
-        <Articulation name="tenuto">
-          <velocity>100</velocity>
-          <gateTime>100</gateTime>
-          </Articulation>
-        <Articulation name="marcato">
-          <velocity>120</velocity>
-          <gateTime>67</gateTime>
-          </Articulation>
-        <Articulation name="sforzato">
-          <velocity>150</velocity>
-          <gateTime>100</gateTime>
-          </Articulation>
-        <Articulation name="sforzatoStaccato">
-          <velocity>150</velocity>
-          <gateTime>50</gateTime>
-          </Articulation>
-        <Articulation name="marcatoStaccato">
-          <velocity>120</velocity>
-          <gateTime>50</gateTime>
-          </Articulation>
-        <Articulation name="marcatoTenuto">
-          <velocity>120</velocity>
-          <gateTime>100</gateTime>
-          </Articulation>
-        <Channel name="open">
+        <Channel>
           <program value="30"/>
           <controller ctrl="10" value="63"/>
           <midiPort>0</midiPort>
           <midiChannel>2</midiChannel>
-          </Channel>
-        <Channel name="harmonics">
-          <program value="31"/>
-          <midiPort>0</midiPort>
-          <midiChannel>1</midiChannel>
-          </Channel>
-        <Channel name="distortion">
-          <program value="30"/>
-          <midiPort>0</midiPort>
-          <midiChannel>3</midiChannel>
-          </Channel>
-        <Channel name="overdriven">
-          <program value="29"/>
-          <midiPort>0</midiPort>
-          <midiChannel>4</midiChannel>
-          </Channel>
-        <Channel name="mute">
-          <program value="28"/>
-          <midiPort>0</midiPort>
-          <midiChannel>5</midiChannel>
-          </Channel>
-        <Channel name="jazz">
-          <program value="26"/>
-          <midiPort>0</midiPort>
-          <midiChannel>6</midiChannel>
           </Channel>
         </Instrument>
       </Part>
@@ -251,20 +135,14 @@ Gtr. 1</shortName>
         </Staff>
       <trackName>Electric
 Guitar 2</trackName>
-      <Instrument id="electric-guitar">
+      <Instrument>
         <longName>Electric
 Guitar 2</longName>
         <shortName>Elec.
 Gtr. 2</shortName>
         <trackName>Electric Guitar</trackName>
-        <minPitchP>40</minPitchP>
-        <maxPitchP>88</maxPitchP>
-        <minPitchA>40</minPitchA>
-        <maxPitchA>86</maxPitchA>
-        <instrumentId>pluck.guitar.electric</instrumentId>
-        <clef>G8vb</clef>
         <StringData>
-          <frets>24</frets>
+          <frets>25</frets>
           <string>40</string>
           <string>45</string>
           <string>50</string>
@@ -272,76 +150,11 @@ Gtr. 2</shortName>
           <string>59</string>
           <string>64</string>
           </StringData>
-        <Articulation>
-          <velocity>100</velocity>
-          <gateTime>100</gateTime>
-          </Articulation>
-        <Articulation name="staccatissimo">
-          <velocity>100</velocity>
-          <gateTime>33</gateTime>
-          </Articulation>
-        <Articulation name="staccato">
-          <velocity>100</velocity>
-          <gateTime>50</gateTime>
-          </Articulation>
-        <Articulation name="portato">
-          <velocity>100</velocity>
-          <gateTime>67</gateTime>
-          </Articulation>
-        <Articulation name="tenuto">
-          <velocity>100</velocity>
-          <gateTime>100</gateTime>
-          </Articulation>
-        <Articulation name="marcato">
-          <velocity>120</velocity>
-          <gateTime>67</gateTime>
-          </Articulation>
-        <Articulation name="sforzato">
-          <velocity>150</velocity>
-          <gateTime>100</gateTime>
-          </Articulation>
-        <Articulation name="sforzatoStaccato">
-          <velocity>150</velocity>
-          <gateTime>50</gateTime>
-          </Articulation>
-        <Articulation name="marcatoStaccato">
-          <velocity>120</velocity>
-          <gateTime>50</gateTime>
-          </Articulation>
-        <Articulation name="marcatoTenuto">
-          <velocity>120</velocity>
-          <gateTime>100</gateTime>
-          </Articulation>
-        <Channel name="open">
+        <Channel>
           <program value="28"/>
           <controller ctrl="10" value="63"/>
           <midiPort>0</midiPort>
           <midiChannel>8</midiChannel>
-          </Channel>
-        <Channel name="harmonics">
-          <program value="31"/>
-          <midiPort>0</midiPort>
-          <midiChannel>7</midiChannel>
-          </Channel>
-        <Channel name="distortion">
-          <program value="30"/>
-          <midiPort>0</midiPort>
-          <midiChannel>10</midiChannel>
-          </Channel>
-        <Channel name="overdriven">
-          <program value="29"/>
-          <midiPort>0</midiPort>
-          <midiChannel>11</midiChannel>
-          </Channel>
-        <Channel name="mute">
-          <program value="28"/>
-          <midiPort>0</midiPort>
-          <midiChannel>12</midiChannel>
-          </Channel>
-        <Channel name="jazz">
-          <program value="26"/>
-          <midiPort>0</midiPort>
-          <midiChannel>13</midiChannel>
           </Channel>
         </Instrument>
       </Part>
@@ -377,21 +190,14 @@ Gtr. 2</shortName>
         </Staff>
       <trackName>Acoustic
 Guitar</trackName>
-      <Instrument id="guitar-steel">
+      <Instrument>
         <longName>Acoustic
 Guitar</longName>
         <shortName>Ac.
 Gtr.</shortName>
         <trackName>Acoustic Guitar</trackName>
-        <minPitchP>40</minPitchP>
-        <maxPitchP>84</maxPitchP>
-        <minPitchA>40</minPitchA>
-        <maxPitchA>83</maxPitchA>
-        <instrumentId>pluck.guitar.acoustic</instrumentId>
-        <clef>G8vb</clef>
-        <singleNoteDynamics>0</singleNoteDynamics>
         <StringData>
-          <frets>20</frets>
+          <frets>25</frets>
           <string>40</string>
           <string>45</string>
           <string>50</string>
@@ -399,61 +205,11 @@ Gtr.</shortName>
           <string>59</string>
           <string>64</string>
           </StringData>
-        <Articulation>
-          <velocity>100</velocity>
-          <gateTime>100</gateTime>
-          </Articulation>
-        <Articulation name="staccatissimo">
-          <velocity>100</velocity>
-          <gateTime>33</gateTime>
-          </Articulation>
-        <Articulation name="staccato">
-          <velocity>100</velocity>
-          <gateTime>50</gateTime>
-          </Articulation>
-        <Articulation name="portato">
-          <velocity>100</velocity>
-          <gateTime>67</gateTime>
-          </Articulation>
-        <Articulation name="tenuto">
-          <velocity>100</velocity>
-          <gateTime>100</gateTime>
-          </Articulation>
-        <Articulation name="marcato">
-          <velocity>120</velocity>
-          <gateTime>67</gateTime>
-          </Articulation>
-        <Articulation name="sforzato">
-          <velocity>150</velocity>
-          <gateTime>100</gateTime>
-          </Articulation>
-        <Articulation name="sforzatoStaccato">
-          <velocity>150</velocity>
-          <gateTime>50</gateTime>
-          </Articulation>
-        <Articulation name="marcatoStaccato">
-          <velocity>120</velocity>
-          <gateTime>50</gateTime>
-          </Articulation>
-        <Articulation name="marcatoTenuto">
-          <velocity>120</velocity>
-          <gateTime>100</gateTime>
-          </Articulation>
-        <Channel name="open">
+        <Channel>
           <program value="24"/>
           <controller ctrl="10" value="63"/>
           <midiPort>0</midiPort>
           <midiChannel>15</midiChannel>
-          </Channel>
-        <Channel name="mute">
-          <program value="28"/>
-          <midiPort>0</midiPort>
-          <midiChannel>14</midiChannel>
-          </Channel>
-        <Channel name="jazz">
-          <program value="26"/>
-          <midiPort>1</midiPort>
-          <midiChannel>0</midiChannel>
           </Channel>
         </Instrument>
       </Part>
@@ -471,57 +227,11 @@ Gtr.</shortName>
           </StaffType>
         </Staff>
       <trackName>Piano 2</trackName>
-      <Instrument id="piano">
+      <Instrument>
         <longName>Piano 2</longName>
         <shortName>Pno.
 2</shortName>
         <trackName>Piano</trackName>
-        <minPitchP>21</minPitchP>
-        <maxPitchP>108</maxPitchP>
-        <minPitchA>21</minPitchA>
-        <maxPitchA>108</maxPitchA>
-        <instrumentId>keyboard.piano</instrumentId>
-        <clef staff="2">F</clef>
-        <Articulation>
-          <velocity>100</velocity>
-          <gateTime>95</gateTime>
-          </Articulation>
-        <Articulation name="staccatissimo">
-          <velocity>100</velocity>
-          <gateTime>33</gateTime>
-          </Articulation>
-        <Articulation name="staccato">
-          <velocity>100</velocity>
-          <gateTime>50</gateTime>
-          </Articulation>
-        <Articulation name="portato">
-          <velocity>100</velocity>
-          <gateTime>67</gateTime>
-          </Articulation>
-        <Articulation name="tenuto">
-          <velocity>100</velocity>
-          <gateTime>100</gateTime>
-          </Articulation>
-        <Articulation name="marcato">
-          <velocity>120</velocity>
-          <gateTime>67</gateTime>
-          </Articulation>
-        <Articulation name="sforzato">
-          <velocity>150</velocity>
-          <gateTime>100</gateTime>
-          </Articulation>
-        <Articulation name="sforzatoStaccato">
-          <velocity>150</velocity>
-          <gateTime>50</gateTime>
-          </Articulation>
-        <Articulation name="marcatoStaccato">
-          <velocity>120</velocity>
-          <gateTime>50</gateTime>
-          </Articulation>
-        <Articulation name="marcatoTenuto">
-          <velocity>120</velocity>
-          <gateTime>100</gateTime>
-          </Articulation>
         <Channel>
           <program value="0"/>
           <controller ctrl="10" value="63"/>
@@ -576,7 +286,7 @@ Gtr.</shortName>
             </Rest>
           <BarLine>
             <subtype>end</subtype>
-            <span>0</span>
+            <span>1</span>
             </BarLine>
           </voice>
         </Measure>
@@ -616,7 +326,6 @@ Gtr.</shortName>
             </Rest>
           <BarLine>
             <subtype>end</subtype>
-            <span>0</span>
             </BarLine>
           </voice>
         </Measure>
@@ -656,7 +365,6 @@ Gtr.</shortName>
             </Rest>
           <BarLine>
             <subtype>end</subtype>
-            <span>0</span>
             </BarLine>
           </voice>
         </Measure>
@@ -696,7 +404,6 @@ Gtr.</shortName>
             </Rest>
           <BarLine>
             <subtype>end</subtype>
-            <span>0</span>
             </BarLine>
           </voice>
         </Measure>

--- a/src/importexport/musicxml/tests/tst_mxml_io.cpp
+++ b/src/importexport/musicxml/tests/tst_mxml_io.cpp
@@ -68,6 +68,7 @@ class TestMxmlIO : public QObject, public MTest
     void mxmlMscxExportTestRefBreaks(const char* file);
     void mxmlReadTestCompr(const char* file);
     void mxmlReadWriteTestCompr(const char* file);
+    void mxmlImportTestRef(const char* file);
 
     // The list of MusicXML regression tests
     // Currently failing tests are commented out and annotated with the failure reason
@@ -198,6 +199,7 @@ private slots:
     void stringVoiceName() { mxmlIoTestRef("testStringVoiceName"); }
     void systemBrackets1() { mxmlIoTest("testSystemBrackets1"); }
     void systemBrackets2() { mxmlIoTest("testSystemBrackets2"); }
+    void systemBrackets3() { mxmlImportTestRef("testSystemBrackets3"); }
     void tablature1() { mxmlIoTest("testTablature1"); }
     void tablature2() { mxmlIoTest("testTablature2"); }
     void tablature3() { mxmlIoTest("testTablature3"); }
@@ -451,6 +453,26 @@ void TestMxmlIO::mxmlReadWriteTestCompr(const char* file)
     score->doLayout();
     // write and verify
     QVERIFY(saveCompareMusicXmlScore(score, QString(file) + "_mxl_read_write.xml", XML_IO_DATA_DIR + file + ".xml"));
+    delete score;
+}
+
+//---------------------------------------------------------
+//   mxmlImportTestRef
+//   read a MusicXML file, write to a new MuseScore mscx file
+//   and verify against a MuseScore mscx reference file
+//---------------------------------------------------------
+
+void TestMxmlIO::mxmlImportTestRef(const char* file)
+{
+    MScore::debugMode = false;
+    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(static_cast<int>(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual)));
+    setValue(PREF_EXPORT_MUSICXML_EXPORTLAYOUT, Val(false));
+
+    MasterScore* score = readScore(XML_IO_DATA_DIR + file + ".xml");
+    QVERIFY(score);
+    fixupScore(score);
+    score->doLayout();
+    QVERIFY(saveCompareScore(score, QString(file) + ".mscx", XML_IO_DATA_DIR + file + "_ref.mscx"));
     delete score;
 }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/290694

[MU3] fix #290694 - ensure that final barline created during musicxml import (and elsewhere) spans across multi-staff parts

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://musescore.org/en/cla)
- [ x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x] I made sure the code compiles on my machine
- [ x] I made sure there are no unnecessary changes in the code
- [ x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
