### PR TITLE
Implement registering recent files with the operating system

### DIFF
--- a/src/userscores/CMakeLists.txt
+++ b/src/userscores/CMakeLists.txt
@@ -35,6 +35,11 @@ if (OS_IS_MAC)
 
     set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosrecentfilescontroller.mm
                                 PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+elseif(OS_IS_WIN)
+    set(PLATFORM_SRC
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/windows/windowsrecentfilescontroller.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/windows/windowsrecentfilescontroller.h
+    )
 else()
     set(PLATFORM_SRC
         ${CMAKE_CURRENT_LIST_DIR}/internal/platform/stub/stubrecentfilescontroller.cpp

--- a/src/userscores/CMakeLists.txt
+++ b/src/userscores/CMakeLists.txt
@@ -24,6 +24,24 @@ set(MODULE_QRC userscores.qrc)
 
 set(MODULE_QML_IMPORT ${CMAKE_CURRENT_LIST_DIR}/qml)
 
+if (OS_IS_MAC)
+    set(PLATFORM_SRC
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosrecentfilescontroller.mm
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosrecentfilescontroller.h
+    )
+    # Don't mix C++ and Objective-C++ in Unity Build
+    set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosrecentfilescontroller.mm
+                                PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+
+    set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosrecentfilescontroller.mm
+                                PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+else()
+    set(PLATFORM_SRC
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/stub/stubrecentfilescontroller.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/stub/stubrecentfilescontroller.h
+    )
+endif()
+
 set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/userscoresmodule.cpp
     ${CMAKE_CURRENT_LIST_DIR}/userscoresmodule.h
@@ -48,6 +66,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/exportdialogmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/filescorecontroller.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/filescorecontroller.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/iplatformrecentfilescontroller.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/userscoresconfiguration.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/userscoresconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/userscoresservice.cpp
@@ -61,6 +80,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/exporttype.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/exportscorescenario.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/exportscorescenario.h
+    ${PLATFORM_SRC}
     )
 
 set(MODULE_LINK notation)

--- a/src/userscores/internal/filescorecontroller.cpp
+++ b/src/userscores/internal/filescorecontroller.cpp
@@ -207,6 +207,7 @@ void FileScoreController::importPdf()
 void FileScoreController::clearRecentScores()
 {
     configuration()->setRecentScorePaths({});
+    platformRecentFilesController()->clearRecentFiles();
 }
 
 void FileScoreController::continueLastSession()
@@ -313,6 +314,7 @@ void FileScoreController::prependToRecentScoreList(const io::path& filePath)
 
     recentScorePaths.insert(recentScorePaths.begin(), filePath);
     configuration()->setRecentScorePaths(recentScorePaths);
+    platformRecentFilesController()->addRecentFile(filePath);
 }
 
 bool FileScoreController::isScoreOpened() const

--- a/src/userscores/internal/filescorecontroller.h
+++ b/src/userscores/internal/filescorecontroller.h
@@ -31,15 +31,17 @@
 #include "async/asyncable.h"
 #include "notation/inotationcreator.h"
 #include "context/iglobalcontext.h"
+#include "iplatformrecentfilescontroller.h"
 
 namespace mu::userscores {
 class FileScoreController : public IFileScoreController, public actions::Actionable, public async::Asyncable
 {
-    INJECT(scores, actions::IActionsDispatcher, dispatcher)
-    INJECT(scores, framework::IInteractive, interactive)
-    INJECT(scores, notation::INotationCreator, notationCreator)
-    INJECT(scores, context::IGlobalContext, globalContext)
-    INJECT(scores, IUserScoresConfiguration, configuration)
+    INJECT(userscores, actions::IActionsDispatcher, dispatcher)
+    INJECT(userscores, framework::IInteractive, interactive)
+    INJECT(userscores, notation::INotationCreator, notationCreator)
+    INJECT(userscores, context::IGlobalContext, globalContext)
+    INJECT(userscores, IUserScoresConfiguration, configuration)
+    INJECT(userscores, IPlatformRecentFilesController, platformRecentFilesController)
 
 public:
     void init();

--- a/src/userscores/internal/iplatformrecentfilescontroller.h
+++ b/src/userscores/internal/iplatformrecentfilescontroller.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_USERSCORES_IPLATFORMRECENTFILESCONTROLLER_H
+#define MU_USERSCORES_IPLATFORMRECENTFILESCONTROLLER_H
+
+#include "modularity/imoduleexport.h"
+#include "io/path.h"
+
+namespace mu::userscores {
+class IPlatformRecentFilesController : MODULE_EXPORT_INTERFACE
+{
+    INTERFACE_ID(IPlatformRecentFilesController)
+
+public:
+    virtual ~IPlatformRecentFilesController() = default;
+
+    virtual void addRecentFile(const io::path& path) = 0;
+    virtual void clearRecentFiles() = 0;
+};
+}
+
+#endif // MU_USERSCORES_IPLATFORMRECENTFILESCONTROLLER_H

--- a/src/userscores/internal/platform/macos/macosrecentfilescontroller.h
+++ b/src/userscores/internal/platform/macos/macosrecentfilescontroller.h
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_USERSCORES_MACOSRECENTFILESCONTROLLER_H
+#define MU_USERSCORES_MACOSRECENTFILESCONTROLLER_H
+
+#include "internal/iplatformrecentfilescontroller.h"
+
+namespace mu::userscores {
+class MacOSRecentFilesController : public IPlatformRecentFilesController
+{
+public:
+    void addRecentFile(const io::path& path) override;
+    void clearRecentFiles() override;
+};
+}
+
+#endif // MU_USERSCORES_MACOSRECENTFILESCONTROLLER_H

--- a/src/userscores/internal/platform/macos/macosrecentfilescontroller.mm
+++ b/src/userscores/internal/platform/macos/macosrecentfilescontroller.mm
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <Cocoa/Cocoa.h>
+
+#include "macosrecentfilescontroller.h"
+
+using namespace mu::userscores;
+
+void MacOSRecentFilesController::addRecentFile(const io::path& path)
+{
+    NSString* string = path.toQString().toNSString();
+    NSURL* url = [NSURL fileURLWithPath:string];
+    [[NSDocumentController sharedDocumentController] noteNewRecentDocumentURL:url];
+}
+
+void MacOSRecentFilesController::clearRecentFiles()
+{
+    [[NSDocumentController sharedDocumentController] clearRecentDocuments:nil];
+}

--- a/src/userscores/internal/platform/stub/stubrecentfilescontroller.cpp
+++ b/src/userscores/internal/platform/stub/stubrecentfilescontroller.cpp
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "stubrecentfilescontroller.h"
+
+using namespace mu::userscores;
+
+void StubRecentFilesController::addRecentFile(const io::path&)
+{
+}
+
+void StubRecentFilesController::clearRecentFiles()
+{
+}

--- a/src/userscores/internal/platform/stub/stubrecentfilescontroller.h
+++ b/src/userscores/internal/platform/stub/stubrecentfilescontroller.h
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_USERSCORES_STUBRECENTFILESCONTROLLER_H
+#define MU_USERSCORES_STUBRECENTFILESCONTROLLER_H
+
+namespace mu::userscores {
+class StubRecentFilesController : public IPlatformRecentFilesController
+{
+public:
+    void addRecentFile(const io::path& path) override;
+    void clearRecentFiles() override;
+};
+}
+
+#endif // MU_USERSCORES_STUBRECENTFILESCONTROLLER_H

--- a/src/userscores/internal/platform/windows/windowsrecentfilescontroller.cpp
+++ b/src/userscores/internal/platform/windows/windowsrecentfilescontroller.cpp
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "windowsrecentfilescontroller.h"
+
+#include <Windows.h>
+#include <shlobj.h>
+
+using namespace mu::userscores;
+
+void WindowsRecentFilesController::addRecentFile(const io::path& path)
+{
+    std::wstring pathString = path.toStdWString();
+    SHAddToRecentDocs(SHARD_PATHW, pathString.c_str());
+}
+
+void WindowsRecentFilesController::clearRecentFiles()
+{
+    // The "docs" seem to say that this should clear the recent files list
+    // But in practice it's not sure if that's the case
+    SHAddToRecentDocs(0, NULL);
+}

--- a/src/userscores/internal/platform/windows/windowsrecentfilescontroller.h
+++ b/src/userscores/internal/platform/windows/windowsrecentfilescontroller.h
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_USERSCORES_STUBRECENTFILESCONTROLLER_H
+#define MU_USERSCORES_STUBRECENTFILESCONTROLLER_H
+
+namespace mu::userscores {
+class WindowsRecentFilesController : public IPlatformRecentFilesController
+{
+public:
+    void addRecentFile(const io::path& path) override;
+    void clearRecentFiles() override;
+};
+}
+
+#endif // MU_USERSCORES_STUBRECENTFILESCONTROLLER_H

--- a/src/userscores/userscoresmodule.cpp
+++ b/src/userscores/userscoresmodule.cpp
@@ -42,6 +42,8 @@
 
 #ifdef Q_OS_MAC
 #include "internal/platform/macos/macosrecentfilescontroller.h"
+#elif defined (Q_OS_WIN)
+#include "internal/platform/windows/windowsrecentfilescontroller.h"
 #else
 #include "internal/platform/stub/stubrecentfilescontroller.h"
 #endif
@@ -78,6 +80,8 @@ void UserScoresModule::registerExports()
 
 #ifdef Q_OS_MAC
     ioc()->registerExport<IPlatformRecentFilesController>(moduleName(), new MacOSRecentFilesController());
+#elif defined (Q_OS_WIN)
+    ioc()->registerExport<IPlatformRecentFilesController>(moduleName(), new WindowsRecentFilesController());
 #else
     ioc()->registerExport<IPlatformRecentFilesController>(moduleName(), new StubRecentFilesController());
 #endif

--- a/src/userscores/userscoresmodule.cpp
+++ b/src/userscores/userscoresmodule.cpp
@@ -40,6 +40,12 @@
 #include "internal/templatesrepository.h"
 #include "internal/userscoresuiactions.h"
 
+#ifdef Q_OS_MAC
+#include "internal/platform/macos/macosrecentfilescontroller.h"
+#else
+#include "internal/platform/stub/stubrecentfilescontroller.h"
+#endif
+
 #include "ui/iinteractiveuriregister.h"
 #include "ui/iuiactionsregister.h"
 
@@ -69,6 +75,12 @@ void UserScoresModule::registerExports()
     ioc()->registerExport<ITemplatesRepository>(moduleName(), new TemplatesRepository());
     ioc()->registerExport<IFileScoreController>(moduleName(), s_fileController);
     ioc()->registerExport<IExportScoreScenario>(moduleName(), s_exportScoreScenario);
+
+#ifdef Q_OS_MAC
+    ioc()->registerExport<IPlatformRecentFilesController>(moduleName(), new MacOSRecentFilesController());
+#else
+    ioc()->registerExport<IPlatformRecentFilesController>(moduleName(), new StubRecentFilesController());
+#endif
 }
 
 void UserScoresModule::resolveImports()


### PR DESCRIPTION
In macOS apps that are built entirely with Apple's SDK, and in some special other apps, the most recently used files appear in the context menu of the app icon in the Dock (among other places). I implemented this also for MuseScore. 
This will enable users to get back to what they were doing even quicker, using the functionality they know from other apps.<sup>1</sup>
<img alt="RecentFilesMacOS" src="https://user-images.githubusercontent.com/48658420/121774281-08dfbe00-cb82-11eb-8546-96a0b9dd8fd2.png" width="250"/>
(normally, there is a separator line between the recent files and the other items in the dock menu, but it's missing due to a bug in macOS, which I reported to Apple.)

Similar functionality appeared to exist on Windows. So I implemented it for Windows too.
<img width="299" alt="Schermafbeelding 2021-06-12 om 13 34 02" src="https://user-images.githubusercontent.com/48658420/121774474-de423500-cb82-11eb-8e0a-38859d07a9f0.png">
NOTE: On Windows, it will only work if the app is [registered](https://docs.microsoft.com/en-us/windows/win32/shell/app-registration) for the correct file types. So in development versions of MuseScore 4 it probably won't work (unless you register it manually in the Register editor, as I did), but in the released version it will, because the .msi installer registers the app (that's at least the case with MuseScore 3).

Also note: clearing the recent files does work on macOS, but does not seem to work on Windows. I did what the [documentation](https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shaddtorecentdocs) seemed to want me to do, but without success. I'm not sure if it's even possible at all.

<sup>1</sup> I've probably watched too much WWDC 😅.