### PR TITLE
[MU4] fix #7883 - ensure reordering parts changes order of excerpts

### DIFF
--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -625,23 +625,17 @@ void MasterNotation::updateExcerpts()
 {
     ExcerptNotationList newExcerpts;
 
-    for (IExcerptNotationPtr excerpt : m_excerpts.val) {
-        if (!get_impl(excerpt)->excerpt()->isEmpty()) {
-            newExcerpts.push_back(excerpt);
-        }
-    }
-
     QList<Ms::Excerpt*> excerpts = score()->excerpts();
 
     for (Part* part: score()->parts()) {
-        bool isNewPart = true;
+        auto existing = std::find_if(m_excerpts.val.begin(), m_excerpts.val.end(), [part](auto e) {
+            return get_impl(e)->excerpt()->containsPart(part);
+        });
 
-        for (Ms::Excerpt* exceprt: excerpts) {
-            isNewPart &= !exceprt->containsPart(part);
-        }
-
-        if (isNewPart) {
+        if (existing == m_excerpts.val.end()) {
             newExcerpts.push_back(createExcerpt(part));
+        } else if (std::find(newExcerpts.begin(), newExcerpts.end(), *existing) == newExcerpts.end()) {
+            newExcerpts.push_back(*existing);
         }
     }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/7883

Re-ordering parts doesn't re-order excerpts.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
