### PR TITLE
[MU3 Backend] Eng-53: Horizontal spacer for FretDiagrams

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1305,11 +1305,27 @@ Shape ChordRest::shape() const
             if (e->isHarmony() && e->staffIdx() == staffIdx()) {
                   Harmony* h = toHarmony(e);
                   // calculate bbox only (do not reset position)
-                  h->layout1();
+                  if (h->bbox().isEmpty()) h->layout1();
                   const qreal margin = styleP(Sid::minHarmonyDistance) * 0.5;
                   x1 = qMin(x1, e->bbox().x() - margin + e->pos().x());
                   x2 = qMax(x2, e->bbox().x() + e->bbox().width() + margin + e->pos().x());
                   adjustWidth = true;
+                  }
+            else if (e->isFretDiagram()) {
+                  FretDiagram* fd = toFretDiagram(e);
+                  if (fd->bbox().isEmpty()) fd->calculateBoundingRect();
+                  qreal margin = styleP(Sid::fretMinDistance) * 0.5;
+                  x1 = qMin(x1, e->bbox().x() - margin + e->pos().x());
+                  x2 = qMax(x2, e->bbox().x() + e->bbox().width() + margin + e->pos().x());
+                  adjustWidth = true;
+                  if (fd->harmony()) {
+                        Harmony* h = fd->harmony();
+                        if (h->bbox().isEmpty()) h->layout1();
+                        margin = styleP(Sid::minHarmonyDistance) * 0.5;
+                        x1 = qMin(x1, h->bbox().x() - margin + h->pos().x() + e->pos().x());
+                        x2 = qMax(x2, h->bbox().x() + h->bbox().width() + margin + h->pos().x() + e->pos().x());
+                        adjustWidth = true;
+                        }
                   }
             }
       if (adjustWidth)

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -64,7 +64,6 @@ ChordRest::ChordRest(Score* s)
       _up          = true;
       _beamMode    = Beam::Mode::AUTO;
       _small       = false;
-      _melismaEnd  = false;
       _crossMeasure = CrossMeasure::UNKNOWN;
       }
 
@@ -80,7 +79,7 @@ ChordRest::ChordRest(const ChordRest& cr, bool link)
       _beamMode     = cr._beamMode;
       _up           = cr._up;
       _small        = cr._small;
-      _melismaEnd   = cr._melismaEnd;
+      _melismaEnds   = cr._melismaEnds;
       _crossMeasure = cr._crossMeasure;
 
       for (Lyrics* l : cr._lyrics) {        // make deep copy
@@ -1232,20 +1231,31 @@ QString ChordRest::accessibleExtraInfo() const
 
 bool ChordRest::isMelismaEnd() const
       {
-      return _melismaEnd;
+      return !_melismaEnds.empty();
       }
 
 //---------------------------------------------------------
-//   setMelismaEnd
+//   removeMelismaEnd()
+//    removes a Lyrics object from the _melismaEnds set
+//    if present by iterating through the set.
+//    Returns a boolean representing whether the Lyrics
+//    was found.
+//    No-op and return false if Lyrics not present in _melismaEnds.
 //---------------------------------------------------------
 
-void ChordRest::setMelismaEnd(bool v)
+bool ChordRest::removeMelismaEnd(const Lyrics* l)
       {
-      _melismaEnd = v;
-      // TODO: don't take "false" at face value
-      // check to see if some other melisma ends here,
-      // in which case we can leave this set to true
-      // for now, rely on the fact that we'll generate the value correctly on layout
+      bool found = false;
+      for (std::set<Lyrics*>::iterator it = _melismaEnds.begin(); it != _melismaEnds.end(); ) {
+            if (*it == l) {
+                  it = _melismaEnds.erase(it); // Returns next iterator
+                  found = true;
+                  }
+            else {
+                  ++it;
+                  }
+            }
+      return found;
       }
 
 //---------------------------------------------------------
@@ -1256,6 +1266,8 @@ Shape ChordRest::shape() const
       {
       Shape shape;
       {
+      // Add horizontal spacing for lyrics
+
       qreal x1 = 1000000.0;
       qreal x2 = -1000000.0;
       bool adjustWidth = false;
@@ -1265,11 +1277,14 @@ Shape ChordRest::shape() const
             qreal lmargin = score()->styleS(Sid::lyricsMinDistance).val() * spatium() * 0.5;
             qreal rmargin = lmargin;
             Lyrics::Syllabic syl = l->syllabic();
-            if ((syl == Lyrics::Syllabic::BEGIN || syl == Lyrics::Syllabic::MIDDLE) && score()->styleB(Sid::lyricsDashForce))
+            bool hasHyphen = syl == Lyrics::Syllabic::BEGIN || syl == Lyrics::Syllabic::MIDDLE;
+            if (hasHyphen && score()->styleB(Sid::lyricsDashForce))
                   rmargin = qMax(rmargin, styleP(Sid::lyricsDashMinLength));
-            // for horizontal spacing we only need the lyrics width:
+            // for horizontal spacing we only need the lyrics' width:
             x1 = qMin(x1, l->bbox().x() - lmargin + l->pos().x());
-            x2 = qMax(x2, l->bbox().x() + l->bbox().width() + rmargin + l->pos().x());
+            // Melismas (without hyphens) only create right spacing on their last note
+            if (!l->isMelisma() || hasHyphen)
+                  x2 = qMax(x2, l->bbox().x() + l->bbox().width() + rmargin + l->pos().x());
             if (l->ticks() == Fraction::fromTicks(Lyrics::TEMP_MELISMA_TICKS))
                   x2 += spatium();
             adjustWidth = true;
@@ -1279,6 +1294,8 @@ Shape ChordRest::shape() const
       }
 
       {
+      // Add horizontal spacing for annotations
+
       qreal x1 = 1000000.0;
       qreal x2 = -1000000.0;
       bool adjustWidth = false;
@@ -1300,8 +1317,24 @@ Shape ChordRest::shape() const
       }
 
       if (isMelismaEnd()) {
+            // Add horizontal spacing (only on the right) for melismaEnds
+            // in case a melisma syllable extends beyond its last note.
+            // TODO: distribute this extra spacing rather than dumping
+            // it all on the last note (or otherwise overhaul horizontal spacing).
+            // TODO: this doesn't redraw on layout reset (like line breaks), 
+            // causing temporary incorrect rendering.
+
+            qreal rmargin = score()->styleS(Sid::lyricsMinDistance).val() * spatium() * 0.5;
             qreal right = rightEdge();
-            shape.addHorizontalSpacing(Shape::SPACING_LYRICS, right, right);
+
+            for (Lyrics* me : melismaEnds()) {
+                  if (me->measure()->system() != measure()->system()) // ignore cross-system melisma
+                        continue;
+                  // Lyric's right edge relative to Chord by way of page position
+                  qreal meRight = me->pageBoundingRect().right() + rmargin - pagePos().x();
+                  right = qMax(right, meRight);
+                  }
+            shape.addHorizontalSpacing(Shape::SPACING_LYRICS, 0, right);
             }
 
       return shape;

--- a/libmscore/chordrest.h
+++ b/libmscore/chordrest.h
@@ -61,7 +61,7 @@ class ChordRest : public DurationElement {
       Beam::Mode _beamMode;
       bool _up;                           // actual stem direction
       bool _small;
-      bool _melismaEnd;
+      std::set<Lyrics*> _melismaEnds;     // lyrics ending on this ChordRest, used for spacing
 
       // CrossMeasure: combine 2 tied notes if across a bar line and can be combined in a single duration
       CrossMeasure _crossMeasure;         ///< 0: no cross-measure modification; 1: 1st note of a mod.; -1: 2nd note
@@ -138,8 +138,10 @@ class ChordRest : public DurationElement {
       std::vector<Lyrics*>& lyrics()             { return _lyrics; }
       Lyrics* lyrics(int verse, Placement) const;
       int lastVerse(Placement) const;
+      const std::set<Lyrics*>& melismaEnds() const { return _melismaEnds; }
+      std::set<Lyrics*>& melismaEnds()             { return _melismaEnds; }
+      bool removeMelismaEnd(const Lyrics* l);
       bool isMelismaEnd() const;
-      void setMelismaEnd(bool v);
 
       virtual void add(Element*);
       virtual void remove(Element*);

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -452,10 +452,10 @@ void FretDiagram::draw(QPainter* painter) const
       }
 
 //---------------------------------------------------------
-//   layout
+//   calculateBoundingRect()
 //---------------------------------------------------------
 
-void FretDiagram::layout()
+void FretDiagram::calculateBoundingRect()
       {
       qreal _spatium  = spatium() * _userMag;
       stringLw        = _spatium * 0.08;
@@ -492,7 +492,15 @@ void FretDiagram::layout()
             }
 
       bbox().setRect(x, y, w, h);
+      }
 
+//---------------------------------------------------------
+//   layout
+//---------------------------------------------------------
+
+void FretDiagram::layout()
+      {
+      calculateBoundingRect();
       if (!parent() || !parent()->isSegment()) {
             setPos(QPointF());
             return;
@@ -522,7 +530,7 @@ void FretDiagram::layout()
             mainWidth = stringDist * (_strings - 1);
       else if (_orientation == Orientation::HORIZONTAL)
             mainWidth = fretDist * (_frets + 0.5);
-      setPos((noteheadWidth - mainWidth)/2, -(h + styleP(Sid::fretY)));
+      setPos((noteheadWidth - mainWidth)/2, -(bbox().height() + styleP(Sid::fretY)));
 
       autoplaceSegmentElement();
 

--- a/libmscore/fret.h
+++ b/libmscore/fret.h
@@ -173,6 +173,7 @@ class FretDiagram final : public Element {
 
       ElementType type() const override { return ElementType::FRET_DIAGRAM; }
       void layout() override;
+      void calculateBoundingRect();
       void write(XmlWriter& xml) const override;
       void writeNew(XmlWriter& xml) const;
       void writeOld(XmlWriter& xml) const;

--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -188,7 +188,7 @@ void Lyrics::remove(Element* el)
                   if (!e)
                         e = score()->findCRinStaff(_separator->tick2(), track());
                   if (e && e->isChordRest())
-                        toChordRest(e)->setMelismaEnd(false);
+                        toChordRest(e)->removeMelismaEnd(this);
 #endif
                   // Lyrics::remove() and LyricsLine::removeUnmanaged() call each other;
                   // be sure each finds a clean context
@@ -368,7 +368,7 @@ void Lyrics::layout()
             // set melisma end
             ChordRest* ecr = score()->findCR(endTick(), track());
             if (ecr)
-                  ecr->setMelismaEnd(true);
+                  ecr->melismaEnds().insert(this);
             }
 
       }
@@ -525,7 +525,7 @@ void Lyrics::removeFromScore()
             // clear melismaEnd flag from end cr
             ChordRest* ecr = score()->findCR(endTick(), track());
             if (ecr)
-                  ecr->setMelismaEnd(false);
+                  ecr->removeMelismaEnd(this);
             }
       if (_separator) {
             _separator->removeUnmanaged();
@@ -567,16 +567,13 @@ bool Lyrics::setProperty(Pid propertyId, const QVariant& v)
                   break;
             case Pid::LYRIC_TICKS:
                   if (_ticks.isNotZero()) {
-                        // clear melismaEnd flag from previous end cr
-                        // this might be premature, as there may be other melismas ending there
-                        // but flag will be generated correctly on layout
                         // TODO: after inserting a measure,
                         // endTick info is wrong.
                         // Somehow we need to fix this.
                         // See https://musescore.org/en/node/285304 and https://musescore.org/en/node/311289
                         ChordRest* ecr = score()->findCR(endTick(), track());
                         if (ecr)
-                              ecr->setMelismaEnd(false);
+                              ecr->removeMelismaEnd(this);
                         }
                   _ticks = v.value<Fraction>();
                   break;

--- a/libmscore/lyrics.h
+++ b/libmscore/lyrics.h
@@ -51,7 +51,6 @@ class Lyrics final : public TextBase {
       Syllabic _syllabic;
       LyricsLine* _separator;
 
-      bool isMelisma() const;
       void undoChangeProperty(Pid id, const QVariant&, PropertyFlags ps) override;
 
    protected:
@@ -93,6 +92,7 @@ class Lyrics final : public TextBase {
       Fraction ticks() const                          { return _ticks;    }
       void setTicks(const Fraction& tick)             { _ticks = tick;    }
       Fraction endTick() const;
+      bool isMelisma() const;
       void removeFromScore();
 
       using ScoreElement::undoChangeProperty;

--- a/libmscore/shape.cpp
+++ b/libmscore/shape.cpp
@@ -28,7 +28,11 @@ void Shape::addHorizontalSpacing(HorizontalSpacingType type, qreal leftEdge, qre
       const qreal y = eps * int(type);
       if (leftEdge == rightEdge) // HACK zero-width shapes collide with everything currently.
             rightEdge += eps;
+#ifndef NDEBUG
+      add(QRectF(leftEdge, y, rightEdge - leftEdge, 0), "Horizontal Spacing");
+#else
       add(QRectF(leftEdge, y, rightEdge - leftEdge, 0));
+#endif
       }
 
 //---------------------------------------------------------

--- a/mtest/musicxml/io/testLyricExtensions2_ref.mscx
+++ b/mtest/musicxml/io/testLyricExtensions2_ref.mscx
@@ -1,0 +1,681 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.02">
+  <programVersion>3.6.2</programVersion>
+  <programRevision></programRevision>
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <enableVerticalSpread>1</enableVerticalSpread>
+      <hideEmptyStaves>1</hideEmptyStaves>
+      <dontHidStavesInFirstSystm>0</dontHidStavesInFirstSystm>
+      <Spatium>1.74978</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer">Henry Ives</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2021-05-21</metaTag>
+    <metaTag name="encoding">MuseScore 0.7.02007-09-10</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="originalFormat">xml</metaTag>
+    <metaTag name="platform">Microsoft Windows</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber">MuseScore testfile</metaTag>
+    <metaTag name="workTitle">Lyric Extensions</metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument id="piano">
+        <longName>Piano</longName>
+        <trackName>Staff 1</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <singleNoteDynamics>0</singleNoteDynamics>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <controller ctrl="10" value="63"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>Title</style>
+          <text>Lyrics with Non-Extended Melismata</text>
+          </Text>
+        <Text>
+          <style>Subtitle</style>
+          <text>MuseScore testfile</text>
+          </Text>
+        <Text>
+          <style>Composer</style>
+          <text>Henry Ives</text>
+          </Text>
+        </VBox>
+      <!-- Measure 1 -->
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            </Clef>
+          <KeySig>
+            <accidental>-3</accidental>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <durationType>16th</durationType>
+            <Lyrics>
+              <text>What</text>
+              </Lyrics>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Lyrics>
+              <text>so</text>
+              </Lyrics>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Lyrics>
+              <syllabic>begin</syllabic>
+              <text>proud</text>
+              </Lyrics>
+            <Spanner type="Slur">
+              <Slur>
+                <SlurSegment no="0">
+                  <o4 x="0" y="-0.179253"/>
+                  </SlurSegment>
+                </Slur>
+              <next>
+                <location>
+                  <fractions>1/8</fractions>
+                  </location>
+                </next>
+              </Spanner>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Note>
+              <Spanner type="Tie">
+                <Tie>
+                  </Tie>
+                <next>
+                  <location>
+                    <fractions>1/16</fractions>
+                    </location>
+                  </next>
+                </Spanner>
+              <pitch>63</pitch>
+              <tpc>11</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <dots>1</dots>
+            <durationType>half</durationType>
+            <Spanner type="Slur">
+              <prev>
+                <location>
+                  <fractions>-1/8</fractions>
+                  </location>
+                </prev>
+              </Spanner>
+            <Note>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <fractions>-1/16</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
+              <pitch>63</pitch>
+              <tpc>11</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <!-- Measure 2 -->
+      <Measure>
+        <LayoutBreak>
+          <subtype>line</subtype>
+          </LayoutBreak>
+        <voice>
+          <Chord>
+            <durationType>16th</durationType>
+            <Lyrics>
+              <syllabic>end</syllabic>
+              <ticks_f>0/4</ticks_f>
+              <text>ly</text>
+              </Lyrics>
+            <Note>
+              <pitch>65</pitch>
+              <tpc>13</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Lyrics>
+              <text>we</text>
+              </Lyrics>
+            <Note>
+              <pitch>65</pitch>
+              <tpc>13</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Lyrics>
+              <ticks>1680</ticks>
+              <ticks_f>7/8</ticks_f>
+              <text>hail'd</text>
+              </Lyrics>
+            <Spanner type="Slur">
+              <Slur>
+                <SlurSegment no="1">
+                  <o4 x="0.126751" y="0"/>
+                  </SlurSegment>
+                </Slur>
+              <next>
+                <location>
+                  <measures>1</measures>
+                  <fractions>-1/8</fractions>
+                  </location>
+                </next>
+              </Spanner>
+            <Note>
+              <pitch>65</pitch>
+              <tpc>13</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Note>
+              <Spanner type="Tie">
+                <Tie>
+                  </Tie>
+                <next>
+                  <location>
+                    <fractions>1/16</fractions>
+                    </location>
+                  </next>
+                </Spanner>
+              <pitch>62</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <dots>1</dots>
+            <durationType>half</durationType>
+            <Note>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <fractions>-1/16</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
+              <pitch>62</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <!-- Measure 3 -->
+      <Measure>
+        <voice>
+          <Chord>
+            <durationType>16th</durationType>
+            <Spanner type="Slur">
+              <prev>
+                <location>
+                  <measures>-1</measures>
+                  <fractions>1/8</fractions>
+                  </location>
+                </prev>
+              </Spanner>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Lyrics>
+              <text>at</text>
+              </Lyrics>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Lyrics>
+              <text>the</text>
+              </Lyrics>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Lyrics>
+              <syllabic>begin</syllabic>
+              <text>twi</text>
+              </Lyrics>
+            <Note>
+              <pitch>63</pitch>
+              <tpc>11</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Lyrics>
+              <syllabic>end</syllabic>
+              <ticks>120</ticks>
+              <ticks_f>1/16</ticks_f>
+              <text>light's</text>
+              </Lyrics>
+            <Spanner type="Slur">
+              <Slur>
+                </Slur>
+              <next>
+                <location>
+                  <fractions>1/16</fractions>
+                  </location>
+                </next>
+              </Spanner>
+            <Note>
+              <pitch>68</pitch>
+              <tpc>10</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Spanner type="Slur">
+              <prev>
+                <location>
+                  <fractions>-1/16</fractions>
+                  </location>
+                </prev>
+              </Spanner>
+            <Note>
+              <pitch>68</pitch>
+              <tpc>10</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Lyrics>
+              <ticks>120</ticks>
+              <ticks_f>1/16</ticks_f>
+              <text>last</text>
+              </Lyrics>
+            <Spanner type="Slur">
+              <Slur>
+                </Slur>
+              <next>
+                <location>
+                  <fractions>1/16</fractions>
+                  </location>
+                </next>
+              </Spanner>
+            <Note>
+              <pitch>68</pitch>
+              <tpc>10</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Spanner type="Slur">
+              <prev>
+                <location>
+                  <fractions>-1/16</fractions>
+                  </location>
+                </prev>
+              </Spanner>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Lyrics>
+              <syllabic>begin</syllabic>
+              <text>glea</text>
+              </Lyrics>
+            <Spanner type="Slur">
+              <Slur>
+                </Slur>
+              <next>
+                <location>
+                  <fractions>1/8</fractions>
+                  </location>
+                </next>
+              </Spanner>
+            <Note>
+              <pitch>75</pitch>
+              <tpc>11</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Note>
+              <pitch>75</pitch>
+              <tpc>11</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Spanner type="Slur">
+              <prev>
+                <location>
+                  <fractions>-1/8</fractions>
+                  </location>
+                </prev>
+              </Spanner>
+            <Note>
+              <pitch>75</pitch>
+              <tpc>11</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Lyrics>
+              <syllabic>end</syllabic>
+              <ticks>120</ticks>
+              <ticks_f>1/16</ticks_f>
+              <text>ming</text>
+              </Lyrics>
+            <Note>
+              <Spanner type="Tie">
+                <Tie>
+                  </Tie>
+                <next>
+                  <location>
+                    <fractions>1/16</fractions>
+                    </location>
+                  </next>
+                </Spanner>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <fractions>-1/16</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <!-- Measure 4 -->
+      <Measure>
+        <LayoutBreak>
+          <subtype>line</subtype>
+          </LayoutBreak>
+        <voice>
+          <StaffText>
+            <offset x="0" y="-3.43421"/>
+            <text>Gang vocals</text>
+            </StaffText>
+          <Chord>
+            <durationType>16th</durationType>
+            <Lyrics>
+              <text>(the</text>
+              </Lyrics>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Lyrics>
+              <syllabic>begin</syllabic>
+              <text>twi</text>
+              </Lyrics>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Lyrics>
+              <syllabic>end</syllabic>
+              <ticks>120</ticks>
+              <ticks_f>1/16</ticks_f>
+              <text>light's</text>
+              </Lyrics>
+            <Spanner type="Slur">
+              <Slur>
+                </Slur>
+              <next>
+                <location>
+                  <fractions>1/16</fractions>
+                  </location>
+                </next>
+              </Spanner>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Spanner type="Slur">
+              <prev>
+                <location>
+                  <fractions>-1/16</fractions>
+                  </location>
+                </prev>
+              </Spanner>
+            <Note>
+              <pitch>62</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Lyrics>
+              <text>last</text>
+              </Lyrics>
+            <Note>
+              <pitch>68</pitch>
+              <tpc>10</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Lyrics>
+              <syllabic>begin</syllabic>
+              <text>glea</text>
+              </Lyrics>
+            <Note>
+              <pitch>68</pitch>
+              <tpc>10</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Lyrics>
+              <syllabic>end</syllabic>
+              <ticks>720</ticks>
+              <ticks_f>6/16</ticks_f>
+              <text>ming)</text>
+              </Lyrics>
+            <Spanner type="Slur">
+              <Slur>
+                <SlurSegment no="0">
+                  <o4 x="-0.201205" y="9.16829e-15"/>
+                  </SlurSegment>
+                </Slur>
+              <next>
+                <location>
+                  <fractions>3/8</fractions>
+                  </location>
+                </next>
+              </Spanner>
+            <Note>
+              <pitch>68</pitch>
+              <tpc>10</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Note>
+              <pitch>77</pitch>
+              <tpc>13</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Note>
+              <pitch>77</pitch>
+              <tpc>13</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Note>
+              <pitch>77</pitch>
+              <tpc>13</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <Note>
+              <Spanner type="Tie">
+                <Tie>
+                  </Tie>
+                <next>
+                  <location>
+                    <fractions>1/16</fractions>
+                    </location>
+                  </next>
+                </Spanner>
+              <pitch>74</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Spanner type="Slur">
+              <prev>
+                <location>
+                  <fractions>-3/8</fractions>
+                  </location>
+                </prev>
+              </Spanner>
+            <Note>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <fractions>-1/16</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
+              <pitch>74</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>


### PR DESCRIPTION
Resolves: [ENG-53](https://mu--se.atlassian.net/jira/software/projects/ENG/boards/21?selectedIssue=ENG-53): Fretboard diagrams need to create horizontal space

This adds a case for including fretboard diagrams when
creating horizontal spacing in the `ChordRest::shape()` function. In
pursuit of this, it also extracts a `calculateBoundingRect()` function from
`FretDiagram::layout()`.

NOTE: In order to allow "orphaned" FretDiagrams to still create space,
the spacer is added to all staves. This is redundant in some cases, so
a more performant solution may be desirable in the future.

This PR also includes the commit from #8176, as this is built on top of it.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
