### PR TITLE
Fix #8084: two checkmarks in Note Input menu in NoteInputBar

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledMenu.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledMenu.qml
@@ -73,14 +73,21 @@ StyledPopupView {
         prv.hasItemsWithSubmenu = false
         prv.hasItemsWithShortcut = false
 
+        //! NOTE Policy:
+        //! - if the menu contains checkable items, space for the checkmarks is reserved
+        //! - if the menu contains items with an icon, space for icons is reserved
+        //! - selectable items that don't have an icon are treated as checkable
+        //! - selectable items that do have an icon are treated as non-checkable
+        //! - all selectable items that are selected get an accent color background
+
         for (let i = 0; i < model.length; i++) {
             let item = model[i]
             let hasIcon = (Boolean(item.icon) && item.icon !== IconCode.NONE)
 
-            if ((item.checkable || item.selectable) && hasIcon) {
+            if (item.checkable && hasIcon) {
                 prv.hasItemsWithIconAndCheckable = true
                 prv.hasItemsWithIconOrCheckable = true
-            } else if (item.checkable || item.selectable || hasIcon) {
+            } else if (item.checkable || hasIcon || item.selectable) {
                 prv.hasItemsWithIconOrCheckable = true
             }
 

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -42,6 +42,7 @@ void NotationActionController::init()
     dispatcher()->reg(this, ESCAPE_ACTION_CODE, this, &NotationActionController::resetState);
 
     dispatcher()->reg(this, "note-input", [this]() { toggleNoteInput(); });
+    dispatcher()->reg(this, "note-input-steptime", [this]() { toggleNoteInputMethod(NoteInputMethod::STEPTIME); });
     dispatcher()->reg(this, "note-input-rhythm", [this]() { toggleNoteInputMethod(NoteInputMethod::RHYTHM); });
     dispatcher()->reg(this, "note-input-repitch", [this]() { toggleNoteInputMethod(NoteInputMethod::REPITCH); });
     dispatcher()->reg(this, "note-input-realtime-auto", [this]() { toggleNoteInputMethod(NoteInputMethod::REALTIME_AUTO); });
@@ -359,20 +360,6 @@ INotationUndoStackPtr NotationActionController::currentNotationUndoStack() const
     return notation->undoStack();
 }
 
-void NotationActionController::toggleNoteInput()
-{
-    auto noteInput = currentNotationNoteInput();
-    if (!noteInput) {
-        return;
-    }
-
-    if (noteInput->isNoteInputMode()) {
-        noteInput->endNoteInput();
-    } else {
-        noteInput->startNoteInput();
-    }
-}
-
 void NotationActionController::resetState()
 {
     auto isAudioPlaying = [this]() {
@@ -414,6 +401,20 @@ void NotationActionController::resetState()
     }
 }
 
+void NotationActionController::toggleNoteInput()
+{
+    auto noteInput = currentNotationNoteInput();
+    if (!noteInput) {
+        return;
+    }
+
+    if (noteInput->isNoteInputMode()) {
+        noteInput->endNoteInput();
+    } else {
+        noteInput->startNoteInput();
+    }
+}
+
 void NotationActionController::toggleNoteInputMethod(NoteInputMethod method)
 {
     auto noteInput = currentNotationNoteInput();
@@ -423,6 +424,9 @@ void NotationActionController::toggleNoteInputMethod(NoteInputMethod method)
 
     if (!noteInput->isNoteInputMode()) {
         noteInput->startNoteInput();
+    } else if (noteInput->state().method == method) {
+        noteInput->endNoteInput();
+        return;
     }
 
     noteInput->toggleNoteInputMethod(method);

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -114,6 +114,11 @@ void NotationNoteInput::startNoteInput()
 
     m_interaction->select({ el }, SelectType::SINGLE, 0);
 
+    // Not strictly necessary, just for safety
+    if (is.noteEntryMethod() == Ms::NoteEntryMethod::UNKNOWN) {
+        is.setNoteEntryMethod(Ms::NoteEntryMethod::STEPTIME);
+    }
+
     Duration d(is.duration());
     if (!d.isValid() || d.isZero() || d.type() == Duration::DurationType::V_MEASURE) {
         is.setDuration(Duration(Duration::DurationType::V_QUARTER));

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -942,10 +942,16 @@ const UiActionList NotationUiActions::m_actions = {
 const UiActionList NotationUiActions::m_noteInputActions = {
     UiAction("note-input",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Default (Step time)"),
+             QT_TRANSLATE_NOOP("action", "Note Input"),
              QT_TRANSLATE_NOOP("action", "Enter notes with a mouse or keyboard"),
              IconCode::Code::EDIT,
              Checkable::Yes
+             ),
+    UiAction("note-input-steptime",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Default (Step time)"),
+             QT_TRANSLATE_NOOP("action", "Enter notes with a mouse or keyboard"),
+             IconCode::Code::EDIT
              ),
     UiAction("note-input-rhythm",
              mu::context::UiCtxNotationOpened,

--- a/src/notation/qml/MuseScore/NotationScene/NoteInputBar.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NoteInputBar.qml
@@ -157,7 +157,9 @@ Rectangle {
 
             StyledMenuLoader {
                 id: menuLoader
-                onHandleAction: noteInputModel.handleAction(actionCode, actionIndex)
+                onHandleAction: function(actionCode) {
+                    noteInputModel.handleAction(actionCode)
+                }
             }
         }
     }

--- a/src/notation/view/noteinputbarmodel.cpp
+++ b/src/notation/view/noteinputbarmodel.cpp
@@ -43,7 +43,7 @@ static const ActionCode TUPLET_ACTION_CODE("tuplet");
 static int INVALID_INDEX = -1;
 
 static const std::vector<std::pair<ActionCode, NoteInputMethod> > noteInputModeActions = {
-    { "note-input", NoteInputMethod::STEPTIME },
+    { "note-input-steptime", NoteInputMethod::STEPTIME },
     { "note-input-rhythm", NoteInputMethod::RHYTHM },
     { "note-input-repitch", NoteInputMethod::REPITCH },
     { "note-input-realtime-auto", NoteInputMethod::REALTIME_AUTO },
@@ -218,37 +218,6 @@ void NoteInputBarModel::onNotationChanged()
     }
 
     updateState();
-}
-
-void NoteInputBarModel::toggleNoteInput()
-{
-    if (!noteInput()) {
-        return;
-    }
-
-    if (isNoteInputMode()) {
-        noteInput()->endNoteInput();
-    } else {
-        noteInput()->startNoteInput();
-    }
-}
-
-void NoteInputBarModel::toggleNoteInputMethod(const ActionCode& actionCode)
-{
-    if (!noteInput()) {
-        return;
-    }
-
-    NoteInputMethod currentMethod = noteInputState().method;
-    NoteInputMethod actionMethod = noteInputMethodForActionCode(actionCode);
-    if (currentMethod == actionMethod) {
-        toggleNoteInput();
-    } else {
-        if (!isNoteInputMode()) {
-            noteInput()->startNoteInput();
-        }
-        noteInput()->toggleNoteInputMethod(actionMethod);
-    }
 }
 
 void NoteInputBarModel::updateState()
@@ -590,7 +559,7 @@ bool NoteInputBarModel::resolveSlurSelected() const
 
 bool NoteInputBarModel::isNoteInputModeAction(const ActionCode& actionCode) const
 {
-    return noteInputMethodForActionCode(actionCode) != NoteInputMethod::UNKNOWN;
+    return actionCode == "note-input" || noteInputMethodForActionCode(actionCode) != NoteInputMethod::UNKNOWN;
 }
 
 UiAction NoteInputBarModel::currentNoteInputModeAction() const
@@ -857,18 +826,9 @@ std::vector<std::string> NoteInputBarModel::currentWorkspaceActions() const
     return toolbarData->actions;
 }
 
-void NoteInputBarModel::handleAction(const QString& action, int actionIndex)
+void NoteInputBarModel::handleAction(const QString& action)
 {
     ActionCode actionCode = codeFromQString(action);
-    if (isNoteInputModeAction(actionCode)) {
-        if (actionIndex != INVALID_INDEX) {
-            toggleNoteInputMethod(actionCode);
-        } else {
-            toggleNoteInput();
-        }
-        return;
-    }
-
     dispatcher()->dispatch(actionCode);
 }
 

--- a/src/notation/view/noteinputbarmodel.h
+++ b/src/notation/view/noteinputbarmodel.h
@@ -54,7 +54,7 @@ public:
     QHash<int, QByteArray> roleNames() const override;
 
     Q_INVOKABLE void load();
-    Q_INVOKABLE void handleAction(const QString& action, int actionIndex = -1);
+    Q_INVOKABLE void handleAction(const QString& action);
 
     Q_INVOKABLE QVariantMap get(int index);
 
@@ -80,9 +80,6 @@ private:
     INotationPtr notation() const;
 
     void onNotationChanged();
-
-    void toggleNoteInput();
-    void toggleNoteInputMethod(const actions::ActionCode& actionCode);
 
     void updateState();
     void updateNoteInputState();


### PR DESCRIPTION
Resolves: #8084

This PR solves several issues with the Note Input menu. 

First, the order of the items was wrong, because the items were added by iterating over a QMap, which does not maintain the order (it sorts by key). Now, I changed this into a `std::vector<std::pair<...>>`, so we get the order we want.

Then, I fixed the checkmarks issue. I added a separate action for just toggling note input and setting the note input method to "Steptime (default)". This is also how it was in MuseScore 3.

However, in the original design, there is no checkmark at all; the selected method is just highlighted, so the checkmark is somewhat redundant. So I removed it in the third commit. Here's the two versions, so you can choose:
|With checkmark|Without checkmark|
|-|-|
|<img width="308" alt="Schermafbeelding 2021-06-10 om 23 03 28" src="https://user-images.githubusercontent.com/48658420/121598584-40475100-ca42-11eb-81b3-105ea9fab198.png">|<img width="280" alt="Schermafbeelding 2021-06-10 om 23 18 53" src="https://user-images.githubusercontent.com/48658420/121598622-4b9a7c80-ca42-11eb-81db-42872ef2cb48.png">|