### PR TITLE
Fix #8364 - remove dangerous and unneeded museScoreCore global variable

### DIFF
--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -300,7 +300,6 @@ void Score::endCmd(const bool isCmdFromInspector, bool rollback)
         masterScore()->setPlaylistDirty();      // TODO: flag individual operations
         masterScore()->setAutosaveDirty(true);
     }
-    MuseScoreCore::mscoreCore->endCmd(isCmdFromInspector, rollback);
     cmdState().reset();
 }
 

--- a/src/engraving/libmscore/mscore.cpp
+++ b/src/engraving/libmscore/mscore.cpp
@@ -136,7 +136,6 @@ double MScore::pixelRatio  = 0.8;         // DPI / logicalDPI
 MPaintDevice* MScore::_paintDevice;
 
 Sequencer* MScore::seq = 0;
-MuseScoreCore* MuseScoreCore::mscoreCore;
 
 extern void initDrumset();
 extern QString mscoreGlobalShare;

--- a/src/engraving/libmscore/musescoreCore.h
+++ b/src/engraving/libmscore/musescoreCore.h
@@ -42,8 +42,7 @@ protected:
     QList<MasterScore*> scoreList;
 
 public:
-    static MuseScoreCore* mscoreCore;
-    MuseScoreCore() { mscoreCore = this; }
+    MuseScoreCore() = default;
     virtual ~MuseScoreCore() = default;
     Score* currentScore() const { return cs; }
     void setCurrentScore(Score* score) { cs = score; }
@@ -51,15 +50,12 @@ public:
     virtual bool saveAs(Score*, bool /*saveCopy*/, const QString& /*path*/, const QString& /*ext*/,
                         SaveReplacePolicy* /*replacePolicy*/ = nullptr) { return false; }
     virtual void closeScore(Score*) {}
-    virtual void cmd(QAction* /*a*/) {}
     virtual void setCurrentView(int /*tabIdx*/, int /*idx*/) {}
 
     virtual int appendScore(MasterScore* s) { scoreList.append(s); return 0; }
-    virtual void endCmd(const bool /*isCmdFromInspector*/ = false, const bool /*undoRedo*/ = false) {}
     virtual Score* openScore(const QString& /*fn*/, bool /*switchTab*/, bool considerInCurrentSession = true,
                              const QString& /*withFilename*/ = "") { Q_UNUSED(considerInCurrentSession); return 0; }
     QList<MasterScore*>& scores() { return scoreList; }
-    virtual void updateInspector() {}
 };
 } // namespace Ms
 #endif

--- a/src/engraving/libmscore/ottava.cpp
+++ b/src/engraving/libmscore/ottava.cpp
@@ -119,7 +119,6 @@ void OttavaSegment::undoChangeProperty(Pid id, const QVariant& v, PropertyFlags 
 {
     if (id == Pid::OTTAVA_TYPE || id == Pid::NUMBERS_ONLY) {
         ScoreElement::undoChangeProperty(id, v, ps);
-        MuseScoreCore::mscoreCore->updateInspector();
     } else {
         ScoreElement::undoChangeProperty(id, v, ps);
     }
@@ -130,7 +129,6 @@ void Ottava::undoChangeProperty(Pid id, const QVariant& v, PropertyFlags ps)
     if (id == Pid::OTTAVA_TYPE || id == Pid::NUMBERS_ONLY) {
         TextLineBase::undoChangeProperty(id, v, ps);
         styleChanged();       // these properties may change style settings
-        MuseScoreCore::mscoreCore->updateInspector();
     } else {
         TextLineBase::undoChangeProperty(id, v, ps);
     }

--- a/src/engraving/libmscore/spanner.cpp
+++ b/src/engraving/libmscore/spanner.cpp
@@ -1641,7 +1641,6 @@ void Spanner::undoChangeProperty(Pid id, const QVariant& v, PropertyFlags ps)
                 s->triggerLayout();
             }
         }
-        MuseScoreCore::mscoreCore->updateInspector();
         return;
     }
     Element::undoChangeProperty(id, v, ps);

--- a/src/engraving/libmscore/tempotext.cpp
+++ b/src/engraving/libmscore/tempotext.cpp
@@ -295,8 +295,6 @@ void TempoText::undoChangeProperty(Pid id, const QVariant& v, PropertyFlags ps)
         ScoreElement::undoChangeProperty(id, v, ps);
         if (_followText) {
             updateTempo();
-            // update inspector?
-            MuseScoreCore::mscoreCore->updateInspector();
         }
     } else {
         ScoreElement::undoChangeProperty(id, v, ps);

--- a/src/engraving/libmscore/textline.cpp
+++ b/src/engraving/libmscore/textline.cpp
@@ -353,7 +353,6 @@ void TextLine::undoChangeProperty(Pid id, const QVariant& v, PropertyFlags ps)
             score()->undo(new ChangeTextLineProperty(s, v));
             triggerLayout();
         }
-        MuseScoreCore::mscoreCore->updateInspector();
         return;
     }
     TextLineBase::undoChangeProperty(id, v, ps);

--- a/src/notation/internal/scorecallbacks.h
+++ b/src/notation/internal/scorecallbacks.h
@@ -23,13 +23,12 @@
 #define MU_NOTATION_SCORECALLBACKS_H
 
 #include "libmscore/mscoreview.h"
-#include "libmscore/musescoreCore.h"
 
 class QRectF;
 class QRect;
 
 namespace mu::notation {
-class ScoreCallbacks : public Ms::MuseScoreView, public Ms::MuseScoreCore
+class ScoreCallbacks : public Ms::MuseScoreView
 {
 public:
     ScoreCallbacks() = default;

--- a/src/plugins/api/qmlplugin.cpp
+++ b/src/plugins/api/qmlplugin.cpp
@@ -32,14 +32,4 @@ namespace Ms {
 QmlPlugin::QmlPlugin(QQuickItem* parent)
     : QQuickItem(parent)
 {}
-
-MuseScoreCore* QmlPlugin::msc() const
-{
-    if (!MuseScoreCore::mscoreCore) {
-        static MuseScoreCore stub;
-        return &stub;
-    }
-
-    return MuseScoreCore::mscoreCore;
-}
 }

--- a/src/plugins/api/qmlplugin.h
+++ b/src/plugins/api/qmlplugin.h
@@ -70,7 +70,7 @@ class QmlPlugin : public QQuickItem
 
 protected:
     QString _filePath;              // the path of the source file, without file name
-    MuseScoreCore* msc() const;
+    virtual MuseScoreCore* msc() const = 0;
 
 public slots:
     virtual void endCmd(const QMap<QString, QVariant>&) = 0;

--- a/src/plugins/api/qmlpluginapi.cpp
+++ b/src/plugins/api/qmlpluginapi.cpp
@@ -374,5 +374,16 @@ void PluginAPI::registerQmlTypes()
 
     qmlTypesRegistered = true;
 }
+
+MuseScoreCore* PluginAPI::msc() const
+{
+    static MuseScoreCore mscStatic;
+    if (this->context() && this->context()->currentNotation()) {
+        mscStatic.setCurrentScore(this->context()->currentNotation()->elements()->msScore());
+    } else {
+        mscStatic.setCurrentScore(0);
+    }
+    return &mscStatic;
+}
 }
 }

--- a/src/plugins/api/qmlpluginapi.h
+++ b/src/plugins/api/qmlpluginapi.h
@@ -33,11 +33,13 @@
 #include "libmscore/score.h"
 #include "libmscore/spanner.h"
 #include "framework/shortcuts/ishortcutscontroller.h"
+#include "context/iglobalcontext.h"
 #include "modularity/ioc.h"
 
 namespace Ms {
 class Element;
 class MScore;
+class MuseScoreCore;
 
 /**
  * \namespace Ms::PluginAPI
@@ -74,6 +76,7 @@ class PluginAPI : public Ms::QmlPlugin
     Q_OBJECT
 
     INJECT(plugins, mu::shortcuts::IShortcutsController, shortcuts)
+    INJECT(userscores, mu::context::IGlobalContext, context)
 
     /** Path where the plugin is placed in menu */
     Q_PROPERTY(QString menuPath READ menuPath WRITE setMenuPath)
@@ -276,6 +279,9 @@ public:
     Q_INVOKABLE void closeLog();
 
     Q_INVOKABLE Ms::PluginAPI::FractionWrapper* fraction(int numerator, int denominator) const;
+
+protected:
+    virtual MuseScoreCore* msc() const;
 };
 
 #undef DECLARE_API_ENUM


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8364

Dangerous use of museScoreCore global variable was causing random crashes

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
