### PR TITLE
[MU4] fix #7644 - use last modified date for recent scores screen

### DIFF
--- a/src/framework/global/dataformatter.cpp
+++ b/src/framework/global/dataformatter.cpp
@@ -33,7 +33,7 @@ double DataFormatter::formatDouble(const double& val, const int decimals)
     return QString::number(val, 'f', decimals).toDouble();
 }
 
-QString DataFormatter::formatTimeSinceCreation(const QDate& creationDate)
+QString DataFormatter::formatTimeSince(const QDate& dateTime)
 {
     QDateTime currentDateTime = QDateTime::currentDateTime();
 #if (defined (_MSCVER) || defined (_MSC_VER))
@@ -44,7 +44,7 @@ QString DataFormatter::formatTimeSinceCreation(const QDate& creationDate)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
     // ToDo for Qt 5.15: QDateTime::QDateTime() vs. QDate::startOfDay() (available as of Qt 5.14) ??
-    int days = QDateTime(creationDate).daysTo(currentDateTime);
+    int days = QDateTime(dateTime).daysTo(currentDateTime);
 #if (defined (_MSCVER) || defined (_MSC_VER))
 #pragma warning (pop)
 #else
@@ -83,7 +83,7 @@ QString DataFormatter::formatTimeSinceCreation(const QDate& creationDate)
 
     QDate currentDate = currentDateTime.date();
     constexpr int monthInYear = 12;
-    int months = (currentDate.year() - creationDate.year()) * monthInYear + (currentDate.month() - creationDate.month());
+    int months = (currentDate.year() - dateTime.year()) * monthInYear + (currentDate.month() - dateTime.month());
 
     if (months == 1) {
         return qtrc("global", "Last month");
@@ -93,7 +93,7 @@ QString DataFormatter::formatTimeSinceCreation(const QDate& creationDate)
         return qtrc("global", "%1 months ago").arg(months);
     }
 
-    int years = currentDate.year() - creationDate.year();
+    int years = currentDate.year() - dateTime.year();
     if (years == 1) {
         return qtrc("global", "1 year ago");
     }

--- a/src/framework/global/dataformatter.h
+++ b/src/framework/global/dataformatter.h
@@ -29,7 +29,7 @@ class DataFormatter
 {
 public:
     static double formatDouble(const double& val, const int decimals = 2);
-    static QString formatTimeSinceCreation(const QDate& creationDate);
+    static QString formatTimeSince(const QDate& creationDate);
 };
 
 #endif // MU_FRAMEWORK_DATAFORMATTER_H

--- a/src/userscores/qml/MuseScore/UserScores/internal/RecentScoresView.qml
+++ b/src/userscores/qml/MuseScore/UserScores/internal/RecentScoresView.qml
@@ -103,7 +103,7 @@ GridView {
             title: score.title
             thumbnail: score.thumbnail
             isAdd: score.isAddNew
-            timeSinceCreation: !isAdd ? score.timeSinceCreation : ""
+            timeSinceModified: !isAdd ? score.timeSinceModified : ""
 
             onClicked: {
                 if (isAdd) {

--- a/src/userscores/qml/MuseScore/UserScores/internal/ScoreItem.qml
+++ b/src/userscores/qml/MuseScore/UserScores/internal/ScoreItem.qml
@@ -30,7 +30,7 @@ FocusScope {
     id: root
 
     property string title: ""
-    property alias timeSinceCreation: timeSinceCreation.text
+    property alias timeSinceModified: timeSinceModified.text
     property alias thumbnail: loader.thumbnail
     property bool isAdd: false
 
@@ -160,7 +160,7 @@ FocusScope {
             }
 
             StyledTextLabel {
-                id: timeSinceCreation
+                id: timeSinceModified
 
                 anchors.horizontalCenter: parent.horizontalCenter
 

--- a/src/userscores/view/recentscoresmodel.cpp
+++ b/src/userscores/view/recentscoresmodel.cpp
@@ -34,7 +34,7 @@ namespace {
 const QString SCORE_TITLE_KEY("title");
 const QString SCORE_PATH_KEY("path");
 const QString SCORE_THUMBNAIL_KEY("thumbnail");
-const QString SCORE_TIME_SINCE_CREATION_KEY("timeSinceCreation");
+const QString SCORE_TIME_SINCE_MODIFIED_KEY("timeSinceModified");
 const QString SCORE_ADD_NEW_KEY("isAddNew");
 }
 
@@ -114,7 +114,7 @@ void RecentScoresModel::updateRecentScores(const MetaList& recentScoresList)
         obj[SCORE_TITLE_KEY] = !meta.title.isEmpty() ? meta.title : meta.fileName.toQString();
         obj[SCORE_PATH_KEY] = meta.filePath.toQString();
         obj[SCORE_THUMBNAIL_KEY] = meta.thumbnail;
-        obj[SCORE_TIME_SINCE_CREATION_KEY] = DataFormatter::formatTimeSinceCreation(meta.creationDate);
+        obj[SCORE_TIME_SINCE_MODIFIED_KEY] = DataFormatter::formatTimeSince(QFileInfo(meta.filePath.toQString()).lastModified().date());
         obj[SCORE_ADD_NEW_KEY] = false;
 
         recentScores << obj;


### PR DESCRIPTION

Resolves: https://github.com/musescore/MuseScore/issues/7644

Recent scores screen was showing meta-data "creation" date/time which @Tantacrul agreed was unexpected and should be "last saved" date/time instead.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
