### PR TITLE
Fixed positioning of checkmark for Selectable menu items

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledMenu.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledMenu.qml
@@ -77,10 +77,10 @@ StyledPopupView {
             let item = model[i]
             let hasIcon = (Boolean(item.icon) && item.icon !== IconCode.NONE)
 
-            if (item.checkable && hasIcon) {
+            if ((item.checkable || item.selectable) && hasIcon) {
                 prv.hasItemsWithIconAndCheckable = true
                 prv.hasItemsWithIconOrCheckable = true
-            } else if (item.checkable || hasIcon) {
+            } else if (item.checkable || item.selectable || hasIcon) {
                 prv.hasItemsWithIconOrCheckable = true
             }
 


### PR DESCRIPTION
Problem was that only `checkable` items were taken into account, but not `selectable` items.
|Before|After|
|-|-|
|<img width="194" alt="Schermafbeelding 2021-06-04 om 14 46 21" src="https://user-images.githubusercontent.com/48658420/120805951-9a2daf80-c546-11eb-8308-989c3079d1d9.png">|<img width="194" alt="Schermafbeelding 2021-06-04 om 14 54 52" src="https://user-images.githubusercontent.com/48658420/120805985-a0239080-c546-11eb-9958-e8d95f6e9619.png">|