### PR TITLE
[MU4] fix #7674 - playback doesn't update after changing notation

### DIFF
--- a/src/engraving/libmscore/rendermidi.h
+++ b/src/engraving/libmscore/rendermidi.h
@@ -115,8 +115,8 @@ private:
 
     void renderStaffChunk(const Chunk&, EventMap* events, const StaffContext& sctx);
     void renderSpanners(const Chunk&, EventMap* events);
-    void renderMetronome(const Chunk&, EventMap* events);
-    void renderMetronome(EventMap* events, Measure const* m, const Fraction& tickOffset);
+    void renderMetronome(const Chunk&, EventMap* events, bool audible);
+    void renderMetronome(EventMap* events, Measure const* m, const Fraction& tickOffset, bool audible);
 
     void collectMeasureEvents(EventMap* events, Measure const* m, const MidiRenderer::StaffContext& sctx, int tickOffset);
     void collectMeasureEventsSimple(EventMap* events, Measure const* m, const StaffContext& sctx, int tickOffset);

--- a/src/notation/internal/notationplayback.cpp
+++ b/src/notation/internal/notationplayback.cpp
@@ -258,7 +258,7 @@ void NotationPlayback::makeChunk(midi::Chunk& chunk, tick_t fromTick) const
 
         midi::EventType etype = static_cast<midi::EventType>(ev.type());
         static const std::set<EventType> SKIP_EVENTS
-            = { EventType::ME_INVALID, EventType::ME_EOT, EventType::ME_TICK1, EventType::ME_TICK2 };
+            = { EventType::ME_INVALID, EventType::ME_EOT };
         if (SKIP_EVENTS.find(etype) != SKIP_EVENTS.end()) {
             continue;
         }
@@ -716,7 +716,7 @@ QRect NotationPlayback::loopBoundaryRectByTick(LoopBoundaryType boundaryType, in
 
     for (int i = 0; i < score()->nstaves(); ++i) {
         Ms::SysStaff* ss = system->staff(i);
-        if (!ss->show() || !score()->staff(i)->show()) {
+        if (!ss || !ss->show() || !score()->staff(i)->show()) {
             continue;
         }
         y2 = ss->y() + ss->bbox().height();

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -61,6 +61,14 @@ void PlaybackController::init()
     onNotationChanged();
     globalContext()->currentNotationChanged().onNotify(this, [this]() {
         onNotationChanged();
+        auto notation = globalContext()->currentNotation();
+        if (notation) {
+            notation->notationChanged().onNotify(this, [this, notation]() {
+                if (notation == m_notation) {
+                    onNotationChanged();
+                }
+            });
+        }
     });
 
     sequencer()->statusChanged().onReceive(this, [this](const ISequencer::Status&) {


### PR DESCRIPTION
And cursor doesn't advance through tacet passages.

Resolves: https://github.com/musescore/MuseScore/issues/7674 and possibly others

The sequencer was not getting correctly stopped on changing notes in the score, meaning after doing so, it just keep playing from the same cached "playback" data. 
Further the way stepped time works means that no events were triggering the cursor to advance when no notes are playing.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
