### PR TITLE
[MU4] Removed FreeType dependency for libmscore 

### DIFF
--- a/src/engraving/CMakeLists.txt
+++ b/src/engraving/CMakeLists.txt
@@ -47,6 +47,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/draw/fontcompat.h
     ${CMAKE_CURRENT_LIST_DIR}/draw/qfontprovider.cpp
     ${CMAKE_CURRENT_LIST_DIR}/draw/qfontprovider.h
+    ${CMAKE_CURRENT_LIST_DIR}/draw/fontengineft.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/draw/fontengineft.h
     ${CMAKE_CURRENT_LIST_DIR}/draw/utils/drawlogger.cpp
     ${CMAKE_CURRENT_LIST_DIR}/draw/utils/drawlogger.h
     ${CMAKE_CURRENT_LIST_DIR}/draw/utils/drawjson.cpp

--- a/src/engraving/draw/bufferedpaintprovider.cpp
+++ b/src/engraving/draw/bufferedpaintprovider.cpp
@@ -152,7 +152,7 @@ void BufferedPaintProvider::setFont(const Font& f)
     editableState().font = f;
 }
 
-Font BufferedPaintProvider::font() const
+const Font& BufferedPaintProvider::font() const
 {
     return currentState().font;
 }
@@ -241,6 +241,11 @@ void BufferedPaintProvider::drawTextWorkaround(mu::draw::Font& f, const QPointF&
 {
     setFont(f);
     drawText(pos, text);
+}
+
+void BufferedPaintProvider::drawSymbol(const QPointF& point, uint ucs4Code)
+{
+    drawText(point, QString::fromUcs4(&ucs4Code, 1));
 }
 
 void BufferedPaintProvider::drawPixmap(const QPointF& p, const QPixmap& pm)

--- a/src/engraving/draw/bufferedpaintprovider.h
+++ b/src/engraving/draw/bufferedpaintprovider.h
@@ -55,7 +55,7 @@ public:
     void setCompositionMode(CompositionMode mode) override;
 
     void setFont(const Font& font) override;
-    Font font() const override;
+    const Font& font() const override;
 
     void setPen(const QPen& pen) override;
     void setNoPen() override;
@@ -77,6 +77,8 @@ public:
     void drawText(const QPointF& point, const QString& text) override;
     void drawText(const QRectF& rect, int flags, const QString& text) override;
     void drawTextWorkaround(mu::draw::Font& f, const QPointF& pos, const QString& text) override;
+
+    void drawSymbol(const QPointF& point, uint ucs4Code) override;
 
     void drawPixmap(const QPointF& p, const QPixmap& pm) override;
     void drawTiledPixmap(const QRectF& rect, const QPixmap& pm, const QPointF& offset = QPointF()) override;

--- a/src/engraving/draw/font.cpp
+++ b/src/engraving/draw/font.cpp
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "font.h"
+#include "global/realfn.h"
 
 using namespace mu::draw;
 
@@ -28,9 +29,14 @@ Font::Font(const QString& family)
 {
 }
 
-Font::Font(const Font& f)
-    : m_family(f.m_family), m_pointSizeF(f.m_pointSizeF), m_style(f.m_style)
+bool Font::operator ==(const Font& other) const
 {
+    return m_family == other.m_family
+           && RealIsEqual(m_pointSizeF, other.m_pointSizeF)
+           && m_weight == other.m_weight
+           && m_style == other.m_style
+           && m_noFontMerging == other.m_noFontMerging
+           && m_hinting == other.m_hinting;
 }
 
 void Font::setFamily(const QString& family)
@@ -85,12 +91,12 @@ void Font::setItalic(bool arg)
 
 bool Font::underline() const
 {
-    return m_style.testFlag(Style::Undefined);
+    return m_style.testFlag(Style::Underline);
 }
 
 void Font::setUnderline(bool arg)
 {
-    m_style.setFlag(Style::Undefined, arg);
+    m_style.setFlag(Style::Underline, arg);
 }
 
 void Font::setNoFontMerging(bool arg)

--- a/src/engraving/draw/font.h
+++ b/src/engraving/draw/font.h
@@ -29,13 +29,12 @@ class Font
 {
 public:
     Font(const QString& family = QString());
-    Font(const Font& font);
 
     enum class Style {
-        Undefined = 0,
-        Bold = 1 << 1,
-        Italic = 1 << 2,
-        Underline = 1 << 3
+        Undefined   = 0,
+        Bold        = 1 << 1,
+        Italic      = 1 << 2,
+        Underline   = 1 << 3
     };
 
     enum class Hinting {
@@ -79,10 +78,13 @@ public:
     Hinting hinting() const;
     void setHinting(Hinting hinting);
 
+    bool operator ==(const Font& other) const;
+    bool operator !=(const Font& other) const { return !this->operator ==(other); }
+
 private:
 
     QString m_family;
-    qreal m_pointSizeF = 0;
+    qreal m_pointSizeF = -1;
     Weight m_weight = Weight::Normal;
     QFlags<Style> m_style{ Style::Undefined };
     bool m_noFontMerging = false;

--- a/src/engraving/draw/fontcompat.cpp
+++ b/src/engraving/draw/fontcompat.cpp
@@ -24,7 +24,10 @@
 QFont mu::draw::toQFont(const Font& f)
 {
     QFont qf(f.family());
-    qf.setPointSizeF(f.pointSizeF());
+
+    if (f.pointSizeF() > 0) {
+        qf.setPointSizeF(f.pointSizeF());
+    }
     qf.setWeight(static_cast<QFont::Weight>(f.weight()));
     qf.setBold(f.bold());
     qf.setItalic(f.italic());

--- a/src/engraving/draw/fontengineft.cpp
+++ b/src/engraving/draw/fontengineft.cpp
@@ -1,0 +1,148 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "fontengineft.h"
+
+#include <QFile>
+#include <QHash>
+
+#include "ft2build.h"
+#include FT_FREETYPE_H
+#include FT_GLYPH_H
+#include FT_BBOX_H
+
+#include "log.h"
+
+static FT_Library ftlib = nullptr;
+
+using namespace mu::draw;
+
+static bool _init_ft()
+{
+    int error = 0;
+    if (!ftlib) {
+        error = FT_Init_FreeType(&ftlib);
+        if (!ftlib || error) {
+            LOGE() << "init freetype library failed";
+        }
+    }
+    return error == 0;
+}
+
+struct mu::draw::FTGlyphMetrics
+{
+    FT_BBox bb;
+    double linearHoriAdvance = 0.0;
+};
+
+struct mu::draw::FTData
+{
+    QByteArray fontData;
+    FT_Face face = nullptr;
+    QHash<uint, FTGlyphMetrics> metrics;
+};
+
+FontEngineFT::FontEngineFT()
+{
+    m_data = new FTData();
+}
+
+FontEngineFT::~FontEngineFT()
+{
+    delete m_data;
+}
+
+bool FontEngineFT::load(const QString& path)
+{
+    if (!_init_ft()) {
+        return false;
+    }
+
+    QFile f(path);
+    if (!f.open(QIODevice::ReadOnly)) {
+        LOGE() << "failed open font: " << path;
+        return false;
+    }
+
+    m_data->fontData = f.readAll();
+
+    int rval = FT_New_Memory_Face(ftlib, (FT_Byte*)m_data->fontData.data(), m_data->fontData.size(), 0, &m_data->face);
+    if (rval) {
+        LOGE() << "freetype: cannot create face: " << path << ", rval: " << rval;
+        return false;
+    }
+
+    qreal pixelSize = 200.0;
+    FT_Set_Pixel_Sizes(m_data->face, 0, int(pixelSize + .5));
+
+    return true;
+}
+
+QRectF FontEngineFT::bbox(uint ucs4, qreal DPI_F) const
+{
+    FTGlyphMetrics* gm = glyphMetrics(ucs4);
+    if (!gm) {
+        return QRectF();
+    }
+
+    const FT_BBox& bb = gm->bb;
+    double m = 640.0 / DPI_F;
+    QRectF bbox;
+    bbox.setCoords(bb.xMin / m, -bb.yMax / m, bb.xMax / m, -bb.yMin / m);
+    return bbox;
+}
+
+qreal FontEngineFT::advance(uint ucs4, qreal DPI_F) const
+{
+    FTGlyphMetrics* gm = glyphMetrics(ucs4);
+    if (!gm) {
+        return 0.0;
+    }
+
+    return gm->linearHoriAdvance * DPI_F / 655360.0;
+}
+
+FTGlyphMetrics* FontEngineFT::glyphMetrics(uint ucs4) const
+{
+    if (m_data->metrics.contains(ucs4)) {
+        return &m_data->metrics[ucs4];
+    }
+
+    FT_UInt index = FT_Get_Char_Index(m_data->face, ucs4);
+    if (index == 0) {
+        return nullptr;
+    }
+
+    if (FT_Load_Glyph(m_data->face, index, FT_LOAD_DEFAULT) != 0) {
+        return nullptr;
+    }
+
+    FT_BBox bb;
+    if (FT_Outline_Get_BBox(&m_data->face->glyph->outline, &bb) != 0) {
+        return nullptr;
+    }
+
+    FTGlyphMetrics& gm = m_data->metrics[ucs4];
+    gm.bb = bb;
+    gm.linearHoriAdvance = m_data->face->glyph->linearHoriAdvance;
+
+    return &gm;
+}

--- a/src/engraving/draw/fontengineft.h
+++ b/src/engraving/draw/fontengineft.h
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_DRAW_FONTENGINEFT_H
+#define MU_DRAW_FONTENGINEFT_H
+
+#include <QString>
+#include <QByteArray>
+
+namespace mu::draw {
+struct FTData;
+struct FTGlyphMetrics;
+class FontEngineFT
+{
+public:
+    FontEngineFT();
+    ~FontEngineFT();
+
+    bool load(const QString& path);
+
+    QRectF bbox(uint ucs4, qreal DPI_F) const;
+    qreal advance(uint ucs4, qreal DPI_F) const;
+
+private:
+
+    FTGlyphMetrics* glyphMetrics(uint ucs4) const;
+
+    FTData* m_data = nullptr;
+};
+}
+
+#endif // MU_DRAW_FONTENGINEFT_H

--- a/src/engraving/draw/fontmetrics.cpp
+++ b/src/engraving/draw/fontmetrics.cpp
@@ -55,12 +55,22 @@ qreal FontMetrics::descent() const
 
 qreal FontMetrics::width(const QString& string) const
 {
-    return boundingRect(string).width();
+    return horizontalAdvance(string);
 }
 
 qreal FontMetrics::width(const QChar& ch) const
 {
-    return boundingRect(ch).width();
+    return horizontalAdvance(ch);
+}
+
+qreal FontMetrics::horizontalAdvance(const QString& string) const
+{
+    return fontProvider()->horizontalAdvance(m_font, string);
+}
+
+qreal FontMetrics::horizontalAdvance(const QChar& ch) const
+{
+    return fontProvider()->horizontalAdvance(m_font, ch);
 }
 
 QRectF FontMetrics::boundingRect(const QString& string) const

--- a/src/engraving/draw/fontmetrics.h
+++ b/src/engraving/draw/fontmetrics.h
@@ -43,6 +43,9 @@ public:
     qreal width(const QString& string) const;
     qreal width(const QChar& ch) const;
 
+    qreal horizontalAdvance(const QString& string) const;
+    qreal horizontalAdvance(const QChar& ch) const;
+
     QRectF boundingRect(const QString& string) const;
     QRectF boundingRect(const QChar& ch) const;
     QRectF boundingRect(const QRectF& r, int flags, const QString& string) const;

--- a/src/engraving/draw/ifontprovider.h
+++ b/src/engraving/draw/ifontprovider.h
@@ -35,6 +35,8 @@ class IFontProvider : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IFontProvider() = default;
 
+    virtual int addApplicationFont(const QString& path) = 0;
+
     virtual qreal lineSpacing(const Font& f) const = 0;
     virtual qreal xHeight(const Font& f) const = 0;
     virtual qreal height(const Font& f) const = 0;

--- a/src/engraving/draw/ifontprovider.h
+++ b/src/engraving/draw/ifontprovider.h
@@ -35,7 +35,8 @@ class IFontProvider : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IFontProvider() = default;
 
-    virtual int addApplicationFont(const QString& path) = 0;
+    virtual int addApplicationFont(const QString& family, const QString& path) = 0;
+    virtual void insertSubstitution(const QString& familyName, const QString& substituteName) = 0;
 
     virtual qreal lineSpacing(const Font& f) const = 0;
     virtual qreal xHeight(const Font& f) const = 0;
@@ -43,13 +44,21 @@ public:
     virtual qreal ascent(const Font& f) const = 0;
     virtual qreal descent(const Font& f) const = 0;
 
+    virtual bool inFont(const Font& f, QChar ch) const = 0;
+    virtual bool inFontUcs4(const Font& f, uint ucs4) const = 0;
+
+    // Text
+    virtual qreal horizontalAdvance(const Font& f, const QString& string) const = 0;
+    virtual qreal horizontalAdvance(const Font& f, const QChar& ch) const = 0;
+
     virtual QRectF boundingRect(const Font& f, const QString& string) const = 0;
     virtual QRectF boundingRect(const Font& f, const QChar& ch) const = 0;
     virtual QRectF boundingRect(const Font& f, const QRectF& r, int flags, const QString& string) const = 0;
     virtual QRectF tightBoundingRect(const Font& f, const QString& string) const = 0;
 
-    virtual bool inFont(const Font& f, QChar ch) const = 0;
-    virtual bool inFontUcs4(const Font& f, uint ucs4) const = 0;
+    // Score symbols
+    virtual QRectF symBBox(const Font& f, uint ucs4, qreal DPI_F) const = 0;
+    virtual qreal symAdvance(const Font& f, uint ucs4, qreal DPI_F) const = 0;
 };
 }
 

--- a/src/engraving/draw/ipaintprovider.h
+++ b/src/engraving/draw/ipaintprovider.h
@@ -54,7 +54,7 @@ public:
     virtual void setCompositionMode(CompositionMode mode) = 0;
 
     virtual void setFont(const Font& font) = 0;
-    virtual Font font() const = 0;
+    virtual const Font& font() const = 0;
 
     virtual void setPen(const QPen& pen) = 0;
     virtual void setNoPen() = 0;
@@ -76,6 +76,8 @@ public:
     virtual void drawText(const QPointF& point, const QString& text) = 0;
     virtual void drawText(const QRectF& rect, int flags, const QString& text) = 0;
     virtual void drawTextWorkaround(mu::draw::Font& f, const QPointF& pos, const QString& text) = 0; // see Painter::drawTextWorkaround .h file
+
+    virtual void drawSymbol(const QPointF& point, uint ucs4Code) = 0;
 
     virtual void drawPixmap(const QPointF& point, const QPixmap& pm) = 0;
     virtual void drawTiledPixmap(const QRectF& rect, const QPixmap& pm, const QPointF& offset = QPointF()) = 0;

--- a/src/engraving/draw/painter.cpp
+++ b/src/engraving/draw/painter.cpp
@@ -153,7 +153,7 @@ void Painter::setFont(const Font& font)
     }
 }
 
-Font Painter::font() const
+const Font& Painter::font() const
 {
     return m_provider->font();
 }
@@ -425,6 +425,14 @@ void Painter::drawTextWorkaround(mu::draw::Font& f, const QPointF pos, const QSt
     m_provider->drawTextWorkaround(f, pos, text);
     if (extended) {
         extended->drawTextWorkaround(f, pos, text);
+    }
+}
+
+void Painter::drawSymbol(const QPointF& point, uint ucs4Code)
+{
+    m_provider->drawSymbol(point, ucs4Code);
+    if (extended) {
+        extended->drawSymbol(point, ucs4Code);
     }
 }
 

--- a/src/engraving/draw/painter.h
+++ b/src/engraving/draw/painter.h
@@ -74,7 +74,7 @@ public:
     void setCompositionMode(CompositionMode mode);
 
     void setFont(const Font& font);
-    Font font() const;
+    const Font& font() const;
 
     void setPen(const QPen& pen);
     inline void setPen(const QColor& color);
@@ -159,6 +159,8 @@ public:
     //! bold and underlined.
     //! (moved from TextBase::drawTextWorkaround)
     void drawTextWorkaround(mu::draw::Font& f, const QPointF pos, const QString text);
+
+    void drawSymbol(const QPointF& point, uint ucs4Code);
 
     void fillRect(const QRectF& rect, const QBrush& brush);
 

--- a/src/engraving/draw/qfontprovider.cpp
+++ b/src/engraving/draw/qfontprovider.cpp
@@ -26,12 +26,19 @@
 
 #include "libmscore/mscore.h"
 #include "fontcompat.h"
+#include "fontengineft.h"
 
 using namespace mu::draw;
 
-int QFontProvider::addApplicationFont(const QString& path)
+int QFontProvider::addApplicationFont(const QString& family, const QString& path)
 {
+    m_paths[family] = path;
     return QFontDatabase::addApplicationFont(path);
+}
+
+void QFontProvider::insertSubstitution(const QString& familyName, const QString& substituteName)
+{
+    QFont::insertSubstitution(familyName, substituteName);
 }
 
 qreal QFontProvider::lineSpacing(const Font& f) const
@@ -59,6 +66,26 @@ qreal QFontProvider::descent(const Font& f) const
     return QFontMetricsF(toQFont(f), Ms::MScore::paintDevice()).descent();
 }
 
+bool QFontProvider::inFont(const Font& f, QChar ch) const
+{
+    return QFontMetricsF(toQFont(f), Ms::MScore::paintDevice()).inFont(ch);
+}
+
+bool QFontProvider::inFontUcs4(const Font& f, uint ucs4) const
+{
+    return QFontMetricsF(toQFont(f), Ms::MScore::paintDevice()).inFontUcs4(ucs4);
+}
+
+qreal QFontProvider::horizontalAdvance(const Font& f, const QString& string) const
+{
+    return QFontMetricsF(toQFont(f), Ms::MScore::paintDevice()).horizontalAdvance(string);
+}
+
+qreal QFontProvider::horizontalAdvance(const Font& f, const QChar& ch) const
+{
+    return QFontMetricsF(toQFont(f), Ms::MScore::paintDevice()).horizontalAdvance(ch);
+}
+
 QRectF QFontProvider::boundingRect(const Font& f, const QString& string) const
 {
     return QFontMetricsF(toQFont(f), Ms::MScore::paintDevice()).boundingRect(string);
@@ -79,12 +106,40 @@ QRectF QFontProvider::tightBoundingRect(const Font& f, const QString& string) co
     return QFontMetricsF(toQFont(f), Ms::MScore::paintDevice()).tightBoundingRect(string);
 }
 
-bool QFontProvider::inFont(const Font& f, QChar ch) const
+// Score symbols
+QRectF QFontProvider::symBBox(const Font& f, uint ucs4, qreal DPI_F) const
 {
-    return QFontMetricsF(toQFont(f), Ms::MScore::paintDevice()).inFont(ch);
+    FontEngineFT* engine = symEngine(f);
+    if (!engine) {
+        return QRectF();
+    }
+    return engine->bbox(ucs4, DPI_F);
 }
 
-bool QFontProvider::inFontUcs4(const Font& f, uint ucs4) const
+qreal QFontProvider::symAdvance(const Font& f, uint ucs4, qreal DPI_F) const
 {
-    return QFontMetricsF(toQFont(f), Ms::MScore::paintDevice()).inFontUcs4(ucs4);
+    FontEngineFT* engine = symEngine(f);
+    if (!engine) {
+        return 0.0;
+    }
+    return engine->advance(ucs4, DPI_F);
+}
+
+FontEngineFT* QFontProvider::symEngine(const Font& f) const
+{
+    QString path = m_paths.value(f.family());
+    if (path.isEmpty()) {
+        return nullptr;
+    }
+
+    FontEngineFT* engine = m_symEngines.value(path, nullptr);
+    if (!engine) {
+        engine = new FontEngineFT();
+        if (!engine->load(path)) {
+            delete engine;
+            return nullptr;
+        }
+        m_symEngines[path] = engine;
+    }
+    return engine;
 }

--- a/src/engraving/draw/qfontprovider.cpp
+++ b/src/engraving/draw/qfontprovider.cpp
@@ -21,12 +21,18 @@
  */
 #include "qfontprovider.h"
 
+#include <QFontDatabase>
 #include <QFontMetricsF>
 
 #include "libmscore/mscore.h"
 #include "fontcompat.h"
 
 using namespace mu::draw;
+
+int QFontProvider::addApplicationFont(const QString& path)
+{
+    return QFontDatabase::addApplicationFont(path);
+}
 
 qreal QFontProvider::lineSpacing(const Font& f) const
 {

--- a/src/engraving/draw/qfontprovider.h
+++ b/src/engraving/draw/qfontprovider.h
@@ -30,6 +30,8 @@ class QFontProvider : public IFontProvider
 public:
     QFontProvider() = default;
 
+    int addApplicationFont(const QString& path) override;
+
     qreal lineSpacing(const Font& f) const override;
     qreal xHeight(const Font& f) const override;
     qreal height(const Font& f) const override;

--- a/src/engraving/draw/qfontprovider.h
+++ b/src/engraving/draw/qfontprovider.h
@@ -22,15 +22,18 @@
 #ifndef MU_DRAW_QFONTPROVIDER_H
 #define MU_DRAW_QFONTPROVIDER_H
 
+#include <QHash>
 #include "ifontprovider.h"
 
 namespace mu::draw {
+class FontEngineFT;
 class QFontProvider : public IFontProvider
 {
 public:
     QFontProvider() = default;
 
-    int addApplicationFont(const QString& path) override;
+    int addApplicationFont(const QString& family, const QString& path) override;
+    void insertSubstitution(const QString& familyName, const QString& substituteName) override;
 
     qreal lineSpacing(const Font& f) const override;
     qreal xHeight(const Font& f) const override;
@@ -38,13 +41,28 @@ public:
     qreal ascent(const Font& f) const override;
     qreal descent(const Font& f) const override;
 
+    bool inFont(const Font& f, QChar ch) const override;
+    bool inFontUcs4(const Font& f, uint ucs4) const override;
+
+    // Text
+    qreal horizontalAdvance(const Font& f, const QString& string) const override;
+    qreal horizontalAdvance(const Font& f, const QChar& ch) const override;
+
     QRectF boundingRect(const Font& f, const QString& string) const override;
     QRectF boundingRect(const Font& f, const QChar& ch) const override;
     QRectF boundingRect(const Font& f, const QRectF& r, int flags, const QString& string) const override;
     QRectF tightBoundingRect(const Font& f, const QString& string) const override;
 
-    bool inFont(const Font& f, QChar ch) const override;
-    bool inFontUcs4(const Font& f, uint ucs4) const override;
+    // Score symbols
+    QRectF symBBox(const Font& f, uint ucs4, qreal DPI_F) const override;
+    qreal symAdvance(const Font& f, uint ucs4, qreal DPI_F) const override;
+
+private:
+
+    FontEngineFT* symEngine(const Font& f) const;
+
+    QHash<QString /*family*/, QString /*path*/> m_paths;
+    mutable QHash<QString /*path*/, FontEngineFT*> m_symEngines;
 };
 }
 

--- a/src/engraving/draw/qpainterprovider.h
+++ b/src/engraving/draw/qpainterprovider.h
@@ -53,7 +53,7 @@ public:
     void setCompositionMode(CompositionMode mode) override;
 
     void setFont(const Font& font) override;
-    Font font() const override;
+    const Font& font() const override;
 
     void setPen(const QPen& pen) override;
     void setNoPen() override;
@@ -76,11 +76,14 @@ public:
     void drawText(const QRectF& rect, int flags, const QString& text) override;
     void drawTextWorkaround(mu::draw::Font& f, const QPointF& pos, const QString& text) override;
 
+    void drawSymbol(const QPointF& point, uint ucs4Code) override;
+
     void drawPixmap(const QPointF& point, const QPixmap& pm) override;
     void drawTiledPixmap(const QRectF& rect, const QPixmap& pm, const QPointF& offset = QPointF()) override;
 
 private:
     QPainter* m_painter = nullptr;
+    Font m_font;
     bool m_overship = false;
     DrawObjectsLogger* m_drawObjectsLogger = nullptr;
 

--- a/src/engraving/libmscore/sym.cpp
+++ b/src/engraving/libmscore/sym.cpp
@@ -21,7 +21,6 @@
  */
 
 #include <cmath>
-#include <QFontDatabase>
 #include <QJsonParseError>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -191,7 +190,7 @@ void ScoreFont::draw(SymId id, mu::draw::Painter* painter, const QSizeF& mag, co
     if (MScore::pdfPrinting) {
         if (font == 0) {
             QString s(_fontPath + _filename);
-            if (-1 == QFontDatabase::addApplicationFont(s)) {
+            if (-1 == fontProvider()->addApplicationFont(s)) {
                 qDebug("Mscore: fatal error: cannot load internal font <%s>", qPrintable(s));
                 return;
             }

--- a/src/engraving/libmscore/sym.h
+++ b/src/engraving/libmscore/sym.h
@@ -200,8 +200,8 @@ public:
     static const QVector<ScoreFont>& scoreFonts() { return _scoreFonts; }
     static QJsonObject initGlyphNamesJson();
 
-    QString toString(SymId) const;
-    QPixmap sym2pixmap(SymId, qreal) { return QPixmap(); }        // TODOxxxx
+    QString toString(SymId id) const;
+    uint symCode(SymId id) const;
 
     void draw(SymId id,                  mu::draw::Painter*, const QSizeF& mag, const QPointF& pos, qreal scale) const;
     void draw(SymId id,                  mu::draw::Painter*, qreal mag,         const QPointF& pos, qreal scale) const;

--- a/src/engraving/libmscore/sym.h
+++ b/src/engraving/libmscore/sym.h
@@ -33,6 +33,9 @@
 #include "draw/painter.h"
 #include "draw/font.h"
 
+#include "modularity/ioc.h"
+#include "draw/ifontprovider.h"
+
 #include "ft2build.h"
 #include FT_FREETYPE_H
 
@@ -154,6 +157,8 @@ inline uint qHash(const GlyphKey& k)
 
 class ScoreFont
 {
+    INJECT(score, mu::draw::IFontProvider, fontProvider)
+
     FT_Face face = 0;
     QVector<Sym> _symbols;
     QString _name;


### PR DESCRIPTION
### Draw symbols
We render the text (for example, the name of the instruments) using the draw as text.
But how we draw symbols (for example, notes) rather depends on what we draw on:
1. If we draw on the screen, then FreeType is used, and images (bitmaps) are drawn. At the same time, we also create bitmaps of each symbol for each zoom value, including fractional ones when we zoom with the mouse wheel, thus creating tens of thousands of symbols bitmaps.
2. If we draw for Pdf or Svg, then we draw symbols with a painter as text. This is necessary for scaling to work, especially for Svg.

It turns out two systems for rendering symbols!!!

As I understand it, two symbols rendering systems emerged in 2015 when they added symbols rendering as text for printing. Probably before that there was only drawing based on FreeType and bitmaps.
But it is not clear why the old bitmap rendering was not removed. Perhaps they were afraid to break something. But, drawing symbols as text either works (and it doesn't matter what we draw on) or does not work, and then this is a critical bug that needs to be fixed (export to Pdf and Svg is critically important)

Now I have removed the rendering system based on FreeType and bitmaps.

### Symbols metrics
Since FreeType is no longer used for drawing symbols, I also wanted to remove its use for obtaining symbol metrics, use QFontMetrics for this.
But no matter how hard I tried, I couldn't do it, the values obtained are too different, and the layout is based precisely on the FreeType values of the symbol metrics, which they would not be.
So I kept the use of FreeType to get symbols metrics, but hid the use of FreeType behind the IFontProvider interfaces.