### PR TITLE
Temporary solution for horizontal DockPanels

### DIFF
--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -228,9 +228,9 @@ DockPage {
 
             allowedAreas: Qt.TopDockWidgetArea | Qt.BottomDockWidgetArea
 
-            height: root.defaultPanelWidth
-            minimumHeight: root.defaultPanelWidth
-            maximumHeight: root.defaultPanelWidth
+            height: 200
+            minimumHeight: 100
+            maximumHeight: 300
 
             tabifyPanel: pianoRollPanel
 
@@ -253,9 +253,9 @@ DockPage {
 
             allowedAreas: Qt.TopDockWidgetArea | Qt.BottomDockWidgetArea
 
-            height: root.defaultPanelWidth
-            minimumHeight: root.defaultPanelWidth
-            maximumHeight: root.defaultPanelWidth
+            height: 200
+            minimumHeight: 100
+            maximumHeight: 300
 
             Rectangle {
                 anchors.fill: parent

--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -23,6 +23,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 
 import MuseScore.Ui 1.0
+import MuseScore.UiComponents 1.0
 import MuseScore.Dock 1.0
 import MuseScore.AppShell 1.0
 
@@ -213,6 +214,58 @@ DockPage {
             }
 
             InspectorForm {}
+        },
+
+        // =============================================
+        // Horizontal Panels
+        // =============================================
+
+        DockPanel {
+            id: mixerPanel
+
+            objectName: "mixerPanel"
+            title: qsTrc("appshell", "Mixer")
+
+            allowedAreas: Qt.TopDockWidgetArea | Qt.BottomDockWidgetArea
+
+            height: root.defaultPanelWidth
+            minimumHeight: root.defaultPanelWidth
+            maximumHeight: root.defaultPanelWidth
+
+            tabifyPanel: pianoRollPanel
+
+            Rectangle {
+                anchors.fill: parent
+                color: ui.theme.backgroundPrimaryColor
+
+                StyledTextLabel {
+                    anchors.centerIn: parent
+                    text: mixerPanel.title
+                }
+            }
+        },
+
+        DockPanel {
+            id: pianoRollPanel
+
+            objectName: "pianoRollPanel"
+            title: qsTrc("appshell", "Piano Roll")
+
+            allowedAreas: Qt.TopDockWidgetArea | Qt.BottomDockWidgetArea
+
+            height: root.defaultPanelWidth
+            minimumHeight: root.defaultPanelWidth
+            maximumHeight: root.defaultPanelWidth
+
+            Rectangle {
+                anchors.fill: parent
+                color: ui.theme.backgroundPrimaryColor
+
+                StyledTextLabel {
+                    anchors.centerIn: parent
+                    text: pianoRollPanel.title
+                }
+            }
         }
     ]
 

--- a/src/appshell/qml/dockwindow/DockPage.qml
+++ b/src/appshell/qml/dockwindow/DockPage.qml
@@ -64,4 +64,31 @@ Dock.DockPage {
             Rectangle { color: ui.theme.backgroundPrimaryColor }
         }
     ]
+
+    panelsDockingHolders: [
+        Dock.DockPanelHolder {
+            objectName: root.objectName + "_panelsDockingHolderLeft"
+            location: Dock.DockBase.Left
+
+            Rectangle { color: ui.theme.backgroundPrimaryColor }
+        },
+        Dock.DockPanelHolder {
+            objectName: root.objectName + "_panelsDockingHolderRight"
+            location: Dock.DockBase.Right
+
+            Rectangle { color: ui.theme.backgroundPrimaryColor }
+        },
+        Dock.DockPanelHolder {
+            objectName: root.objectName + "_panelsDockingHolderTop"
+            location: Dock.DockBase.Top
+
+            Rectangle { color: ui.theme.backgroundPrimaryColor }
+        },
+        Dock.DockPanelHolder {
+            objectName: root.objectName + "_panelsDockingHolderBottom"
+            location: Dock.DockBase.Bottom
+
+            Rectangle { color: ui.theme.backgroundPrimaryColor }
+        }
+    ]
 }

--- a/src/appshell/view/dockwindow/dockpage.cpp
+++ b/src/appshell/view/dockwindow/dockpage.cpp
@@ -25,6 +25,7 @@
 #include "docktoolbar.h"
 #include "dockcentral.h"
 #include "dockpanel.h"
+#include "dockpanelholder.h"
 #include "dockstatusbar.h"
 
 #include "log.h"
@@ -36,7 +37,8 @@ DockPage::DockPage(QQuickItem* parent)
     m_mainToolBars(this),
     m_toolBars(this),
     m_toolBarsDockingHolders(this),
-    m_panels(this)
+    m_panels(this),
+    m_panelsDockingHolders(this)
 {
 }
 
@@ -72,6 +74,11 @@ QQmlListProperty<DockToolBarHolder> DockPage::toolBarsDockingHoldersProperty()
     return m_toolBarsDockingHolders.property();
 }
 
+QQmlListProperty<DockPanelHolder> DockPage::panelsDockingHoldersProperty()
+{
+    return m_panelsDockingHolders.property();
+}
+
 QList<DockToolBar*> DockPage::mainToolBars() const
 {
     return m_mainToolBars.list();
@@ -82,22 +89,22 @@ QList<DockToolBar*> DockPage::toolBars() const
     //! NOTE: Order is important for correct drawing
     auto list = m_toolBars.list();
 
-    DockToolBarHolder* leftHolder = holderByLocation(DockBase::DockLocation::Left);
+    DockToolBarHolder* leftHolder = toolBarHolderByLocation(DockBase::DockLocation::Left);
     if (leftHolder) {
         list.prepend(leftHolder);
     }
 
-    DockToolBarHolder* rightHolder = holderByLocation(DockBase::DockLocation::Right);
+    DockToolBarHolder* rightHolder = toolBarHolderByLocation(DockBase::DockLocation::Right);
     if (rightHolder) {
         list.append(rightHolder);
     }
 
-    DockToolBarHolder* bottomHolder = holderByLocation(DockBase::DockLocation::Bottom);
+    DockToolBarHolder* bottomHolder = toolBarHolderByLocation(DockBase::DockLocation::Bottom);
     if (bottomHolder) {
         list.prepend(bottomHolder);
     }
 
-    DockToolBarHolder* topHolder = holderByLocation(DockBase::DockLocation::Top);
+    DockToolBarHolder* topHolder = toolBarHolderByLocation(DockBase::DockLocation::Top);
     if (topHolder) {
         list.append(topHolder);
     }
@@ -122,7 +129,35 @@ DockStatusBar* DockPage::statusBar() const
 
 QList<DockPanel*> DockPage::panels() const
 {
-    return m_panels.list();
+    //! NOTE: Order is important for correct drawing
+    auto list = m_panels.list();
+
+    DockPanelHolder* leftHolder = panelHolderByLocation(DockBase::DockLocation::Left);
+    if (leftHolder) {
+        list.prepend(leftHolder);
+    }
+
+    DockPanelHolder* rightHolder = panelHolderByLocation(DockBase::DockLocation::Right);
+    if (rightHolder) {
+        list.append(rightHolder);
+    }
+
+    DockPanelHolder* bottomHolder = panelHolderByLocation(DockBase::DockLocation::Bottom);
+    if (bottomHolder) {
+        list.prepend(bottomHolder);
+    }
+
+    DockPanelHolder* topHolder = panelHolderByLocation(DockBase::DockLocation::Top);
+    if (topHolder) {
+        list.append(topHolder);
+    }
+
+    return list;
+}
+
+QList<DockPanelHolder*> DockPage::panelsHolders() const
+{
+    return m_panelsDockingHolders.list();
 }
 
 DockBase* DockPage::dockByName(const QString& dockName) const
@@ -136,9 +171,20 @@ DockBase* DockPage::dockByName(const QString& dockName) const
     return nullptr;
 }
 
-DockToolBarHolder* DockPage::holderByLocation(DockBase::DockLocation location) const
+DockToolBarHolder* DockPage::toolBarHolderByLocation(DockBase::DockLocation location) const
 {
     for (DockToolBarHolder* holder : m_toolBarsDockingHolders.list()) {
+        if (holder->location() == location) {
+            return holder;
+        }
+    }
+
+    return nullptr;
+}
+
+DockPanelHolder* DockPage::panelHolderByLocation(DockBase::DockLocation location) const
+{
+    for (DockPanelHolder* holder : m_panelsDockingHolders.list()) {
         if (holder->location() == location) {
             return holder;
         }

--- a/src/appshell/view/dockwindow/dockpage.h
+++ b/src/appshell/view/dockwindow/dockpage.h
@@ -36,6 +36,7 @@ class DockPanel;
 class DockCentral;
 class DockStatusBar;
 class DockToolBarHolder;
+class DockPanelHolder;
 class DockPage : public QQuickItem
 {
     Q_OBJECT
@@ -45,6 +46,7 @@ class DockPage : public QQuickItem
     Q_PROPERTY(QQmlListProperty<mu::dock::DockToolBar> toolBars READ toolBarsProperty)
     Q_PROPERTY(QQmlListProperty<mu::dock::DockToolBarHolder> toolBarsDockingHolders READ toolBarsDockingHoldersProperty)
     Q_PROPERTY(QQmlListProperty<mu::dock::DockPanel> panels READ panelsProperty)
+    Q_PROPERTY(QQmlListProperty<mu::dock::DockPanelHolder> panelsDockingHolders READ panelsDockingHoldersProperty)
     Q_PROPERTY(mu::dock::DockCentral* centralDock READ centralDock WRITE setCentralDock NOTIFY centralDockChanged)
     Q_PROPERTY(mu::dock::DockStatusBar* statusBar READ statusBar WRITE setStatusBar NOTIFY statusBarChanged)
 
@@ -58,8 +60,9 @@ public:
 
     QQmlListProperty<DockToolBar> mainToolBarsProperty();
     QQmlListProperty<DockToolBar> toolBarsProperty();
-    QQmlListProperty<DockPanel> panelsProperty();
     QQmlListProperty<DockToolBarHolder> toolBarsDockingHoldersProperty();
+    QQmlListProperty<DockPanel> panelsProperty();
+    QQmlListProperty<DockPanelHolder> panelsDockingHoldersProperty();
 
     QList<DockToolBar*> mainToolBars() const;
     QList<DockToolBar*> toolBars() const;
@@ -67,10 +70,12 @@ public:
     DockCentral* centralDock() const;
     DockStatusBar* statusBar() const;
     QList<DockPanel*> panels() const;
+    QList<DockPanelHolder*> panelsHolders() const;
     QList<DockBase*> allDocks() const;
 
     DockBase* dockByName(const QString& dockName) const;
-    DockToolBarHolder* holderByLocation(DockBase::DockLocation location) const;
+    DockToolBarHolder* toolBarHolderByLocation(DockBase::DockLocation location) const;
+    DockPanelHolder* panelHolderByLocation(DockBase::DockLocation location) const;
 
 public slots:
     void setUri(const QString& uri);
@@ -90,6 +95,7 @@ private:
     uicomponents::QmlListProperty<DockToolBar> m_toolBars;
     uicomponents::QmlListProperty<DockToolBarHolder> m_toolBarsDockingHolders;
     uicomponents::QmlListProperty<DockPanel> m_panels;
+    uicomponents::QmlListProperty<DockPanelHolder> m_panelsDockingHolders;
     DockCentral* m_central = nullptr;
     DockStatusBar* m_statusBar = nullptr;
 };

--- a/src/appshell/view/dockwindow/dockpanelholder.cpp
+++ b/src/appshell/view/dockwindow/dockpanelholder.cpp
@@ -20,35 +20,18 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MU_DOCK_DOCKPANEL_H
-#define MU_DOCK_DOCKPANEL_H
+#include "dockpanelholder.h"
 
-#include "internal/dockbase.h"
+using namespace mu::dock;
 
-#include "framework/uicomponents/view/qmllistproperty.h"
-
-namespace mu::dock {
-class DockPanel : public DockBase
+DockPanelHolder::DockPanelHolder(QQuickItem* parent)
+    : DockPanel(parent)
 {
-    Q_OBJECT
-
-    Q_PROPERTY(DockPanel * tabifyPanel READ tabifyPanel WRITE setTabifyPanel NOTIFY tabifyPanelChanged)
-
-public:
-    explicit DockPanel(QQuickItem* parent = nullptr);
-
-    DockPanel* tabifyPanel() const;
-
-public slots:
-    void setTabifyPanel(DockPanel* panel);
-
-signals:
-    void tabifyPanelChanged(DockPanel* panel);
-
-private:
-    DockType type() const override;
-    DockPanel* m_tabifyPanel = nullptr;
-};
+    setVisible(false);
+    //setMovable(false);
 }
 
-#endif // MU_DOCK_DOCKPANEL_H
+DockType DockPanelHolder::type() const
+{
+    return DockType::PanelDockingHolder;
+}

--- a/src/appshell/view/dockwindow/dockpanelholder.h
+++ b/src/appshell/view/dockwindow/dockpanelholder.h
@@ -20,35 +20,22 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MU_DOCK_DOCKPANEL_H
-#define MU_DOCK_DOCKPANEL_H
+#ifndef MU_DOCK_DOCKPANELHOLDER_H
+#define MU_DOCK_DOCKPANELHOLDER_H
 
-#include "internal/dockbase.h"
-
-#include "framework/uicomponents/view/qmllistproperty.h"
+#include "dockpanel.h"
 
 namespace mu::dock {
-class DockPanel : public DockBase
+class DockPanelHolder : public DockPanel
 {
     Q_OBJECT
 
-    Q_PROPERTY(DockPanel * tabifyPanel READ tabifyPanel WRITE setTabifyPanel NOTIFY tabifyPanelChanged)
-
 public:
-    explicit DockPanel(QQuickItem* parent = nullptr);
-
-    DockPanel* tabifyPanel() const;
-
-public slots:
-    void setTabifyPanel(DockPanel* panel);
-
-signals:
-    void tabifyPanelChanged(DockPanel* panel);
+    explicit DockPanelHolder(QQuickItem* parent = nullptr);
 
 private:
     DockType type() const override;
-    DockPanel* m_tabifyPanel = nullptr;
 };
 }
 
-#endif // MU_DOCK_DOCKPANEL_H
+#endif // MU_DOCK_DOCKPANELHOLDER_H

--- a/src/appshell/view/dockwindow/docksetup.cpp
+++ b/src/appshell/view/dockwindow/docksetup.cpp
@@ -28,6 +28,7 @@
 
 #include "dockwindow.h"
 #include "dockpanel.h"
+#include "dockpanelholder.h"
 #include "dockstatusbar.h"
 #include "docktoolbarholder.h"
 #include "dockcentral.h"
@@ -86,6 +87,7 @@ void DockSetup::registerQmlTypes()
 {
     qmlRegisterType<DockWindow>("MuseScore.Dock", 1, 0, "DockWindow");
     qmlRegisterType<DockPanel>("MuseScore.Dock", 1, 0, "DockPanel");
+    qmlRegisterType<DockPanelHolder>("MuseScore.Dock", 1, 0, "DockPanelHolder");
     qmlRegisterType<DockStatusBar>("MuseScore.Dock", 1, 0, "DockStatusBar");
     qmlRegisterType<DockToolBar>("MuseScore.Dock", 1, 0, "DockToolBar");
     qmlRegisterType<DockToolBarHolder>("MuseScore.Dock", 1, 0, "DockToolBarHolder");

--- a/src/appshell/view/dockwindow/docktypes.h
+++ b/src/appshell/view/dockwindow/docktypes.h
@@ -30,6 +30,7 @@ namespace mu::dock {
 enum class DockType {
     Undefined = -1,
     Panel,
+    PanelDockingHolder,
     ToolBar,
     ToolBarDockingHolder,
     StatusBar,

--- a/src/appshell/view/dockwindow/dockwindow.cmake
+++ b/src/appshell/view/dockwindow/dockwindow.cmake
@@ -43,6 +43,8 @@ set (DOCKWINDOW_SRC
     ${CMAKE_CURRENT_LIST_DIR}/dockpage.h
     ${CMAKE_CURRENT_LIST_DIR}/dockpanel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dockpanel.h
+    ${CMAKE_CURRENT_LIST_DIR}/dockpanelholder.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/dockpanelholder.h
     ${CMAKE_CURRENT_LIST_DIR}/dockstatusbar.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dockstatusbar.h
     ${CMAKE_CURRENT_LIST_DIR}/docktoolbar.cpp

--- a/src/appshell/view/dockwindow/dockwindow.cpp
+++ b/src/appshell/view/dockwindow/dockwindow.cpp
@@ -468,15 +468,17 @@ DockToolBarHolder* DockWindow::resolveToolbarDockingHolder(const QPoint& localPo
     }
 
     QRect centralFrameGeometry = centralDock->frameGeometry();
-    centralFrameGeometry.setTopLeft(m_mainWindow->mapFromGlobal(centralDock->mapToGlobal({ centralDock->x(), centralDock->y() })));
+    centralFrameGeometry.moveTopLeft(m_mainWindow->mapFromGlobal(centralDock->mapToGlobal({ centralDock->x(), centralDock->y() })));
 
     QRect mainFrameGeometry = m_mainWindow->rect();
     DockToolBarHolder* newHolder = nullptr;
 
     if (localPos.y() < MAX_DISTANCE_TO_HOLDER) { // main toolbar holder
         newHolder = m_mainToolBarDockingHolder;
-    } else if (localPos.y() > centralFrameGeometry.top()
-               && localPos.y() < centralFrameGeometry.top() + MAX_DISTANCE_TO_HOLDER) { // page top toolbar holder
+    }
+    // TODO: Need to take any panels docked at top into account
+    else if (localPos.y() > centralFrameGeometry.top()
+             && localPos.y() < centralFrameGeometry.top() + MAX_DISTANCE_TO_HOLDER) {   // page top toolbar holder
         newHolder = page->toolBarHolderByLocation(DockBase::DockLocation::Top);
     } else if (localPos.y() < centralFrameGeometry.bottom()) { // page left toolbar holder
         if (localPos.x() < MAX_DISTANCE_TO_HOLDER) {
@@ -504,9 +506,7 @@ DockPanelHolder* DockWindow::resolvePanelDockingHolder(const QPoint& localPos) c
     }
 
     QRect centralFrameGeometry = centralDock->frameGeometry();
-    centralFrameGeometry.setTopLeft(m_mainWindow->mapFromGlobal(centralDock->mapToGlobal({ centralDock->x(), centralDock->y() })));
-
-    QRect mainFrameGeometry = m_mainWindow->rect();
+    centralFrameGeometry.moveTopLeft(m_mainWindow->mapFromGlobal(centralDock->mapToGlobal({ centralDock->x(), centralDock->y() })));
     DockPanelHolder* newHolder = nullptr;
 
     if (localPos.y() > centralFrameGeometry.top()
@@ -515,10 +515,10 @@ DockPanelHolder* DockWindow::resolvePanelDockingHolder(const QPoint& localPos) c
     } else if (localPos.y() < centralFrameGeometry.bottom()) { // page left panel holder
         if (localPos.x() < MAX_DISTANCE_TO_HOLDER) {
             newHolder = page->panelHolderByLocation(DockBase::DockLocation::Left);
-        } else if (localPos.x() > mainFrameGeometry.right() - MAX_DISTANCE_TO_HOLDER) { // page right panel holder
+        } else if (localPos.x() > centralFrameGeometry.right() - MAX_DISTANCE_TO_HOLDER) { // page right panel holder
             newHolder = page->panelHolderByLocation(DockBase::DockLocation::Right);
         }
-    } else if (localPos.y() < mainFrameGeometry.bottom()) { // page bottom panel holder
+    } else if (localPos.y() < centralFrameGeometry.bottom()) { // page bottom panel holder
         newHolder = page->panelHolderByLocation(DockBase::DockLocation::Bottom);
     }
 

--- a/src/appshell/view/dockwindow/dockwindow.cpp
+++ b/src/appshell/view/dockwindow/dockwindow.cpp
@@ -33,6 +33,7 @@
 #include "docktoolbarholder.h"
 #include "dockcentral.h"
 #include "dockpanel.h"
+#include "dockpanelholder.h"
 
 using namespace mu::dock;
 
@@ -70,6 +71,7 @@ void DockWindow::componentComplete()
 
     mainWindow()->hideAllDockingHoldersRequested().onNotify(this, [this]() {
         hideCurrentToolBarDockingHolder();
+        hideCurrentPanelDockingHolder();
     });
 
     mainWindow()->showToolBarDockingHolderRequested().onReceive(this, [this](const QPoint& mouseGlobalPos) {
@@ -95,6 +97,32 @@ void DockWindow::componentComplete()
         }
 
         m_currentToolBarDockingHolder = holder;
+    });
+
+    mainWindow()->showPanelDockingHolderRequested().onReceive(this, [this](const QPoint& mouseGlobalPos) {
+        QPoint localPos = m_mainWindow->mapFromGlobal(mouseGlobalPos);
+        QRect mainFrameGeometry = m_mainWindow->rect();
+
+        if (!mainFrameGeometry.contains(localPos)) {
+            return;
+        }
+
+        if (isMouseOverCurrentPanelDockingHolder(localPos)) {
+            return;
+        }
+
+        DockPanelHolder* holder = resolvePanelDockingHolder(localPos);
+
+        if (holder != m_currentPanelDockingHolder) {
+            hideCurrentPanelDockingHolder();
+
+            if (holder) {
+                qDebug() << holder->location();
+                holder->show();
+            }
+        }
+
+        m_currentPanelDockingHolder = holder;
     });
 }
 
@@ -186,10 +214,7 @@ void DockWindow::loadPageContent(const DockPage* page)
 
     addDock(page->centralDock(), KDDockWidgets::Location_OnRight);
 
-    for (DockPanel* panel : page->panels()) {
-        //! TODO: add an ability to change location of panels
-        addDock(panel, KDDockWidgets::Location_OnLeft);
-    }
+    loadPagePanels(page);
 
     loadPageToolbars(page);
 
@@ -274,6 +299,55 @@ void DockWindow::loadPageToolbars(const DockPage* page)
 
     for (int i = topSideToolbars.size() - 1; i >= 0; --i) {
         addDock(topSideToolbars[i], KDDockWidgets::Location_OnTop);
+    }
+}
+
+void DockWindow::loadPagePanels(const DockPage* page)
+{
+    QList<DockPanel*> leftSidePanels;
+    QList<DockPanel*> rightSidePanels;
+    QList<DockPanel*> topSidePanels;
+    QList<DockPanel*> bottomSidePanels;
+
+    QList<DockPanel*> pagePanels = page->panels();
+    for (DockPanel* panel : pagePanels) {
+        switch (panel->location()) {
+        case DockBase::DockLocation::Left:
+            leftSidePanels << panel;
+            break;
+        case DockBase::DockLocation::Right:
+            rightSidePanels << panel;
+            break;
+        case DockBase::DockLocation::Top:
+            topSidePanels << panel;
+            break;
+        case DockBase::DockLocation::Bottom:
+            bottomSidePanels << panel;
+            break;
+        default:
+            if (panel->allowedAreas() & Qt::BottomDockWidgetArea) {
+                bottomSidePanels << panel;
+            } else {
+                leftSidePanels << panel;
+            }
+            break;
+        }
+    }
+
+    for (int i = leftSidePanels.size() - 1; i >= 0; --i) {
+        addDock(leftSidePanels[i], KDDockWidgets::Location_OnLeft);
+    }
+
+    for (int i = 0; i < rightSidePanels.size(); ++i) {
+        addDock(rightSidePanels[i], KDDockWidgets::Location_OnRight);
+    }
+
+    for (int i = 0; i < bottomSidePanels.size(); ++i) {
+        addDock(bottomSidePanels[i], KDDockWidgets::Location_OnBottom);
+    }
+
+    for (int i = topSidePanels.size() - 1; i >= 0; --i) {
+        addDock(topSidePanels[i], KDDockWidgets::Location_OnTop);
     }
 }
 
@@ -403,15 +477,49 @@ DockToolBarHolder* DockWindow::resolveToolbarDockingHolder(const QPoint& localPo
         newHolder = m_mainToolBarDockingHolder;
     } else if (localPos.y() > centralFrameGeometry.top()
                && localPos.y() < centralFrameGeometry.top() + MAX_DISTANCE_TO_HOLDER) { // page top toolbar holder
-        newHolder = page->holderByLocation(DockBase::DockLocation::Top);
+        newHolder = page->toolBarHolderByLocation(DockBase::DockLocation::Top);
     } else if (localPos.y() < centralFrameGeometry.bottom()) { // page left toolbar holder
         if (localPos.x() < MAX_DISTANCE_TO_HOLDER) {
-            newHolder = page->holderByLocation(DockBase::DockLocation::Left);
+            newHolder = page->toolBarHolderByLocation(DockBase::DockLocation::Left);
         } else if (localPos.x() > mainFrameGeometry.right() - MAX_DISTANCE_TO_HOLDER) { // page right toolbar holder
-            newHolder = page->holderByLocation(DockBase::DockLocation::Right);
+            newHolder = page->toolBarHolderByLocation(DockBase::DockLocation::Right);
         }
     } else if (localPos.y() < mainFrameGeometry.bottom()) { // page bottom toolbar holder
-        newHolder = page->holderByLocation(DockBase::DockLocation::Bottom);
+        newHolder = page->toolBarHolderByLocation(DockBase::DockLocation::Bottom);
+    }
+
+    return newHolder;
+}
+
+DockPanelHolder* DockWindow::resolvePanelDockingHolder(const QPoint& localPos) const
+{
+    const DockPage* page = currentPage();
+    if (!page) {
+        return nullptr;
+    }
+
+    const KDDockWidgets::DockWidgetBase* centralDock = page->centralDock()->dockWidget();
+    if (!centralDock) {
+        return nullptr;
+    }
+
+    QRect centralFrameGeometry = centralDock->frameGeometry();
+    centralFrameGeometry.setTopLeft(m_mainWindow->mapFromGlobal(centralDock->mapToGlobal({ centralDock->x(), centralDock->y() })));
+
+    QRect mainFrameGeometry = m_mainWindow->rect();
+    DockPanelHolder* newHolder = nullptr;
+
+    if (localPos.y() > centralFrameGeometry.top()
+        && localPos.y() < centralFrameGeometry.top() + MAX_DISTANCE_TO_HOLDER) { // page top panel holder
+        newHolder = page->panelHolderByLocation(DockBase::DockLocation::Top);
+    } else if (localPos.y() < centralFrameGeometry.bottom()) { // page left panel holder
+        if (localPos.x() < MAX_DISTANCE_TO_HOLDER) {
+            newHolder = page->panelHolderByLocation(DockBase::DockLocation::Left);
+        } else if (localPos.x() > mainFrameGeometry.right() - MAX_DISTANCE_TO_HOLDER) { // page right panel holder
+            newHolder = page->panelHolderByLocation(DockBase::DockLocation::Right);
+        }
+    } else if (localPos.y() < mainFrameGeometry.bottom()) { // page bottom panel holder
+        newHolder = page->panelHolderByLocation(DockBase::DockLocation::Bottom);
     }
 
     return newHolder;
@@ -427,6 +535,16 @@ void DockWindow::hideCurrentToolBarDockingHolder()
     m_currentToolBarDockingHolder = nullptr;
 }
 
+void DockWindow::hideCurrentPanelDockingHolder()
+{
+    if (!m_currentPanelDockingHolder) {
+        return;
+    }
+
+    m_currentPanelDockingHolder->hide();
+    m_currentPanelDockingHolder = nullptr;
+}
+
 bool DockWindow::isMouseOverCurrentToolBarDockingHolder(const QPoint& mouseLocalPos) const
 {
     if (!m_currentToolBarDockingHolder || !m_mainWindow) {
@@ -434,6 +552,22 @@ bool DockWindow::isMouseOverCurrentToolBarDockingHolder(const QPoint& mouseLocal
     }
 
     const KDDockWidgets::DockWidgetBase* holderDock = m_currentToolBarDockingHolder->dockWidget();
+    if (!holderDock) {
+        return false;
+    }
+
+    QRect holderFrameGeometry = holderDock->frameGeometry();
+    holderFrameGeometry.setTopLeft(m_mainWindow->mapFromGlobal(holderDock->mapToGlobal({ holderDock->x(), holderDock->y() })));
+    return holderFrameGeometry.contains(mouseLocalPos);
+}
+
+bool DockWindow::isMouseOverCurrentPanelDockingHolder(const QPoint& mouseLocalPos) const
+{
+    if (!m_currentPanelDockingHolder || !m_mainWindow) {
+        return false;
+    }
+
+    const KDDockWidgets::DockWidgetBase* holderDock = m_currentPanelDockingHolder->dockWidget();
     if (!holderDock) {
         return false;
     }

--- a/src/appshell/view/dockwindow/dockwindow.h
+++ b/src/appshell/view/dockwindow/dockwindow.h
@@ -43,6 +43,7 @@ class LayoutSaver;
 namespace mu::dock {
 class DockToolBar;
 class DockToolBarHolder;
+class DockPanelHolder;
 class DockPage;
 class DockBase;
 class DockWindow : public QQuickItem, public async::Asyncable
@@ -91,6 +92,7 @@ private:
     void loadPageContent(const DockPage* page);
     void unitePanelsToTabs(const DockPage* page);
     void loadPageToolbars(const DockPage* page);
+    void loadPagePanels(const DockPage* page);
 
     void addDock(DockBase* dock, KDDockWidgets::Location location, const DockBase* relativeTo = nullptr);
 
@@ -107,9 +109,12 @@ private:
     void initDocks(DockPage* page);
 
     DockToolBarHolder* resolveToolbarDockingHolder(const QPoint& localPos) const;
-
     void hideCurrentToolBarDockingHolder();
     bool isMouseOverCurrentToolBarDockingHolder(const QPoint& mouseLocalPos) const;
+
+    DockPanelHolder* resolvePanelDockingHolder(const QPoint& localPos) const;
+    void hideCurrentPanelDockingHolder();
+    bool isMouseOverCurrentPanelDockingHolder(const QPoint& mouseLocalPos) const;
 
     KDDockWidgets::MainWindowBase* m_mainWindow = nullptr;
     QString m_currentPageUri;
@@ -117,6 +122,7 @@ private:
     DockToolBarHolder* m_mainToolBarDockingHolder = nullptr;
     uicomponents::QmlListProperty<DockPage> m_pages;
     DockToolBarHolder* m_currentToolBarDockingHolder = nullptr;
+    DockPanelHolder* m_currentPanelDockingHolder = nullptr;
 };
 }
 

--- a/src/appshell/view/dockwindow/internal/dropindicators.cpp
+++ b/src/appshell/view/dockwindow/internal/dropindicators.cpp
@@ -235,24 +235,55 @@ bool DropIndicators::isDropAllowed(DropLocation location) const
         DropLocation::DropLocation_Left,
         DropLocation::DropLocation_Right
     };
+    bool isSideLocation = sideLocations.contains(location);
 
-    Qt::DockWidgetArea area = locationToDockArea(location);
-    bool isAreaAllowed = draggedDockProperties.allowedAreas.testFlag(area);
-    bool equalOrientations = dockOrientation(*hoveredDock) == dockOrientation(*draggedDock);
+    switch (hoveredDockType) {
+    case DockType::Central: {
+        if (isDragged(DockType::Panel)) {
+            Qt::DockWidgetArea area = locationToDockArea(location);
+            bool isAreaAllowed = draggedDockProperties.allowedAreas.testFlag(area);
 
-    if (hoveredDockType == draggedDockType && equalOrientations) {
-        return sideLocations.contains(location) || isDragged(DockType::Panel);
-    }
+            // For top/bottom location, we need to use the Panel-/Toolbar docking holders
+            // Because a panel or toolbar at the top needs to go also outside the left/right
+            // panels/toolbars. Therefore, only side locations are allowed.
+            return isSideLocation && isAreaAllowed;
+        }
+    } break;
 
-    if (isDragged(DockType::Panel)) {
-        if (isHovered(DockType::Central)) {
-            return isAreaAllowed;
+    case DockType::Panel:
+    case DockType::PanelDockingHolder: {
+        if (!isDragged(DockType::Panel)) {
+            return false;
         }
 
-        return false;
+        // TODO: Determine location of hovered panel or panel docking holder and check if
+        // that is one of the allowed areas of the dragged panel
+
+        if (isHovered(DockType::PanelDockingHolder)) {
+            // Avoid tabbing with docking holder, because it breaks the holders system
+            return location != DropLocation_Center;
+        }
+
+        return true;
+    } break;
+
+    case DockType::ToolBar:
+    case DockType::ToolBarDockingHolder: {
+        if (!isDragged(DockType::ToolBar)) {
+            return false;
+        }
+
+        // TODO: what is our policy with vertical toolbars?
+        // Currently not important because there's at most one toolbar that may become vertical.
+        bool equalOrientations = dockOrientation(*hoveredDock) == dockOrientation(*draggedDock);
+        return isSideLocation && equalOrientations;
+    } break;
+
+    default:
+        break;
     }
 
-    return isAreaAllowed;
+    return false;
 }
 
 bool DropIndicators::isDropOnHoveredDockAllowed() const

--- a/src/appshell/view/dockwindow/internal/dropindicators.h
+++ b/src/appshell/view/dockwindow/internal/dropindicators.h
@@ -80,13 +80,16 @@ private:
 
     bool isIndicatorVisible(DropLocation location) const;
     bool isDropAllowed(DropLocation location) const;
-    bool isHoveredDockAllowedForDrop() const;
+    bool isDropOnHoveredDockAllowed() const;
     bool isDraggedDockToolBar() const;
+    bool isDraggedDockPanel() const;
     bool needShowToolBarHolders() const;
+    bool needShowPanelHolders() const;
 
     const KDDockWidgets::DockWidgetBase* hoveredDock() const;
     const KDDockWidgets::DockWidgetBase* draggedDock() const;
 
+    DockType dockType(const KDDockWidgets::DockWidgetBase* dock) const;
     framework::Orientation dockOrientation(const KDDockWidgets::DockWidgetBase& dock) const;
 
     DropLocation dropLocationForToolBar(const QPoint& hoveredGlobalPos) const;

--- a/src/appshell/view/dockwindow/mainwindowprovider.cpp
+++ b/src/appshell/view/dockwindow/mainwindowprovider.cpp
@@ -90,12 +90,22 @@ Channel<QString, mu::framework::Orientation> MainWindowProvider::changeToolBarOr
 
 void MainWindowProvider::requestShowToolBarDockingHolder(const QPoint& globalPos)
 {
-    m_showDockingHolderRequested.send(globalPos);
+    m_showToolBarDockingHolderRequested.send(globalPos);
 }
 
 mu::async::Channel<QPoint> MainWindowProvider::showToolBarDockingHolderRequested() const
 {
-    return m_showDockingHolderRequested;
+    return m_showToolBarDockingHolderRequested;
+}
+
+void MainWindowProvider::requestShowPanelDockingHolder(const QPoint& globalPos)
+{
+    m_showPanelDockingHolderRequested.send(globalPos);
+}
+
+mu::async::Channel<QPoint> MainWindowProvider::showPanelDockingHolderRequested() const
+{
+    return m_showPanelDockingHolderRequested;
 }
 
 void MainWindowProvider::requestHideAllDockingHolders()

--- a/src/appshell/view/dockwindow/mainwindowprovider.h
+++ b/src/appshell/view/dockwindow/mainwindowprovider.h
@@ -42,12 +42,16 @@ public:
     void requestShowToolBarDockingHolder(const QPoint& globalPos) override;
     async::Channel<QPoint> showToolBarDockingHolderRequested() const override;
 
+    void requestShowPanelDockingHolder(const QPoint& globalPos) override;
+    async::Channel<QPoint> showPanelDockingHolderRequested() const override;
+
     void requestHideAllDockingHolders() override;
     async::Notification hideAllDockingHoldersRequested() const override;
 
 private:
     async::Channel<QString, framework::Orientation> m_dockOrientationChanged;
-    async::Channel<QPoint> m_showDockingHolderRequested;
+    async::Channel<QPoint> m_showToolBarDockingHolderRequested;
+    async::Channel<QPoint> m_showPanelDockingHolderRequested;
     async::Notification m_hideAllHoldersRequested;
 };
 }

--- a/src/framework/ui/imainwindow.h
+++ b/src/framework/ui/imainwindow.h
@@ -54,6 +54,9 @@ public:
     virtual void requestShowToolBarDockingHolder(const QPoint& globalPos) = 0;
     virtual async::Channel<QPoint> showToolBarDockingHolderRequested() const = 0;
 
+    virtual void requestShowPanelDockingHolder(const QPoint& globalPos) = 0;
+    virtual async::Channel<QPoint> showPanelDockingHolderRequested() const = 0;
+
     virtual void requestHideAllDockingHolders() = 0;
     virtual async::Notification hideAllDockingHoldersRequested() const = 0;
 };


### PR DESCRIPTION
Needed to start working on the Piano Roll (and Mixer).

Later I will probably dive deeper into the dock widgets stuff and make a better solution. But first I would like to make some progress with the Piano Roll. 

TODO: 
- The design is not correct yet
- There is quite some code duplication for toolbars and panels
- The panel holders appear in the wrong place and don't work (I couldn't find out what is the problem here... 😞)
- Ultimately, we need nested toolbars inside the Piano Roll Panel. This might add more complexity the dock widgets system. 

Screenshot of current situation:

<img width="1262" alt="Schermafbeelding 2021-06-06 om 23 57 04" src="https://user-images.githubusercontent.com/48658420/120941404-e6354b80-c722-11eb-892c-4a3c62be0e67.png">