### PR TITLE
fix #315904: [MusicMXL import] incomplete import from ScoreScan XML f…

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -5863,7 +5863,6 @@ void MusicXMLParserNotations::technical()
                                                                  _e.attributes(), "technical");
             notation.setText(_e.readElementText());
             _notations.push_back(notation);
-            _e.readNext();
         } else if (_e.name() == "harmonic") {
             harmonic();
             _e.readNext();

--- a/src/importexport/musicxml/tests/tst_mxml_io.cpp
+++ b/src/importexport/musicxml/tests/tst_mxml_io.cpp
@@ -146,6 +146,7 @@ private slots:
     void invisibleElements() { mxmlIoTest("testInvisibleElements"); }
     void keysig1() { mxmlIoTest("testKeysig1"); }
     void keysig2() { mxmlIoTest("testKeysig2"); }
+    void lessWhiteSpace() { mxmlIoTestRef("testLessWhiteSpace"); }
     void lines1() { mxmlIoTest("testLines1"); }
     void lines2() { mxmlIoTest("testLines2"); }
     void lines3() { mxmlIoTest("testLines3"); }


### PR DESCRIPTION
…ile (sync PR7442 to master)

Resolves: https://musescore.org/en/node/315904

An incorrect readNext() caused the MusicXML parser to get out of sync
if no white space is present between the end elements of fingering
and technical. This is legal but seems to occur only in files produced
by ScanScore. It results in incomplete import.

Synced 3.x https://github.com/musescore/MuseScore/pull/7442 to master as requested by igorkorsukov on Feb 15.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
