### PR TITLE
[MU4] fix #7675 - custom page size score behaves erratically

### DIFF
--- a/src/inspector/models/score/scoreappearancesettingsmodel.cpp
+++ b/src/inspector/models/score/scoreappearancesettingsmodel.cpp
@@ -62,7 +62,8 @@ void ScoreAppearanceSettingsModel::loadProperties()
 {
     QSizeF pageSize = QSizeF(styleValue(Ms::Sid::pageWidth).toDouble(), styleValue(Ms::Sid::pageHeight).toDouble());
 
-    m_pageTypeListModel->setCurrentPageSizeId(static_cast<int>(QPageSize::id(pageSize, QPageSize::Inch, QPageSize::FuzzyOrientationMatch)));
+    m_currentPageSizeId = static_cast<int>(QPageSize::id(pageSize, QPageSize::Inch, QPageSize::FuzzyOrientationMatch));
+    m_pageTypeListModel->setCurrentPageSizeId(m_currentPageSizeId);
 
     ScoreAppearanceTypes::OrientationType pageOrientationType = pageSize.width() > pageSize.height()
                                                                 ? ScoreAppearanceTypes::OrientationType::ORIENTATION_LANDSCAPE
@@ -112,6 +113,9 @@ void ScoreAppearanceSettingsModel::setPageTypeListModel(PageTypeListModel* pageT
     m_pageTypeListModel = pageTypeListModel;
 
     connect(m_pageTypeListModel, &PageTypeListModel::currentPageSizeIdChanged, this, [this](const int newCurrentPageSizeId) {
+        if (m_currentPageSizeId == newCurrentPageSizeId) {
+            return;
+        }
         QSizeF pageSize = QPageSize::size(QPageSize::PageSizeId(newCurrentPageSizeId), QPageSize::Inch);
 
         updateStyleValue(Ms::Sid::pageWidth, pageSize.width());

--- a/src/inspector/models/score/scoreappearancesettingsmodel.h
+++ b/src/inspector/models/score/scoreappearancesettingsmodel.h
@@ -69,6 +69,7 @@ signals:
 private:
     void updatePageSize();
 
+    int m_currentPageSizeId = -1;
     int m_orientationType = 0;
     qreal m_staffSpacing = 0.0;
     qreal m_staffDistance = 0.0;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/7675

Whenever the inspector was programmatically updated to show the current page properties, it was triggering an event handler that updated the score's page width & height. For Custom this was a major issue as it was setting them to -1.  But really the event handler should only do anything when the user actually changes the page size in the drop down.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
