### PR TITLE
[MU4] Enabled lasso selection

### DIFF
--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -40,6 +40,7 @@
 
 namespace Ms {
 class ShadowNote;
+class Lasso;
 }
 
 namespace mu::notation {
@@ -188,6 +189,8 @@ private:
     void notifyAboutNotationChanged();
     void notifyAboutTextEditingStarted();
     void notifyAboutTextEditingChanged();
+    void doDragLasso(const QPointF& p);
+    void endLasso();
 
     Ms::Page* point2page(const QPointF& p) const;
     QList<Element*> hitElements(const QPointF& p_in, float w) const;
@@ -277,6 +280,8 @@ private:
     async::Notification m_dropChanged;
 
     async::Channel<ScoreConfigType> m_scoreConfigChanged;
+
+    Ms::Lasso* m_lasso;
 };
 }
 

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -399,6 +399,12 @@ void NotationViewInputController::mouseMoveEvent(QMouseEvent* event)
 
         m_view->notationInteraction()->drag(m_interactData.beginPoint, logicPos, mode);
         return;
+    } else if (m_interactData.hitElement == nullptr && (event->modifiers() & Qt::ShiftModifier)) {
+        if (!m_view->notationInteraction()->isDragStarted()) {
+            m_view->notationInteraction()->startDrag(std::vector<Element*>(), QPoint(), [](const Element*) { return false; });
+        }
+        m_view->notationInteraction()->drag(m_interactData.beginPoint, logicPos, DragMode::BothXY);
+        return;
     }
 
     // move canvas
@@ -431,7 +437,8 @@ void NotationViewInputController::startDragElements(ElementType elementsType, co
 
 void NotationViewInputController::mouseReleaseEvent(QMouseEvent*)
 {
-    if (!m_interactData.hitElement && !m_isCanvasDragged && !m_view->notationInteraction()->isGripEditStarted()) {
+    if (!m_interactData.hitElement && !m_isCanvasDragged && !m_view->notationInteraction()->isGripEditStarted()
+        && !m_view->notationInteraction()->isDragStarted()) {
         m_view->notationInteraction()->clearSelection();
     }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8148

Lasso selection functionality from MU3 wasn't implemented in MU4.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://musescore.org/en/cla)
- [x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x ] I made sure the code compiles on my machine
- [x ] I made sure there are no unnecessary changes in the code
- [x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
