### PR TITLE
Prevent need for QtWidgets include directory

### DIFF
--- a/src/engraving/draw/fontmetrics.h
+++ b/src/engraving/draw/fontmetrics.h
@@ -24,7 +24,7 @@
 
 #include "font.h"
 
-#include "modularity/ioc.h"
+#include "framework/global/modularity/ioc.h"
 #include "ifontprovider.h"
 #include "geometry.h"
 

--- a/src/engraving/draw/ifontprovider.h
+++ b/src/engraving/draw/ifontprovider.h
@@ -23,7 +23,7 @@
 #ifndef MU_DRAW_IFONTPROVIDER_H
 #define MU_DRAW_IFONTPROVIDER_H
 
-#include "modularity/imoduleexport.h"
+#include "framework/global/modularity/imoduleexport.h"
 
 #include "font.h"
 #include "geometry.h"

--- a/src/engraving/libmscore/harmony.cpp
+++ b/src/engraving/libmscore/harmony.cpp
@@ -23,6 +23,7 @@
 #include "harmony.h"
 
 #include <QStack>
+#include <QRegularExpression>
 
 #include "chordlist.h"
 #include "fret.h"

--- a/src/engraving/libmscore/lyrics.cpp
+++ b/src/engraving/libmscore/lyrics.cpp
@@ -23,6 +23,7 @@
 #include "lyrics.h"
 
 #include <QClipboard>
+#include <QRegularExpression>
 
 #include "chord.h"
 #include "score.h"

--- a/src/engraving/libmscore/mscore.cpp
+++ b/src/engraving/libmscore/mscore.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <QDir>
+#include <QComboBox>
 
 #include "config.h"
 #include "musescoreCore.h"

--- a/src/engraving/libmscore/scorediff.cpp
+++ b/src/engraving/libmscore/scorediff.cpp
@@ -22,6 +22,8 @@
 
 #include "scorediff.h"
 
+#include <QRegularExpression>
+
 #include "duration.h"
 #include "measure.h"
 #include "score.h"

--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -25,6 +25,7 @@
 #include <QStack>
 #include <QTextFragment>
 #include <QTextDocument>
+#include <QRegularExpression>
 
 #include "text.h"
 #include "textedit.h"

--- a/src/engraving/libmscore/textbase.h
+++ b/src/engraving/libmscore/textbase.h
@@ -25,6 +25,8 @@
 
 #include <QTextCursor>
 
+class QInputMethodEvent;
+
 #include "element.h"
 #include "property.h"
 #include "style.h"

--- a/src/engraving/libmscore/types.h
+++ b/src/engraving/libmscore/types.h
@@ -23,7 +23,9 @@
 #ifndef __TYPES_H__
 #define __TYPES_H__
 
-#include <QComboBox>
+class QComboBox;
+class QAction;
+class QMimeData;
 
 #include "config.h"
 


### PR DESCRIPTION
Just to confirm what the full set of dependencies for engraving.lib were I created a console app that just instantiated an Ms::Score. Currently including score.h requires having the QtWidgets library include path, which shouldn't technically be necessary, so this change obviates the need for that.
I was able to successfully link the app just using:
engraving.lib
qzip.lib
Qt5Core.lib
Qt5Widgets.lib
Qt5Gui.lib
Qt5Svg.lib
zlibstat.lib

Proving that engraving.lib doesn't have any concrete dependencies on other MuseScore libraries.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
