### PR TITLE
lasso list selection

### DIFF
--- a/src/libmscore/score.cpp
+++ b/src/libmscore/score.cpp
@@ -3719,7 +3719,7 @@ void Score::lassoSelect(const QRectF& bbox)
 //   lassoSelectEnd
 //---------------------------------------------------------
 
-void Score::lassoSelectEnd()
+void Score::lassoSelectEnd(bool convertToRange)
 {
     int noteRestCount     = 0;
     Segment* startSegment = 0;
@@ -3734,6 +3734,11 @@ void Score::lassoSelectEnd()
         return;
     }
     _selection.setState(SelState::LIST);
+
+    if (!convertToRange) {
+        setUpdateAll();
+        return;
+    }
 
     foreach (const Element* e, _selection.elements()) {
         if (e->type() != ElementType::NOTE && e->type() != ElementType::REST) {

--- a/src/libmscore/score.h
+++ b/src/libmscore/score.h
@@ -1028,7 +1028,7 @@ public:
     void setScoreOrder(ScoreOrder* order) { _scoreOrder = order; }
 
     void lassoSelect(const QRectF&);
-    void lassoSelectEnd();
+    void lassoSelectEnd(bool);
 
     Page* searchPage(const QPointF&) const;
     QList<System*> searchSystem(const QPointF& p, const System* preferredSystem = nullptr, qreal spacingFactor = 0.5,

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -600,7 +600,7 @@ void NotationInteraction::endLasso()
 {
     score()->addRefresh(m_lasso->canvasBoundingRect());
     m_lasso->setbbox(QRectF());
-    score()->lassoSelectEnd();
+    score()->lassoSelectEnd(m_dragData.mode != DragMode::LassoList);
     score()->update();
 }
 
@@ -610,6 +610,7 @@ void NotationInteraction::drag(const QPointF& fromPos, const QPointF& toPos, Dra
         m_dragData.beginMove = fromPos;
         m_dragData.ed.pos = fromPos;
     }
+    m_dragData.mode = mode;
 
     QPointF normalizedBegin = m_dragData.beginMove - m_dragData.elementOffset;
 
@@ -618,6 +619,7 @@ void NotationInteraction::drag(const QPointF& fromPos, const QPointF& toPos, Dra
 
     switch (mode) {
     case DragMode::BothXY:
+    case DragMode::LassoList:
         break;
     case DragMode::OnlyX:
         delta.setY(m_dragData.ed.delta.y());

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -248,6 +248,7 @@ private:
         Ms::EditData ed;
         std::vector<Element*> elements;
         std::vector<std::unique_ptr<Ms::ElementGroup> > dragGroups;
+        DragMode mode { DragMode::BothXY };
         void reset();
     };
 

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -102,7 +102,8 @@ enum class DragMode
 {
     BothXY = 0,
     OnlyX,
-    OnlyY
+    OnlyY,
+    LassoList
 };
 
 enum class MoveDirection

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -399,11 +399,12 @@ void NotationViewInputController::mouseMoveEvent(QMouseEvent* event)
 
         m_view->notationInteraction()->drag(m_interactData.beginPoint, logicPos, mode);
         return;
-    } else if (m_interactData.hitElement == nullptr && (event->modifiers() & Qt::ShiftModifier)) {
+    } else if (m_interactData.hitElement == nullptr && (keyState & (Qt::ShiftModifier | Qt::ControlModifier))) {
         if (!m_view->notationInteraction()->isDragStarted()) {
             m_view->notationInteraction()->startDrag(std::vector<Element*>(), QPoint(), [](const Element*) { return false; });
         }
-        m_view->notationInteraction()->drag(m_interactData.beginPoint, logicPos, DragMode::BothXY);
+        m_view->notationInteraction()->drag(m_interactData.beginPoint, logicPos,
+                                            keyState & Qt::ControlModifier ? DragMode::LassoList : DragMode::BothXY);
         return;
     }
 


### PR DESCRIPTION
Resolves: Adding new feature to support lasso selection without converting to range

Current MU3 behaviour of always converting the list selection shown while drawing the lasso to a range is not always desirable or expected, e.g. if you need to select all notes between a certain pitch range.
This includes the changes in PR https://github.com/musescore/MuseScore/pull/8157 which are required.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://musescore.org/en/cla)
- [x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x ] I made sure the code compiles on my machine
- [x ] I made sure there are no unnecessary changes in the code
- [x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
