### PR TITLE
Allow right-clicking as alternative to long-clicking in NoteInputBar

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/FlatButton.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/FlatButton.qml
@@ -50,8 +50,8 @@ FocusScope {
 
     property bool isClickOnKeyNavTriggered: true
 
-    signal clicked()
-    signal pressAndHold()
+    signal clicked(var mouse)
+    signal pressAndHold(var mouse)
 
     objectName: root.text
 
@@ -62,8 +62,9 @@ FocusScope {
 
     QtObject {
         id: prv
-        property color defaultColor: accentButton ? ui.theme.accentColor : ui.theme.buttonColor
-        property bool isVertical: orientation === Qt.Vertical
+
+        property color defaultColor: root.accentButton ? ui.theme.accentColor : ui.theme.buttonColor
+        property bool isVertical: root.orientation === Qt.Vertical
     }
 
     NavigationControl {
@@ -184,8 +185,8 @@ FocusScope {
 
         hoverEnabled: true
 
-        onClicked: root.clicked()
-        onPressAndHold: root.pressAndHold()
+        onClicked: function (mouse) { root.clicked(mouse) }
+        onPressAndHold: function (mouse) { root.pressAndHold(mouse) }
 
         onContainsMouseChanged: {
             if (!Boolean(root.toolTipTitle)) {

--- a/src/notation/view/noteinputbarmodel.cpp
+++ b/src/notation/view/noteinputbarmodel.cpp
@@ -68,7 +68,7 @@ QVariant NoteInputBarModel::data(const QModelIndex& index, int role) const
     case DescriptionRole: return item.description;
     case ShortcutRole: return QString::fromStdString(item.shortcut);
     case SubitemsRole: return subitems(item.code);
-    case ShowSubitemsByPressAndHoldRole: return isNeedShowSubitemsByPressAndHold(item.code);
+    case IsMenuSecondaryRole: return isMenuSecondary(item.code);
     case OrderRole: return index.row();
     }
     return QVariant();
@@ -90,7 +90,7 @@ QHash<int, QByteArray> NoteInputBarModel::roleNames() const
         { DescriptionRole, "descriptionRole" },
         { ShortcutRole, "shortcutRole" },
         { SubitemsRole, "subitemsRole" },
-        { ShowSubitemsByPressAndHoldRole, "showSubitemsByPressAndHoldRole" },
+        { IsMenuSecondaryRole, "isMenuSecondaryRole" },
         { OrderRole, "orderRole" },
     };
     return roles;
@@ -787,7 +787,7 @@ MenuItemList NoteInputBarModel::linesItems() const
     return items;
 }
 
-bool NoteInputBarModel::isNeedShowSubitemsByPressAndHold(const ActionCode& actionCode) const
+bool NoteInputBarModel::isMenuSecondary(const ActionCode& actionCode) const
 {
     if (isNoteInputModeAction(actionCode)) {
         return true;

--- a/src/notation/view/noteinputbarmodel.h
+++ b/src/notation/view/noteinputbarmodel.h
@@ -71,7 +71,7 @@ private:
         DescriptionRole,
         ShortcutRole,
         SubitemsRole,
-        ShowSubitemsByPressAndHoldRole,
+        IsMenuSecondaryRole,
         OrderRole
     };
 
@@ -117,7 +117,7 @@ private:
     ui::MenuItemList textItems() const;
     ui::MenuItemList linesItems() const;
 
-    bool isNeedShowSubitemsByPressAndHold(const actions::ActionCode& actionCode) const;
+    bool isMenuSecondary(const actions::ActionCode& actionCode) const;
 
     void notifyAboutTupletItemChanged();
     void notifyAboutAddItemChanged();


### PR DESCRIPTION
Allow right-clicking as alternative to long-clicking in NoteInputBar on buttons that have both an action and a menu.
Also renamed `showSubitemsByPressAndHold` to `isMenuSecondary`, because the property means that triggering the action is the primary function of the button and opening the menu the secondary function.
Also enhanced (accent) color behaviour.
Oh -- and also avoid some "unqualified lookups".

Here's a screen recording of the new behaviour, but you can't judge very well from this because you can't know which mouse buttons I'm using. 

https://user-images.githubusercontent.com/48658420/119560446-42ec4a00-bda4-11eb-83a7-e6a888a3f10e.mov

