### PR TITLE
fix #321924 allow sub and sup tags in instrument names

### DIFF
--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -2783,7 +2783,7 @@ bool TextBase::validateText(QString& s)
                 d.append("&amp;");
             }
         } else if (c == '<') {
-            const char* ok[] { "b>", "/b>", "i>", "/i>", "u>", "/u", "font ", "/font>", "sym>", "/sym>" };
+            const char* ok[] { "b>", "/b>", "i>", "/i>", "u>", "/u", "font ", "/font>", "sym>", "/sym>", "sub>", "/sub>", "sup>", "/sup>" };
             QString t = s.mid(i + 1);
             bool found = false;
             for (auto k : ok) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/321924

Use of sub- and superscript in text including instrument names is very common and already supported by the rendering engine.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
