### PR TITLE
Fixed compiling the tests on macOS

### DIFF
--- a/src/framework/ui/tests/CMakeLists.txt
+++ b/src/framework/ui/tests/CMakeLists.txt
@@ -24,12 +24,19 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/environment.cpp
     ${CMAKE_CURRENT_LIST_DIR}/navigationcontroller_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mocks/navigationmocks.h
-)
+    )
 
 set(MODULE_TEST_LINK
     actions
     ui
     )
+
+if (OS_IS_MAC)
+    set(MODULE_TEST_LINK
+        ${MODULE_TEST_LINK}
+        ${OsxFrameworks}
+        )
+endif()
 
 include(${PROJECT_SOURCE_DIR}/src/framework/testing/gtest.cmake)
 

--- a/src/importexport/musicxml/tests/CMakeLists.txt
+++ b/src/importexport/musicxml/tests/CMakeLists.txt
@@ -33,6 +33,13 @@ set(MODULE_TEST_LINK
     iex_musicxml
     )
 
+if (OS_IS_MAC)
+    set(MODULE_TEST_LINK
+        ${MODULE_TEST_LINK}
+        ${OsxFrameworks}
+        )
+endif()
+
 set(MODULE_TEST_DATA_ROOT ${CMAKE_CURRENT_LIST_DIR})
 
 include(${PROJECT_SOURCE_DIR}/src/framework/testing/qtest.cmake)


### PR DESCRIPTION
When compiling the tests on macOS, I got this errors:
```
FAILED: src/importexport/musicxml/tests/iex_musicxml_tests 
: && /usr/bin/clang++ -g -arch x86_64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk -mmacosx-version-min=10.14 -Wl,-search_paths_first -Wl,-headerpad_max_install_names  src/importexport/musicxml/tests/CMakeFiles/iex_musicxml_tests.dir/iex_musicxml_tests_autogen/mocs_compilation.cpp.o src/importexport/musicxml/tests/CMakeFiles/iex_musicxml_tests.dir/__/__/__/framework/testing/qmain.cpp.o src/importexport/musicxml/tests/CMakeFiles/iex_musicxml_tests.dir/__/__/__/framework/testing/environment.cpp.o src/importexport/musicxml/tests/CMakeFiles/iex_musicxml_tests.dir/environment.cpp.o src/importexport/musicxml/tests/CMakeFiles/iex_musicxml_tests.dir/testbase.cpp.o src/importexport/musicxml/tests/CMakeFiles/iex_musicxml_tests.dir/tst_mxml_io.cpp.o -o src/importexport/musicxml/tests/iex_musicxml_tests  -Wl,-rpath,/Users/casper/Qt/5.15.2/clang_64/lib  /Users/casper/Qt/5.15.2/clang_64/lib/QtTest.framework/QtTest  src/framework/global/libglobal.a  src/framework/system/libsystem.a  src/engraving/libengraving.a  src/framework/fonts/libfonts.a  src/importexport/musicxml/libiex_musicxml.a  src/notation/libnotation.a  src/commonscene/libcommonscene.a  src/engraving/libengraving.a  thirdparty/freetype/libmscore_freetype.a  src/framework/midi_old/libmidi_old.a  thirdparty/qzip/libqzip.a  -lz  src/framework/uicomponents/libuicomponents.a  src/framework/ui/libui.a  src/framework/accessibility/libaccessibility.a  src/framework/global/libglobal.a  /Users/casper/Qt/5.15.2/clang_64/lib/QtNetworkAuth.framework/QtNetworkAuth  /Users/casper/Qt/5.15.2/clang_64/lib/QtQuickControls2.framework/QtQuickControls2  /Users/casper/Qt/5.15.2/clang_64/lib/QtQuickTemplates2.framework/QtQuickTemplates2  /Users/casper/Qt/5.15.2/clang_64/lib/QtQuickWidgets.framework/QtQuickWidgets  /Users/casper/Qt/5.15.2/clang_64/lib/QtQuick.framework/QtQuick  /Users/casper/Qt/5.15.2/clang_64/lib/QtQmlModels.framework/QtQmlModels  /Users/casper/Qt/5.15.2/clang_64/lib/QtQml.framework/QtQml  /Users/casper/Qt/5.15.2/clang_64/lib/QtXml.framework/QtXml  /Users/casper/Qt/5.15.2/clang_64/lib/QtXmlPatterns.framework/QtXmlPatterns  /Users/casper/Qt/5.15.2/clang_64/lib/QtNetwork.framework/QtNetwork  /Users/casper/Qt/5.15.2/clang_64/lib/QtSvg.framework/QtSvg  /Users/casper/Qt/5.15.2/clang_64/lib/QtPrintSupport.framework/QtPrintSupport  /Users/casper/Qt/5.15.2/clang_64/lib/QtOpenGL.framework/QtOpenGL  /Users/casper/Qt/5.15.2/clang_64/lib/QtWidgets.framework/QtWidgets  /Users/casper/Qt/5.15.2/clang_64/lib/QtGui.framework/QtGui  /Users/casper/Qt/5.15.2/clang_64/lib/QtConcurrent.framework/QtConcurrent  /Users/casper/Qt/5.15.2/clang_64/lib/QtCore.framework/QtCore && :
Undefined symbols for architecture x86_64:
  "_NSApp", referenced from:
      mu::ui::MacOSPlatformTheme::applyPlatformStyleOnAppForTheme(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >) in libui.a(macosplatformtheme.mm.o)
  "_NSAppearanceNameAqua", referenced from:
      mu::ui::MacOSPlatformTheme::applyPlatformStyleOnAppForTheme(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >) in libui.a(macosplatformtheme.mm.o)
  "_NSAppearanceNameDarkAqua", referenced from:
      mu::ui::MacOSPlatformTheme::applyPlatformStyleOnAppForTheme(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >) in libui.a(macosplatformtheme.mm.o)
  "_NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification", referenced from:
      mu::ui::MacOSPlatformTheme::startListening() in libui.a(macosplatformtheme.mm.o)
  "_OBJC_CLASS_$_NSAppearance", referenced from:
      objc-class-ref in libui.a(macosplatformtheme.mm.o)
  "_OBJC_CLASS_$_NSColor", referenced from:
      objc-class-ref in libui.a(macosplatformtheme.mm.o)
  "_OBJC_CLASS_$_NSDistributedNotificationCenter", referenced from:
      objc-class-ref in libui.a(macosplatformtheme.mm.o)
  "_OBJC_CLASS_$_NSUserDefaults", referenced from:
      objc-class-ref in libui.a(macosplatformtheme.mm.o)
  "_OBJC_CLASS_$_NSWorkspace", referenced from:
      objc-class-ref in libui.a(macosplatformtheme.mm.o)
  "___CFConstantStringClassReference", referenced from:
      CFString in libui.a(macosplatformtheme.mm.o)
      CFString in libui.a(macosplatformtheme.mm.o)
      CFString in libui.a(macosplatformtheme.mm.o)
  "_objc_msgSend", referenced from:
      mu::ui::MacOSPlatformTheme::startListening() in libui.a(macosplatformtheme.mm.o)
      mu::ui::MacOSPlatformTheme::stopListening() in libui.a(macosplatformtheme.mm.o)
      mu::ui::MacOSPlatformTheme::isSystemDarkMode() const in libui.a(macosplatformtheme.mm.o)
      mu::ui::MacOSPlatformTheme::isSystemHighContrast() const in libui.a(macosplatformtheme.mm.o)
      mu::ui::MacOSPlatformTheme::applyPlatformStyleOnAppForTheme(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >) in libui.a(macosplatformtheme.mm.o)
      mu::ui::MacOSPlatformTheme::applyPlatformStyleOnWindowForTheme(QWindow*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >) in libui.a(macosplatformtheme.mm.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```
So I added the missing linking steps in the CMakeLists.

However, I think it's strange that the MusicXML tests are apparently linked with the UI module (why?? Seems we don't tell any linker to do so) and therefore also need to be linked with macOS's (UI) frameworks. 