### PR TITLE
Fix #7972: Emphasize checkbox attachment to Concert Pitch button

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/ConcertPitchControl.qml
+++ b/src/notation/qml/MuseScore/NotationScene/ConcertPitchControl.qml
@@ -40,25 +40,28 @@ Row {
         model.load()
     }
 
-    CheckBox {
-        anchors.verticalCenter: parent.verticalCenter
-
-        checked: model.concertPitchEnabled
-
-        onClicked: {
-            model.toggleConcertPitch()
-        }
-    }
-
     FlatButton {
         icon: IconCode.TUNING_FORK
         text: qsTrc("notation", "Concert pitch")
+
+        width: 150
 
         orientation: Qt.Horizontal
         normalStateColor: "transparent"
 
         onClicked: {
             model.toggleConcertPitch()
+        }
+
+        CheckBox {
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.right: parent.right
+
+            checked: model.concertPitchEnabled
+
+            onClicked: {
+                model.toggleConcertPitch()
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/7972*

Move the checkbox to the right, as suggested in the issue,
and put it inside the button.
Flaw: In dark theme, overmousing the button hide the checkbox.

![standard theme gif](https://user-images.githubusercontent.com/54242350/120365962-5b61e480-c30f-11eb-99c2-28db9c896de5.gif)
![black theme gif](https://user-images.githubusercontent.com/54242350/120365748-1ccc2a00-c30f-11eb-8205-8539423b3a8f.gif)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
