### PR TITLE
Better fix for element-specific shortcut keys

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2230,6 +2230,7 @@ void NotationInteraction::deleteSelection()
         auto textBase = toTextBase(m_textEditData.element);
         if (!textBase->deleteSelectedText(m_textEditData)) {
             m_textEditData.key = Qt::Key_Backspace;
+            m_textEditData.modifiers = 0;
             textBase->edit(m_textEditData);
         }
     } else {

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1901,7 +1901,7 @@ void NotationInteraction::moveText(MoveDirection d, bool quickly)
 
 bool NotationInteraction::isTextEditingStarted() const
 {
-    return m_textEditData.element != nullptr;
+    return m_textEditData.element && m_textEditData.element->isTextBase();
 }
 
 void NotationInteraction::startEditText(Element* element, const PointF& cursorPos)
@@ -1937,18 +1937,26 @@ void NotationInteraction::startEditText(Element* element, const PointF& cursorPo
 
 void NotationInteraction::editText(QKeyEvent* event)
 {
-    IF_ASSERT_FAILED(m_textEditData.element) {
+    if (!m_textEditData.element && selection()->element()) {
+        m_textEditData.element = selection()->element();
+    }
+
+    if (!m_textEditData.element) {
         return;
     }
 
     m_textEditData.key = event->key();
     m_textEditData.modifiers = event->modifiers();
     m_textEditData.s = event->text();
-    m_textEditData.element->edit(m_textEditData);
+    if (m_textEditData.element->edit(m_textEditData)) {
+        event->accept();
+    }
 
     score()->update();
 
-    notifyAboutTextEditingChanged();
+    if (isTextEditingStarted()) {
+        notifyAboutTextEditingChanged();
+    }
 }
 
 void NotationInteraction::endEditText()

--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -652,6 +652,7 @@ void NotationPaintView::mousePressEvent(QMouseEvent* event)
 {
     setFocus(true);
     emit activeFocusRequested();
+    forceActiveFocus();
 
     if (isInited()) {
         m_inputController->mousePressEvent(event);
@@ -691,26 +692,7 @@ void NotationPaintView::hoverMoveEvent(QHoverEvent* event)
 void NotationPaintView::shortcutOverride(QKeyEvent* event)
 {
     if (isInited()) {
-        std::string sequence = QKeySequence(event->key()).toString().toStdString();
-        if (event->key() < Qt::Key_Shift && sequence.length() > 0) {
-            if (event->modifiers() & Qt::KeyboardModifier::ShiftModifier) {
-                sequence = "Shift+" + sequence;
-            }
-            if (event->modifiers() & Qt::KeyboardModifier::AltModifier) {
-                sequence = "Alt+" + sequence;
-            }
-            if (event->modifiers() & Qt::KeyboardModifier::ControlModifier) {
-                sequence = "Ctrl+" + sequence;
-            }
-            const auto& shortcuts = shortcutsRegister()->shortcutsForSequence(sequence);
-            const std::shared_ptr<IUiActionsRegister> theRegister = actionsRegister();
-            if (std::find_if(shortcuts.begin(), shortcuts.end(), [theRegister](auto s) {
-                return theRegister->actionState(s.action).enabled;
-            }) != shortcuts.end()) {
-                return;
-            }
-        }
-        m_inputController->keyReleaseEvent(event);
+        m_inputController->keyPressEvent(event);
     }
 }
 

--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -688,7 +688,7 @@ void NotationPaintView::hoverMoveEvent(QHoverEvent* event)
     }
 }
 
-void NotationPaintView::keyReleaseEvent(QKeyEvent* event)
+void NotationPaintView::shortcutOverride(QKeyEvent* event)
 {
     if (isInited()) {
         std::string sequence = QKeySequence(event->key()).toString().toStdString();
@@ -712,6 +712,14 @@ void NotationPaintView::keyReleaseEvent(QKeyEvent* event)
         }
         m_inputController->keyReleaseEvent(event);
     }
+}
+
+bool NotationPaintView::event(QEvent* ev)
+{
+    if (ev->type() == QEvent::Type::ShortcutOverride) {
+        shortcutOverride(static_cast<QKeyEvent*>(ev));
+    }
+    return QQuickPaintedItem::event(ev);
 }
 
 void NotationPaintView::dragEnterEvent(QDragEnterEvent* event)

--- a/src/notation/view/notationpaintview.h
+++ b/src/notation/view/notationpaintview.h
@@ -155,8 +155,8 @@ private:
     void mouseDoubleClickEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
     void hoverMoveEvent(QHoverEvent* event) override;
-    void keyReleaseEvent(QKeyEvent* event) override;
-
+    bool event(QEvent*) override;
+    void shortcutOverride(QKeyEvent* event);
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dragLeaveEvent(QDragLeaveEvent* event) override;
     void dragMoveEvent(QDragMoveEvent* event) override;

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -473,11 +473,9 @@ void NotationViewInputController::hoverMoveEvent(QHoverEvent* event)
     }
 }
 
-void NotationViewInputController::keyReleaseEvent(QKeyEvent* event)
+void NotationViewInputController::keyPressEvent(QKeyEvent* event)
 {
-    if (m_view->notationInteraction()->isTextEditingStarted()) {
-        m_view->notationInteraction()->editText(event);
-    }
+    m_view->notationInteraction()->editText(event);
 }
 
 void NotationViewInputController::dragEnterEvent(QDragEnterEvent* event)

--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -88,7 +88,7 @@ public:
     void mouseReleaseEvent(QMouseEvent* event);
     void mouseDoubleClickEvent(QMouseEvent* event);
     void hoverMoveEvent(QHoverEvent* event);
-    void keyReleaseEvent(QKeyEvent* event);
+    void keyPressEvent(QKeyEvent* event);
 
     void dragEnterEvent(QDragEnterEvent* event);
     void dragLeaveEvent(QDragLeaveEvent* event);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/7687 etc.

For now, this reverts to MU3's mechanism of letting the current selected element have "first bite" at any keypress, and only if it doesn't process it, allow any actions that the shortcut key maps to to fire.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [  ] I created the test (mtest, vtest, script test) to verify the changes I made
