### PR TITLE
[MU4] Optional smaller margin for FlatButton

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/FlatButton.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/FlatButton.qml
@@ -41,6 +41,8 @@ FocusScope {
     property color pressedStateColor: prv.defaultColor
     property bool accentButton: false
 
+    property bool narrowMargins: false
+
     property int orientation: Qt.Vertical
 
     property alias navigation: navCtrl
@@ -58,7 +60,13 @@ FocusScope {
     objectName: root.text
 
     height: contentLoader.item.height + 14
-    width: (Boolean(text) ? Math.max(contentLoader.item.width + 32, prv.isVertical ? 132 : 0) : contentLoader.item.width + 16)
+    width: {
+        if (narrowMargins) {
+            return (Boolean(text) ? Math.max(contentLoader.item.width + 12, prv.isVertical ? 24 : 0) : contentLoader.item.width + 16)
+        } else {
+            return (Boolean(text) ? Math.max(contentLoader.item.width + 32, prv.isVertical ? 132 : 0) : contentLoader.item.width + 16)
+        }
+    }
 
     opacity: root.enabled ? 1.0 : ui.theme.itemOpacityDisabled
 

--- a/src/instruments/qml/MuseScore/Instruments/internal/SelectedInstrumentsView.qml
+++ b/src/instruments/qml/MuseScore/Instruments/internal/SelectedInstrumentsView.qml
@@ -175,6 +175,8 @@ Item {
                 anchors.rightMargin: 4
                 anchors.verticalCenter: parent.verticalCenter
 
+                narrowMargins: true
+
                 visible: root.currentInstrumentIndex === index
 
                 text: soloistsButtonText(modelData.isSoloist)


### PR DESCRIPTION
Adds an option to `FlatButton` to enable smaller margins left and right of the text. Soloist button will use these new small margins. It is the implementation of the [suggested changes](https://github.com/musescore/MuseScore/pull/8099#issuecomment-841179574) regarding the `Make/Undo Soloist` button.

Originally this change was part of PR #8267 but due to rebase conflicts this taken out and made into a separate PR.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
