### PR TITLE
[MU4] Fix #8263 ensure score refreshed after adding attached elements from palette

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -26,6 +26,7 @@
 #include <QRectF>
 #include <QPainter>
 #include <QClipboard>
+#include <QApplication>
 
 #include "ptrutils.h"
 
@@ -95,12 +96,16 @@ Ms::Score* NotationInteraction::score() const
 
 void NotationInteraction::startEdit()
 {
+    m_notifyAboutDropChanged = false;
     m_undoStack->prepareChanges();
 }
 
 void NotationInteraction::apply()
 {
     m_undoStack->commitChanges();
+    if (m_notifyAboutDropChanged) {
+        notifyAboutDropChanged();
+    }
 }
 
 void NotationInteraction::notifyAboutDragChanged()
@@ -1392,7 +1397,7 @@ void NotationInteraction::applyDropPaletteElement(Ms::Score* score, Ms::Element*
         }
         dropData.dropElement = 0;
 
-        notifyAboutDropChanged();
+        m_notifyAboutDropChanged = true;
     }
 }
 
@@ -1599,7 +1604,7 @@ bool NotationInteraction::dragMeasureAnchorElement(const PointF& pos)
         m_dropData.ed.dropElement->score()->addRefresh(m_dropData.ed.dropElement->canvasBoundingRect());
         m_dropData.ed.dropElement->setTrack(track);
         m_dropData.ed.dropElement->score()->addRefresh(m_dropData.ed.dropElement->canvasBoundingRect());
-        notifyAboutDropChanged();
+        m_notifyAboutDropChanged = true;
         return true;
     }
     m_dropData.ed.dropElement->score()->addRefresh(m_dropData.ed.dropElement->canvasBoundingRect());

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -283,6 +283,8 @@ private:
     async::Channel<ScoreConfigType> m_scoreConfigChanged;
 
     Ms::Lasso* m_lasso = nullptr;
+
+    bool m_notifyAboutDropChanged = false;
 };
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8263

Accidentals weren't appearing after adding them from the palette to notes or trill lines

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
