### PR TITLE
Fix #8202: Change Lirycist to Lyricist

### DIFF
--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -779,8 +779,8 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("poet-text",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Lirycist"),
-             QT_TRANSLATE_NOOP("action", "Add lirycist text")
+             QT_TRANSLATE_NOOP("action", "Lyricist"),
+             QT_TRANSLATE_NOOP("action", "Add lyricist text")
              ),
     UiAction("part-text",
              mu::context::UiCtxNotationOpened,


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/8202*

The string "lyricist" was misspelled in the UI Action *poet-text* in notationuiactions.cpp, fixed.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
