### PR TITLE
Add the possibility to have async::Channels that take more than one parameter

### DIFF
--- a/src/appshell/view/dockwindow/dockwindow.cpp
+++ b/src/appshell/view/dockwindow/dockwindow.cpp
@@ -59,12 +59,12 @@ void DockWindow::componentComplete()
         resetWindowState();
     });
 
-    mainWindow()->changeToolBarOrientationRequested().onReceive(this, [this](std::pair<QString, mu::framework::Orientation> orientation) {
+    mainWindow()->changeToolBarOrientationRequested().onReceive(this, [this](QString name, mu::framework::Orientation orientation) {
         const DockPage* page = currentPage();
-        DockToolBar* toolBar = page ? dynamic_cast<DockToolBar*>(page->dockByName(orientation.first)) : nullptr;
+        DockToolBar* toolBar = page ? dynamic_cast<DockToolBar*>(page->dockByName(name)) : nullptr;
 
         if (toolBar) {
-            toolBar->setOrientation(static_cast<Qt::Orientation>(orientation.second));
+            toolBar->setOrientation(static_cast<Qt::Orientation>(orientation));
         }
     });
 

--- a/src/appshell/view/dockwindow/mainwindowprovider.cpp
+++ b/src/appshell/view/dockwindow/mainwindowprovider.cpp
@@ -80,10 +80,10 @@ const QScreen* MainWindowProvider::screen() const
 
 void MainWindowProvider::requestChangeToolBarOrientation(const QString& toolBarName, mu::framework::Orientation orientation)
 {
-    m_dockOrientationChanged.send({ toolBarName, orientation });
+    m_dockOrientationChanged.send(toolBarName, orientation);
 }
 
-mu::async::Channel<std::pair<QString, mu::framework::Orientation> > MainWindowProvider::changeToolBarOrientationRequested() const
+Channel<QString, mu::framework::Orientation> MainWindowProvider::changeToolBarOrientationRequested() const
 {
     return m_dockOrientationChanged;
 }

--- a/src/appshell/view/dockwindow/mainwindowprovider.h
+++ b/src/appshell/view/dockwindow/mainwindowprovider.h
@@ -37,7 +37,7 @@ public:
     const QScreen* screen() const override;
 
     void requestChangeToolBarOrientation(const QString& toolBarName, framework::Orientation orientation) override;
-    async::Channel<std::pair<QString, framework::Orientation> > changeToolBarOrientationRequested() const override;
+    async::Channel<QString, framework::Orientation> changeToolBarOrientationRequested() const override;
 
     void requestShowToolBarDockingHolder(const QPoint& globalPos) override;
     async::Channel<QPoint> showToolBarDockingHolderRequested() const override;
@@ -46,7 +46,7 @@ public:
     async::Notification hideAllDockingHoldersRequested() const override;
 
 private:
-    async::Channel<std::pair<QString, framework::Orientation> > m_dockOrientationChanged;
+    async::Channel<QString, framework::Orientation> m_dockOrientationChanged;
     async::Channel<QPoint> m_showDockingHolderRequested;
     async::Notification m_hideAllHoldersRequested;
 };

--- a/src/engraving/accessibility/accessibleelement.cpp
+++ b/src/engraving/accessibility/accessibleelement.cpp
@@ -127,7 +127,7 @@ void AccessibleElement::focused()
 
     ascore->setActive(true);
     ascore->setFocusedElement(this);
-    m_accessibleStateChanged.send({ IAccessible::State::Focused, true });
+    m_accessibleStateChanged.send(IAccessible::State::Focused, true);
 }
 
 const IAccessible* AccessibleElement::accessibleParent() const
@@ -215,7 +215,7 @@ mu::async::Channel<IAccessible::Property> AccessibleElement::accessiblePropertyC
     return ch;
 }
 
-mu::async::Channel<std::pair<IAccessible::State, bool> > AccessibleElement::accessibleStateChanged() const
+mu::async::Channel<IAccessible::State, bool> AccessibleElement::accessibleStateChanged() const
 {
     return m_accessibleStateChanged;
 }

--- a/src/engraving/accessibility/accessibleelement.h
+++ b/src/engraving/accessibility/accessibleelement.h
@@ -54,7 +54,7 @@ public:
     QRect accessibleRect() const override;
 
     async::Channel<Property> accessiblePropertyChanged() const override;
-    async::Channel<std::pair<State, bool> > accessibleStateChanged() const override;
+    async::Channel<State, bool> accessibleStateChanged() const override;
     // ---
 
 private:
@@ -65,7 +65,7 @@ private:
     Ms::Element* m_element = nullptr;
     bool m_registred = false;
 
-    mu::async::Channel<std::pair<IAccessible::State, bool> > m_accessibleStateChanged;
+    mu::async::Channel<IAccessible::State, bool> m_accessibleStateChanged;
 };
 }
 

--- a/src/engraving/accessibility/accessiblescore.cpp
+++ b/src/engraving/accessibility/accessiblescore.cpp
@@ -65,7 +65,7 @@ void AccessibleScore::setActive(bool arg)
     }
 
     m_active = arg;
-    m_accessibleStateChanged.send({ State::Active, arg });
+    m_accessibleStateChanged.send(State::Active, arg);
 }
 
 void AccessibleScore::setFocusedElement(AccessibleElement* e)
@@ -134,7 +134,7 @@ mu::async::Channel<IAccessible::Property> AccessibleScore::accessiblePropertyCha
     return ch;
 }
 
-mu::async::Channel<std::pair<IAccessible::State, bool> > AccessibleScore::accessibleStateChanged() const
+mu::async::Channel<IAccessible::State, bool> AccessibleScore::accessibleStateChanged() const
 {
     return m_accessibleStateChanged;
 }

--- a/src/engraving/accessibility/accessiblescore.h
+++ b/src/engraving/accessibility/accessiblescore.h
@@ -57,14 +57,14 @@ public:
     bool accessibleState(State st) const override;
     QRect accessibleRect() const override;
     mu::async::Channel<Property> accessiblePropertyChanged() const override;
-    mu::async::Channel<std::pair<State, bool> > accessibleStateChanged() const override;
+    mu::async::Channel<State, bool> accessibleStateChanged() const override;
 
 private:
 
     Ms::Score* m_score = nullptr;
     bool m_registred = false;
     bool m_active = false;
-    mu::async::Channel<std::pair<IAccessible::State, bool> > m_accessibleStateChanged;
+    mu::async::Channel<IAccessible::State, bool> m_accessibleStateChanged;
     QList<AccessibleElement*> m_children;
     AccessibleElement* m_focusedElement = nullptr;
 };

--- a/src/framework/accessibility/iaccessible.h
+++ b/src/framework/accessibility/iaccessible.h
@@ -81,7 +81,7 @@ public:
     virtual QRect accessibleRect() const = 0;
 
     virtual async::Channel<IAccessible::Property> accessiblePropertyChanged() const = 0;
-    virtual async::Channel<std::pair<IAccessible::State, bool> > accessibleStateChanged() const = 0;
+    virtual async::Channel<IAccessible::State, bool> accessibleStateChanged() const = 0;
 };
 }
 

--- a/src/framework/accessibility/internal/accessibilitycontroller.cpp
+++ b/src/framework/accessibility/internal/accessibilitycontroller.cpp
@@ -169,8 +169,8 @@ void AccessibilityController::reg(IAccessible* item)
         propertyChanged(item, p);
     });
 
-    item->accessibleStateChanged().onReceive(this, [this, item](const std::pair<State, bool>& st) {
-        stateChanged(item, st.first, st.second);
+    item->accessibleStateChanged().onReceive(this, [this, item](const State& state, bool arg) {
+        stateChanged(item, state, arg);
     });
 
     QAccessibleEvent ev(it.object, QAccessible::ObjectCreated);
@@ -405,8 +405,8 @@ mu::async::Channel<IAccessible::Property> AccessibilityController::accessiblePro
     return ch;
 }
 
-mu::async::Channel<std::pair<IAccessible::State, bool> > AccessibilityController::accessibleStateChanged() const
+mu::async::Channel<IAccessible::State, bool> AccessibilityController::accessibleStateChanged() const
 {
-    static async::Channel<std::pair<IAccessible::State, bool> > ch;
+    static async::Channel<IAccessible::State, bool> ch;
     return ch;
 }

--- a/src/framework/accessibility/internal/accessibilitycontroller.h
+++ b/src/framework/accessibility/internal/accessibilitycontroller.h
@@ -75,7 +75,7 @@ public:
     QRect accessibleRect() const override;
 
     async::Channel<Property> accessiblePropertyChanged() const override;
-    async::Channel<std::pair<State, bool> > accessibleStateChanged() const override;
+    async::Channel<State, bool> accessibleStateChanged() const override;
     // -----
 
     QAccessibleInterface* parentIface(const IAccessible* item) const;

--- a/src/framework/global/async/channel.h
+++ b/src/framework/global/async/channel.h
@@ -25,8 +25,8 @@
 #include "thirdparty/deto_async/async/channel.h"
 namespace mu {
 namespace async {
-template<typename T>
-using Channel = deto::async::Channel<T>;
+template<typename ... T>
+using Channel = deto::async::Channel<T...>;
 }
 }
 

--- a/src/framework/midi/imidiinport.h
+++ b/src/framework/midi/imidiinport.h
@@ -48,7 +48,7 @@ public:
     virtual Ret run() = 0;
     virtual void stop() = 0;
     virtual bool isRunning() const = 0;
-    virtual async::Channel<std::pair<tick_t, Event> > eventReceived() const = 0;
+    virtual async::Channel<tick_t, Event> eventReceived() const = 0;
 };
 }
 

--- a/src/framework/midi/internal/dummymidiinport.cpp
+++ b/src/framework/midi/internal/dummymidiinport.cpp
@@ -69,7 +69,7 @@ bool DummyMidiInPort::isRunning() const
     return m_running;
 }
 
-async::Channel<std::pair<tick_t, Event> > DummyMidiInPort::eventReceived() const
+async::Channel<tick_t, Event> DummyMidiInPort::eventReceived() const
 {
     return m_eventReceived;
 }

--- a/src/framework/midi/internal/dummymidiinport.h
+++ b/src/framework/midi/internal/dummymidiinport.h
@@ -38,13 +38,13 @@ public:
     Ret run() override;
     void stop() override;
     bool isRunning() const override;
-    async::Channel<std::pair<tick_t, Event> > eventReceived() const override;
+    async::Channel<tick_t, Event> eventReceived() const override;
 
 private:
 
     MidiDeviceID m_deviceID;
     bool m_running = false;
-    async::Channel<std::pair<tick_t, Event> > m_eventReceived;
+    async::Channel<tick_t, Event> m_eventReceived;
 };
 }
 

--- a/src/framework/midi/internal/platform/lin/alsamidiinport.cpp
+++ b/src/framework/midi/internal/platform/lin/alsamidiinport.cpp
@@ -280,7 +280,7 @@ void AlsaMidiInPort::doProcess()
 
         e = e.toMIDI20();
         if (e) {
-            m_eventReceived.send({ static_cast<tick_t>(ev->time.tick), e });
+            m_eventReceived.send(static_cast<tick_t>(ev->time.tick), e);
         }
 
         snd_seq_free_event(ev);
@@ -307,7 +307,7 @@ bool AlsaMidiInPort::isRunning() const
     return false;
 }
 
-mu::async::Channel<std::pair<tick_t, Event> > AlsaMidiInPort::eventReceived() const
+mu::async::Channel<tick_t, Event> AlsaMidiInPort::eventReceived() const
 {
     return m_eventReceived;
 }

--- a/src/framework/midi/internal/platform/lin/alsamidiinport.h
+++ b/src/framework/midi/internal/platform/lin/alsamidiinport.h
@@ -47,7 +47,7 @@ public:
     Ret run() override;
     void stop() override;
     bool isRunning() const override;
-    async::Channel<std::pair<tick_t, Event> > eventReceived() const override;
+    async::Channel<tick_t, Event> eventReceived() const override;
 
 private:
     static void process(AlsaMidiInPort* self);
@@ -60,7 +60,7 @@ private:
     MidiDeviceID m_deviceID;
     std::shared_ptr<std::thread> m_thread;
     std::atomic<bool> m_running{ false };
-    async::Channel<std::pair<tick_t, Event> > m_eventReceived;
+    async::Channel<tick_t, Event> m_eventReceived;
 
     async::Notification m_devicesChanged;
     MidiDevicesListener m_devicesListener;

--- a/src/framework/midi/internal/platform/osx/coremidiinport.cpp
+++ b/src/framework/midi/internal/platform/osx/coremidiinport.cpp
@@ -160,7 +160,7 @@ void CoreMidiInPort::doProcess(uint32_t message, tick_t timing)
 {
     auto e = Event::fromMIDI10Package(message).toMIDI20();
     if (e) {
-        m_eventReceived.send({ timing, e });
+        m_eventReceived.send(timing, e);
     }
 }
 
@@ -247,7 +247,7 @@ bool CoreMidiInPort::isRunning() const
     return m_running;
 }
 
-async::Channel<std::pair<tick_t, Event> > CoreMidiInPort::eventReceived() const
+async::Channel<tick_t, Event> CoreMidiInPort::eventReceived() const
 {
     return m_eventReceived;
 }

--- a/src/framework/midi/internal/platform/osx/coremidiinport.h
+++ b/src/framework/midi/internal/platform/osx/coremidiinport.h
@@ -46,7 +46,7 @@ public:
     Ret run() override;
     void stop() override;
     bool isRunning() const override;
-    async::Channel<std::pair<tick_t, Event> > eventReceived() const override;
+    async::Channel<tick_t, Event> eventReceived() const override;
 
     //internal
     void doProcess(uint32_t message, tick_t timing);
@@ -58,7 +58,7 @@ private:
     std::unique_ptr<Core> m_core;
     MidiDeviceID m_deviceID;
     bool m_running = false;
-    async::Channel<std::pair<tick_t, Event> > m_eventReceived;
+    async::Channel<tick_t, Event> m_eventReceived;
 
     async::Notification m_devicesChanged;
     MidiDevicesListener m_devicesListener;

--- a/src/framework/midi/internal/platform/win/winmidiinport.cpp
+++ b/src/framework/midi/internal/platform/win/winmidiinport.cpp
@@ -131,7 +131,7 @@ void WinMidiInPort::doProcess(uint32_t message, tick_t timing)
 {
     auto e = Event::fromMIDI10Package(message).toMIDI20();
     if (e) {
-        m_eventReceived.send({ timing, e });
+        m_eventReceived.send(timing, e);
     }
 }
 
@@ -216,7 +216,7 @@ bool WinMidiInPort::isRunning() const
     return m_running;
 }
 
-mu::async::Channel<std::pair<tick_t, Event> > WinMidiInPort::eventReceived() const
+mu::async::Channel<tick_t, Event> WinMidiInPort::eventReceived() const
 {
     return m_eventReceived;
 }

--- a/src/framework/midi/internal/platform/win/winmidiinport.h
+++ b/src/framework/midi/internal/platform/win/winmidiinport.h
@@ -46,7 +46,7 @@ public:
     Ret run() override;
     void stop() override;
     bool isRunning() const override;
-    async::Channel<std::pair<tick_t, Event> > eventReceived() const override;
+    async::Channel<tick_t, Event> eventReceived() const override;
 
     // internal;
     void doProcess(uint32_t message, tick_t timing);
@@ -56,7 +56,7 @@ private:
     std::unique_ptr<Win> m_win;
     MidiDeviceID m_deviceID;
     bool m_running = false;
-    async::Channel<std::pair<tick_t, Event> > m_eventReceived;
+    async::Channel<tick_t, Event> m_eventReceived;
 
     async::Notification m_devicesChanged;
     MidiDevicesListener m_devicesListener;

--- a/src/framework/midi/view/devtools/midiportdevmodel.cpp
+++ b/src/framework/midi/view/devtools/midiportdevmodel.cpp
@@ -28,8 +28,8 @@ using namespace mu::midi;
 MidiPortDevModel::MidiPortDevModel(QObject* parent)
     : QObject(parent)
 {
-    midiInPort()->eventReceived().onReceive(this, [this](const std::pair<tick_t, Event>& ev) {
-        QString str = "tick: " + QString::number(ev.first) + " " + QString::fromStdString(ev.second.to_string());
+    midiInPort()->eventReceived().onReceive(this, [this](tick_t tick, const Event& event) {
+        QString str = "tick: " + QString::number(tick) + " " + QString::fromStdString(event.to_string());
         LOGI() << str;
 
         m_inputEvents.prepend(str);

--- a/src/framework/ui/imainwindow.h
+++ b/src/framework/ui/imainwindow.h
@@ -49,7 +49,7 @@ public:
     virtual const QScreen* screen() const = 0;
 
     virtual void requestChangeToolBarOrientation(const QString& toolBarName, framework::Orientation orientation) = 0;
-    virtual async::Channel<std::pair<QString, framework::Orientation> > changeToolBarOrientationRequested() const = 0;
+    virtual async::Channel<QString, framework::Orientation> changeToolBarOrientationRequested() const = 0;
 
     virtual void requestShowToolBarDockingHolder(const QPoint& globalPos) = 0;
     virtual async::Channel<QPoint> showToolBarDockingHolderRequested() const = 0;

--- a/src/framework/ui/view/qmlaccessible.cpp
+++ b/src/framework/ui/view/qmlaccessible.cpp
@@ -145,7 +145,7 @@ mu::async::Channel<IAccessible::Property> AccessibleItem::accessiblePropertyChan
     return m_accessiblePropertyChanged;
 }
 
-mu::async::Channel<std::pair<IAccessible::State, bool> > AccessibleItem::accessibleStateChanged() const
+mu::async::Channel<IAccessible::State, bool> AccessibleItem::accessibleStateChanged() const
 {
     return m_accessibleStateChanged;
 }
@@ -185,7 +185,7 @@ void AccessibleItem::setState(IAccessible::State st, bool arg)
     emit stateChanged();
 
     if (!m_ignored) {
-        m_accessibleStateChanged.send({ st, arg });
+        m_accessibleStateChanged.send(st, arg);
     }
 }
 

--- a/src/framework/ui/view/qmlaccessible.h
+++ b/src/framework/ui/view/qmlaccessible.h
@@ -108,7 +108,7 @@ public:
     QRect accessibleRect() const override;
 
     async::Channel<Property> accessiblePropertyChanged() const override;
-    async::Channel<std::pair<State, bool> > accessibleStateChanged() const override;
+    async::Channel<State, bool> accessibleStateChanged() const override;
     // -----
 
     // QQmlParserStatus
@@ -142,7 +142,7 @@ private:
     QQuickItem* m_visualItem = nullptr;
     QMap<State, bool> m_state;
     async::Channel<Property> m_accessiblePropertyChanged;
-    async::Channel<std::pair<State, bool> > m_accessibleStateChanged;
+    async::Channel<State, bool> m_accessibleStateChanged;
 };
 }
 

--- a/src/notation/internal/midiinputcontroller.cpp
+++ b/src/notation/internal/midiinputcontroller.cpp
@@ -41,12 +41,12 @@ void MidiInputController::init()
         }
     });
 
-    midiInPort()->eventReceived().onReceive(this, [this](const std::pair<midi::tick_t, midi::Event>& ev) {
+    midiInPort()->eventReceived().onReceive(this, [this](midi::tick_t tick, const midi::Event& event) {
         if (!configuration()->isMidiInputEnabled()) {
             return;
         }
 
-        onMidiEventReceived(ev.first, ev.second);
+        onMidiEventReceived(tick, event);
     });
 }
 

--- a/thirdparty/deto_async/async/changednotify.h
+++ b/thirdparty/deto_async/async/changednotify.h
@@ -107,7 +107,7 @@ private:
         Call f;
         ItemChangedCallT(Call _f)
             : f(_f) {}
-        void itemChanged(const NotifyData& item) { f(item.arg<Arg>()); }
+        void itemChanged(const NotifyData& item) { std::apply(f, item.arg<Arg>()); }
     };
 
     struct IItemAdded {
@@ -120,7 +120,7 @@ private:
         Call f;
         ItemAddedCallT(Call _f)
             : f(_f) {}
-        void itemAdded(const NotifyData& item) { f(item.arg<Arg>()); }
+        void itemAdded(const NotifyData& item) { std::apply(f, item.arg<Arg>()); }
     };
 
     struct IItemRemoved {
@@ -133,7 +133,7 @@ private:
         Call f;
         ItemRemovedCallT(Call _f)
             : f(_f) {}
-        void itemRemoved(const NotifyData& item) { f(item.arg<Arg>()); }
+        void itemRemoved(const NotifyData& item) { std::apply(f, item.arg<Arg>()); }
     };
 
     struct IItemReplaced {
@@ -146,7 +146,7 @@ private:
         Call f;
         ItemReplacedCallT(Call _f)
             : f(_f) {}
-        void itemReplaced(const NotifyData& item) { f(item.arg<Arg>(0), item.arg<Arg>(1)); }
+        void itemReplaced(const NotifyData& item) { f(std::get<0>(item.arg<Arg>(0)), std::get<0>(item.arg<Arg>(1))); }
     };
 
     struct ChangedInvoker : public AbstractInvoker

--- a/thirdparty/deto_async/async/channel.h
+++ b/thirdparty/deto_async/async/channel.h
@@ -6,7 +6,7 @@
 
 namespace deto {
 namespace async {
-template<typename T>
+template<typename ... T>
 class Channel
 {
 public:
@@ -25,17 +25,17 @@ public:
         return *this;
     }
 
-    void send(const T& d)
+    void send(const T&... d)
     {
         NotifyData nd;
-        nd.setArg<T>(0, d);
+        nd.setArg<T...>(0, d ...);
         ptr()->invoke(Receive, nd);
     }
 
     template<typename Func>
     void onReceive(const Asyncable* receiver, Func f, Asyncable::AsyncMode mode = Asyncable::AsyncMode::AsyncSetOnce)
     {
-        ptr()->addCallBack(Receive, const_cast<Asyncable*>(receiver), new ReceiveCall<Func, T>(f), mode);
+        ptr()->addCallBack(Receive, const_cast<Asyncable*>(receiver), new ReceiveCall<Func, T...>(f), mode);
     }
 
     void resetOnReceive(const Asyncable* receiver)
@@ -72,12 +72,12 @@ private:
         virtual void received(const NotifyData& d) = 0;
     };
 
-    template<typename Call, typename Arg>
+    template<typename Call, typename ... Arg>
     struct ReceiveCall : public IReceive {
         Call f;
         ReceiveCall(Call _f)
             : f(_f) {}
-        void received(const NotifyData& d) { f(d.arg<Arg>()); }
+        void received(const NotifyData& d) { std::apply(f, d.arg<Arg...>()); }
     };
 
     struct IClose {

--- a/thirdparty/deto_async/async/internal/abstractinvoker.h
+++ b/thirdparty/deto_async/async/internal/abstractinvoker.h
@@ -18,21 +18,21 @@ class NotifyData
 public:
     NotifyData() {}
 
-    template<typename T>
-    void setArg(int i, const T& val)
+    template<typename ... T>
+    void setArg(int i, const T&... val)
     {
-        IArg* p = new Arg<T>(val);
+        IArg* p = new Arg<T...>(val ...);
         m_args.insert(m_args.begin() + i, std::shared_ptr<IArg>(p));
     }
 
-    template<typename T>
-    T arg(int i = 0) const
+    template<typename ... T>
+    std::tuple<T...> arg(int i = 0) const
     {
         IArg* p = m_args.at(i).get();
         if (!p) {
-            return T();
+            return {};
         }
-        Arg<T>* d = reinterpret_cast<Arg<T>*>(p);
+        Arg<T...>* d = reinterpret_cast<Arg<T...>*>(p);
         return d->val;
     }
 
@@ -40,11 +40,11 @@ public:
         virtual ~IArg() = default;
     };
 
-    template<typename T>
+    template<typename ... T>
     struct Arg : public IArg {
-        T val;
-        Arg(const T& v)
-            : IArg(), val(v) {}
+        std::tuple<T...> val;
+        Arg(const T&... v)
+            : IArg(), val(v ...) {}
     };
 
 private:

--- a/thirdparty/deto_async/async/notification.h
+++ b/thirdparty/deto_async/async/notification.h
@@ -11,13 +11,13 @@ public:
 
     void notify()
     {
-        m_ch.send(0);
+        m_ch.send();
     }
 
     template<typename Func>
     void onNotify(const Asyncable* receiver, Func f, Asyncable::AsyncMode mode = Asyncable::AsyncMode::AsyncSetOnce)
     {
-        m_ch.onReceive(receiver, [f](int) { f(); }, mode);
+        m_ch.onReceive(receiver, f, mode);
     }
 
     void resetOnNotify(const Asyncable* receiver)
@@ -42,7 +42,7 @@ public:
     }
 
 private:
-    Channel<int> m_ch;
+    Channel<> m_ch;
 };
 }
 }


### PR DESCRIPTION
Now we can do like

```
async::Channel<QString, framework::Orientation> m_dockOrientationChanged;

m_dockOrientationChanged.send(toolBarName, orientation);

m_dockOrientationChanged.onReceive(this, [this](QString name, mu::framework::Orientation orientation) {
    ...
})
```

I did this actually because I was fascinated by the possibilities with templates in C++, but I'm not sure if we should really use this. I once heard that such template magic is quite difficult for compilers (although on my Mac with Clang, I didn't notice much difference), and in those few cases where we actually do need to send multiple parameters, using `std::pair` (or `std::tuple`) is not problematic at all. So, it's a costs and benefits consideration.

Also, I'm in fact modifying third party code in this PR, which is... questionable. 