### PR TITLE
[MU4] fix #8302 - ensure we handle keyPress (via shortcutOverride) etc.

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2230,6 +2230,7 @@ void NotationInteraction::deleteSelection()
         auto textBase = toTextBase(m_textEditData.element);
         if (!textBase->deleteSelectedText(m_textEditData)) {
             m_textEditData.key = Qt::Key_Backspace;
+            m_textEditData.modifiers = 0;
             textBase->edit(m_textEditData);
         }
     } else {

--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -688,7 +688,7 @@ void NotationPaintView::hoverMoveEvent(QHoverEvent* event)
     }
 }
 
-void NotationPaintView::keyReleaseEvent(QKeyEvent* event)
+void NotationPaintView::shortcutOverride(QKeyEvent* event)
 {
     if (isInited()) {
         std::string sequence = QKeySequence(event->key()).toString().toStdString();
@@ -712,6 +712,14 @@ void NotationPaintView::keyReleaseEvent(QKeyEvent* event)
         }
         m_inputController->keyReleaseEvent(event);
     }
+}
+
+bool NotationPaintView::event(QEvent* ev)
+{
+    if (ev->type() == QEvent::Type::ShortcutOverride) {
+        shortcutOverride(static_cast<QKeyEvent*>(ev));
+    }
+    return QQuickPaintedItem::event(ev);
 }
 
 void NotationPaintView::dragEnterEvent(QDragEnterEvent* event)

--- a/src/notation/view/notationpaintview.h
+++ b/src/notation/view/notationpaintview.h
@@ -155,8 +155,8 @@ private:
     void mouseDoubleClickEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
     void hoverMoveEvent(QHoverEvent* event) override;
-    void keyReleaseEvent(QKeyEvent* event) override;
-
+    bool event(QEvent*) override;
+    void shortcutOverride(QKeyEvent* event);
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dragLeaveEvent(QDragLeaveEvent* event) override;
     void dragMoveEvent(QDragMoveEvent* event) override;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8302

  Text entry was working via keyReleaseEvent which isn't really right as when editing text you expect to see it appear on key *down*/press.  But Qt's shortcut key mechanism was interfering was this, so it needs to be handled via ShortcutOverride events instead. Also fixed a bug where hitting backspace deleted the previous word, because Ctrl had previously been used and the modifier flag was still set. 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
