### PR TITLE
[MU3] Fix #322347 - ensure hidden rests in V2-4 don't move back to default position

### DIFF
--- a/src/engraving/libmscore/rest.cpp
+++ b/src/engraving/libmscore/rest.cpp
@@ -444,7 +444,7 @@ int Rest::getDotline(TDuration::DurationType durationType)
 int Rest::computeLineOffset(int lines)
 {
     Segment* s = segment();
-    bool offsetVoices = s && measure() && measure()->hasVoices(staffIdx(), tick(), actualTicks());
+    bool offsetVoices = s && measure() && (voice() > 0 || measure()->hasVoices(staffIdx(), tick(), actualTicks()));
     if (offsetVoices && voice() == 0) {
         // do not offset voice 1 rest if there exists a matching invisible rest in voice 2;
         Element* e = s->element(track() + 1);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/322347

Hiding V2-4 rests currently causes them to move back to the default/vertical center position on a stave, causing them to interfere with visible V1 elements. In general hiding items shouldn't cause the hidden item to move.

NB this is only a partial fix - the other improvement would be to ensure that hidden elements are drawn first (in a layer underneath everything else) so that visible ones can't be obscured by them.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
