### PR TITLE
Prevents switch to concert pitch/normal when score is already in concert/normal pitch.

### DIFF
--- a/src/libmscore/score.cpp
+++ b/src/libmscore/score.cpp
@@ -2864,6 +2864,10 @@ void Score::mapExcerptTracks(QList<int>& dst)
 
 void Score::cmdConcertPitchChanged(bool flag)
 {
+    if (flag == styleB(Ms::Sid::concertPitch)) {
+        return;
+    }
+
     undoChangeStyleVal(Sid::concertPitch, flag);         // change style flag
 
     for (Staff* staff : qAsConst(_staves)) {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8184

When switching to concert/normal pitch, transposing instruments are transposed by `Score::cmdConcertPitchChanged()`.
However for some reason when switch the concert pitch within the style editor, the operation is fired twice. So also `Score::cmdConcertPitchChanged()` is called twice and a s result the transposing instruments are transposed twice.

E.g. for a piece in C, the Bb Clarinet is in D. Switching to concert pitch the Bb Clarinet is transposed a major second down, to C. But because the command is fired twice the Bb clarinet is transposed a major second down again resulting in Bb.
When next the tuning fork on the main GUI is used to switch back to normal pitch the Bb Clarinet is transposed a major second up, to C. But now the command is fired only once (as it should be) and the Bb Clarinet now stays into C, like any other non-transposing instrument. Which is wrong. 

With this PR `Score::cmdConcertPitchChanged()` checks first whether the new state is different as the existing state and will transpose transposing instruments when the state really changes.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
