### PR TITLE
Fix QML warning in NoteInputBar

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/NoteInputBar.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NoteInputBar.qml
@@ -80,7 +80,7 @@ Rectangle {
             property var item: Boolean(itemModel) ? itemModel : null
             property var hasMenu: Boolean(item) && item.subitemsRole.length !== 0
 
-            accentButton: Boolean(item) && item.checkedRole || menuLoader.isMenuOpened()
+            accentButton: (Boolean(item) && item.checkedRole) || menuLoader.isMenuOpened
             normalStateColor: accentButton ? ui.theme.accentColor : "transparent"
 
             icon: Boolean(item) ? item.iconRole : IconCode.NONE


### PR DESCRIPTION
The warning was
`qrc:/qml/MuseScore/NotationScene/NoteInputBar.qml:83: TypeError: Type error`

(Arised from the combination of PR #8194 and #8173.)