### PR TITLE
Changed shortcuts export/import implementation

### DIFF
--- a/src/framework/global/iglobalconfiguration.h
+++ b/src/framework/global/iglobalconfiguration.h
@@ -60,6 +60,9 @@ public:
     //! Like: user/documents/MuseScore
     virtual io::path userDataPath() const = 0;
 
+    //! NOTE System paths
+    virtual io::path homePath() const = 0;
+
     virtual bool useFactorySettings() const = 0;
     virtual bool enableExperimental() const = 0;
 };

--- a/src/framework/global/internal/globalconfiguration.cpp
+++ b/src/framework/global/internal/globalconfiguration.cpp
@@ -105,6 +105,11 @@ io::path GlobalConfiguration::userDataPath() const
     return QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
 }
 
+io::path GlobalConfiguration::homePath() const
+{
+    return QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
+}
+
 bool GlobalConfiguration::useFactorySettings() const
 {
     return false;

--- a/src/framework/global/internal/globalconfiguration.h
+++ b/src/framework/global/internal/globalconfiguration.h
@@ -39,6 +39,8 @@ public:
     io::path userBackupPath() const override;
     io::path userDataPath() const override;
 
+    io::path homePath() const override;
+
     bool useFactorySettings() const override;
     bool enableExperimental() const override;
 

--- a/src/framework/shortcuts/internal/midiremote.cpp
+++ b/src/framework/shortcuts/internal/midiremote.cpp
@@ -99,7 +99,7 @@ mu::Ret MidiRemote::process(const Event& ev)
 
 void MidiRemote::readMidiMappings()
 {
-    io::path midiMappingsPath = configuration()->midiMappingsPath();
+    io::path midiMappingsPath = configuration()->midiMappingUserAppDataPath();
     XmlReader reader(midiMappingsPath);
 
     reader.readNextStartElement();
@@ -149,7 +149,7 @@ bool MidiRemote::writeMidiMappings(const MidiMappingList& midiMappings) const
 {
     TRACEFUNC;
 
-    io::path midiMappingsPath = configuration()->midiMappingsPath();
+    io::path midiMappingsPath = configuration()->midiMappingUserAppDataPath();
     XmlWriter writer(midiMappingsPath);
 
     writer.writeStartDocument();

--- a/src/framework/shortcuts/internal/shortcutsconfiguration.cpp
+++ b/src/framework/shortcuts/internal/shortcutsconfiguration.cpp
@@ -22,54 +22,36 @@
 #include "shortcutsconfiguration.h"
 
 #include "settings.h"
+#include "io/path.h"
 
 using namespace mu::shortcuts;
 using namespace mu::framework;
 
-static const std::string module_name("shortcuts");
+static const mu::io::path SHORTCUTS_FILE_NAME("/shortcuts.xml");
+static const mu::io::path SHORTCUTS_DEFAULT_FILE_PATH(":/data" + SHORTCUTS_FILE_NAME);
 
-static const std::string SHORTCUTS_FILE_NAME("shortcuts.xml");
-static const std::string SHORTCUTS_DEFAULT_FILE_PATH(":/data/" + SHORTCUTS_FILE_NAME);
+static const std::string MIDIMAPPINGS_FILE_NAME("/midi_mappings.xml");
 
-static const std::string MIDIMAPPINGS_FILE_NAME("midi_mappings.xml");
-
-static const Settings::Key USER_PATH_KEY(module_name, "application/paths/myShortcuts");
-static const Settings::Key ADVANCE_TO_NEXT_NOTE_ON_KEY_RELEASE(module_name, "io/midi/advanceOnRelease");
+static const Settings::Key ADVANCE_TO_NEXT_NOTE_ON_KEY_RELEASE("shortcuts", "io/midi/advanceOnRelease");
 
 void ShortcutsConfiguration::init()
 {
-    io::path defaultUserPath = globalConfiguration()->userAppDataPath() + "/" + SHORTCUTS_FILE_NAME;
-    settings()->setDefaultValue(USER_PATH_KEY, Val(defaultUserPath.toStdString()));
-
-    settings()->valueChanged(USER_PATH_KEY).onReceive(this, [this](const Val& val) {
-        m_userPathChanged.send(val.toString());
-    });
-
     settings()->setDefaultValue(ADVANCE_TO_NEXT_NOTE_ON_KEY_RELEASE, Val(true));
 }
 
-mu::ValCh<mu::io::path> ShortcutsConfiguration::shortcutsUserPath() const
+mu::io::path ShortcutsConfiguration::shortcutsUserAppDataPath() const
 {
-    ValCh<io::path> result;
-    result.ch = m_userPathChanged;
-    result.val = settings()->value(USER_PATH_KEY).toString();
-
-    return result;
+    return globalConfiguration()->userAppDataPath() + SHORTCUTS_FILE_NAME;
 }
 
-void ShortcutsConfiguration::setShortcutsUserPath(const io::path& path)
-{
-    settings()->setValue(USER_PATH_KEY, Val(path.toStdString()));
-}
-
-mu::io::path ShortcutsConfiguration::shortcutsDefaultPath() const
+mu::io::path ShortcutsConfiguration::shortcutsAppDataPath() const
 {
     return SHORTCUTS_DEFAULT_FILE_PATH;
 }
 
-mu::io::path ShortcutsConfiguration::midiMappingsPath() const
+mu::io::path ShortcutsConfiguration::midiMappingUserAppDataPath() const
 {
-    return globalConfiguration()->userAppDataPath() + "/" + MIDIMAPPINGS_FILE_NAME;
+    return globalConfiguration()->userAppDataPath() + MIDIMAPPINGS_FILE_NAME;
 }
 
 bool ShortcutsConfiguration::advanceToNextNoteOnKeyRelease() const

--- a/src/framework/shortcuts/internal/shortcutsconfiguration.h
+++ b/src/framework/shortcuts/internal/shortcutsconfiguration.h
@@ -35,18 +35,13 @@ class ShortcutsConfiguration : public IShortcutsConfiguration, public async::Asy
 public:
     void init();
 
-    ValCh<io::path> shortcutsUserPath() const override;
-    void setShortcutsUserPath(const io::path& path) override;
+    io::path shortcutsUserAppDataPath() const override;
+    io::path shortcutsAppDataPath() const override;
 
-    io::path shortcutsDefaultPath() const override;
-
-    io::path midiMappingsPath() const override;
+    io::path midiMappingUserAppDataPath() const override;
 
     bool advanceToNextNoteOnKeyRelease() const override;
     void setAdvanceToNextNoteOnKeyRelease(bool value) override;
-
-private:
-    async::Channel<io::path> m_userPathChanged;
 };
 }
 

--- a/src/framework/shortcuts/internal/shortcutsregister.h
+++ b/src/framework/shortcuts/internal/shortcutsregister.h
@@ -26,6 +26,7 @@
 #include "modularity/ioc.h"
 #include "ishortcutsconfiguration.h"
 #include "async/asyncable.h"
+#include "system/ifilesystem.h"
 
 namespace mu::framework {
 class XmlReader;
@@ -36,6 +37,7 @@ namespace mu::shortcuts {
 class ShortcutsRegister : public IShortcutsRegister, public async::Asyncable
 {
     INJECT(shortcuts, IShortcutsConfiguration, configuration)
+    INJECT(shortcuts, system::IFileSystem, fileSystem)
 
 public:
     ShortcutsRegister() = default;
@@ -50,7 +52,8 @@ public:
     const Shortcut& defaultShortcut(const std::string& actionCode) const override;
     ShortcutList shortcutsForSequence(const std::string& sequence) const override;
 
-    Ret saveToFile(const io::path& filePath) const override;
+    Ret importFromFile(const io::path& filePath) override;
+    Ret exportToFile(const io::path& filePath) const override;
 
 private:
 

--- a/src/framework/shortcuts/ishortcutsconfiguration.h
+++ b/src/framework/shortcuts/ishortcutsconfiguration.h
@@ -34,12 +34,10 @@ class IShortcutsConfiguration : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IShortcutsConfiguration() = default;
 
-    virtual ValCh<io::path> shortcutsUserPath() const = 0;
-    virtual void setShortcutsUserPath(const io::path& path) = 0;
+    virtual io::path shortcutsUserAppDataPath() const = 0;
+    virtual io::path shortcutsAppDataPath() const = 0;
 
-    virtual io::path shortcutsDefaultPath() const = 0;
-
-    virtual io::path midiMappingsPath() const = 0;
+    virtual io::path midiMappingUserAppDataPath() const = 0;
 
     virtual bool advanceToNextNoteOnKeyRelease() const = 0;
     virtual void setAdvanceToNextNoteOnKeyRelease(bool value) = 0;

--- a/src/framework/shortcuts/ishortcutsregister.h
+++ b/src/framework/shortcuts/ishortcutsregister.h
@@ -45,7 +45,8 @@ public:
     virtual const Shortcut& defaultShortcut(const std::string& actionCode) const = 0;
     virtual ShortcutList shortcutsForSequence(const std::string& sequence) const = 0;
 
-    virtual Ret saveToFile(const io::path& filePath) const = 0;
+    virtual Ret importFromFile(const io::path& filePath) = 0;
+    virtual Ret exportToFile(const io::path& filePath) const = 0;
 };
 }
 

--- a/src/framework/shortcuts/qml/MuseScore/Shortcuts/ShortcutsPage.qml
+++ b/src/framework/shortcuts/qml/MuseScore/Shortcuts/ShortcutsPage.qml
@@ -143,20 +143,20 @@ Item {
             FlatButton {
                 Layout.preferredWidth: privateProperties.buttonWidth
 
-                text: qsTrc("shortcuts", "Load...")
+                text: qsTrc("shortcuts", "Import")
 
                 onClicked: {
-                    shortcutsModel.loadShortcutsFromFile()
+                    shortcutsModel.importShortcutsFromFile()
                 }
             }
 
             FlatButton {
                 Layout.preferredWidth: privateProperties.buttonWidth
 
-                text: qsTrc("shortcuts", "Save")
+                text: qsTrc("shortcuts", "Export")
 
                 onClicked: {
-                    shortcutsModel.saveShortcutsToFile()
+                    shortcutsModel.exportShortcutsToFile()
                 }
             }
 

--- a/src/framework/shortcuts/shortcutsmodule.cpp
+++ b/src/framework/shortcuts/shortcutsmodule.cpp
@@ -94,8 +94,8 @@ void ShortcutsModule::onInit(const IApplication::RunMode& mode)
 
     auto pr = ioc()->resolve<diagnostics::IDiagnosticsPathsRegister>(moduleName());
     if (pr) {
-        pr->reg("user shortcuts", s_configuration->shortcutsUserPath().val);
-        pr->reg("default shortcuts", s_configuration->shortcutsDefaultPath());
-        pr->reg("midi mappings", s_configuration->midiMappingsPath());
+        pr->reg("shortcutsUserAppDataPath", s_configuration->shortcutsUserAppDataPath());
+        pr->reg("shortcutsAppDataPath", s_configuration->shortcutsAppDataPath());
+        pr->reg("midiMappingUserAppDataPath", s_configuration->midiMappingUserAppDataPath());
     }
 }

--- a/src/framework/shortcuts/view/shortcutsmodel.cpp
+++ b/src/framework/shortcuts/view/shortcutsmodel.cpp
@@ -29,7 +29,7 @@
 using namespace mu::shortcuts;
 using namespace mu::ui;
 
-QString shorcutsFileFilter()
+static QString shorcutsFileFilter()
 {
     return mu::qtrc("shortcuts", "MuseScore Shortcuts File") + " (*.xml)";
 }
@@ -93,7 +93,7 @@ void ShortcutsModel::load()
     beginResetModel();
     m_shortcuts.clear();
 
-    for (const Shortcut& shortcut: shortcutsRegister()->shortcuts()) {
+    for (const Shortcut& shortcut : shortcutsRegister()->shortcuts()) {
         if (actionTitle(shortcut.action).isEmpty()) {
             continue;
         }
@@ -164,30 +164,30 @@ void ShortcutsModel::setSelection(const QItemSelection& selection)
     emit selectionChanged();
 }
 
-void ShortcutsModel::loadShortcutsFromFile()
+void ShortcutsModel::importShortcutsFromFile()
 {
     io::path path = interactive()->selectOpeningFile(
-        qtrc("shortcuts", "Load Shortcuts"),
-        configuration()->shortcutsUserPath().val,
+        qtrc("shortcuts", "Import Shortcuts"),
+        globalConfiguration()->homePath(),
         shorcutsFileFilter());
 
     if (!path.empty()) {
-        configuration()->setShortcutsUserPath(path);
+        shortcutsRegister()->importFromFile(path);
     }
 }
 
-void ShortcutsModel::saveShortcutsToFile()
+void ShortcutsModel::exportShortcutsToFile()
 {
     io::path path = interactive()->selectSavingFile(
-        qtrc("shortcuts", "Save Shortcuts"),
-        configuration()->shortcutsUserPath().val,
+        qtrc("shortcuts", "Export Shortcuts"),
+        globalConfiguration()->homePath(),
         shorcutsFileFilter());
 
     if (path.empty()) {
         return;
     }
 
-    Ret ret = shortcutsRegister()->saveToFile(path);
+    Ret ret = shortcutsRegister()->exportToFile(path);
     if (!ret) {
         LOGE() << ret.toString();
     }

--- a/src/framework/shortcuts/view/shortcutsmodel.h
+++ b/src/framework/shortcuts/view/shortcutsmodel.h
@@ -32,6 +32,7 @@
 #include "ui/iuiactionsregister.h"
 #include "async/asyncable.h"
 #include "iinteractive.h"
+#include "iglobalconfiguration.h"
 
 class QItemSelection;
 
@@ -44,6 +45,7 @@ class ShortcutsModel : public QAbstractListModel, public async::Asyncable
     INJECT(shortcuts, ui::IUiActionsRegister, uiactionsRegister)
     INJECT(shortcuts, framework::IInteractive, interactive)
     INJECT(shortcuts, IShortcutsConfiguration, configuration)
+    INJECT(shortcuts, framework::IGlobalConfiguration, globalConfiguration)
 
     Q_PROPERTY(QItemSelection selection READ selection WRITE setSelection NOTIFY selectionChanged)
     Q_PROPERTY(QString currentSequence READ currentSequence NOTIFY selectionChanged)
@@ -61,8 +63,8 @@ public:
     Q_INVOKABLE void load();
     Q_INVOKABLE bool apply();
 
-    Q_INVOKABLE void loadShortcutsFromFile();
-    Q_INVOKABLE void saveShortcutsToFile();
+    Q_INVOKABLE void importShortcutsFromFile();
+    Q_INVOKABLE void exportShortcutsToFile();
 
     Q_INVOKABLE void applySequenceToCurrentShortcut(const QString& newSequence);
 

--- a/src/framework/system/ifilesystem.h
+++ b/src/framework/system/ifilesystem.h
@@ -36,6 +36,7 @@ public:
 
     virtual Ret exists(const io::path& path) const = 0;
     virtual Ret remove(const io::path& path) const = 0;
+    virtual Ret copy(const io::path& src, const io::path& dst, bool replace = false) const = 0;
 
     virtual Ret makePath(const io::path& path) const = 0;
 

--- a/src/framework/system/internal/filesystem.h
+++ b/src/framework/system/internal/filesystem.h
@@ -30,6 +30,7 @@ class FileSystem : public IFileSystem
 public:
     Ret exists(const io::path& path) const override;
     Ret remove(const io::path& path) const override;
+    Ret copy(const io::path& src, const io::path& dst, bool replace = false) const override;
 
     Ret makePath(const io::path& path) const override;
 
@@ -40,8 +41,9 @@ public:
     Ret writeToFile(const io::path& filePath, const QByteArray& data) const override;
 
 private:
-    Ret removeFile(const QString& path) const;
-    Ret removeDir(const QString& path) const;
+    Ret removeFile(const io::path& path) const;
+    Ret removeDir(const io::path& path) const;
+    Ret copyRecursively(const io::path& src, const io::path& dst) const;
 };
 }
 

--- a/src/framework/system/systemerrors.h
+++ b/src/framework/system/systemerrors.h
@@ -32,10 +32,12 @@ enum class Err {
     UnknownError    = int(Ret::Code::SystemFirst),
 
     FSNotExist,
+    FSIsExist,
     FSRemoveError,
     FSReadError,
     FSWriteError,
-    FSMakingError
+    FSMakingError,
+    FSCopyError
 };
 
 inline Ret make_ret(Err e)
@@ -47,10 +49,12 @@ inline Ret make_ret(Err e)
     case Err::NoError: return Ret(retCode);
     case Err::UnknownError: return Ret(retCode);
     case Err::FSNotExist: return Ret(retCode, trc("system", "The file does not exist"));
+    case Err::FSIsExist: return Ret(retCode, trc("system", "The file is exist"));
     case Err::FSRemoveError: return Ret(retCode, trc("system", "The file could not be removed"));
     case Err::FSReadError: return Ret(retCode, trc("system", "An error occurred when reading from the file"));
     case Err::FSWriteError: return Ret(retCode, trc("system", "An error occurred when writing to the file"));
     case Err::FSMakingError: return Ret(retCode, trc("system", "An error occurred when making a path"));
+    case Err::FSCopyError: return Ret(retCode, trc("system", "An error occurred when coping the file"));
     }
 
     return Ret(static_cast<int>(e));

--- a/src/framework/system/tests/mocks/filesystemmock.h
+++ b/src/framework/system/tests/mocks/filesystemmock.h
@@ -32,6 +32,7 @@ class FileSystemMock : public IFileSystem
 public:
     MOCK_METHOD(Ret, exists, (const io::path&), (const, override));
     MOCK_METHOD(Ret, remove, (const io::path&), (const, override));
+    MOCK_METHOD(Ret, copy, (const io::path& src, const io::path& dst, bool replace), (const, override));
 
     MOCK_METHOD(RetVal<QByteArray>, readFile, (const io::path&), (const, override));
     MOCK_METHOD(Ret, writeToFile, (const io::path&, const QByteArray&), (const, override));


### PR DESCRIPTION
Before:
When a user selects a shortcut file, we save the path to this file and using it.

Now:
When a user selects a shortcut file, we copy this file to `USERAPPDATA` directory and using it.   

Also, the buttons on the shortcut settings form have been renamed accordingly.