### PR TITLE
Fix showing tooltips on buttons

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/FlatButton.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/FlatButton.qml
@@ -187,7 +187,7 @@ FocusScope {
         onPressAndHold: root.pressAndHold()
 
         onContainsMouseChanged: {
-            if (!Boolean(root.hint)) {
+            if (!Boolean(root.toolTipTitle)) {
                 return
             }
 


### PR DESCRIPTION
There was a check like `if (!Boolean(root.hint)) { return; }`, which always failed because the `hint` property was renamed to `toolTipTitle`.

This was originally correct in 1f63b353c8bb26c3f11d99bb89060361b031cff1, but accidentally got reverted in cc3f492fef6f055412b12b370c03bf15b5172992. 