### PR TITLE
Update instrument id of strings

### DIFF
--- a/share/templates/08-Orchestral/01-Classical_Orchestra.mscx
+++ b/share/templates/08-Orchestral/01-Classical_Orchestra.mscx
@@ -505,7 +505,7 @@
         <bracket type="0" span="5" col="0"/>
         </Staff>
       <trackName>Violin I</trackName>
-      <Instrument id="strings">
+      <Instrument id="violins">
         <longName>Violins I</longName>
         <shortName>Vln. I</shortName>
         <trackName>Violins</trackName>
@@ -567,7 +567,7 @@
           </StaffType>
         </Staff>
       <trackName>Violin II</trackName>
-      <Instrument id="strings">
+      <Instrument id="violins">
         <longName>Violins II</longName>
         <shortName>Vln. II</shortName>
         <trackName>Violins</trackName>
@@ -630,7 +630,7 @@
         <defaultClef>C3</defaultClef>
         </Staff>
       <trackName>Viola</trackName>
-      <Instrument id="strings">
+      <Instrument id="violas">
         <longName>Violas</longName>
         <shortName>Vla.</shortName>
         <trackName>Violas</trackName>
@@ -694,7 +694,7 @@
         <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Violoncello</trackName>
-      <Instrument id="strings">
+      <Instrument id="violoncellos">
         <longName>Violoncellos</longName>
         <shortName>Vc.</shortName>
         <trackName>Violoncellos</trackName>
@@ -759,7 +759,7 @@
         <defaultTransposingClef>F</defaultTransposingClef>
         </Staff>
       <trackName>Contrabasses</trackName>
-      <Instrument id="strings">
+      <Instrument id="contrabasses">
         <longName>Contrabasses</longName>
         <shortName>Cb.</shortName>
         <trackName>Contrabasses</trackName>

--- a/share/templates/08-Orchestral/02-Symphony_Orchestra.mscx
+++ b/share/templates/08-Orchestral/02-Symphony_Orchestra.mscx
@@ -1343,7 +1343,7 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName>Violins 1</trackName>
-      <Instrument id="strings">
+      <Instrument id="violins">
         <longName>Violins 1</longName>
         <shortName>Vlns. 1</shortName>
         <trackName>Violins</trackName>


### PR DESCRIPTION
Resolves: none

Update instrument id of strings to make sure automatic bracketing is working correctly when these templates are used.
By having the correct instrument id for `Violins 1`, `Violins 2`, `Violas`, `Violoncellos` and `Contrabasses` the coming automatic bracketing "know" how to apply the correct brackets and bar line span.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
