### PR TITLE
[MU3] Fix #321376: Musescore cannot open MusicXML file it created if filename contains an ampersand

### DIFF
--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -6656,7 +6656,7 @@ static void writeMxlArchive(Score* score, MQZipWriter& zipwriter, const QString&
       xml << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
       xml.stag("container");
       xml.stag("rootfiles");
-      xml.stag(QString("rootfile full-path=\"%1\"").arg(filename));
+      xml.stag(QString("rootfile full-path=\"%1\"").arg(XmlWriter::xmlString(filename)));
       xml.etag();
       xml.etag();
       xml.etag();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/321376

For master see #8188 