### PR TITLE
[MU3 Backend] ENG-34: Fix erroneous space created for melismas

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1243,19 +1243,9 @@ bool ChordRest::isMelismaEnd() const
 //    No-op and return false if Lyrics not present in _melismaEnds.
 //---------------------------------------------------------
 
-bool ChordRest::removeMelismaEnd(const Lyrics* l)
+void ChordRest::removeMelismaEnd(Lyrics* const l)
       {
-      bool found = false;
-      for (std::set<Lyrics*>::iterator it = _melismaEnds.begin(); it != _melismaEnds.end(); ) {
-            if (*it == l) {
-                  it = _melismaEnds.erase(it); // Returns next iterator
-                  found = true;
-                  }
-            else {
-                  ++it;
-                  }
-            }
-      return found;
+      _melismaEnds.erase(l);
       }
 
 //---------------------------------------------------------

--- a/libmscore/chordrest.h
+++ b/libmscore/chordrest.h
@@ -140,7 +140,7 @@ class ChordRest : public DurationElement {
       int lastVerse(Placement) const;
       const std::set<Lyrics*>& melismaEnds() const { return _melismaEnds; }
       std::set<Lyrics*>& melismaEnds()             { return _melismaEnds; }
-      bool removeMelismaEnd(const Lyrics* l);
+      void removeMelismaEnd(Lyrics* const l);
       bool isMelismaEnd() const;
 
       virtual void add(Element*);


### PR DESCRIPTION
(Partially) Resolves: [ENG-34](https://mu--se.atlassian.net/jira/software/projects/ENG/boards/21?selectedIssue=ENG-34): Improve lyrics spacing

Previously, melismas were treated the same as normal Lyrics in terms of
horizontal spacing—they would cause a spacer to be added to the
ChordRest to which they were attached, causing an unnecessary gap after
the first note of a melisma.

This commit prevents a melisma from adding a right spacer to
their first ChordRest, and rather creates a right
spacer on the last ChordRest of a lyric if necessary.

In pursuit of this, this commit refactors ChordRest::_melismaEnd(s) from
a bool to a std::set<*Lyrics>, giving a ChordRest a way to access the
melismatic Lyrics that end on it. This change also solves the problem of
said bool being untrustworthy (i.e. erroneously being changed to false
when one of multiple melismas was removed).


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
