### PR TITLE
[MU3] fix #296212 - formatting lost when copying/pasting text

### DIFF
--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -659,14 +659,14 @@ bool TextCursor::set(const PointF& p, QTextCursor::MoveMode mode)
 //    return current selection
 //---------------------------------------------------------
 
-QString TextCursor::selectedText() const
+QString TextCursor::selectedText(bool withFormat) const
 {
     int r1 = selectLine();
     int r2 = _row;
     int c1 = selectColumn();
     int c2 = column();
     sort(r1, c1, r2, c2);
-    return extractText(r1, c1, r2, c2);
+    return extractText(r1, c1, r2, c2, withFormat);
 }
 
 //---------------------------------------------------------
@@ -674,22 +674,22 @@ QString TextCursor::selectedText() const
 //    return text between (r1,c1) and (r2,c2).
 //---------------------------------------------------------
 
-QString TextCursor::extractText(int r1, int c1, int r2, int c2) const
+QString TextCursor::extractText(int r1, int c1, int r2, int c2, bool withFormat) const
 {
     Q_ASSERT(isSorted(r1, c1, r2, c2));
     const QList<TextBlock>& tb = _text->_layout;
 
     if (r1 == r2) {
-        return tb.at(r1).text(c1, c2 - c1);
+        return tb.at(r1).text(c1, c2 - c1, withFormat);
     }
 
-    QString str = tb.at(r1).text(c1, -1) + "\n";
+    QString str = tb.at(r1).text(c1, -1, withFormat) + "\n";
 
     for (int r = r1 + 1; r < r2; ++r) {
-        str += tb.at(r).text(0, -1) + "\n";
+        str += tb.at(r).text(0, -1, withFormat) + "\n";
     }
 
-    str += tb.at(r2).text(0, c2);
+    str += tb.at(r2).text(0, c2, withFormat);
     return str;
 }
 
@@ -1605,13 +1605,19 @@ TextBlock TextBlock::split(int column, Ms::TextCursor* cursor)
 //    extract text, symbols are marked with <sym>xxx</sym>
 //---------------------------------------------------------
 
-QString TextBlock::text(int col1, int len) const
+QString TextBlock::text(int col1, int len, bool withFormat) const
 {
     QString s;
     int col = 0;
+    qreal size;
+    QString family;
     for (const auto& f : _fragments) {
         if (f.text.isEmpty()) {
             continue;
+        }
+        if (withFormat) {
+            s += TextBase::getHtmlStartTag(f.format.fontSize(), size, f.format.fontFamily(), family, f.format.bold(),
+                                           f.format.italic(), f.format.underline());
         }
         for (const QChar& c : qAsConst(f.text)) {
             if (col >= col1 && (len < 0 || ((col - col1) < len))) {
@@ -1620,6 +1626,9 @@ QString TextBlock::text(int col1, int len) const
             if (!c.isHighSurrogate()) {
                 ++col;
             }
+        }
+        if (withFormat) {
+            s += TextBase::getHtmlEndTag(f.format.bold(), f.format.italic(), f.format.underline());
         }
     }
     return s;
@@ -1827,64 +1836,25 @@ void TextBase::createLayout()
             if (c == '>') {
                 bool unstyleFontStyle = false;
                 state = 0;
-                if (token == "b") {
-                    cursor.format()->setBold(true);
-                    unstyleFontStyle = true;
-                } else if (token == "/b") {
-                    cursor.format()->setBold(false);
-                } else if (token == "i") {
-                    cursor.format()->setItalic(true);
-                    unstyleFontStyle = true;
-                } else if (token == "/i") {
-                    cursor.format()->setItalic(false);
-                } else if (token == "u") {
-                    cursor.format()->setUnderline(true);
-                    unstyleFontStyle = true;
-                } else if (token == "/u") {
-                    cursor.format()->setUnderline(false);
-                } else if (token == "sub") {
-                    cursor.format()->setValign(VerticalAlignment::AlignSubScript);
-                } else if (token == "/sub") {
-                    cursor.format()->setValign(VerticalAlignment::AlignNormal);
-                } else if (token == "sup") {
-                    cursor.format()->setValign(VerticalAlignment::AlignSuperScript);
-                } else if (token == "/sup") {
-                    cursor.format()->setValign(VerticalAlignment::AlignNormal);
-                } else if (token == "sym") {
+                prepareFormat(token, cursor);
+                if (token == "sym") {
                     symState = true;
                     sym.clear();
                 } else if (token == "/sym") {
                     symState = false;
                     SymId id = Sym::name2id(sym);
                     if (id != SymId::noSym) {
-                        CharFormat fmt = *cursor.format();              // save format
-                        // uint code = score()->scoreFont()->sym(id).code();
+                        CharFormat fmt = *cursor.format();  // save format
+                                                            // uint code = score()->scoreFont()->sym(id).code();
                         uint code = ScoreFont::fallbackFont()->sym(id).code();
                         cursor.format()->setFontFamily("ScoreText");
                         cursor.format()->setBold(false);
                         cursor.format()->setItalic(false);
                         insert(&cursor, code);
-                        cursor.setFormat(fmt);              // restore format
+                        cursor.setFormat(fmt);  // restore format
                     } else {
                         qDebug("unknown symbol <%s>", qPrintable(sym));
                     }
-                } else if (token.startsWith("font ")) {
-                    token = token.mid(5);
-                    if (token.startsWith("size=\"")) {
-                        cursor.format()->setFontSize(parseNumProperty(token.mid(6)));
-                        setPropertyFlags(Pid::FONT_SIZE, PropertyFlags::UNSTYLED);
-                    } else if (token.startsWith("face=\"")) {
-                        QString face = parseStringProperty(token.mid(6));
-                        face = unEscape(face);
-                        cursor.format()->setFontFamily(face);
-                        setPropertyFlags(Pid::FONT_FACE, PropertyFlags::UNSTYLED);
-                    } else {
-                        qDebug("cannot parse html property <%s> in text <%s>",
-                               qPrintable(token), qPrintable(_text));
-                    }
-                }
-                if (unstyleFontStyle) {
-                    setPropertyFlags(Pid::FONT_STYLE, PropertyFlags::UNSTYLED);
                 }
             } else {
                 token += c;
@@ -1912,6 +1882,66 @@ void TextBase::createLayout()
         _layout.append(TextBlock());
     }
     layoutInvalid = false;
+}
+
+//---------------------------------------------------------
+//   prepareFormat - used when reading from XML and when pasting from clipboard
+//---------------------------------------------------------
+bool TextBase::prepareFormat(const QString& token, Ms::CharFormat& format)
+{
+    if (token == "b") {
+        format.setBold(true);
+        return true;
+    } else if (token == "/b") {
+        format.setBold(false);
+    } else if (token == "i") {
+        format.setItalic(true);
+        return true;
+    } else if (token == "/i") {
+        format.setItalic(false);
+    } else if (token == "u") {
+        format.setUnderline(true);
+        return true;
+    } else if (token == "/u") {
+        format.setUnderline(false);
+    } else if (token == "sub") {
+        format.setValign(VerticalAlignment::AlignSubScript);
+    } else if (token == "/sub") {
+        format.setValign(VerticalAlignment::AlignNormal);
+    } else if (token == "sup") {
+        format.setValign(VerticalAlignment::AlignSuperScript);
+    } else if (token == "/sup") {
+        format.setValign(VerticalAlignment::AlignNormal);
+    } else if (token.startsWith("font ")) {
+        QString remainder = token.mid(5);
+        if (remainder.startsWith("size=\"")) {
+            format.setFontSize(parseNumProperty(remainder.mid(6)));
+            return true;
+        } else if (remainder.startsWith("face=\"")) {
+            QString face = parseStringProperty(remainder.mid(6));
+            face = unEscape(face);
+            format.setFontFamily(face);
+            if (face == "ScoreText") {
+                format.setBold(false);
+                format.setItalic(false);
+            }
+            return true;
+        } else {
+            qDebug("cannot parse html property <%s> in text <%s>",
+                   qPrintable(token), qPrintable(_text));
+        }
+    }
+    return false;
+}
+
+//---------------------------------------------------------
+//   prepareFormat - used when reading from XML
+//---------------------------------------------------------
+void TextBase::prepareFormat(const QString& token, Ms::TextCursor& cursor)
+{
+    if (prepareFormat(token, *cursor.format())) {
+        setPropertyFlags(Pid::FONT_FACE, PropertyFlags::UNSTYLED);
+    }
 }
 
 //---------------------------------------------------------
@@ -3056,6 +3086,50 @@ Sid TextBase::offsetSid() const
 }
 
 //---------------------------------------------------------
+//   getHtmlStartTag - helper function for extractText with withFormat = true
+//---------------------------------------------------------
+QString TextBase::getHtmlStartTag(qreal newSize, qreal& curSize, const QString& newFamily, QString& curFamily, bool bold, bool italic,
+                                  bool underline)
+{
+    QString s;
+    if (fabs(newSize - curSize) > 0.1) {
+        curSize = newSize;
+        s += QString("<font size=\"%1\"/>").arg(newSize);
+    }
+    if (newFamily != curFamily) {
+        curFamily = newFamily;
+        s += QString("<font face=\"%1\"/>").arg(newFamily);
+    }
+    if (bold) {
+        s += "<b>";
+    }
+    if (italic) {
+        s += "<i>";
+    }
+    if (underline) {
+        s += "<u>";
+    }
+    return s;
+}
+
+//---------------------------------------------------------
+//   getHtmlEndTag - helper function for extractText with withFormat = true
+//---------------------------------------------------------
+QString TextBase::getHtmlEndTag(bool bold, bool italic, bool underline)
+{
+    if (underline) {
+        return "</u>";
+    }
+    if (italic) {
+        return "</i>";
+    }
+    if (bold) {
+        return "</b>";
+    }
+    return QString();
+}
+
+//---------------------------------------------------------
 //   getPropertyStyle
 //---------------------------------------------------------
 
@@ -3163,7 +3237,7 @@ void TextBase::editCut(EditData& ed)
 {
     TextEditData* ted = static_cast<TextEditData*>(ed.getData(this));
     TextCursor* cursor = ted->cursor();
-    QString s = cursor->selectedText();
+    QString s = cursor->selectedText(true);
 
     if (!s.isEmpty()) {
         QApplication::clipboard()->setText(s, QClipboard::Clipboard);
@@ -3185,7 +3259,7 @@ void TextBase::editCopy(EditData& ed)
     //
     TextEditData* ted = static_cast<TextEditData*>(ed.getData(this));
     TextCursor* cursor = ted->cursor();
-    QString s = cursor->selectedText();
+    QString s = cursor->selectedText(true);
     if (!s.isEmpty()) {
         QApplication::clipboard()->setText(s, QClipboard::Clipboard);
     }

--- a/src/engraving/libmscore/textbase.h
+++ b/src/engraving/libmscore/textbase.h
@@ -158,8 +158,8 @@ public:
     QString currentWord() const;
     QString currentLine() const;
     bool set(const mu::PointF& p, QTextCursor::MoveMode mode = QTextCursor::MoveAnchor);
-    QString selectedText() const;
-    QString extractText(int r1, int c1, int r2, int c2) const;
+    QString selectedText(bool withFormat = false) const;
+    QString extractText(int r1, int c1, int r2, int c2, bool withFormat = false) const;
     void updateCursorFormat();
     void setFormat(FormatId, QVariant);
     void changeSelectionFormat(FormatId id, QVariant val);
@@ -235,7 +235,7 @@ public:
     qreal y() const { return _y; }
     void setY(qreal val) { _y = val; }
     qreal lineSpacing() const { return _lineSpacing; }
-    QString text(int, int) const;
+    QString text(int, int, bool = false) const;
     bool eol() const { return _eol; }
     void setEol(bool val) { _eol = val; }
     void changeFormat(FormatId, QVariant val, int start, int n);
@@ -282,6 +282,10 @@ class TextBase : public Element
     QString stripText(bool, bool, bool) const;
     Sid offsetSid() const;
 
+    static QString getHtmlStartTag(qreal newSize, qreal& curSize, const QString& newFamily, QString& curFamily, bool bold, bool italic,
+                                   bool underline);
+    static QString getHtmlEndTag(bool bold, bool italic, bool underline);
+
 protected:
     QColor textColor() const;
     mu::RectF frame;             // calculated in layout()
@@ -289,6 +293,8 @@ protected:
     void layoutEdit();
     void createLayout();
     void insertSym(EditData& ed, SymId id);
+    void prepareFormat(const QString& token, Ms::TextCursor& cursor);
+    bool prepareFormat(const QString& token, Ms::CharFormat& format);
 
 public:
     TextBase(Score* = 0, Tid tid = Tid::DEFAULT, ElementFlags = ElementFlag::NOTHING);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/296212#comment-1084020

Copying & pasting text from within text elements on a score doesn't behave as expected - formatting is lost and sometimes apparently randomly re-applied. There's also a bug with deleting all text and using "undo" to restore (formatting not properly restored if musical symbols used).

However a bigger problem is that copy/paste etc. doesn't seem to work at all currently in MU4 which is blocking the ability to test these changes (they were tested on the 3.6.2 branch only). I'm just creating this so the work doesn't get lost.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
