### PR TITLE
[MU3 Backend] ENG-11: Articulations initially drawn incorrectly

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2920,20 +2920,11 @@ void MuseScore::dropEvent(QDropEvent* event)
       {
       const QMimeData* dta = event->mimeData();
       if (dta->hasUrls()) {
-            int view = -1;
             foreach(const QUrl& u, event->mimeData()->urls()) {
                   if (u.scheme() == "file") {
                         QString file = u.toLocalFile();
-                        MasterScore* score = readScore(file);
-                        if (score) {
-                              view = appendScore(score);
-                              addRecentScore(score);
-                              }
+                        openScore(file);
                         }
-                  }
-            if (view != -1) {
-                  setCurrentScoreView(view);
-                  writeSessionFile(false);
                   }
             event->acceptProposedAction();
             }


### PR DESCRIPTION
Resolves: [ENG-11](https://mu--se.atlassian.net/jira/software/projects/ENG/boards/21?selectedIssue=ENG-11): Articulation marks initially drawn in wrong position

Specifically when dragging-and-dropping an XML file into MuseScore, the
articulations didn't layout correctly. This was due to a difference
between `openScore` (called when opening recent or from files) and
`dropEvent` (called when dropping).

~~This commit adds the style and layout-related lines to make sure `score->layout` is called after loading, which fixes the issue.~~

~~There appear to be further differences regarding migration, which may be worth further investigation.~~
 
This commit removes the partially-duplicated code in `dropEvent` and
rather calls `openScore` to handle loading, preventing discrepancies
between the two approaches.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
