### PR TITLE
Fixes persistent crashes when quitting MuseScore

### DIFF
--- a/src/appshell/view/dockwindow/internal/dockbase.cpp
+++ b/src/appshell/view/dockwindow/internal/dockbase.cpp
@@ -292,7 +292,7 @@ void DockBase::listenFloatingChanges()
     }
 
     connect(m_dockWidget, &KDDockWidgets::DockWidgetQuick::parentChanged, [this]() {
-        if (!m_dockWidget->parentItem()) {
+        if (!m_dockWidget || !m_dockWidget->parentItem()) {
             return;
         }
 

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -1279,18 +1279,19 @@ void NotationUiActions::init()
         }
         m_actionCheckedChanged.send(actions);
 
-        m_controller->currentNotationInteraction()->scoreConfigChanged().onReceive(this, [this](ScoreConfigType configType) {
-            static const std::unordered_map<ScoreConfigType, std::string> configActions = {
-                { ScoreConfigType::ShowInvisibleElements, SHOW_INVISIBLE_CODE },
-                { ScoreConfigType::ShowUnprintableElements, SHOW_UNPRINTABLE_CODE },
-                { ScoreConfigType::ShowFrames, SHOW_FRAMES_CODE },
-                { ScoreConfigType::ShowPageMargins, SHOW_PAGEBORDERS_CODE },
-                { ScoreConfigType::MarkIrregularMeasures, SHOW_IRREGULAR_CODE }
-            };
+        if (m_controller->currentNotationInteraction()) {
+            m_controller->currentNotationInteraction()->scoreConfigChanged().onReceive(this, [this](ScoreConfigType configType) {
+                static const std::unordered_map<ScoreConfigType, std::string> configActions = {
+                    { ScoreConfigType::ShowInvisibleElements, SHOW_INVISIBLE_CODE },
+                    { ScoreConfigType::ShowUnprintableElements, SHOW_UNPRINTABLE_CODE },
+                    { ScoreConfigType::ShowFrames, SHOW_FRAMES_CODE },
+                    { ScoreConfigType::ShowPageMargins, SHOW_PAGEBORDERS_CODE },
+                    { ScoreConfigType::MarkIrregularMeasures, SHOW_IRREGULAR_CODE }
+                };
 
-            m_actionCheckedChanged.send({ configActions.at(configType) });
-        });
-
+                m_actionCheckedChanged.send({ configActions.at(configType) });
+            });
+        }
         m_controller->currentNotationStyleChanged().onNotify(this, [this]() {
             m_actionCheckedChanged.send({ TOGGLE_CONCERT_PITCH_CODE });
         });


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

Every time I quit MuseScore it would crash at various locations

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
