### PR TITLE
Text element clipboard support

### DIFF
--- a/src/context/internal/uicontextresolver.cpp
+++ b/src/context/internal/uicontextresolver.cpp
@@ -102,7 +102,7 @@ bool UiContextResolver::match(const ui::UiContext& currentCtx, const ui::UiConte
     //! NOTE If now editing the notation text, then we allow actions only with the context `UiCtxNotationTextEditing`,
     //! all others, even `UiCtxAny`, are forbidden
     if (currentCtx == context::UiCtxNotationTextEditing) {
-        return actCtx == context::UiCtxNotationTextEditing;
+        return actCtx == context::UiCtxNotationTextEditing || actCtx == context::UiCtxNotationOpenedOrTextEditing;
     }
 
     if (actCtx == context::UiCtxAny) {
@@ -111,7 +111,7 @@ bool UiContextResolver::match(const ui::UiContext& currentCtx, const ui::UiConte
 
     //! NOTE If the current context is `UiCtxNotationFocused`, then we allow `UiCtxNotationOpened` too
     if (currentCtx == context::UiCtxNotationFocused) {
-        if (actCtx == context::UiCtxNotationOpened) {
+        if (actCtx == context::UiCtxNotationOpened || actCtx == context::UiCtxNotationOpenedOrTextEditing) {
             return true;
         }
         return actCtx == context::UiCtxNotationFocused;

--- a/src/context/uicontext.h
+++ b/src/context/uicontext.h
@@ -38,6 +38,7 @@ static constexpr ui::UiContext UiCtxHomeOpened = "UiCtxHomeOpened";
 // notation detail
 static constexpr ui::UiContext UiCtxNotationFocused = "UiCtxNotationFocused";
 static constexpr ui::UiContext UiCtxNotationTextEditing = "UiCtxNotationTextEditing";
+static constexpr ui::UiContext UiCtxNotationOpenedOrTextEditing = "UiCtxNotationOpenedOrTextEditing";
 }
 
 #endif // MU_CONTEXT_UICONTEXT_H

--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -2318,10 +2318,8 @@ void TextBase::selectAll(TextCursor* cursor)
         return;
     }
 
-    cursor->setSelectLine(0);
-    cursor->setSelectColumn(0);
-    cursor->setRow(rows() - 1);
-    cursor->setColumn(cursor->curLine().columns());
+    cursor->movePosition(QTextCursor::Start, QTextCursor::MoveMode::MoveAnchor);
+    cursor->movePosition(QTextCursor::End, QTextCursor::MoveMode::KeepAnchor);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -659,14 +659,14 @@ bool TextCursor::set(const PointF& p, QTextCursor::MoveMode mode)
 //    return current selection
 //---------------------------------------------------------
 
-QString TextCursor::selectedText() const
+QString TextCursor::selectedText(bool withFormat) const
 {
     int r1 = selectLine();
     int r2 = _row;
     int c1 = selectColumn();
     int c2 = column();
     sort(r1, c1, r2, c2);
-    return extractText(r1, c1, r2, c2);
+    return extractText(r1, c1, r2, c2, withFormat);
 }
 
 //---------------------------------------------------------
@@ -674,22 +674,22 @@ QString TextCursor::selectedText() const
 //    return text between (r1,c1) and (r2,c2).
 //---------------------------------------------------------
 
-QString TextCursor::extractText(int r1, int c1, int r2, int c2) const
+QString TextCursor::extractText(int r1, int c1, int r2, int c2, bool withFormat) const
 {
     Q_ASSERT(isSorted(r1, c1, r2, c2));
     const QList<TextBlock>& tb = _text->_layout;
 
     if (r1 == r2) {
-        return tb.at(r1).text(c1, c2 - c1);
+        return tb.at(r1).text(c1, c2 - c1, withFormat);
     }
 
-    QString str = tb.at(r1).text(c1, -1) + "\n";
+    QString str = tb.at(r1).text(c1, -1, withFormat) + "\n";
 
     for (int r = r1 + 1; r < r2; ++r) {
-        str += tb.at(r).text(0, -1) + "\n";
+        str += tb.at(r).text(0, -1, withFormat) + "\n";
     }
 
-    str += tb.at(r2).text(0, c2);
+    str += tb.at(r2).text(0, c2, withFormat);
     return str;
 }
 
@@ -1605,13 +1605,19 @@ TextBlock TextBlock::split(int column, Ms::TextCursor* cursor)
 //    extract text, symbols are marked with <sym>xxx</sym>
 //---------------------------------------------------------
 
-QString TextBlock::text(int col1, int len) const
+QString TextBlock::text(int col1, int len, bool withFormat) const
 {
     QString s;
     int col = 0;
+    qreal size;
+    QString family;
     for (const auto& f : _fragments) {
         if (f.text.isEmpty()) {
             continue;
+        }
+        if (withFormat) {
+            s += TextBase::getHtmlStartTag(f.format.fontSize(), size, f.format.fontFamily(), family, f.format.bold(),
+                                           f.format.italic(), f.format.underline());
         }
         for (const QChar& c : qAsConst(f.text)) {
             if (col >= col1 && (len < 0 || ((col - col1) < len))) {
@@ -1620,6 +1626,9 @@ QString TextBlock::text(int col1, int len) const
             if (!c.isHighSurrogate()) {
                 ++col;
             }
+        }
+        if (withFormat) {
+            s += TextBase::getHtmlEndTag(f.format.bold(), f.format.italic(), f.format.underline());
         }
     }
     return s;
@@ -1827,64 +1836,25 @@ void TextBase::createLayout()
             if (c == '>') {
                 bool unstyleFontStyle = false;
                 state = 0;
-                if (token == "b") {
-                    cursor.format()->setBold(true);
-                    unstyleFontStyle = true;
-                } else if (token == "/b") {
-                    cursor.format()->setBold(false);
-                } else if (token == "i") {
-                    cursor.format()->setItalic(true);
-                    unstyleFontStyle = true;
-                } else if (token == "/i") {
-                    cursor.format()->setItalic(false);
-                } else if (token == "u") {
-                    cursor.format()->setUnderline(true);
-                    unstyleFontStyle = true;
-                } else if (token == "/u") {
-                    cursor.format()->setUnderline(false);
-                } else if (token == "sub") {
-                    cursor.format()->setValign(VerticalAlignment::AlignSubScript);
-                } else if (token == "/sub") {
-                    cursor.format()->setValign(VerticalAlignment::AlignNormal);
-                } else if (token == "sup") {
-                    cursor.format()->setValign(VerticalAlignment::AlignSuperScript);
-                } else if (token == "/sup") {
-                    cursor.format()->setValign(VerticalAlignment::AlignNormal);
-                } else if (token == "sym") {
+                prepareFormat(token, cursor);
+                if (token == "sym") {
                     symState = true;
                     sym.clear();
                 } else if (token == "/sym") {
                     symState = false;
                     SymId id = Sym::name2id(sym);
                     if (id != SymId::noSym) {
-                        CharFormat fmt = *cursor.format();              // save format
-                        // uint code = score()->scoreFont()->sym(id).code();
+                        CharFormat fmt = *cursor.format();  // save format
+                                                            // uint code = score()->scoreFont()->sym(id).code();
                         uint code = ScoreFont::fallbackFont()->sym(id).code();
                         cursor.format()->setFontFamily("ScoreText");
                         cursor.format()->setBold(false);
                         cursor.format()->setItalic(false);
                         insert(&cursor, code);
-                        cursor.setFormat(fmt);              // restore format
+                        cursor.setFormat(fmt);  // restore format
                     } else {
                         qDebug("unknown symbol <%s>", qPrintable(sym));
                     }
-                } else if (token.startsWith("font ")) {
-                    token = token.mid(5);
-                    if (token.startsWith("size=\"")) {
-                        cursor.format()->setFontSize(parseNumProperty(token.mid(6)));
-                        setPropertyFlags(Pid::FONT_SIZE, PropertyFlags::UNSTYLED);
-                    } else if (token.startsWith("face=\"")) {
-                        QString face = parseStringProperty(token.mid(6));
-                        face = unEscape(face);
-                        cursor.format()->setFontFamily(face);
-                        setPropertyFlags(Pid::FONT_FACE, PropertyFlags::UNSTYLED);
-                    } else {
-                        qDebug("cannot parse html property <%s> in text <%s>",
-                               qPrintable(token), qPrintable(_text));
-                    }
-                }
-                if (unstyleFontStyle) {
-                    setPropertyFlags(Pid::FONT_STYLE, PropertyFlags::UNSTYLED);
                 }
             } else {
                 token += c;
@@ -1912,6 +1882,66 @@ void TextBase::createLayout()
         _layout.append(TextBlock());
     }
     layoutInvalid = false;
+}
+
+//---------------------------------------------------------
+//   prepareFormat - used when reading from XML and when pasting from clipboard
+//---------------------------------------------------------
+bool TextBase::prepareFormat(const QString& token, Ms::CharFormat& format)
+{
+    if (token == "b") {
+        format.setBold(true);
+        return true;
+    } else if (token == "/b") {
+        format.setBold(false);
+    } else if (token == "i") {
+        format.setItalic(true);
+        return true;
+    } else if (token == "/i") {
+        format.setItalic(false);
+    } else if (token == "u") {
+        format.setUnderline(true);
+        return true;
+    } else if (token == "/u") {
+        format.setUnderline(false);
+    } else if (token == "sub") {
+        format.setValign(VerticalAlignment::AlignSubScript);
+    } else if (token == "/sub") {
+        format.setValign(VerticalAlignment::AlignNormal);
+    } else if (token == "sup") {
+        format.setValign(VerticalAlignment::AlignSuperScript);
+    } else if (token == "/sup") {
+        format.setValign(VerticalAlignment::AlignNormal);
+    } else if (token.startsWith("font ")) {
+        QString remainder = token.mid(5);
+        if (remainder.startsWith("size=\"")) {
+            format.setFontSize(parseNumProperty(remainder.mid(6)));
+            return true;
+        } else if (remainder.startsWith("face=\"")) {
+            QString face = parseStringProperty(remainder.mid(6));
+            face = unEscape(face);
+            format.setFontFamily(face);
+            if (face == "ScoreText") {
+                format.setBold(false);
+                format.setItalic(false);
+            }
+            return true;
+        } else {
+            qDebug("cannot parse html property <%s> in text <%s>",
+                   qPrintable(token), qPrintable(_text));
+        }
+    }
+    return false;
+}
+
+//---------------------------------------------------------
+//   prepareFormat - used when reading from XML
+//---------------------------------------------------------
+void TextBase::prepareFormat(const QString& token, Ms::TextCursor& cursor)
+{
+    if (prepareFormat(token, *cursor.format())) {
+        setPropertyFlags(Pid::FONT_FACE, PropertyFlags::UNSTYLED);
+    }
 }
 
 //---------------------------------------------------------
@@ -3056,6 +3086,50 @@ Sid TextBase::offsetSid() const
 }
 
 //---------------------------------------------------------
+//   getHtmlStartTag - helper function for extractText with withFormat = true
+//---------------------------------------------------------
+QString TextBase::getHtmlStartTag(qreal newSize, qreal& curSize, const QString& newFamily, QString& curFamily, bool bold, bool italic,
+                                  bool underline)
+{
+    QString s;
+    if (fabs(newSize - curSize) > 0.1) {
+        curSize = newSize;
+        s += QString("<font size=\"%1\"/>").arg(newSize);
+    }
+    if (newFamily != curFamily) {
+        curFamily = newFamily;
+        s += QString("<font face=\"%1\"/>").arg(newFamily);
+    }
+    if (bold) {
+        s += "<b>";
+    }
+    if (italic) {
+        s += "<i>";
+    }
+    if (underline) {
+        s += "<u>";
+    }
+    return s;
+}
+
+//---------------------------------------------------------
+//   getHtmlEndTag - helper function for extractText with withFormat = true
+//---------------------------------------------------------
+QString TextBase::getHtmlEndTag(bool bold, bool italic, bool underline)
+{
+    if (underline) {
+        return "</u>";
+    }
+    if (italic) {
+        return "</i>";
+    }
+    if (bold) {
+        return "</b>";
+    }
+    return QString();
+}
+
+//---------------------------------------------------------
 //   getPropertyStyle
 //---------------------------------------------------------
 
@@ -3163,7 +3237,7 @@ void TextBase::editCut(EditData& ed)
 {
     TextEditData* ted = static_cast<TextEditData*>(ed.getData(this));
     TextCursor* cursor = ted->cursor();
-    QString s = cursor->selectedText();
+    QString s = cursor->selectedText(true);
 
     if (!s.isEmpty()) {
         QApplication::clipboard()->setText(s, QClipboard::Clipboard);
@@ -3185,7 +3259,7 @@ void TextBase::editCopy(EditData& ed)
     //
     TextEditData* ted = static_cast<TextEditData*>(ed.getData(this));
     TextCursor* cursor = ted->cursor();
-    QString s = cursor->selectedText();
+    QString s = cursor->selectedText(true);
     if (!s.isEmpty()) {
         QApplication::clipboard()->setText(s, QClipboard::Clipboard);
     }

--- a/src/engraving/libmscore/textbase.h
+++ b/src/engraving/libmscore/textbase.h
@@ -158,8 +158,8 @@ public:
     QString currentWord() const;
     QString currentLine() const;
     bool set(const mu::PointF& p, QTextCursor::MoveMode mode = QTextCursor::MoveAnchor);
-    QString selectedText() const;
-    QString extractText(int r1, int c1, int r2, int c2) const;
+    QString selectedText(bool withFormat = false) const;
+    QString extractText(int r1, int c1, int r2, int c2, bool withFormat = false) const;
     void updateCursorFormat();
     void setFormat(FormatId, QVariant);
     void changeSelectionFormat(FormatId id, QVariant val);
@@ -235,7 +235,7 @@ public:
     qreal y() const { return _y; }
     void setY(qreal val) { _y = val; }
     qreal lineSpacing() const { return _lineSpacing; }
-    QString text(int, int) const;
+    QString text(int, int, bool = false) const;
     bool eol() const { return _eol; }
     void setEol(bool val) { _eol = val; }
     void changeFormat(FormatId, QVariant val, int start, int n);
@@ -282,6 +282,10 @@ class TextBase : public Element
     QString stripText(bool, bool, bool) const;
     Sid offsetSid() const;
 
+    static QString getHtmlStartTag(qreal newSize, qreal& curSize, const QString& newFamily, QString& curFamily, bool bold, bool italic,
+                                   bool underline);
+    static QString getHtmlEndTag(bool bold, bool italic, bool underline);
+
 protected:
     QColor textColor() const;
     mu::RectF frame;             // calculated in layout()
@@ -289,6 +293,8 @@ protected:
     void layoutEdit();
     void createLayout();
     void insertSym(EditData& ed, SymId id);
+    void prepareFormat(const QString& token, Ms::TextCursor& cursor);
+    bool prepareFormat(const QString& token, Ms::CharFormat& format);
 
 public:
     TextBase(Score* = 0, Tid tid = Tid::DEFAULT, ElementFlags = ElementFlag::NOTHING);

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -296,17 +296,17 @@ bool NotationActionController::canReceiveAction(const actions::ActionCode& code)
         return false;
     }
 
-    //! NOTE At the moment, if we are in the text editing mode, we can only process the escape
-    if (isTextEditting()) {
-        return code == ESCAPE_ACTION_CODE;
-    }
-
     if (code == UNDO_ACTION_CODE) {
         return canUndo();
     }
 
     if (code == REDO_ACTION_CODE) {
         return canRedo();
+    }
+
+    //! NOTE At the moment, if we are in the text editing mode, we can only handle clipboard commands
+    if (isTextEditting()) {
+        return code == ESCAPE_ACTION_CODE || code == "copy" || code == "paste" || code == "cut" || code == "select-all" || code == "delete";
     }
 
     return true;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -492,7 +492,12 @@ void NotationInteraction::select(const std::vector<Element*>& elements, SelectTy
 
 void NotationInteraction::selectAll()
 {
-    score()->cmdSelectAll();
+    if (isTextEditingStarted()) {
+        auto textBase = toTextBase(m_textEditData.element);
+        textBase->selectAll(textBase->cursorFromEditData(m_textEditData));
+    } else {
+        score()->cmdSelectAll();
+    }
 
     notifyAboutSelectionChanged();
 }
@@ -2137,12 +2142,15 @@ void NotationInteraction::copySelection()
         return;
     }
 
-    QMimeData* mimeData = selection()->mimeData();
-    if (!mimeData) {
-        return;
+    if (isTextEditingStarted()) {
+        m_textEditData.element->editCopy(m_textEditData);
+    } else {
+        QMimeData* mimeData = selection()->mimeData();
+        if (!mimeData) {
+            return;
+        }
+        QApplication::clipboard()->setMimeData(mimeData);
     }
-
-    QApplication::clipboard()->setMimeData(mimeData);
 }
 
 void NotationInteraction::copyLyrics()
@@ -2155,9 +2163,12 @@ void NotationInteraction::pasteSelection(const Fraction& scale)
 {
     startEdit();
 
-    const QMimeData* mimeData = QApplication::clipboard()->mimeData();
-    score()->cmdPaste(mimeData, nullptr, scale);
-
+    if (isTextEditingStarted()) {
+        toTextBase(m_textEditData.element)->paste(m_textEditData);
+    } else {
+        const QMimeData* mimeData = QApplication::clipboard()->mimeData();
+        score()->cmdPaste(mimeData, nullptr, scale);
+    }
     apply();
 
     notifyAboutSelectionChanged();
@@ -2217,7 +2228,15 @@ void NotationInteraction::deleteSelection()
     }
 
     startEdit();
-    score()->cmdDeleteSelection();
+    if (isTextEditingStarted()) {
+        auto textBase = toTextBase(m_textEditData.element);
+        if (!textBase->deleteSelectedText(m_textEditData)) {
+            m_textEditData.key = Qt::Key_Backspace;
+            textBase->edit(m_textEditData);
+        }
+    } else {
+        score()->cmdDeleteSelection();
+    }
     apply();
 
     notifyAboutSelectionChanged();

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -137,15 +137,15 @@ const UiActionList NotationUiActions::m_actions = {
              QT_TRANSLATE_NOOP("action", "Pitch up by an octave or move text or articulation up")
              ),
     UiAction("cut",
-             mu::context::UiCtxNotationOpened,
+             mu::context::UiCtxNotationOpenedOrTextEditing,
              QT_TRANSLATE_NOOP("action", "Cut")
              ),
     UiAction("copy",
-             mu::context::UiCtxNotationOpened,
+             mu::context::UiCtxNotationOpenedOrTextEditing,
              QT_TRANSLATE_NOOP("action", "Copy")
              ),
     UiAction("paste",
-             mu::context::UiCtxNotationOpened,
+             mu::context::UiCtxNotationOpenedOrTextEditing,
              QT_TRANSLATE_NOOP("action", "Paste")
              ),
     UiAction("paste-half",
@@ -174,7 +174,7 @@ const UiActionList NotationUiActions::m_actions = {
              QT_TRANSLATE_NOOP("action", "Toggle visibility of elements")
              ),
     UiAction("select-all",
-             mu::context::UiCtxNotationOpened,
+             mu::context::UiCtxNotationOpenedOrTextEditing,
              QT_TRANSLATE_NOOP("action", "Select All"),
              QT_TRANSLATE_NOOP("action", "Select all")
              ),
@@ -204,7 +204,7 @@ const UiActionList NotationUiActions::m_actions = {
              QT_TRANSLATE_NOOP("action", "Select all similar elements with more options")
              ),
     UiAction("delete",
-             mu::context::UiCtxNotationFocused,
+             mu::context::UiCtxNotationOpenedOrTextEditing,
              QT_TRANSLATE_NOOP("action", "Delete"),
              QT_TRANSLATE_NOOP("action", "Delete the selected element(s)"),
              IconCode::Code::DELETE_TANK
@@ -329,13 +329,13 @@ const UiActionList NotationUiActions::m_actions = {
              QT_TRANSLATE_NOOP("action", "Edit score properties")
              ),
     UiAction("undo",
-             mu::context::UiCtxNotationOpened,
+             mu::context::UiCtxNotationOpenedOrTextEditing,
              QT_TRANSLATE_NOOP("action", "Undo"),
              QT_TRANSLATE_NOOP("action", "Undo last change"),
              IconCode::Code::UNDO
              ),
     UiAction("redo",
-             mu::context::UiCtxNotationOpened,
+             mu::context::UiCtxNotationOpenedOrTextEditing,
              QT_TRANSLATE_NOOP("action", "Redo"),
              QT_TRANSLATE_NOOP("action", "Redo last undo"),
              IconCode::Code::REDO

--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -691,6 +691,25 @@ void NotationPaintView::hoverMoveEvent(QHoverEvent* event)
 void NotationPaintView::keyReleaseEvent(QKeyEvent* event)
 {
     if (isInited()) {
+        std::string sequence = QKeySequence(event->key()).toString().toStdString();
+        if (event->key() < Qt::Key_Shift && sequence.length() > 0) {
+            if (event->modifiers() & Qt::KeyboardModifier::ShiftModifier) {
+                sequence = "Shift+" + sequence;
+            }
+            if (event->modifiers() & Qt::KeyboardModifier::AltModifier) {
+                sequence = "Alt+" + sequence;
+            }
+            if (event->modifiers() & Qt::KeyboardModifier::ControlModifier) {
+                sequence = "Ctrl+" + sequence;
+            }
+            const auto& shortcuts = shortcutsRegister()->shortcutsForSequence(sequence);
+            const std::shared_ptr<IUiActionsRegister> theRegister = actionsRegister();
+            if (std::find_if(shortcuts.begin(), shortcuts.end(), [theRegister](auto s) {
+                return theRegister->actionState(s.action).enabled;
+            }) != shortcuts.end()) {
+                return;
+            }
+        }
         m_inputController->keyReleaseEvent(event);
     }
 }

--- a/src/notation/view/notationpaintview.h
+++ b/src/notation/view/notationpaintview.h
@@ -34,6 +34,8 @@
 #include "context/iglobalcontext.h"
 #include "async/asyncable.h"
 #include "playback/iplaybackcontroller.h"
+#include "shortcuts/ishortcutsregister.h"
+#include "ui/iuiactionsregister.h"
 
 #include "notationviewinputcontroller.h"
 #include "noteinputcursor.h"
@@ -50,6 +52,8 @@ class NotationPaintView : public QQuickPaintedItem, public IControlledView, publ
     INJECT(notation, context::IGlobalContext, globalContext)
     INJECT(notation, playback::IPlaybackController, playbackController)
     INJECT(notation, INotationContextMenu, notationContextMenu)
+    INJECT(notation, mu::shortcuts::IShortcutsRegister, shortcutsRegister)
+    INJECT(notation, ui::IUiActionsRegister, actionsRegister)
 
     Q_PROPERTY(qreal startHorizontalScrollPosition READ startHorizontalScrollPosition NOTIFY horizontalScrollChanged)
     Q_PROPERTY(qreal horizontalScrollSize READ horizontalScrollSize NOTIFY horizontalScrollChanged)


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8302

Clipboard operations for text editing weren't hooked up

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
