### PR TITLE
[MU4] fix #7667 - right click should not alter current selection

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -312,16 +312,17 @@ void NotationViewInputController::mousePressEvent(QMouseEvent* event)
 
     if (m_interactData.hitElement) {
         if (!m_interactData.hitElement->selected()) {
-            SelectType selectType = SelectType::SINGLE;
-            if (keyState == Qt::NoModifier) {
-                selectType = SelectType::SINGLE;
-            } else if (keyState & Qt::ShiftModifier) {
-                selectType = SelectType::RANGE;
-            } else if (keyState & Qt::ControlModifier) {
-                selectType = SelectType::ADD;
+            if (event->button() != Qt::MouseButton::RightButton) {
+                SelectType selectType = SelectType::SINGLE;
+                if (keyState == Qt::NoModifier) {
+                    selectType = SelectType::SINGLE;
+                } else if (keyState & Qt::ShiftModifier) {
+                    selectType = SelectType::RANGE;
+                } else if (keyState & Qt::ControlModifier) {
+                    selectType = SelectType::ADD;
+                }
+                m_view->notationInteraction()->select({ m_interactData.hitElement }, selectType, m_interactData.hitStaffIndex);
             }
-
-            m_view->notationInteraction()->select({ m_interactData.hitElement }, selectType, m_interactData.hitStaffIndex);
         }
     }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/7667 (maybe)

Couldn't reproduce exactly what described but I can definitely reproduce that after selecting multiple staves, right clicking on one of them to bring up the context menu changes the current selection to just that staff, which it shouldn't.  In fact right-clicking should never cause new elements to get selected.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
