### PR TITLE
[MU4] Solve crash when a new score was created.

### DIFF
--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -141,7 +141,7 @@ void NotationParts::setParts(const mu::instruments::PartInstrumentList& parts)
     appendNewParts(parts);
     updateSoloist(parts);
 
-    sortParts(parts, originalStaves);
+    sortParts(parts, masterScore(), originalStaves);
 
     updateScore();
 
@@ -728,7 +728,7 @@ void NotationParts::removeParts(const IDList& partsIds)
 
     removeMissingParts(parts);
 
-    sortParts(parts, originalStaves);
+    sortParts(parts, masterScore(), originalStaves);
 
     updateScore();
 }
@@ -837,9 +837,7 @@ void NotationParts::moveParts(const IDList& sourcePartsIds, const ID& destinatio
         parts << pi;
     }
 
-    QList<Ms::Staff*> originalStaves = masterScore()->staves();
-
-    sortParts(parts, originalStaves);
+    sortParts(parts, masterScore(), masterScore()->staves());
 
     updateScore();
 
@@ -1327,12 +1325,8 @@ void NotationParts::updateSoloist(const PartInstrumentList& parts)
     }
 }
 
-void NotationParts::sortParts(const PartInstrumentList& parts, const QList<Ms::Staff*>& originalStaves)
+void NotationParts::sortParts(const PartInstrumentList& parts, const Ms::Score* score, const QList<Ms::Staff*>& originalStaves)
 {
-    Q_ASSERT(!originalStaves.empty());
-
-    Ms::Score* score = originalStaves[0]->score();
-
     QList<int> staffMapping;
     QList<int> trackMapping;
     int runningStaffIndex = 0;

--- a/src/notation/internal/notationparts.h
+++ b/src/notation/internal/notationparts.h
@@ -152,7 +152,7 @@ private:
     void removeMissingParts(const instruments::PartInstrumentList& parts);
     void appendNewParts(const instruments::PartInstrumentList& parts);
     void updateSoloist(const instruments::PartInstrumentList& parts);
-    void sortParts(const instruments::PartInstrumentList& parts, const QList<Ms::Staff*>& originalStaves);
+    void sortParts(const instruments::PartInstrumentList& parts, const Ms::Score* score, const QList<Ms::Staff*>& originalStaves);
 
     IDList allInstrumentsIds() const;
     int lastStaffIndex() const;


### PR DESCRIPTION
Instead of taking the `Score` from the list of `originalStaves` (which is empty for a new score, hence the crash) the `Score` is passed as an argument to `sortParts()`.

Resolves: an issue reported on [discord](https://discord.com/channels/818804595450445834/818848130027880479/855010633455239179)

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
