### PR TITLE
[MU4] Fix #321376: Musescore cannot open MusicXML file it created if filename contains an ampersand

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -7026,7 +7026,7 @@ static void writeMxlArchive(Score* score, MQZipWriter& zipwriter, const QString&
     xml << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
     xml.stag("container");
     xml.stag("rootfiles");
-    xml.stag(QString("rootfile full-path=\"%1\"").arg(filename));
+    xml.stag(QString("rootfile full-path=\"%1\"").arg(XmlWriter::xmlString(filename)));
     xml.etag();
     xml.etag();
     xml.etag();


### PR DESCRIPTION
Resolves: Resolves: https://musescore.org/en/node/321376

This is for master what #8187 is for 3.x