### PR TITLE
[MU4] fix #7706 fix drag & drop memory leaks

### DIFF
--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -1814,7 +1814,7 @@ void Score::toggleAccidental(AccidentalType at, const EditData& ed)
         _is.setRest(false);
     } else {
         if (selection().isNone()) {
-            ed.view->startNoteEntryMode();
+            ed.view()->startNoteEntryMode();
             _is.setAccidentalType(at);
             _is.setDuration(TDuration::DurationType::V_QUARTER);
             _is.setRest(false);
@@ -3894,8 +3894,7 @@ void Score::cmdPitchDown()
     if (el && el->isLyrics()) {
         cmdMoveLyrics(toLyrics(el), Direction::DOWN);
     } else if (el && (el->isArticulation() || el->isTextBase())) {
-        el->undoChangeProperty(Pid::OFFSET, QVariant::fromValue(el->offset() + PointF(0.0,
-                                                                                      MScore::nudgeStep* el->spatium())),
+        el->undoChangeProperty(Pid::OFFSET, QVariant::fromValue(el->offset() + PointF(0.0, MScore::nudgeStep* el->spatium())),
                                PropertyFlags::UNSTYLED);
     } else if (el && el->isRest()) {
         cmdMoveRest(toRest(el), Direction::DOWN);
@@ -4319,11 +4318,11 @@ void Score::cmdAddPitch(const EditData& ed, int note, bool addFlag, bool insert)
             }
         }
     }
-    ed.view->startNoteEntryMode();
+    ed.view()->startNoteEntryMode();
 
     int step = octave * 7 + note;
     cmdAddPitch(step,  addFlag, insert);
-    ed.view->adjustCanvasPosition(is.cr(), false);
+    ed.view()->adjustCanvasPosition(is.cr(), false);
 }
 
 void Score::cmdAddPitch(int step, bool addFlag, bool insert)

--- a/src/engraving/libmscore/element.h
+++ b/src/engraving/libmscore/element.h
@@ -135,9 +135,10 @@ class ElementEditData;
 class EditData
 {
     QList<ElementEditData*> data;
+    MuseScoreView* view_ { 0 };
 
 public:
-    MuseScoreView* view              { 0 };
+    MuseScoreView* view() const { return view_; }
 
     QVector<mu::RectF> grip;
     int grips                        { 0 };                 // number of grips
@@ -166,7 +167,7 @@ public:
     Element* dropElement             { 0 };
 
     EditData(MuseScoreView* v = nullptr)
-        : view(v) {}
+        : view_(v) {}
     ~EditData();
     void clearData();
 

--- a/src/engraving/libmscore/lasso.cpp
+++ b/src/engraving/libmscore/lasso.cpp
@@ -58,7 +58,7 @@ void Lasso::draw(mu::draw::Painter* painter) const
 
 void Lasso::editDrag(EditData& ed)
 {
-    Qt::CursorShape cursorShape = ed.view->cursor().shape();
+    Qt::CursorShape cursorShape = ed.view()->cursor().shape();
     switch (int(ed.curGrip)) {
     case 0:
         cursorShape = Qt::SizeFDiagCursor;
@@ -93,7 +93,7 @@ void Lasso::editDrag(EditData& ed)
         bbox().setLeft(bbox().left() + ed.delta.x());
         break;
     }
-    ed.view->setCursor(QCursor(cursorShape));
+    ed.view()->setCursor(QCursor(cursorShape));
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/line.cpp
+++ b/src/engraving/libmscore/line.cpp
@@ -401,7 +401,7 @@ bool LineSegment::edit(EditData& ed)
     }
 
     if (nls && (nls != this)) {
-        ed.view->changeEditElement(nls);
+        ed.view()->changeEditElement(nls);
     }
     if (ls) {
         score()->undoRemoveElement(ls);
@@ -606,7 +606,7 @@ void LineSegment::rebaseAnchors(EditData& ed, Grip grip)
                 }
 
                 // Switch to dragging the new line segment
-                ed.view->changeEditElement(newLineSegment);
+                ed.view()->changeEditElement(newLineSegment);
             }
 
             // Set offset for the new line segment for grip to appear under the mouse cursor
@@ -696,7 +696,7 @@ void LineSegment::editDrag(EditData& ed)
         //
         // if we touch a different note, change anchor
         //
-        Element* e = ed.view->elementNear(ed.pos);
+        Element* e = ed.view()->elementNear(ed.pos);
         if (e && e->isNote()) {
             SLine* l = line();
             if (ed.curGrip == Grip::END && e != line()->endElement()) {

--- a/src/engraving/libmscore/lyrics.cpp
+++ b/src/engraving/libmscore/lyrics.cpp
@@ -406,7 +406,7 @@ void Lyrics::layout2(int nAbove)
 
 void Lyrics::paste(EditData& ed)
 {
-    MuseScoreView* scoreview = ed.view;
+    MuseScoreView* scoreview = ed.view();
 #if defined(Q_OS_MAC) || defined(Q_OS_WIN)
     QClipboard::Mode mode = QClipboard::Clipboard;
 #else

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -1440,7 +1440,7 @@ RectF Measure::staffabbox(int staffIdx) const
 
 bool Measure::acceptDrop(EditData& data) const
 {
-    MuseScoreView* viewer = data.view;
+    MuseScoreView* viewer = data.view();
     PointF pos = data.pos;
     Element* e = data.dropElement;
 

--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -1897,7 +1897,7 @@ Element* Note::drop(EditData& data)
         return 0;
 
     case ElementType::SLUR:
-        data.view->addSlur(chord(), nullptr, toSlur(e));
+        data.view()->addSlur(chord(), nullptr, toSlur(e));
         delete e;
         return 0;
 

--- a/src/engraving/libmscore/paste.cpp
+++ b/src/engraving/libmscore/paste.cpp
@@ -1064,7 +1064,6 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view, Fraction scale)
             Element* nel = el->clone();
             addRefresh(target->abbox());         // layout() ?!
             EditData ddata(view);
-            ddata.view        = view;
             ddata.dropElement = nel;
             if (target->acceptDrop(ddata)) {
                 if (el->isNote()) {
@@ -1183,7 +1182,6 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view, Fraction scale)
             Element* nel = image->clone();
             addRefresh(target->abbox());         // layout() ?!
             EditData ddata(view);
-            ddata.view       = view;
             ddata.dropElement    = nel;
             if (target->acceptDrop(ddata)) {
                 target->drop(ddata);

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -3034,7 +3034,7 @@ void Score::padToggle(Pad p, const EditData& ed)
             _is.setRest(!_is.rest());
             _is.setAccidentalType(AccidentalType::NONE);
         } else if (selection().isNone()) {
-            ed.view->startNoteEntryMode();
+            ed.view()->startNoteEntryMode();
             _is.setDuration(TDuration::DurationType::V_QUARTER);
             _is.setRest(true);
         } else {
@@ -3185,12 +3185,12 @@ void Score::padToggle(Pad p, const EditData& ed)
         if (cr) {
             crs.push_back(cr);
         } else {
-            ed.view->startNoteEntryMode();
+            ed.view()->startNoteEntryMode();
             deselect(e);
         }
     } else if (selection().isNone() && p != Pad::REST) {
         TDuration td = _is.duration();
-        ed.view->startNoteEntryMode();
+        ed.view()->startNoteEntryMode();
         _is.setDuration(td);
         _is.setAccidentalType(AccidentalType::NONE);
     } else {

--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -244,7 +244,7 @@ void SlurSegment::changeAnchor(EditData& ed, Element* element)
     if (spanner()->spannerSegments().size() != segments) {
         const std::vector<SpannerSegment*>& ss = spanner()->spannerSegments();
         SlurSegment* newSegment = toSlurSegment(ed.curGrip == Grip::END ? ss.back() : ss.front());
-        ed.view->startEdit(newSegment, ed.curGrip);
+        ed.view()->startEdit(newSegment, ed.curGrip);
         triggerLayout();
     }
 }

--- a/src/engraving/libmscore/slurtie.cpp
+++ b/src/engraving/libmscore/slurtie.cpp
@@ -186,21 +186,21 @@ void SlurTieSegment::editDrag(EditData& ed)
         if ((g == Grip::START && isSingleBeginType()) || (g == Grip::END && isSingleEndType())) {
             Spanner* spanner = slurTie();
             Qt::KeyboardModifiers km = qApp->keyboardModifiers();
-            Element* e = ed.view->elementNear(ed.pos);
+            Element* e = ed.view()->elementNear(ed.pos);
             if (e && e->isNote()) {
                 Note* note = toNote(e);
                 Fraction tick = note->chord()->tick();
                 if ((g == Grip::END && tick > slurTie()->tick()) || (g == Grip::START && tick < slurTie()->tick2())) {
                     if (km != (Qt::ShiftModifier | Qt::ControlModifier)) {
                         Chord* c = note->chord();
-                        ed.view->setDropTarget(note);
+                        ed.view()->setDropTarget(note);
                         if (c->part() == spanner->part() && c != spanner->endCR()) {
                             changeAnchor(ed, c);
                         }
                     }
                 }
             } else {
-                ed.view->setDropTarget(0);
+                ed.view()->setDropTarget(0);
             }
         }
         break;

--- a/src/engraving/libmscore/textedit.cpp
+++ b/src/engraving/libmscore/textedit.cpp
@@ -419,9 +419,9 @@ bool TextBase::edit(EditData& ed)
             if (ed.modifiers & CONTROL_MODIFIER) {
                 s = QString(QChar(0xa0));               // non-breaking space
             } else {
-                if (isFingering() && ed.view) {
+                if (isFingering() && ed.view()) {
                     score()->endCmd();
-                    ed.view->textTab(ed.modifiers & Qt::ShiftModifier);
+                    ed.view()->textTab(ed.modifiers & Qt::ShiftModifier);
                     return true;
                 }
                 s = " ";

--- a/src/engraving/libmscore/tie.cpp
+++ b/src/engraving/libmscore/tie.cpp
@@ -141,7 +141,7 @@ void TieSegment::changeAnchor(EditData& ed, Element* element)
         TieSegment* newSegment = toTieSegment(ed.curGrip == Grip::END ? ss.back() : ss.front());
         score()->endCmd();
         score()->startCmd();
-        ed.view->startEdit(newSegment, ed.curGrip);
+        ed.view()->startEdit(newSegment, ed.curGrip);
         triggerLayoutAll();
     }
 }
@@ -162,14 +162,14 @@ void TieSegment::editDrag(EditData& ed)
         //
         if ((g == Grip::START && isSingleBeginType()) || (g == Grip::END && isSingleEndType())) {
             Spanner* spanner = tie();
-            Element* e = ed.view->elementNear(ed.pos);
+            Element* e = ed.view()->elementNear(ed.pos);
             Note* note = (e && e->isNote()) ? toNote(e) : nullptr;
             if (note && ((g == Grip::END && note->tick() > tie()->tick()) || (g == Grip::START && note->tick() < tie()->tick2()))) {
                 if (g == Grip::END) {
                     Tie* tie = toTie(spanner);
                     if (tie->startNote()->pitch() == note->pitch()
                         && tie->startNote()->chord()->tick() < note->chord()->tick()) {
-                        ed.view->setDropTarget(note);
+                        ed.view()->setDropTarget(note);
                         if (note != tie->endNote()) {
                             changeAnchor(ed, note);
                             return;
@@ -177,7 +177,7 @@ void TieSegment::editDrag(EditData& ed)
                     }
                 }
             } else {
-                ed.view->setDropTarget(0);
+                ed.view()->setDropTarget(0);
             }
         }
     } else if (g == Grip::BEZIER1 || g == Grip::BEZIER2) {

--- a/src/engraving/tests/tst_breath.cpp
+++ b/src/engraving/tests/tst_breath.cpp
@@ -76,7 +76,6 @@ void TestBreath::breath()
     score->cmdSelectAll();
     for (Element* e : score->selection().elements()) {
         EditData dd(0);
-        dd.view = 0;
         Breath* b = new Breath(score);
         b->setSymId(SymId::breathMarkComma);
         dd.dropElement = b;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -35,6 +35,7 @@
 
 #include "libmscore/element.h"
 #include "libmscore/elementgroup.h"
+#include "scorecallbacks.h"
 
 namespace Ms {
 class ShadowNote;
@@ -256,6 +257,7 @@ private:
         Element* dropTarget = nullptr;
     };
 
+    ScoreCallbacks m_scoreCallbacks;
     Notation* m_notation = nullptr;
     INotationUndoStackPtr m_undoStack;
 

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -179,8 +179,7 @@ void NotationNoteInput::toggleNoteInputMethod(NoteInputMethod method)
 
 void NotationNoteInput::addNote(NoteName noteName, NoteAddingMode addingMode)
 {
-    Ms::EditData editData;
-    editData.view = m_scoreCallbacks;
+    Ms::EditData editData(m_scoreCallbacks);
 
     startEdit();
     int inote = static_cast<int>(noteName);
@@ -194,11 +193,10 @@ void NotationNoteInput::addNote(NoteName noteName, NoteAddingMode addingMode)
 
 void NotationNoteInput::padNote(const Pad& pad)
 {
-    Ms::EditData ed;
-    ed.view = m_scoreCallbacks;
+    Ms::EditData editData(m_scoreCallbacks);
 
     startEdit();
-    score()->padToggle(pad, ed);
+    score()->padToggle(pad, editData);
     apply();
 
     notifyAboutStateChanged();
@@ -215,8 +213,7 @@ void NotationNoteInput::putNote(const QPointF& pos, bool replace, bool insert)
 
 void NotationNoteInput::setAccidental(AccidentalType accidentalType)
 {
-    Ms::EditData editData;
-    editData.view = m_scoreCallbacks;
+    Ms::EditData editData(m_scoreCallbacks);
 
     score()->toggleAccidental(accidentalType, editData);
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/7706

Lots of unnecessary new-ing (and no deleting!) when dragging & dropping

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
