### PR TITLE
[MU4] fix #8206 default for scale barlines should be false

### DIFF
--- a/src/engraving/libmscore/style.cpp
+++ b/src/engraving/libmscore/style.cpp
@@ -618,7 +618,7 @@ static const StyleType styleTypes[] {
     { Sid::tupletFrameBgColor,      "tupletFrameBgColor",      QColor(255, 255, 255, 0) },
 
     { Sid::barreLineWidth,          "barreLineWidth",          QVariant(1.0) },
-    { Sid::scaleBarlines,           "scaleBarlines",           QVariant(true) },
+    { Sid::scaleBarlines,           "scaleBarlines",           QVariant(false) },
     { Sid::barGraceDistance,        "barGraceDistance",        Spatium(1.0) },
     { Sid::minVerticalDistance,     "minVerticalDistance",     Spatium(0.5) },
     { Sid::ornamentStyle,           "ornamentStyle",           int(MScore::OrnamentStyle::DEFAULT) },


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8206

None of the traditionally engraved/typeset scores I have show barlines at a narrower width on ossia/rehearsal-only and other similar scaled-down staves, and it looks quite odd when the barline changes width when spanning from a scaled-down staff to a regular size one.


- [ x] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
