### PR TITLE
[MU4] Fix #321730: Crash on corrupt MXL import

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -1625,8 +1625,9 @@ void MusicXMLParserPass2::scorePartwise()
     }
     // set last measure barline to normal or MuseScore will generate light-heavy EndBarline
     // TODO, handle other tracks?
-    if (_score->lastMeasure()->endBarLineType() == BarLineType::NORMAL) {
-        _score->lastMeasure()->setEndBarLineType(BarLineType::NORMAL, 0);
+    auto lm = _score->lastMeasure();
+    if (lm && lm->endBarLineType() == BarLineType::NORMAL) {
+        lm->setEndBarLineType(BarLineType::NORMAL, 0);
     }
 }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/321730

This is for master what #8199 is for 3.x