### PR TITLE
fix #311353: Playback fix for half-diminished chords

### DIFF
--- a/src/engraving/libmscore/realizedharmony.cpp
+++ b/src/engraving/libmscore/realizedharmony.cpp
@@ -426,6 +426,9 @@ RealizedHarmony::PitchMap RealizedHarmony::getIntervals(int rootTpc, bool litera
         if (!(omit & (1 << 5))) {
             ret.insert(step2pitchInterval(5, -1) + RANK_MULT * RANK_3RD, tpcInterval(rootTpc, 5, -1));         //dim5
         }
+        if (!(omit & (1 << 7)) && quality == "half-diminished") {
+            ret.insert(step2pitchInterval(7, -1) + RANK_MULT * RANK_7TH, tpcInterval(rootTpc, 7, -1));           //min7
+        }
         alt5 = true;
     } else { //major or dominant
         if (!(omit & (1 << 3))) {
@@ -466,6 +469,8 @@ RealizedHarmony::PitchMap RealizedHarmony::getIntervals(int rootTpc, bool litera
                 ret.insert(11 + RANK_MULT * RANK_7TH, tpcInterval(rootTpc, 7, 0));
             } else if (quality == "diminished") {
                 ret.insert(9 + RANK_MULT * RANK_7TH, tpcInterval(rootTpc, 7, -2));
+            } else if (quality == "half-diminished") {
+                // 7th note already added when handling chord quality
             } else {         //dominant or augmented or minor
                 ret.insert(10 + RANK_MULT * RANK_7TH, tpcInterval(rootTpc, 7, -1));
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/311353

The 7th note is automatically added to the half-diminished chord without the need for specifying it.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
