### PR TITLE
Update instruments.xml to add families and improve sorting

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -34,32 +34,128 @@
       <Genre id="classroom">
             <name>Classroom</name>
       </Genre>
+      <Family id="winds">
+            <name>Winds</name>
+      </Family>
       <Family id="flutes">
             <name>Flutes</name>
       </Family>
-      <Family id="oboes">
-            <name>Oboes</name>
+      <Family id="dizis">
+            <name>Dizis</name>
       </Family>
-      <Family id="clarinets">
-            <name>Clarinets</name>
+      <Family id="fifes">
+            <name>Fifes</name>
       </Family>
-      <Family id="bassoons">
-            <name>Bassoons</name>
+      <Family id="whistles">
+            <name>Whistles</name>
       </Family>
-      <Family id="saxophones">
-            <name>Saxophones</name>
+      <Family id="flageolets">
+            <name>Flageolets</name>
       </Family>
       <Family id="recorders">
             <name>Recorders</name>
       </Family>
+      <Family id="ocarinas">
+            <name>Ocarinas</name>
+      </Family>
+      <Family id="gemshorns">
+            <name>Gemshorns</name>
+      </Family>
+      <Family id="pan-flutes">
+            <name>Pan Flutes</name>
+      </Family>
+      <Family id="quenas">
+            <name>Quenas</name>
+      </Family>
+      <Family id="oboes">
+            <name>Oboes</name>
+      </Family>
+      <Family id="shawms">
+            <name>Shawms</name>
+      </Family>
+      <Family id="cromornes">
+            <name>Cromornes</name>
+      </Family>
+      <Family id="crumhorns">
+            <name>Crumhorns</name>
+      </Family>
+      <Family id="cornamuses">
+            <name>Cornamuses</name>
+      </Family>
+      <Family id="kelhorns">
+            <name>Kelhorns</name>
+      </Family>
+      <Family id="rauschpfeifes">
+            <name>Rauschpfeifes</name>
+      </Family>
+      <Family id="duduks">
+            <name>Duduks</name>
+      </Family>
+      <Family id="shenais">
+            <name>Shenais</name>
+      </Family>
+      <Family id="clarinets">
+            <name>Clarinets</name>
+      </Family>
+      <Family id="chalumeaus">
+            <name>Chalumeaus</name>
+      </Family>
+      <Family id="xaphoons">
+            <name>Xaphoons</name>
+      </Family>
+      <Family id="tarogatos">
+            <name>Tarogatos</name>
+      </Family>
+      <Family id="octavins">
+            <name>Octavins</name>
+      </Family>
+      <Family id="saxophones">
+            <name>Saxophones</name>
+      </Family>
+      <Family id="bassoons">
+            <name>Bassoons</name>
+      </Family>
+      <Family id="reed-contrabasses">
+            <name>Reed Contrabasses</name>
+      </Family>
+      <Family id="dulcians">
+            <name>Dulcians</name>
+      </Family>
+      <Family id="racketts">
+            <name>Racketts</name>
+      </Family>
+      <Family id="sarrusophones">
+            <name>Sarrusophones</name>
+      </Family>
+      <Family id="bagpipes">
+            <name>Bagpipes</name>
+      </Family>
+      <Family id="accordions">
+            <name>Accordions</name>
+      </Family>
+      <Family id="harmonicas">
+            <name>Harmonicas</name>
+      </Family>
+      <Family id="melodicas">
+            <name>Melodicas</name>
+      </Family>
+      <Family id="shengs">
+            <name>Shengs</name>
+      </Family>
+      <Family id="brass">
+            <name>Brass</name>
+      </Family>
       <Family id="horns">
             <name>Horns</name>
+      </Family>
+      <Family id="wagner-tubas">
+            <name>Wagner Tubas</name>
       </Family>
       <Family id="cornets">
             <name>Cornets</name>
       </Family>
-      <Family id="flugelhorns">
-            <name>Flugelhorns</name>
+      <Family id="saxhorns">
+            <name>Saxhorns</name>
       </Family>
       <Family id="alto-horns">
             <name>Alto Horns</name>
@@ -67,32 +163,101 @@
       <Family id="baritone-horns">
             <name>Baritone Horns</name>
       </Family>
-      <Family id="euphoniums">
-            <name>Euphoniums</name>
+      <Family id="posthorns">
+            <name>Posthorns</name>
       </Family>
       <Family id="trumpets">
             <name>Trumpets</name>
       </Family>
+      <Family id="baroque-trumpets">
+            <name>Baroque Trumpets</name>
+      </Family>
+      <Family id="bugles">
+            <name>Bugles</name>
+      </Family>
+      <Family id="flugelhorns">
+            <name>Flugelhorns</name>
+      </Family>
+      <Family id="ophicleides">
+            <name>Ophicleides</name>
+      </Family>
+      <Family id="cornetts">
+            <name>Cornetts</name>
+      </Family>
+      <Family id="serpents">
+            <name>Serpents</name>
+      </Family>
       <Family id="trombones">
             <name>Trombones</name>
+      </Family>
+      <Family id="sackbuts">
+            <name>Sackbuts</name>
+      </Family>
+      <Family id="euphoniums">
+            <name>Euphoniums</name>
       </Family>
       <Family id="tubas">
             <name>Tubas</name>
       </Family>
+      <Family id="sousaphones">
+            <name>Sousaphones</name>
+      </Family>
+      <Family id="conches">
+            <name>Conches</name>
+      </Family>
+      <Family id="alphorns">
+            <name>Alphorns</name>
+      </Family>
+      <Family id="rag-dungs">
+            <name>Rag Dungs</name>
+      </Family>
+      <Family id="didgeridoos">
+            <name>Didgeridoos</name>
+      </Family>
+      <Family id="shofars">
+            <name>Shofars</name>
+      </Family>
+      <Family id="vuvuzelas">
+            <name>Vuvuzelas</name>
+      </Family>
       <Family id="timpani">
             <name>Timpani</name>
+      </Family>
+      <Family id="roto-toms">
+            <name>Roto Toms</name>
+      </Family>
+      <Family id="tubaphones">
+            <name>Tubaphones</name>
+      </Family>
+      <Family id="steel-drums">
+            <name>Steel Drums</name>
       </Family>
       <Family id="keyboard-percussion">
             <name>Keyboard Percussion</name>
       </Family>
-      <Family id="harps">
-            <name>Harps</name>
+      <Family id="pitched-metal-percussion">
+            <name>Pitched Metal Percussion</name>
       </Family>
       <Family id="orff-percussion">
             <name>Orff Percussion</name>
       </Family>
-      <Family id="pitched-percussion">
-            <name>Pitched Percussion</name>
+      <Family id="flexatones">
+            <name>Flexatones</name>
+      </Family>
+      <Family id="musical-saws">
+            <name>Musical Saws</name>
+      </Family>
+      <Family id="glass-percussion">
+            <name>Glass Percussion</name>
+      </Family>
+      <Family id="klaxon-horns">
+            <name>Klaxon Horns</name>
+      </Family>
+      <Family id="kalimbas">
+            <name>Kalimbas</name>
+      </Family>
+      <Family id="drums">
+            <name>Drums</name>
       </Family>
       <Family id="unpitched-metal-percussion">
             <name>Unpitched Metal Percussion</name>
@@ -100,17 +265,23 @@
       <Family id="unpitched-wooden-percussion">
             <name>Unpitched Wooden Percussion</name>
       </Family>
-      <Family id="drums">
-            <name>Drums</name>
+      <Family id="other-percussion">
+            <name>Other Percussion</name>
       </Family>
       <Family id="batterie">
             <name>Batterie</name>
       </Family>
-      <Family id="other-percussion">
-            <name>Other Percussion</name>
+      <Family id="body-percussion">
+            <name>Body Percussion</name>
       </Family>
       <Family id="voices">
             <name>Voices</name>
+      </Family>
+      <Family id="voice-groups">
+            <name>Voice Groups</name>
+      </Family>
+      <Family id="kazoos">
+            <name>Kazoos</name>
       </Family>
       <Family id="keyboards">
             <name>Keyboards</name>
@@ -121,8 +292,8 @@
       <Family id="synths">
             <name>Synths</name>
       </Family>
-      <Family id="plucked-strings">
-            <name>Plucked Strings</name>
+      <Family id="harps">
+            <name>Harps</name>
       </Family>
       <Family id="guitars">
             <name>Guitars</name>
@@ -130,11 +301,65 @@
       <Family id="bass-guitars">
             <name>Bass Guitars</name>
       </Family>
+      <Family id="banjos">
+            <name>Banjos</name>
+      </Family>
+      <Family id="ukuleles">
+            <name>Ukuleles</name>
+      </Family>
+      <Family id="mandolins">
+            <name>Mandolins</name>
+      </Family>
+      <Family id="mtn-dulcimers">
+            <name>Mtn Dulcimers</name>
+      </Family>
+      <Family id="lutes">
+            <name>Lutes</name>
+      </Family>
+      <Family id="balalaikas">
+            <name>Balalaikas</name>
+      </Family>
+      <Family id="bouzoukis">
+            <name>Bouzoukis</name>
+      </Family>
+      <Family id="kotos">
+            <name>Kotos</name>
+      </Family>
+      <Family id="ouds">
+            <name>Ouds</name>
+      </Family>
+      <Family id="shamisens">
+            <name>Shamisens</name>
+      </Family>
+      <Family id="sitars">
+            <name>Sitars</name>
+      </Family>
+      <Family id="tamburicas">
+            <name>Tamburicas</name>
+      </Family>
+      <Family id="bandurrias">
+            <name>Bandurrias</name>
+      </Family>
+      <Family id="lauds">
+            <name>Lauds</name>
+      </Family>
+      <Family id="strings">
+            <name>Strings</name>
+      </Family>
       <Family id="orchestral-strings">
             <name>Orchestral Strings</name>
       </Family>
       <Family id="viols">
             <name>Viols</name>
+      </Family>
+      <Family id="octobasses">
+            <name>Octobasses</name>
+      </Family>
+      <Family id="erhus">
+            <name>Erhus</name>
+      </Family>
+      <Family id="nyckelharpas">
+            <name>Nyckelharpas</name>
       </Family>
       <Articulation>
             <velocity>100</velocity>
@@ -179,9 +404,10 @@
       <InstrumentGroup id="woodwinds">
             <name>Woodwinds</name>
             <Instrument id="Winds">
+                  <family>winds</family>
                   <longName>Winds</longName>
                   <shortName>Wi.</shortName>
-                  <description>Winds Section</description>
+                  <description>Wind section on grand staff.</description>
                   <musicXMLid>wind.group</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -196,52 +422,11 @@
                         <program value="73"/> <!--Flute-->
                   </Channel>
             </Instrument>
-            <Instrument id="piccolo">
-                  <family>flutes</family>
-                  <longName>Piccolo</longName>
-                  <shortName>Picc.</shortName>
-                  <description>Piccolo Flute</description>
-                  <musicXMLid>wind.flutes.flute.piccolo</musicXMLid>
-                  <transposingClef>G</transposingClef>
-                  <concertClef>G8va</concertClef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>74-105</aPitchRange>
-                  <pPitchRange>74-108</pPitchRange>
-                  <transposeDiatonic>7</transposeDiatonic>
-                  <transposeChromatic>12</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 72; MS General: Piccolo-->
-                        <program value="72"/> <!--Piccolo-->
-                  </Channel>
-                  <genre>common</genre>
-                  <genre>jazz</genre>
-                  <genre>orchestra</genre>
-                  <genre>concertband</genre>
-                  <genre>marching</genre>
-            </Instrument>
-            <Instrument id="db-piccolo">
-                  <family>flutes</family>
-                  <longName>D♭ Piccolo</longName>
-                  <shortName>D♭ Picc.</shortName>
-                  <description>Piccolo Flute in D♭</description>
-                  <musicXMLid>wind.flutes.flute.piccolo</musicXMLid>
-                  <transposingClef>G</transposingClef>
-                  <concertClef>G8va</concertClef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>75-106</aPitchRange>
-                  <pPitchRange>75-109</pPitchRange>
-                  <transposeDiatonic>8</transposeDiatonic>
-                  <transposeChromatic>13</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 72; MS General: Piccolo-->
-                        <program value="72"/> <!--Piccolo-->
-                  </Channel>
-            </Instrument>
             <Instrument id="eb-piccolo">
                   <family>flutes</family>
                   <longName>E♭ Piccolo</longName>
                   <shortName>E♭ Picc.</shortName>
-                  <description>Piccolo Flute in E♭</description>
+                  <description>Piccolo</description>
                   <musicXMLid>wind.flutes.flute.piccolo</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8va</concertClef>
@@ -255,26 +440,42 @@
                         <program value="72"/> <!--Piccolo-->
                   </Channel>
             </Instrument>
-            <Instrument id="flute">
+            <Instrument id="db-piccolo">
                   <family>flutes</family>
-                  <longName>Flute</longName>
-                  <shortName>Fl.</shortName>
-                  <description>Standard Concert Flute</description>
-                  <musicXMLid>wind.flutes.flute</musicXMLid>
-                  <clef>G</clef>
+                  <longName>D♭ Piccolo</longName>
+                  <shortName>D♭ Picc.</shortName>
+                  <description>Piccolo</description>
+                  <musicXMLid>wind.flutes.flute.piccolo</musicXMLid>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>G8va</concertClef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>60-93</aPitchRange>
-                  <pPitchRange>59-98</pPitchRange>
+                  <aPitchRange>75-106</aPitchRange>
+                  <pPitchRange>75-109</pPitchRange>
+                  <transposeDiatonic>8</transposeDiatonic>
+                  <transposeChromatic>13</transposeChromatic>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 73; MS General: Flute-->
-                        <program value="73"/> <!--Flute-->
+                        <!--MIDI: Bank 0, Prog 72; MS General: Piccolo-->
+                        <program value="72"/> <!--Piccolo-->
                   </Channel>
-                  <Articulation>
-                        <velocity>100</velocity>
-                        <gateTime>95</gateTime>
-                  </Articulation>
+            </Instrument>
+            <Instrument id="piccolo">
+                  <family>flutes</family>
+                  <longName>Piccolo</longName>
+                  <shortName>Picc.</shortName>
+                  <description>Piccolo</description>
+                  <musicXMLid>wind.flutes.flute.piccolo</musicXMLid>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>G8va</concertClef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>74-105</aPitchRange>
+                  <pPitchRange>74-108</pPitchRange>
+                  <transposeDiatonic>7</transposeDiatonic>
+                  <transposeChromatic>12</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 72; MS General: Piccolo-->
+                        <program value="72"/> <!--Piccolo-->
+                  </Channel>
                   <genre>common</genre>
-                  <genre>popular</genre>
                   <genre>jazz</genre>
                   <genre>orchestra</genre>
                   <genre>concertband</genre>
@@ -297,11 +498,27 @@
                         <program value="72"/> <!--Piccolo-->
                   </Channel>
             </Instrument>
+            <Instrument id="danso">
+                  <family>flutes</family>
+                  <longName>Danso</longName>
+                  <shortName>Da.</shortName>
+                  <description>Danso</description>
+                  <musicXMLid>wind.flutes.danso</musicXMLid>
+                  <clef>G8va</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>67-91</aPitchRange>
+                  <pPitchRange>67-91</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 76; MS General: Bottle Chiff-->
+                        <program value="76"/> <!--Blown Bottle-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
             <Instrument id="soprano-flute">
                   <family>flutes</family>
                   <longName>Soprano Flute</longName>
                   <shortName>Sop. Fl.</shortName>
-                  <description>E♭ Flute minor third above concert flute</description>
+                  <description>Flute in E♭, a minor third above concert flute.</description>
                   <musicXMLid>wind.flutes.flute</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -314,23 +531,66 @@
                         <program value="73"/> <!--Flute-->
                   </Channel>
             </Instrument>
-            <Instrument id="subcontra-alto-flute">
+            <Instrument id="irish-flute">
                   <family>flutes</family>
-                  <longName>Sub Contra-alto Flute</longName>
-                  <shortName>Sc-a. Fl.</shortName>
-                  <description>Subcontra-alto Flute</description>
-                  <musicXMLid>wind.flutes.flute.subcontrabass</musicXMLid>
-                  <transposingClef>G</transposingClef>
-                  <concertClef>F</concertClef>
+                  <longName>Irish Flute</longName>
+                  <shortName>Ir. Fl.</shortName>
+                  <description>6 hole tranverse flute</description>
+                  <musicXMLid>wind.flutes.flute.irish</musicXMLid>
+                  <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>31-60</aPitchRange>
-                  <pPitchRange>31-64</pPitchRange>
-                  <transposeDiatonic>-17</transposeDiatonic>
-                  <transposeChromatic>-29</transposeChromatic>
+                  <aPitchRange>62-86</aPitchRange>
+                  <pPitchRange>62-98</pPitchRange>
                   <Channel>
                         <!--MIDI: Bank 0, Prog 73; MS General: Flute-->
                         <program value="73"/> <!--Flute-->
                   </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="traverso">
+                  <family>flutes</family>
+                  <longName>Traverso</longName>
+                  <shortName>Trv.</shortName>
+                  <description>Traverso</description>
+                  <musicXMLid>wind.flutes.flute</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>62-88</aPitchRange>
+                  <pPitchRange>62-93</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 73; MS General: Flute-->
+                        <program value="73"/> <!--Flute-->
+                  </Channel>
+                  <Articulation>
+                        <velocity>100</velocity>
+                        <gateTime>95</gateTime>
+                  </Articulation>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="flute">
+                  <family>flutes</family>
+                  <longName>Flute</longName>
+                  <shortName>Fl.</shortName>
+                  <description>Standard concert flute.</description>
+                  <musicXMLid>wind.flutes.flute</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>60-93</aPitchRange>
+                  <pPitchRange>59-98</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 73; MS General: Flute-->
+                        <program value="73"/> <!--Flute-->
+                  </Channel>
+                  <Articulation>
+                        <velocity>100</velocity>
+                        <gateTime>95</gateTime>
+                  </Articulation>
+                  <genre>common</genre>
+                  <genre>popular</genre>
+                  <genre>jazz</genre>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
+                  <genre>marching</genre>
             </Instrument>
             <Instrument id="alto-flute">
                   <family>flutes</family>
@@ -406,6 +666,24 @@
                         <program value="73"/> <!--Flute-->
                   </Channel>
             </Instrument>
+            <Instrument id="subcontra-alto-flute">
+                  <family>flutes</family>
+                  <longName>Sub Contra-alto Flute</longName>
+                  <shortName>Sc-a. Fl.</shortName>
+                  <description>Subcontra-alto Flute</description>
+                  <musicXMLid>wind.flutes.flute.subcontrabass</musicXMLid>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>F</concertClef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>31-60</aPitchRange>
+                  <pPitchRange>31-64</pPitchRange>
+                  <transposeDiatonic>-17</transposeDiatonic>
+                  <transposeChromatic>-29</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 73; MS General: Flute-->
+                        <program value="73"/> <!--Flute-->
+                  </Channel>
+            </Instrument>
             <Instrument id="double-contrabass-flute">
                   <family>flutes</family>
                   <longName>Double Contrabass Flute</longName>
@@ -442,76 +720,11 @@
                         <program value="73"/> <!--Flute-->
                   </Channel>
             </Instrument>
-            <Instrument id="traverso">
-                  <family>flutes</family>
-                  <longName>Traverso</longName>
-                  <shortName>Trv.</shortName>
-                  <description>Traverso</description>
-                  <musicXMLid>wind.flutes.flute</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>62-88</aPitchRange>
-                  <pPitchRange>62-93</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 73; MS General: Flute-->
-                        <program value="73"/> <!--Flute-->
-                  </Channel>
-                  <Articulation>
-                        <velocity>100</velocity>
-                        <gateTime>95</gateTime>
-                  </Articulation>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="danso">
-                  <family>flutes</family>
-                  <longName>Danso</longName>
-                  <shortName>Da.</shortName>
-                  <description>Danso</description>
-                  <musicXMLid>wind.flutes.danso</musicXMLid>
-                  <clef>G8va</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>67-91</aPitchRange>
-                  <pPitchRange>67-91</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 76; MS General: Bottle Chiff-->
-                        <program value="76"/> <!--Blown Bottle-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="d-dizi">
-                  <longName>Dizi</longName>
-                  <shortName>Di.</shortName>
-                  <description>Dizi</description>
-                  <musicXMLid>wind.flutes.di-zi</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>69-95</aPitchRange>
-                  <pPitchRange>69-100</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 72; MS General: Piccolo-->
-                        <program value="72"/> <!--Piccolo-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="c-dizi">
-                  <longName>C Dizi</longName>
-                  <shortName>C Di.</shortName>
-                  <description>C Dizi</description>
-                  <musicXMLid>wind.flutes.di-zi</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>67-93</aPitchRange>
-                  <pPitchRange>67-98</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 72; MS General: Piccolo-->
-                        <program value="72"/> <!--Piccolo-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
             <Instrument id="a-dizi">
+                  <family>dizis</family>
                   <longName>A Dizi</longName>
                   <shortName>A Di.</shortName>
-                  <description>A Dizi</description>
+                  <description>Chinese flute tuned to A (written in C, non-transposing).</description>
                   <musicXMLid>wind.flutes.di-zi</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -524,9 +737,10 @@
                   <genre>world</genre>
             </Instrument>
             <Instrument id="g-dizi">
+                  <family>dizis</family>
                   <longName>G Dizi</longName>
                   <shortName>G Di.</shortName>
-                  <description>G Dizi</description>
+                  <description>Chinese flute tuned to G (written in C, non-transposing). The most common Dizi.</description>
                   <musicXMLid>wind.flutes.di-zi</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -539,9 +753,10 @@
                   <genre>world</genre>
             </Instrument>
             <Instrument id="f-dizi">
+                  <family>dizis</family>
                   <longName>F Dizi</longName>
                   <shortName>F Di.</shortName>
-                  <description>F Dizi</description>
+                  <description>Chinese flute tuned to F (written in C, non-transposing).</description>
                   <musicXMLid>wind.flutes.di-zi</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -554,9 +769,10 @@
                   <genre>world</genre>
             </Instrument>
             <Instrument id="e-dizi">
+                  <family>dizis</family>
                   <longName>E Dizi</longName>
                   <shortName>E Di.</shortName>
-                  <description>E Dizi</description>
+                  <description>Chinese flute tuned to E (written in C, non-transposing).</description>
                   <musicXMLid>wind.flutes.di-zi</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -568,10 +784,43 @@
                   </Channel>
                   <genre>world</genre>
             </Instrument>
+            <Instrument id="d-dizi">
+                  <family>dizis</family>
+                  <longName>Dizi</longName>
+                  <shortName>Di.</shortName>
+                  <description>Chinese flute tuned to D (written in C, non-transposing).</description>
+                  <musicXMLid>wind.flutes.di-zi</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>69-95</aPitchRange>
+                  <pPitchRange>69-100</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 72; MS General: Piccolo-->
+                        <program value="72"/> <!--Piccolo-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="c-dizi">
+                  <family>dizis</family>
+                  <longName>C Dizi</longName>
+                  <shortName>C Di.</shortName>
+                  <description>Chinese flute tuned to C (non-transposing).</description>
+                  <musicXMLid>wind.flutes.di-zi</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>67-93</aPitchRange>
+                  <pPitchRange>67-98</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 72; MS General: Piccolo-->
+                        <program value="72"/> <!--Piccolo-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
             <Instrument id="fife">
+                  <family>fifes</family>
                   <longName>B♭ Fife</longName>
                   <shortName>B♭ Fife</shortName>
-                  <description>B♭ Fife (A♭ transposing instrument)</description>
+                  <description>Fife tuned to B♭ when all 6 holes are covered (written in A♭, transposing). The standard fife.</description>
                   <musicXMLid>wind.flutes.fife</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -584,21 +833,69 @@
                         <program value="72"/> <!--Piccolo-->
                   </Channel>
             </Instrument>
-            <Instrument id="flageolet">
-                  <longName>Flageolet</longName>
-                  <shortName>Fla.</shortName>
-                  <description>6 hole Flageolet</description>
-                  <musicXMLid>wind.flutes.flageolet</musicXMLid>
+            <Instrument id="d-tin-whistle">
+                  <family>whistles</family>
+                  <longName>D Tin Whistle</longName>
+                  <shortName>D Tin Wh.</shortName>
+                  <description>Whistle tuned to B♭ (written in C, non-transposing)</description>
+                  <musicXMLid>wind.flutes.whistle.tin.d</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>74-98</aPitchRange>
-                  <pPitchRange>74-98</pPitchRange>
+                  <pPitchRange>74-104</pPitchRange>
                   <Channel>
                         <!--MIDI: Bank 0, Prog 78; MS General: Whistle-->
                         <program value="78"/> <!--Whistle-->
                   </Channel>
             </Instrument>
+            <Instrument id="c-tin-whistle">
+                  <family>whistles</family>
+                  <longName>C Tin Whistle</longName>
+                  <shortName>C Tin Wh.</shortName>
+                  <description>Whistle tuned to B♭ (written in C, non-transposing)</description>
+                  <musicXMLid>wind.flutes.whistle.tin</musicXMLid>
+                  <clef>G8va</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>72-96</aPitchRange>
+                  <pPitchRange>72-102</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 78; MS General: Whistle-->
+                        <program value="78"/> <!--Whistle-->
+                  </Channel>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="bflat-tin-whistle">
+                  <family>whistles</family>
+                  <longName>B♭ Tin Whistle</longName>
+                  <shortName>B♭ Tin Wh.</shortName>
+                  <description>Whistle tuned to B♭ (written in C, non-transposing)</description>
+                  <musicXMLid>wind.flutes.whistle.tin.bflat</musicXMLid>
+                  <clef>G8va</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>70-94</aPitchRange>
+                  <pPitchRange>70-100</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 78; MS General: Whistle-->
+                        <program value="78"/> <!--Whistle-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="slide-whistle">
+                  <family>whistles</family>
+                  <longName>Slide Whistle</longName>
+                  <shortName>Sl. Wh.</shortName>
+                  <description>Slide or Swanee Whistle</description>
+                  <musicXMLid>wind.flutes.slide</musicXMLid>
+                  <clef>G8va</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>69-96</aPitchRange>
+                  <pPitchRange>69-96</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
+                        <program value="79"/> <!--Ocarina-->
+                  </Channel>
+            </Instrument>
             <Instrument id="french-flageolet">
+                  <family>flageolets</family>
                   <longName>French Flageolet</longName>
                   <shortName>Fr. Fla.</shortName>
                   <description>4 hole Flageolet</description>
@@ -613,6 +910,7 @@
                   </Channel>
             </Instrument>
             <Instrument id="english-flageolet">
+                  <family>flageolets</family>
                   <longName>English Flageolet</longName>
                   <shortName>Eng. Fla.</shortName>
                   <description>6 hole Flageolet</description>
@@ -626,352 +924,20 @@
                         <program value="78"/> <!--Whistle-->
                   </Channel>
             </Instrument>
-            <Instrument id="irish-flute">
-                  <longName>Irish Flute</longName>
-                  <shortName>Ir. Fl.</shortName>
-                  <description>6 hole tranverse flute</description>
-                  <musicXMLid>wind.flutes.flute.irish</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>62-86</aPitchRange>
-                  <pPitchRange>62-98</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 73; MS General: Flute-->
-                        <program value="73"/> <!--Flute-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="gemshorn">
-                  <longName>Gemshorn</longName>
-                  <shortName>Gh.</shortName>
-                  <description>Gemshorn</description>
-                  <musicXMLid>wind.flutes.gemshorn</musicXMLid>
+            <Instrument id="flageolet">
+                  <family>flageolets</family>
+                  <longName>Flageolet</longName>
+                  <shortName>Fla.</shortName>
+                  <description>6 hole Flageolet</description>
+                  <musicXMLid>wind.flutes.flageolet</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>72-87</aPitchRange>
-                  <pPitchRange>72-87</pPitchRange>
+                  <aPitchRange>74-98</aPitchRange>
+                  <pPitchRange>74-98</pPitchRange>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
-                        <program value="79"/> <!--Ocarina-->
+                        <!--MIDI: Bank 0, Prog 78; MS General: Whistle-->
+                        <program value="78"/> <!--Whistle-->
                   </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="soprano-gemshorn">
-                  <longName>Soprano Gemshorn</longName>
-                  <shortName>S. Gh.</shortName>
-                  <description>Soprano Gemshorn</description>
-                  <musicXMLid>wind.flutes.gemshorn</musicXMLid>
-                  <clef>G8va</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>72-87</aPitchRange>
-                  <pPitchRange>72-87</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
-                        <program value="79"/> <!--Ocarina-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="alto-gemshorn">
-                  <longName>Alto Gemshorn</longName>
-                  <shortName>A. Gh.</shortName>
-                  <description>Alto Gemshorn</description>
-                  <musicXMLid>wind.flutes.gemshorn</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>65-80</aPitchRange>
-                  <pPitchRange>65-80</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
-                        <program value="79"/> <!--Ocarina-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="tenor-gemshorn">
-                  <longName>Tenor Gemshorn</longName>
-                  <shortName>T. Gh.</shortName>
-                  <description>Tenor Gemshorn</description>
-                  <musicXMLid>wind.flutes.gemshorn</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>60-75</aPitchRange>
-                  <pPitchRange>60-75</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
-                        <program value="79"/> <!--Ocarina-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="bass-gemshorn">
-                  <longName>Bass Gemshorn</longName>
-                  <shortName>B. Gh.</shortName>
-                  <description>Bass Gemshorn</description>
-                  <musicXMLid>wind.flutes.gemshorn</musicXMLid>
-                  <clef>F8va</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>53-68</aPitchRange>
-                  <pPitchRange>53-68</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
-                        <program value="79"/> <!--Ocarina-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="ocarina">
-                  <longName>Ocarina</longName>
-                  <shortName>Oc.</shortName>
-                  <description>Ocarina</description>
-                  <musicXMLid>wind.flutes.ocarina</musicXMLid>
-                  <clef>G8va</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>72-86</aPitchRange>
-                  <pPitchRange>72-88</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
-                        <program value="79"/> <!--Ocarina-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="g-soprano-ocarina">
-                  <longName>G Soprano Ocarina</longName>
-                  <shortName>G S. Oc.</shortName>
-                  <description>G Soprano Ocarina</description>
-                  <musicXMLid>wind.flutes.ocarina</musicXMLid>
-                  <clef>G8va</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>79-93</aPitchRange>
-                  <pPitchRange>79-95</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
-                        <program value="79"/> <!--Ocarina-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="f-soprano-ocarina">
-                  <longName>F Soprano Ocarina</longName>
-                  <shortName>F S. Oc.</shortName>
-                  <description>F Soprano Ocarina</description>
-                  <musicXMLid>wind.flutes.ocarina</musicXMLid>
-                  <clef>G8va</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>77-91</aPitchRange>
-                  <pPitchRange>77-93</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
-                        <program value="79"/> <!--Ocarina-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="c-soprano-ocarina">
-                  <longName>C Soprano Ocarina</longName>
-                  <shortName>C S. Oc.</shortName>
-                  <description>C Soprano Ocarina</description>
-                  <musicXMLid>wind.flutes.ocarina</musicXMLid>
-                  <clef>G8va</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>72-86</aPitchRange>
-                  <pPitchRange>72-88</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
-                        <program value="79"/> <!--Ocarina-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="bb-soprano-ocarina">
-                  <longName>B♭ Soprano Ocarina</longName>
-                  <shortName>B♭ S. Oc.</shortName>
-                  <description>B♭ Soprano Ocarina</description>
-                  <musicXMLid>wind.flutes.ocarina</musicXMLid>
-                  <clef>G8va</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>70-84</aPitchRange>
-                  <pPitchRange>70-86</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
-                        <program value="79"/> <!--Ocarina-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="g-alto-ocarina">
-                  <longName>G Alto Ocarina</longName>
-                  <shortName>G A. Oc.</shortName>
-                  <description>G Alto Ocarina</description>
-                  <musicXMLid>wind.flutes.ocarina</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>67-81</aPitchRange>
-                  <pPitchRange>67-83</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
-                        <program value="79"/> <!--Ocarina-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="f-alto-ocarina">
-                  <longName>F Alto Ocarina</longName>
-                  <shortName>F A. Oc.</shortName>
-                  <description>F Alto Ocarina</description>
-                  <musicXMLid>wind.flutes.ocarina</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>65-79</aPitchRange>
-                  <pPitchRange>65-81</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
-                        <program value="79"/> <!--Ocarina-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="c-alto-ocarina">
-                  <longName>C Alto Ocarina</longName>
-                  <shortName>C A. Oc.</shortName>
-                  <description>C Alto Ocarina</description>
-                  <musicXMLid>wind.flutes.ocarina</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>60-74</aPitchRange>
-                  <pPitchRange>60-76</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
-                        <program value="79"/> <!--Ocarina-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="bb-alto-ocarina">
-                  <longName>B♭ Alto Ocarina</longName>
-                  <shortName>B♭ A. Oc.</shortName>
-                  <description>B♭ Alto Ocarina</description>
-                  <musicXMLid>wind.flutes.ocarina</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>58-72</aPitchRange>
-                  <pPitchRange>58-74</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
-                        <program value="79"/> <!--Ocarina-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="c-bass-ocarina">
-                  <longName>C Bass Ocarina</longName>
-                  <shortName>C B. Oc.</shortName>
-                  <description>C Bass Ocarina</description>
-                  <musicXMLid>wind.flutes.ocarina</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>48-62</aPitchRange>
-                  <pPitchRange>48-64</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
-                        <program value="79"/> <!--Ocarina-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="pan-flute">
-                  <longName>Pan Flute</longName>
-                  <shortName>Pn. Fl.</shortName>
-                  <description>Pan Flute</description>
-                  <musicXMLid>wind.flutes.panpipes</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>60-96</aPitchRange>
-                  <pPitchRange>60-96</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 75; MS General: Pan Flute-->
-                        <program value="75"/> <!--Pan Flute-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="quena">
-                  <longName>Quena</longName>
-                  <shortName>Qn.</shortName>
-                  <description>Quena</description>
-                  <musicXMLid>wind.flutes.quena</musicXMLid>
-                  <clef>G8va</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>72-92</aPitchRange>
-                  <pPitchRange>72-96</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="c-quena">
-                  <longName>C Quena</longName>
-                  <shortName>C Qn.</shortName>
-                  <description>C Quena</description>
-                  <musicXMLid>wind.flutes.quena</musicXMLid>
-                  <clef>G8va</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>72-92</aPitchRange>
-                  <pPitchRange>72-96</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="g-quena">
-                  <longName>G Quena</longName>
-                  <shortName>G Qn.</shortName>
-                  <description>G Quena</description>
-                  <musicXMLid>wind.flutes.quena</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>67-87</aPitchRange>
-                  <pPitchRange>67-91</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="f-quena">
-                  <longName>F Quena</longName>
-                  <shortName>F Qn.</shortName>
-                  <description>F Quena</description>
-                  <musicXMLid>wind.flutes.quena</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>65-85</aPitchRange>
-                  <pPitchRange>65-89</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="d-quena">
-                  <longName>Quena</longName>
-                  <shortName>Qn.</shortName>
-                  <description>Quena</description>
-                  <musicXMLid>wind.flutes.quena</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>62-82</aPitchRange>
-                  <pPitchRange>62-86</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="recorder">
-                  <family>recorders</family>
-                  <longName>Recorder</longName>
-                  <shortName>Rec.</shortName>
-                  <description>Recorder</description>
-                  <musicXMLid>wind.flutes.recorder</musicXMLid>
-                  <clef>G8va</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>72-93</aPitchRange>
-                  <pPitchRange>72-98</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 74; MS General: Recorder-->
-                        <program value="74"/> <!--Recorder-->
-                  </Channel>
-                  <genre>common</genre>
-                  <genre>classroom</genre>
             </Instrument>
             <Instrument id="garklein-recorder">
                   <family>recorders</family>
@@ -1020,6 +986,23 @@
                         <program value="74"/> <!--Recorder-->
                   </Channel>
                   <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="recorder">
+                  <family>recorders</family>
+                  <longName>Recorder</longName>
+                  <shortName>Rec.</shortName>
+                  <description>Recorder</description>
+                  <musicXMLid>wind.flutes.recorder</musicXMLid>
+                  <clef>G8va</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>72-93</aPitchRange>
+                  <pPitchRange>72-98</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 74; MS General: Recorder-->
+                        <program value="74"/> <!--Recorder-->
+                  </Channel>
+                  <genre>common</genre>
+                  <genre>classroom</genre>
             </Instrument>
             <Instrument id="alto-recorder">
                   <family>recorders</family>
@@ -1101,61 +1084,355 @@
                   </Channel>
                   <genre>earlymusic</genre>
             </Instrument>
-            <Instrument id="slide-whistle">
-                  <longName>Slide Whistle</longName>
-                  <shortName>Sl. Wh.</shortName>
-                  <description>Slide or Swanee Whistle</description>
-                  <musicXMLid>wind.flutes.slide</musicXMLid>
+            <Instrument id="g-soprano-ocarina">
+                  <family>ocarinas</family>
+                  <longName>G Soprano Ocarina</longName>
+                  <shortName>G S. Oc.</shortName>
+                  <description>G Soprano Ocarina</description>
+                  <musicXMLid>wind.flutes.ocarina</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>69-96</aPitchRange>
-                  <pPitchRange>69-96</pPitchRange>
+                  <aPitchRange>79-93</aPitchRange>
+                  <pPitchRange>79-95</pPitchRange>
                   <Channel>
                         <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
                         <program value="79"/> <!--Ocarina-->
                   </Channel>
+                  <genre>world</genre>
             </Instrument>
-            <Instrument id="bflat-tin-whistle">
-                  <longName>B♭ Tin Whistle</longName>
-                  <shortName>B♭ Tin Wh.</shortName>
-                  <description>same as 6 hole Flageolet but metal construction</description>
-                  <musicXMLid>wind.flutes.whistle.tin.bflat</musicXMLid>
+            <Instrument id="f-soprano-ocarina">
+                  <family>ocarinas</family>
+                  <longName>F Soprano Ocarina</longName>
+                  <shortName>F S. Oc.</shortName>
+                  <description>F Soprano Ocarina</description>
+                  <musicXMLid>wind.flutes.ocarina</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>70-94</aPitchRange>
-                  <pPitchRange>70-100</pPitchRange>
+                  <aPitchRange>77-91</aPitchRange>
+                  <pPitchRange>77-93</pPitchRange>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 78; MS General: Whistle-->
-                        <program value="78"/> <!--Whistle-->
+                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
+                        <program value="79"/> <!--Ocarina-->
                   </Channel>
+                  <genre>world</genre>
             </Instrument>
-            <Instrument id="c-tin-whistle">
-                  <longName>C Tin Whistle</longName>
-                  <shortName>C Tin Wh.</shortName>
-                  <description>same as 6 hole Flageolet but metal construction</description>
-                  <musicXMLid>wind.flutes.whistle.tin</musicXMLid>
+            <Instrument id="ocarina">
+                  <family>ocarinas</family>
+                  <longName>Ocarina</longName>
+                  <shortName>Oc.</shortName>
+                  <description>Ocarina</description>
+                  <musicXMLid>wind.flutes.ocarina</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>72-96</aPitchRange>
-                  <pPitchRange>72-102</pPitchRange>
+                  <aPitchRange>72-86</aPitchRange>
+                  <pPitchRange>72-88</pPitchRange>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 78; MS General: Whistle-->
-                        <program value="78"/> <!--Whistle-->
+                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
+                        <program value="79"/> <!--Ocarina-->
                   </Channel>
-                  <genre>classroom</genre>
+                  <genre>world</genre>
             </Instrument>
-            <Instrument id="d-tin-whistle">
-                  <longName>D Tin Whistle</longName>
-                  <shortName>D Tin Wh.</shortName>
-                  <description>same as 6 hole Flageolet but metal construction</description>
-                  <musicXMLid>wind.flutes.whistle.tin.d</musicXMLid>
+            <Instrument id="c-soprano-ocarina">
+                  <family>ocarinas</family>
+                  <longName>C Soprano Ocarina</longName>
+                  <shortName>C S. Oc.</shortName>
+                  <description>C Soprano Ocarina</description>
+                  <musicXMLid>wind.flutes.ocarina</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>74-98</aPitchRange>
-                  <pPitchRange>74-104</pPitchRange>
+                  <aPitchRange>72-86</aPitchRange>
+                  <pPitchRange>72-88</pPitchRange>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 78; MS General: Whistle-->
-                        <program value="78"/> <!--Whistle-->
+                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
+                        <program value="79"/> <!--Ocarina-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="bb-soprano-ocarina">
+                  <family>ocarinas</family>
+                  <longName>B♭ Soprano Ocarina</longName>
+                  <shortName>B♭ S. Oc.</shortName>
+                  <description>B♭ Soprano Ocarina</description>
+                  <musicXMLid>wind.flutes.ocarina</musicXMLid>
+                  <clef>G8va</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>70-84</aPitchRange>
+                  <pPitchRange>70-86</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
+                        <program value="79"/> <!--Ocarina-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="g-alto-ocarina">
+                  <family>ocarinas</family>
+                  <longName>G Alto Ocarina</longName>
+                  <shortName>G A. Oc.</shortName>
+                  <description>G Alto Ocarina</description>
+                  <musicXMLid>wind.flutes.ocarina</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>67-81</aPitchRange>
+                  <pPitchRange>67-83</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
+                        <program value="79"/> <!--Ocarina-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="f-alto-ocarina">
+                  <family>ocarinas</family>
+                  <longName>F Alto Ocarina</longName>
+                  <shortName>F A. Oc.</shortName>
+                  <description>F Alto Ocarina</description>
+                  <musicXMLid>wind.flutes.ocarina</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>65-79</aPitchRange>
+                  <pPitchRange>65-81</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
+                        <program value="79"/> <!--Ocarina-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="c-alto-ocarina">
+                  <family>ocarinas</family>
+                  <longName>C Alto Ocarina</longName>
+                  <shortName>C A. Oc.</shortName>
+                  <description>C Alto Ocarina</description>
+                  <musicXMLid>wind.flutes.ocarina</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>60-74</aPitchRange>
+                  <pPitchRange>60-76</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
+                        <program value="79"/> <!--Ocarina-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="bb-alto-ocarina">
+                  <family>ocarinas</family>
+                  <longName>B♭ Alto Ocarina</longName>
+                  <shortName>B♭ A. Oc.</shortName>
+                  <description>B♭ Alto Ocarina</description>
+                  <musicXMLid>wind.flutes.ocarina</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>58-72</aPitchRange>
+                  <pPitchRange>58-74</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
+                        <program value="79"/> <!--Ocarina-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="c-bass-ocarina">
+                  <family>ocarinas</family>
+                  <longName>C Bass Ocarina</longName>
+                  <shortName>C B. Oc.</shortName>
+                  <description>C Bass Ocarina</description>
+                  <musicXMLid>wind.flutes.ocarina</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>48-62</aPitchRange>
+                  <pPitchRange>48-64</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
+                        <program value="79"/> <!--Ocarina-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="gemshorn">
+                  <family>gemshorns</family>
+                  <longName>Gemshorn</longName>
+                  <shortName>Gh.</shortName>
+                  <description>Gemshorn</description>
+                  <musicXMLid>wind.flutes.gemshorn</musicXMLid>
+                  <clef>G8va</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>72-87</aPitchRange>
+                  <pPitchRange>72-87</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
+                        <program value="79"/> <!--Ocarina-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="soprano-gemshorn">
+                  <family>gemshorns</family>
+                  <longName>Soprano Gemshorn</longName>
+                  <shortName>S. Gh.</shortName>
+                  <description>Soprano Gemshorn</description>
+                  <musicXMLid>wind.flutes.gemshorn</musicXMLid>
+                  <clef>G8va</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>72-87</aPitchRange>
+                  <pPitchRange>72-87</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
+                        <program value="79"/> <!--Ocarina-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="alto-gemshorn">
+                  <family>gemshorns</family>
+                  <longName>Alto Gemshorn</longName>
+                  <shortName>A. Gh.</shortName>
+                  <description>Alto Gemshorn</description>
+                  <musicXMLid>wind.flutes.gemshorn</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>65-80</aPitchRange>
+                  <pPitchRange>65-80</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
+                        <program value="79"/> <!--Ocarina-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="tenor-gemshorn">
+                  <family>gemshorns</family>
+                  <longName>Tenor Gemshorn</longName>
+                  <shortName>T. Gh.</shortName>
+                  <description>Tenor Gemshorn</description>
+                  <musicXMLid>wind.flutes.gemshorn</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>60-75</aPitchRange>
+                  <pPitchRange>60-75</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
+                        <program value="79"/> <!--Ocarina-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="bass-gemshorn">
+                  <family>gemshorns</family>
+                  <longName>Bass Gemshorn</longName>
+                  <shortName>B. Gh.</shortName>
+                  <description>Bass Gemshorn</description>
+                  <musicXMLid>wind.flutes.gemshorn</musicXMLid>
+                  <clef>F8va</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>53-68</aPitchRange>
+                  <pPitchRange>53-68</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
+                        <program value="79"/> <!--Ocarina-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="pan-flute">
+                  <family>pan-flutes</family>
+                  <longName>Pan Flute</longName>
+                  <shortName>Pn. Fl.</shortName>
+                  <description>Pan Flute</description>
+                  <musicXMLid>wind.flutes.panpipes</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>60-96</aPitchRange>
+                  <pPitchRange>60-96</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 75; MS General: Pan Flute-->
+                        <program value="75"/> <!--Pan Flute-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="quena">
+                  <family>quenas</family>
+                  <longName>Quena</longName>
+                  <shortName>Qn.</shortName>
+                  <description>South American traditional flute tuned to C (non-transposing).</description>
+                  <musicXMLid>wind.flutes.quena</musicXMLid>
+                  <clef>G8va</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>72-92</aPitchRange>
+                  <pPitchRange>72-96</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="c-quena">
+                  <family>quenas</family>
+                  <longName>C Quena</longName>
+                  <shortName>C Qn.</shortName>
+                  <description>South American traditional flute tuned to C (non-transposing).</description>
+                  <musicXMLid>wind.flutes.quena</musicXMLid>
+                  <clef>G8va</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>72-92</aPitchRange>
+                  <pPitchRange>72-96</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="g-quena">
+                  <family>quenas</family>
+                  <longName>G Quena</longName>
+                  <shortName>G Qn.</shortName>
+                  <description>South American traditional flute tuned to G (written in C, non-transposing).</description>
+                  <musicXMLid>wind.flutes.quena</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>67-87</aPitchRange>
+                  <pPitchRange>67-91</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="f-quena">
+                  <family>quenas</family>
+                  <longName>F Quena</longName>
+                  <shortName>F Qn.</shortName>
+                  <description>South American traditional flute tuned to F (written in C, non-transposing).</description>
+                  <musicXMLid>wind.flutes.quena</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>65-85</aPitchRange>
+                  <pPitchRange>65-89</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="d-quena">
+                  <family>quenas</family>
+                  <longName>Quena</longName>
+                  <shortName>Qn.</shortName>
+                  <description>South American traditional flute tuned to D (written in C, non-transposing).</description>
+                  <musicXMLid>wind.flutes.quena</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>62-82</aPitchRange>
+                  <pPitchRange>62-86</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="piccolo-heckelphone">
+                  <family>oboes</family>
+                  <longName>Piccolo Heckelphone</longName>
+                  <shortName>P. Hph.</shortName>
+                  <description>Piccolo Heckelphone</description>
+                  <musicXMLid>wind.reed.heckelphone.piccolo</musicXMLid>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>63-92</aPitchRange>
+                  <pPitchRange>63-92</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 68; MS General: Oboe-->
+                        <program value="68"/> <!--Oboe-->
                   </Channel>
             </Instrument>
             <Instrument id="piccolo-oboe">
@@ -1175,6 +1452,22 @@
                         <program value="68"/> <!--Oboe-->
                   </Channel>
             </Instrument>
+            <Instrument id="baroque-oboe">
+                  <family>oboes</family>
+                  <longName>Baroque Oboe</longName>
+                  <shortName>Bq. Ob.</shortName>
+                  <description>Baroque Oboe</description>
+                  <musicXMLid>wind.reed.oboe</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>60-83</aPitchRange>
+                  <pPitchRange>60-86</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 69; MS General: English Horn-->
+                        <program value="69"/> <!--English Horn-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
             <Instrument id="oboe">
                   <family>oboes</family>
                   <longName>Oboe</longName>
@@ -1193,27 +1486,11 @@
                   <genre>orchestra</genre>
                   <genre>concertband</genre>
             </Instrument>
-            <Instrument id="baroque-oboe">
-                  <family>oboes</family>
-                  <longName>Baroque Oboe</longName>
-                  <shortName>Bq. Ob.</shortName>
-                  <description>Baroque Oboe</description>
-                  <musicXMLid>wind.reed.oboe</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>60-83</aPitchRange>
-                  <pPitchRange>60-86</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 69; MS General: English Horn-->
-                        <program value="69"/> <!--English Horn-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
             <Instrument id="oboe-d'amore">
                   <family>oboes</family>
                   <longName>Oboe d'amore</longName>
                   <shortName>Ob. d'a.</shortName>
-                  <description>Oboe d'amore</description>
+                  <description>Oboe d’amore</description>
                   <musicXMLid>wind.reed.oboe-damore</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1278,21 +1555,6 @@
                         <program value="68"/> <!--Oboe-->
                   </Channel>
             </Instrument>
-            <Instrument id="piccolo-heckelphone">
-                  <family>oboes</family>
-                  <longName>Piccolo Heckelphone</longName>
-                  <shortName>P. Hph.</shortName>
-                  <description>Piccolo Heckelphone</description>
-                  <musicXMLid>wind.reed.heckelphone.piccolo</musicXMLid>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>63-92</aPitchRange>
-                  <pPitchRange>63-92</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 68; MS General: Oboe-->
-                        <program value="68"/> <!--Oboe-->
-                  </Channel>
-            </Instrument>
             <Instrument id="heckelphone">
                   <family>oboes</family>
                   <longName>Heckelphone</longName>
@@ -1328,21 +1590,8 @@
                         <program value="68"/> <!--Oboe-->
                   </Channel>
             </Instrument>
-            <Instrument id="heckelphone-clarinet">
-                  <longName>Heckelphone-clarinet</longName>
-                  <shortName>Hph.-cl.</shortName>
-                  <description>Heckelphone</description>
-                  <musicXMLid>wind.reed.heckelphone-clarinet</musicXMLid>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>50-84</aPitchRange>
-                  <pPitchRange>50-84</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 68; MS General: Oboe-->
-                        <program value="68"/> <!--Oboe-->
-                  </Channel>
-            </Instrument>
             <Instrument id="sopranino-shawm">
+                  <family>shawms</family>
                   <longName>Sopranino Shawm</longName>
                   <shortName>Si. Sh.</shortName>
                   <description>Sopranino Shawm</description>
@@ -1358,6 +1607,7 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="soprano-shawm">
+                  <family>shawms</family>
                   <longName>Soprano Shawm</longName>
                   <shortName>S. Sh.</shortName>
                   <description>Shawm</description>
@@ -1373,6 +1623,7 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="alto-shawm">
+                  <family>shawms</family>
                   <longName>Alto Shawm</longName>
                   <shortName>A. Sh.</shortName>
                   <description>Alto Shawm</description>
@@ -1388,6 +1639,7 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="tenor-shawm">
+                  <family>shawms</family>
                   <longName>Tenor Shawm</longName>
                   <shortName>T. Sh.</shortName>
                   <description>Tenor Shawm</description>
@@ -1403,6 +1655,7 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="bass-shawm">
+                  <family>shawms</family>
                   <longName>Bass Shawm</longName>
                   <shortName>B. Sh.</shortName>
                   <description>Bass Shawm</description>
@@ -1418,6 +1671,7 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="great-bass-shawm">
+                  <family>shawms</family>
                   <longName>Great Bass Shawm</longName>
                   <shortName>G.B. Sh.</shortName>
                   <description>Great Bass Shawm</description>
@@ -1433,9 +1687,10 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="cromorne">
+                  <family>cromornes</family>
                   <longName>Cromorne</longName>
                   <shortName>Cr.</shortName>
-                  <description>Cromorne probably same as crumhorn</description>
+                  <description>French reed instrument from early Baroque period.</description>
                   <musicXMLid>wind.reed.cromorne</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1448,9 +1703,10 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="crumhorn">
+                  <family>crumhorns</family>
                   <longName>Crumhorn</longName>
                   <shortName>Crh.</shortName>
-                  <description>Crumhorn</description>
+                  <description>Renaissance double-reed instrument with curved end.</description>
                   <musicXMLid>wind.reed.crumhorn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1463,9 +1719,10 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="soprano-crumhorn">
+                  <family>crumhorns</family>
                   <longName>Soprano Crumhorn</longName>
                   <shortName>S. Crh.</shortName>
-                  <description>Soprano Crumhorn</description>
+                  <description>Renaissance double-reed instrument with curved end.</description>
                   <musicXMLid>wind.reed.crumhorn.soprano</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1478,9 +1735,10 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="alto-crumhorn">
+                  <family>crumhorns</family>
                   <longName>Alto Crumhorn</longName>
                   <shortName>A. Crh.</shortName>
-                  <description>Alto Crumhorn</description>
+                  <description>Renaissance double-reed instrument with curved end.</description>
                   <musicXMLid>wind.reed.crumhorn.alto</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1493,9 +1751,10 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="tenor-crumhorn">
+                  <family>crumhorns</family>
                   <longName>Tenor Crumhorn</longName>
                   <shortName>T. Crh.</shortName>
-                  <description>Tenor Crumhorn</description>
+                  <description>Renaissance double-reed instrument with curved end.</description>
                   <musicXMLid>wind.reed.crumhorn.tenor</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1508,9 +1767,10 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="bass-crumhorn">
+                  <family>crumhorns</family>
                   <longName>Bass Crumhorn</longName>
                   <shortName>B. Crh.</shortName>
-                  <description>Bass Crumhorn</description>
+                  <description>Renaissance double-reed instrument with curved end.</description>
                   <musicXMLid>wind.reed.crumhorn.bass</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1523,9 +1783,10 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="greatbass-crumhorn">
+                  <family>crumhorns</family>
                   <longName>Greatbass Crumhorn</longName>
                   <shortName>Gb. Crh.</shortName>
-                  <description>Greatbass Crumhorn</description>
+                  <description>Renaissance double-reed instrument with curved end.</description>
                   <musicXMLid>wind.reed.crumhorn.great-bass</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1538,9 +1799,10 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="cornamuse">
+                  <family>cornamuses</family>
                   <longName>Cornamuse</longName>
                   <shortName>Cm.</shortName>
-                  <description>Cornamuse</description>
+                  <description>Renaissance double-reed instrument with straight end and single bore.</description>
                   <musicXMLid>wind.reed.cornamuse</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1552,9 +1814,10 @@
                   </Channel>
             </Instrument>
             <Instrument id="soprano-cornamuse">
+                  <family>cornamuses</family>
                   <longName>Soprano Cornamuse</longName>
                   <shortName>S. Cm.</shortName>
-                  <description>Soprano Cornamuse</description>
+                  <description>Renaissance double-reed instrument with straight end and single bore.</description>
                   <musicXMLid>wind.reed.cornamuse</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1566,9 +1829,10 @@
                   </Channel>
             </Instrument>
             <Instrument id="alto-cornamuse">
+                  <family>cornamuses</family>
                   <longName>Alto Cornamuse</longName>
                   <shortName>A. Cm.</shortName>
-                  <description>Alto Cornamuse</description>
+                  <description>Renaissance double-reed instrument with straight end and single bore.</description>
                   <musicXMLid>wind.reed.cornamuse</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1580,9 +1844,10 @@
                   </Channel>
             </Instrument>
             <Instrument id="tenor-cornamuse">
+                  <family>cornamuses</family>
                   <longName>Tenor Cornamuse</longName>
                   <shortName>T. Cm.</shortName>
-                  <description>Tenor Cornamuse</description>
+                  <description>Renaissance double-reed instrument with straight end and single bore.</description>
                   <musicXMLid>wind.reed.cornamuse</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1594,9 +1859,10 @@
                   </Channel>
             </Instrument>
             <Instrument id="bass-cornamuse">
+                  <family>cornamuses</family>
                   <longName>Bass Cornamuse</longName>
                   <shortName>B. Cm.</shortName>
-                  <description>Bass Cornamuse</description>
+                  <description>Renaissance double-reed instrument with straight end and single bore.</description>
                   <musicXMLid>wind.reed.cornamuse</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1607,157 +1873,8 @@
                         <program value="67"/> <!--Baritone Sax-->
                   </Channel>
             </Instrument>
-            <Instrument id="duduk">
-                  <longName>Duduk</longName>
-                  <shortName>Du.</shortName>
-                  <description>Duduk</description>
-                  <musicXMLid>wind.reed.duduk</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>66-81</aPitchRange>
-                  <pPitchRange>64-84</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
-                        <program value="71"/> <!--Clarinet-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="f-duduk">
-                  <longName>F Duduk</longName>
-                  <shortName>F Du.</shortName>
-                  <description>F Duduk</description>
-                  <musicXMLid>wind.reed.duduk</musicXMLid>
-                  <clef>G8va</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>74-89</aPitchRange>
-                  <pPitchRange>72-92</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
-                        <program value="71"/> <!--Clarinet-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="e-duduk">
-                  <longName>E Duduk</longName>
-                  <shortName>E Du.</shortName>
-                  <description>E Duduk</description>
-                  <musicXMLid>wind.reed.duduk</musicXMLid>
-                  <clef>G8va</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>73-88</aPitchRange>
-                  <pPitchRange>71-91</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
-                        <program value="71"/> <!--Clarinet-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="d-duduk">
-                  <longName>Duduk</longName>
-                  <shortName>Du.</shortName>
-                  <description>Duduk</description>
-                  <musicXMLid>wind.reed.duduk</musicXMLid>
-                  <clef>G8va</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>71-86</aPitchRange>
-                  <pPitchRange>69-89</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
-                        <program value="71"/> <!--Clarinet-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="c-duduk">
-                  <longName>C Duduk</longName>
-                  <shortName>C Du.</shortName>
-                  <description>C Duduk</description>
-                  <musicXMLid>wind.reed.duduk</musicXMLid>
-                  <clef>G8va</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>69-84</aPitchRange>
-                  <pPitchRange>67-87</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
-                        <program value="71"/> <!--Clarinet-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="b-duduk">
-                  <longName>B Duduk</longName>
-                  <shortName>B Du.</shortName>
-                  <description>B Duduk</description>
-                  <musicXMLid>wind.reed.duduk</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>68-83</aPitchRange>
-                  <pPitchRange>66-86</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
-                        <program value="71"/> <!--Clarinet-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="bb-duduk">
-                  <longName>B♭ Duduk</longName>
-                  <shortName>B♭ Du.</shortName>
-                  <description>B♭ Duduk</description>
-                  <musicXMLid>wind.reed.duduk</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>67-82</aPitchRange>
-                  <pPitchRange>65-85</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
-                        <program value="71"/> <!--Clarinet-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="a-duduk">
-                  <longName>A Duduk</longName>
-                  <shortName>A Du.</shortName>
-                  <description>A Duduk</description>
-                  <musicXMLid>wind.reed.duduk</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>66-81</aPitchRange>
-                  <pPitchRange>64-84</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
-                        <program value="71"/> <!--Clarinet-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="g-duduk">
-                  <longName>G Duduk</longName>
-                  <shortName>G Du.</shortName>
-                  <description>G Duduk</description>
-                  <musicXMLid>wind.reed.duduk</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>64-79</aPitchRange>
-                  <pPitchRange>62-82</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
-                        <program value="71"/> <!--Clarinet-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="a-bass-duduk">
-                  <longName>A Bass Duduk</longName>
-                  <shortName>A B. Du.</shortName>
-                  <description>A Bass Duduk</description>
-                  <musicXMLid>wind.reed.duduk</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>54-69</aPitchRange>
-                  <pPitchRange>52-72</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
-                        <program value="71"/> <!--Clarinet-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
             <Instrument id="soprano-kelhorn">
+                  <family>kelhorns</family>
                   <longName>Soprano Kelhorn</longName>
                   <shortName>S. Kh.</shortName>
                   <description>Soprano Kelhorn</description>
@@ -1772,6 +1889,7 @@
                   <genre>world</genre>
             </Instrument>
             <Instrument id="alto-kelhorn">
+                  <family>kelhorns</family>
                   <longName>Alto Kelhorn</longName>
                   <shortName>A. Kh.</shortName>
                   <description>Alto Kelhorn</description>
@@ -1786,6 +1904,7 @@
                   <genre>world</genre>
             </Instrument>
             <Instrument id="tenor-kelhorn">
+                  <family>kelhorns</family>
                   <longName>Tenor Kelhorn</longName>
                   <shortName>T. Kh.</shortName>
                   <description>Tenor Kelhorn</description>
@@ -1800,6 +1919,7 @@
                   <genre>world</genre>
             </Instrument>
             <Instrument id="bass-kelhorn">
+                  <family>kelhorns</family>
                   <longName>Bass Kelhorn</longName>
                   <shortName>B. Kh.</shortName>
                   <description>Bass Kelhorn</description>
@@ -1814,6 +1934,7 @@
                   <genre>world</genre>
             </Instrument>
             <Instrument id="greatbass-kelhorn">
+                  <family>kelhorns</family>
                   <longName>Greatbass Kelhorn</longName>
                   <shortName>Gb. Kh.</shortName>
                   <description>Greatbass Kelhorn</description>
@@ -1827,22 +1948,8 @@
                   </Channel>
                   <genre>world</genre>
             </Instrument>
-            <Instrument id="rauschpfeife">
-                  <longName>Rauschpfeife</longName>
-                  <shortName>Rpf.</shortName>
-                  <description>Rauschpfeife</description>
-                  <musicXMLid>wind.reed.rauschpfeife</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>60-76</aPitchRange>
-                  <pPitchRange>60-79</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
             <Instrument id="sopranino-rauschpfeife">
+                  <family>rauschpfeifes</family>
                   <longName>Sopranino Rauschpfeife</longName>
                   <shortName>Si. Rpf.</shortName>
                   <description>Sopranino Rauschpfeife</description>
@@ -1857,7 +1964,24 @@
                   </Channel>
                   <genre>world</genre>
             </Instrument>
+            <Instrument id="rauschpfeife">
+                  <family>rauschpfeifes</family>
+                  <longName>Rauschpfeife</longName>
+                  <shortName>Rpf.</shortName>
+                  <description>Rauschpfeife</description>
+                  <musicXMLid>wind.reed.rauschpfeife</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>60-76</aPitchRange>
+                  <pPitchRange>60-79</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
             <Instrument id="soprano-rauschpfeife">
+                  <family>rauschpfeifes</family>
                   <longName>Soprano Rauschpfeife</longName>
                   <shortName>S. Rpf.</shortName>
                   <description>Soprano Rauschpfeife</description>
@@ -1872,7 +1996,168 @@
                   </Channel>
                   <genre>world</genre>
             </Instrument>
+            <Instrument id="f-duduk">
+                  <family>duduks</family>
+                  <longName>F Duduk</longName>
+                  <shortName>F Du.</shortName>
+                  <description>Armenian double reed woodwind instrument tuned to F (written in C, non-transposing)</description>
+                  <musicXMLid>wind.reed.duduk</musicXMLid>
+                  <clef>G8va</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>74-89</aPitchRange>
+                  <pPitchRange>72-92</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
+                        <program value="71"/> <!--Clarinet-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="e-duduk">
+                  <family>duduks</family>
+                  <longName>E Duduk</longName>
+                  <shortName>E Du.</shortName>
+                  <description>Armenian double reed woodwind instrument tuned to E (written in C, non-transposing)</description>
+                  <musicXMLid>wind.reed.duduk</musicXMLid>
+                  <clef>G8va</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>73-88</aPitchRange>
+                  <pPitchRange>71-91</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
+                        <program value="71"/> <!--Clarinet-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="d-duduk">
+                  <family>duduks</family>
+                  <longName>Duduk</longName>
+                  <shortName>Du.</shortName>
+                  <description>Armenian double reed woodwind instrument tuned to D (written in C, non-transposing)</description>
+                  <musicXMLid>wind.reed.duduk</musicXMLid>
+                  <clef>G8va</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>71-86</aPitchRange>
+                  <pPitchRange>69-89</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
+                        <program value="71"/> <!--Clarinet-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="c-duduk">
+                  <family>duduks</family>
+                  <longName>C Duduk</longName>
+                  <shortName>C Du.</shortName>
+                  <description>Armenian double reed woodwind instrument tuned to C (written in C, non-transposing)</description>
+                  <musicXMLid>wind.reed.duduk</musicXMLid>
+                  <clef>G8va</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>69-84</aPitchRange>
+                  <pPitchRange>67-87</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
+                        <program value="71"/> <!--Clarinet-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="b-duduk">
+                  <family>duduks</family>
+                  <longName>B Duduk</longName>
+                  <shortName>B Du.</shortName>
+                  <description>Armenian double reed woodwind instrument tuned to B (written in C, non-transposing)</description>
+                  <musicXMLid>wind.reed.duduk</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>68-83</aPitchRange>
+                  <pPitchRange>66-86</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
+                        <program value="71"/> <!--Clarinet-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="bb-duduk">
+                  <family>duduks</family>
+                  <longName>B♭ Duduk</longName>
+                  <shortName>B♭ Du.</shortName>
+                  <description>Armenian double reed woodwind instrument tuned to B♭ (written in C, non-transposing)</description>
+                  <musicXMLid>wind.reed.duduk</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>67-82</aPitchRange>
+                  <pPitchRange>65-85</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
+                        <program value="71"/> <!--Clarinet-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="duduk">
+                  <family>duduks</family>
+                  <longName>Duduk</longName>
+                  <shortName>Du.</shortName>
+                  <description>Armenian double reed woodwind instrument tuned to A (written in C, non-transposing)</description>
+                  <musicXMLid>wind.reed.duduk</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>66-81</aPitchRange>
+                  <pPitchRange>64-84</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
+                        <program value="71"/> <!--Clarinet-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="a-duduk">
+                  <family>duduks</family>
+                  <longName>A Duduk</longName>
+                  <shortName>A Du.</shortName>
+                  <description>Armenian double reed woodwind instrument tuned to A (written in C, non-transposing)</description>
+                  <musicXMLid>wind.reed.duduk</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>66-81</aPitchRange>
+                  <pPitchRange>64-84</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
+                        <program value="71"/> <!--Clarinet-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="g-duduk">
+                  <family>duduks</family>
+                  <longName>G Duduk</longName>
+                  <shortName>G Du.</shortName>
+                  <description>Armenian double reed woodwind instrument tuned to G (written in C, non-transposing)</description>
+                  <musicXMLid>wind.reed.duduk</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>64-79</aPitchRange>
+                  <pPitchRange>62-82</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
+                        <program value="71"/> <!--Clarinet-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="a-bass-duduk">
+                  <family>duduks</family>
+                  <longName>A Bass Duduk</longName>
+                  <shortName>A B. Du.</shortName>
+                  <description>Armenian double reed woodwind instrument tuned to A (written in C, non-transposing)</description>
+                  <musicXMLid>wind.reed.duduk</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>54-69</aPitchRange>
+                  <pPitchRange>52-72</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
+                        <program value="71"/> <!--Clarinet-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
             <Instrument id="shenai">
+                  <family>shenais</family>
                   <longName>Shenai</longName>
                   <shortName>She.</shortName>
                   <description>Shenai</description>
@@ -1886,23 +2171,6 @@
                         <program value="111"/> <!--Shanai-->
                   </Channel>
                   <genre>world</genre>
-            </Instrument>
-            <Instrument id="clarinet">
-                  <family>clarinets</family>
-                  <longName>Clarinet</longName>
-                  <shortName>Cl.</shortName>
-                  <description>B♭ Clarinet (generic)</description>
-                  <musicXMLid>wind.reed.clarinet</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>50-89</aPitchRange>
-                  <pPitchRange>50-94</pPitchRange>
-                  <transposeDiatonic>-1</transposeDiatonic>
-                  <transposeChromatic>-2</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
-                        <program value="71"/> <!--Clarinet-->
-                  </Channel>
             </Instrument>
             <Instrument id="piccolo-clarinet">
                   <family>clarinets</family>
@@ -1939,43 +2207,11 @@
                   </Channel>
                   <genre>concertband</genre>
             </Instrument>
-            <Instrument id="c-clarinet">
-                  <family>clarinets</family>
-                  <longName>C Clarinet</longName>
-                  <shortName>C Cl.</shortName>
-                  <description>C Clarinet</description>
-                  <musicXMLid>wind.reed.clarinet</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>52-89</aPitchRange>
-                  <pPitchRange>52-94</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
-                        <program value="71"/> <!--Clarinet-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="d-clarinet">
-                  <family>clarinets</family>
-                  <longName>D Clarinet</longName>
-                  <shortName>D Cl.</shortName>
-                  <description>D Clarinet</description>
-                  <musicXMLid>wind.reed.clarinet</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>54-93</aPitchRange>
-                  <pPitchRange>54-98</pPitchRange>
-                  <transposeDiatonic>1</transposeDiatonic>
-                  <transposeChromatic>2</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
-                        <program value="71"/> <!--Clarinet-->
-                  </Channel>
-            </Instrument>
             <Instrument id="eb-clarinet">
                   <family>clarinets</family>
                   <longName>E♭ Clarinet</longName>
                   <shortName>E♭ Cl.</shortName>
-                  <description>E♭ Clarinet</description>
+                  <description>A soprano clarinet (single-reed woodwind instrument). Sometimes classified as a sopranino clarinet.</description>
                   <musicXMLid>wind.reed.clarinet.eflat</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1991,18 +2227,33 @@
                   <genre>orchestra</genre>
                   <genre>concertband</genre>
             </Instrument>
-            <Instrument id="g-clarinet">
+            <Instrument id="d-clarinet">
                   <family>clarinets</family>
-                  <longName>G Clarinet</longName>
-                  <shortName>G Cl.</shortName>
-                  <description>G Clarinet</description>
+                  <longName>D Clarinet</longName>
+                  <shortName>D Cl.</shortName>
+                  <description>A soprano clarinet (single-reed woodwind instrument). Sometimes classified as a sopranino clarinet.</description>
                   <musicXMLid>wind.reed.clarinet</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>47-86</aPitchRange>
-                  <pPitchRange>47-91</pPitchRange>
-                  <transposeDiatonic>-3</transposeDiatonic>
-                  <transposeChromatic>-5</transposeChromatic>
+                  <aPitchRange>54-93</aPitchRange>
+                  <pPitchRange>54-98</pPitchRange>
+                  <transposeDiatonic>1</transposeDiatonic>
+                  <transposeChromatic>2</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
+                        <program value="71"/> <!--Clarinet-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="c-clarinet">
+                  <family>clarinets</family>
+                  <longName>C Clarinet</longName>
+                  <shortName>C Cl.</shortName>
+                  <description>A soprano clarinet (single-reed woodwind instrument).</description>
+                  <musicXMLid>wind.reed.clarinet</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>52-89</aPitchRange>
+                  <pPitchRange>52-94</pPitchRange>
                   <Channel>
                         <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
                         <program value="71"/> <!--Clarinet-->
@@ -2012,7 +2263,7 @@
                   <family>clarinets</family>
                   <longName>B♭ Clarinet</longName>
                   <shortName>B♭ Cl.</shortName>
-                  <description>B♭ Clarinet (same as clarinet, added for MusicXML 3 compatibility)</description>
+                  <description>A soprano clarinet (single-reed woodwind instrument). The standard clarinet.</description>
                   <musicXMLid>wind.reed.clarinet.bflat</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2030,11 +2281,28 @@
                   <genre>concertband</genre>
                   <genre>marching</genre>
             </Instrument>
+            <Instrument id="clarinet">
+                  <family>clarinets</family>
+                  <longName>Clarinet</longName>
+                  <shortName>Cl.</shortName>
+                  <description>A soprano clarinet (single-reed woodwind instrument).</description>
+                  <musicXMLid>wind.reed.clarinet</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>50-89</aPitchRange>
+                  <pPitchRange>50-94</pPitchRange>
+                  <transposeDiatonic>-1</transposeDiatonic>
+                  <transposeChromatic>-2</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
+                        <program value="71"/> <!--Clarinet-->
+                  </Channel>
+            </Instrument>
             <Instrument id="a-clarinet">
                   <family>clarinets</family>
                   <longName>A Clarinet</longName>
                   <shortName>A Cl.</shortName>
-                  <description>A Clarinet</description>
+                  <description>A soprano clarinet (single-reed woodwind instrument).</description>
                   <musicXMLid>wind.reed.clarinet.a</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2047,6 +2315,40 @@
                         <program value="71"/> <!--Clarinet-->
                   </Channel>
                   <genre>orchestra</genre>
+            </Instrument>
+            <Instrument id="g-clarinet">
+                  <family>clarinets</family>
+                  <longName>G Clarinet</longName>
+                  <shortName>G Cl.</shortName>
+                  <description>A soprano clarinet (single-reed woodwind instrument).</description>
+                  <musicXMLid>wind.reed.clarinet</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>47-86</aPitchRange>
+                  <pPitchRange>47-91</pPitchRange>
+                  <transposeDiatonic>-3</transposeDiatonic>
+                  <transposeChromatic>-5</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
+                        <program value="71"/> <!--Clarinet-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="basset-clarinet">
+                  <family>clarinets</family>
+                  <longName>Basset Clarinet</longName>
+                  <shortName>Ba. Cl.</shortName>
+                  <description>Basset Clarinet</description>
+                  <musicXMLid>wind.reed.clarinet.basset</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>45-88</aPitchRange>
+                  <pPitchRange>45-93</pPitchRange>
+                  <transposeDiatonic>-2</transposeDiatonic>
+                  <transposeChromatic>-3</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
+                        <program value="71"/> <!--Clarinet-->
+                  </Channel>
             </Instrument>
             <Instrument id="alto-clarinet">
                   <family>clarinets</family>
@@ -2065,23 +2367,6 @@
                         <program value="71"/> <!--Clarinet-->
                   </Channel>
                   <genre>concertband</genre>
-            </Instrument>
-            <Instrument id="basset-clarinet">
-                  <family>clarinets</family>
-                  <longName>Basset Clarinet</longName>
-                  <shortName>Ba. Cl.</shortName>
-                  <description>Basset Clarinet</description>
-                  <musicXMLid>wind.reed.clarinet.basset</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>45-88</aPitchRange>
-                  <pPitchRange>45-93</pPitchRange>
-                  <transposeDiatonic>-2</transposeDiatonic>
-                  <transposeChromatic>-3</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
-                        <program value="71"/> <!--Clarinet-->
-                  </Channel>
             </Instrument>
             <Instrument id="basset-horn">
                   <family>clarinets</family>
@@ -2239,43 +2524,104 @@
                   <genre>orchestra</genre>
                   <genre>concertband</genre>
             </Instrument>
-            <Instrument id="xaphoon">
-                  <longName>Pocket Sax in C</longName>
-                  <shortName>C Pkt. Sax</shortName>
-                  <description>Xaphoon/Pocket Sax in C</description>
-                  <musicXMLid>wind.reed.xaphoon</musicXMLid>
-                  <transposingClef>G</transposingClef>
-                  <concertClef>G8vb</concertClef>
+            <Instrument id="sopranino-chalumeau">
+                  <family>chalumeaus</family>
+                  <longName>Sopranino Chalumeau</longName>
+                  <shortName>Si. Cha.</shortName>
+                  <description>Sopranino Chalumeau</description>
+                  <musicXMLid>wind.reed.chalumeau</musicXMLid>
+                  <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>60-77</aPitchRange>
-                  <pPitchRange>59-84</pPitchRange>
+                  <aPitchRange>65-79</aPitchRange>
+                  <pPitchRange>65-82</pPitchRange>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
-                        <program value="71"/> <!--Clarinet-->
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
                   </Channel>
-                  <genre>jazz</genre>
-                  <genre>world</genre>
+                  <genre>earlymusic</genre>
             </Instrument>
-            <Instrument id="bb-xaphoon">
-                  <longName>Pocket Sax in B♭</longName>
-                  <shortName>B♭ Pkt. Sax</shortName>
-                  <description>Xaphoon/Pocket Sax in B♭</description>
-                  <musicXMLid>wind.reed.xaphoon</musicXMLid>
-                  <transposingClef>G</transposingClef>
-                  <concertClef>G8vb</concertClef>
+            <Instrument id="soprano-chalumeau">
+                  <family>chalumeaus</family>
+                  <longName>Soprano Chalumeau</longName>
+                  <shortName>S. Cha.</shortName>
+                  <description>Soprano Chalumeau</description>
+                  <musicXMLid>wind.reed.chalumeau</musicXMLid>
+                  <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>58-75</aPitchRange>
-                  <pPitchRange>57-83</pPitchRange>
-                  <transposeDiatonic>-1</transposeDiatonic>
-                  <transposeChromatic>-2</transposeChromatic>
+                  <aPitchRange>60-74</aPitchRange>
+                  <pPitchRange>60-77</pPitchRange>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
-                        <program value="71"/> <!--Clarinet-->
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
                   </Channel>
-                  <genre>jazz</genre>
-                  <genre>world</genre>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="alto-chalumeau">
+                  <family>chalumeaus</family>
+                  <longName>Alto Chalumeau</longName>
+                  <shortName>A. Cha.</shortName>
+                  <description>Alto Chalumeau</description>
+                  <musicXMLid>wind.reed.chalumeau</musicXMLid>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>53-67</aPitchRange>
+                  <pPitchRange>53-70</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="chalumeau">
+                  <family>chalumeaus</family>
+                  <longName>Chalumeau</longName>
+                  <shortName>Cha.</shortName>
+                  <description>Chalumeau</description>
+                  <musicXMLid>wind.reed.chalumeau</musicXMLid>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>48-62</aPitchRange>
+                  <pPitchRange>48-65</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="tenor-chalumeau">
+                  <family>chalumeaus</family>
+                  <longName>Tenor Chalumeau</longName>
+                  <shortName>T. Cha.</shortName>
+                  <description>Tenor Chalumeau</description>
+                  <musicXMLid>wind.reed.chalumeau</musicXMLid>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>48-62</aPitchRange>
+                  <pPitchRange>48-65</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="bass-chalumeau">
+                  <family>chalumeaus</family>
+                  <longName>Bass Chalumeau</longName>
+                  <shortName>B. Cha.</shortName>
+                  <description>Bass Chalumeau</description>
+                  <musicXMLid>wind.reed.chalumeau</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>41-55</aPitchRange>
+                  <pPitchRange>41-58</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+                  <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="d-xaphoon">
+                  <family>xaphoons</family>
                   <longName>Pocket Sax in D</longName>
                   <shortName>D Pkt. Sax</shortName>
                   <description>Xaphoon/Pocket Sax in D</description>
@@ -2294,7 +2640,46 @@
                   <genre>jazz</genre>
                   <genre>world</genre>
             </Instrument>
+            <Instrument id="xaphoon">
+                  <family>xaphoons</family>
+                  <longName>Pocket Sax in C</longName>
+                  <shortName>C Pkt. Sax</shortName>
+                  <description>Xaphoon/Pocket Sax in C</description>
+                  <musicXMLid>wind.reed.xaphoon</musicXMLid>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>G8vb</concertClef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>60-77</aPitchRange>
+                  <pPitchRange>59-84</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
+                        <program value="71"/> <!--Clarinet-->
+                  </Channel>
+                  <genre>jazz</genre>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="bb-xaphoon">
+                  <family>xaphoons</family>
+                  <longName>Pocket Sax in B♭</longName>
+                  <shortName>B♭ Pkt. Sax</shortName>
+                  <description>Xaphoon/Pocket Sax in B♭</description>
+                  <musicXMLid>wind.reed.xaphoon</musicXMLid>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>G8vb</concertClef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>58-75</aPitchRange>
+                  <pPitchRange>57-83</pPitchRange>
+                  <transposeDiatonic>-1</transposeDiatonic>
+                  <transposeChromatic>-2</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 71; MS General: Clarinet-->
+                        <program value="71"/> <!--Clarinet-->
+                  </Channel>
+                  <genre>jazz</genre>
+                  <genre>world</genre>
+            </Instrument>
             <Instrument id="g-xaphoon">
+                  <family>xaphoons</family>
                   <longName>Pocket Sax in G</longName>
                   <shortName>G Pkt. Sax</shortName>
                   <description>Xaphoon/Pocket Sax in G</description>
@@ -2313,97 +2698,8 @@
                   <genre>jazz</genre>
                   <genre>world</genre>
             </Instrument>
-            <Instrument id="chalumeau">
-                  <longName>Chalumeau</longName>
-                  <shortName>Cha.</shortName>
-                  <description>Chalumeau</description>
-                  <musicXMLid>wind.reed.chalumeau</musicXMLid>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>48-62</aPitchRange>
-                  <pPitchRange>48-65</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="sopranino-chalumeau">
-                  <longName>Sopranino Chalumeau</longName>
-                  <shortName>Si. Cha.</shortName>
-                  <description>Sopranino Chalumeau</description>
-                  <musicXMLid>wind.reed.chalumeau</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>65-79</aPitchRange>
-                  <pPitchRange>65-82</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="soprano-chalumeau">
-                  <longName>Soprano Chalumeau</longName>
-                  <shortName>S. Cha.</shortName>
-                  <description>Soprano Chalumeau</description>
-                  <musicXMLid>wind.reed.chalumeau</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>60-74</aPitchRange>
-                  <pPitchRange>60-77</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="alto-chalumeau">
-                  <longName>Alto Chalumeau</longName>
-                  <shortName>A. Cha.</shortName>
-                  <description>Alto Chalumeau</description>
-                  <musicXMLid>wind.reed.chalumeau</musicXMLid>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>53-67</aPitchRange>
-                  <pPitchRange>53-70</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="tenor-chalumeau">
-                  <longName>Tenor Chalumeau</longName>
-                  <shortName>T. Cha.</shortName>
-                  <description>Tenor Chalumeau</description>
-                  <musicXMLid>wind.reed.chalumeau</musicXMLid>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>48-62</aPitchRange>
-                  <pPitchRange>48-65</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="bass-chalumeau">
-                  <longName>Bass Chalumeau</longName>
-                  <shortName>B. Cha.</shortName>
-                  <description>Bass Chalumeau</description>
-                  <musicXMLid>wind.reed.chalumeau</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>41-55</aPitchRange>
-                  <pPitchRange>41-58</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
             <Instrument id="tarogato">
+                  <family>tarogatos</family>
                   <longName>Tarogato</longName>
                   <shortName>Tar.</shortName>
                   <description>Tarogato</description>
@@ -2419,6 +2715,7 @@
                   <genre>world</genre>
             </Instrument>
             <Instrument id="octavin">
+                  <family>octavins</family>
                   <longName>Octavin</longName>
                   <shortName>Oct.</shortName>
                   <description>Octavin</description>
@@ -2430,240 +2727,6 @@
                   <Channel>
                         <!--MIDI: Bank 0, Prog 69; MS General: English Horn-->
                         <program value="69"/> <!--English Horn-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="bassoon">
-                  <family>bassoons</family>
-                  <longName>Bassoon</longName>
-                  <shortName>Bsn.</shortName>
-                  <description>Bassoon</description>
-                  <musicXMLid>wind.reed.bassoon</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>34-69</aPitchRange>
-                  <pPitchRange>34-76</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 70; MS General: Bassoon-->
-                        <program value="70"/> <!--Bassoon-->
-                  </Channel>
-                  <genre>common</genre>
-                  <genre>orchestra</genre>
-                  <genre>concertband</genre>
-            </Instrument>
-            <Instrument id="contrabassoon">
-                  <family>bassoons</family>
-                  <longName>Contrabassoon</longName>
-                  <shortName>Cbsn.</shortName>
-                  <description>Contrabassoon</description>
-                  <musicXMLid>wind.reed.contrabassoon</musicXMLid>
-                  <transposingClef>F</transposingClef>
-                  <concertClef>F8vb</concertClef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>22-57</aPitchRange>
-                  <pPitchRange>22-60</pPitchRange>
-                  <transposeDiatonic>-7</transposeDiatonic>
-                  <transposeChromatic>-12</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 70; MS General: Bassoon-->
-                        <program value="70"/> <!--Bassoon-->
-                  </Channel>
-                  <genre>orchestra</genre>
-                  <genre>concertband</genre>
-            </Instrument>
-            <Instrument id="reed-contrabass">
-                  <longName>Reed Contrabass</longName>
-                  <shortName>Rd. Cbs.</shortName>
-                  <description>ReeContrabass</description>
-                  <musicXMLid>wind.reed.contrabass</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>22-57</aPitchRange>
-                  <pPitchRange>22-60</pPitchRange>
-                  <transposeDiatonic>-7</transposeDiatonic>
-                  <transposeChromatic>-12</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 70; MS General: Bassoon-->
-                        <program value="70"/> <!--Bassoon-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="dulcian">
-                  <longName>Dulcian</longName>
-                  <shortName>Du.</shortName>
-                  <description>Dulcian</description>
-                  <musicXMLid>wind.reed.dulcian</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>40-62</aPitchRange>
-                  <pPitchRange>40-65</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="rackett">
-                  <longName>Rackett</longName>
-                  <shortName>Ra.</shortName>
-                  <description>Rackett</description>
-                  <musicXMLid>wind.reed.rackett</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>34-62</aPitchRange>
-                  <pPitchRange>34-65</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="sarrusophone">
-                  <longName>Sarrusophone</longName>
-                  <shortName>Sar.</shortName>
-                  <description>Sarrusophone</description>
-                  <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>56-87</aPitchRange>
-                  <pPitchRange>56-92</pPitchRange>
-                  <transposeDiatonic>-1</transposeDiatonic>
-                  <transposeChromatic>-2</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="sopranino-sarrusophone">
-                  <longName>Sopranino Sarrusophone</longName>
-                  <shortName>Si. Sar.</shortName>
-                  <description>Sopranino Sarrusophone</description>
-                  <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>61-87</aPitchRange>
-                  <pPitchRange>61-90</pPitchRange>
-                  <transposeDiatonic>2</transposeDiatonic>
-                  <transposeChromatic>3</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="soprano-sarrusophone">
-                  <longName>Soprano Sarrusophone</longName>
-                  <shortName>S. Sar.</shortName>
-                  <description>Soprano Sarrusophone</description>
-                  <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>56-87</aPitchRange>
-                  <pPitchRange>56-92</pPitchRange>
-                  <transposeDiatonic>-1</transposeDiatonic>
-                  <transposeChromatic>-2</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="alto-sarrusophone">
-                  <longName>Alto Sarrusophone</longName>
-                  <shortName>A. Sar.</shortName>
-                  <description>Alto Sarrusophone</description>
-                  <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>49-80</aPitchRange>
-                  <pPitchRange>49-85</pPitchRange>
-                  <transposeDiatonic>-5</transposeDiatonic>
-                  <transposeChromatic>-9</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="tenor-sarrusophone">
-                  <longName>Tenor Sarrusophone</longName>
-                  <shortName>T. Sar.</shortName>
-                  <description>Tenor Sarrusophone</description>
-                  <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
-                  <transposingClef>G</transposingClef>
-                  <concertClef>G8vb</concertClef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>44-75</aPitchRange>
-                  <pPitchRange>44-80</pPitchRange>
-                  <transposeDiatonic>-8</transposeDiatonic>
-                  <transposeChromatic>-14</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="baritone-sarrusophone">
-                  <longName>Baritone Sarrusophone</longName>
-                  <shortName>Bar. Sar.</shortName>
-                  <description>Baritone Sarrusophone</description>
-                  <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
-                  <transposingClef>G</transposingClef>
-                  <concertClef>F</concertClef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>37-68</aPitchRange>
-                  <pPitchRange>36-73</pPitchRange>
-                  <transposeDiatonic>-12</transposeDiatonic>
-                  <transposeChromatic>-21</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="bass-sarrusophone">
-                  <longName>Bass Sarrusophone</longName>
-                  <shortName>B. Sar.</shortName>
-                  <description>Bass Sarrusophone</description>
-                  <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
-                  <transposingClef>G</transposingClef>
-                  <concertClef>F</concertClef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>32-63</aPitchRange>
-                  <pPitchRange>32-68</pPitchRange>
-                  <transposeDiatonic>-15</transposeDiatonic>
-                  <transposeChromatic>-26</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="contrabass-sarrusophone">
-                  <longName>Contrabass Sarrusophone</longName>
-                  <shortName>Cb. Sar.</shortName>
-                  <description>Contrabass Sarrusophone</description>
-                  <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
-                  <transposingClef>G</transposingClef>
-                  <concertClef>F8vb</concertClef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>25-53</aPitchRange>
-                  <pPitchRange>25-56</pPitchRange>
-                  <transposeDiatonic>-19</transposeDiatonic>
-                  <transposeChromatic>-33</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
-                        <program value="67"/> <!--Baritone Sax-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="saxophone">
-                  <family>saxophones</family>
-                  <longName>Saxophone</longName>
-                  <shortName>Sax.</shortName>
-                  <description>Saxophone</description>
-                  <musicXMLid>wind.reed.saxophone</musicXMLid>
-                  <transposingClef>G</transposingClef>
-                  <concertClef>G8vb</concertClef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>44-77</aPitchRange>
-                  <pPitchRange>44-82</pPitchRange>
-                  <transposeDiatonic>-8</transposeDiatonic>
-                  <transposeChromatic>-14</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 66; MS General: Tenor Sax-->
-                        <program value="66"/> <!--Tenor Sax-->
                   </Channel>
             </Instrument>
             <Instrument id="sopranissimo-saxophone">
@@ -2701,6 +2764,23 @@
                   </Channel>
                   <genre>jazz</genre>
             </Instrument>
+            <Instrument id="aulochrome">
+                  <family>saxophones</family>
+                  <longName>Aulochrome</longName>
+                  <shortName>Aul.</shortName>
+                  <description>2 soprano saxes joined together</description>
+                  <musicXMLid>wind.reed.saxophone.aulochrome</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>56-89</aPitchRange>
+                  <pPitchRange>56-94</pPitchRange>
+                  <transposeDiatonic>-1</transposeDiatonic>
+                  <transposeChromatic>-2</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 64; MS General: Soprano Sax-->
+                        <program value="64"/> <!--Soprano Sax-->
+                  </Channel>
+            </Instrument>
             <Instrument id="soprano-saxophone">
                   <family>saxophones</family>
                   <longName>Soprano Saxophone</longName>
@@ -2723,23 +2803,6 @@
                   <genre>concertband</genre>
                   <genre>marching</genre>
             </Instrument>
-            <Instrument id="aulochrome">
-                  <family>saxophones</family>
-                  <longName>Aulochrome</longName>
-                  <shortName>Aul.</shortName>
-                  <description>2 soprano saxes joined together</description>
-                  <musicXMLid>wind.reed.saxophone.aulochrome</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>56-89</aPitchRange>
-                  <pPitchRange>56-94</pPitchRange>
-                  <transposeDiatonic>-1</transposeDiatonic>
-                  <transposeChromatic>-2</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 64; MS General: Soprano Sax-->
-                        <program value="64"/> <!--Soprano Sax-->
-                  </Channel>
-            </Instrument>
             <Instrument id="mezzo-soprano-saxophone">
                   <family>saxophones</family>
                   <longName>Mezzo-Soprano Saxophone</longName>
@@ -2755,6 +2818,21 @@
                   <Channel>
                         <!--MIDI: Bank 0, Prog 65; MS General: Alto Sax-->
                         <program value="65"/> <!--Alto Sax-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="heckelphone-clarinet">
+                  <family>saxophones</family>
+                  <longName>Heckelphone-clarinet</longName>
+                  <shortName>Hph.-cl.</shortName>
+                  <description>Heckelphone</description>
+                  <musicXMLid>wind.reed.heckelphone-clarinet</musicXMLid>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>50-84</aPitchRange>
+                  <pPitchRange>50-84</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 68; MS General: Oboe-->
+                        <program value="68"/> <!--Oboe-->
                   </Channel>
             </Instrument>
             <Instrument id="alto-saxophone">
@@ -2793,6 +2871,24 @@
                   <pPitchRange>46-77</pPitchRange>
                   <transposeDiatonic>-7</transposeDiatonic>
                   <transposeChromatic>-12</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 66; MS General: Tenor Sax-->
+                        <program value="66"/> <!--Tenor Sax-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="saxophone">
+                  <family>saxophones</family>
+                  <longName>Saxophone</longName>
+                  <shortName>Sax.</shortName>
+                  <description>Saxophone</description>
+                  <musicXMLid>wind.reed.saxophone</musicXMLid>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>G8vb</concertClef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>44-77</aPitchRange>
+                  <pPitchRange>44-82</pPitchRange>
+                  <transposeDiatonic>-8</transposeDiatonic>
+                  <transposeChromatic>-14</transposeChromatic>
                   <Channel>
                         <!--MIDI: Bank 0, Prog 66; MS General: Tenor Sax-->
                         <program value="66"/> <!--Tenor Sax-->
@@ -2900,7 +2996,235 @@
                         <program value="67"/> <!--Baritone Sax-->
                   </Channel>
             </Instrument>
+            <Instrument id="bassoon">
+                  <family>bassoons</family>
+                  <longName>Bassoon</longName>
+                  <shortName>Bsn.</shortName>
+                  <description>Bassoon</description>
+                  <musicXMLid>wind.reed.bassoon</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>34-69</aPitchRange>
+                  <pPitchRange>34-76</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 70; MS General: Bassoon-->
+                        <program value="70"/> <!--Bassoon-->
+                  </Channel>
+                  <genre>common</genre>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
+            </Instrument>
+            <Instrument id="contrabassoon">
+                  <family>bassoons</family>
+                  <longName>Contrabassoon</longName>
+                  <shortName>Cbsn.</shortName>
+                  <description>Contrabassoon</description>
+                  <musicXMLid>wind.reed.contrabassoon</musicXMLid>
+                  <transposingClef>F</transposingClef>
+                  <concertClef>F8vb</concertClef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>22-57</aPitchRange>
+                  <pPitchRange>22-60</pPitchRange>
+                  <transposeDiatonic>-7</transposeDiatonic>
+                  <transposeChromatic>-12</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 70; MS General: Bassoon-->
+                        <program value="70"/> <!--Bassoon-->
+                  </Channel>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
+            </Instrument>
+            <Instrument id="reed-contrabass">
+                  <family>reed-contrabasses</family>
+                  <longName>Reed Contrabass</longName>
+                  <shortName>Rd. Cbs.</shortName>
+                  <description>Reed Contrabass</description>
+                  <musicXMLid>wind.reed.contrabass</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>22-57</aPitchRange>
+                  <pPitchRange>22-60</pPitchRange>
+                  <transposeDiatonic>-7</transposeDiatonic>
+                  <transposeChromatic>-12</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 70; MS General: Bassoon-->
+                        <program value="70"/> <!--Bassoon-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="dulcian">
+                  <family>dulcians</family>
+                  <longName>Dulcian</longName>
+                  <shortName>Du.</shortName>
+                  <description>Dulcian</description>
+                  <musicXMLid>wind.reed.dulcian</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>40-62</aPitchRange>
+                  <pPitchRange>40-65</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="rackett">
+                  <family>racketts</family>
+                  <longName>Rackett</longName>
+                  <shortName>Ra.</shortName>
+                  <description>Rackett</description>
+                  <musicXMLid>wind.reed.rackett</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>34-62</aPitchRange>
+                  <pPitchRange>34-65</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="sopranino-sarrusophone">
+                  <family>sarrusophones</family>
+                  <longName>Sopranino Sarrusophone</longName>
+                  <shortName>Si. Sar.</shortName>
+                  <description>Sopranino Sarrusophone</description>
+                  <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>61-87</aPitchRange>
+                  <pPitchRange>61-90</pPitchRange>
+                  <transposeDiatonic>2</transposeDiatonic>
+                  <transposeChromatic>3</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="sarrusophone">
+                  <family>sarrusophones</family>
+                  <longName>Sarrusophone</longName>
+                  <shortName>Sar.</shortName>
+                  <description>Sarrusophone</description>
+                  <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>56-87</aPitchRange>
+                  <pPitchRange>56-92</pPitchRange>
+                  <transposeDiatonic>-1</transposeDiatonic>
+                  <transposeChromatic>-2</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="soprano-sarrusophone">
+                  <family>sarrusophones</family>
+                  <longName>Soprano Sarrusophone</longName>
+                  <shortName>S. Sar.</shortName>
+                  <description>Soprano Sarrusophone</description>
+                  <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>56-87</aPitchRange>
+                  <pPitchRange>56-92</pPitchRange>
+                  <transposeDiatonic>-1</transposeDiatonic>
+                  <transposeChromatic>-2</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="alto-sarrusophone">
+                  <family>sarrusophones</family>
+                  <longName>Alto Sarrusophone</longName>
+                  <shortName>A. Sar.</shortName>
+                  <description>Alto Sarrusophone</description>
+                  <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>49-80</aPitchRange>
+                  <pPitchRange>49-85</pPitchRange>
+                  <transposeDiatonic>-5</transposeDiatonic>
+                  <transposeChromatic>-9</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="tenor-sarrusophone">
+                  <family>sarrusophones</family>
+                  <longName>Tenor Sarrusophone</longName>
+                  <shortName>T. Sar.</shortName>
+                  <description>Tenor Sarrusophone</description>
+                  <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>G8vb</concertClef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>44-75</aPitchRange>
+                  <pPitchRange>44-80</pPitchRange>
+                  <transposeDiatonic>-8</transposeDiatonic>
+                  <transposeChromatic>-14</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="baritone-sarrusophone">
+                  <family>sarrusophones</family>
+                  <longName>Baritone Sarrusophone</longName>
+                  <shortName>Bar. Sar.</shortName>
+                  <description>Baritone Sarrusophone</description>
+                  <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>F</concertClef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>37-68</aPitchRange>
+                  <pPitchRange>36-73</pPitchRange>
+                  <transposeDiatonic>-12</transposeDiatonic>
+                  <transposeChromatic>-21</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="bass-sarrusophone">
+                  <family>sarrusophones</family>
+                  <longName>Bass Sarrusophone</longName>
+                  <shortName>B. Sar.</shortName>
+                  <description>Bass Sarrusophone</description>
+                  <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>F</concertClef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>32-63</aPitchRange>
+                  <pPitchRange>32-68</pPitchRange>
+                  <transposeDiatonic>-15</transposeDiatonic>
+                  <transposeChromatic>-26</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="contrabass-sarrusophone">
+                  <family>sarrusophones</family>
+                  <longName>Contrabass Sarrusophone</longName>
+                  <shortName>Cb. Sar.</shortName>
+                  <description>Contrabass Sarrusophone</description>
+                  <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>F8vb</concertClef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>25-53</aPitchRange>
+                  <pPitchRange>25-56</pPitchRange>
+                  <transposeDiatonic>-19</transposeDiatonic>
+                  <transposeChromatic>-33</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
+                        <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+            </Instrument>
             <Instrument id="bagpipe">
+                  <family>bagpipes</family>
                   <longName>Bagpipe</longName>
                   <shortName>Bagp.</shortName>
                   <description>Bagpipe</description>
@@ -2920,248 +3244,8 @@
       </InstrumentGroup>
       <InstrumentGroup id="free-reed">
             <name>Free Reed</name>
-            <Instrument id="harmonica">
-                  <longName>Harmonica</longName>
-                  <shortName>Harm.</shortName>
-                  <description>Harmonica</description>
-                  <musicXMLid>wind.reed.harmonica</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>60-96</aPitchRange>
-                  <pPitchRange>60-96</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
-                        <program value="22"/> <!--Harmonica-->
-                  </Channel>
-                  <genre>common</genre>
-                  <genre>popular</genre>
-                  <genre>jazz</genre>
-            </Instrument>
-            <Instrument id="harmonica-c12c">
-                  <longName>12 Hole C Chromatic Harmonica</longName>
-                  <shortName>Harm.</shortName>
-                  <description>12 Hole Chromatic Harmonica in C</description>
-                  <musicXMLid>wind.reed.harmonica</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>60-98</aPitchRange>
-                  <pPitchRange>60-98</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
-                        <program value="22"/> <!--Harmonica-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="harmonica-c14c">
-                  <longName>14 Hole C Chromatic Harmonica</longName>
-                  <shortName>Harm.</shortName>
-                  <description>14 Hole Chromatic Harmonica in C</description>
-                  <musicXMLid>wind.reed.harmonica</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>55-98</aPitchRange>
-                  <pPitchRange>55-98</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
-                        <program value="22"/> <!--Harmonica-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="harmonica-c12g">
-                  <longName>12 Hole G Chromatic Harmonica</longName>
-                  <shortName>Harm.</shortName>
-                  <description>12 Hole Chromatic Harmonica in G</description>
-                  <musicXMLid>wind.reed.harmonica</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>55-93</aPitchRange>
-                  <pPitchRange>55-93</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
-                        <program value="22"/> <!--Harmonica-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="harmonica-c16c">
-                  <longName>16 Hole C Chromatic Harmonica</longName>
-                  <shortName>Harm.</shortName>
-                  <description>16 Hole Chromatic Harmonica in C</description>
-                  <musicXMLid>wind.reed.harmonica</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>48-98</aPitchRange>
-                  <pPitchRange>48-98</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
-                        <program value="22"/> <!--Harmonica-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="harmonica-c12tenor-c">
-                  <longName>12 Hole Tenor C Chromatic Harmonica</longName>
-                  <shortName>Harm.</shortName>
-                  <description>12 Hole Chromatic Harmonica in Tenor C</description>
-                  <musicXMLid>wind.reed.harmonica</musicXMLid>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>48-86</aPitchRange>
-                  <pPitchRange>48-86</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
-                        <program value="22"/> <!--Harmonica-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="harmonica-d12high-g">
-                  <longName>10 Hole High G Diatonic Harmonica</longName>
-                  <shortName>Harm.</shortName>
-                  <description>10 Hole Diatonic Harmonica in High G</description>
-                  <musicXMLid>wind.reed.harmonica</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>67-103</aPitchRange>
-                  <pPitchRange>67-103</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
-                        <program value="22"/> <!--Harmonica-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="harmonica-d12f">
-                  <longName>10 Hole F Diatonic Harmonica</longName>
-                  <shortName>Harm.</shortName>
-                  <description>10 Hole Diatonic Harmonica in F</description>
-                  <musicXMLid>wind.reed.harmonica</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>65-101</aPitchRange>
-                  <pPitchRange>65-101</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
-                        <program value="22"/> <!--Harmonica-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="harmonica-d12d">
-                  <longName>10 Hole D Diatonic Harmonica</longName>
-                  <shortName>Harm.</shortName>
-                  <description>10 Hole Diatonic Harmonica in D</description>
-                  <musicXMLid>wind.reed.harmonica</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>62-98</aPitchRange>
-                  <pPitchRange>62-98</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
-                        <program value="22"/> <!--Harmonica-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="harmonica-d12c">
-                  <longName>10 Hole C Diatonic Harmonica</longName>
-                  <shortName>Harm.</shortName>
-                  <description>10 Hole Diatonic Harmonica in C</description>
-                  <musicXMLid>wind.reed.harmonica</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>60-96</aPitchRange>
-                  <pPitchRange>60-96</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
-                        <program value="22"/> <!--Harmonica-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="harmonica-d12a">
-                  <longName>10 Hole A Diatonic Harmonica</longName>
-                  <shortName>Harm.</shortName>
-                  <description>10 Hole Diatonic Harmonica in A</description>
-                  <musicXMLid>wind.reed.harmonica</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>57-93</aPitchRange>
-                  <pPitchRange>57-93</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
-                        <program value="22"/> <!--Harmonica-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="harmonica-d12-g">
-                  <longName>10 Hole G Diatonic Harmonica</longName>
-                  <shortName>Harm.</shortName>
-                  <description>10 Hole Diatonic Harmonica in G</description>
-                  <musicXMLid>wind.reed.harmonica</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>55-91</aPitchRange>
-                  <pPitchRange>55-91</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
-                        <program value="22"/> <!--Harmonica-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="harmonica-d10low-d">
-                  <longName>10 Hole Low D Diatonic Harmonica</longName>
-                  <shortName>Harm.</shortName>
-                  <description>10 Hole Diatonic Harmonica in Low D</description>
-                  <musicXMLid>wind.reed.harmonica</musicXMLid>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>50-86</aPitchRange>
-                  <pPitchRange>50-86</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
-                        <program value="22"/> <!--Harmonica-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="harmonica-chordet">
-                  <longName>20 Hole Chordet Harmonica</longName>
-                  <shortName>Harm.</shortName>
-                  <description>20 Hole Huang Chordet Harmonica</description>
-                  <musicXMLid>wind.reed.harmonica</musicXMLid>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>58-66</aPitchRange>
-                  <pPitchRange>58-66</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
-                        <program value="22"/> <!--Harmonica-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="bass-harmonica">
-                  <longName>Bass Harmonica</longName>
-                  <shortName>Bs. Harm.</shortName>
-                  <description>Bass Harmonica</description>
-                  <musicXMLid>wind.reed.harmonica.bass</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>40-64</aPitchRange>
-                  <pPitchRange>40-64</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
-                        <program value="22"/> <!--Harmonica-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="bass-harmonica-hohner">
-                  <longName>Bass Hohner Harmonica</longName>
-                  <shortName>Bs. Harm.</shortName>
-                  <description>Bass 31 hole Hohner Harmonica</description>
-                  <musicXMLid>wind.reed.harmonica.bass</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>40-72</aPitchRange>
-                  <pPitchRange>40-72</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
-                        <program value="22"/> <!--Harmonica-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="bass-harmonica-huang">
-                  <longName>Bass Huang Harmonica</longName>
-                  <shortName>Bs. Harm.</shortName>
-                  <description>Bass 30 hole Huang Harmonica</description>
-                  <musicXMLid>wind.reed.harmonica.bass</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>40-65</aPitchRange>
-                  <pPitchRange>40-65</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
-                        <program value="22"/> <!--Harmonica-->
-                  </Channel>
-            </Instrument>
             <Instrument id="accordion">
+                  <family>accordions</family>
                   <longName>Accordion</longName>
                   <shortName>Acc.</shortName>
                   <description>Accordion</description>
@@ -3182,6 +3266,7 @@
                   <genre>jazz</genre>
             </Instrument>
             <Instrument id="bandoneon">
+                  <family>accordions</family>
                   <longName>Bandoneon</longName>
                   <shortName>Ban.</shortName>
                   <description>Bandoneon</description>
@@ -3201,6 +3286,7 @@
                   <genre>world</genre>
             </Instrument>
             <Instrument id="concertina">
+                  <family>accordions</family>
                   <longName>Concertina</longName>
                   <shortName>Conc.</shortName>
                   <description>Concertina</description>
@@ -3218,7 +3304,266 @@
                         <program value="21"/> <!--Accordion-->
                   </Channel>
             </Instrument>
+            <Instrument id="harmonica">
+                  <family>harmonicas</family>
+                  <longName>Harmonica</longName>
+                  <shortName>Harm.</shortName>
+                  <description>Harmonica</description>
+                  <musicXMLid>wind.reed.harmonica</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>60-96</aPitchRange>
+                  <pPitchRange>60-96</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
+                        <program value="22"/> <!--Harmonica-->
+                  </Channel>
+                  <genre>common</genre>
+                  <genre>popular</genre>
+                  <genre>jazz</genre>
+            </Instrument>
+            <Instrument id="harmonica-d12high-g">
+                  <family>harmonicas</family>
+                  <longName>10 Hole High G Diatonic Harmonica</longName>
+                  <shortName>Harm.</shortName>
+                  <description>Harmonica tuned to G (written in C, non-transposing).</description>
+                  <musicXMLid>wind.reed.harmonica</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>67-103</aPitchRange>
+                  <pPitchRange>67-103</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
+                        <program value="22"/> <!--Harmonica-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="harmonica-d12f">
+                  <family>harmonicas</family>
+                  <longName>10 Hole F Diatonic Harmonica</longName>
+                  <shortName>Harm.</shortName>
+                  <description>Harmonica tuned to F (written in C, non-transposing).</description>
+                  <musicXMLid>wind.reed.harmonica</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>65-101</aPitchRange>
+                  <pPitchRange>65-101</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
+                        <program value="22"/> <!--Harmonica-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="harmonica-d12d">
+                  <family>harmonicas</family>
+                  <longName>10 Hole D Diatonic Harmonica</longName>
+                  <shortName>Harm.</shortName>
+                  <description>Harmonica tuned to D (written in C, non-transposing).</description>
+                  <musicXMLid>wind.reed.harmonica</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>62-98</aPitchRange>
+                  <pPitchRange>62-98</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
+                        <program value="22"/> <!--Harmonica-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="harmonica-d12c">
+                  <family>harmonicas</family>
+                  <longName>10 Hole C Diatonic Harmonica</longName>
+                  <shortName>Harm.</shortName>
+                  <description>Harmonica tuned to C (non-transposing).</description>
+                  <musicXMLid>wind.reed.harmonica</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>60-96</aPitchRange>
+                  <pPitchRange>60-96</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
+                        <program value="22"/> <!--Harmonica-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="harmonica-d12a">
+                  <family>harmonicas</family>
+                  <longName>10 Hole A Diatonic Harmonica</longName>
+                  <shortName>Harm.</shortName>
+                  <description>Harmonica tuned to A (written in C, non-transposing).</description>
+                  <musicXMLid>wind.reed.harmonica</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>57-93</aPitchRange>
+                  <pPitchRange>57-93</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
+                        <program value="22"/> <!--Harmonica-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="harmonica-d12-g">
+                  <family>harmonicas</family>
+                  <longName>10 Hole G Diatonic Harmonica</longName>
+                  <shortName>Harm.</shortName>
+                  <description>Harmonica tuned to G (written in C, non-transposing).</description>
+                  <musicXMLid>wind.reed.harmonica</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>55-91</aPitchRange>
+                  <pPitchRange>55-91</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
+                        <program value="22"/> <!--Harmonica-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="harmonica-d10low-d">
+                  <family>harmonicas</family>
+                  <longName>10 Hole Low D Diatonic Harmonica</longName>
+                  <shortName>Harm.</shortName>
+                  <description>Harmonica tuned to D (written in C, non-transposing).</description>
+                  <musicXMLid>wind.reed.harmonica</musicXMLid>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>50-86</aPitchRange>
+                  <pPitchRange>50-86</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
+                        <program value="22"/> <!--Harmonica-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="harmonica-c12c">
+                  <family>harmonicas</family>
+                  <longName>12 Hole C Chromatic Harmonica</longName>
+                  <shortName>Harm.</shortName>
+                  <description>Harmonica tuned to C (non-transposing).</description>
+                  <musicXMLid>wind.reed.harmonica</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>60-98</aPitchRange>
+                  <pPitchRange>60-98</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
+                        <program value="22"/> <!--Harmonica-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="harmonica-c12g">
+                  <family>harmonicas</family>
+                  <longName>12 Hole G Chromatic Harmonica</longName>
+                  <shortName>Harm.</shortName>
+                  <description>Harmonica tuned to G (written in C, non-transposing).</description>
+                  <musicXMLid>wind.reed.harmonica</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>55-93</aPitchRange>
+                  <pPitchRange>55-93</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
+                        <program value="22"/> <!--Harmonica-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="harmonica-c12tenor-c">
+                  <family>harmonicas</family>
+                  <longName>12 Hole Tenor C Chromatic Harmonica</longName>
+                  <shortName>Harm.</shortName>
+                  <description>Harmonica tuned to C (non-transposing).</description>
+                  <musicXMLid>wind.reed.harmonica</musicXMLid>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>48-86</aPitchRange>
+                  <pPitchRange>48-86</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
+                        <program value="22"/> <!--Harmonica-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="harmonica-c14c">
+                  <family>harmonicas</family>
+                  <longName>14 Hole C Chromatic Harmonica</longName>
+                  <shortName>Harm.</shortName>
+                  <description>Harmonica tuned to C (non-transposing).</description>
+                  <musicXMLid>wind.reed.harmonica</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>55-98</aPitchRange>
+                  <pPitchRange>55-98</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
+                        <program value="22"/> <!--Harmonica-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="harmonica-c16c">
+                  <family>harmonicas</family>
+                  <longName>16 Hole C Chromatic Harmonica</longName>
+                  <shortName>Harm.</shortName>
+                  <description>Harmonica tuned to C (non-transposing).</description>
+                  <musicXMLid>wind.reed.harmonica</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>48-98</aPitchRange>
+                  <pPitchRange>48-98</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
+                        <program value="22"/> <!--Harmonica-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="harmonica-chordet">
+                  <family>harmonicas</family>
+                  <longName>20 Hole Chordet Harmonica</longName>
+                  <shortName>Harm.</shortName>
+                  <description>20 Hole Huang Chordet Harmonica</description>
+                  <musicXMLid>wind.reed.harmonica</musicXMLid>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>58-66</aPitchRange>
+                  <pPitchRange>58-66</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
+                        <program value="22"/> <!--Harmonica-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="bass-harmonica-hohner">
+                  <family>harmonicas</family>
+                  <longName>Bass Hohner Harmonica</longName>
+                  <shortName>Bs. Harm.</shortName>
+                  <description>Bass 31 hole Hohner Harmonica</description>
+                  <musicXMLid>wind.reed.harmonica.bass</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>40-72</aPitchRange>
+                  <pPitchRange>40-72</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
+                        <program value="22"/> <!--Harmonica-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="bass-harmonica-huang">
+                  <family>harmonicas</family>
+                  <longName>Bass Huang Harmonica</longName>
+                  <shortName>Bs. Harm.</shortName>
+                  <description>Bass 30 hole Huang Harmonica</description>
+                  <musicXMLid>wind.reed.harmonica.bass</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>40-65</aPitchRange>
+                  <pPitchRange>40-65</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
+                        <program value="22"/> <!--Harmonica-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="bass-harmonica">
+                  <family>harmonicas</family>
+                  <longName>Bass Harmonica</longName>
+                  <shortName>Bs. Harm.</shortName>
+                  <description>Bass Harmonica</description>
+                  <musicXMLid>wind.reed.harmonica.bass</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>40-64</aPitchRange>
+                  <pPitchRange>40-64</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 22; MS General: Harmonica-->
+                        <program value="22"/> <!--Harmonica-->
+                  </Channel>
+            </Instrument>
             <Instrument id="melodica">
+                  <family>melodicas</family>
                   <longName>Melodica</longName>
                   <shortName>Mel.</shortName>
                   <description>Melodica</description>
@@ -3233,6 +3578,7 @@
                   </Channel>
             </Instrument>
             <Instrument id="sheng">
+                  <family>shengs</family>
                   <longName>Sheng</longName>
                   <shortName>She.</shortName>
                   <description>Sheng (generic)</description>
@@ -3248,6 +3594,7 @@
                   <genre>world</genre>
             </Instrument>
             <Instrument id="soprano-sheng">
+                  <family>shengs</family>
                   <longName>Soprano Sheng</longName>
                   <shortName>S She.</shortName>
                   <description>Soprano Sheng</description>
@@ -3263,6 +3610,7 @@
                   <genre>world</genre>
             </Instrument>
             <Instrument id="alto-sheng">
+                  <family>shengs</family>
                   <longName>Alto Sheng</longName>
                   <shortName>A She.</shortName>
                   <description>Alto Sheng</description>
@@ -3278,6 +3626,7 @@
                   <genre>world</genre>
             </Instrument>
             <Instrument id="tenor-sheng">
+                  <family>shengs</family>
                   <longName>Tenor Sheng</longName>
                   <shortName>T She.</shortName>
                   <description>Tenor Sheng</description>
@@ -3293,6 +3642,7 @@
                   <genre>world</genre>
             </Instrument>
             <Instrument id="bass-sheng">
+                  <family>shengs</family>
                   <longName>Bass Sheng</longName>
                   <shortName>B She.</shortName>
                   <description>Bass Sheng</description>
@@ -3311,9 +3661,10 @@
       <InstrumentGroup id="brass">
             <name>Brass</name>
             <Instrument id="brass">
+                  <family>brass</family>
                   <longName>Brass</longName>
                   <shortName>Br.</shortName>
-                  <description>Brass Section</description>
+                  <description>Brass section on grand staff as used in Tchaikovsky’s 1812 Overture.</description>
                   <musicXMLid>brass.group</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -3327,31 +3678,6 @@
                         <!--MIDI: Bank 0, Prog 61; MS General: Brass Section-->
                         <program value="61"/> <!--Brass Section-->
                   </Channel>
-            </Instrument>
-            <Instrument id="horn">
-                  <family>horns</family>
-                  <longName>Horn in F</longName>
-                  <shortName>F Hn.</shortName>
-                  <description>Horn</description>
-                  <musicXMLid>brass.french-horn</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>41-69</aPitchRange>
-                  <pPitchRange>31-77</pPitchRange>
-                  <transposeDiatonic>-4</transposeDiatonic>
-                  <transposeChromatic>-7</transposeChromatic>
-                  <Channel name="open">
-                        <!--MIDI: Bank 0, Prog 60; MS General: French Horns-->
-                        <program value="60"/> <!--French Horn-->
-                  </Channel>
-                  <Channel name="mute">
-                        <!--MIDI: Bank 0, Prog 59; MS General: Harmon Mute Trumpet-->
-                        <program value="59"/> <!--Muted Trumpet-->
-                  </Channel>
-                  <genre>common</genre>
-                  <genre>orchestra</genre>
-                  <genre>concertband</genre>
-                  <genre>marching</genre>
             </Instrument>
             <Instrument id="c-horn-alto">
                   <family>horns</family>
@@ -3519,6 +3845,31 @@
                         <program value="59"/> <!--Muted Trumpet-->
                   </Channel>
             </Instrument>
+            <Instrument id="horn">
+                  <family>horns</family>
+                  <longName>Horn in F</longName>
+                  <shortName>F Hn.</shortName>
+                  <description>Horn</description>
+                  <musicXMLid>brass.french-horn</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>41-69</aPitchRange>
+                  <pPitchRange>31-77</pPitchRange>
+                  <transposeDiatonic>-4</transposeDiatonic>
+                  <transposeChromatic>-7</transposeChromatic>
+                  <Channel name="open">
+                        <!--MIDI: Bank 0, Prog 60; MS General: French Horns-->
+                        <program value="60"/> <!--French Horn-->
+                  </Channel>
+                  <Channel name="mute">
+                        <!--MIDI: Bank 0, Prog 59; MS General: Harmon Mute Trumpet-->
+                        <program value="59"/> <!--Muted Trumpet-->
+                  </Channel>
+                  <genre>common</genre>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
+                  <genre>marching</genre>
+            </Instrument>
             <Instrument id="c-horn">
                   <family>horns</family>
                   <longName>Horn in C</longName>
@@ -3546,7 +3897,7 @@
                   <trackName>Horn in C (Bass Clef)</trackName>
                   <longName>Horn in C</longName>
                   <shortName>C Hn.</shortName>
-                  <description>Horn in C</description>
+                  <description>Horn in C (bass clef)</description>
                   <musicXMLid>brass.natural-horn</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3601,6 +3952,57 @@
                   <Channel name="mute">
                         <!--MIDI: Bank 0, Prog 59; MS General: Harmon Mute Trumpet-->
                         <program value="59"/> <!--Muted Trumpet-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="bb-wagner-tuba">
+                  <family>wagner-tubas</family>
+                  <longName>B♭ Wagner Tuba</longName>
+                  <shortName>B♭ Wag. Tb.</shortName>
+                  <description>B♭ Wagner Tuba</description>
+                  <musicXMLid>brass.wagner-tuba</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>40-75</aPitchRange>
+                  <pPitchRange>40-79</pPitchRange>
+                  <transposeDiatonic>-1</transposeDiatonic>
+                  <transposeChromatic>-2</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 60; MS General: French Horns-->
+                        <program value="60"/> <!--French Horn-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="f-wagner-tuba">
+                  <family>wagner-tubas</family>
+                  <longName>F Wagner Tuba</longName>
+                  <shortName>F Wag. Tb.</shortName>
+                  <description>F Wagner Tuba</description>
+                  <musicXMLid>brass.wagner-tuba</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>35-74</aPitchRange>
+                  <pPitchRange>35-77</pPitchRange>
+                  <transposeDiatonic>-4</transposeDiatonic>
+                  <transposeChromatic>-7</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 56; MS General: Trumpet-->
+                        <program value="56"/> <!--Trumpet-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="wagner-tuba">
+                  <family>wagner-tubas</family>
+                  <longName>Wagner Tuba</longName>
+                  <shortName>Wag. Tb.</shortName>
+                  <description>F Wagner Tuba (generic)</description>
+                  <musicXMLid>brass.wagner-tuba</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>35-74</aPitchRange>
+                  <pPitchRange>35-77</pPitchRange>
+                  <transposeDiatonic>-4</transposeDiatonic>
+                  <transposeChromatic>-7</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 56; MS General: Trumpet-->
+                        <program value="56"/> <!--Trumpet-->
                   </Channel>
             </Instrument>
             <Instrument id="eb-cornet">
@@ -3690,6 +4092,7 @@
                   </Channel>
             </Instrument>
             <Instrument id="saxhorn">
+                  <family>saxhorns</family>
                   <longName>Saxhorn</longName>
                   <shortName>Saxhorn</shortName>
                   <description>Saxhorn</description>
@@ -3778,7 +4181,7 @@
                   <trackName>Baritone Horn (Treble Clef)</trackName>
                   <longName>Baritone Horn</longName>
                   <shortName>Bar. Hn.</shortName>
-                  <description>Baritone Horn</description>
+                  <description>Baritone Horn (treble clef)</description>
                   <musicXMLid>brass.baritone-horn</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -3796,28 +4199,6 @@
                         <program value="59"/> <!--Muted Trumpet-->
                   </Channel>
                   <genre>concertband</genre>
-            </Instrument>
-            <Instrument id="baritone-horn-central-europe">
-                  <family>baritone-horns</family>
-                  <trackName>Baritone Horn (Central Europe)</trackName>
-                  <longName>Baritone Horn</longName>
-                  <shortName>Bar. Hn.</shortName>
-                  <description>Baritone Horn (Central Europe)</description>
-                  <musicXMLid>brass.baritone-horn</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>40-67</aPitchRange>
-                  <pPitchRange>34-70</pPitchRange>
-                  <Channel name="open">
-                        <!--MIDI: Bank 0, Prog 60; MS General: French Horns-->
-                        <program value="60"/> <!--French Horn-->
-                  </Channel>
-                  <Channel name="mute">
-                        <!--MIDI: Bank 0, Prog 59; MS General: Harmon Mute Trumpet-->
-                        <program value="59"/> <!--Muted Trumpet-->
-                  </Channel>
-                  <genre>concertband</genre>
-                  <genre>marching</genre>
             </Instrument>
             <Instrument id="baritone-horn-central-europe-treble">
                   <family>baritone-horns</family>
@@ -3844,7 +4225,30 @@
                   <genre>concertband</genre>
                   <genre>marching</genre>
             </Instrument>
+            <Instrument id="baritone-horn-central-europe">
+                  <family>baritone-horns</family>
+                  <trackName>Baritone Horn (Central Europe)</trackName>
+                  <longName>Baritone Horn</longName>
+                  <shortName>Bar. Hn.</shortName>
+                  <description>Baritone Horn (Central Europe)</description>
+                  <musicXMLid>brass.baritone-horn</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>40-67</aPitchRange>
+                  <pPitchRange>34-70</pPitchRange>
+                  <Channel name="open">
+                        <!--MIDI: Bank 0, Prog 60; MS General: French Horns-->
+                        <program value="60"/> <!--French Horn-->
+                  </Channel>
+                  <Channel name="mute">
+                        <!--MIDI: Bank 0, Prog 59; MS General: Harmon Mute Trumpet-->
+                        <program value="59"/> <!--Muted Trumpet-->
+                  </Channel>
+                  <genre>concertband</genre>
+                  <genre>marching</genre>
+            </Instrument>
             <Instrument id="posthorn">
+                  <family>posthorns</family>
                   <longName>Posthorn</longName>
                   <shortName>Psthn.</shortName>
                   <description>Posthorn</description>
@@ -3862,46 +4266,11 @@
                         <program value="59"/> <!--Muted Trumpet-->
                   </Channel>
             </Instrument>
-            <Instrument id="alphorn">
-                  <longName>Alphorn</longName>
-                  <shortName>AlpHn.</shortName>
-                  <description>Alphorn</description>
-                  <musicXMLid>brass.alphorn</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>34-67</aPitchRange>
-                  <pPitchRange>30-72</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 60; MS General: French Horns-->
-                        <program value="60"/> <!--French Horn-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="trumpet">
+            <Instrument id="bb-piccolo-trumpet">
                   <family>trumpets</family>
-                  <longName>Trumpet</longName>
-                  <shortName>Tpt.</shortName>
-                  <description>B♭ Trumpet (generic)</description>
-                  <musicXMLid>brass.trumpet</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>52-80</aPitchRange>
-                  <pPitchRange>52-85</pPitchRange>
-                  <transposeDiatonic>-1</transposeDiatonic>
-                  <transposeChromatic>-2</transposeChromatic>
-                  <Channel name="open">
-                        <!--MIDI: Bank 0, Prog 56; MS General: Trumpet-->
-                        <program value="56"/> <!--Trumpet-->
-                  </Channel>
-                  <Channel name="mute">
-                        <!--MIDI: Bank 0, Prog 59; MS General: Harmon Mute Trumpet-->
-                        <program value="59"/> <!--Muted Trumpet-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="piccolo-trumpet">
-                  <family>trumpets</family>
-                  <longName>Piccolo Trumpet</longName>
-                  <shortName>P. Tpt.</shortName>
-                  <description>Piccolo Trumpet in B♭ (generic)</description>
+                  <longName>Piccolo Trumpet in B♭</longName>
+                  <shortName>P. Tpt. B♭</shortName>
+                  <description>Piccolo Trumpet in B♭</description>
                   <musicXMLid>brass.trumpet.piccolo</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3918,11 +4287,11 @@
                         <program value="59"/> <!--Muted Trumpet-->
                   </Channel>
             </Instrument>
-            <Instrument id="bb-piccolo-trumpet">
+            <Instrument id="piccolo-trumpet">
                   <family>trumpets</family>
-                  <longName>Piccolo Trumpet in B♭</longName>
-                  <shortName>P. Tpt. B♭</shortName>
-                  <description>Piccolo Trumpet in B♭</description>
+                  <longName>Piccolo Trumpet</longName>
+                  <shortName>P. Tpt.</shortName>
+                  <description>Piccolo Trumpet in B♭ (generic)</description>
                   <musicXMLid>brass.trumpet.piccolo</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4048,7 +4417,7 @@
                   <family>trumpets</family>
                   <longName>C Trumpet</longName>
                   <shortName>C Tpt.</shortName>
-                  <description>C Trumpet</description>
+                  <description>Most commonly used transposition in contemporary works.</description>
                   <musicXMLid>brass.trumpet.c</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4063,6 +4432,27 @@
                         <program value="59"/> <!--Muted Trumpet-->
                   </Channel>
                   <genre>orchestra</genre>
+            </Instrument>
+            <Instrument id="trumpet">
+                  <family>trumpets</family>
+                  <longName>Trumpet</longName>
+                  <shortName>Tpt.</shortName>
+                  <description>B♭ Trumpet (generic)</description>
+                  <musicXMLid>brass.trumpet</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>52-80</aPitchRange>
+                  <pPitchRange>52-85</pPitchRange>
+                  <transposeDiatonic>-1</transposeDiatonic>
+                  <transposeChromatic>-2</transposeChromatic>
+                  <Channel name="open">
+                        <!--MIDI: Bank 0, Prog 56; MS General: Trumpet-->
+                        <program value="56"/> <!--Trumpet-->
+                  </Channel>
+                  <Channel name="mute">
+                        <!--MIDI: Bank 0, Prog 59; MS General: Harmon Mute Trumpet-->
+                        <program value="59"/> <!--Muted Trumpet-->
+                  </Channel>
             </Instrument>
             <Instrument id="bb-trumpet">
                   <family>trumpets</family>
@@ -4175,28 +4565,6 @@
                         <program value="59"/> <!--Muted Trumpet-->
                   </Channel>
             </Instrument>
-            <Instrument id="bass-trumpet">
-                  <family>trumpets</family>
-                  <longName>Bass Trumpet</longName>
-                  <shortName>B. Tpt.</shortName>
-                  <description>Bass Trumpet in B♭ (generic)</description>
-                  <musicXMLid>brass.trumpet.bass</musicXMLid>
-                  <transposingClef>G</transposingClef>
-                  <concertClef>G8vb</concertClef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>39-66</aPitchRange>
-                  <pPitchRange>39-69</pPitchRange>
-                  <transposeDiatonic>-8</transposeDiatonic>
-                  <transposeChromatic>-14</transposeChromatic>
-                  <Channel name="open">
-                        <!--MIDI: Bank 0, Prog 56; MS General: Trumpet-->
-                        <program value="56"/> <!--Trumpet-->
-                  </Channel>
-                  <Channel name="mute">
-                        <!--MIDI: Bank 0, Prog 59; MS General: Harmon Mute Trumpet-->
-                        <program value="59"/> <!--Muted Trumpet-->
-                  </Channel>
-            </Instrument>
             <Instrument id="eb-bass-trumpet">
                   <family>trumpets</family>
                   <longName>E♭ Bass Trumpet</longName>
@@ -4205,8 +4573,8 @@
                   <musicXMLid>brass.trumpet.bass</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>46-73</aPitchRange>
-                  <pPitchRange>46-76</pPitchRange>
+                  <aPitchRange>44-72</aPitchRange>
+                  <pPitchRange>44-75</pPitchRange>
                   <transposeDiatonic>-5</transposeDiatonic>
                   <transposeChromatic>-9</transposeChromatic>
                   <Channel name="open">
@@ -4228,10 +4596,32 @@
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>39-66</aPitchRange>
-                  <pPitchRange>39-69</pPitchRange>
+                  <aPitchRange>42-69</aPitchRange>
+                  <pPitchRange>42-72</pPitchRange>
                   <transposeDiatonic>-7</transposeDiatonic>
                   <transposeChromatic>-12</transposeChromatic>
+                  <Channel name="open">
+                        <!--MIDI: Bank 0, Prog 56; MS General: Trumpet-->
+                        <program value="56"/> <!--Trumpet-->
+                  </Channel>
+                  <Channel name="mute">
+                        <!--MIDI: Bank 0, Prog 59; MS General: Harmon Mute Trumpet-->
+                        <program value="59"/> <!--Muted Trumpet-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="bass-trumpet">
+                  <family>trumpets</family>
+                  <longName>Bass Trumpet</longName>
+                  <shortName>B. Tpt.</shortName>
+                  <description>Bass Trumpet in B♭ (generic)</description>
+                  <musicXMLid>brass.trumpet.bass</musicXMLid>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>G8vb</concertClef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>40-67</aPitchRange>
+                  <pPitchRange>40-70</pPitchRange>
+                  <transposeDiatonic>-8</transposeDiatonic>
+                  <transposeChromatic>-14</transposeChromatic>
                   <Channel name="open">
                         <!--MIDI: Bank 0, Prog 56; MS General: Trumpet-->
                         <program value="56"/> <!--Trumpet-->
@@ -4250,8 +4640,8 @@
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>39-66</aPitchRange>
-                  <pPitchRange>39-69</pPitchRange>
+                  <aPitchRange>40-67</aPitchRange>
+                  <pPitchRange>40-70</pPitchRange>
                   <transposeDiatonic>-8</transposeDiatonic>
                   <transposeChromatic>-14</transposeChromatic>
                   <Channel name="open">
@@ -4264,30 +4654,8 @@
                   </Channel>
                   <genre>orchestra</genre>
             </Instrument>
-            <Instrument id="baroque-trumpet">
-                  <family>trumpets</family>
-                  <longName>Baroque Trumpet</longName>
-                  <shortName>Bq. Tpt.</shortName>
-                  <description>Baroque Trumpet in B♭ (generic)</description>
-                  <musicXMLid>brass.trumpet.baroque</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>58-79</aPitchRange>
-                  <pPitchRange>58-83</pPitchRange>
-                  <transposeDiatonic>-1</transposeDiatonic>
-                  <transposeChromatic>-2</transposeChromatic>
-                  <Channel name="open">
-                        <!--MIDI: Bank 0, Prog 56; MS General: Trumpet-->
-                        <program value="56"/> <!--Trumpet-->
-                  </Channel>
-                  <Channel name="mute">
-                        <!--MIDI: Bank 0, Prog 59; MS General: Harmon Mute Trumpet-->
-                        <program value="59"/> <!--Muted Trumpet-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
             <Instrument id="f-baroque-trumpet">
-                  <family>trumpets</family>
+                  <family>baroque-trumpets</family>
                   <longName>Baroque Trumpet in F</longName>
                   <shortName>Bq. Tpt. F</shortName>
                   <description>Baroque Trumpet in F</description>
@@ -4309,7 +4677,7 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="eb-baroque-trumpet">
-                  <family>trumpets</family>
+                  <family>baroque-trumpets</family>
                   <longName>Baroque Trumpet in E♭</longName>
                   <shortName>Bq. Tpt. E♭</shortName>
                   <description>Baroque Trumpet in E♭</description>
@@ -4331,7 +4699,7 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="d-baroque-trumpet">
-                  <family>trumpets</family>
+                  <family>baroque-trumpets</family>
                   <longName>Baroque Trumpet in D</longName>
                   <shortName>Bq. Tpt. D</shortName>
                   <description>Baroque Trumpet in D</description>
@@ -4353,7 +4721,7 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="c-baroque-trumpet">
-                  <family>trumpets</family>
+                  <family>baroque-trumpets</family>
                   <longName>Baroque Trumpet in C</longName>
                   <shortName>Bq. Tpt. C</shortName>
                   <description>Baroque Trumpet in C</description>
@@ -4373,7 +4741,7 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="bb-baroque-trumpet">
-                  <family>trumpets</family>
+                  <family>baroque-trumpets</family>
                   <longName>Baroque Trumpet in B♭</longName>
                   <shortName>Bq. Tpt. B♭</shortName>
                   <description>Baroque Trumpet in B♭</description>
@@ -4394,15 +4762,18 @@
                   </Channel>
                   <genre>earlymusic</genre>
             </Instrument>
-            <Instrument id="rag-dung">
-                  <longName>Rag Dung</longName>
-                  <shortName>Rg. Dng.</shortName>
-                  <description>Rag Dung (Tibetan Trumpet)</description>
-                  <musicXMLid>brass.rag-dung</musicXMLid>
-                  <clef>F</clef>
+            <Instrument id="baroque-trumpet">
+                  <family>baroque-trumpets</family>
+                  <longName>Baroque Trumpet</longName>
+                  <shortName>Bq. Tpt.</shortName>
+                  <description>Baroque Trumpet in B♭ (generic)</description>
+                  <musicXMLid>brass.trumpet.baroque</musicXMLid>
+                  <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>34-67</aPitchRange>
-                  <pPitchRange>30-72</pPitchRange>
+                  <aPitchRange>58-79</aPitchRange>
+                  <pPitchRange>58-83</pPitchRange>
+                  <transposeDiatonic>-1</transposeDiatonic>
+                  <transposeChromatic>-2</transposeChromatic>
                   <Channel name="open">
                         <!--MIDI: Bank 0, Prog 56; MS General: Trumpet-->
                         <program value="56"/> <!--Trumpet-->
@@ -4411,9 +4782,10 @@
                         <!--MIDI: Bank 0, Prog 59; MS General: Harmon Mute Trumpet-->
                         <program value="59"/> <!--Muted Trumpet-->
                   </Channel>
-                  <genre>world</genre>
+                  <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="bugle">
+                  <family>bugles</family>
                   <longName>Bugle</longName>
                   <shortName>Bu.</shortName>
                   <description>Bugle</description>
@@ -4428,6 +4800,7 @@
                   </Channel>
             </Instrument>
             <Instrument id="soprano-bugle">
+                  <family>bugles</family>
                   <longName>Soprano Bugle</longName>
                   <shortName>S. Bu.</shortName>
                   <description>Soprano Bugle</description>
@@ -4443,6 +4816,7 @@
                   <genre>marching</genre>
             </Instrument>
             <Instrument id="alto-bugle">
+                  <family>bugles</family>
                   <longName>Alto Bugle</longName>
                   <shortName>A. Bu.</shortName>
                   <description>Alto Bugle</description>
@@ -4457,7 +4831,27 @@
                   </Channel>
                   <genre>marching</genre>
             </Instrument>
+            <Instrument id="mellophone">
+                  <family>bugles</family>
+                  <longName>Mellophone</longName>
+                  <shortName>Mello.</shortName>
+                  <description>Mellophone</description>
+                  <musicXMLid>brass.mellophone</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>47-74</aPitchRange>
+                  <pPitchRange>47-77</pPitchRange>
+                  <transposeDiatonic>-4</transposeDiatonic>
+                  <transposeChromatic>-7</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 60; MS General: French Horns-->
+                        <program value="60"/> <!--French Horn-->
+                  </Channel>
+                  <genre>jazz</genre>
+                  <genre>marching</genre>
+            </Instrument>
             <Instrument id="baritone-bugle">
+                  <family>bugles</family>
                   <longName>Baritone Bugle</longName>
                   <shortName>Bar. Bu.</shortName>
                   <description>Bugle</description>
@@ -4473,6 +4867,79 @@
                         <program value="58"/> <!--Tuba-->
                   </Channel>
                   <genre>marching</genre>
+            </Instrument>
+            <Instrument id="euphonium-bugle">
+                  <family>bugles</family>
+                  <longName>Euphonium Bugle</longName>
+                  <shortName>Euph. Bu.</shortName>
+                  <description>Euphonium Bugle</description>
+                  <musicXMLid>brass.bugle.euphonium-bugle</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>50-62</aPitchRange>
+                  <pPitchRange>43-67</pPitchRange>
+                  <transposeDiatonic>-7</transposeDiatonic>
+                  <transposeChromatic>-12</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 58; MS General: Tuba-->
+                        <program value="58"/> <!--Tuba-->
+                  </Channel>
+                  <genre>marching</genre>
+            </Instrument>
+            <Instrument id="mellophon-bugle">
+                  <family>bugles</family>
+                  <longName>Mellophone Bugle</longName>
+                  <shortName>Mello. Bu.</shortName>
+                  <description>Bugle</description>
+                  <musicXMLid>brass.bugle.mellophone-bugle</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>41-77</aPitchRange>
+                  <pPitchRange>36-81</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 58; MS General: Tuba-->
+                        <program value="58"/> <!--Tuba-->
+                  </Channel>
+                  <genre>marching</genre>
+            </Instrument>
+            <Instrument id="contrabass-bugle">
+                  <family>bugles</family>
+                  <longName>Contrabass Bugle</longName>
+                  <shortName>Cb. Bu.</shortName>
+                  <description>Contrabass Bugle</description>
+                  <musicXMLid>brass.bugle.contrabass</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>43-55</aPitchRange>
+                  <pPitchRange>36-60</pPitchRange>
+                  <transposeDiatonic>-14</transposeDiatonic>
+                  <transposeChromatic>-24</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 58; MS General: Tuba-->
+                        <program value="58"/> <!--Tuba-->
+                  </Channel>
+                  <genre>marching</genre>
+            </Instrument>
+            <Instrument id="fiscorn">
+                  <family>flugelhorns</family>
+                  <longName>Fiscorn</longName>
+                  <shortName>Fsc.</shortName>
+                  <description>Fiscorn</description>
+                  <musicXMLid>brass.fiscorn</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>52-79</aPitchRange>
+                  <pPitchRange>52-82</pPitchRange>
+                  <transposeDiatonic>-1</transposeDiatonic>
+                  <transposeChromatic>-2</transposeChromatic>
+                  <Channel name="open">
+                        <!--MIDI: Bank 0, Prog 56; MS General: Trumpet-->
+                        <program value="56"/> <!--Trumpet-->
+                  </Channel>
+                  <Channel name="mute">
+                        <!--MIDI: Bank 0, Prog 59; MS General: Harmon Mute Trumpet-->
+                        <program value="59"/> <!--Muted Trumpet-->
+                  </Channel>
             </Instrument>
             <Instrument id="flugelhorn">
                   <family>flugelhorns</family>
@@ -4498,27 +4965,8 @@
                   <genre>concertband</genre>
                   <genre>marching</genre>
             </Instrument>
-            <Instrument id="fiscorn">
-                  <longName>Fiscorn</longName>
-                  <shortName>Fsc.</shortName>
-                  <description>Fiscorn</description>
-                  <musicXMLid>brass.fiscorn</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>52-79</aPitchRange>
-                  <pPitchRange>52-82</pPitchRange>
-                  <transposeDiatonic>-1</transposeDiatonic>
-                  <transposeChromatic>-2</transposeChromatic>
-                  <Channel name="open">
-                        <!--MIDI: Bank 0, Prog 56; MS General: Trumpet-->
-                        <program value="56"/> <!--Trumpet-->
-                  </Channel>
-                  <Channel name="mute">
-                        <!--MIDI: Bank 0, Prog 59; MS General: Harmon Mute Trumpet-->
-                        <program value="59"/> <!--Muted Trumpet-->
-                  </Channel>
-            </Instrument>
             <Instrument id="kuhlohorn">
+                  <family>flugelhorns</family>
                   <longName>Kuhlohorn</longName>
                   <shortName>Klhn.</shortName>
                   <description>Kuhllohorn</description>
@@ -4538,88 +4986,8 @@
                         <program value="59"/> <!--Muted Trumpet-->
                   </Channel>
             </Instrument>
-            <Instrument id="euphonium-bugle">
-                  <longName>Euphonium Bugle</longName>
-                  <shortName>Euph. Bu.</shortName>
-                  <description>Euphonium Bugle</description>
-                  <musicXMLid>brass.bugle.euphonium-bugle</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>50-62</aPitchRange>
-                  <pPitchRange>43-67</pPitchRange>
-                  <transposeDiatonic>-7</transposeDiatonic>
-                  <transposeChromatic>-12</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 58; MS General: Tuba-->
-                        <program value="58"/> <!--Tuba-->
-                  </Channel>
-                  <genre>marching</genre>
-            </Instrument>
-            <Instrument id="mellophon-bugle">
-                  <longName>Mellophone Bugle</longName>
-                  <shortName>Mello. Bu.</shortName>
-                  <description>Bugle</description>
-                  <musicXMLid>brass.bugle.mellophone-bugle</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>41-77</aPitchRange>
-                  <pPitchRange>36-81</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 58; MS General: Tuba-->
-                        <program value="58"/> <!--Tuba-->
-                  </Channel>
-                  <genre>marching</genre>
-            </Instrument>
-            <Instrument id="contrabass-bugle">
-                  <longName>Contrabass Bugle</longName>
-                  <shortName>Cb. Bu.</shortName>
-                  <description>Contrabass Bugle</description>
-                  <musicXMLid>brass.bugle.contrabass</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>43-55</aPitchRange>
-                  <pPitchRange>36-60</pPitchRange>
-                  <transposeDiatonic>-14</transposeDiatonic>
-                  <transposeChromatic>-24</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 58; MS General: Tuba-->
-                        <program value="58"/> <!--Tuba-->
-                  </Channel>
-                  <genre>marching</genre>
-            </Instrument>
-            <Instrument id="mellophone">
-                  <longName>Mellophone</longName>
-                  <shortName>Mello.</shortName>
-                  <description>Mellophone</description>
-                  <musicXMLid>brass.mellophone</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>47-74</aPitchRange>
-                  <pPitchRange>47-77</pPitchRange>
-                  <transposeDiatonic>-4</transposeDiatonic>
-                  <transposeChromatic>-7</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 60; MS General: French Horns-->
-                        <program value="60"/> <!--French Horn-->
-                  </Channel>
-                  <genre>jazz</genre>
-                  <genre>marching</genre>
-            </Instrument>
-            <Instrument id="ophicleide">
-                  <longName>Ophicleide</longName>
-                  <shortName>Oph.</shortName>
-                  <description>C Bass Ophicleide (generic)</description>
-                  <musicXMLid>brass.ophicleide</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>35-63</aPitchRange>
-                  <pPitchRange>35-67</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 56; MS General: Trumpet-->
-                        <program value="56"/> <!--Trumpet-->
-                  </Channel>
-            </Instrument>
             <Instrument id="f-alto-ophicleide">
+                  <family>ophicleides</family>
                   <longName>F Alto Ophicleide</longName>
                   <shortName>F A. Oph.</shortName>
                   <description>F Alto Ophicleide</description>
@@ -4634,6 +5002,7 @@
                   </Channel>
             </Instrument>
             <Instrument id="eb-alto-ophicleide">
+                  <family>ophicleides</family>
                   <longName>E♭ Alto Ophicleide</longName>
                   <shortName>E♭ A. Oph.</shortName>
                   <description>E♭ Alto Ophicleide</description>
@@ -4647,7 +5016,23 @@
                         <program value="56"/> <!--Trumpet-->
                   </Channel>
             </Instrument>
+            <Instrument id="ophicleide">
+                  <family>ophicleides</family>
+                  <longName>Ophicleide</longName>
+                  <shortName>Oph.</shortName>
+                  <description>Bass Ophicleide (generic)</description>
+                  <musicXMLid>brass.ophicleide</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>35-63</aPitchRange>
+                  <pPitchRange>35-67</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 56; MS General: Trumpet-->
+                        <program value="56"/> <!--Trumpet-->
+                  </Channel>
+            </Instrument>
             <Instrument id="c-bass-ophicleide">
+                  <family>ophicleides</family>
                   <longName>C Bass Ophicleide</longName>
                   <shortName>C B. Oph.</shortName>
                   <description>C Bass Ophicleide</description>
@@ -4662,6 +5047,7 @@
                   </Channel>
             </Instrument>
             <Instrument id="bb-bass-ophicleide">
+                  <family>ophicleides</family>
                   <longName>B♭ Bass Ophicleide</longName>
                   <shortName>B♭ B. Oph.</shortName>
                   <description>B♭ Bass Ophicleide</description>
@@ -4676,6 +5062,7 @@
                   </Channel>
             </Instrument>
             <Instrument id="eb-contrabass-ophicleide">
+                  <family>ophicleides</family>
                   <longName>E♭ Contrabass Ophicleide</longName>
                   <shortName>E♭ Cb. Oph.</shortName>
                   <description>E♭ Contrabass Ophicleide</description>
@@ -4690,6 +5077,7 @@
                   </Channel>
             </Instrument>
             <Instrument id="cornettino">
+                  <family>cornetts</family>
                   <longName>Cornettino</longName>
                   <shortName>Co.</shortName>
                   <description>Cornettino</description>
@@ -4705,6 +5093,7 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="cornett">
+                  <family>cornetts</family>
                   <longName>Cornett</longName>
                   <shortName>Co.</shortName>
                   <description>Soprano Cornett (generic)</description>
@@ -4720,9 +5109,10 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="soprano-cornett">
+                  <family>cornetts</family>
                   <longName>Soprano Cornett</longName>
                   <shortName>S. Co.</shortName>
-                  <description>Soprano Cornett</description>
+                  <description>The most common cornett.</description>
                   <musicXMLid>brass.cornett</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4735,6 +5125,7 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="alto-cornett">
+                  <family>cornetts</family>
                   <longName>Alto Cornett</longName>
                   <shortName>A. Co.</shortName>
                   <description>Alto Cornett</description>
@@ -4750,6 +5141,7 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="tenor-cornett">
+                  <family>cornetts</family>
                   <longName>Tenor Cornett</longName>
                   <shortName>T. Co.</shortName>
                   <description>Tenor Cornett</description>
@@ -4765,6 +5157,7 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="serpent">
+                  <family>serpents</family>
                   <longName>Serpent</longName>
                   <shortName>Spt.</shortName>
                   <description>Serpent</description>
@@ -4778,99 +5171,6 @@
                         <program value="56"/> <!--Trumpet-->
                   </Channel>
                   <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="alto-sackbut">
-                  <longName>Alto Sackbut</longName>
-                  <shortName>A. Sack.</shortName>
-                  <description>Alto Sackbut</description>
-                  <musicXMLid>brass.sackbutt.alto</musicXMLid>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>45-74</aPitchRange>
-                  <pPitchRange>45-77</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 57; MS General: Trombone-->
-                        <program value="57"/> <!--Trombone-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="tenor-sackbut">
-                  <longName>Tenor Sackbut</longName>
-                  <shortName>T. Sack.</shortName>
-                  <description>Tenor Sackbut</description>
-                  <musicXMLid>brass.sackbutt.tenor</musicXMLid>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>40-70</aPitchRange>
-                  <pPitchRange>40-74</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 57; MS General: Trombone-->
-                        <program value="57"/> <!--Trombone-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="bass-sackbut">
-                  <longName>Bass Sackbut</longName>
-                  <shortName>B. Sack.</shortName>
-                  <description>Bass Sackbut</description>
-                  <musicXMLid>brass.sackbutt.bass</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>36-70</aPitchRange>
-                  <pPitchRange>36-74</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 57; MS General: Trombone-->
-                        <program value="57"/> <!--Trombone-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="trombone">
-                  <family>trombones</family>
-                  <longName>Trombone</longName>
-                  <shortName>Tbn.</shortName>
-                  <description>Trombone</description>
-                  <musicXMLid>brass.trombone</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>40-71</aPitchRange>
-                  <pPitchRange>36-74</pPitchRange>
-                  <Channel name="open">
-                        <!--MIDI: Bank 0, Prog 57; MS General: Trombone-->
-                        <program value="57"/> <!--Trombone-->
-                  </Channel>
-                  <Channel name="mute">
-                        <!--MIDI: Bank 0, Prog 59; MS General: Harmon Mute Trumpet-->
-                        <program value="59"/> <!--Muted Trumpet-->
-                  </Channel>
-                  <genre>common</genre>
-                  <genre>popular</genre>
-                  <genre>jazz</genre>
-                  <genre>orchestra</genre>
-                  <genre>concertband</genre>
-                  <genre>marching</genre>
-            </Instrument>
-            <Instrument id="trombone-treble">
-                  <family>trombones</family>
-                  <trackName>Trombone (Treble Clef)</trackName>
-                  <longName>Trombone</longName>
-                  <shortName>Tbn.</shortName>
-                  <description>Trombone</description>
-                  <musicXMLid>brass.trombone</musicXMLid>
-                  <transposingClef>G</transposingClef>
-                  <concertClef>F</concertClef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>40-71</aPitchRange>
-                  <pPitchRange>36-74</pPitchRange>
-                  <transposeDiatonic>-8</transposeDiatonic>
-                  <transposeChromatic>-14</transposeChromatic>
-                  <Channel name="open">
-                        <!--MIDI: Bank 0, Prog 57; MS General: Trombone-->
-                        <program value="57"/> <!--Trombone-->
-                  </Channel>
-                  <Channel name="mute">
-                        <!--MIDI: Bank 0, Prog 59; MS General: Harmon Mute Trumpet-->
-                        <program value="59"/> <!--Muted Trumpet-->
-                  </Channel>
             </Instrument>
             <Instrument id="soprano-trombone">
                   <family>trombones</family>
@@ -4930,6 +5230,74 @@
                         <program value="59"/> <!--Muted Trumpet-->
                   </Channel>
             </Instrument>
+            <Instrument id="trombone">
+                  <family>trombones</family>
+                  <longName>Trombone</longName>
+                  <shortName>Tbn.</shortName>
+                  <description>Trombone</description>
+                  <musicXMLid>brass.trombone</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>40-71</aPitchRange>
+                  <pPitchRange>36-74</pPitchRange>
+                  <Channel name="open">
+                        <!--MIDI: Bank 0, Prog 57; MS General: Trombone-->
+                        <program value="57"/> <!--Trombone-->
+                  </Channel>
+                  <Channel name="mute">
+                        <!--MIDI: Bank 0, Prog 59; MS General: Harmon Mute Trumpet-->
+                        <program value="59"/> <!--Muted Trumpet-->
+                  </Channel>
+                  <genre>common</genre>
+                  <genre>popular</genre>
+                  <genre>jazz</genre>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
+                  <genre>marching</genre>
+            </Instrument>
+            <Instrument id="trombone-treble">
+                  <family>trombones</family>
+                  <trackName>Trombone (Treble Clef)</trackName>
+                  <longName>Trombone</longName>
+                  <shortName>Tbn.</shortName>
+                  <description>Trombone (treble clef, B♭)</description>
+                  <musicXMLid>brass.trombone</musicXMLid>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>F</concertClef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>40-71</aPitchRange>
+                  <pPitchRange>36-74</pPitchRange>
+                  <transposeDiatonic>-8</transposeDiatonic>
+                  <transposeChromatic>-14</transposeChromatic>
+                  <Channel name="open">
+                        <!--MIDI: Bank 0, Prog 57; MS General: Trombone-->
+                        <program value="57"/> <!--Trombone-->
+                  </Channel>
+                  <Channel name="mute">
+                        <!--MIDI: Bank 0, Prog 59; MS General: Harmon Mute Trumpet-->
+                        <program value="59"/> <!--Muted Trumpet-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="contrabass-trombone">
+                  <family>trombones</family>
+                  <longName>Contrabass Trombone</longName>
+                  <shortName>Cb. Tbn.</shortName>
+                  <description>Contrabass Trombone</description>
+                  <musicXMLid>brass.trombone.contrabass</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>28-55</aPitchRange>
+                  <pPitchRange>28-58</pPitchRange>
+                  <Channel name="open">
+                        <!--MIDI: Bank 0, Prog 57; MS General: Trombone-->
+                        <program value="57"/> <!--Trombone-->
+                  </Channel>
+                  <Channel name="mute">
+                        <!--MIDI: Bank 0, Prog 59; MS General: Harmon Mute Trumpet-->
+                        <program value="59"/> <!--Muted Trumpet-->
+                  </Channel>
+                  <genre>orchestra</genre>
+            </Instrument>
             <Instrument id="bass-trombone">
                   <family>trombones</family>
                   <longName>Bass Trombone</longName>
@@ -4953,26 +5321,6 @@
                   <genre>concertband</genre>
                   <genre>marching</genre>
             </Instrument>
-            <Instrument id="contrabass-trombone">
-                  <family>trombones</family>
-                  <longName>Contrabass Trombone</longName>
-                  <shortName>Cb. Tbn.</shortName>
-                  <description>Contrabass Trombone</description>
-                  <musicXMLid>brass.trombone.contrabass</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>28-55</aPitchRange>
-                  <pPitchRange>28-58</pPitchRange>
-                  <Channel name="open">
-                        <!--MIDI: Bank 0, Prog 57; MS General: Trombone-->
-                        <program value="57"/> <!--Trombone-->
-                  </Channel>
-                  <Channel name="mute">
-                        <!--MIDI: Bank 0, Prog 59; MS General: Harmon Mute Trumpet-->
-                        <program value="59"/> <!--Muted Trumpet-->
-                  </Channel>
-                  <genre>orchestra</genre>
-            </Instrument>
             <Instrument id="cimbasso">
                   <family>trombones</family>
                   <longName>Cimbasso</longName>
@@ -4987,6 +5335,54 @@
                         <!--MIDI: Bank 0, Prog 57; MS General: Trombone-->
                         <program value="57"/> <!--Trombone-->
                   </Channel>
+            </Instrument>
+            <Instrument id="alto-sackbut">
+                  <family>sackbuts</family>
+                  <longName>Alto Sackbut</longName>
+                  <shortName>A. Sack.</shortName>
+                  <description>Alto Sackbut</description>
+                  <musicXMLid>brass.sackbutt.alto</musicXMLid>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>45-74</aPitchRange>
+                  <pPitchRange>45-77</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 57; MS General: Trombone-->
+                        <program value="57"/> <!--Trombone-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="tenor-sackbut">
+                  <family>sackbuts</family>
+                  <longName>Tenor Sackbut</longName>
+                  <shortName>T. Sack.</shortName>
+                  <description>Tenor Sackbut</description>
+                  <musicXMLid>brass.sackbutt.tenor</musicXMLid>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>40-70</aPitchRange>
+                  <pPitchRange>40-74</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 57; MS General: Trombone-->
+                        <program value="57"/> <!--Trombone-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="bass-sackbut">
+                  <family>sackbuts</family>
+                  <longName>Bass Sackbut</longName>
+                  <shortName>B. Sack.</shortName>
+                  <description>Bass Sackbut</description>
+                  <musicXMLid>brass.sackbutt.bass</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>36-70</aPitchRange>
+                  <pPitchRange>36-74</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 57; MS General: Trombone-->
+                        <program value="57"/> <!--Trombone-->
+                  </Channel>
+                  <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="euphonium">
                   <family>euphoniums</family>
@@ -5010,7 +5406,7 @@
                   <trackName>Euphonium (Treble Clef)</trackName>
                   <longName>Euphonium</longName>
                   <shortName>Euph.</shortName>
-                  <description>Euphonium</description>
+                  <description>Euphonium (treble clef, B♭)</description>
                   <musicXMLid>brass.euphonium</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -5030,7 +5426,7 @@
                   <family>tubas</family>
                   <longName>Tuba</longName>
                   <shortName>Tba.</shortName>
-                  <description>Tuba (generic)</description>
+                  <description>Composers write for the "Tuba" and they don't care which one plays it</description>
                   <musicXMLid>brass.tuba</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5050,7 +5446,6 @@
                   <family>tubas</family>
                   <longName>F Tuba</longName>
                   <shortName>F Tb.</shortName>
-                  <description>F Tuba</description>
                   <musicXMLid>brass.tuba</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5066,8 +5461,37 @@
                   <family>tubas</family>
                   <longName>E♭ Tuba</longName>
                   <shortName>E♭ Tb.</shortName>
-                  <description>E♭ Tuba</description>
                   <musicXMLid>brass.tuba</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>26-64</aPitchRange>
+                  <pPitchRange>24-72</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 58; MS General: Tuba-->
+                        <program value="58"/> <!--Tuba-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="bass-eb-tuba">
+                  <family>tubas</family>
+                  <longName>Bass Tuba in E♭</longName>
+                  <shortName>Ba. Tb. E♭</shortName>
+                  <description>Bass Tuba</description>
+                  <musicXMLid>brass.tuba.bass</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>26-64</aPitchRange>
+                  <pPitchRange>24-72</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 58; MS General: Tuba-->
+                        <program value="58"/> <!--Tuba-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="bass-f-tuba">
+                  <family>tubas</family>
+                  <longName>Bass Tuba in F</longName>
+                  <shortName>Ba. Tb. F</shortName>
+                  <description>Bass Tuba</description>
+                  <musicXMLid>brass.tuba.bass</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>26-64</aPitchRange>
@@ -5082,7 +5506,7 @@
                   <trackName>E♭ Tuba (Treble Clef)</trackName>
                   <longName>E♭ Tuba</longName>
                   <shortName>E♭ Tb.</shortName>
-                  <description>E♭ Tuba</description>
+                  <description>Bass Tuba (treble clef)</description>
                   <musicXMLid>brass.tuba</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -5100,7 +5524,7 @@
                   <family>tubas</family>
                   <longName>C Tuba</longName>
                   <shortName>C Tb.</shortName>
-                  <description>C Tuba</description>
+                  <description>Contrabass Tuba</description>
                   <musicXMLid>brass.tuba</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5115,7 +5539,7 @@
                   <family>tubas</family>
                   <longName>B♭ Tuba</longName>
                   <shortName>B♭ Tb.</shortName>
-                  <description>B♭ Tuba</description>
+                  <description>Contrabass Tuba</description>
                   <musicXMLid>brass.tuba</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5132,7 +5556,7 @@
                   <trackName>B♭ Tuba (Treble Clef)</trackName>
                   <longName>B♭ Tuba</longName>
                   <shortName>B♭ Tb.</shortName>
-                  <description>B♭ Tuba</description>
+                  <description>Contrabass Tuba (treble clef)</description>
                   <musicXMLid>brass.tuba</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -5141,36 +5565,6 @@
                   <pPitchRange>22-72</pPitchRange>
                   <transposeDiatonic>-15</transposeDiatonic>
                   <transposeChromatic>-26</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 58; MS General: Tuba-->
-                        <program value="58"/> <!--Tuba-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="bass-f-tuba">
-                  <family>tubas</family>
-                  <longName>Bass Tuba in F</longName>
-                  <shortName>Ba. Tb. F</shortName>
-                  <description>Bass Tuba in F</description>
-                  <musicXMLid>brass.tuba.bass</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>26-64</aPitchRange>
-                  <pPitchRange>24-72</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 58; MS General: Tuba-->
-                        <program value="58"/> <!--Tuba-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="bass-eb-tuba">
-                  <family>tubas</family>
-                  <longName>Bass Tuba in E♭</longName>
-                  <shortName>Ba. Tb. E♭</shortName>
-                  <description>Bass Tuba in E♭</description>
-                  <musicXMLid>brass.tuba.bass</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>26-64</aPitchRange>
-                  <pPitchRange>24-72</pPitchRange>
                   <Channel>
                         <!--MIDI: Bank 0, Prog 58; MS General: Tuba-->
                         <program value="58"/> <!--Tuba-->
@@ -5191,40 +5585,11 @@
                         <program value="58"/> <!--Tuba-->
                   </Channel>
             </Instrument>
-            <Instrument id="helicon">
-                  <longName>Helicon</longName>
-                  <shortName>Helicon</shortName>
-                  <description>Helicon</description>
-                  <musicXMLid>brass.helicon</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>28-58</aPitchRange>
-                  <pPitchRange>22-72</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 58; MS General: Tuba-->
-                        <program value="58"/> <!--Tuba-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="sousaphone">
-                  <longName>Sousaphone</longName>
-                  <shortName>Sphn.</shortName>
-                  <description>Sousaphone</description>
-                  <musicXMLid>brass.sousaphone</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>28-58</aPitchRange>
-                  <pPitchRange>22-72</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 58; MS General: Tuba-->
-                        <program value="58"/> <!--Tuba-->
-                  </Channel>
-                  <genre>jazz</genre>
-                  <genre>marching</genre>
-            </Instrument>
             <Instrument id="bb-sousaphone">
+                  <family>sousaphones</family>
                   <longName>B♭ Sousaphone</longName>
                   <shortName>B♭ Sphn.</shortName>
-                  <description>B♭ Sousaphone</description>
+                  <description>Sousaphone (B♭)</description>
                   <musicXMLid>brass.sousaphone</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5239,58 +5604,40 @@
                   <genre>jazz</genre>
                   <genre>marching</genre>
             </Instrument>
-            <Instrument id="wagner-tuba">
-                  <family>horns</family>
-                  <longName>Wagner Tuba</longName>
-                  <shortName>Wag. Tb.</shortName>
-                  <description>F Wagner Tuba (generic)</description>
-                  <musicXMLid>brass.wagner-tuba</musicXMLid>
+            <Instrument id="sousaphone">
+                  <family>sousaphones</family>
+                  <longName>Sousaphone</longName>
+                  <shortName>Sphn.</shortName>
+                  <description>Sousaphone (concert pitch)</description>
+                  <musicXMLid>brass.sousaphone</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>35-74</aPitchRange>
-                  <pPitchRange>35-77</pPitchRange>
-                  <transposeDiatonic>-4</transposeDiatonic>
-                  <transposeChromatic>-7</transposeChromatic>
+                  <aPitchRange>28-58</aPitchRange>
+                  <pPitchRange>22-72</pPitchRange>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 56; MS General: Trumpet-->
-                        <program value="56"/> <!--Trumpet-->
+                        <!--MIDI: Bank 0, Prog 58; MS General: Tuba-->
+                        <program value="58"/> <!--Tuba-->
                   </Channel>
+                  <genre>jazz</genre>
+                  <genre>marching</genre>
             </Instrument>
-            <Instrument id="bb-wagner-tuba">
-                  <family>horns</family>
-                  <longName>B♭ Wagner Tuba</longName>
-                  <shortName>B♭ Wag. Tb.</shortName>
-                  <description>B♭ Wagner Tuba</description>
-                  <musicXMLid>brass.wagner-tuba</musicXMLid>
+            <Instrument id="helicon">
+                  <family>sousaphones</family>
+                  <longName>Helicon</longName>
+                  <shortName>Helicon</shortName>
+                  <description>Helicon</description>
+                  <musicXMLid>brass.helicon</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>40-75</aPitchRange>
-                  <pPitchRange>40-79</pPitchRange>
-                  <transposeDiatonic>-1</transposeDiatonic>
-                  <transposeChromatic>-2</transposeChromatic>
+                  <aPitchRange>28-58</aPitchRange>
+                  <pPitchRange>22-72</pPitchRange>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 60; MS General: French Horns-->
-                        <program value="60"/> <!--French Horn-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="f-wagner-tuba">
-                  <family>horns</family>
-                  <longName>F Wagner Tuba</longName>
-                  <shortName>F Wag. Tb.</shortName>
-                  <description>F Wagner Tuba</description>
-                  <musicXMLid>brass.wagner-tuba</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>35-74</aPitchRange>
-                  <pPitchRange>35-77</pPitchRange>
-                  <transposeDiatonic>-4</transposeDiatonic>
-                  <transposeChromatic>-7</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 56; MS General: Trumpet-->
-                        <program value="56"/> <!--Trumpet-->
+                        <!--MIDI: Bank 0, Prog 58; MS General: Tuba-->
+                        <program value="58"/> <!--Tuba-->
                   </Channel>
             </Instrument>
             <Instrument id="conch">
+                  <family>conches</family>
                   <longName>Conch</longName>
                   <shortName>Cnch.</shortName>
                   <description>Conch Shell</description>
@@ -5305,22 +5652,8 @@
                   </Channel>
                   <genre>world</genre>
             </Instrument>
-            <Instrument id="didgeridoo">
-                  <longName>Didgeridoo</longName>
-                  <shortName>Doo.</shortName>
-                  <description>Didgeridoo</description>
-                  <musicXMLid>brass.didgeridoo</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>24-36</aPitchRange>
-                  <pPitchRange>24-36</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 57; MS General: Trombone-->
-                        <program value="57"/> <!--Trombone-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
             <Instrument id="horagai">
+                  <family>conches</family>
                   <longName>Horagai</longName>
                   <shortName>Hor.</shortName>
                   <description>Horagai Conch</description>
@@ -5335,7 +5668,59 @@
                   </Channel>
                   <genre>world</genre>
             </Instrument>
+            <Instrument id="alphorn">
+                  <family>alphorns</family>
+                  <longName>Alphorn</longName>
+                  <shortName>AlpHn.</shortName>
+                  <description>Alphorn</description>
+                  <musicXMLid>brass.alphorn</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>34-67</aPitchRange>
+                  <pPitchRange>30-72</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 60; MS General: French Horns-->
+                        <program value="60"/> <!--French Horn-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="rag-dung">
+                  <family>rag-dungs</family>
+                  <longName>Rag Dung</longName>
+                  <shortName>Rg. Dng.</shortName>
+                  <description>Rag Dung (Tibetan Trumpet)</description>
+                  <musicXMLid>brass.rag-dung</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>34-67</aPitchRange>
+                  <pPitchRange>30-72</pPitchRange>
+                  <Channel name="open">
+                        <!--MIDI: Bank 0, Prog 56; MS General: Trumpet-->
+                        <program value="56"/> <!--Trumpet-->
+                  </Channel>
+                  <Channel name="mute">
+                        <!--MIDI: Bank 0, Prog 59; MS General: Harmon Mute Trumpet-->
+                        <program value="59"/> <!--Muted Trumpet-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="didgeridoo">
+                  <family>didgeridoos</family>
+                  <longName>Didgeridoo</longName>
+                  <shortName>Doo.</shortName>
+                  <description>Didgeridoo</description>
+                  <musicXMLid>brass.didgeridoo</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>24-36</aPitchRange>
+                  <pPitchRange>24-36</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 57; MS General: Trombone-->
+                        <program value="57"/> <!--Trombone-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
             <Instrument id="shofar">
+                  <family>shofars</family>
                   <longName>Shofar</longName>
                   <shortName>Sho.</shortName>
                   <description>Shofar Ramshorn</description>
@@ -5351,6 +5736,7 @@
                   <genre>world</genre>
             </Instrument>
             <Instrument id="vuvuzela">
+                  <family>vuvuzelas</family>
                   <longName>Vuvuzela</longName>
                   <shortName>Vuv.</shortName>
                   <description>Vuvuzela</description>
@@ -5372,7 +5758,7 @@
                   <family>timpani</family>
                   <longName>Timpani</longName>
                   <shortName>Timp.</shortName>
-                  <description>Timpani</description>
+                  <description>Large orchestral drums (kettledrums) often with a pedal to change tuning. A single staff may be used for multiple timpani (i.e. multiple tunings). Modern music is always written in C (non-transposing).</description>
                   <musicXMLid>drum.timpani</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5389,6 +5775,7 @@
                   <genre>marching</genre>
             </Instrument>
             <Instrument id="roto-toms">
+                  <family>roto-toms</family>
                   <longName>Roto-Toms</longName>
                   <shortName>Roto</shortName>
                   <description>Roto-Toms</description>
@@ -5401,6 +5788,138 @@
                   <Channel>
                         <!--MIDI: Bank 0, Prog 117; MS General: Melodic Tom-->
                         <program value="117"/> <!--Melodic Tom-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="tubaphone">
+                  <family>tubaphones</family>
+                  <longName>Tubaphone</longName>
+                  <shortName>Tph.</shortName>
+                  <description>Tubaphone</description>
+                  <clef>G15ma</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>84-108</aPitchRange>
+                  <pPitchRange>84-108</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 47; MS General: Timpani-->
+                        <program value="47"/> <!--Timpani-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="soprano-steel-drums">
+                  <family>steel-drums</family>
+                  <longName>Soprano Steel Drums</longName>
+                  <shortName>S. St. Dr.</shortName>
+                  <description>Soprano Steel Drums</description>
+                  <musicXMLid>metal.steel-drums</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>60-88</aPitchRange>
+                  <pPitchRange>60-88</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 114; MS General: Steel Drums-->
+                        <program value="114"/> <!--Steel Drums-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="alto-steel-drums">
+                  <family>steel-drums</family>
+                  <longName>Alto Steel Drums</longName>
+                  <shortName>A. St. Dr.</shortName>
+                  <description>Alto Steel Drums</description>
+                  <musicXMLid>metal.steel-drums</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>56-85</aPitchRange>
+                  <pPitchRange>56-85</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 114; MS General: Steel Drums-->
+                        <program value="114"/> <!--Steel Drums-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="guitar-steel-drums">
+                  <family>steel-drums</family>
+                  <longName>Guitar Steel Drums</longName>
+                  <shortName>Gtr. St. Dr.</shortName>
+                  <description>Guitar Steel Drums</description>
+                  <musicXMLid>metal.steel-drums</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>54-81</aPitchRange>
+                  <pPitchRange>54-81</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 114; MS General: Steel Drums-->
+                        <program value="114"/> <!--Steel Drums-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="tenor-steel-drums">
+                  <family>steel-drums</family>
+                  <longName>Tenor Steel Drums</longName>
+                  <shortName>T. St. Dr.</shortName>
+                  <description>Tenor Steel Drums</description>
+                  <musicXMLid>metal.steel-drums</musicXMLid>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>52-69</aPitchRange>
+                  <pPitchRange>52-69</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 114; MS General: Steel Drums-->
+                        <program value="114"/> <!--Steel Drums-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="cello-steel-drums">
+                  <family>steel-drums</family>
+                  <longName>Cello Steel Drums</longName>
+                  <shortName>Ce. St. Dr.</shortName>
+                  <description>Cello Steel Drums</description>
+                  <musicXMLid>metal.steel-drums</musicXMLid>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>47-67</aPitchRange>
+                  <pPitchRange>47-67</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 114; MS General: Steel Drums-->
+                        <program value="114"/> <!--Steel Drums-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="steel-drums">
+                  <family>steel-drums</family>
+                  <longName>Steel Drums</longName>
+                  <shortName>St. Dr.</shortName>
+                  <description>Steel Drums (generic)</description>
+                  <musicXMLid>metal.steel-drums</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>36-88</aPitchRange>
+                  <pPitchRange>36-88</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 114; MS General: Steel Drums-->
+                        <program value="114"/> <!--Steel Drums-->
+                  </Channel>
+                  <genre>jazz</genre>
+            </Instrument>
+            <Instrument id="bass-steel-drums">
+                  <family>steel-drums</family>
+                  <longName>Bass Steel Drums</longName>
+                  <shortName>B. St. Dr.</shortName>
+                  <description>Bass Steel Drums</description>
+                  <musicXMLid>metal.steel-drums</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>36-53</aPitchRange>
+                  <pPitchRange>36-53</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 114; MS General: Steel Drums-->
+                        <program value="114"/> <!--Steel Drums-->
                   </Channel>
             </Instrument>
             <Instrument id="glockenspiel">
@@ -5428,420 +5947,6 @@
                   <genre>marching</genre>
                   <genre>classroom</genre>
             </Instrument>
-            <Instrument id="orff-soprano-glockenspiel">
-                  <family>orff-percussion</family>
-                  <longName>Orff Soprano Glockenspiel</longName>
-                  <shortName>O. S. Glk.</shortName>
-                  <description>Orff Soprano Glockenspiel</description>
-                  <musicXMLid>pitched-percussion.glockenspiel.soprano</musicXMLid>
-                  <clef>G15ma</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>84-105</aPitchRange>
-                  <pPitchRange>84-105</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 9; MS General: Glockenspiel-->
-                        <program value="9"/> <!--Glockenspiel-->
-                  </Channel>
-                  <genre>classroom</genre>
-            </Instrument>
-            <Instrument id="orff-alto-glockenspiel">
-                  <family>orff-percussion</family>
-                  <longName>Orff Alto Glockenspiel</longName>
-                  <shortName>O. A. Glk.</shortName>
-                  <description>Orff Alto Glockenspiel</description>
-                  <musicXMLid>pitched-percussion.glockenspiel.alto</musicXMLid>
-                  <clef>G8va</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>72-93</aPitchRange>
-                  <pPitchRange>72-93</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 9; MS General: Glockenspiel-->
-                        <program value="9"/> <!--Glockenspiel-->
-                  </Channel>
-                  <genre>classroom</genre>
-            </Instrument>
-            <Instrument id="crotales">
-                  <family>pitched-percussion</family>
-                  <longName>Crotales</longName>
-                  <shortName>Crot.</shortName>
-                  <description>Crotales</description>
-                  <musicXMLid>metal.crotales</musicXMLid>
-                  <transposingClef>G</transposingClef>
-                  <concertClef>G15ma</concertClef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>84-108</aPitchRange>
-                  <pPitchRange>84-108</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <transposeDiatonic>14</transposeDiatonic>
-                  <transposeChromatic>24</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 10; MS General: Music Box-->
-                        <program value="10"/> <!--Music Box-->
-                  </Channel>
-                  <genre>orchestra</genre>
-                  <genre>concertband</genre>
-                  <genre>marching</genre>
-            </Instrument>
-            <Instrument id="tubaphone">
-                  <family>pitched-percussion</family>
-                  <longName>Tubaphone</longName>
-                  <shortName>Tph.</shortName>
-                  <description>Tubaphone</description>
-                  <clef>G15ma</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>84-108</aPitchRange>
-                  <pPitchRange>84-108</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 47; MS General: Timpani-->
-                        <program value="47"/> <!--Timpani-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="almglocken">
-                  <longName>Almglocken</longName>
-                  <shortName>Almg.</shortName>
-                  <description>Almglocken</description>
-                  <musicXMLid>metal.bells.almglocken</musicXMLid>
-                  <staves>2</staves>
-                  <clef>G15ma</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F15ma</clef>
-                  <aPitchRange>60-105</aPitchRange>
-                  <pPitchRange>60-105</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 108; MS General: Kalimba-->
-                        <program value="108"/> <!--Kalimba-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="vibraphone">
-                  <family>keyboard-percussion</family>
-                  <longName>Vibraphone</longName>
-                  <shortName>Vib.</shortName>
-                  <description>Vibraphone</description>
-                  <musicXMLid>pitched-percussion.vibraphone</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>53-89</aPitchRange>
-                  <pPitchRange>48-96</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 11; MS General: Vibraphone-->
-                        <program value="11"/> <!--Vibraphone-->
-                  </Channel>
-                  <genre>common</genre>
-                  <genre>jazz</genre>
-                  <genre>orchestra</genre>
-                  <genre>concertband</genre>
-                  <genre>marching</genre>
-            </Instrument>
-            <Instrument id="metallophone">
-                  <family>orff-percussion</family>
-                  <longName>Metallophone</longName>
-                  <shortName>Met.</shortName>
-                  <description>Orff Metallophone (generic)</description>
-                  <musicXMLid>pitched-percussion.metallophone</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>60-81</aPitchRange>
-                  <pPitchRange>60-81</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 11; MS General: Vibraphone-->
-                        <program value="11"/> <!--Vibraphone-->
-                  </Channel>
-                  <genre>classroom</genre>
-            </Instrument>
-            <Instrument id="orff-soprano-metallophone">
-                  <family>orff-percussion</family>
-                  <longName>Orff Soprano Metallophone</longName>
-                  <shortName>O. S. Met.</shortName>
-                  <description>Orff Soprano Metallophone</description>
-                  <musicXMLid>pitched-percussion.metallophone.soprano</musicXMLid>
-                  <clef>G8va</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>72-93</aPitchRange>
-                  <pPitchRange>72-93</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 11; MS General: Vibraphone-->
-                        <program value="11"/> <!--Vibraphone-->
-                  </Channel>
-                  <genre>classroom</genre>
-            </Instrument>
-            <Instrument id="orff-alto-metallophone">
-                  <family>orff-percussion</family>
-                  <longName>Orff Alto Metallophone</longName>
-                  <shortName>O. A. Met.</shortName>
-                  <description>Orff Alto Metallophone</description>
-                  <musicXMLid>pitched-percussion.metallophone.alto</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>60-81</aPitchRange>
-                  <pPitchRange>60-81</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 11; MS General: Vibraphone-->
-                        <program value="11"/> <!--Vibraphone-->
-                  </Channel>
-                  <genre>classroom</genre>
-            </Instrument>
-            <Instrument id="orff-bass-metallophone">
-                  <family>orff-percussion</family>
-                  <longName>Orff Bass Metallophone</longName>
-                  <shortName>O. B. Met.</shortName>
-                  <description>Orff Bass Metallophone</description>
-                  <musicXMLid>pitched-percussion.metallophone.bass</musicXMLid>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>48-69</aPitchRange>
-                  <pPitchRange>48-69</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 11; MS General: Vibraphone-->
-                        <program value="11"/> <!--Vibraphone-->
-                  </Channel>
-                  <genre>classroom</genre>
-            </Instrument>
-            <Instrument id="tubular-bells">
-                  <family>pitched-percussion</family>
-                  <longName>Chimes</longName>
-                  <shortName>Cme.</shortName>
-                  <description>Chimes or Tubular Bells</description>
-                  <musicXMLid>pitched-percussion.tubular-bells</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>60-79</aPitchRange>
-                  <pPitchRange>53-79</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 14; MS General: Tubular Bells-->
-                        <program value="14"/> <!--Tubular Bells-->
-                  </Channel>
-                  <genre>common</genre>
-                  <genre>orchestra</genre>
-                  <genre>concertband</genre>
-            </Instrument>
-            <Instrument id="steel-drums">
-                  <family>pitched-percussion</family>
-                  <longName>Steel Drums</longName>
-                  <shortName>St. Dr.</shortName>
-                  <description>Steel Drums (generic)</description>
-                  <musicXMLid>metal.steel-drums</musicXMLid>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <aPitchRange>36-88</aPitchRange>
-                  <pPitchRange>36-88</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 114; MS General: Steel Drums-->
-                        <program value="114"/> <!--Steel Drums-->
-                  </Channel>
-                  <genre>jazz</genre>
-            </Instrument>
-            <Instrument id="soprano-steel-drums">
-                  <family>pitched-percussion</family>
-                  <longName>Soprano Steel Drums</longName>
-                  <shortName>S. St. Dr.</shortName>
-                  <description>Soprano Steel Drums</description>
-                  <musicXMLid>metal.steel-drums</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>60-88</aPitchRange>
-                  <pPitchRange>60-88</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 114; MS General: Steel Drums-->
-                        <program value="114"/> <!--Steel Drums-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="alto-steel-drums">
-                  <family>pitched-percussion</family>
-                  <longName>Alto Steel Drums</longName>
-                  <shortName>A. St. Dr.</shortName>
-                  <description>Alto Steel Drums</description>
-                  <musicXMLid>metal.steel-drums</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>56-85</aPitchRange>
-                  <pPitchRange>56-85</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 114; MS General: Steel Drums-->
-                        <program value="114"/> <!--Steel Drums-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="guitar-steel-drums">
-                  <family>pitched-percussion</family>
-                  <longName>Guitar Steel Drums</longName>
-                  <shortName>Gtr. St. Dr.</shortName>
-                  <description>Guitar Steel Drums</description>
-                  <musicXMLid>metal.steel-drums</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>54-81</aPitchRange>
-                  <pPitchRange>54-81</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 114; MS General: Steel Drums-->
-                        <program value="114"/> <!--Steel Drums-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="tenor-steel-drums">
-                  <family>pitched-percussion</family>
-                  <longName>Tenor Steel Drums</longName>
-                  <shortName>T. St. Dr.</shortName>
-                  <description>Tenor Steel Drums</description>
-                  <musicXMLid>metal.steel-drums</musicXMLid>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>52-69</aPitchRange>
-                  <pPitchRange>52-69</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 114; MS General: Steel Drums-->
-                        <program value="114"/> <!--Steel Drums-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="cello-steel-drums">
-                  <family>pitched-percussion</family>
-                  <longName>Cello Steel Drums</longName>
-                  <shortName>Ce. St. Dr.</shortName>
-                  <description>Cello Steel Drums</description>
-                  <musicXMLid>metal.steel-drums</musicXMLid>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>47-67</aPitchRange>
-                  <pPitchRange>47-67</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 114; MS General: Steel Drums-->
-                        <program value="114"/> <!--Steel Drums-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="bass-steel-drums">
-                  <family>pitched-percussion</family>
-                  <longName>Bass Steel Drums</longName>
-                  <shortName>B. St. Dr.</shortName>
-                  <description>Bass Steel Drums</description>
-                  <musicXMLid>metal.steel-drums</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>36-53</aPitchRange>
-                  <pPitchRange>36-53</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 114; MS General: Steel Drums-->
-                        <program value="114"/> <!--Steel Drums-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="hand-bells">
-                  <family>pitched-percussion</family>
-                  <longName>Hand Bells</longName>
-                  <shortName>Ha. Be.</shortName>
-                  <description>Hand Bells</description>
-                  <musicXMLid>pitched-percussion.handbells</musicXMLid>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <aPitchRange>36-97</aPitchRange>
-                  <pPitchRange>36-97</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 112; MS General: Tinker Bell-->
-                        <program value="112"/> <!--Tinkle Bell-->
-                  </Channel>
-                  <genre>common</genre>
-                  <genre>choral</genre>
-            </Instrument>
-            <Instrument id="tuned-gongs">
-                  <family>pitched-percussion</family>
-                  <longName>Tuned Gongs</longName>
-                  <shortName>Td. Gon.</shortName>
-                  <description>Tuned Gongs</description>
-                  <musicXMLid>metal.gong</musicXMLid>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>45-57</aPitchRange>
-                  <pPitchRange>45-57</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 14; MS General: Tubular Bells-->
-                        <program value="14"/> <!--Tubular Bells-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="flexatone">
-                  <family>pitched-percussion</family>
-                  <longName>Flexatone</longName>
-                  <shortName>Flt.</shortName>
-                  <description>Flexatone</description>
-                  <musicXMLid>metal.flexatone</musicXMLid>
-                  <clef>G8va</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>76-93</aPitchRange>
-                  <pPitchRange>76-93</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 14; MS General: Tubular Bells-->
-                        <program value="14"/> <!--Tubular Bells-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="musical-saw">
-                  <family>pitched-percussion</family>
-                  <longName>Musical Saw</longName>
-                  <shortName>Mu. Sw.</shortName>
-                  <description>Musical Saw</description>
-                  <musicXMLid>metal.musical-saw</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>64-100</aPitchRange>
-                  <pPitchRange>64-100</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 92; MS General: Bowed Glass-->
-                        <program value="92"/> <!--Pad 5 (bowed)-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="musical-glasses">
-                  <family>pitched-percussion</family>
-                  <longName>Musical Glasses</longName>
-                  <shortName>Mu. Gla.</shortName>
-                  <description>Musical Glasses</description>
-                  <musicXMLid>pitched-percussion.crystal-glasses</musicXMLid>
-                  <clef>G8va</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>72-91</aPitchRange>
-                  <pPitchRange>72-91</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 93; MS General: Metal Pad-->
-                        <program value="93"/> <!--Pad 6 (metallic)-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="glass-harmonica">
-                  <family>pitched-percussion</family>
-                  <longName>Glass Harmonica</longName>
-                  <shortName>Gla. Har.</shortName>
-                  <description>Glass Harmonica</description>
-                  <musicXMLid>pitched-percussion.glass-harmonica</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>53-89</aPitchRange>
-                  <pPitchRange>53-89</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 92; MS General: Bowed Glass-->
-                        <program value="92"/> <!--Pad 5 (bowed)-->
-                  </Channel>
-            </Instrument>
             <Instrument id="xylophone">
                   <family>keyboard-percussion</family>
                   <longName>Xylophone</longName>
@@ -5867,57 +5972,6 @@
                   <genre>marching</genre>
                   <genre>classroom</genre>
             </Instrument>
-            <Instrument id="orff-soprano-xylophone">
-                  <family>orff-percussion</family>
-                  <longName>Orff Soprano Xylophone</longName>
-                  <shortName>O. S. Xyl.</shortName>
-                  <description>Orff Soprano Xylophone</description>
-                  <musicXMLid>pitched-percussion.xylophone.soprano</musicXMLid>
-                  <clef>G8va</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>72-93</aPitchRange>
-                  <pPitchRange>72-93</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 12; MS General: Marimba-->
-                        <program value="12"/> <!--Marimba-->
-                  </Channel>
-                  <genre>classroom</genre>
-            </Instrument>
-            <Instrument id="orff-alto-xylophone">
-                  <family>orff-percussion</family>
-                  <longName>Orff Alto Xylophone</longName>
-                  <shortName>O. A. Xyl.</shortName>
-                  <description>Orff Alto Xylophone</description>
-                  <musicXMLid>pitched-percussion.xylophone.alto</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>60-81</aPitchRange>
-                  <pPitchRange>60-81</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 12; MS General: Marimba-->
-                        <program value="12"/> <!--Marimba-->
-                  </Channel>
-                  <genre>classroom</genre>
-            </Instrument>
-            <Instrument id="orff-bass-xylophone">
-                  <family>orff-percussion</family>
-                  <longName>Orff Bass Xylophone</longName>
-                  <shortName>O. B. Xyl.</shortName>
-                  <description>Orff Bass Xylophone</description>
-                  <musicXMLid>pitched-percussion.xylophone.soprano</musicXMLid>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>48-69</aPitchRange>
-                  <pPitchRange>48-69</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 12; MS General: Marimba-->
-                        <program value="12"/> <!--Marimba-->
-                  </Channel>
-                  <genre>classroom</genre>
-            </Instrument>
             <Instrument id="xylomarimba">
                   <family>keyboard-percussion</family>
                   <longName>Xylomarimba</longName>
@@ -5939,6 +5993,67 @@
                   </Channel>
                   <genre>jazz</genre>
                   <genre>orchestra</genre>
+            </Instrument>
+            <Instrument id="vibraphone">
+                  <family>keyboard-percussion</family>
+                  <longName>Vibraphone</longName>
+                  <shortName>Vib.</shortName>
+                  <description>Vibraphone</description>
+                  <musicXMLid>pitched-percussion.vibraphone</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>53-89</aPitchRange>
+                  <pPitchRange>48-96</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 11; MS General: Vibraphone-->
+                        <program value="11"/> <!--Vibraphone-->
+                  </Channel>
+                  <genre>common</genre>
+                  <genre>jazz</genre>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
+                  <genre>marching</genre>
+            </Instrument>
+            <Instrument id="dulcimer">
+                  <family>keyboard-percussion</family>
+                  <longName>Dulcimer</longName>
+                  <shortName>Dlc.</shortName>
+                  <description>Dulcimer</description>
+                  <musicXMLid>pitched-percussion.hammer-dulcimer</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>48-86</aPitchRange>
+                  <pPitchRange>48-86</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 15; MS General: Dulcimer-->
+                        <program value="15"/> <!--Dulcimer-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="cimbalom">
+                  <family>keyboard-percussion</family>
+                  <longName>Cimbalom</longName>
+                  <shortName>Cimb.</shortName>
+                  <description>Concert Cimbalom</description>
+                  <musicXMLid>pitched-percussion.cimbalom</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>48-88</aPitchRange>
+                  <pPitchRange>40-93</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 15; MS General: Dulcimer-->
+                        <program value="15"/> <!--Dulcimer-->
+                  </Channel>
             </Instrument>
             <Instrument id="marimba">
                   <family>keyboard-percussion</family>
@@ -6025,107 +6140,69 @@
                   </Channel>
                   <genre>orchestra</genre>
             </Instrument>
-            <Instrument id="dulcimer">
-                  <family>keyboard-percussion</family>
-                  <longName>Dulcimer</longName>
-                  <shortName>Dlc.</shortName>
-                  <description>Dulcimer</description>
-                  <musicXMLid>pitched-percussion.hammer-dulcimer</musicXMLid>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <aPitchRange>48-86</aPitchRange>
-                  <pPitchRange>48-86</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 15; MS General: Dulcimer-->
-                        <program value="15"/> <!--Dulcimer-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="cimbalom">
-                  <family>keyboard-percussion</family>
-                  <longName>Cimbalom</longName>
-                  <shortName>Cimb.</shortName>
-                  <description>Concert Cimbalom</description>
-                  <musicXMLid>pitched-percussion.cimbalom</musicXMLid>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <aPitchRange>48-88</aPitchRange>
-                  <pPitchRange>40-93</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 15; MS General: Dulcimer-->
-                        <program value="15"/> <!--Dulcimer-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="tuned-klaxon-horns">
-                  <family>pitched-percussion</family>
-                  <longName>Tuned Klaxon Horns</longName>
-                  <shortName>Tn. Klx. Hns.</shortName>
-                  <description>Tuned Klaxon Horns</description>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <aPitchRange>48-72</aPitchRange>
-                  <pPitchRange>48-72</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 84; MS General: Charang-->
-                        <program value="84"/> <!--Lead 5 (charang)-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="kalimba">
-                  <longName>Kalimba</longName>
-                  <shortName>Kal.</shortName>
-                  <description>Kalimba (generic)</description>
-                  <musicXMLid>pitched-percussion.kalimba</musicXMLid>
-                  <clef>G</clef>
+            <Instrument id="crotales">
+                  <family>pitched-metal-percussion</family>
+                  <longName>Crotales</longName>
+                  <shortName>Crot.</shortName>
+                  <description>Crotales</description>
+                  <musicXMLid>metal.crotales</musicXMLid>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>G15ma</concertClef>
                   <barlineSpan>1</barlineSpan>
+                  <aPitchRange>84-108</aPitchRange>
+                  <pPitchRange>84-108</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <transposeDiatonic>14</transposeDiatonic>
+                  <transposeChromatic>24</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 10; MS General: Music Box-->
+                        <program value="10"/> <!--Music Box-->
+                  </Channel>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
+                  <genre>marching</genre>
+            </Instrument>
+            <Instrument id="almglocken">
+                  <family>pitched-metal-percussion</family>
+                  <longName>Almglocken</longName>
+                  <shortName>Almg.</shortName>
+                  <description>Almglocken</description>
+                  <musicXMLid>metal.bells.almglocken</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G15ma</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F15ma</clef>
+                  <aPitchRange>60-105</aPitchRange>
+                  <pPitchRange>60-105</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
                   <Channel>
                         <!--MIDI: Bank 0, Prog 108; MS General: Kalimba-->
                         <program value="108"/> <!--Kalimba-->
                   </Channel>
-                  <genre>world</genre>
             </Instrument>
-            <Instrument id="treble-kalimba">
-                  <longName>Treble Kalimba</longName>
-                  <shortName>Tr. Kal.</shortName>
-                  <description>Treble Kalimba</description>
-                  <musicXMLid>pitched-percussion.kalimba</musicXMLid>
+            <Instrument id="tubular-bells">
+                  <family>pitched-metal-percussion</family>
+                  <longName>Chimes</longName>
+                  <shortName>Cme.</shortName>
+                  <description>Chimes or Tubular Bells</description>
+                  <musicXMLid>pitched-percussion.tubular-bells</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
+                  <aPitchRange>60-79</aPitchRange>
+                  <pPitchRange>53-79</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 108; MS General: Kalimba-->
-                        <program value="108"/> <!--Kalimba-->
+                        <!--MIDI: Bank 0, Prog 14; MS General: Tubular Bells-->
+                        <program value="14"/> <!--Tubular Bells-->
                   </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="alto-kalimba">
-                  <longName>Alto Kalimba</longName>
-                  <shortName>A. Kal.</shortName>
-                  <description>Alto Kalimba</description>
-                  <musicXMLid>pitched-percussion.kalimba</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 108; MS General: Kalimba-->
-                        <program value="108"/> <!--Kalimba-->
-                  </Channel>
-                  <genre>world</genre>
+                  <genre>common</genre>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
             </Instrument>
             <Instrument id="carillon">
+                  <family>pitched-metal-percussion</family>
                   <longName>Carillon</longName>
                   <shortName>Car.</shortName>
                   <description>Carillon</description>
@@ -6145,29 +6222,441 @@
                   </Channel>
                   <genre>world</genre>
             </Instrument>
+            <Instrument id="tuned-gongs">
+                  <family>pitched-metal-percussion</family>
+                  <longName>Tuned Gongs</longName>
+                  <shortName>Td. Gon.</shortName>
+                  <description>Tuned Gongs</description>
+                  <musicXMLid>metal.gong</musicXMLid>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>45-57</aPitchRange>
+                  <pPitchRange>45-57</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 14; MS General: Tubular Bells-->
+                        <program value="14"/> <!--Tubular Bells-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="hand-bells">
+                  <family>pitched-metal-percussion</family>
+                  <longName>Hand Bells</longName>
+                  <shortName>Ha. Be.</shortName>
+                  <description>Hand Bells</description>
+                  <musicXMLid>pitched-percussion.handbells</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>36-97</aPitchRange>
+                  <pPitchRange>36-97</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 112; MS General: Tinker Bell-->
+                        <program value="112"/> <!--Tinkle Bell-->
+                  </Channel>
+                  <genre>common</genre>
+                  <genre>choral</genre>
+            </Instrument>
+            <Instrument id="orff-soprano-glockenspiel">
+                  <family>orff-percussion</family>
+                  <longName>Orff Soprano Glockenspiel</longName>
+                  <shortName>O. S. Glk.</shortName>
+                  <description>Orff Soprano Glockenspiel</description>
+                  <musicXMLid>pitched-percussion.glockenspiel.soprano</musicXMLid>
+                  <clef>G15ma</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>84-105</aPitchRange>
+                  <pPitchRange>84-105</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 9; MS General: Glockenspiel-->
+                        <program value="9"/> <!--Glockenspiel-->
+                  </Channel>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="orff-alto-glockenspiel">
+                  <family>orff-percussion</family>
+                  <longName>Orff Alto Glockenspiel</longName>
+                  <shortName>O. A. Glk.</shortName>
+                  <description>Orff Alto Glockenspiel</description>
+                  <musicXMLid>pitched-percussion.glockenspiel.alto</musicXMLid>
+                  <clef>G8va</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>72-93</aPitchRange>
+                  <pPitchRange>72-93</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 9; MS General: Glockenspiel-->
+                        <program value="9"/> <!--Glockenspiel-->
+                  </Channel>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="orff-soprano-metallophone">
+                  <family>orff-percussion</family>
+                  <longName>Orff Soprano Metallophone</longName>
+                  <shortName>O. S. Met.</shortName>
+                  <description>Orff Soprano Metallophone</description>
+                  <musicXMLid>pitched-percussion.metallophone.soprano</musicXMLid>
+                  <clef>G8va</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>72-93</aPitchRange>
+                  <pPitchRange>72-93</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 11; MS General: Vibraphone-->
+                        <program value="11"/> <!--Vibraphone-->
+                  </Channel>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="orff-soprano-xylophone">
+                  <family>orff-percussion</family>
+                  <longName>Orff Soprano Xylophone</longName>
+                  <shortName>O. S. Xyl.</shortName>
+                  <description>Orff Soprano Xylophone</description>
+                  <musicXMLid>pitched-percussion.xylophone.soprano</musicXMLid>
+                  <clef>G8va</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>72-93</aPitchRange>
+                  <pPitchRange>72-93</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 12; MS General: Marimba-->
+                        <program value="12"/> <!--Marimba-->
+                  </Channel>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="metallophone">
+                  <family>orff-percussion</family>
+                  <longName>Metallophone</longName>
+                  <shortName>Met.</shortName>
+                  <description>Orff Metallophone (generic)</description>
+                  <musicXMLid>pitched-percussion.metallophone</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>60-81</aPitchRange>
+                  <pPitchRange>60-81</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 11; MS General: Vibraphone-->
+                        <program value="11"/> <!--Vibraphone-->
+                  </Channel>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="orff-alto-metallophone">
+                  <family>orff-percussion</family>
+                  <longName>Orff Alto Metallophone</longName>
+                  <shortName>O. A. Met.</shortName>
+                  <description>Orff Alto Metallophone</description>
+                  <musicXMLid>pitched-percussion.metallophone.alto</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>60-81</aPitchRange>
+                  <pPitchRange>60-81</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 11; MS General: Vibraphone-->
+                        <program value="11"/> <!--Vibraphone-->
+                  </Channel>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="orff-alto-xylophone">
+                  <family>orff-percussion</family>
+                  <longName>Orff Alto Xylophone</longName>
+                  <shortName>O. A. Xyl.</shortName>
+                  <description>Orff Alto Xylophone</description>
+                  <musicXMLid>pitched-percussion.xylophone.alto</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>60-81</aPitchRange>
+                  <pPitchRange>60-81</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 12; MS General: Marimba-->
+                        <program value="12"/> <!--Marimba-->
+                  </Channel>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="orff-bass-metallophone">
+                  <family>orff-percussion</family>
+                  <longName>Orff Bass Metallophone</longName>
+                  <shortName>O. B. Met.</shortName>
+                  <description>Orff Bass Metallophone</description>
+                  <musicXMLid>pitched-percussion.metallophone.bass</musicXMLid>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>48-69</aPitchRange>
+                  <pPitchRange>48-69</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 11; MS General: Vibraphone-->
+                        <program value="11"/> <!--Vibraphone-->
+                  </Channel>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="orff-bass-xylophone">
+                  <family>orff-percussion</family>
+                  <longName>Orff Bass Xylophone</longName>
+                  <shortName>O. B. Xyl.</shortName>
+                  <description>Orff Bass Xylophone</description>
+                  <musicXMLid>pitched-percussion.xylophone.soprano</musicXMLid>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>48-69</aPitchRange>
+                  <pPitchRange>48-69</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 12; MS General: Marimba-->
+                        <program value="12"/> <!--Marimba-->
+                  </Channel>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="flexatone">
+                  <family>flexatones</family>
+                  <longName>Flexatone</longName>
+                  <shortName>Flt.</shortName>
+                  <description>Flexatone</description>
+                  <musicXMLid>metal.flexatone</musicXMLid>
+                  <clef>G8va</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>76-93</aPitchRange>
+                  <pPitchRange>76-93</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 14; MS General: Tubular Bells-->
+                        <program value="14"/> <!--Tubular Bells-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="musical-saw">
+                  <family>musical-saws</family>
+                  <longName>Musical Saw</longName>
+                  <shortName>Mu. Sw.</shortName>
+                  <description>Musical Saw</description>
+                  <musicXMLid>metal.musical-saw</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>64-100</aPitchRange>
+                  <pPitchRange>64-100</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 92; MS General: Bowed Glass-->
+                        <program value="92"/> <!--Pad 5 (bowed)-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="musical-glasses">
+                  <family>glass-percussion</family>
+                  <longName>Musical Glasses</longName>
+                  <shortName>Mu. Gla.</shortName>
+                  <description>Musical Glasses</description>
+                  <musicXMLid>pitched-percussion.crystal-glasses</musicXMLid>
+                  <clef>G8va</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>72-91</aPitchRange>
+                  <pPitchRange>72-91</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 93; MS General: Metal Pad-->
+                        <program value="93"/> <!--Pad 6 (metallic)-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="glass-harmonica">
+                  <family>glass-percussion</family>
+                  <longName>Glass Harmonica</longName>
+                  <shortName>Gla. Har.</shortName>
+                  <description>Glass Harmonica</description>
+                  <musicXMLid>pitched-percussion.glass-harmonica</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>53-89</aPitchRange>
+                  <pPitchRange>53-89</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 92; MS General: Bowed Glass-->
+                        <program value="92"/> <!--Pad 5 (bowed)-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="tuned-klaxon-horns">
+                  <family>klaxon-horns</family>
+                  <longName>Tuned Klaxon Horns</longName>
+                  <shortName>Tn. Klx. Hns.</shortName>
+                  <description>Tuned Klaxon Horns</description>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>48-72</aPitchRange>
+                  <pPitchRange>48-72</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 84; MS General: Charang-->
+                        <program value="84"/> <!--Lead 5 (charang)-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="alto-kalimba">
+                  <family>kalimbas</family>
+                  <longName>Alto Kalimba</longName>
+                  <shortName>A. Kal.</shortName>
+                  <description>Alto Kalimba</description>
+                  <musicXMLid>pitched-percussion.kalimba</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 108; MS General: Kalimba-->
+                        <program value="108"/> <!--Kalimba-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="kalimba">
+                  <family>kalimbas</family>
+                  <longName>Kalimba</longName>
+                  <shortName>Kal.</shortName>
+                  <description>Kalimba (generic)</description>
+                  <musicXMLid>pitched-percussion.kalimba</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 108; MS General: Kalimba-->
+                        <program value="108"/> <!--Kalimba-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="treble-kalimba">
+                  <family>kalimbas</family>
+                  <longName>Treble Kalimba</longName>
+                  <shortName>Tr. Kal.</shortName>
+                  <description>Treble Kalimba</description>
+                  <musicXMLid>pitched-percussion.kalimba</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 108; MS General: Kalimba-->
+                        <program value="108"/> <!--Kalimba-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
       </InstrumentGroup>
       <InstrumentGroup id="unpitched-percussion">
             <name>Percussion - Unpitched</name>
-            <Instrument id="drumset">
+            <Instrument id="automobile-brake-drums">
                   <family>drums</family>
-                  <!--Drums for the basic drumset are hard-coded in instrument.cpp for some reason.-->
-                  <longName>Drumset</longName>
-                  <shortName>D. Set</shortName>
-                  <description>Drumset</description>
-                  <musicXMLid>drum.group.set</musicXMLid>
+                  <longName>Automobile Brake Drums</longName>
+                  <shortName>Aut. Brk. Dr.</shortName>
+                  <description>Automobile Brake Drums</description>
+                  <musicXMLid>metal.brake-drums</musicXMLid>
                   <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc5Line">percussion</stafftype>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="68"> <!--Low Agogô-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Low Agogo</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
                   <Channel>
                         <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
                         <controller ctrl="0" value="1"/> <!--Bank MSB-->
                         <program value="0"/> <!--Standard Kit-->
                   </Channel>
-                  <genre>common</genre>
+                  <genre>concertband</genre>
+                  <genre>marching</genre>
+            </Instrument>
+            <Instrument id="bongos">
+                  <family>drums</family>
+                  <longName>Bongos</longName>
+                  <shortName>Bon.</shortName>
+                  <description>Bongos</description>
+                  <musicXMLid>drum.bongo</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="60"> <!--High Bongo-->
+                        <head>normal</head>
+                        <line>-1</line>
+                        <voice>0</voice>
+                        <name>High Bongo</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Drum pitch="61"> <!--Low Bongo-->
+                        <head>normal</head>
+                        <line>1</line>
+                        <voice>0</voice>
+                        <name>Low Bongo</name>
+                        <stem>1</stem>
+                        <shortcut>B</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="48"/> <!--Orchestra Kit-->
+                  </Channel>
                   <genre>popular</genre>
                   <genre>jazz</genre>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
+                  <genre>marching</genre>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="chinese-tom-toms">
+                  <family>drums</family>
+                  <longName>Chinese Tom-Toms</longName>
+                  <shortName>Ch. Toms</shortName>
+                  <description>Chinese Tom-toms</description>
+                  <musicXMLid>drum.group.chinese</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="61"> <!--Low Bongo-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Low Bongo</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="48"/> <!--Orchestra Kit-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="bass-drum">
+                  <family>drums</family>
+                  <longName>Concert Bass Drum</longName>
+                  <shortName>Con. BD</shortName>
+                  <description>Bass Drum</description>
+                  <musicXMLid>drum.bass-drum</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="35"> <!--Acoustic Bass Drum-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Acoustic Bass Drum</name>
+                        <stem>2</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="48"/> <!--Orchestra Kit-->
+                  </Channel>
+                  <genre>common</genre>
                   <genre>orchestra</genre>
                   <genre>concertband</genre>
                   <genre>marching</genre>
@@ -6209,101 +6698,6 @@
                   <genre>orchestra</genre>
                   <genre>concertband</genre>
                   <genre>marching</genre>
-            </Instrument>
-            <Instrument id="bass-drum">
-                  <family>drums</family>
-                  <longName>Concert Bass Drum</longName>
-                  <shortName>Con. BD</shortName>
-                  <description>Bass Drum</description>
-                  <musicXMLid>drum.bass-drum</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="35"> <!--Acoustic Bass Drum-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Acoustic Bass Drum</name>
-                        <stem>2</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="48"/> <!--Orchestra Kit-->
-                  </Channel>
-                  <genre>common</genre>
-                  <genre>orchestra</genre>
-                  <genre>concertband</genre>
-                  <genre>marching</genre>
-            </Instrument>
-            <Instrument id="piccolo-snare-drum">
-                  <family>drums</family>
-                  <longName>Piccolo Snare</longName>
-                  <shortName>Picc. Sn.</shortName>
-                  <description>Piccolo Snare Drum</description>
-                  <musicXMLid>drum.snare-drum</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="37"> <!--Side Stick-->
-                        <head>cross</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Side Stick</name>
-                        <stem>2</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Drum pitch="40"> <!--Electric Snare-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Electric Snare</name>
-                        <stem>2</stem>
-                        <shortcut>B</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="48"/> <!--Orchestra Kit-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="military-drum">
-                  <family>drums</family>
-                  <longName>Field Drum</longName>
-                  <shortName>Field Dr.</shortName>
-                  <description>Military Field Drum</description>
-                  <musicXMLid>drum.snare-drum</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="37"> <!--Side Stick-->
-                        <head>cross</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Side Stick</name>
-                        <stem>2</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Drum pitch="38"> <!--Acoustic Snare-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Acoustic Snare</name>
-                        <stem>2</stem>
-                        <shortcut>B</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="48"/> <!--Orchestra Kit-->
-                  </Channel>
             </Instrument>
             <Instrument id="tom-toms">
                   <family>drums</family>
@@ -6367,71 +6761,6 @@
                   <genre>concertband</genre>
                   <genre>marching</genre>
             </Instrument>
-            <Instrument id="chinese-tom-toms">
-                  <family>drums</family>
-                  <longName>Chinese Tom-Toms</longName>
-                  <shortName>Ch. Toms</shortName>
-                  <description>Chinese Tom-toms</description>
-                  <musicXMLid>drum.group.chinese</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="61"> <!--Low Bongo-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Low Bongo</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="48"/> <!--Orchestra Kit-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="bongos">
-                  <family>drums</family>
-                  <longName>Bongos</longName>
-                  <shortName>Bon.</shortName>
-                  <description>Bongos</description>
-                  <musicXMLid>drum.bongo</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="60"> <!--High Bongo-->
-                        <head>normal</head>
-                        <line>-1</line>
-                        <voice>0</voice>
-                        <name>High Bongo</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Drum pitch="61"> <!--Low Bongo-->
-                        <head>normal</head>
-                        <line>1</line>
-                        <voice>0</voice>
-                        <name>Low Bongo</name>
-                        <stem>1</stem>
-                        <shortcut>B</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="48"/> <!--Orchestra Kit-->
-                  </Channel>
-                  <genre>popular</genre>
-                  <genre>jazz</genre>
-                  <genre>orchestra</genre>
-                  <genre>concertband</genre>
-                  <genre>marching</genre>
-                  <genre>classroom</genre>
-            </Instrument>
             <Instrument id="congas">
                   <family>drums</family>
                   <longName>Congas</longName>
@@ -6478,6 +6807,215 @@
                   <genre>concertband</genre>
                   <genre>marching</genre>
             </Instrument>
+            <Instrument id="cuica">
+                  <family>drums</family>
+                  <longName>Cuica</longName>
+                  <shortName>Cu.</shortName>
+                  <description>Cuica</description>
+                  <musicXMLid>drum.cuica</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="78"> <!--Mute Cuica-->
+                        <head>cross</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Mute Cuica</name>
+                        <stem>1</stem>
+                        <shortcut>B</shortcut>
+                  </Drum>
+                  <Drum pitch="79"> <!--Open Cuica-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Open Cuica</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="drumset">
+                  <family>drums</family>
+                  <!--Drums for the basic drumset are hard-coded in instrument.cpp for some reason.-->
+                  <longName>Drumset</longName>
+                  <shortName>D. Set</shortName>
+                  <description>Drumset</description>
+                  <musicXMLid>drum.group.set</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc5Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+                  <genre>common</genre>
+                  <genre>popular</genre>
+                  <genre>jazz</genre>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
+                  <genre>marching</genre>
+            </Instrument>
+            <Instrument id="military-drum">
+                  <family>drums</family>
+                  <longName>Field Drum</longName>
+                  <shortName>Field Dr.</shortName>
+                  <description>Military Field Drum</description>
+                  <musicXMLid>drum.snare-drum</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="37"> <!--Side Stick-->
+                        <head>cross</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Side Stick</name>
+                        <stem>2</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Drum pitch="38"> <!--Acoustic Snare-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Acoustic Snare</name>
+                        <stem>2</stem>
+                        <shortcut>B</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="48"/> <!--Orchestra Kit-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="frame-drum">
+                  <family>drums</family>
+                  <longName>Frame Drum</longName>
+                  <shortName>Fr. Dr.</shortName>
+                  <description>Frame Drum</description>
+                  <musicXMLid>drum.frame-drum</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="45"> <!--Low Tom-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Low Tom</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="piccolo-snare-drum">
+                  <family>drums</family>
+                  <longName>Piccolo Snare</longName>
+                  <shortName>Picc. Sn.</shortName>
+                  <description>Piccolo Snare Drum</description>
+                  <musicXMLid>drum.snare-drum</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="37"> <!--Side Stick-->
+                        <head>cross</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Side Stick</name>
+                        <stem>2</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Drum pitch="40"> <!--Electric Snare-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Electric Snare</name>
+                        <stem>2</stem>
+                        <shortcut>B</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="48"/> <!--Orchestra Kit-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="slit-drum">
+                  <family>drums</family>
+                  <longName>Slit Drum</longName>
+                  <shortName>Slt. Dr.</shortName>
+                  <description>Slit Drum</description>
+                  <musicXMLid>drum.slit-drum</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="77"> <!--Low Woodblock-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Low Wood Block</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="tablas">
+                  <family>drums</family>
+                  <longName>Tablas</longName>
+                  <shortName>Tbs.</shortName>
+                  <description>Tablas</description>
+                  <musicXMLid>drum.tabla</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="62"> <!--Mute High Conga-->
+                        <head>normal</head>
+                        <line>-1</line>
+                        <voice>0</voice>
+                        <name>Mute High Conga</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Drum pitch="64"> <!--Low Conga-->
+                        <head>normal</head>
+                        <line>1</line>
+                        <voice>0</voice>
+                        <name>Low Conga</name>
+                        <stem>1</stem>
+                        <shortcut>B</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
             <Instrument id="timbales">
                   <family>drums</family>
                   <longName>Timbales</longName>
@@ -6514,22 +7052,48 @@
                   <genre>concertband</genre>
                   <genre>marching</genre>
             </Instrument>
-            <Instrument id="frame-drum">
-                  <family>drums</family>
-                  <longName>Frame Drum</longName>
-                  <shortName>Fr. Dr.</shortName>
-                  <description>Frame Drum</description>
-                  <musicXMLid>drum.frame-drum</musicXMLid>
+            <Instrument id="anvil">
+                  <family>unpitched-metal-percussion</family>
+                  <longName>Anvil</longName>
+                  <shortName>Anv.</shortName>
+                  <description>Anvil</description>
+                  <musicXMLid>metal.anvil</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="45"> <!--Low Tom-->
+                  <Drum pitch="53"> <!--Ride Bell-->
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>Low Tom</name>
+                        <name>Ride Bell</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="48"/> <!--Orchestra Kit-->
+                  </Channel>
+                  <genre>orchestra</genre>
+            </Instrument>
+            <Instrument id="bell-plate">
+                  <family>unpitched-metal-percussion</family>
+                  <longName>Bell Plate</longName>
+                  <shortName>Be. Pla.</shortName>
+                  <description>Bell Plate</description>
+                  <musicXMLid>metal.bells.bell-plate</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="58"> <!--Vibra Slap-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Vibraslap</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
@@ -6538,64 +7102,47 @@
                         <controller ctrl="0" value="1"/> <!--Bank MSB-->
                         <program value="0"/> <!--Standard Kit-->
                   </Channel>
-                  <genre>world</genre>
             </Instrument>
-            <Instrument id="tablas">
-                  <longName>Tablas</longName>
-                  <shortName>Tbs.</shortName>
-                  <description>Tablas</description>
-                  <musicXMLid>drum.tabla</musicXMLid>
+            <Instrument id="bells">
+                  <family>unpitched-metal-percussion</family>
+                  <longName>Bells</longName>
+                  <shortName>Be.</shortName>
+                  <description>Bells</description>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="62"> <!--Mute High Conga-->
-                        <head>normal</head>
-                        <line>-1</line>
-                        <voice>0</voice>
-                        <name>Mute High Conga</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Drum pitch="64"> <!--Low Conga-->
-                        <head>normal</head>
-                        <line>1</line>
-                        <voice>0</voice>
-                        <name>Low Conga</name>
-                        <stem>1</stem>
-                        <shortcut>B</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="cuica">
-                  <longName>Cuica</longName>
-                  <shortName>Cu.</shortName>
-                  <description>Cuica</description>
-                  <musicXMLid>drum.cuica</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="78"> <!--Mute Cuica-->
+                  <Drum pitch="53"> <!--Ride Bell-->
                         <head>cross</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>Mute Cuica</name>
+                        <name>Ride Bell</name>
                         <stem>1</stem>
-                        <shortcut>B</shortcut>
+                        <shortcut>A</shortcut>
                   </Drum>
-                  <Drum pitch="79"> <!--Open Cuica-->
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="bowl-gongs">
+                  <family>unpitched-metal-percussion</family>
+                  <longName>Bowl Gongs</longName>
+                  <shortName>Bw. Gon.</shortName>
+                  <description>Bowl Gongs</description>
+                  <musicXMLid>metal.gong</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="52"> <!--Chinese Cymbal-->
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>Open Cuica</name>
+                        <name>Chinese Cymbal</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
@@ -6606,7 +7153,142 @@
                   </Channel>
                   <genre>world</genre>
             </Instrument>
+            <Instrument id="chains">
+                  <family>unpitched-metal-percussion</family>
+                  <longName>Chains</longName>
+                  <shortName>Chn.</shortName>
+                  <description>Chains</description>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="69"> <!--Cabasa-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Cabasa</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="chinese-cymbal">
+                  <family>unpitched-metal-percussion</family>
+                  <longName>Chinese Cymbal</longName>
+                  <shortName>Ch. Cym.</shortName>
+                  <description>Chinese Cymbal</description>
+                  <musicXMLid>metal.cymbal.chinese</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="52"> <!--Chinese Cymbal-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Chinese Cymbal</name>
+                        <stem>2</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+                  <genre>concertband</genre>
+                  <genre>marching</genre>
+            </Instrument>
+            <Instrument id="cowbell">
+                  <family>unpitched-metal-percussion</family>
+                  <longName>Cowbell</longName>
+                  <shortName>Cwb.</shortName>
+                  <description>Cowbell</description>
+                  <musicXMLid>metal.bells.cowbell</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="56"> <!--Cowbell-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Cowbell</name>
+                        <stem>2</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="crash-cymbal">
+                  <family>unpitched-metal-percussion</family>
+                  <longName>Crash Cymbal</longName>
+                  <shortName>Cr. Cym.</shortName>
+                  <description>Crash Cymbal</description>
+                  <musicXMLid>metal.cymbal.crash</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="57"> <!--Crash Cymbal 2-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Crash Cymbal 1</name>
+                        <stem>2</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="48"/> <!--Orchestra Kit-->
+                  </Channel>
+                  <genre>concertband</genre>
+                  <genre>marching</genre>
+            </Instrument>
+            <Instrument id="cymbal">
+                  <family>unpitched-metal-percussion</family>
+                  <longName>Cymbal</longName>
+                  <shortName>Cym.</shortName>
+                  <description>Cymbal</description>
+                  <musicXMLid>metal.cymbal.crash</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="57"> <!--Crash Cymbal 2-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Crash Cymbal 2</name>
+                        <stem>2</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="48"/> <!--Orchestra Kit-->
+                  </Channel>
+                  <genre>common</genre>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
+                  <genre>marching</genre>
+                  <genre>classroom</genre>
+            </Instrument>
             <Instrument id="finger-cymbals">
+                  <family>unpitched-metal-percussion</family>
                   <longName>Finger Cymbals</longName>
                   <shortName>Fi. Cym.</shortName>
                   <description>Finger Cymbals</description>
@@ -6672,171 +7354,21 @@
                         <program value="0"/> <!--Standard Kit-->
                   </Channel>
             </Instrument>
-            <Instrument id="tam-tam">
+            <Instrument id="iron-pipes">
                   <family>unpitched-metal-percussion</family>
-                  <longName>Tam-Tam</longName>
-                  <shortName>Tam</shortName>
-                  <description>Tam-Tam</description>
-                  <musicXMLid>metal.tamtam</musicXMLid>
+                  <longName>Iron Pipes</longName>
+                  <shortName>Ir. Pi.</shortName>
+                  <description>Iron Pipes</description>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="52"> <!--Chinese Cymbal-->
-                        <head>cross</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Chinese Cymbal</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-                  <genre>orchestra</genre>
-                  <genre>concertband</genre>
-                  <genre>marching</genre>
-            </Instrument>
-            <Instrument id="bells">
-                  <family>pitched-percussion</family>
-                  <longName>Bells</longName>
-                  <shortName>Be.</shortName>
-                  <description>Bells</description>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="53"> <!--Ride Bell-->
-                        <head>cross</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Ride Bell</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="sleigh-bells">
-                  <family>unpitched-metal-percussion</family>
-                  <longName>Sleigh Bells</longName>
-                  <shortName>Sle. Be.</shortName>
-                  <description>Sleigh Bells</description>
-                  <musicXMLid>metal.bells.sleigh-bells</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="83"> <!--Jingle Bell-->
+                  <Drum pitch="68"> <!--Low Agogô-->
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>Sleigh Bell</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-                  <genre>classroom</genre>
-            </Instrument>
-            <Instrument id="bell-plate">
-                  <family>pitched-percussion</family>
-                  <longName>Bell Plate</longName>
-                  <shortName>Be. Pla.</shortName>
-                  <description>Bell Plate</description>
-                  <musicXMLid>metal.bells.bell-plate</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="58"> <!--Vibra Slap-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Vibraslap</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="bowl-gongs">
-                  <longName>Bowl Gongs</longName>
-                  <shortName>Bw. Gon.</shortName>
-                  <description>Bowl Gongs</description>
-                  <musicXMLid>metal.gong</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="52"> <!--Chinese Cymbal-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Chinese Cymbal</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="tubo">
-                  <longName>Tubo</longName>
-                  <shortName>Tu.</shortName>
-                  <description>Tubo</description>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="82"> <!--Shaker-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Shaker</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="shaker">
-                  <longName>Shaker</longName>
-                  <shortName>Sh.</shortName>
-                  <description>Shaker</description>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <Drum pitch="82"> <!--Shaker-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Shaker</name>
+                        <name>Low Agogo</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
@@ -6872,62 +7404,12 @@
                   <genre>orchestra</genre>
                   <genre>world</genre>
             </Instrument>
-            <Instrument id="automobile-brake-drums">
-                  <family>drums</family>
-                  <longName>Automobile Brake Drums</longName>
-                  <shortName>Aut. Brk. Dr.</shortName>
-                  <description>Automobile Brake Drums</description>
-                  <musicXMLid>metal.brake-drums</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="68"> <!--Low Agogô-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Low Agogo</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-                  <genre>concertband</genre>
-                  <genre>marching</genre>
-            </Instrument>
-            <Instrument id="iron-pipes">
+            <Instrument id="metal-wind-chimes">
                   <family>unpitched-metal-percussion</family>
-                  <longName>Iron Pipes</longName>
-                  <shortName>Ir. Pi.</shortName>
-                  <description>Iron Pipes</description>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="68"> <!--Low Agogô-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Low Agogo</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="chains">
-                  <family>unpitched-metal-percussion</family>
-                  <longName>Chains</longName>
-                  <shortName>Chn.</shortName>
-                  <description>Chains</description>
+                  <longName>Metal Wind Chimes</longName>
+                  <shortName>Met. Wn Ch.</shortName>
+                  <description>Metal Wind Chimes</description>
+                  <musicXMLid>metal.bells.wind-chimes</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
@@ -6946,97 +7428,114 @@
                         <controller ctrl="0" value="1"/> <!--Bank MSB-->
                         <program value="0"/> <!--Standard Kit-->
                   </Channel>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
+                  <genre>marching</genre>
             </Instrument>
-            <Instrument id="anvil">
+            <Instrument id="ride-cymbal">
                   <family>unpitched-metal-percussion</family>
-                  <longName>Anvil</longName>
-                  <shortName>Anv.</shortName>
-                  <description>Anvil</description>
-                  <musicXMLid>metal.anvil</musicXMLid>
+                  <longName>Ride Cymbal</longName>
+                  <shortName>R. Cym.</shortName>
+                  <description>Ride Cymbal</description>
+                  <musicXMLid>metal.cymbal.ride</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="51"> <!--Ride Cymbal 1-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Ride Cymbal 1</name>
+                        <stem>2</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
                   <Drum pitch="53"> <!--Ride Bell-->
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
                         <name>Ride Bell</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
+                        <stem>2</stem>
+                        <shortcut>B</shortcut>
                   </Drum>
                   <Channel>
-                        <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
                         <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="48"/> <!--Orchestra Kit-->
+                        <program value="0"/> <!--Standard Kit-->
                   </Channel>
-                  <genre>orchestra</genre>
             </Instrument>
-            <Instrument id="wood-blocks">
-                  <family>unpitched-wooden-percussion</family>
-                  <longName>Wood Blocks</longName>
-                  <shortName>Wd. Bl.</shortName>
-                  <description>Wood Blocks</description>
-                  <musicXMLid>wood.wood-block</musicXMLid>
+            <Instrument id="sleigh-bells">
+                  <family>unpitched-metal-percussion</family>
+                  <longName>Sleigh Bells</longName>
+                  <shortName>Sle. Be.</shortName>
+                  <description>Sleigh Bells</description>
+                  <musicXMLid>metal.bells.sleigh-bells</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="76"> <!--High Woodblock-->
+                  <Drum pitch="83"> <!--Jingle Bell-->
                         <head>normal</head>
-                        <line>-1</line>
+                        <line>0</line>
                         <voice>0</voice>
-                        <name>High Wood Block</name>
+                        <name>Sleigh Bell</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
-                  <Drum pitch="77"> <!--Low Woodblock-->
-                        <head>normal</head>
-                        <line>1</line>
-                        <voice>0</voice>
-                        <name>Low Wood Block</name>
-                        <stem>1</stem>
-                        <shortcut>B</shortcut>
-                  </Drum>
                   <Channel>
-                        <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
                         <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="48"/> <!--Orchestra Kit-->
+                        <program value="0"/> <!--Standard Kit-->
                   </Channel>
-                  <genre>common</genre>
-                  <genre>orchestra</genre>
-                  <genre>concertband</genre>
-                  <genre>marching</genre>
                   <genre>classroom</genre>
             </Instrument>
-            <Instrument id="temple-blocks">
-                  <family>unpitched-wooden-percussion</family>
-                  <longName>Temple Blocks</longName>
-                  <shortName>Tmp. Bl.</shortName>
-                  <description>Temple Blocks</description>
-                  <musicXMLid>wood.temple-block</musicXMLid>
+            <Instrument id="splash-cymbal">
+                  <family>unpitched-metal-percussion</family>
+                  <longName>Splash Cymbal</longName>
+                  <shortName>Sp. Cym.</shortName>
+                  <description>Splash Cymbal</description>
+                  <musicXMLid>metal.cymbal.splash</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="76"> <!--High Woodblock-->
+                  <Drum pitch="55"> <!--Splash Cymbal-->
                         <head>normal</head>
-                        <line>-1</line>
+                        <line>0</line>
                         <voice>0</voice>
-                        <name>High Wood Block</name>
-                        <stem>1</stem>
+                        <name>Splash Cymbal</name>
+                        <stem>2</stem>
                         <shortcut>A</shortcut>
                   </Drum>
-                  <Drum pitch="77"> <!--Low Woodblock-->
-                        <head>normal</head>
-                        <line>1</line>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+                  <genre>concertband</genre>
+                  <genre>marching</genre>
+            </Instrument>
+            <Instrument id="tam-tam">
+                  <family>unpitched-metal-percussion</family>
+                  <longName>Tam-Tam</longName>
+                  <shortName>Tam</shortName>
+                  <description>Tam-Tam</description>
+                  <musicXMLid>metal.tamtam</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="52"> <!--Chinese Cymbal-->
+                        <head>cross</head>
+                        <line>0</line>
                         <voice>0</voice>
-                        <name>Low Wood Block</name>
+                        <name>Chinese Cymbal</name>
                         <stem>1</stem>
-                        <shortcut>B</shortcut>
+                        <shortcut>A</shortcut>
                   </Drum>
                   <Channel>
                         <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
@@ -7046,6 +7545,31 @@
                   <genre>orchestra</genre>
                   <genre>concertband</genre>
                   <genre>marching</genre>
+            </Instrument>
+            <Instrument id="thundersheet">
+                  <family>unpitched-metal-percussion</family>
+                  <longName>Thundersheet</longName>
+                  <shortName>Thu.</shortName>
+                  <description>Thundersheet</description>
+                  <musicXMLid>metal.thundersheet</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="49"> <!--Crash Cymbal 1-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Crash Cymbal 1</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
             </Instrument>
             <Instrument id="triangle">
                   <family>unpitched-metal-percussion</family>
@@ -7085,86 +7609,23 @@
                   <genre>marching</genre>
                   <genre>classroom</genre>
             </Instrument>
-            <Instrument id="cymbal">
-                  <family>unpitched-metal-percussion</family>
-                  <longName>Cymbal</longName>
-                  <shortName>Cym.</shortName>
-                  <description>Cymbal</description>
-                  <musicXMLid>metal.cymbal.crash</musicXMLid>
+            <Instrument id="bamboo-wind-chimes">
+                  <family>unpitched-wooden-percussion</family>
+                  <longName>Bamboo Wind Chimes</longName>
+                  <shortName>Bam. Wn. Ch.</shortName>
+                  <description>Bamboo Wind Chimes</description>
+                  <musicXMLid>metal.bells.wind-chimes</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="57"> <!--Crash Cymbal 2-->
+                  <Drum pitch="69"> <!--Cabasa-->
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>Crash Cymbal 2</name>
-                        <stem>2</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="48"/> <!--Orchestra Kit-->
-                  </Channel>
-                  <genre>common</genre>
-                  <genre>orchestra</genre>
-                  <genre>concertband</genre>
-                  <genre>marching</genre>
-                  <genre>classroom</genre>
-            </Instrument>
-            <Instrument id="ride-cymbal">
-                  <family>unpitched-metal-percussion</family>
-                  <longName>Ride Cymbal</longName>
-                  <shortName>R. Cym.</shortName>
-                  <description>Ride Cymbal</description>
-                  <musicXMLid>metal.cymbal.ride</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="51"> <!--Ride Cymbal 1-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Ride Cymbal 1</name>
-                        <stem>2</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Drum pitch="53"> <!--Ride Bell-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Ride Bell</name>
-                        <stem>2</stem>
-                        <shortcut>B</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="chinese-cymbal">
-                  <family>unpitched-metal-percussion</family>
-                  <longName>Chinese Cymbal</longName>
-                  <shortName>Ch. Cym.</shortName>
-                  <description>Chinese Cymbal</description>
-                  <musicXMLid>metal.cymbal.chinese</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="52"> <!--Chinese Cymbal-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Chinese Cymbal</name>
-                        <stem>2</stem>
+                        <name>Cabasa</name>
+                        <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
                   <Channel>
@@ -7172,53 +7633,24 @@
                         <controller ctrl="0" value="1"/> <!--Bank MSB-->
                         <program value="0"/> <!--Standard Kit-->
                   </Channel>
-                  <genre>concertband</genre>
-                  <genre>marching</genre>
             </Instrument>
-            <Instrument id="crash-cymbal">
-                  <family>unpitched-metal-percussion</family>
-                  <longName>Crash Cymbal</longName>
-                  <shortName>Cr. Cym.</shortName>
-                  <description>Crash Cymbal</description>
-                  <musicXMLid>metal.cymbal.crash</musicXMLid>
+            <Instrument id="castanets">
+                  <family>unpitched-wooden-percussion</family>
+                  <longName>Castanets</longName>
+                  <shortName>Cst.</shortName>
+                  <description>Castanets</description>
+                  <musicXMLid>wood.castanets</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="57"> <!--Crash Cymbal 2-->
+                  <Drum pitch="85"> <!--Castanets-->
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>Crash Cymbal 1</name>
-                        <stem>2</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="48"/> <!--Orchestra Kit-->
-                  </Channel>
-                  <genre>concertband</genre>
-                  <genre>marching</genre>
-            </Instrument>
-            <Instrument id="splash-cymbal">
-                  <family>unpitched-metal-percussion</family>
-                  <longName>Splash Cymbal</longName>
-                  <shortName>Sp. Cym.</shortName>
-                  <description>Splash Cymbal</description>
-                  <musicXMLid>metal.cymbal.splash</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="55"> <!--Splash Cymbal-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Splash Cymbal</name>
-                        <stem>2</stem>
+                        <name>Castanets</name>
+                        <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
                   <Channel>
@@ -7226,34 +7658,7 @@
                         <controller ctrl="0" value="1"/> <!--Bank MSB-->
                         <program value="0"/> <!--Standard Kit-->
                   </Channel>
-                  <genre>concertband</genre>
-                  <genre>marching</genre>
-            </Instrument>
-            <Instrument id="cowbell">
-                  <family>unpitched-metal-percussion</family>
-                  <longName>Cowbell</longName>
-                  <shortName>Cwb.</shortName>
-                  <description>Cowbell</description>
-                  <musicXMLid>metal.bells.cowbell</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="56"> <!--Cowbell-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Cowbell</name>
-                        <stem>2</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-                  <genre>classroom</genre>
+                  <genre>world</genre>
             </Instrument>
             <Instrument id="claves">
                   <family>unpitched-wooden-percussion</family>
@@ -7285,32 +7690,6 @@
                   <genre>marching</genre>
                   <genre>classroom</genre>
             </Instrument>
-            <Instrument id="castanets">
-                  <family>unpitched-wooden-percussion</family>
-                  <longName>Castanets</longName>
-                  <shortName>Cst.</shortName>
-                  <description>Castanets</description>
-                  <musicXMLid>wood.castanets</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="85"> <!--Castanets-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Castanets</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
             <Instrument id="guiro">
                   <family>unpitched-wooden-percussion</family>
                   <longName>Güiro</longName>
@@ -7339,143 +7718,12 @@
                   <genre>world</genre>
                   <genre>classroom</genre>
             </Instrument>
-            <Instrument id="maracas">
-                  <family>other-percussion</family>
-                  <longName>Maracas</longName>
-                  <shortName>Mrcs.</shortName>
-                  <description>Maracas</description>
-                  <musicXMLid>rattle.maraca</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="70"> <!--Maracas-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Maracas</name>
-                        <stem>2</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-                  <genre>orchestra</genre>
-                  <genre>world</genre>
-                  <genre>classroom</genre>
-            </Instrument>
-            <Instrument id="cabasa">
-                  <family>other-percussion</family>
-                  <longName>Cabasa</longName>
-                  <shortName>Cabs.</shortName>
-                  <description>Cabasa</description>
-                  <musicXMLid>rattle.cabasa</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="69"> <!--Cabasa-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Cabasa</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="quijada">
-                  <longName>Quijada</longName>
-                  <shortName>Qui.</shortName>
-                  <description>Quijada</description>
-                  <musicXMLid>rattle.jawbone</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="69"> <!--Cabasa-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Cabasa</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="vibraslap">
-                  <family>other-percussion</family>
-                  <longName>Vibraslap</longName>
-                  <shortName>Vibslp.</shortName>
-                  <description>Vibraslap</description>
-                  <musicXMLid>rattle.vibraslap</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="58"> <!--Vibra Slap-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Vibraslap</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-                  <genre>concertband</genre>
-                  <genre>classroom</genre>
-            </Instrument>
-            <Instrument id="slit-drum">
-                  <family>drums</family>
-                  <longName>Slit Drum</longName>
-                  <shortName>Slt. Dr.</shortName>
-                  <description>Slit Drum</description>
-                  <musicXMLid>drum.slit-drum</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="77"> <!--Low Woodblock-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Low Wood Block</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="whip">
-                  <family>other-percussion</family>
-                  <longName>Whip</longName>
-                  <shortName>Wh.</shortName>
-                  <description>Whip</description>
-                  <musicXMLid>effect.whip</musicXMLid>
+            <Instrument id="temple-blocks">
+                  <family>unpitched-wooden-percussion</family>
+                  <longName>Temple Blocks</longName>
+                  <shortName>Tmp. Bl.</shortName>
+                  <description>Temple Blocks</description>
+                  <musicXMLid>wood.temple-block</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
@@ -7483,11 +7731,19 @@
                   <singleNoteDynamics>0</singleNoteDynamics>
                   <Drum pitch="76"> <!--High Woodblock-->
                         <head>normal</head>
-                        <line>0</line>
+                        <line>-1</line>
                         <voice>0</voice>
                         <name>High Wood Block</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
+                  </Drum>
+                  <Drum pitch="77"> <!--Low Woodblock-->
+                        <head>normal</head>
+                        <line>1</line>
+                        <voice>0</voice>
+                        <name>Low Wood Block</name>
+                        <stem>1</stem>
+                        <shortcut>B</shortcut>
                   </Drum>
                   <Channel>
                         <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
@@ -7496,82 +7752,44 @@
                   </Channel>
                   <genre>orchestra</genre>
                   <genre>concertband</genre>
-                  <genre>classroom</genre>
+                  <genre>marching</genre>
             </Instrument>
-            <Instrument id="ratchet">
-                  <family>other-percussion</family>
-                  <longName>Ratchet</longName>
-                  <shortName>Rat.</shortName>
-                  <description>Ratchet</description>
-                  <musicXMLid>rattle.ratchet</musicXMLid>
+            <Instrument id="wood-blocks">
+                  <family>unpitched-wooden-percussion</family>
+                  <longName>Wood Blocks</longName>
+                  <shortName>Wd. Bl.</shortName>
+                  <description>Wood Blocks</description>
+                  <musicXMLid>wood.wood-block</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="73"> <!--Short Guiro-->
+                  <Drum pitch="76"> <!--High Woodblock-->
                         <head>normal</head>
-                        <line>0</line>
+                        <line>-1</line>
                         <voice>0</voice>
-                        <name>Short Güiro</name>
+                        <name>High Wood Block</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="thundersheet">
-                  <family>unpitched-metal-percussion</family>
-                  <longName>Thundersheet</longName>
-                  <shortName>Thu.</shortName>
-                  <description>Thundersheet</description>
-                  <musicXMLid>metal.thundersheet</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="49"> <!--Crash Cymbal 1-->
+                  <Drum pitch="77"> <!--Low Woodblock-->
                         <head>normal</head>
-                        <line>0</line>
+                        <line>1</line>
                         <voice>0</voice>
-                        <name>Crash Cymbal 1</name>
+                        <name>Low Wood Block</name>
                         <stem>1</stem>
-                        <shortcut>A</shortcut>
+                        <shortcut>B</shortcut>
                   </Drum>
                   <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
                         <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
+                        <program value="48"/> <!--Orchestra Kit-->
                   </Channel>
-            </Instrument>
-            <Instrument id="sandpaper-blocks">
-                  <family>other-percussion</family>
-                  <longName>Sandpaper Blocks</longName>
-                  <shortName>Sa. Bl.</shortName>
-                  <description>Sandpaper Blocks</description>
-                  <musicXMLid>wood.sand-block</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="70"> <!--Maracas-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Maracas</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
+                  <genre>common</genre>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
+                  <genre>marching</genre>
                   <genre>classroom</genre>
             </Instrument>
             <Instrument id="wooden-wind-chimes">
@@ -7599,12 +7817,12 @@
                         <program value="0"/> <!--Standard Kit-->
                   </Channel>
             </Instrument>
-            <Instrument id="bamboo-wind-chimes">
-                  <family>unpitched-wooden-percussion</family>
-                  <longName>Bamboo Wind Chimes</longName>
-                  <shortName>Bam. Wn. Ch.</shortName>
-                  <description>Bamboo Wind Chimes</description>
-                  <musicXMLid>metal.bells.wind-chimes</musicXMLid>
+            <Instrument id="cabasa">
+                  <family>other-percussion</family>
+                  <longName>Cabasa</longName>
+                  <shortName>Cabs.</shortName>
+                  <description>Cabasa</description>
+                  <musicXMLid>rattle.cabasa</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
@@ -7623,34 +7841,7 @@
                         <controller ctrl="0" value="1"/> <!--Bank MSB-->
                         <program value="0"/> <!--Standard Kit-->
                   </Channel>
-            </Instrument>
-            <Instrument id="metal-wind-chimes">
-                  <family>unpitched-metal-percussion</family>
-                  <longName>Metal Wind Chimes</longName>
-                  <shortName>Met. Wn Ch.</shortName>
-                  <description>Metal Wind Chimes</description>
-                  <musicXMLid>metal.bells.wind-chimes</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="69"> <!--Cabasa-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Cabasa</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-                  <genre>orchestra</genre>
-                  <genre>concertband</genre>
-                  <genre>marching</genre>
+                  <genre>world</genre>
             </Instrument>
             <Instrument id="glass-wind-chimes">
                   <family>other-percussion</family>
@@ -7677,72 +7868,22 @@
                         <program value="0"/> <!--Standard Kit-->
                   </Channel>
             </Instrument>
-            <Instrument id="shell-wind-chimes">
+            <Instrument id="maracas">
                   <family>other-percussion</family>
-                  <longName>Shell Wind Chimes</longName>
-                  <shortName>Sh. Wn Ch.</shortName>
-                  <description>Shell Wind Chimes</description>
-                  <musicXMLid>metal.bells.wind-chimes</musicXMLid>
+                  <longName>Maracas</longName>
+                  <shortName>Mrcs.</shortName>
+                  <description>Maracas</description>
+                  <musicXMLid>rattle.maraca</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="69"> <!--Cabasa-->
+                  <Drum pitch="70"> <!--Maracas-->
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>Cabasa</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="stones">
-                  <family>other-percussion</family>
-                  <longName>Stones</longName>
-                  <shortName>Sto.</shortName>
-                  <description>Stones</description>
-                  <musicXMLid>rattle.lava-stones</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="67"> <!--High Agogô-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>High Agogo</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="tambourine">
-                  <family>other-percussion</family>
-                  <longName>Tambourine</longName>
-                  <shortName>Tamb.</shortName>
-                  <description>Tambourine</description>
-                  <musicXMLid>drum.tambourine</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="54"> <!--Tambourine-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Tambourine</name>
+                        <name>Maracas</name>
                         <stem>2</stem>
                         <shortcut>A</shortcut>
                   </Drum>
@@ -7751,11 +7892,8 @@
                         <controller ctrl="0" value="1"/> <!--Bank MSB-->
                         <program value="0"/> <!--Standard Kit-->
                   </Channel>
-                  <genre>common</genre>
-                  <genre>popular</genre>
                   <genre>orchestra</genre>
-                  <genre>concertband</genre>
-                  <genre>marching</genre>
+                  <genre>world</genre>
                   <genre>classroom</genre>
             </Instrument>
             <Instrument id="percussion">
@@ -7940,6 +8078,267 @@
                   <genre>orchestra</genre>
                   <genre>concertband</genre>
                   <genre>marching</genre>
+            </Instrument>
+            <Instrument id="quijada">
+                  <family>other-percussion</family>
+                  <longName>Quijada</longName>
+                  <shortName>Qui.</shortName>
+                  <description>Dried donkey or horse jawbone traditionally used as a rattle in some Latin American countries.</description>
+                  <musicXMLid>rattle.jawbone</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="69"> <!--Cabasa-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Cabasa</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="ratchet">
+                  <family>other-percussion</family>
+                  <longName>Ratchet</longName>
+                  <shortName>Rat.</shortName>
+                  <description>Ratchet</description>
+                  <musicXMLid>rattle.ratchet</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="73"> <!--Short Guiro-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Short Güiro</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="sandpaper-blocks">
+                  <family>other-percussion</family>
+                  <longName>Sandpaper Blocks</longName>
+                  <shortName>Sa. Bl.</shortName>
+                  <description>Sandpaper Blocks</description>
+                  <musicXMLid>wood.sand-block</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="70"> <!--Maracas-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Maracas</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="shaker">
+                  <family>other-percussion</family>
+                  <longName>Shaker</longName>
+                  <shortName>Sh.</shortName>
+                  <description>Shaker</description>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <Drum pitch="82"> <!--Shaker-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Shaker</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="shell-wind-chimes">
+                  <family>other-percussion</family>
+                  <longName>Shell Wind Chimes</longName>
+                  <shortName>Sh. Wn Ch.</shortName>
+                  <description>Shell Wind Chimes</description>
+                  <musicXMLid>metal.bells.wind-chimes</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="69"> <!--Cabasa-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Cabasa</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="stones">
+                  <family>other-percussion</family>
+                  <longName>Stones</longName>
+                  <shortName>Sto.</shortName>
+                  <description>Stones</description>
+                  <musicXMLid>rattle.lava-stones</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="67"> <!--High Agogô-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>High Agogo</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="tambourine">
+                  <family>other-percussion</family>
+                  <longName>Tambourine</longName>
+                  <shortName>Tamb.</shortName>
+                  <description>Tambourine</description>
+                  <musicXMLid>drum.tambourine</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="54"> <!--Tambourine-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Tambourine</name>
+                        <stem>2</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+                  <genre>common</genre>
+                  <genre>popular</genre>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
+                  <genre>marching</genre>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="tubo">
+                  <family>other-percussion</family>
+                  <longName>Tubo</longName>
+                  <shortName>Tu.</shortName>
+                  <description>Tubo</description>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="82"> <!--Shaker-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Shaker</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="vibraslap">
+                  <family>other-percussion</family>
+                  <longName>Vibraslap</longName>
+                  <shortName>Vibslp.</shortName>
+                  <description>Vibraslap</description>
+                  <musicXMLid>rattle.vibraslap</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="58"> <!--Vibra Slap-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Vibraslap</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+                  <genre>concertband</genre>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="whip">
+                  <family>other-percussion</family>
+                  <longName>Whip</longName>
+                  <shortName>Wh.</shortName>
+                  <description>Whip</description>
+                  <musicXMLid>effect.whip</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="76"> <!--High Woodblock-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>High Wood Block</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
+                  <genre>classroom</genre>
             </Instrument>
       </InstrumentGroup>
       <InstrumentGroup id="marching-percussion">
@@ -8480,6 +8879,7 @@
       <InstrumentGroup id="body-percussion">
             <name>Percussion - Body</name>
             <Instrument id="finger-snap">
+                  <family>body-percussion</family>
                   <longName>Finger Snap</longName>
                   <shortName>Fi. Sna.</shortName>
                   <description>Finger Snap</description>
@@ -8508,6 +8908,7 @@
                   <genre>classroom</genre>
             </Instrument>
             <Instrument id="hand-clap">
+                  <family>body-percussion</family>
                   <longName>Hand Clap</longName>
                   <shortName>Hd. Clp.</shortName>
                   <description>Hand Clap</description>
@@ -8536,6 +8937,7 @@
                   <genre>classroom</genre>
             </Instrument>
             <Instrument id="slap">
+                  <family>body-percussion</family>
                   <longName>Slap</longName>
                   <shortName>Sla.</shortName>
                   <description>Slap</description>
@@ -8564,6 +8966,7 @@
                   <genre>classroom</genre>
             </Instrument>
             <Instrument id="stamp">
+                  <family>body-percussion</family>
                   <longName>Stamp</longName>
                   <shortName>Sta.</shortName>
                   <description>Stamp</description>
@@ -8594,25 +8997,6 @@
       </InstrumentGroup>
       <InstrumentGroup id="vocals">
             <name>Vocals</name>
-            <Instrument id="voice">
-                  <family>voices</family>
-                  <!--don't remove this 'instrument', it is used in ...mscore/noteGroups.cpp to generate the time sig dialog of the master palette-->
-                  <longName>Voice</longName>
-                  <shortName>Vo.</shortName>
-                  <description>Voice</description>
-                  <musicXMLid>voice.vocals</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>41-79</aPitchRange>
-                  <pPitchRange>38-84</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 52; MS General: Choir Aahs-->
-                        <program value="52"/> <!--Choir Aahs-->
-                  </Channel>
-                  <genre>common</genre>
-                  <genre>jazz</genre>
-                  <genre>choral</genre>
-            </Instrument>
             <Instrument id="boy-soprano">
                   <family>voices</family>
                   <longName>Boy Soprano</longName>
@@ -8620,7 +9004,6 @@
                   <description>Boy Soprano</description>
                   <musicXMLid>voice.child</musicXMLid>
                   <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
                   <aPitchRange>60-81</aPitchRange>
                   <pPitchRange>60-84</pPitchRange>
                   <Channel>
@@ -8637,7 +9020,6 @@
                   <description>Soprano</description>
                   <musicXMLid>voice.soprano</musicXMLid>
                   <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
                   <aPitchRange>60-79</aPitchRange>
                   <pPitchRange>60-84</pPitchRange>
                   <Channel>
@@ -8657,7 +9039,6 @@
                   <description>Soprano (C Clef)</description>
                   <musicXMLid>voice.soprano</musicXMLid>
                   <clef>C1</clef>
-                  <barlineSpan>1</barlineSpan>
                   <aPitchRange>60-79</aPitchRange>
                   <pPitchRange>60-84</pPitchRange>
                   <Channel>
@@ -8673,7 +9054,6 @@
                   <description>Mezzo-soprano</description>
                   <musicXMLid>voice.mezzo-soprano</musicXMLid>
                   <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
                   <aPitchRange>57-77</aPitchRange>
                   <pPitchRange>57-81</pPitchRange>
                   <Channel>
@@ -8692,7 +9072,6 @@
                   <description>Mezzo-soprano (C Clef)</description>
                   <musicXMLid>voice.mezzo-soprano</musicXMLid>
                   <clef>C2</clef>
-                  <barlineSpan>1</barlineSpan>
                   <aPitchRange>57-77</aPitchRange>
                   <pPitchRange>57-81</pPitchRange>
                   <Channel>
@@ -8701,6 +9080,21 @@
                   </Channel>
                   <genre>earlymusic</genre>
             </Instrument>
+            <Instrument id="countertenor">
+                  <family>voices</family>
+                  <longName>Countertenor</longName>
+                  <shortName>Ct.</shortName>
+                  <description>Countertenor or Male Alto</description>
+                  <musicXMLid>voice.countertenor</musicXMLid>
+                  <clef>G</clef>
+                  <aPitchRange>55-76</aPitchRange>
+                  <pPitchRange>55-79</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 52; MS General: Choir Aahs-->
+                        <program value="52"/> <!--Choir Aahs-->
+                  </Channel>
+                  <genre>choral</genre>
+            </Instrument>
             <Instrument id="alto">
                   <family>voices</family>
                   <longName>Alto</longName>
@@ -8708,7 +9102,6 @@
                   <description>Alto</description>
                   <musicXMLid>voice.alto</musicXMLid>
                   <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
                   <aPitchRange>55-74</aPitchRange>
                   <pPitchRange>52-77</pPitchRange>
                   <Channel>
@@ -8728,7 +9121,6 @@
                   <description>Alto (C Clef)</description>
                   <musicXMLid>voice.alto</musicXMLid>
                   <clef>C3</clef>
-                  <barlineSpan>1</barlineSpan>
                   <aPitchRange>55-74</aPitchRange>
                   <pPitchRange>52-77</pPitchRange>
                   <Channel>
@@ -8744,7 +9136,6 @@
                   <description>Female Alto</description>
                   <musicXMLid>voice.alto</musicXMLid>
                   <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
                   <aPitchRange>55-74</aPitchRange>
                   <pPitchRange>52-77</pPitchRange>
                   <Channel>
@@ -8754,22 +9145,6 @@
                   <genre>choral</genre>
                   <genre>orchestra</genre>
             </Instrument>
-            <Instrument id="countertenor">
-                  <family>voices</family>
-                  <longName>Countertenor</longName>
-                  <shortName>Ct.</shortName>
-                  <description>Countertenor or Male Alto</description>
-                  <musicXMLid>voice.countertenor</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>55-76</aPitchRange>
-                  <pPitchRange>55-79</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 52; MS General: Choir Aahs-->
-                        <program value="52"/> <!--Choir Aahs-->
-                  </Channel>
-                  <genre>choral</genre>
-            </Instrument>
             <Instrument id="tenor">
                   <family>voices</family>
                   <longName>Tenor</longName>
@@ -8777,7 +9152,6 @@
                   <description>Tenor</description>
                   <musicXMLid>voice.tenor</musicXMLid>
                   <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
                   <aPitchRange>48-69</aPitchRange>
                   <pPitchRange>48-72</pPitchRange>
                   <Channel>
@@ -8797,7 +9171,6 @@
                   <description>Tenor (C Clef)</description>
                   <musicXMLid>voice.tenor</musicXMLid>
                   <clef>C4</clef>
-                  <barlineSpan>1</barlineSpan>
                   <aPitchRange>48-69</aPitchRange>
                   <pPitchRange>48-72</pPitchRange>
                   <Channel>
@@ -8813,7 +9186,6 @@
                   <description>Baritone</description>
                   <musicXMLid>voice.baritone</musicXMLid>
                   <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
                   <aPitchRange>43-64</aPitchRange>
                   <pPitchRange>41-65</pPitchRange>
                   <Channel>
@@ -8833,7 +9205,6 @@
                   <description>Baritone (C Clef)</description>
                   <musicXMLid>voice.baritone</musicXMLid>
                   <clef>C5</clef>
-                  <barlineSpan>1</barlineSpan>
                   <aPitchRange>43-64</aPitchRange>
                   <pPitchRange>41-65</pPitchRange>
                   <Channel>
@@ -8842,6 +9213,24 @@
                   </Channel>
                   <genre>earlymusic</genre>
             </Instrument>
+            <Instrument id="voice">
+                  <family>voices</family>
+                  <!--don't remove this 'instrument', it is used in ...mscore/noteGroups.cpp to generate the time sig dialog of the master palette-->
+                  <longName>Voice</longName>
+                  <shortName>Vo.</shortName>
+                  <description>Voice</description>
+                  <musicXMLid>voice.vocals</musicXMLid>
+                  <clef>G</clef>
+                  <aPitchRange>41-79</aPitchRange>
+                  <pPitchRange>38-84</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 52; MS General: Choir Aahs-->
+                        <program value="52"/> <!--Choir Aahs-->
+                  </Channel>
+                  <genre>common</genre>
+                  <genre>jazz</genre>
+                  <genre>choral</genre>
+            </Instrument>
             <Instrument id="bass">
                   <family>voices</family>
                   <longName>Bass</longName>
@@ -8849,7 +9238,6 @@
                   <description>Bass</description>
                   <musicXMLid>voice.bass</musicXMLid>
                   <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
                   <aPitchRange>41-60</aPitchRange>
                   <pPitchRange>38-62</pPitchRange>
                   <Channel>
@@ -8862,13 +9250,12 @@
                   <genre>orchestra</genre>
             </Instrument>
             <Instrument id="women">
-                  <family>voices</family>
+                  <family>voice-groups</family>
                   <longName>Women</longName>
                   <shortName>W.</shortName>
                   <description>Women</description>
                   <musicXMLid>voice.female</musicXMLid>
                   <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
                   <aPitchRange>55-81</aPitchRange>
                   <pPitchRange>55-84</pPitchRange>
                   <Channel name="Soprano">
@@ -8885,13 +9272,12 @@
                   <genre>orchestra</genre>
             </Instrument>
             <Instrument id="men">
-                  <family>voices</family>
+                  <family>voice-groups</family>
                   <longName>Men</longName>
                   <shortName>M.</shortName>
                   <description>Men</description>
                   <musicXMLid>voice.male</musicXMLid>
                   <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
                   <aPitchRange>41-67</aPitchRange>
                   <pPitchRange>38-69</pPitchRange>
                   <Channel name="Tenor">
@@ -8908,12 +9294,12 @@
                   <genre>orchestra</genre>
             </Instrument>
             <Instrument id="kazoo">
+                  <family>kazoos</family>
                   <longName>Kazoo</longName>
                   <shortName>Kaz.</shortName>
                   <description>Kazoo</description>
                   <musicXMLid>voice.kazoo</musicXMLid>
                   <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
                   <aPitchRange>41-81</aPitchRange>
                   <pPitchRange>41-84</pPitchRange>
                   <Channel>
@@ -8926,136 +9312,30 @@
       </InstrumentGroup>
       <InstrumentGroup id="keyboards">
             <name>Keyboards</name>
-            <Instrument id="piano">
+            <Instrument id="celesta">
                   <family>keyboards</family>
-                  <longName>Piano</longName>
-                  <shortName>Pno.</shortName>
-                  <description>Piano</description>
-                  <musicXMLid>keyboard.piano</musicXMLid>
+                  <longName>Celesta</longName>
+                  <shortName>Cel.</shortName>
+                  <description>Celesta</description>
+                  <musicXMLid>keyboard.celesta</musicXMLid>
                   <staves>2</staves>
-                  <clef>G</clef>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>G8va</concertClef>
                   <bracket>1</bracket>
                   <bracketSpan>2</bracketSpan>
                   <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <aPitchRange>21-108</aPitchRange>
-                  <pPitchRange>21-108</pPitchRange>
+                  <transposingClef staff="2">F</transposingClef>
+                  <concertClef staff="2">F8va</concertClef>
+                  <aPitchRange>48-113</aPitchRange>
+                  <pPitchRange>48-113</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
+                  <transposeDiatonic>7</transposeDiatonic>
+                  <transposeChromatic>12</transposeChromatic>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 0; MS General: Grand Piano-->
-                        <program value="0"/> <!--Acoustic Grand Piano-->
+                        <!--MIDI: Bank 0, Prog 8; MS General: Celesta-->
+                        <program value="8"/> <!--Celesta-->
                   </Channel>
-                  <Articulation>
-                        <velocity>100</velocity>
-                        <gateTime>95</gateTime>
-                  </Articulation>
-                  <genre>common</genre>
-                  <genre>popular</genre>
-                  <genre>jazz</genre>
-                  <genre>choral</genre>
                   <genre>orchestra</genre>
-                  <genre>classroom</genre>
-            </Instrument>
-            <Instrument id="grand-piano">
-                  <family>keyboards</family>
-                  <longName>Grand Piano</longName>
-                  <shortName>Pno.</shortName>
-                  <description>Grand Piano</description>
-                  <musicXMLid>keyboard.piano.grand</musicXMLid>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <aPitchRange>21-108</aPitchRange>
-                  <pPitchRange>21-108</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 0; MS General: Grand Piano-->
-                        <program value="0"/> <!--Acoustic Grand Piano-->
-                  </Channel>
-                  <Articulation>
-                        <velocity>100</velocity>
-                        <gateTime>95</gateTime>
-                  </Articulation>
-                  <genre>orchestra</genre>
-                  <genre>concertband</genre>
-            </Instrument>
-            <Instrument id="upright-piano">
-                  <family>keyboards</family>
-                  <longName>Upright Piano</longName>
-                  <shortName>Pno.</shortName>
-                  <description>Piano</description>
-                  <musicXMLid>keyboard.piano.upright</musicXMLid>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <aPitchRange>21-108</aPitchRange>
-                  <pPitchRange>21-108</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 0; MS General: Grand Piano-->
-                        <program value="0"/> <!--Acoustic Grand Piano-->
-                  </Channel>
-                  <Articulation>
-                        <velocity>100</velocity>
-                        <gateTime>95</gateTime>
-                  </Articulation>
-            </Instrument>
-            <Instrument id="honky-tonk-piano">
-                  <family>keyboards</family>
-                  <longName>Honky Tonk Piano</longName>
-                  <shortName>Hnk. Pno.</shortName>
-                  <description>Honky Tonk Piano</description>
-                  <musicXMLid>keyboard.piano.honky-tonk</musicXMLid>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <aPitchRange>21-108</aPitchRange>
-                  <pPitchRange>21-108</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 3; MS General: Honky-Tonk Piano-->
-                        <program value="3"/> <!--Honky-tonk Piano-->
-                  </Channel>
-                  <Articulation>
-                        <velocity>100</velocity>
-                        <gateTime>95</gateTime>
-                  </Articulation>
-                  <genre>popular</genre>
-                  <genre>jazz</genre>
-            </Instrument>
-            <Instrument id="toy-piano">
-                  <family>keyboards</family>
-                  <longName>Toy Piano</longName>
-                  <shortName>Toy Pno.</shortName>
-                  <description>Toy Piano</description>
-                  <musicXMLid>keyboard.piano.toy</musicXMLid>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <aPitchRange>21-108</aPitchRange>
-                  <pPitchRange>21-108</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 0; MS General: Grand Piano-->
-                        <program value="0"/> <!--Acoustic Grand Piano-->
-                  </Channel>
-                  <Articulation>
-                        <velocity>100</velocity>
-                        <gateTime>95</gateTime>
-                  </Articulation>
-                  <genre>classroom</genre>
             </Instrument>
             <Instrument id="clavichord">
                   <family>keyboards</family>
@@ -9077,6 +9357,27 @@
                         <program value="7"/> <!--Clavi-->
                   </Channel>
                   <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="clavinet">
+                  <family>keyboards</family>
+                  <longName>Clavinet</longName>
+                  <shortName>Clav.</shortName>
+                  <description>Clavinet</description>
+                  <musicXMLid>keyboard.clavichord.synth</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>29-89</aPitchRange>
+                  <pPitchRange>29-89</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 7; MS General: Clavinet-->
+                        <program value="7"/> <!--Clavi-->
+                  </Channel>
+                  <genre>jazz</genre>
             </Instrument>
             <Instrument id="harpsichord">
                   <family>keyboards</family>
@@ -9122,31 +9423,6 @@
                   </Channel>
                   <genre>earlymusic</genre>
             </Instrument>
-            <Instrument id="celesta">
-                  <family>keyboards</family>
-                  <longName>Celesta</longName>
-                  <shortName>Cel.</shortName>
-                  <description>Celesta</description>
-                  <musicXMLid>keyboard.celesta</musicXMLid>
-                  <staves>2</staves>
-                  <transposingClef>G</transposingClef>
-                  <concertClef>G8va</concertClef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <transposingClef staff="2">F</transposingClef>
-                  <concertClef staff="2">F8va</concertClef>
-                  <aPitchRange>48-113</aPitchRange>
-                  <pPitchRange>48-113</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <transposeDiatonic>7</transposeDiatonic>
-                  <transposeChromatic>12</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 8; MS General: Celesta-->
-                        <program value="8"/> <!--Celesta-->
-                  </Channel>
-                  <genre>orchestra</genre>
-            </Instrument>
             <Instrument id="electric-piano">
                   <family>keyboards</family>
                   <longName>Electric Piano</longName>
@@ -9169,25 +9445,156 @@
                   <genre>popular</genre>
                   <genre>jazz</genre>
             </Instrument>
-            <Instrument id="clavinet">
+            <Instrument id="grand-piano">
                   <family>keyboards</family>
-                  <longName>Clavinet</longName>
-                  <shortName>Clav.</shortName>
-                  <description>Clavinet</description>
-                  <musicXMLid>keyboard.clavichord.synth</musicXMLid>
+                  <longName>Grand Piano</longName>
+                  <shortName>Pno.</shortName>
+                  <description>Grand Piano</description>
+                  <musicXMLid>keyboard.piano.grand</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
                   <bracket>1</bracket>
                   <bracketSpan>2</bracketSpan>
                   <barlineSpan>2</barlineSpan>
                   <clef staff="2">F</clef>
-                  <aPitchRange>29-89</aPitchRange>
-                  <pPitchRange>29-89</pPitchRange>
+                  <aPitchRange>21-108</aPitchRange>
+                  <pPitchRange>21-108</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 7; MS General: Clavinet-->
-                        <program value="7"/> <!--Clavi-->
+                        <!--MIDI: Bank 0, Prog 0; MS General: Grand Piano-->
+                        <program value="0"/> <!--Acoustic Grand Piano-->
                   </Channel>
+                  <Articulation>
+                        <velocity>100</velocity>
+                        <gateTime>95</gateTime>
+                  </Articulation>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
+            </Instrument>
+            <Instrument id="honky-tonk-piano">
+                  <family>keyboards</family>
+                  <longName>Honky Tonk Piano</longName>
+                  <shortName>Hnk. Pno.</shortName>
+                  <description>Honky Tonk Piano</description>
+                  <musicXMLid>keyboard.piano.honky-tonk</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>21-108</aPitchRange>
+                  <pPitchRange>21-108</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 3; MS General: Honky-Tonk Piano-->
+                        <program value="3"/> <!--Honky-tonk Piano-->
+                  </Channel>
+                  <Articulation>
+                        <velocity>100</velocity>
+                        <gateTime>95</gateTime>
+                  </Articulation>
+                  <genre>popular</genre>
+                  <genre>jazz</genre>
+            </Instrument>
+            <Instrument id="piano">
+                  <family>keyboards</family>
+                  <longName>Piano</longName>
+                  <shortName>Pno.</shortName>
+                  <description>Piano</description>
+                  <musicXMLid>keyboard.piano</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>21-108</aPitchRange>
+                  <pPitchRange>21-108</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 0; MS General: Grand Piano-->
+                        <program value="0"/> <!--Acoustic Grand Piano-->
+                  </Channel>
+                  <Articulation>
+                        <velocity>100</velocity>
+                        <gateTime>95</gateTime>
+                  </Articulation>
+                  <genre>common</genre>
+                  <genre>popular</genre>
+                  <genre>jazz</genre>
+                  <genre>choral</genre>
+                  <genre>orchestra</genre>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="toy-piano">
+                  <family>keyboards</family>
+                  <longName>Toy Piano</longName>
+                  <shortName>Toy Pno.</shortName>
+                  <description>Toy Piano</description>
+                  <musicXMLid>keyboard.piano.toy</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>21-108</aPitchRange>
+                  <pPitchRange>21-108</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 0; MS General: Grand Piano-->
+                        <program value="0"/> <!--Acoustic Grand Piano-->
+                  </Channel>
+                  <Articulation>
+                        <velocity>100</velocity>
+                        <gateTime>95</gateTime>
+                  </Articulation>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="upright-piano">
+                  <family>keyboards</family>
+                  <longName>Upright Piano</longName>
+                  <shortName>Pno.</shortName>
+                  <description>Piano</description>
+                  <musicXMLid>keyboard.piano.upright</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>21-108</aPitchRange>
+                  <pPitchRange>21-108</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 0; MS General: Grand Piano-->
+                        <program value="0"/> <!--Acoustic Grand Piano-->
+                  </Channel>
+                  <Articulation>
+                        <velocity>100</velocity>
+                        <gateTime>95</gateTime>
+                  </Articulation>
+            </Instrument>
+            <Instrument id="hammond-organ">
+                  <family>organs</family>
+                  <longName>Hammond Organ</longName>
+                  <shortName>Hm. Org.</shortName>
+                  <description>Hammond Electronic Organ</description>
+                  <musicXMLid>keyboard.organ.drawbar</musicXMLid>
+                  <staves>3</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <clef staff="3">F</clef>
+                  <barlineSpan staff="3">1</barlineSpan>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 16; MS General: Drawbar Organ-->
+                        <program value="16"/> <!--Drawbar Organ-->
+                  </Channel>
+                  <genre>popular</genre>
                   <genre>jazz</genre>
             </Instrument>
             <Instrument id="organ">
@@ -9232,46 +9639,6 @@
                         <program value="17"/> <!--Percussive Organ-->
                   </Channel>
             </Instrument>
-            <Instrument id="hammond-organ">
-                  <family>organs</family>
-                  <longName>Hammond Organ</longName>
-                  <shortName>Hm. Org.</shortName>
-                  <description>Hammond Electronic Organ</description>
-                  <musicXMLid>keyboard.organ.drawbar</musicXMLid>
-                  <staves>3</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <clef staff="3">F</clef>
-                  <barlineSpan staff="3">1</barlineSpan>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 16; MS General: Drawbar Organ-->
-                        <program value="16"/> <!--Drawbar Organ-->
-                  </Channel>
-                  <genre>popular</genre>
-                  <genre>jazz</genre>
-            </Instrument>
-            <Instrument id="rotary-organ">
-                  <family>organs</family>
-                  <longName>Rotary Organ</longName>
-                  <shortName>Rot. Org.</shortName>
-                  <description>Electronic Rotary Organ (usually means Hammond with Leslie Speaker)</description>
-                  <musicXMLid>keyboard.organ.rotary</musicXMLid>
-                  <staves>3</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <clef staff="3">F</clef>
-                  <barlineSpan staff="3">1</barlineSpan>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 18; MS General: Rock Organ-->
-                        <program value="18"/> <!--Rock Organ-->
-                  </Channel>
-            </Instrument>
             <Instrument id="pipe-organ">
                   <family>organs</family>
                   <trackName>Pipe Organ</trackName>
@@ -9293,6 +9660,25 @@
                   </Channel>
                   <genre>common</genre>
                   <genre>orchestra</genre>
+            </Instrument>
+            <Instrument id="rotary-organ">
+                  <family>organs</family>
+                  <longName>Rotary Organ</longName>
+                  <shortName>Rot. Org.</shortName>
+                  <description>Electronic Rotary Organ (usually means Hammond with Leslie Speaker)</description>
+                  <musicXMLid>keyboard.organ.rotary</musicXMLid>
+                  <staves>3</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <clef staff="3">F</clef>
+                  <barlineSpan staff="3">1</barlineSpan>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 18; MS General: Rock Organ-->
+                        <program value="18"/> <!--Rock Organ-->
+                  </Channel>
             </Instrument>
             <Instrument id="harmonium">
                   <family>organs</family>
@@ -9335,50 +9721,68 @@
       </InstrumentGroup>
       <InstrumentGroup id="electronic-instruments">
             <name>Electronic</name>
-            <Instrument id="effect-synth">
-                  <longName>Effect Synthesizer</longName>
-                  <shortName>Synth.</shortName>
-                  <description>GM Effect Synthesizer (generic)</description>
-                  <musicXMLid>synth.effects</musicXMLid>
+            <Instrument id="mallet-synthesizer">
+                  <family>synths</family>
+                  <longName>Mallet Synthesizer</longName>
+                  <shortName>Mal. Syn.</shortName>
+                  <description>Mallet Synthesizer</description>
+                  <musicXMLid>synth.group</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
                   <bracket>1</bracket>
                   <bracketSpan>2</bracketSpan>
                   <barlineSpan>2</barlineSpan>
                   <clef staff="2">F</clef>
-                  <aPitchRange>36-96</aPitchRange>
-                  <pPitchRange>21-108</pPitchRange>
-                  <Channel name="rain">
-                        <!--MIDI: Bank 0, Prog 96; MS General: Ice Rain-->
-                        <program value="96"/> <!--FX 1 (rain)-->
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 80; MS General: Square Lead-->
+                        <program value="80"/> <!--Lead 1 (square)-->
                   </Channel>
-                  <Channel name="soundtrack">
-                        <!--MIDI: Bank 0, Prog 97; MS General: SoundTrack-->
-                        <program value="97"/> <!--FX 2 (soundtrack)-->
+                  <genre>popular</genre>
+                  <genre>marching</genre>
+                  <genre>electronic</genre>
+            </Instrument>
+            <Instrument id="ondes-martenot">
+                  <family>synths</family>
+                  <longName>Ondes Martenot</longName>
+                  <shortName>O.M.</shortName>
+                  <description>Ondes Martenot</description>
+                  <musicXMLid>keyboard.ondes-martenot</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
+                        <program value="79"/> <!--Ocarina-->
                   </Channel>
-                  <Channel name="crystal">
-                        <!--MIDI: Bank 0, Prog 98; MS General: Crystal-->
-                        <program value="98"/> <!--FX 3 (crystal)-->
-                  </Channel>
-                  <Channel name="atmosphere">
-                        <!--MIDI: Bank 0, Prog 99; MS General: Atmosphere-->
-                        <program value="99"/> <!--FX 4 (atmosphere)-->
-                  </Channel>
-                  <Channel name="brightness">
-                        <!--MIDI: Bank 0, Prog 100; MS General: Brightness-->
-                        <program value="100"/> <!--FX 5 (brightness)-->
-                  </Channel>
-                  <Channel name="goblins">
-                        <!--MIDI: Bank 0, Prog 101; MS General: Goblin-->
-                        <program value="101"/> <!--FX 6 (goblins)-->
-                  </Channel>
-                  <Channel name="echoes">
-                        <!--MIDI: Bank 0, Prog 102; MS General: Echo Drops-->
-                        <program value="102"/> <!--FX 7 (echoes)-->
-                  </Channel>
-                  <Channel name="scifi">
-                        <!--MIDI: Bank 0, Prog 103; MS General: Star Theme-->
-                        <program value="103"/> <!--FX 8 (sci-fi)-->
+                  <genre>popular</genre>
+                  <genre>marching</genre>
+                  <genre>electronic</genre>
+            </Instrument>
+            <Instrument id="percussion-synthesizer">
+                  <family>synths</family>
+                  <longName>Percussion Synthesizer</longName>
+                  <shortName>Perc. Syn.</shortName>
+                  <description>Percussion Synthesizer</description>
+                  <musicXMLid>drum.snare-drum.electric</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <Drum pitch="40"> <!--Electric Snare-->
+                        <head>normal</head>
+                        <line>4</line>
+                        <voice>0</voice>
+                        <name>Electric Snare</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
                   </Channel>
                   <genre>popular</genre>
                   <genre>marching</genre>
@@ -9406,6 +9810,80 @@
                   <genre>marching</genre>
                   <genre>electronic</genre>
             </Instrument>
+            <Instrument id="bass-synthesizer">
+                  <family>synths</family>
+                  <longName>Bass Synthesizer</longName>
+                  <shortName>Synth.</shortName>
+                  <description>Bass Synthesizer</description>
+                  <musicXMLid>pluck.bass.synth</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>36-96</aPitchRange>
+                  <pPitchRange>21-108</pPitchRange>
+                  <Channel name="synth-bass-1">
+                        <!--MIDI: Bank 0, Prog 38; MS General: Synth Bass 1-->
+                        <program value="38"/> <!--Synth Bass 1-->
+                  </Channel>
+                  <Channel name="synth-bass-2">
+                        <!--MIDI: Bank 0, Prog 39; MS General: Synth Bass 2-->
+                        <program value="39"/> <!--Synth Bass 2-->
+                  </Channel>
+                  <genre>popular</genre>
+                  <genre>marching</genre>
+                  <genre>electronic</genre>
+            </Instrument>
+            <Instrument id="bowed-synth">
+                  <family>synths</family>
+                  <longName>Bowed Synthesizer</longName>
+                  <shortName>Synth.</shortName>
+                  <description>Bowed Pad Synthesizer</description>
+                  <musicXMLid>synth.pad.bowed</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>36-96</aPitchRange>
+                  <pPitchRange>21-108</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 92; MS General: Bowed Glass-->
+                        <program value="92"/> <!--Pad 5 (bowed)-->
+                  </Channel>
+                  <genre>popular</genre>
+                  <genre>marching</genre>
+                  <genre>electronic</genre>
+            </Instrument>
+            <Instrument id="brass-synthesizer">
+                  <family>synths</family>
+                  <longName>Brass Synthesizer</longName>
+                  <shortName>Synth.</shortName>
+                  <description>Brass Synthesizer</description>
+                  <musicXMLid>brass.group.synth</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>36-96</aPitchRange>
+                  <pPitchRange>21-108</pPitchRange>
+                  <Channel name="synth-brass-1">
+                        <!--MIDI: Bank 0, Prog 62; MS General: Synth Brass 1-->
+                        <program value="62"/> <!--Synth Brass 1-->
+                  </Channel>
+                  <Channel name="synth-brass-2">
+                        <!--MIDI: Bank 0, Prog 63; MS General: Synth Brass 2-->
+                        <program value="63"/> <!--Synth Brass 2-->
+                  </Channel>
+                  <genre>popular</genre>
+                  <genre>marching</genre>
+                  <genre>electronic</genre>
+            </Instrument>
             <Instrument id="brightness-synth">
                   <family>synths</family>
                   <longName>Brightness Synthesizer</longName>
@@ -9423,6 +9901,28 @@
                   <Channel>
                         <!--MIDI: Bank 0, Prog 100; MS General: Brightness-->
                         <program value="100"/> <!--FX 5 (brightness)-->
+                  </Channel>
+                  <genre>popular</genre>
+                  <genre>marching</genre>
+                  <genre>electronic</genre>
+            </Instrument>
+            <Instrument id="choir-synth">
+                  <family>synths</family>
+                  <longName>Choir Synthesizer</longName>
+                  <shortName>Synth.</shortName>
+                  <description>Choir Pad Synthesizer</description>
+                  <musicXMLid>synth.pad.choir</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>36-96</aPitchRange>
+                  <pPitchRange>21-108</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 91; MS General: Space Voice-->
+                        <program value="91"/> <!--Pad 4 (choir)-->
                   </Channel>
                   <genre>popular</genre>
                   <genre>marching</genre>
@@ -9472,6 +9972,56 @@
                   <genre>marching</genre>
                   <genre>electronic</genre>
             </Instrument>
+            <Instrument id="effect-synth">
+                  <family>synths</family>
+                  <longName>Effect Synthesizer</longName>
+                  <shortName>Synth.</shortName>
+                  <description>GM Effect Synthesizer (generic)</description>
+                  <musicXMLid>synth.effects</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>36-96</aPitchRange>
+                  <pPitchRange>21-108</pPitchRange>
+                  <Channel name="rain">
+                        <!--MIDI: Bank 0, Prog 96; MS General: Ice Rain-->
+                        <program value="96"/> <!--FX 1 (rain)-->
+                  </Channel>
+                  <Channel name="soundtrack">
+                        <!--MIDI: Bank 0, Prog 97; MS General: SoundTrack-->
+                        <program value="97"/> <!--FX 2 (soundtrack)-->
+                  </Channel>
+                  <Channel name="crystal">
+                        <!--MIDI: Bank 0, Prog 98; MS General: Crystal-->
+                        <program value="98"/> <!--FX 3 (crystal)-->
+                  </Channel>
+                  <Channel name="atmosphere">
+                        <!--MIDI: Bank 0, Prog 99; MS General: Atmosphere-->
+                        <program value="99"/> <!--FX 4 (atmosphere)-->
+                  </Channel>
+                  <Channel name="brightness">
+                        <!--MIDI: Bank 0, Prog 100; MS General: Brightness-->
+                        <program value="100"/> <!--FX 5 (brightness)-->
+                  </Channel>
+                  <Channel name="goblins">
+                        <!--MIDI: Bank 0, Prog 101; MS General: Goblin-->
+                        <program value="101"/> <!--FX 6 (goblins)-->
+                  </Channel>
+                  <Channel name="echoes">
+                        <!--MIDI: Bank 0, Prog 102; MS General: Echo Drops-->
+                        <program value="102"/> <!--FX 7 (echoes)-->
+                  </Channel>
+                  <Channel name="scifi">
+                        <!--MIDI: Bank 0, Prog 103; MS General: Star Theme-->
+                        <program value="103"/> <!--FX 8 (sci-fi)-->
+                  </Channel>
+                  <genre>popular</genre>
+                  <genre>marching</genre>
+                  <genre>electronic</genre>
+            </Instrument>
             <Instrument id="goblins-synth">
                   <family>synths</family>
                   <longName>Goblins Synthesizer</longName>
@@ -9494,12 +10044,12 @@
                   <genre>marching</genre>
                   <genre>electronic</genre>
             </Instrument>
-            <Instrument id="rain-synth">
+            <Instrument id="halo-synth">
                   <family>synths</family>
-                  <longName>Rain Synthesizer</longName>
+                  <longName>Halo Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Rain Effect Synthesizer</description>
-                  <musicXMLid>synth.effects.rain</musicXMLid>
+                  <description>Halo Pad Synthesizer</description>
+                  <musicXMLid>synth.pad.halo</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
                   <bracket>1</bracket>
@@ -9509,19 +10059,19 @@
                   <aPitchRange>36-96</aPitchRange>
                   <pPitchRange>21-108</pPitchRange>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 96; MS General: Ice Rain-->
-                        <program value="96"/> <!--FX 1 (rain)-->
+                        <!--MIDI: Bank 0, Prog 94; MS General: Halo Pad-->
+                        <program value="94"/> <!--Pad 7 (halo)-->
                   </Channel>
                   <genre>popular</genre>
                   <genre>marching</genre>
                   <genre>electronic</genre>
             </Instrument>
-            <Instrument id="sci-fi-synth">
+            <Instrument id="metallic-synth">
                   <family>synths</family>
-                  <longName>Sci-fi Synthesizer</longName>
+                  <longName>Metallic Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Sci-fi Effect Synthesizer</description>
-                  <musicXMLid>synth.effects.sci-fi</musicXMLid>
+                  <description>Metallic Pad Synthesizer</description>
+                  <musicXMLid>synth.pad.metallic</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
                   <bracket>1</bracket>
@@ -9531,19 +10081,19 @@
                   <aPitchRange>36-96</aPitchRange>
                   <pPitchRange>21-108</pPitchRange>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 103; MS General: Star Theme-->
-                        <program value="103"/> <!--FX 8 (sci-fi)-->
+                        <!--MIDI: Bank 0, Prog 93; MS General: Metal Pad-->
+                        <program value="93"/> <!--Pad 6 (metallic)-->
                   </Channel>
                   <genre>popular</genre>
                   <genre>marching</genre>
                   <genre>electronic</genre>
             </Instrument>
-            <Instrument id="soundtrack-synth">
+            <Instrument id="new-age-synth">
                   <family>synths</family>
-                  <longName>Soundtrack Synthesizer</longName>
+                  <longName>New Age Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Soundtrack Effect Synthesizer</description>
-                  <musicXMLid>synth.effects.soundtrack</musicXMLid>
+                  <description>New Age Pad Synthesizer</description>
+                  <musicXMLid>synth.pad</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
                   <bracket>1</bracket>
@@ -9553,8 +10103,8 @@
                   <aPitchRange>36-96</aPitchRange>
                   <pPitchRange>21-108</pPitchRange>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 97; MS General: SoundTrack-->
-                        <program value="97"/> <!--FX 2 (soundtrack)-->
+                        <!--MIDI: Bank 0, Prog 88; MS General: Fantasia-->
+                        <program value="88"/> <!--Pad 1 (new age)-->
                   </Channel>
                   <genre>popular</genre>
                   <genre>marching</genre>
@@ -9610,50 +10160,6 @@
                   <genre>marching</genre>
                   <genre>electronic</genre>
             </Instrument>
-            <Instrument id="new-age-synth">
-                  <family>synths</family>
-                  <longName>New Age Synthesizer</longName>
-                  <shortName>Synth.</shortName>
-                  <description>New Age Pad Synthesizer</description>
-                  <musicXMLid>synth.pad</musicXMLid>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <aPitchRange>36-96</aPitchRange>
-                  <pPitchRange>21-108</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 88; MS General: Fantasia-->
-                        <program value="88"/> <!--Pad 1 (new age)-->
-                  </Channel>
-                  <genre>popular</genre>
-                  <genre>marching</genre>
-                  <genre>electronic</genre>
-            </Instrument>
-            <Instrument id="warm-synth">
-                  <family>synths</family>
-                  <longName>Warm Synthesizer</longName>
-                  <shortName>Synth.</shortName>
-                  <description>Warm Pad Synthesizer</description>
-                  <musicXMLid>synth.pad.warm</musicXMLid>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <aPitchRange>36-96</aPitchRange>
-                  <pPitchRange>21-108</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 89; MS General: Warm Pad-->
-                        <program value="89"/> <!--Pad 2 (warm)-->
-                  </Channel>
-                  <genre>popular</genre>
-                  <genre>marching</genre>
-                  <genre>electronic</genre>
-            </Instrument>
             <Instrument id="poly-synth">
                   <family>synths</family>
                   <longName>Poly Synthesizer</longName>
@@ -9676,12 +10182,12 @@
                   <genre>marching</genre>
                   <genre>electronic</genre>
             </Instrument>
-            <Instrument id="choir-synth">
+            <Instrument id="rain-synth">
                   <family>synths</family>
-                  <longName>Choir Synthesizer</longName>
+                  <longName>Rain Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Choir Pad Synthesizer</description>
-                  <musicXMLid>synth.pad.choir</musicXMLid>
+                  <description>Rain Effect Synthesizer</description>
+                  <musicXMLid>synth.effects.rain</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
                   <bracket>1</bracket>
@@ -9691,96 +10197,8 @@
                   <aPitchRange>36-96</aPitchRange>
                   <pPitchRange>21-108</pPitchRange>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 91; MS General: Space Voice-->
-                        <program value="91"/> <!--Pad 4 (choir)-->
-                  </Channel>
-                  <genre>popular</genre>
-                  <genre>marching</genre>
-                  <genre>electronic</genre>
-            </Instrument>
-            <Instrument id="bowed-synth">
-                  <family>synths</family>
-                  <longName>Bowed Synthesizer</longName>
-                  <shortName>Synth.</shortName>
-                  <description>Bowed Pad Synthesizer</description>
-                  <musicXMLid>synth.pad.bowed</musicXMLid>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <aPitchRange>36-96</aPitchRange>
-                  <pPitchRange>21-108</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 92; MS General: Bowed Glass-->
-                        <program value="92"/> <!--Pad 5 (bowed)-->
-                  </Channel>
-                  <genre>popular</genre>
-                  <genre>marching</genre>
-                  <genre>electronic</genre>
-            </Instrument>
-            <Instrument id="metallic-synth">
-                  <family>synths</family>
-                  <longName>Metallic Synthesizer</longName>
-                  <shortName>Synth.</shortName>
-                  <description>Metallic Pad Synthesizer</description>
-                  <musicXMLid>synth.pad.metallic</musicXMLid>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <aPitchRange>36-96</aPitchRange>
-                  <pPitchRange>21-108</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 93; MS General: Metal Pad-->
-                        <program value="93"/> <!--Pad 6 (metallic)-->
-                  </Channel>
-                  <genre>popular</genre>
-                  <genre>marching</genre>
-                  <genre>electronic</genre>
-            </Instrument>
-            <Instrument id="halo-synth">
-                  <family>synths</family>
-                  <longName>Halo Synthesizer</longName>
-                  <shortName>Synth.</shortName>
-                  <description>Halo Pad Synthesizer</description>
-                  <musicXMLid>synth.pad.halo</musicXMLid>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <aPitchRange>36-96</aPitchRange>
-                  <pPitchRange>21-108</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 94; MS General: Halo Pad-->
-                        <program value="94"/> <!--Pad 7 (halo)-->
-                  </Channel>
-                  <genre>popular</genre>
-                  <genre>marching</genre>
-                  <genre>electronic</genre>
-            </Instrument>
-            <Instrument id="sweep-synth">
-                  <family>synths</family>
-                  <longName>Sweep Synthesizer</longName>
-                  <shortName>Synth.</shortName>
-                  <description>Sweep Pad Synthesizer</description>
-                  <musicXMLid>synth.pad.warm</musicXMLid>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <aPitchRange>36-96</aPitchRange>
-                  <pPitchRange>21-108</pPitchRange>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 95; MS General: Sweep Pad-->
-                        <program value="95"/> <!--Pad 8 (sweep)-->
+                        <!--MIDI: Bank 0, Prog 96; MS General: Ice Rain-->
+                        <program value="96"/> <!--FX 1 (rain)-->
                   </Channel>
                   <genre>popular</genre>
                   <genre>marching</genre>
@@ -9808,6 +10226,28 @@
                   <genre>marching</genre>
                   <genre>electronic</genre>
             </Instrument>
+            <Instrument id="sci-fi-synth">
+                  <family>synths</family>
+                  <longName>Sci-fi Synthesizer</longName>
+                  <shortName>Synth.</shortName>
+                  <description>Sci-fi Effect Synthesizer</description>
+                  <musicXMLid>synth.effects.sci-fi</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>36-96</aPitchRange>
+                  <pPitchRange>21-108</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 103; MS General: Star Theme-->
+                        <program value="103"/> <!--FX 8 (sci-fi)-->
+                  </Channel>
+                  <genre>popular</genre>
+                  <genre>marching</genre>
+                  <genre>electronic</genre>
+            </Instrument>
             <Instrument id="sine-synth">
                   <family>synths</family>
                   <longName>Sine Synthesizer</longName>
@@ -9830,6 +10270,28 @@
                   <genre>marching</genre>
                   <genre>electronic</genre>
             </Instrument>
+            <Instrument id="soundtrack-synth">
+                  <family>synths</family>
+                  <longName>Soundtrack Synthesizer</longName>
+                  <shortName>Synth.</shortName>
+                  <description>Soundtrack Effect Synthesizer</description>
+                  <musicXMLid>synth.effects.soundtrack</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>36-96</aPitchRange>
+                  <pPitchRange>21-108</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 97; MS General: SoundTrack-->
+                        <program value="97"/> <!--FX 2 (soundtrack)-->
+                  </Channel>
+                  <genre>popular</genre>
+                  <genre>marching</genre>
+                  <genre>electronic</genre>
+            </Instrument>
             <Instrument id="square-synth">
                   <family>synths</family>
                   <longName>Square Synthesizer</longName>
@@ -9847,98 +10309,6 @@
                   <Channel>
                         <!--MIDI: Bank 0, Prog 80; MS General: Square Lead-->
                         <program value="80"/> <!--Lead 1 (square)-->
-                  </Channel>
-                  <genre>popular</genre>
-                  <genre>marching</genre>
-                  <genre>electronic</genre>
-            </Instrument>
-            <Instrument id="ondes-martenot">
-                  <family>synths</family>
-                  <longName>Ondes Martenot</longName>
-                  <shortName>O.M.</shortName>
-                  <description>Ondes Martenot</description>
-                  <musicXMLid>keyboard.ondes-martenot</musicXMLid>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
-                        <program value="79"/> <!--Ocarina-->
-                  </Channel>
-                  <genre>popular</genre>
-                  <genre>marching</genre>
-                  <genre>electronic</genre>
-            </Instrument>
-            <Instrument id="mallet-synthesizer">
-                  <family>synths</family>
-                  <longName>Mallet Synthesizer</longName>
-                  <shortName>Mal. Syn.</shortName>
-                  <description>Mallet Synthesizer</description>
-                  <musicXMLid>synth.group</musicXMLid>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 80; MS General: Square Lead-->
-                        <program value="80"/> <!--Lead 1 (square)-->
-                  </Channel>
-                  <genre>popular</genre>
-                  <genre>marching</genre>
-                  <genre>electronic</genre>
-            </Instrument>
-            <Instrument id="bass-synthesizer">
-                  <family>synths</family>
-                  <longName>Bass Synthesizer</longName>
-                  <shortName>Synth.</shortName>
-                  <description>Bass Synthesizer</description>
-                  <musicXMLid>pluck.bass.synth</musicXMLid>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <aPitchRange>36-96</aPitchRange>
-                  <pPitchRange>21-108</pPitchRange>
-                  <Channel name="synth-bass-1">
-                        <!--MIDI: Bank 0, Prog 38; MS General: Synth Bass 1-->
-                        <program value="38"/> <!--Synth Bass 1-->
-                  </Channel>
-                  <Channel name="synth-bass-2">
-                        <!--MIDI: Bank 0, Prog 39; MS General: Synth Bass 2-->
-                        <program value="39"/> <!--Synth Bass 2-->
-                  </Channel>
-                  <genre>popular</genre>
-                  <genre>marching</genre>
-                  <genre>electronic</genre>
-            </Instrument>
-            <Instrument id="brass-synthesizer">
-                  <family>synths</family>
-                  <longName>Brass Synthesizer</longName>
-                  <shortName>Synth.</shortName>
-                  <description>Brass Synthesizer</description>
-                  <musicXMLid>brass.group.synth</musicXMLid>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <aPitchRange>36-96</aPitchRange>
-                  <pPitchRange>21-108</pPitchRange>
-                  <Channel name="synth-brass-1">
-                        <!--MIDI: Bank 0, Prog 62; MS General: Synth Brass 1-->
-                        <program value="62"/> <!--Synth Brass 1-->
-                  </Channel>
-                  <Channel name="synth-brass-2">
-                        <!--MIDI: Bank 0, Prog 63; MS General: Synth Brass 2-->
-                        <program value="63"/> <!--Synth Brass 2-->
                   </Channel>
                   <genre>popular</genre>
                   <genre>marching</genre>
@@ -9970,6 +10340,28 @@
                   <genre>marching</genre>
                   <genre>electronic</genre>
             </Instrument>
+            <Instrument id="sweep-synth">
+                  <family>synths</family>
+                  <longName>Sweep Synthesizer</longName>
+                  <shortName>Synth.</shortName>
+                  <description>Sweep Pad Synthesizer</description>
+                  <musicXMLid>synth.pad.warm</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>36-96</aPitchRange>
+                  <pPitchRange>21-108</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 95; MS General: Sweep Pad-->
+                        <program value="95"/> <!--Pad 8 (sweep)-->
+                  </Channel>
+                  <genre>popular</genre>
+                  <genre>marching</genre>
+                  <genre>electronic</genre>
+            </Instrument>
             <Instrument id="theremin">
                   <family>synths</family>
                   <longName>Theremin</longName>
@@ -9992,28 +10384,23 @@
                   <genre>marching</genre>
                   <genre>electronic</genre>
             </Instrument>
-            <Instrument id="percussion-synthesizer">
+            <Instrument id="warm-synth">
                   <family>synths</family>
-                  <longName>Percussion Synthesizer</longName>
-                  <shortName>Perc. Syn.</shortName>
-                  <description>Percussion Synthesizer</description>
-                  <musicXMLid>drum.snare-drum.electric</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <Drum pitch="40"> <!--Electric Snare-->
-                        <head>normal</head>
-                        <line>4</line>
-                        <voice>0</voice>
-                        <name>Electric Snare</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
+                  <longName>Warm Synthesizer</longName>
+                  <shortName>Synth.</shortName>
+                  <description>Warm Pad Synthesizer</description>
+                  <musicXMLid>synth.pad.warm</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>36-96</aPitchRange>
+                  <pPitchRange>21-108</pPitchRange>
                   <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
+                        <!--MIDI: Bank 0, Prog 89; MS General: Warm Pad-->
+                        <program value="89"/> <!--Pad 2 (warm)-->
                   </Channel>
                   <genre>popular</genre>
                   <genre>marching</genre>
@@ -10022,310 +10409,67 @@
       </InstrumentGroup>
       <InstrumentGroup id="plucked-strings">
             <name>Strings - Plucked</name>
-            <Instrument id="banjo">
-                  <family>plucked-strings</family>
-                  <longName>Banjo</longName>
-                  <shortName>Bj.</shortName>
-                  <description>5 string Banjo</description>
-                  <musicXMLid>pluck.banjo</musicXMLid>
+            <Instrument id="harp">
+                  <family>harps</family>
+                  <longName>Harp</longName>
+                  <shortName>Hrp.</shortName>
+                  <description>Harp</description>
+                  <musicXMLid>pluck.harp</musicXMLid>
+                  <staves>2</staves>
+                  <clef>G</clef>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>23-104</aPitchRange>
+                  <pPitchRange>23-104</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 46; MS General: Harp-->
+                        <program value="46"/> <!--Orchestral Harp-->
+                  </Channel>
+                  <Channel name="staccato">
+                        <!--MIDI: Bank 0, Prog 45; MS General: Strings Pizzicato-->
+                        <program value="45"/> <!--Pizzicato Strings-->
+                  </Channel>
+                  <Channel name="flageoletti">
+                        <!--MIDI: Bank 0, Prog 11; MS General: Vibraphone-->
+                        <program value="11"/> <!--Vibraphone-->
+                  </Channel>
+                  <genre>common</genre>
+                  <genre>orchestra</genre>
+            </Instrument>
+            <Instrument id="cavaquinho">
+                  <family>guitars</family>
+                  <longName>Cavaquinho</longName>
+                  <shortName>Cava.</shortName>
+                  <description>Cavaquinho (4-string Guitar)</description>
+                  <musicXMLid>pluck.guitar</musicXMLid>
                   <StringData>
                         <frets>19</frets>
+                        <string>62</string>
                         <string>67</string>
-                        <string>50</string>
-                        <string>55</string>
-                        <string>59</string>
-                        <string>62</string>
-                  </StringData>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>48-87</aPitchRange>
-                  <pPitchRange>48-87</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 105; MS General: Banjo-->
-                        <program value="105"/> <!--Banjo-->
-                  </Channel>
-                  <genre>common</genre>
-                  <genre>popular</genre>
-                  <genre>jazz</genre>
-            </Instrument>
-            <Instrument id="banjo-tablature">
-                  <family>plucked-strings</family>
-                  <trackName>Banjo (Tablature)</trackName>
-                  <init>banjo</init>
-                  <description>Banjo (Tablature)</description>
-                  <musicXMLid>pluck.banjo</musicXMLid>
-                  <stafftype staffTypePreset="tab5StrCommon">tablature</stafftype>
-                  <genre>common</genre>
-                  <genre>jazz</genre>
-            </Instrument>
-            <Instrument id="tenor-banjo">
-                  <family>plucked-strings</family>
-                  <longName>Tenor Banjo</longName>
-                  <shortName>T. Bj.</shortName>
-                  <description>4 string Tenor Banjo</description>
-                  <musicXMLid>pluck.banjo.tenor</musicXMLid>
-                  <StringData>
-                        <frets>19</frets>
-                        <string>48</string>
-                        <string>55</string>
-                        <string>62</string>
-                        <string>69</string>
-                  </StringData>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>48-83</aPitchRange>
-                  <pPitchRange>48-83</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 105; MS General: Banjo-->
-                        <program value="105"/> <!--Banjo-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="irish-tenor-banjo">
-                  <family>plucked-strings</family>
-                  <longName>Irish Tenor Banjo</longName>
-                  <shortName>ITB</shortName>
-                  <description>4 string Irish Tenor Banjo</description>
-                  <musicXMLid>pluck.banjo.tenor</musicXMLid>
-                  <StringData>
-                        <frets>19</frets>
-                        <string>43</string>
-                        <string>50</string>
-                        <string>57</string>
-                        <string>64</string>
-                  </StringData>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>43-69</aPitchRange>
-                  <pPitchRange>43-76</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 105; MS General: Banjo-->
-                        <program value="105"/> <!--Banjo-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="irish-tenor-banjo-tablature">
-                  <family>plucked-strings</family>
-                  <trackName>Irish Tenor Banjo (Tablature)</trackName>
-                  <init>irish-tenor-banjo</init>
-                  <description>Irish Tenor Banjo (Tablature)</description>
-                  <musicXMLid>pluck.banjo.tenor</musicXMLid>
-                  <stafftype staffTypePreset="tab4StrCommon">tablature</stafftype>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="balalaika">
-                  <family>plucked-strings</family>
-                  <trackName>Balalaika</trackName>
-                  <longName>Balalaika</longName>
-                  <shortName>Bal.</shortName>
-                  <description>Balalaika in fact the prima but a generic for simplicity</description>
-                  <musicXMLid>pluck.balalaika</musicXMLid>
-                  <StringData>
-                        <frets>17</frets>
-                        <string>64</string>
-                        <string>64</string>
-                        <string>69</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>64-86</aPitchRange>
-                  <pPitchRange>64-86</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 107; MS General: Koto-->
-                        <program value="107"/> <!--Koto-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="balalaika-piccolo">
-                  <family>plucked-strings</family>
-                  <trackName>Piccolo Balalaika</trackName>
-                  <longName>Piccolo Balalaika</longName>
-                  <shortName>Pic. Bal.</shortName>
-                  <description>Piccolo Balalaika (the smallest and rarest of the family)</description>
-                  <musicXMLid>pluck.balalaika.piccolo</musicXMLid>
-                  <StringData>
-                        <frets>17</frets>
                         <string>71</string>
-                        <string>76</string>
-                        <string>81</string>
+                        <string>74</string>
                   </StringData>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>71-98</aPitchRange>
-                  <pPitchRange>71-98</pPitchRange>
+                  <aPitchRange>62-93</aPitchRange>
+                  <pPitchRange>62-93</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 107; MS General: Koto-->
-                        <program value="107"/> <!--Koto-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="balalaika-prima">
-                  <family>plucked-strings</family>
-                  <trackName>Prima Balalaika</trackName>
-                  <longName>Prima Balalaika</longName>
-                  <shortName>Pr. Bal.</shortName>
-                  <description>Prima Balalaika (the most commonly played of the family)</description>
-                  <musicXMLid>pluck.balalaika.prima</musicXMLid>
-                  <StringData>
-                        <frets>17</frets>
-                        <string>64</string>
-                        <string>64</string>
-                        <string>69</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>64-86</aPitchRange>
-                  <pPitchRange>64-86</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 107; MS General: Koto-->
-                        <program value="107"/> <!--Koto-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="balalaika-secunda">
-                  <family>plucked-strings</family>
-                  <trackName>Secunda Balalaika</trackName>
-                  <longName>Secunda Balalaika</longName>
-                  <shortName>Sec. Bal.</shortName>
-                  <description>Secunda Balalaika</description>
-                  <musicXMLid>pluck.balalaika.secunda</musicXMLid>
-                  <StringData>
-                        <frets>17</frets>
-                        <string>57</string>
-                        <string>57</string>
-                        <string>62</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>57-79</aPitchRange>
-                  <pPitchRange>57-79</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 107; MS General: Koto-->
-                        <program value="107"/> <!--Koto-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="balalaika-alto">
-                  <family>plucked-strings</family>
-                  <trackName>Alto Balalaika</trackName>
-                  <longName>Alto Balalaika</longName>
-                  <shortName>Al. Bal.</shortName>
-                  <description>Alto Balalaika</description>
-                  <musicXMLid>pluck.balalaika.alto</musicXMLid>
-                  <StringData>
-                        <frets>17</frets>
-                        <string>52</string>
-                        <string>52</string>
-                        <string>57</string>
-                  </StringData>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>52-74</aPitchRange>
-                  <pPitchRange>52-74</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 107; MS General: Koto-->
-                        <program value="107"/> <!--Koto-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="balalaika-bass">
-                  <family>plucked-strings</family>
-                  <trackName>Bass Balalaika</trackName>
-                  <longName>Bass Balalaika</longName>
-                  <shortName>B. Bal.</shortName>
-                  <description>Bass Balalaika</description>
-                  <musicXMLid>pluck.balalaika.bass</musicXMLid>
-                  <StringData>
-                        <frets>17</frets>
-                        <string>40</string>
-                        <string>45</string>
-                        <string>50</string>
-                  </StringData>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>40-67</aPitchRange>
-                  <pPitchRange>40-67</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 107; MS General: Koto-->
-                        <program value="107"/> <!--Koto-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="balalaika-contrabass">
-                  <family>plucked-strings</family>
-                  <trackName>Contrabass Balalaika</trackName>
-                  <longName>Contrabass Balalaika</longName>
-                  <shortName>Cb. Bal.</shortName>
-                  <description>Contrabass Balalaika</description>
-                  <musicXMLid>pluck.balalaika.contrabass</musicXMLid>
-                  <StringData>
-                        <frets>17</frets>
-                        <string>28</string>
-                        <string>33</string>
-                        <string>38</string>
-                  </StringData>
-                  <clef>F8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>28-55</aPitchRange>
-                  <pPitchRange>28-55</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 107; MS General: Koto-->
-                        <program value="107"/> <!--Koto-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="bouzouki-3-course">
-                  <family>plucked-strings</family>
-                  <trackName>Bouzouki (3-course)</trackName>
-                  <longName>Bouzouki</longName>
-                  <shortName>Bou.</shortName>
-                  <description>Bouzouki (3-course)</description>
-                  <musicXMLid>pluck.bouzouki</musicXMLid>
-                  <StringData>
-                        <frets>26</frets>
-                        <string>50</string>
-                        <string>57</string>
-                        <string>62</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>50-89</aPitchRange>
-                  <pPitchRange>50-90</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
-                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <!--MIDI: Bank 0, Prog 25; MS General: Steel String Guitar-->
                         <program value="25"/> <!--Acoustic Guitar (steel)-->
                   </Channel>
                   <genre>world</genre>
             </Instrument>
-            <Instrument id="bouzouki-4-course">
-                  <family>plucked-strings</family>
-                  <trackName>Bouzouki (4-course)</trackName>
-                  <longName>Bouzouki</longName>
-                  <shortName>Bou.</shortName>
-                  <description>Bouzouki (4-course)</description>
-                  <musicXMLid>pluck.bouzouki</musicXMLid>
-                  <StringData>
-                        <frets>26</frets>
-                        <string>48</string>
-                        <string>53</string>
-                        <string>57</string>
-                        <string>62</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>48-88</aPitchRange>
-                  <pPitchRange>48-90</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
-                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
-                  </Channel>
+            <Instrument id="cavaquinho-tablature">
+                  <init>cavaquinho</init>
+                  <family>guitars</family>
+                  <trackName>Cavaquinho (Tablature)</trackName>
+                  <description>Cavaquinho (4-string Guitar) (Tablature)</description>
+                  <musicXMLid>pluck.guitar</musicXMLid>
+                  <stafftype staffTypePreset="tab4StrSimple">tablature</stafftype>
                   <genre>world</genre>
             </Instrument>
             <Instrument id="soprano-guitar">
@@ -10385,385 +10529,6 @@
                         <!--MIDI: Bank 0, Prog 28; MS General: Palm Muted Guitar-->
                         <program value="28"/> <!--Electric Guitar (muted)-->
                   </Channel>
-            </Instrument>
-            <Instrument id="guitar-nylon">
-                  <family>guitars</family>
-                  <longName>Classical Guitar</longName>
-                  <shortName>Guit.</shortName>
-                  <description>Acoustic Nylon-strung Guitar</description>
-                  <musicXMLid>pluck.guitar.nylon-string</musicXMLid>
-                  <StringData>
-                        <frets>19</frets>
-                        <string>40</string>
-                        <string>45</string>
-                        <string>50</string>
-                        <string>55</string>
-                        <string>59</string>
-                        <string>64</string>
-                  </StringData>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>40-83</aPitchRange>
-                  <pPitchRange>40-83</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel name="open">
-                        <!--MIDI: Bank 0, Prog 24; MS General: Nylon String Guitar-->
-                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
-                  </Channel>
-                  <Channel name="mute">
-                        <!--MIDI: Bank 0, Prog 28; MS General: Palm Muted Guitar-->
-                        <program value="28"/> <!--Electric Guitar (muted)-->
-                  </Channel>
-                  <genre>common</genre>
-                  <genre>popular</genre>
-            </Instrument>
-            <Instrument id="guitar-nylon-treble-clef">
-                  <family>guitars</family>
-                  <trackName>Guitar (Treble Clef)</trackName>
-                  <longName>Guitar</longName>
-                  <shortName>Guit.</shortName>
-                  <description>Acoustic Nylon-strung Guitar (Treble Clef)</description>
-                  <musicXMLid>pluck.guitar.nylon-string</musicXMLid>
-                  <StringData>
-                        <frets>19</frets>
-                        <string>52</string>
-                        <string>57</string>
-                        <string>62</string>
-                        <string>67</string>
-                        <string>71</string>
-                        <string>76</string>
-                  </StringData>
-                  <transposingClef>G</transposingClef>
-                  <concertClef>G8vb</concertClef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>40-83</aPitchRange>
-                  <pPitchRange>40-83</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <transposeDiatonic>-7</transposeDiatonic>
-                  <transposeChromatic>-12</transposeChromatic>
-                  <Channel name="open">
-                        <!--MIDI: Bank 0, Prog 24; MS General: Nylon String Guitar-->
-                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
-                  </Channel>
-                  <Channel name="mute">
-                        <!--MIDI: Bank 0, Prog 28; MS General: Palm Muted Guitar-->
-                        <program value="28"/> <!--Electric Guitar (muted)-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="guitar-nylon-tablature">
-                  <family>guitars</family>
-                  <trackName>Classical Guitar (Tablature)</trackName>
-                  <init>guitar-nylon</init>
-                  <description>Acoustic Nylon Strung Guitar (Tablature)</description>
-                  <musicXMLid>pluck.guitar.nylon-string</musicXMLid>
-                  <stafftype staffTypePreset="tab6StrCommon">tablature</stafftype>
-                  <genre>common</genre>
-            </Instrument>
-            <Instrument id="7-string-guitar">
-                  <family>guitars</family>
-                  <longName>7-string Guitar</longName>
-                  <shortName>Guit.</shortName>
-                  <description>7-string Guitar</description>
-                  <musicXMLid>pluck.guitar.nylon-string</musicXMLid>
-                  <StringData>
-                        <frets>19</frets>
-                        <string>35</string>
-                        <string>40</string>
-                        <string>45</string>
-                        <string>50</string>
-                        <string>55</string>
-                        <string>59</string>
-                        <string>64</string>
-                  </StringData>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>35-83</aPitchRange>
-                  <pPitchRange>35-83</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 24; MS General: Nylon String Guitar-->
-                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="7-string-guitar-tablature">
-                  <family>guitars</family>
-                  <trackName>7-string Guitar (Tablature)</trackName>
-                  <init>7-string-guitar</init>
-                  <description>7-string Guitar (Tablature)</description>
-                  <musicXMLid>pluck.guitar.nylon-string</musicXMLid>
-                  <stafftype staffTypePreset="tab7StrCommon">tablature</stafftype>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="cavaquinho">
-                  <family>plucked-strings</family>
-                  <longName>Cavaquinho</longName>
-                  <shortName>Cava.</shortName>
-                  <description>Cavaquinho (4-string Guitar)</description>
-                  <musicXMLid>pluck.guitar</musicXMLid>
-                  <StringData>
-                        <frets>19</frets>
-                        <string>62</string>
-                        <string>67</string>
-                        <string>71</string>
-                        <string>74</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>62-93</aPitchRange>
-                  <pPitchRange>62-93</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 25; MS General: Steel String Guitar-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="cavaquinho-tablature">
-                  <family>plucked-strings</family>
-                  <trackName>Cavaquinho (Tablature)</trackName>
-                  <init>cavaquinho</init>
-                  <description>Cavaquinho (4-string Guitar) (Tablature)</description>
-                  <musicXMLid>pluck.guitar</musicXMLid>
-                  <stafftype staffTypePreset="tab4StrSimple">tablature</stafftype>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="baritone-guitar">
-                  <family>guitars</family>
-                  <longName>Baritone Guitar</longName>
-                  <shortName>Bar. Guit.</shortName>
-                  <description>Baritone Guitar</description>
-                  <musicXMLid>pluck.guitar</musicXMLid>
-                  <StringData>
-                        <frets>19</frets>
-                        <string>35</string>
-                        <string>40</string>
-                        <string>45</string>
-                        <string>50</string>
-                        <string>54</string>
-                        <string>59</string>
-                  </StringData>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>35-78</aPitchRange>
-                  <pPitchRange>35-78</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 24; MS General: Nylon String Guitar-->
-                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="contra-guitar">
-                  <family>guitars</family>
-                  <longName>Contra Guitar</longName>
-                  <shortName>C. Guit.</shortName>
-                  <description>Acoustic Contra Guitar</description>
-                  <musicXMLid>pluck.guitar</musicXMLid>
-                  <StringData>
-                        <frets>19</frets>
-                        <string open="1">31</string>
-                        <string open="1">32</string>
-                        <string open="1">33</string>
-                        <string open="1">34</string>
-                        <string open="1">35</string>
-                        <string open="1">36</string>
-                        <string open="1">37</string>
-                        <string open="1">38</string>
-                        <string open="1">39</string>
-                        <string>40</string>
-                        <string>45</string>
-                        <string>50</string>
-                        <string>55</string>
-                        <string>59</string>
-                        <string>64</string>
-                  </StringData>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>31-83</aPitchRange>
-                  <pPitchRange>31-83</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel name="open">
-                        <!--MIDI: Bank 0, Prog 24; MS General: Nylon String Guitar-->
-                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
-                  </Channel>
-                  <Channel name="mute">
-                        <!--MIDI: Bank 0, Prog 28; MS General: Palm Muted Guitar-->
-                        <program value="28"/> <!--Electric Guitar (muted)-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="guitar-steel">
-                  <family>guitars</family>
-                  <longName>Acoustic Guitar</longName>
-                  <shortName>Guit.</shortName>
-                  <description>Acoustic Steel-strung Guitar</description>
-                  <musicXMLid>pluck.guitar.acoustic</musicXMLid>
-                  <StringData>
-                        <frets>20</frets>
-                        <string>40</string>
-                        <string>45</string>
-                        <string>50</string>
-                        <string>55</string>
-                        <string>59</string>
-                        <string>64</string>
-                  </StringData>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>40-83</aPitchRange>
-                  <pPitchRange>40-84</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel name="open">
-                        <!--MIDI: Bank 0, Prog 25; MS General: Steel String Guitar-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
-                  </Channel>
-                  <Channel name="mute">
-                        <!--MIDI: Bank 0, Prog 28; MS General: Palm Muted Guitar-->
-                        <program value="28"/> <!--Electric Guitar (muted)-->
-                  </Channel>
-                  <Channel name="jazz">
-                        <!--MIDI: Bank 0, Prog 26; MS General: Jazz Guitar-->
-                        <program value="26"/> <!--Electric Guitar (jazz)-->
-                  </Channel>
-                  <genre>common</genre>
-                  <genre>popular</genre>
-                  <genre>jazz</genre>
-                  <genre>classroom</genre>
-            </Instrument>
-            <Instrument id="guitar-steel-treble-clef">
-                  <family>guitars</family>
-                  <trackName>Acoustic Guitar (Treble Clef)</trackName>
-                  <longName>Guitar</longName>
-                  <shortName>Guit.</shortName>
-                  <description>Acoustic Steel-strung Guitar (Treble Clef)</description>
-                  <musicXMLid>pluck.guitar.acoustic</musicXMLid>
-                  <StringData>
-                        <frets>20</frets>
-                        <string>52</string>
-                        <string>57</string>
-                        <string>62</string>
-                        <string>67</string>
-                        <string>71</string>
-                        <string>76</string>
-                  </StringData>
-                  <transposingClef>G</transposingClef>
-                  <concertClef>G8vb</concertClef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>40-83</aPitchRange>
-                  <pPitchRange>40-84</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <transposeDiatonic>-7</transposeDiatonic>
-                  <transposeChromatic>-12</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 25; MS General: Steel String Guitar-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="guitar-steel-tablature">
-                  <family>guitars</family>
-                  <trackName>Acoustic Guitar (Tablature)</trackName>
-                  <init>guitar-steel</init>
-                  <description>Acoustic Steel Strung Guitar (Tablature)</description>
-                  <musicXMLid>pluck.guitar.acoustic</musicXMLid>
-                  <stafftype staffTypePreset="tab6StrCommon">tablature</stafftype>
-                  <genre>common</genre>
-                  <genre>classroom</genre>
-            </Instrument>
-            <Instrument id="11-string-alto-guitar">
-                  <family>guitars</family>
-                  <longName>11-string Alto Guitar</longName>
-                  <shortName>11-str. A. Guit.</shortName>
-                  <description>11-string Alto Guitar</description>
-                  <musicXMLid>pluck.guitar</musicXMLid>
-                  <StringData>
-                        <frets>19</frets>
-                        <string>35</string>
-                        <string>36</string>
-                        <string>38</string>
-                        <string>39</string>
-                        <string>41</string>
-                        <string>43</string>
-                        <string>48</string>
-                        <string>53</string>
-                        <string>57</string>
-                        <string>62</string>
-                        <string>67</string>
-                  </StringData>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <aPitchRange>34-86</aPitchRange>
-                  <pPitchRange>34-86</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel name="open">
-                        <!--MIDI: Bank 0, Prog 24; MS General: Nylon String Guitar-->
-                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
-                  </Channel>
-                  <Channel name="mute">
-                        <!--MIDI: Bank 0, Prog 28; MS General: Palm Muted Guitar-->
-                        <program value="28"/> <!--Electric Guitar (muted)-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="12-string-guitar">
-                  <family>guitars</family>
-                  <longName>12-string Guitar</longName>
-                  <shortName>12-str. Guit.</shortName>
-                  <description>12-string Guitar</description>
-                  <musicXMLid>pluck.guitar</musicXMLid>
-                  <StringData>
-                        <frets>21</frets>
-                        <string>40</string>
-                        <string>45</string>
-                        <string>50</string>
-                        <string>55</string>
-                        <string>59</string>
-                        <string>64</string>
-                  </StringData>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>40-83</aPitchRange>
-                  <pPitchRange>40-85</pPitchRange>
-                  <Channel name="open">
-                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
-                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
-                  </Channel>
-                  <Channel name="mute">
-                        <!--MIDI: Bank 0, Prog 28; MS General: Palm Muted Guitar-->
-                        <program value="28"/> <!--Electric Guitar (muted)-->
-                  </Channel>
-                  <Channel name="jazz">
-                        <!--MIDI: Bank 0, Prog 26; MS General: Jazz Guitar-->
-                        <program value="26"/> <!--Electric Guitar (jazz)-->
-                  </Channel>
-                  <genre>popular</genre>
-            </Instrument>
-            <Instrument id="pedal-steel-guitar">
-                  <family>guitars</family>
-                  <longName>Pedal Steel Guitar</longName>
-                  <shortName>Ped. St. Guit.</shortName>
-                  <description>Pedal Steel Guitar</description>
-                  <musicXMLid>pluck.guitar.pedal-steel</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>35-84</aPitchRange>
-                  <pPitchRange>35-84</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel name="open">
-                        <!--MIDI: Bank 0, Prog 25; MS General: Steel String Guitar-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
-                  </Channel>
-                  <Channel name="mute">
-                        <!--MIDI: Bank 0, Prog 28; MS General: Palm Muted Guitar-->
-                        <program value="28"/> <!--Electric Guitar (muted)-->
-                  </Channel>
-                  <Channel name="jazz">
-                        <!--MIDI: Bank 0, Prog 26; MS General: Jazz Guitar-->
-                        <program value="26"/> <!--Electric Guitar (jazz)-->
-                  </Channel>
-                  <genre>popular</genre>
             </Instrument>
             <Instrument id="electric-guitar">
                   <family>guitars</family>
@@ -10844,429 +10609,300 @@
                         <program value="27"/> <!--Electric Guitar (clean)-->
                   </Channel>
             </Instrument>
+            <Instrument id="guitar-steel">
+                  <family>guitars</family>
+                  <longName>Acoustic Guitar</longName>
+                  <shortName>Guit.</shortName>
+                  <description>Acoustic Steel-strung Guitar</description>
+                  <musicXMLid>pluck.guitar.acoustic</musicXMLid>
+                  <StringData>
+                        <frets>20</frets>
+                        <string>40</string>
+                        <string>45</string>
+                        <string>50</string>
+                        <string>55</string>
+                        <string>59</string>
+                        <string>64</string>
+                  </StringData>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>40-83</aPitchRange>
+                  <pPitchRange>40-84</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel name="open">
+                        <!--MIDI: Bank 0, Prog 25; MS General: Steel String Guitar-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+                  <Channel name="mute">
+                        <!--MIDI: Bank 0, Prog 28; MS General: Palm Muted Guitar-->
+                        <program value="28"/> <!--Electric Guitar (muted)-->
+                  </Channel>
+                  <Channel name="jazz">
+                        <!--MIDI: Bank 0, Prog 26; MS General: Jazz Guitar-->
+                        <program value="26"/> <!--Electric Guitar (jazz)-->
+                  </Channel>
+                  <genre>common</genre>
+                  <genre>popular</genre>
+                  <genre>jazz</genre>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="guitar-steel-treble-clef">
+                  <family>guitars</family>
+                  <trackName>Acoustic Guitar (Treble Clef)</trackName>
+                  <longName>Guitar</longName>
+                  <shortName>Guit.</shortName>
+                  <description>Acoustic Steel-strung Guitar (Treble Clef)</description>
+                  <musicXMLid>pluck.guitar.acoustic</musicXMLid>
+                  <StringData>
+                        <frets>20</frets>
+                        <string>52</string>
+                        <string>57</string>
+                        <string>62</string>
+                        <string>67</string>
+                        <string>71</string>
+                        <string>76</string>
+                  </StringData>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>G8vb</concertClef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>40-83</aPitchRange>
+                  <pPitchRange>40-84</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <transposeDiatonic>-7</transposeDiatonic>
+                  <transposeChromatic>-12</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 25; MS General: Steel String Guitar-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="guitar-nylon">
+                  <family>guitars</family>
+                  <longName>Classical Guitar</longName>
+                  <shortName>Guit.</shortName>
+                  <description>Acoustic Nylon-strung Guitar</description>
+                  <musicXMLid>pluck.guitar.nylon-string</musicXMLid>
+                  <StringData>
+                        <frets>19</frets>
+                        <string>40</string>
+                        <string>45</string>
+                        <string>50</string>
+                        <string>55</string>
+                        <string>59</string>
+                        <string>64</string>
+                  </StringData>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>40-83</aPitchRange>
+                  <pPitchRange>40-83</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel name="open">
+                        <!--MIDI: Bank 0, Prog 24; MS General: Nylon String Guitar-->
+                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
+                  </Channel>
+                  <Channel name="mute">
+                        <!--MIDI: Bank 0, Prog 28; MS General: Palm Muted Guitar-->
+                        <program value="28"/> <!--Electric Guitar (muted)-->
+                  </Channel>
+                  <genre>common</genre>
+                  <genre>popular</genre>
+            </Instrument>
+            <Instrument id="guitar-nylon-treble-clef">
+                  <family>guitars</family>
+                  <trackName>Guitar (Treble Clef)</trackName>
+                  <longName>Guitar</longName>
+                  <shortName>Guit.</shortName>
+                  <description>Acoustic Nylon-strung Guitar (Treble Clef)</description>
+                  <musicXMLid>pluck.guitar.nylon-string</musicXMLid>
+                  <StringData>
+                        <frets>19</frets>
+                        <string>52</string>
+                        <string>57</string>
+                        <string>62</string>
+                        <string>67</string>
+                        <string>71</string>
+                        <string>76</string>
+                  </StringData>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>G8vb</concertClef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>40-83</aPitchRange>
+                  <pPitchRange>40-83</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <transposeDiatonic>-7</transposeDiatonic>
+                  <transposeChromatic>-12</transposeChromatic>
+                  <Channel name="open">
+                        <!--MIDI: Bank 0, Prog 24; MS General: Nylon String Guitar-->
+                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
+                  </Channel>
+                  <Channel name="mute">
+                        <!--MIDI: Bank 0, Prog 28; MS General: Palm Muted Guitar-->
+                        <program value="28"/> <!--Electric Guitar (muted)-->
+                  </Channel>
+            </Instrument>
             <Instrument id="electric-guitar-tablature">
-                  <trackName>Electric Guitar (Tablature)</trackName>
                   <init>electric-guitar</init>
+                  <family>guitars</family>
+                  <trackName>Electric Guitar (Tablature)</trackName>
                   <description>Electric Guitar (Tablature)</description>
                   <stafftype staffTypePreset="tab6StrCommon">tablature</stafftype>
                   <genre>common</genre>
                   <genre>popular</genre>
             </Instrument>
-            <Instrument id="harp">
-                  <family>harps</family>
-                  <longName>Harp</longName>
-                  <shortName>Hrp.</shortName>
-                  <description>Harp</description>
-                  <musicXMLid>pluck.harp</musicXMLid>
-                  <staves>2</staves>
-                  <clef>G</clef>
-                  <bracket>1</bracket>
-                  <bracketSpan>2</bracketSpan>
-                  <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
-                  <aPitchRange>23-104</aPitchRange>
-                  <pPitchRange>23-104</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 46; MS General: Harp-->
-                        <program value="46"/> <!--Orchestral Harp-->
-                  </Channel>
-                  <Channel name="staccato">
-                        <!--MIDI: Bank 0, Prog 45; MS General: Strings Pizzicato-->
-                        <program value="45"/> <!--Pizzicato Strings-->
-                  </Channel>
-                  <Channel name="flageoletti">
-                        <!--MIDI: Bank 0, Prog 11; MS General: Vibraphone-->
-                        <program value="11"/> <!--Vibraphone-->
-                  </Channel>
+            <Instrument id="guitar-nylon-tablature">
+                  <init>guitar-nylon</init>
+                  <family>guitars</family>
+                  <trackName>Classical Guitar (Tablature)</trackName>
+                  <description>Acoustic Nylon Strung Guitar (Tablature)</description>
+                  <musicXMLid>pluck.guitar.nylon-string</musicXMLid>
+                  <stafftype staffTypePreset="tab6StrCommon">tablature</stafftype>
                   <genre>common</genre>
-                  <genre>orchestra</genre>
             </Instrument>
-            <Instrument id="koto">
-                  <longName>Koto</longName>
-                  <shortName>Ko.</shortName>
-                  <description>Koto</description>
-                  <musicXMLid>pluck.koto</musicXMLid>
+            <Instrument id="guitar-steel-tablature">
+                  <init>guitar-steel</init>
+                  <family>guitars</family>
+                  <trackName>Acoustic Guitar (Tablature)</trackName>
+                  <description>Acoustic Steel Strung Guitar (Tablature)</description>
+                  <musicXMLid>pluck.guitar.acoustic</musicXMLid>
+                  <stafftype staffTypePreset="tab6StrCommon">tablature</stafftype>
+                  <genre>common</genre>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="pedal-steel-guitar">
+                  <family>guitars</family>
+                  <longName>Pedal Steel Guitar</longName>
+                  <shortName>Ped. St. Guit.</shortName>
+                  <description>Pedal Steel Guitar</description>
+                  <musicXMLid>pluck.guitar.pedal-steel</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>43-83</aPitchRange>
-                  <pPitchRange>43-83</pPitchRange>
+                  <aPitchRange>35-84</aPitchRange>
+                  <pPitchRange>35-84</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 107; MS General: Koto-->
-                        <program value="107"/> <!--Koto-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="mtn-dulcimer-std">
-                  <longName>Mtn. Dulcimer</longName>
-                  <shortName>Mtn. Dc.</shortName>
-                  <description>Standard Mountain Dulcimer</description>
-                  <musicXMLid>pluck.dulcimer</musicXMLid>
-                  <StringData>
-                        <frets>28</frets>
-                        <string>50</string>
-                        <string>57</string>
-                        <string>62</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>50-90</aPitchRange>
-                  <pPitchRange>50-90</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
+                  <Channel name="open">
                         <!--MIDI: Bank 0, Prog 25; MS General: Steel String Guitar-->
                         <program value="25"/> <!--Acoustic Guitar (steel)-->
                   </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="mtn-dulcimer-std-chrom-tab">
-                  <trackName>Mtn. Dulcimer (Tablature)</trackName>
-                  <init>mtn-dulcimer-std</init>
-                  <description>Mtn. Dulcimer (3-str. chromatic TAB)</description>
-                  <stafftype staffTypePreset="tabDulcimer">tablature</stafftype>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="mtn-dulcimer-baritone">
-                  <longName>Mtn. Dulcimer - Baritone</longName>
-                  <shortName>Bar. M.D.</shortName>
-                  <description>Baritone Mountain Dulcimer</description>
-                  <musicXMLid>pluck.dulcimer</musicXMLid>
-                  <StringData>
-                        <frets>23</frets>
-                        <string>45</string>
-                        <string>52</string>
-                        <string>57</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>45-80</aPitchRange>
-                  <pPitchRange>45-80</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 25; MS General: Steel String Guitar-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  <Channel name="mute">
+                        <!--MIDI: Bank 0, Prog 28; MS General: Palm Muted Guitar-->
+                        <program value="28"/> <!--Electric Guitar (muted)-->
                   </Channel>
-                  <genre>world</genre>
+                  <Channel name="jazz">
+                        <!--MIDI: Bank 0, Prog 26; MS General: Jazz Guitar-->
+                        <program value="26"/> <!--Electric Guitar (jazz)-->
+                  </Channel>
+                  <genre>popular</genre>
             </Instrument>
-            <Instrument id="mtn-dulcimer-bartn-chrom-tab">
-                  <trackName>Mtn. Dulcimer - Baritone (Tablature)</trackName>
-                  <init>mtn-dulcimer-baritone</init>
-                  <description>Baritone Mtn. Dulcimer (3-str. chromatic TAB)</description>
-                  <stafftype staffTypePreset="tabDulcimer">tablature</stafftype>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="mtn-dulcimer-bass">
-                  <longName>Mtn. Dulcimer - Bass</longName>
-                  <shortName>Bs. M.D.</shortName>
-                  <description>Bass Mountain Dulcimer</description>
-                  <musicXMLid>pluck.dulcimer</musicXMLid>
+            <Instrument id="baritone-guitar">
+                  <family>guitars</family>
+                  <longName>Baritone Guitar</longName>
+                  <shortName>Bar. Guit.</shortName>
+                  <description>Baritone Guitar</description>
+                  <musicXMLid>pluck.guitar</musicXMLid>
                   <StringData>
-                        <frets>28</frets>
-                        <string>38</string>
+                        <frets>19</frets>
+                        <string>35</string>
+                        <string>40</string>
                         <string>45</string>
                         <string>50</string>
+                        <string>54</string>
+                        <string>59</string>
                   </StringData>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>38-78</aPitchRange>
-                  <pPitchRange>38-78</pPitchRange>
+                  <aPitchRange>35-78</aPitchRange>
+                  <pPitchRange>35-78</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 25; MS General: Steel String Guitar-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                        <!--MIDI: Bank 0, Prog 24; MS General: Nylon String Guitar-->
+                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
                   </Channel>
-                  <genre>world</genre>
             </Instrument>
-            <Instrument id="mtn-dulcimer-bass-chrom-tab">
-                  <trackName>Mtn. Dulcimer - Bass (Tablature)</trackName>
-                  <init>mtn-dulcimer-bass</init>
-                  <description>Bass Mtn. Dulcimer (3-str. chromatic TAB)</description>
-                  <stafftype staffTypePreset="tabDulcimer">tablature</stafftype>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="oud">
-                  <longName>Oud</longName>
-                  <shortName>O.</shortName>
-                  <description>Oud</description>
-                  <musicXMLid>pluck.oud</musicXMLid>
+            <Instrument id="contra-guitar">
+                  <family>guitars</family>
+                  <longName>Contra Guitar</longName>
+                  <shortName>C. Guit.</shortName>
+                  <description>Acoustic Contra Guitar</description>
+                  <musicXMLid>pluck.guitar</musicXMLid>
                   <StringData>
-                        <frets>15</frets>
-                        <string>48</string>
-                        <string>53</string>
-                        <string>57</string>
-                        <string>62</string>
-                        <string>67</string>
-                        <string>72</string>
-                  </StringData>
-                  <transposingClef>G</transposingClef>
-                  <concertClef>G8vb</concertClef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>36-75</aPitchRange>
-                  <pPitchRange>36-75</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <transposeDiatonic>-7</transposeDiatonic>
-                  <transposeChromatic>-12</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
-                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
-                  </Channel>
-                  <genre>world</genre>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="lute">
-                  <longName>Lute</longName>
-                  <shortName>Lt.</shortName>
-                  <description>Lute</description>
-                  <musicXMLid>pluck.lute</musicXMLid>
-                  <StringData>
-                        <frets>13</frets>
-                        <string>43</string>
-                        <string>48</string>
-                        <string>53</string>
-                        <string>57</string>
-                        <string>62</string>
-                        <string>67</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>33-79</aPitchRange>
-                  <pPitchRange>33-79</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
-                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="lute-tablature">
-                  <trackName>Lute (Tablature)</trackName>
-                  <init>lute</init>
-                  <description>Lute (Tablature)</description>
-                  <musicXMLid>pluck.lute</musicXMLid>
-                  <stafftype staffTypePreset="tab6StrFrench">tablature</stafftype>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="ren.-tenor-lute-5-course">
-                  <trackName>Lute 5-course</trackName>
-                  <longName>Lute</longName>
-                  <shortName>Lt.</shortName>
-                  <description>Ren. Tenor Lute (5-course)</description>
-                  <musicXMLid>pluck.lute</musicXMLid>
-                  <StringData>
-                        <frets>13</frets>
-                        <string>48</string>
-                        <string>53</string>
-                        <string>57</string>
-                        <string>62</string>
-                        <string>67</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>48-79</aPitchRange>
-                  <pPitchRange>48-79</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
-                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="ren.-tenor-lute-6-course">
-                  <trackName>Lute 6-course</trackName>
-                  <longName>Lute</longName>
-                  <shortName>Lt.</shortName>
-                  <description>Ren. Tenor Lute (6-course)</description>
-                  <musicXMLid>pluck.lute</musicXMLid>
-                  <StringData>
-                        <frets>13</frets>
-                        <string>43</string>
-                        <string>48</string>
-                        <string>53</string>
-                        <string>57</string>
-                        <string>62</string>
-                        <string>67</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>43-79</aPitchRange>
-                  <pPitchRange>43-79</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
-                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="ren.-tenor-lute-7-course">
-                  <trackName>Lute 7-course</trackName>
-                  <longName>Lute</longName>
-                  <shortName>Lt.</shortName>
-                  <description>Ren. Tenor Lute (7-course)</description>
-                  <musicXMLid>pluck.lute</musicXMLid>
-                  <StringData>
-                        <frets>13</frets>
-                        <string>38</string>
-                        <string>43</string>
-                        <string>48</string>
-                        <string>53</string>
-                        <string>57</string>
-                        <string>62</string>
-                        <string>67</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>38-79</aPitchRange>
-                  <pPitchRange>38-79</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
-                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="ren.-tenor-lute-8-course">
-                  <trackName>Lute 8-course</trackName>
-                  <longName>Lute</longName>
-                  <shortName>Lt.</shortName>
-                  <description>Ren. Tenor Lute (8-course)</description>
-                  <musicXMLid>pluck.lute</musicXMLid>
-                  <StringData>
-                        <frets>13</frets>
-                        <string>38</string>
-                        <string>41</string>
-                        <string>43</string>
-                        <string>48</string>
-                        <string>53</string>
-                        <string>57</string>
-                        <string>62</string>
-                        <string>67</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>38-79</aPitchRange>
-                  <pPitchRange>38-79</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
-                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="ren.-tenor-lute-9-course">
-                  <trackName>Lute 9-course</trackName>
-                  <longName>Lute</longName>
-                  <shortName>Lt.</shortName>
-                  <description>Ren. Tenor Lute (9-course)</description>
-                  <musicXMLid>pluck.lute</musicXMLid>
-                  <StringData>
-                        <frets>13</frets>
-                        <string open="1">36</string>
-                        <string>38</string>
-                        <string>41</string>
-                        <string>43</string>
-                        <string>48</string>
-                        <string>53</string>
-                        <string>57</string>
-                        <string>62</string>
-                        <string>67</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>36-79</aPitchRange>
-                  <pPitchRange>36-79</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
-                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="ren.-tenor-lute-10-course">
-                  <trackName>Lute 10-course</trackName>
-                  <longName>Lute</longName>
-                  <shortName>Lt.</shortName>
-                  <description>Ren. Tenor Lute (10-course)</description>
-                  <musicXMLid>pluck.lute</musicXMLid>
-                  <StringData>
-                        <frets>13</frets>
-                        <string open="1">36</string>
-                        <string open="1">38</string>
-                        <string>40</string>
-                        <string>41</string>
-                        <string>43</string>
-                        <string>48</string>
-                        <string>53</string>
-                        <string>57</string>
-                        <string>62</string>
-                        <string>67</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>36-79</aPitchRange>
-                  <pPitchRange>36-79</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
-                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="baroque-lute-13-course">
-                  <trackName>Lute 13-course</trackName>
-                  <longName>Lute</longName>
-                  <shortName>Lt.</shortName>
-                  <description>Baroque Lute (13-course)</description>
-                  <musicXMLid>pluck.lute</musicXMLid>
-                  <StringData>
-                        <frets>13</frets>
-                        <string open="1">33</string>
-                        <string open="1">35</string>
-                        <string open="1">36</string>
-                        <string open="1">38</string>
-                        <string open="1">40</string>
-                        <string>41</string>
-                        <string>43</string>
-                        <string>45</string>
-                        <string>50</string>
-                        <string>53</string>
-                        <string>57</string>
-                        <string>62</string>
-                        <string>65</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>33-77</aPitchRange>
-                  <pPitchRange>33-77</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
-                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="archlute-14-course">
-                  <longName>Archlute</longName>
-                  <shortName>A. Lt.</shortName>
-                  <description>Archlute (14-course)</description>
-                  <musicXMLid>pluck.archlute</musicXMLid>
-                  <StringData>
-                        <frets>13</frets>
-                        <string open="1">29</string>
+                        <frets>19</frets>
                         <string open="1">31</string>
+                        <string open="1">32</string>
                         <string open="1">33</string>
                         <string open="1">34</string>
+                        <string open="1">35</string>
                         <string open="1">36</string>
+                        <string open="1">37</string>
                         <string open="1">38</string>
+                        <string open="1">39</string>
+                        <string>40</string>
+                        <string>45</string>
+                        <string>50</string>
+                        <string>55</string>
+                        <string>59</string>
+                        <string>64</string>
+                  </StringData>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>31-83</aPitchRange>
+                  <pPitchRange>31-83</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel name="open">
+                        <!--MIDI: Bank 0, Prog 24; MS General: Nylon String Guitar-->
+                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
+                  </Channel>
+                  <Channel name="mute">
+                        <!--MIDI: Bank 0, Prog 28; MS General: Palm Muted Guitar-->
+                        <program value="28"/> <!--Electric Guitar (muted)-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="7-string-guitar">
+                  <family>guitars</family>
+                  <longName>7-string Guitar</longName>
+                  <shortName>Guit.</shortName>
+                  <description>7-string Guitar</description>
+                  <musicXMLid>pluck.guitar.nylon-string</musicXMLid>
+                  <StringData>
+                        <frets>19</frets>
+                        <string>35</string>
+                        <string>40</string>
+                        <string>45</string>
+                        <string>50</string>
+                        <string>55</string>
+                        <string>59</string>
+                        <string>64</string>
+                  </StringData>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>35-83</aPitchRange>
+                  <pPitchRange>35-83</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 24; MS General: Nylon String Guitar-->
+                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="7-string-guitar-tablature">
+                  <init>7-string-guitar</init>
+                  <family>guitars</family>
+                  <trackName>7-string Guitar (Tablature)</trackName>
+                  <description>7-string Guitar (Tablature)</description>
+                  <musicXMLid>pluck.guitar.nylon-string</musicXMLid>
+                  <stafftype staffTypePreset="tab7StrCommon">tablature</stafftype>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="11-string-alto-guitar">
+                  <family>guitars</family>
+                  <longName>11-string Alto Guitar</longName>
+                  <shortName>11-str. A. Guit.</shortName>
+                  <description>11-string Alto Guitar</description>
+                  <musicXMLid>pluck.guitar</musicXMLid>
+                  <StringData>
+                        <frets>19</frets>
+                        <string>35</string>
+                        <string>36</string>
+                        <string>38</string>
                         <string>39</string>
                         <string>41</string>
                         <string>43</string>
@@ -11276,343 +10912,194 @@
                         <string>62</string>
                         <string>67</string>
                   </StringData>
+                  <staves>2</staves>
                   <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>29-77</aPitchRange>
-                  <pPitchRange>29-77</pPitchRange>
+                  <bracket>1</bracket>
+                  <bracketSpan>2</bracketSpan>
+                  <barlineSpan>2</barlineSpan>
+                  <clef staff="2">F</clef>
+                  <aPitchRange>34-86</aPitchRange>
+                  <pPitchRange>34-86</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
-                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  <Channel name="open">
+                        <!--MIDI: Bank 0, Prog 24; MS General: Nylon String Guitar-->
+                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
                   </Channel>
-                  <genre>earlymusic</genre>
+                  <Channel name="mute">
+                        <!--MIDI: Bank 0, Prog 28; MS General: Palm Muted Guitar-->
+                        <program value="28"/> <!--Electric Guitar (muted)-->
+                  </Channel>
             </Instrument>
-            <Instrument id="theorbo-14-course">
-                  <longName>Theorbo</longName>
-                  <shortName>Thb.</shortName>
-                  <description>Theorbo (14-course)</description>
-                  <musicXMLid>pluck.theorbo</musicXMLid>
+            <Instrument id="12-string-guitar">
+                  <family>guitars</family>
+                  <longName>12-string Guitar</longName>
+                  <shortName>12-str. Guit.</shortName>
+                  <description>12-string Guitar</description>
+                  <musicXMLid>pluck.guitar</musicXMLid>
                   <StringData>
-                        <frets>13</frets>
-                        <string open="1">31</string>
-                        <string open="1">33</string>
-                        <string open="1">35</string>
-                        <string open="1">36</string>
-                        <string open="1">38</string>
-                        <string open="1">40</string>
-                        <string open="1">41</string>
-                        <string open="1">43</string>
+                        <frets>21</frets>
+                        <string>40</string>
                         <string>45</string>
                         <string>50</string>
                         <string>55</string>
                         <string>59</string>
-                        <string>52</string>
-                        <string>57</string>
+                        <string>64</string>
                   </StringData>
-                  <clef>G</clef>
+                  <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>31-71</aPitchRange>
-                  <pPitchRange>31-71</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
+                  <aPitchRange>40-83</aPitchRange>
+                  <pPitchRange>40-85</pPitchRange>
+                  <Channel name="open">
                         <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
                         <controller ctrl="32" value="8"/> <!--Bank LSB-->
                         <program value="25"/> <!--Acoustic Guitar (steel)-->
                   </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="mandolin">
-                  <family>plucked-strings</family>
-                  <longName>Mandolin</longName>
-                  <shortName>Mdn.</shortName>
-                  <description>Mandolin</description>
-                  <musicXMLid>pluck.mandolin</musicXMLid>
-                  <StringData>
-                        <frets>24</frets>
-                        <string>55</string>
-                        <string>62</string>
-                        <string>69</string>
-                        <string>76</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>55-85</aPitchRange>
-                  <pPitchRange>55-100</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 16, Prog 25; MS General: Mandolin-->
-                        <controller ctrl="32" value="16"/> <!--Bank LSB-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  <Channel name="mute">
+                        <!--MIDI: Bank 0, Prog 28; MS General: Palm Muted Guitar-->
+                        <program value="28"/> <!--Electric Guitar (muted)-->
+                  </Channel>
+                  <Channel name="jazz">
+                        <!--MIDI: Bank 0, Prog 26; MS General: Jazz Guitar-->
+                        <program value="26"/> <!--Electric Guitar (jazz)-->
                   </Channel>
                   <genre>popular</genre>
             </Instrument>
-            <Instrument id="mandolin-tablature">
-                  <family>plucked-strings</family>
-                  <trackName>Mandolin (Tablature)</trackName>
-                  <init>mandolin</init>
-                  <description>Mandolin (Tablature)</description>
-                  <musicXMLid>pluck.mandolin</musicXMLid>
-                  <stafftype staffTypePreset="tab4StrCommon">tablature</stafftype>
-                  <genre>popular</genre>
-            </Instrument>
-            <Instrument id="mandola">
-                  <longName>Mandola</longName>
-                  <shortName>Mda.</shortName>
-                  <description>Mandola</description>
-                  <musicXMLid>pluck.mandola</musicXMLid>
+            <Instrument id="5-string-electric-bass">
+                  <family>bass-guitars</family>
+                  <longName>5-str. Electric Bass</longName>
+                  <shortName>El. B.</shortName>
+                  <description>5-string Electric Bass</description>
+                  <musicXMLid>pluck.bass.electric</musicXMLid>
                   <StringData>
                         <frets>24</frets>
-                        <string>48</string>
+                        <string>35</string>
+                        <string>40</string>
+                        <string>45</string>
+                        <string>50</string>
                         <string>55</string>
-                        <string>62</string>
-                        <string>69</string>
                   </StringData>
-                  <clef>C3</clef>
+                  <transposingClef>F</transposingClef>
+                  <concertClef>F8vb</concertClef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>48-87</aPitchRange>
-                  <pPitchRange>48-93</pPitchRange>
+                  <aPitchRange>23-65</aPitchRange>
+                  <pPitchRange>23-67</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
+                  <transposeDiatonic>-7</transposeDiatonic>
+                  <transposeChromatic>-12</transposeChromatic>
                   <Channel>
-                        <!--MIDI: Bank 16, Prog 25; MS General: Mandolin-->
-                        <controller ctrl="32" value="16"/> <!--Bank LSB-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                        <!--MIDI: Bank 0, Prog 33; MS General: Fingered Bass-->
+                        <program value="33"/> <!--Electric Bass (finger)-->
                   </Channel>
-            </Instrument>
-            <Instrument id="alto-mandola">
-                  <family>plucked-strings</family>
-                  <longName>Alto Mandola</longName>
-                  <shortName>A. Mda.</shortName>
-                  <description>Mandola Viola tuning</description>
-                  <musicXMLid>pluck.mandola</musicXMLid>
-                  <StringData>
-                        <frets>24</frets>
-                        <string>48</string>
-                        <string>55</string>
-                        <string>62</string>
-                        <string>69</string>
-                  </StringData>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>48-87</aPitchRange>
-                  <pPitchRange>48-93</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 16, Prog 25; MS General: Mandolin-->
-                        <controller ctrl="32" value="16"/> <!--Bank LSB-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  <Channel name="slap">
+                        <!--MIDI: Bank 0, Prog 36; MS General: Slap Bass-->
+                        <program value="36"/> <!--Slap Bass 1-->
                   </Channel>
-            </Instrument>
-            <Instrument id="tenor-mandola">
-                  <longName>Tenor Mandola</longName>
-                  <shortName>T. Mda.</shortName>
-                  <description>Mandola 8va mandolin tuning</description>
-                  <musicXMLid>pluck.mandola</musicXMLid>
-                  <StringData>
-                        <frets>24</frets>
-                        <string>43</string>
-                        <string>50</string>
-                        <string>57</string>
-                        <string>64</string>
-                  </StringData>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>48-87</aPitchRange>
-                  <pPitchRange>48-93</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 16, Prog 25; MS General: Mandolin-->
-                        <controller ctrl="32" value="16"/> <!--Bank LSB-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="mandocello">
-                  <longName>Mandocello</longName>
-                  <shortName>Mncl.</shortName>
-                  <description>Mandocello</description>
-                  <musicXMLid>pluck.mandocello</musicXMLid>
-                  <StringData>
-                        <frets>24</frets>
-                        <string>36</string>
-                        <string>43</string>
-                        <string>50</string>
-                        <string>57</string>
-                  </StringData>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>36-75</aPitchRange>
-                  <pPitchRange>36-81</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 16, Prog 25; MS General: Mandolin-->
-                        <controller ctrl="32" value="16"/> <!--Bank LSB-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="octave-mandolin">
-                  <longName>Octave Mandolin</longName>
-                  <shortName>OM.</shortName>
-                  <description>Octave Mandolin</description>
-                  <musicXMLid>pluck.mandolin.octave</musicXMLid>
-                  <StringData>
-                        <frets>24</frets>
-                        <string>43</string>
-                        <string>50</string>
-                        <string>57</string>
-                        <string>64</string>
-                  </StringData>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>43-73</aPitchRange>
-                  <pPitchRange>36-88</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 16, Prog 25; MS General: Mandolin-->
-                        <controller ctrl="32" value="16"/> <!--Bank LSB-->
-                        <program value="25"/> <!--Acoustic Guitar (steel)-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="shamisen">
-                  <longName>Shamisen</longName>
-                  <shortName>Sh.</shortName>
-                  <description>Shamisen</description>
-                  <musicXMLid>pluck.shamisen</musicXMLid>
-                  <clef>G8vb</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>50-83</aPitchRange>
-                  <pPitchRange>50-83</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 106; MS General: Shamisen-->
-                        <program value="106"/> <!--Shamisen-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="sitar">
-                  <longName>Sitar</longName>
-                  <shortName>Si.</shortName>
-                  <description>Sitar</description>
-                  <musicXMLid>pluck.sitar</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>36-84</aPitchRange>
-                  <pPitchRange>36-84</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 104; MS General: Sitar-->
-                        <program value="104"/> <!--Sitar-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="ukulele">
-                  <family>plucked-strings</family>
-                  <longName>Ukulele</longName>
-                  <shortName>Uk.</shortName>
-                  <description>Ukulele</description>
-                  <musicXMLid>pluck.ukulele</musicXMLid>
-                  <StringData>
-                        <frets>18</frets>
-                        <string>67</string>
-                        <string>60</string>
-                        <string>64</string>
-                        <string>69</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>60-81</aPitchRange>
-                  <pPitchRange>60-81</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 8, Prog 24; MS General: Ukulele-->
-                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
-                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
+                  <Channel name="pop">
+                        <!--MIDI: Bank 0, Prog 37; MS General: Pop Bass-->
+                        <program value="37"/> <!--Slap Bass 2-->
                   </Channel>
                   <genre>common</genre>
                   <genre>popular</genre>
-                  <genre>classroom</genre>
+                  <genre>jazz</genre>
             </Instrument>
-            <Instrument id="ukulele-4-str-tab">
-                  <family>plucked-strings</family>
-                  <trackName>Ukulele (Tablature)</trackName>
-                  <init>ukulele</init>
-                  <description>Ukulele (4-str. TAB)</description>
-                  <musicXMLid>pluck.ukulele</musicXMLid>
-                  <stafftype staffTypePreset="tabUkulele">tablature</stafftype>
-                  <genre>common</genre>
-                  <genre>popular</genre>
-                  <genre>classroom</genre>
-            </Instrument>
-            <Instrument id="ukulele-low-g">
-                  <family>plucked-strings</family>
-                  <longName>Ukulele (Low G)</longName>
-                  <shortName>Uk.</shortName>
-                  <description>Ukulele (Low G)</description>
-                  <musicXMLid>pluck.ukulele</musicXMLid>
+            <Instrument id="5-string-electric-bass-high-c">
+                  <family>bass-guitars</family>
+                  <trackName>5-str. Electric Bass (High C/Tenor)</trackName>
+                  <longName>5-str. Electric Bass</longName>
+                  <shortName>El. B.</shortName>
+                  <description>5-string Electric Bass (High C/Tenor)</description>
+                  <musicXMLid>pluck.bass.electric</musicXMLid>
                   <StringData>
-                        <frets>18</frets>
-                        <string>55</string>
-                        <string>60</string>
-                        <string>64</string>
-                        <string>69</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>55-81</aPitchRange>
-                  <pPitchRange>55-81</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 8, Prog 24; MS General: Ukulele-->
-                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
-                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="tenor-ukulele">
-                  <family>plucked-strings</family>
-                  <longName>Tenor Ukulele</longName>
-                  <shortName>Ten. Uk.</shortName>
-                  <description>Tenor Ukulele</description>
-                  <musicXMLid>pluck.ukulele.tenor</musicXMLid>
-                  <StringData>
-                        <frets>18</frets>
-                        <string>67</string>
-                        <string>60</string>
-                        <string>64</string>
-                        <string>69</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>60-81</aPitchRange>
-                  <pPitchRange>60-81</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 8, Prog 24; MS General: Ukulele-->
-                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
-                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="baritone-ukulele">
-                  <family>plucked-strings</family>
-                  <longName>Baritone Ukulele</longName>
-                  <shortName>Bar. Uk.</shortName>
-                  <description>Baritone Ukulele</description>
-                  <musicXMLid>pluck.ukulele.tenor</musicXMLid>
-                  <StringData>
-                        <frets>18</frets>
+                        <frets>24</frets>
+                        <string>40</string>
+                        <string>45</string>
                         <string>50</string>
                         <string>55</string>
-                        <string>59</string>
-                        <string>64</string>
+                        <string>60</string>
                   </StringData>
-                  <clef>G8vb</clef>
+                  <transposingClef>F</transposingClef>
+                  <concertClef>F8vb</concertClef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>50-76</aPitchRange>
-                  <pPitchRange>50-76</pPitchRange>
+                  <aPitchRange>23-65</aPitchRange>
+                  <pPitchRange>23-67</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
+                  <transposeDiatonic>-7</transposeDiatonic>
+                  <transposeChromatic>-12</transposeChromatic>
                   <Channel>
-                        <!--MIDI: Bank 8, Prog 24; MS General: Ukulele-->
-                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
-                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
+                        <!--MIDI: Bank 0, Prog 33; MS General: Fingered Bass-->
+                        <program value="33"/> <!--Electric Bass (finger)-->
                   </Channel>
+                  <Channel name="slap">
+                        <!--MIDI: Bank 0, Prog 36; MS General: Slap Bass-->
+                        <program value="36"/> <!--Slap Bass 1-->
+                  </Channel>
+                  <Channel name="pop">
+                        <!--MIDI: Bank 0, Prog 37; MS General: Pop Bass-->
+                        <program value="37"/> <!--Slap Bass 2-->
+                  </Channel>
+                  <genre>jazz</genre>
+            </Instrument>
+            <Instrument id="5-string-electric-bass-tab">
+                  <init>5-string-electric-bass</init>
+                  <family>bass-guitars</family>
+                  <trackName>5-str. Electric Bass (Tablature)</trackName>
+                  <description>5-string Electric Bass (Tablature)</description>
+                  <stafftype staffTypePreset="tab5StrCommon">tablature</stafftype>
+                  <genre>common</genre>
+                  <genre>popular</genre>
+            </Instrument>
+            <Instrument id="5-string-electric-bass-tab-high-c">
+                  <init>5-string-electric-bass-high-c</init>
+                  <family>bass-guitars</family>
+                  <trackName>5-str. Electric Bass (High C/Tenor) (Tablature)</trackName>
+                  <description>5-string Electric Bass (High C/Tenor) (Tablature)</description>
+                  <stafftype staffTypePreset="tab5StrCommon">tablature</stafftype>
+                  <genre>jazz</genre>
+            </Instrument>
+            <Instrument id="6-string-electric-bass">
+                  <family>bass-guitars</family>
+                  <longName>6-str. Electric Bass</longName>
+                  <shortName>El. B.</shortName>
+                  <description>6-string Electric Bass</description>
+                  <musicXMLid>pluck.bass.electric</musicXMLid>
+                  <StringData>
+                        <frets>24</frets>
+                        <string>35</string>
+                        <string>40</string>
+                        <string>45</string>
+                        <string>50</string>
+                        <string>55</string>
+                        <string>60</string>
+                  </StringData>
+                  <transposingClef>F</transposingClef>
+                  <concertClef>F8vb</concertClef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>23-70</aPitchRange>
+                  <pPitchRange>23-72</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <transposeDiatonic>-7</transposeDiatonic>
+                  <transposeChromatic>-12</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 33; MS General: Fingered Bass-->
+                        <program value="33"/> <!--Electric Bass (finger)-->
+                  </Channel>
+                  <Channel name="slap">
+                        <!--MIDI: Bank 0, Prog 36; MS General: Slap Bass-->
+                        <program value="36"/> <!--Slap Bass 1-->
+                  </Channel>
+                  <Channel name="pop">
+                        <!--MIDI: Bank 0, Prog 37; MS General: Pop Bass-->
+                        <program value="37"/> <!--Slap Bass 2-->
+                  </Channel>
+                  <genre>jazz</genre>
+            </Instrument>
+            <Instrument id="6-string-electric-bass-tab">
+                  <init>6-string-electric-bass</init>
+                  <family>bass-guitars</family>
+                  <trackName>6-str. Electric Bass (Tablature)</trackName>
+                  <description>6-string Electric Bass (Tablature)</description>
+                  <stafftype staffTypePreset="tab6StrCommon">tablature</stafftype>
+                  <genre>jazz</genre>
             </Instrument>
             <Instrument id="bass-guitar">
                   <family>bass-guitars</family>
@@ -11652,15 +11139,78 @@
                   <genre>jazz</genre>
                   <genre>marching</genre>
             </Instrument>
-            <Instrument id="bass-guitar-tablature">
+            <Instrument id="electric-bass">
                   <family>bass-guitars</family>
-                  <trackName>Bass Guitar (Tablature)</trackName>
-                  <init>bass-guitar</init>
-                  <description>Bass Guitar (Tablature)</description>
-                  <musicXMLid>pluck.bass</musicXMLid>
-                  <stafftype staffTypePreset="tab4StrCommon">tablature</stafftype>
+                  <longName>Electric Bass</longName>
+                  <shortName>El. B.</shortName>
+                  <description>Electric Bass</description>
+                  <musicXMLid>pluck.bass.electric</musicXMLid>
+                  <StringData>
+                        <frets>24</frets>
+                        <string>40</string>
+                        <string>45</string>
+                        <string>50</string>
+                        <string>55</string>
+                  </StringData>
+                  <transposingClef>F</transposingClef>
+                  <concertClef>F8vb</concertClef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>28-65</aPitchRange>
+                  <pPitchRange>28-67</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <transposeDiatonic>-7</transposeDiatonic>
+                  <transposeChromatic>-12</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 33; MS General: Fingered Bass-->
+                        <program value="33"/> <!--Electric Bass (finger)-->
+                  </Channel>
+                  <Channel name="slap">
+                        <!--MIDI: Bank 0, Prog 36; MS General: Slap Bass-->
+                        <program value="36"/> <!--Slap Bass 1-->
+                  </Channel>
+                  <Channel name="pop">
+                        <!--MIDI: Bank 0, Prog 37; MS General: Pop Bass-->
+                        <program value="37"/> <!--Slap Bass 2-->
+                  </Channel>
                   <genre>common</genre>
                   <genre>popular</genre>
+                  <genre>jazz</genre>
+            </Instrument>
+            <Instrument id="fretless-electric-bass">
+                  <family>bass-guitars</family>
+                  <longName>Fretless Electric Bass</longName>
+                  <shortName>Frtl. El. B.</shortName>
+                  <description>Fretless Electric Bass</description>
+                  <musicXMLid>pluck.bass.fretless</musicXMLid>
+                  <StringData>
+                        <frets>24</frets>
+                        <string>28</string>
+                        <string>33</string>
+                        <string>38</string>
+                        <string>43</string>
+                  </StringData>
+                  <transposingClef>F</transposingClef>
+                  <concertClef>F8vb</concertClef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>28-65</aPitchRange>
+                  <pPitchRange>28-67</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <transposeDiatonic>-7</transposeDiatonic>
+                  <transposeChromatic>-12</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 35; MS General: Fretless Bass-->
+                        <program value="35"/> <!--Fretless Bass-->
+                  </Channel>
+                  <Channel name="slap">
+                        <!--MIDI: Bank 0, Prog 36; MS General: Slap Bass-->
+                        <program value="36"/> <!--Slap Bass 1-->
+                  </Channel>
+                  <Channel name="pop">
+                        <!--MIDI: Bank 0, Prog 37; MS General: Pop Bass-->
+                        <program value="37"/> <!--Slap Bass 2-->
+                  </Channel>
+                  <genre>popular</genre>
+                  <genre>jazz</genre>
             </Instrument>
             <Instrument id="acoustic-bass">
                   <family>bass-guitars</family>
@@ -11707,227 +11257,1091 @@
                   <genre>common</genre>
                   <genre>jazz</genre>
             </Instrument>
-            <Instrument id="electric-bass">
+            <Instrument id="bass-guitar-tablature">
+                  <init>bass-guitar</init>
                   <family>bass-guitars</family>
-                  <longName>Electric Bass</longName>
-                  <shortName>El. B.</shortName>
-                  <description>Electric Bass</description>
-                  <musicXMLid>pluck.bass.electric</musicXMLid>
-                  <StringData>
-                        <frets>24</frets>
-                        <string>40</string>
-                        <string>45</string>
-                        <string>50</string>
-                        <string>55</string>
-                  </StringData>
-                  <transposingClef>F</transposingClef>
-                  <concertClef>F8vb</concertClef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>28-65</aPitchRange>
-                  <pPitchRange>28-67</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <transposeDiatonic>-7</transposeDiatonic>
-                  <transposeChromatic>-12</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 33; MS General: Fingered Bass-->
-                        <program value="33"/> <!--Electric Bass (finger)-->
-                  </Channel>
-                  <Channel name="slap">
-                        <!--MIDI: Bank 0, Prog 36; MS General: Slap Bass-->
-                        <program value="36"/> <!--Slap Bass 1-->
-                  </Channel>
-                  <Channel name="pop">
-                        <!--MIDI: Bank 0, Prog 37; MS General: Pop Bass-->
-                        <program value="37"/> <!--Slap Bass 2-->
-                  </Channel>
+                  <trackName>Bass Guitar (Tablature)</trackName>
+                  <description>Bass Guitar (Tablature)</description>
+                  <musicXMLid>pluck.bass</musicXMLid>
+                  <stafftype staffTypePreset="tab4StrCommon">tablature</stafftype>
                   <genre>common</genre>
                   <genre>popular</genre>
-                  <genre>jazz</genre>
             </Instrument>
             <Instrument id="electric-bass-4-str-tab">
+                  <init>electric-bass</init>
                   <family>bass-guitars</family>
                   <trackName>Electric Bass (Tablature)</trackName>
-                  <init>electric-bass</init>
                   <description>Electric Bass (Tablature)</description>
                   <musicXMLid>pluck.bass.electric</musicXMLid>
                   <stafftype staffTypePreset="tab4StrCommon">tablature</stafftype>
                   <genre>common</genre>
                   <genre>popular</genre>
             </Instrument>
-            <Instrument id="fretless-electric-bass">
-                  <family>bass-guitars</family>
-                  <longName>Fretless Electric Bass</longName>
-                  <shortName>Frtl. El. B.</shortName>
-                  <description>Fretless Electric Bass</description>
-                  <musicXMLid>pluck.bass.fretless</musicXMLid>
+            <Instrument id="banjo">
+                  <family>banjos</family>
+                  <longName>Banjo</longName>
+                  <shortName>Bj.</shortName>
+                  <description>5 string Banjo</description>
+                  <musicXMLid>pluck.banjo</musicXMLid>
+                  <StringData>
+                        <frets>19</frets>
+                        <string>67</string>
+                        <string>50</string>
+                        <string>55</string>
+                        <string>59</string>
+                        <string>62</string>
+                  </StringData>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>48-87</aPitchRange>
+                  <pPitchRange>48-87</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 105; MS General: Banjo-->
+                        <program value="105"/> <!--Banjo-->
+                  </Channel>
+                  <genre>common</genre>
+                  <genre>popular</genre>
+                  <genre>jazz</genre>
+            </Instrument>
+            <Instrument id="tenor-banjo">
+                  <family>banjos</family>
+                  <longName>Tenor Banjo</longName>
+                  <shortName>T. Bj.</shortName>
+                  <description>4 string Tenor Banjo</description>
+                  <musicXMLid>pluck.banjo.tenor</musicXMLid>
+                  <StringData>
+                        <frets>19</frets>
+                        <string>48</string>
+                        <string>55</string>
+                        <string>62</string>
+                        <string>69</string>
+                  </StringData>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>48-83</aPitchRange>
+                  <pPitchRange>48-83</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 105; MS General: Banjo-->
+                        <program value="105"/> <!--Banjo-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="banjo-tablature">
+                  <init>banjo</init>
+                  <family>banjos</family>
+                  <trackName>Banjo (Tablature)</trackName>
+                  <description>Banjo (Tablature)</description>
+                  <musicXMLid>pluck.banjo</musicXMLid>
+                  <stafftype staffTypePreset="tab5StrCommon">tablature</stafftype>
+                  <genre>common</genre>
+                  <genre>jazz</genre>
+            </Instrument>
+            <Instrument id="irish-tenor-banjo">
+                  <family>banjos</family>
+                  <longName>Irish Tenor Banjo</longName>
+                  <shortName>ITB</shortName>
+                  <description>4 string Irish Tenor Banjo</description>
+                  <musicXMLid>pluck.banjo.tenor</musicXMLid>
+                  <StringData>
+                        <frets>19</frets>
+                        <string>43</string>
+                        <string>50</string>
+                        <string>57</string>
+                        <string>64</string>
+                  </StringData>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>43-69</aPitchRange>
+                  <pPitchRange>43-76</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 105; MS General: Banjo-->
+                        <program value="105"/> <!--Banjo-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="irish-tenor-banjo-tablature">
+                  <init>irish-tenor-banjo</init>
+                  <family>banjos</family>
+                  <trackName>Irish Tenor Banjo (Tablature)</trackName>
+                  <description>Irish Tenor Banjo (Tablature)</description>
+                  <musicXMLid>pluck.banjo.tenor</musicXMLid>
+                  <stafftype staffTypePreset="tab4StrCommon">tablature</stafftype>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="tenor-ukulele">
+                  <family>ukuleles</family>
+                  <longName>Tenor Ukulele</longName>
+                  <shortName>Ten. Uk.</shortName>
+                  <description>Tenor Ukulele</description>
+                  <musicXMLid>pluck.ukulele.tenor</musicXMLid>
+                  <StringData>
+                        <frets>18</frets>
+                        <string>67</string>
+                        <string>60</string>
+                        <string>64</string>
+                        <string>69</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>60-81</aPitchRange>
+                  <pPitchRange>60-81</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 8, Prog 24; MS General: Ukulele-->
+                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="ukulele">
+                  <family>ukuleles</family>
+                  <longName>Ukulele</longName>
+                  <shortName>Uk.</shortName>
+                  <description>Ukulele</description>
+                  <musicXMLid>pluck.ukulele</musicXMLid>
+                  <StringData>
+                        <frets>18</frets>
+                        <string>67</string>
+                        <string>60</string>
+                        <string>64</string>
+                        <string>69</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>60-81</aPitchRange>
+                  <pPitchRange>60-81</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 8, Prog 24; MS General: Ukulele-->
+                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
+                  </Channel>
+                  <genre>common</genre>
+                  <genre>popular</genre>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="ukulele-low-g">
+                  <family>ukuleles</family>
+                  <longName>Ukulele (Low G)</longName>
+                  <shortName>Uk.</shortName>
+                  <description>A plucked sting instrument with lowest string tuned to G3 (written in C, non-transposing), an octave below the tenor ukulele.</description>
+                  <musicXMLid>pluck.ukulele</musicXMLid>
+                  <StringData>
+                        <frets>18</frets>
+                        <string>55</string>
+                        <string>60</string>
+                        <string>64</string>
+                        <string>69</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>55-81</aPitchRange>
+                  <pPitchRange>55-81</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 8, Prog 24; MS General: Ukulele-->
+                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="ukulele-4-str-tab">
+                  <init>ukulele</init>
+                  <family>ukuleles</family>
+                  <trackName>Ukulele (Tablature)</trackName>
+                  <description>Ukulele (4-str. TAB)</description>
+                  <musicXMLid>pluck.ukulele</musicXMLid>
+                  <stafftype staffTypePreset="tabUkulele">tablature</stafftype>
+                  <genre>common</genre>
+                  <genre>popular</genre>
+                  <genre>classroom</genre>
+            </Instrument>
+            <Instrument id="baritone-ukulele">
+                  <family>ukuleles</family>
+                  <longName>Baritone Ukulele</longName>
+                  <shortName>Bar. Uk.</shortName>
+                  <description>Baritone Ukulele</description>
+                  <musicXMLid>pluck.ukulele.tenor</musicXMLid>
+                  <StringData>
+                        <frets>18</frets>
+                        <string>50</string>
+                        <string>55</string>
+                        <string>59</string>
+                        <string>64</string>
+                  </StringData>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>50-76</aPitchRange>
+                  <pPitchRange>50-76</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 8, Prog 24; MS General: Ukulele-->
+                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="mandolin">
+                  <family>mandolins</family>
+                  <longName>Mandolin</longName>
+                  <shortName>Mdn.</shortName>
+                  <description>Mandolin</description>
+                  <musicXMLid>pluck.mandolin</musicXMLid>
                   <StringData>
                         <frets>24</frets>
+                        <string>55</string>
+                        <string>62</string>
+                        <string>69</string>
+                        <string>76</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>55-85</aPitchRange>
+                  <pPitchRange>55-100</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 16, Prog 25; MS General: Mandolin-->
+                        <controller ctrl="32" value="16"/> <!--Bank LSB-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+                  <genre>popular</genre>
+            </Instrument>
+            <Instrument id="mandolin-tablature">
+                  <init>mandolin</init>
+                  <family>mandolins</family>
+                  <trackName>Mandolin (Tablature)</trackName>
+                  <description>Mandolin (Tablature)</description>
+                  <musicXMLid>pluck.mandolin</musicXMLid>
+                  <stafftype staffTypePreset="tab4StrCommon">tablature</stafftype>
+                  <genre>popular</genre>
+            </Instrument>
+            <Instrument id="alto-mandola">
+                  <family>mandolins</family>
+                  <longName>Alto Mandola</longName>
+                  <shortName>A. Mda.</shortName>
+                  <description>Mandola Viola tuning</description>
+                  <musicXMLid>pluck.mandola</musicXMLid>
+                  <StringData>
+                        <frets>24</frets>
+                        <string>48</string>
+                        <string>55</string>
+                        <string>62</string>
+                        <string>69</string>
+                  </StringData>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>48-87</aPitchRange>
+                  <pPitchRange>48-93</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 16, Prog 25; MS General: Mandolin-->
+                        <controller ctrl="32" value="16"/> <!--Bank LSB-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="mandola">
+                  <family>mandolins</family>
+                  <longName>Mandola</longName>
+                  <shortName>Mda.</shortName>
+                  <description>Mandola</description>
+                  <musicXMLid>pluck.mandola</musicXMLid>
+                  <StringData>
+                        <frets>24</frets>
+                        <string>48</string>
+                        <string>55</string>
+                        <string>62</string>
+                        <string>69</string>
+                  </StringData>
+                  <clef>C3</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>48-87</aPitchRange>
+                  <pPitchRange>48-93</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 16, Prog 25; MS General: Mandolin-->
+                        <controller ctrl="32" value="16"/> <!--Bank LSB-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="tenor-mandola">
+                  <family>mandolins</family>
+                  <longName>Tenor Mandola</longName>
+                  <shortName>T. Mda.</shortName>
+                  <description>Mandola 8va mandolin tuning</description>
+                  <musicXMLid>pluck.mandola</musicXMLid>
+                  <StringData>
+                        <frets>24</frets>
+                        <string>43</string>
+                        <string>50</string>
+                        <string>57</string>
+                        <string>64</string>
+                  </StringData>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>48-87</aPitchRange>
+                  <pPitchRange>48-93</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 16, Prog 25; MS General: Mandolin-->
+                        <controller ctrl="32" value="16"/> <!--Bank LSB-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="octave-mandolin">
+                  <family>mandolins</family>
+                  <longName>Octave Mandolin</longName>
+                  <shortName>OM.</shortName>
+                  <description>Octave Mandolin</description>
+                  <musicXMLid>pluck.mandolin.octave</musicXMLid>
+                  <StringData>
+                        <frets>24</frets>
+                        <string>43</string>
+                        <string>50</string>
+                        <string>57</string>
+                        <string>64</string>
+                  </StringData>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>43-73</aPitchRange>
+                  <pPitchRange>36-88</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 16, Prog 25; MS General: Mandolin-->
+                        <controller ctrl="32" value="16"/> <!--Bank LSB-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="mandocello">
+                  <family>mandolins</family>
+                  <longName>Mandocello</longName>
+                  <shortName>Mncl.</shortName>
+                  <description>Mandocello</description>
+                  <musicXMLid>pluck.mandocello</musicXMLid>
+                  <StringData>
+                        <frets>24</frets>
+                        <string>36</string>
+                        <string>43</string>
+                        <string>50</string>
+                        <string>57</string>
+                  </StringData>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>36-75</aPitchRange>
+                  <pPitchRange>36-81</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 16, Prog 25; MS General: Mandolin-->
+                        <controller ctrl="32" value="16"/> <!--Bank LSB-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="mtn-dulcimer-std">
+                  <family>mtn-dulcimers</family>
+                  <longName>Mtn. Dulcimer</longName>
+                  <shortName>Mtn. Dc.</shortName>
+                  <description>Standard Mountain Dulcimer</description>
+                  <musicXMLid>pluck.dulcimer</musicXMLid>
+                  <StringData>
+                        <frets>28</frets>
+                        <string>50</string>
+                        <string>57</string>
+                        <string>62</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>50-90</aPitchRange>
+                  <pPitchRange>50-90</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 25; MS General: Steel String Guitar-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="mtn-dulcimer-std-chrom-tab">
+                  <init>mtn-dulcimer-std</init>
+                  <family>mtn-dulcimers</family>
+                  <trackName>Mtn. Dulcimer (Tablature)</trackName>
+                  <description>Standard Mountain Dulcimer (3-str. chromatic TAB)</description>
+                  <stafftype staffTypePreset="tabDulcimer">tablature</stafftype>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="mtn-dulcimer-baritone">
+                  <family>mtn-dulcimers</family>
+                  <longName>Mtn. Dulcimer - Baritone</longName>
+                  <shortName>Bar. M.D.</shortName>
+                  <description>Baritone Mountain Dulcimer</description>
+                  <musicXMLid>pluck.dulcimer</musicXMLid>
+                  <StringData>
+                        <frets>23</frets>
+                        <string>45</string>
+                        <string>52</string>
+                        <string>57</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>45-80</aPitchRange>
+                  <pPitchRange>45-80</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 25; MS General: Steel String Guitar-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="mtn-dulcimer-bartn-chrom-tab">
+                  <init>mtn-dulcimer-baritone</init>
+                  <family>mtn-dulcimers</family>
+                  <trackName>Mtn. Dulcimer - Baritone (Tablature)</trackName>
+                  <description>Baritone Mountain Dulcimer (3-str. chromatic TAB)</description>
+                  <stafftype staffTypePreset="tabDulcimer">tablature</stafftype>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="mtn-dulcimer-bass">
+                  <family>mtn-dulcimers</family>
+                  <longName>Mtn. Dulcimer - Bass</longName>
+                  <shortName>Bs. M.D.</shortName>
+                  <description>Bass Mountain Dulcimer</description>
+                  <musicXMLid>pluck.dulcimer</musicXMLid>
+                  <StringData>
+                        <frets>28</frets>
+                        <string>38</string>
+                        <string>45</string>
+                        <string>50</string>
+                  </StringData>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>38-78</aPitchRange>
+                  <pPitchRange>38-78</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 25; MS General: Steel String Guitar-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="mtn-dulcimer-bass-chrom-tab">
+                  <init>mtn-dulcimer-bass</init>
+                  <family>mtn-dulcimers</family>
+                  <trackName>Mtn. Dulcimer - Bass (Tablature)</trackName>
+                  <description>Bass Mountain Dulcimer (3-str. chromatic TAB)</description>
+                  <stafftype staffTypePreset="tabDulcimer">tablature</stafftype>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="lute">
+                  <family>lutes</family>
+                  <longName>Lute</longName>
+                  <shortName>Lt.</shortName>
+                  <description>Lute</description>
+                  <musicXMLid>pluck.lute</musicXMLid>
+                  <StringData>
+                        <frets>13</frets>
+                        <string>43</string>
+                        <string>48</string>
+                        <string>53</string>
+                        <string>57</string>
+                        <string>62</string>
+                        <string>67</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>33-79</aPitchRange>
+                  <pPitchRange>33-79</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
+                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="lute-tablature">
+                  <init>lute</init>
+                  <family>lutes</family>
+                  <trackName>Lute (Tablature)</trackName>
+                  <description>Lute (Tablature)</description>
+                  <musicXMLid>pluck.lute</musicXMLid>
+                  <stafftype staffTypePreset="tab6StrFrench">tablature</stafftype>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="ren.-tenor-lute-5-course">
+                  <family>lutes</family>
+                  <trackName>Lute 5-course</trackName>
+                  <longName>Lute</longName>
+                  <shortName>Lt.</shortName>
+                  <description>Renaissance Tenor Lute (5-course).</description>
+                  <musicXMLid>pluck.lute</musicXMLid>
+                  <StringData>
+                        <frets>13</frets>
+                        <string>48</string>
+                        <string>53</string>
+                        <string>57</string>
+                        <string>62</string>
+                        <string>67</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>48-79</aPitchRange>
+                  <pPitchRange>48-79</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
+                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="ren.-tenor-lute-6-course">
+                  <family>lutes</family>
+                  <trackName>Lute 6-course</trackName>
+                  <longName>Lute</longName>
+                  <shortName>Lt.</shortName>
+                  <description>Renaissance Tenor Lute (6-course).</description>
+                  <musicXMLid>pluck.lute</musicXMLid>
+                  <StringData>
+                        <frets>13</frets>
+                        <string>43</string>
+                        <string>48</string>
+                        <string>53</string>
+                        <string>57</string>
+                        <string>62</string>
+                        <string>67</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>43-79</aPitchRange>
+                  <pPitchRange>43-79</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
+                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="ren.-tenor-lute-7-course">
+                  <family>lutes</family>
+                  <trackName>Lute 7-course</trackName>
+                  <longName>Lute</longName>
+                  <shortName>Lt.</shortName>
+                  <description>Renaissance Tenor Lute (7-course).</description>
+                  <musicXMLid>pluck.lute</musicXMLid>
+                  <StringData>
+                        <frets>13</frets>
+                        <string>38</string>
+                        <string>43</string>
+                        <string>48</string>
+                        <string>53</string>
+                        <string>57</string>
+                        <string>62</string>
+                        <string>67</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>38-79</aPitchRange>
+                  <pPitchRange>38-79</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
+                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="ren.-tenor-lute-8-course">
+                  <family>lutes</family>
+                  <trackName>Lute 8-course</trackName>
+                  <longName>Lute</longName>
+                  <shortName>Lt.</shortName>
+                  <description>Renaissance Tenor Lute (8-course).</description>
+                  <musicXMLid>pluck.lute</musicXMLid>
+                  <StringData>
+                        <frets>13</frets>
+                        <string>38</string>
+                        <string>41</string>
+                        <string>43</string>
+                        <string>48</string>
+                        <string>53</string>
+                        <string>57</string>
+                        <string>62</string>
+                        <string>67</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>38-79</aPitchRange>
+                  <pPitchRange>38-79</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
+                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="ren.-tenor-lute-9-course">
+                  <family>lutes</family>
+                  <trackName>Lute 9-course</trackName>
+                  <longName>Lute</longName>
+                  <shortName>Lt.</shortName>
+                  <description>Renaissance Tenor Lute (9-course).</description>
+                  <musicXMLid>pluck.lute</musicXMLid>
+                  <StringData>
+                        <frets>13</frets>
+                        <string open="1">36</string>
+                        <string>38</string>
+                        <string>41</string>
+                        <string>43</string>
+                        <string>48</string>
+                        <string>53</string>
+                        <string>57</string>
+                        <string>62</string>
+                        <string>67</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>36-79</aPitchRange>
+                  <pPitchRange>36-79</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
+                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="ren.-tenor-lute-10-course">
+                  <family>lutes</family>
+                  <trackName>Lute 10-course</trackName>
+                  <longName>Lute</longName>
+                  <shortName>Lt.</shortName>
+                  <description>Renaissance Tenor Lute (10-course).</description>
+                  <musicXMLid>pluck.lute</musicXMLid>
+                  <StringData>
+                        <frets>13</frets>
+                        <string open="1">36</string>
+                        <string open="1">38</string>
+                        <string>40</string>
+                        <string>41</string>
+                        <string>43</string>
+                        <string>48</string>
+                        <string>53</string>
+                        <string>57</string>
+                        <string>62</string>
+                        <string>67</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>36-79</aPitchRange>
+                  <pPitchRange>36-79</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
+                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="baroque-lute-13-course">
+                  <family>lutes</family>
+                  <trackName>Lute 13-course</trackName>
+                  <longName>Lute</longName>
+                  <shortName>Lt.</shortName>
+                  <description>Baroque Lute (13-course)</description>
+                  <musicXMLid>pluck.lute</musicXMLid>
+                  <StringData>
+                        <frets>13</frets>
+                        <string open="1">33</string>
+                        <string open="1">35</string>
+                        <string open="1">36</string>
+                        <string open="1">38</string>
+                        <string open="1">40</string>
+                        <string>41</string>
+                        <string>43</string>
+                        <string>45</string>
+                        <string>50</string>
+                        <string>53</string>
+                        <string>57</string>
+                        <string>62</string>
+                        <string>65</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>33-77</aPitchRange>
+                  <pPitchRange>33-77</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
+                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="theorbo-14-course">
+                  <family>lutes</family>
+                  <longName>Theorbo</longName>
+                  <shortName>Thb.</shortName>
+                  <description>Theorbo (14-course)</description>
+                  <musicXMLid>pluck.theorbo</musicXMLid>
+                  <StringData>
+                        <frets>13</frets>
+                        <string open="1">31</string>
+                        <string open="1">33</string>
+                        <string open="1">35</string>
+                        <string open="1">36</string>
+                        <string open="1">38</string>
+                        <string open="1">40</string>
+                        <string open="1">41</string>
+                        <string open="1">43</string>
+                        <string>45</string>
+                        <string>50</string>
+                        <string>55</string>
+                        <string>59</string>
+                        <string>52</string>
+                        <string>57</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>31-71</aPitchRange>
+                  <pPitchRange>31-71</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
+                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="archlute-14-course">
+                  <family>lutes</family>
+                  <longName>Archlute</longName>
+                  <shortName>A. Lt.</shortName>
+                  <description>Archlute (14-course)</description>
+                  <musicXMLid>pluck.archlute</musicXMLid>
+                  <StringData>
+                        <frets>13</frets>
+                        <string open="1">29</string>
+                        <string open="1">31</string>
+                        <string open="1">33</string>
+                        <string open="1">34</string>
+                        <string open="1">36</string>
+                        <string open="1">38</string>
+                        <string>39</string>
+                        <string>41</string>
+                        <string>43</string>
+                        <string>48</string>
+                        <string>53</string>
+                        <string>57</string>
+                        <string>62</string>
+                        <string>67</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>29-77</aPitchRange>
+                  <pPitchRange>29-77</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
+                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="balalaika-piccolo">
+                  <family>balalaikas</family>
+                  <trackName>Piccolo Balalaika</trackName>
+                  <longName>Piccolo Balalaika</longName>
+                  <shortName>Pic. Bal.</shortName>
+                  <description>Piccolo Balalaika (the smallest and rarest of the family)</description>
+                  <musicXMLid>pluck.balalaika.piccolo</musicXMLid>
+                  <StringData>
+                        <frets>17</frets>
+                        <string>71</string>
+                        <string>76</string>
+                        <string>81</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>71-98</aPitchRange>
+                  <pPitchRange>71-98</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 107; MS General: Koto-->
+                        <program value="107"/> <!--Koto-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="balalaika">
+                  <family>balalaikas</family>
+                  <trackName>Balalaika</trackName>
+                  <longName>Balalaika</longName>
+                  <shortName>Bal.</shortName>
+                  <description>Balalaika in fact the prima but a generic for simplicity</description>
+                  <musicXMLid>pluck.balalaika</musicXMLid>
+                  <StringData>
+                        <frets>17</frets>
+                        <string>64</string>
+                        <string>64</string>
+                        <string>69</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>64-86</aPitchRange>
+                  <pPitchRange>64-86</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 107; MS General: Koto-->
+                        <program value="107"/> <!--Koto-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="balalaika-prima">
+                  <family>balalaikas</family>
+                  <trackName>Prima Balalaika</trackName>
+                  <longName>Prima Balalaika</longName>
+                  <shortName>Pr. Bal.</shortName>
+                  <description>Prima Balalaika (the most commonly played of the family)</description>
+                  <musicXMLid>pluck.balalaika.prima</musicXMLid>
+                  <StringData>
+                        <frets>17</frets>
+                        <string>64</string>
+                        <string>64</string>
+                        <string>69</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>64-86</aPitchRange>
+                  <pPitchRange>64-86</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 107; MS General: Koto-->
+                        <program value="107"/> <!--Koto-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="balalaika-secunda">
+                  <family>balalaikas</family>
+                  <trackName>Secunda Balalaika</trackName>
+                  <longName>Secunda Balalaika</longName>
+                  <shortName>Sec. Bal.</shortName>
+                  <description>Secunda Balalaika</description>
+                  <musicXMLid>pluck.balalaika.secunda</musicXMLid>
+                  <StringData>
+                        <frets>17</frets>
+                        <string>57</string>
+                        <string>57</string>
+                        <string>62</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>57-79</aPitchRange>
+                  <pPitchRange>57-79</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 107; MS General: Koto-->
+                        <program value="107"/> <!--Koto-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="balalaika-alto">
+                  <family>balalaikas</family>
+                  <trackName>Alto Balalaika</trackName>
+                  <longName>Alto Balalaika</longName>
+                  <shortName>Al. Bal.</shortName>
+                  <description>Alto Balalaika</description>
+                  <musicXMLid>pluck.balalaika.alto</musicXMLid>
+                  <StringData>
+                        <frets>17</frets>
+                        <string>52</string>
+                        <string>52</string>
+                        <string>57</string>
+                  </StringData>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>52-74</aPitchRange>
+                  <pPitchRange>52-74</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 107; MS General: Koto-->
+                        <program value="107"/> <!--Koto-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="balalaika-bass">
+                  <family>balalaikas</family>
+                  <trackName>Bass Balalaika</trackName>
+                  <longName>Bass Balalaika</longName>
+                  <shortName>B. Bal.</shortName>
+                  <description>Bass Balalaika</description>
+                  <musicXMLid>pluck.balalaika.bass</musicXMLid>
+                  <StringData>
+                        <frets>17</frets>
+                        <string>40</string>
+                        <string>45</string>
+                        <string>50</string>
+                  </StringData>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>40-67</aPitchRange>
+                  <pPitchRange>40-67</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 107; MS General: Koto-->
+                        <program value="107"/> <!--Koto-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="balalaika-contrabass">
+                  <family>balalaikas</family>
+                  <trackName>Contrabass Balalaika</trackName>
+                  <longName>Contrabass Balalaika</longName>
+                  <shortName>Cb. Bal.</shortName>
+                  <description>Contrabass Balalaika</description>
+                  <musicXMLid>pluck.balalaika.contrabass</musicXMLid>
+                  <StringData>
+                        <frets>17</frets>
                         <string>28</string>
                         <string>33</string>
                         <string>38</string>
-                        <string>43</string>
                   </StringData>
-                  <transposingClef>F</transposingClef>
-                  <concertClef>F8vb</concertClef>
+                  <clef>F8vb</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>28-65</aPitchRange>
-                  <pPitchRange>28-67</pPitchRange>
+                  <aPitchRange>28-55</aPitchRange>
+                  <pPitchRange>28-55</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <transposeDiatonic>-7</transposeDiatonic>
-                  <transposeChromatic>-12</transposeChromatic>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 35; MS General: Fretless Bass-->
-                        <program value="35"/> <!--Fretless Bass-->
+                        <!--MIDI: Bank 0, Prog 107; MS General: Koto-->
+                        <program value="107"/> <!--Koto-->
                   </Channel>
-                  <Channel name="slap">
-                        <!--MIDI: Bank 0, Prog 36; MS General: Slap Bass-->
-                        <program value="36"/> <!--Slap Bass 1-->
-                  </Channel>
-                  <Channel name="pop">
-                        <!--MIDI: Bank 0, Prog 37; MS General: Pop Bass-->
-                        <program value="37"/> <!--Slap Bass 2-->
-                  </Channel>
-                  <genre>popular</genre>
-                  <genre>jazz</genre>
             </Instrument>
-            <Instrument id="5-string-electric-bass">
-                  <family>bass-guitars</family>
-                  <longName>5-str. Electric Bass</longName>
-                  <shortName>El. B.</shortName>
-                  <description>5-string Electric Bass</description>
-                  <musicXMLid>pluck.bass.electric</musicXMLid>
+            <Instrument id="bouzouki-3-course">
+                  <family>bouzoukis</family>
+                  <trackName>Bouzouki (3-course)</trackName>
+                  <longName>Bouzouki</longName>
+                  <shortName>Bou.</shortName>
+                  <description>Bouzouki (3-course)</description>
+                  <musicXMLid>pluck.bouzouki</musicXMLid>
                   <StringData>
-                        <frets>24</frets>
-                        <string>35</string>
-                        <string>40</string>
-                        <string>45</string>
+                        <frets>26</frets>
                         <string>50</string>
-                        <string>55</string>
+                        <string>57</string>
+                        <string>62</string>
                   </StringData>
-                  <transposingClef>F</transposingClef>
-                  <concertClef>F8vb</concertClef>
+                  <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>23-65</aPitchRange>
-                  <pPitchRange>23-67</pPitchRange>
+                  <aPitchRange>50-89</aPitchRange>
+                  <pPitchRange>50-90</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <transposeDiatonic>-7</transposeDiatonic>
-                  <transposeChromatic>-12</transposeChromatic>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 33; MS General: Fingered Bass-->
-                        <program value="33"/> <!--Electric Bass (finger)-->
+                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
+                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
                   </Channel>
-                  <Channel name="slap">
-                        <!--MIDI: Bank 0, Prog 36; MS General: Slap Bass-->
-                        <program value="36"/> <!--Slap Bass 1-->
-                  </Channel>
-                  <Channel name="pop">
-                        <!--MIDI: Bank 0, Prog 37; MS General: Pop Bass-->
-                        <program value="37"/> <!--Slap Bass 2-->
-                  </Channel>
-                  <genre>common</genre>
-                  <genre>popular</genre>
-                  <genre>jazz</genre>
+                  <genre>world</genre>
             </Instrument>
-            <Instrument id="5-string-electric-bass-tab">
-                  <family>bass-guitars</family>
-                  <trackName>5-str. Electric Bass (Tablature)</trackName>
-                  <init>5-string-electric-bass</init>
-                  <description>5-string Electric Bass (Tablature)</description>
-                  <stafftype staffTypePreset="tab5StrCommon">tablature</stafftype>
-                  <genre>common</genre>
-                  <genre>popular</genre>
-            </Instrument>
-            <Instrument id="5-string-electric-bass-high-c">
-                  <family>bass-guitars</family>
-                  <trackName>5-str. Electric Bass (High C/Tenor)</trackName>
-                  <longName>5-str. Electric Bass</longName>
-                  <shortName>El. B.</shortName>
-                  <description>5-string Electric Bass (High C/Tenor)</description>
-                  <musicXMLid>pluck.bass.electric</musicXMLid>
+            <Instrument id="bouzouki-4-course">
+                  <family>bouzoukis</family>
+                  <trackName>Bouzouki (4-course)</trackName>
+                  <longName>Bouzouki</longName>
+                  <shortName>Bou.</shortName>
+                  <description>Bouzouki (4-course)</description>
+                  <musicXMLid>pluck.bouzouki</musicXMLid>
                   <StringData>
-                        <frets>24</frets>
-                        <string>40</string>
-                        <string>45</string>
-                        <string>50</string>
-                        <string>55</string>
-                        <string>60</string>
+                        <frets>26</frets>
+                        <string>48</string>
+                        <string>53</string>
+                        <string>57</string>
+                        <string>62</string>
                   </StringData>
-                  <transposingClef>F</transposingClef>
-                  <concertClef>F8vb</concertClef>
+                  <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>23-65</aPitchRange>
-                  <pPitchRange>23-67</pPitchRange>
+                  <aPitchRange>48-88</aPitchRange>
+                  <pPitchRange>48-90</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <transposeDiatonic>-7</transposeDiatonic>
-                  <transposeChromatic>-12</transposeChromatic>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 33; MS General: Fingered Bass-->
-                        <program value="33"/> <!--Electric Bass (finger)-->
+                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
+                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
                   </Channel>
-                  <Channel name="slap">
-                        <!--MIDI: Bank 0, Prog 36; MS General: Slap Bass-->
-                        <program value="36"/> <!--Slap Bass 1-->
-                  </Channel>
-                  <Channel name="pop">
-                        <!--MIDI: Bank 0, Prog 37; MS General: Pop Bass-->
-                        <program value="37"/> <!--Slap Bass 2-->
-                  </Channel>
-                  <genre>jazz</genre>
+                  <genre>world</genre>
             </Instrument>
-            <Instrument id="5-string-electric-bass-tab-high-c">
-                  <family>bass-guitars</family>
-                  <trackName>5-str. Electric Bass (High C/Tenor) (Tablature)</trackName>
-                  <init>5-string-electric-bass-high-c</init>
-                  <description>5-string Electric Bass (High C/Tenor) (Tablature)</description>
-                  <stafftype staffTypePreset="tab5StrCommon">tablature</stafftype>
-                  <genre>jazz</genre>
+            <Instrument id="koto">
+                  <family>kotos</family>
+                  <longName>Koto</longName>
+                  <shortName>Ko.</shortName>
+                  <description>Koto</description>
+                  <musicXMLid>pluck.koto</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>43-83</aPitchRange>
+                  <pPitchRange>43-83</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 107; MS General: Koto-->
+                        <program value="107"/> <!--Koto-->
+                  </Channel>
+                  <genre>world</genre>
             </Instrument>
-            <Instrument id="6-string-electric-bass">
-                  <family>bass-guitars</family>
-                  <longName>6-str. Electric Bass</longName>
-                  <shortName>El. B.</shortName>
-                  <description>6-string Electric Bass</description>
-                  <musicXMLid>pluck.bass.electric</musicXMLid>
+            <Instrument id="oud">
+                  <family>ouds</family>
+                  <longName>Oud</longName>
+                  <shortName>O.</shortName>
+                  <description>Oud</description>
+                  <musicXMLid>pluck.oud</musicXMLid>
                   <StringData>
-                        <frets>24</frets>
-                        <string>35</string>
-                        <string>40</string>
-                        <string>45</string>
-                        <string>50</string>
-                        <string>55</string>
-                        <string>60</string>
+                        <frets>15</frets>
+                        <string>48</string>
+                        <string>53</string>
+                        <string>57</string>
+                        <string>62</string>
+                        <string>67</string>
+                        <string>72</string>
                   </StringData>
-                  <transposingClef>F</transposingClef>
-                  <concertClef>F8vb</concertClef>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>G8vb</concertClef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>23-70</aPitchRange>
-                  <pPitchRange>23-72</pPitchRange>
+                  <aPitchRange>36-75</aPitchRange>
+                  <pPitchRange>36-75</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
                   <transposeDiatonic>-7</transposeDiatonic>
                   <transposeChromatic>-12</transposeChromatic>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 33; MS General: Fingered Bass-->
-                        <program value="33"/> <!--Electric Bass (finger)-->
+                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
+                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <program value="25"/> <!--Acoustic Guitar (steel)-->
                   </Channel>
-                  <Channel name="slap">
-                        <!--MIDI: Bank 0, Prog 36; MS General: Slap Bass-->
-                        <program value="36"/> <!--Slap Bass 1-->
-                  </Channel>
-                  <Channel name="pop">
-                        <!--MIDI: Bank 0, Prog 37; MS General: Pop Bass-->
-                        <program value="37"/> <!--Slap Bass 2-->
-                  </Channel>
-                  <genre>jazz</genre>
+                  <genre>world</genre>
+                  <genre>earlymusic</genre>
             </Instrument>
-            <Instrument id="6-string-electric-bass-tab">
-                  <family>guitars</family>
-                  <trackName>6-str. Electric Bass (Tablature)</trackName>
-                  <init>6-string-electric-bass</init>
-                  <description>6-string Electric Bass (Tablature)</description>
-                  <stafftype staffTypePreset="tab6StrCommon">tablature</stafftype>
-                  <genre>jazz</genre>
+            <Instrument id="shamisen">
+                  <family>shamisens</family>
+                  <longName>Shamisen</longName>
+                  <shortName>Sh.</shortName>
+                  <description>Shamisen</description>
+                  <musicXMLid>pluck.shamisen</musicXMLid>
+                  <clef>G8vb</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>50-83</aPitchRange>
+                  <pPitchRange>50-83</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 106; MS General: Shamisen-->
+                        <program value="106"/> <!--Shamisen-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="sitar">
+                  <family>sitars</family>
+                  <longName>Sitar</longName>
+                  <shortName>Si.</shortName>
+                  <description>Sitar</description>
+                  <musicXMLid>pluck.sitar</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>36-84</aPitchRange>
+                  <pPitchRange>36-84</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 104; MS General: Sitar-->
+                        <program value="104"/> <!--Sitar-->
+                  </Channel>
+                  <genre>world</genre>
             </Instrument>
             <Instrument id="prim">
+                  <family>tamburicas</family>
                   <longName>Prim</longName>
                   <shortName>Pr.</shortName>
                   <description>Prim</description>
@@ -11953,6 +12367,7 @@
                   <genre>world</genre>
             </Instrument>
             <Instrument id="brac">
+                  <family>tamburicas</family>
                   <longName>Brač</longName>
                   <shortName>Br.</shortName>
                   <description>Brač</description>
@@ -11975,32 +12390,8 @@
                   </Channel>
                   <genre>world</genre>
             </Instrument>
-            <Instrument id="celo">
-                  <longName>Čelo</longName>
-                  <shortName>Č.</shortName>
-                  <description>Čelo</description>
-                  <musicXMLid>pluck.tambura</musicXMLid>
-                  <StringData>
-                        <frets>15</frets>
-                        <string>40</string>
-                        <string>45</string>
-                        <string>50</string>
-                        <string>55</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>3-60</aPitchRange>
-                  <pPitchRange>3-60</pPitchRange>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <transposeDiatonic>-14</transposeDiatonic>
-                  <transposeChromatic>-24</transposeChromatic>
-                  <Channel>
-                        <!--MIDI: Bank 0, Prog 24; MS General: Nylon String Guitar-->
-                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
             <Instrument id="bugarija">
+                  <family>tamburicas</family>
                   <longName>Bugarija</longName>
                   <shortName>Bu.</shortName>
                   <description>Bugarija</description>
@@ -12026,6 +12417,7 @@
                   <genre>world</genre>
             </Instrument>
             <Instrument id="berda">
+                  <family>tamburicas</family>
                   <longName>Berda</longName>
                   <shortName>Be.</shortName>
                   <description>Berda</description>
@@ -12050,7 +12442,34 @@
                   </Channel>
                   <genre>world</genre>
             </Instrument>
+            <Instrument id="celo">
+                  <family>tamburicas</family>
+                  <longName>Čelo</longName>
+                  <shortName>Č.</shortName>
+                  <description>Čelo</description>
+                  <musicXMLid>pluck.tambura</musicXMLid>
+                  <StringData>
+                        <frets>15</frets>
+                        <string>40</string>
+                        <string>45</string>
+                        <string>50</string>
+                        <string>55</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>3-60</aPitchRange>
+                  <pPitchRange>3-60</pPitchRange>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <transposeDiatonic>-14</transposeDiatonic>
+                  <transposeChromatic>-24</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 24; MS General: Nylon String Guitar-->
+                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
             <Instrument id="bandurria">
+                  <family>bandurrias</family>
                   <longName>Bandurria</longName>
                   <shortName>Band.</shortName>
                   <description>Spanish Bandurria</description>
@@ -12076,14 +12495,16 @@
                   <genre>popular</genre>
             </Instrument>
             <Instrument id="bandurria-tablature">
-                  <trackName>Bandurria (Tablature)</trackName>
                   <init>bandurria</init>
+                  <family>bandurrias</family>
+                  <trackName>Bandurria (Tablature)</trackName>
                   <description>Bandurria (Tablature)</description>
                   <musicXMLid>pluck.bandurria</musicXMLid>
                   <stafftype staffTypePreset="tab6StrCommon">tablature</stafftype>
                   <genre>popular</genre>
             </Instrument>
             <Instrument id="laud">
+                  <family>lauds</family>
                   <longName>Laúd</longName>
                   <shortName>Laúd</shortName>
                   <description>Spanish Laúd</description>
@@ -12109,8 +12530,9 @@
                   <genre>popular</genre>
             </Instrument>
             <Instrument id="laud-tablature">
-                  <trackName>Laúd (Tablature)</trackName>
                   <init>laud</init>
+                  <family>lauds</family>
+                  <trackName>Laúd (Tablature)</trackName>
                   <description>Spanish Laúd (Tablature)</description>
                   <musicXMLid>pluck.laud</musicXMLid>
                   <stafftype staffTypePreset="tab6StrCommon">tablature</stafftype>
@@ -12120,7 +12542,7 @@
       <InstrumentGroup id="strings">
             <name>Strings - Bowed</name>
             <Instrument id="strings">
-                  <family>orchestral-strings</family>
+                  <family>strings</family>
                   <longName>Strings</longName>
                   <shortName>St.</shortName>
                   <description>String Section</description>
@@ -12143,56 +12565,11 @@
                         <program value="44"/> <!--Tremolo Strings-->
                   </Channel>
             </Instrument>
-            <Instrument id="erhu">
-                  <longName>Erhu</longName>
-                  <shortName>Eh.</shortName>
-                  <description>Erhu</description>
-                  <musicXMLid>strings.erhu</musicXMLid>
-                  <StringData>
-                        <frets>24</frets>
-                        <string>62</string>
-                        <string>69</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>62-93</aPitchRange>
-                  <pPitchRange>62-105</pPitchRange>
-                  <Channel name="arco">
-                        <!--MIDI: Bank 0, Prog 110; MS General: Fiddle-->
-                        <program value="110"/> <!--Fiddle-->
-                  </Channel>
-                  <Channel name="pizzicato">
-                        <!--MIDI: Bank 0, Prog 45; MS General: Strings Pizzicato-->
-                        <program value="45"/> <!--Pizzicato Strings-->
-                  </Channel>
-                  <Channel name="tremolo">
-                        <!--MIDI: Bank 0, Prog 44; MS General: Strings Tremolo-->
-                        <program value="44"/> <!--Tremolo Strings-->
-                  </Channel>
-                  <genre>world</genre>
-            </Instrument>
-            <Instrument id="nyckelharpa">
-                  <longName>Nyckelharpa</longName>
-                  <shortName>Nyh.</shortName>
-                  <description>Nyckelharpa</description>
-                  <musicXMLid>strings.nyckelharpa</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>48-79</aPitchRange>
-                  <pPitchRange>48-93</pPitchRange>
-                  <Channel name="arco">
-                        <!--MIDI: Bank 0, Prog 41; MS General: Viola-->
-                        <program value="41"/> <!--Viola-->
-                  </Channel>
-                  <Channel name="pizzicato">
-                        <!--MIDI: Bank 0, Prog 45; MS General: Strings Pizzicato-->
-                        <program value="45"/> <!--Pizzicato Strings-->
-                  </Channel>
-                  <Channel name="tremolo">
-                        <!--MIDI: Bank 0, Prog 44; MS General: Strings Tremolo-->
-                        <program value="44"/> <!--Tremolo Strings-->
-                  </Channel>
-                  <genre>world</genre>
+            <Instrument id="double-bass">
+                  <init>contrabass</init>
+                  <family>orchestral-strings</family>
+                  <longName>Double Bass</longName>
+                  <shortName>Db.</shortName>
             </Instrument>
             <Instrument id="violin">
                   <family>orchestral-strings</family>
@@ -12415,61 +12792,6 @@
                   </Channel>
                   <genre>orchestra</genre>
             </Instrument>
-            <Instrument id="double-bass">
-                  <family>orchestral-strings</family>
-                  <longName>Double Bass</longName>
-                  <shortName>Db.</shortName>
-                  <init>contrabass</init>
-            </Instrument>
-            <Instrument id="octobass">
-                  <longName>Octobass</longName>
-                  <shortName>Otb.</shortName>
-                  <description>Octobass</description>
-                  <musicXMLid>strings.octobass</musicXMLid>
-                  <transposingClef>F</transposingClef>
-                  <concertClef>F15mb</concertClef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>21-31</aPitchRange>
-                  <pPitchRange>12-33</pPitchRange>
-                  <transposeDiatonic>-14</transposeDiatonic>
-                  <transposeChromatic>-24</transposeChromatic>
-                  <Channel name="arco">
-                        <!--MIDI: Bank 0, Prog 43; MS General: Contrabass-->
-                        <program value="43"/> <!--Contrabass-->
-                  </Channel>
-                  <Channel name="pizzicato">
-                        <!--MIDI: Bank 0, Prog 32; MS General: Acoustic Bass-->
-                        <program value="32"/> <!--Acoustic Bass-->
-                  </Channel>
-                  <Channel name="tremolo">
-                        <!--MIDI: Bank 0, Prog 44; MS General: Strings Tremolo-->
-                        <program value="44"/> <!--Tremolo Strings-->
-                  </Channel>
-            </Instrument>
-            <Instrument id="pardessus-de-viole">
-                  <family>viols</family>
-                  <longName>Pardessus de viole</longName>
-                  <shortName>Pds. v.</shortName>
-                  <description>Pardessus de viole</description>
-                  <musicXMLid>strings.viol</musicXMLid>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>55-91</aPitchRange>
-                  <pPitchRange>43-96</pPitchRange>
-                  <Channel name="arco">
-                        <!--MIDI: Bank 0, Prog 40; MS General: Violin-->
-                        <program value="40"/> <!--Violin-->
-                  </Channel>
-                  <Channel name="pizzicato">
-                        <!--MIDI: Bank 0, Prog 45; MS General: Strings Pizzicato-->
-                        <program value="45"/> <!--Pizzicato Strings-->
-                  </Channel>
-                  <Channel name="tremolo">
-                        <!--MIDI: Bank 0, Prog 44; MS General: Strings Tremolo-->
-                        <program value="44"/> <!--Tremolo Strings-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
             <Instrument id="treble-viol">
                   <family>viols</family>
                   <longName>Treble Viol</longName>
@@ -12536,6 +12858,30 @@
                   </Channel>
                   <genre>earlymusic</genre>
             </Instrument>
+            <Instrument id="pardessus-de-viole">
+                  <family>viols</family>
+                  <longName>Pardessus de viole</longName>
+                  <shortName>Pds. v.</shortName>
+                  <description>Pardessus de viole</description>
+                  <musicXMLid>strings.viol</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>55-91</aPitchRange>
+                  <pPitchRange>43-96</pPitchRange>
+                  <Channel name="arco">
+                        <!--MIDI: Bank 0, Prog 40; MS General: Violin-->
+                        <program value="40"/> <!--Violin-->
+                  </Channel>
+                  <Channel name="pizzicato">
+                        <!--MIDI: Bank 0, Prog 45; MS General: Strings Pizzicato-->
+                        <program value="45"/> <!--Pizzicato Strings-->
+                  </Channel>
+                  <Channel name="tremolo">
+                        <!--MIDI: Bank 0, Prog 44; MS General: Strings Tremolo-->
+                        <program value="44"/> <!--Tremolo Strings-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
             <Instrument id="tenor-viol">
                   <family>viols</family>
                   <longName>Tenor Viol</longName>
@@ -12558,6 +12904,39 @@
                   <Channel name="arco">
                         <!--MIDI: Bank 0, Prog 41; MS General: Viola-->
                         <program value="41"/> <!--Viola-->
+                  </Channel>
+                  <Channel name="pizzicato">
+                        <!--MIDI: Bank 0, Prog 45; MS General: Strings Pizzicato-->
+                        <program value="45"/> <!--Pizzicato Strings-->
+                  </Channel>
+                  <Channel name="tremolo">
+                        <!--MIDI: Bank 0, Prog 44; MS General: Strings Tremolo-->
+                        <program value="44"/> <!--Tremolo Strings-->
+                  </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="baryton">
+                  <family>viols</family>
+                  <longName>Baryton</longName>
+                  <shortName>Bary.</shortName>
+                  <description>Baryton</description>
+                  <musicXMLid>strings.baryton</musicXMLid>
+                  <StringData>
+                        <frets>13</frets>
+                        <string>38</string>
+                        <string>43</string>
+                        <string>48</string>
+                        <string>52</string>
+                        <string>57</string>
+                        <string>62</string>
+                  </StringData>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>33-74</aPitchRange>
+                  <pPitchRange>33-79</pPitchRange>
+                  <Channel name="arco">
+                        <!--MIDI: Bank 0, Prog 42; MS General: Cello-->
+                        <program value="42"/> <!--Cello-->
                   </Channel>
                   <Channel name="pizzicato">
                         <!--MIDI: Bank 0, Prog 45; MS General: Strings Pizzicato-->
@@ -12603,51 +12982,20 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="viola-da-gamba-tablature">
+                  <init>viola-da-gamba</init>
                   <family>viols</family>
                   <trackName>Viola da gamba (Tablature)</trackName>
                   <longName>Viola da gamba (Tab)</longName>
                   <shortName>Vla. d. g.</shortName>
-                  <init>viola-da-gamba</init>
                   <description>Viola da gamba (Tablature)</description>
                   <stafftype staffTypePreset="tab6StrFrench">tablature</stafftype>
                   <genre>earlymusic</genre>
             </Instrument>
-            <Instrument id="baryton">
-                  <longName>Baryton</longName>
-                  <shortName>Bary.</shortName>
-                  <description>Baryton</description>
-                  <musicXMLid>strings.baryton</musicXMLid>
-                  <StringData>
-                        <frets>13</frets>
-                        <string>38</string>
-                        <string>43</string>
-                        <string>48</string>
-                        <string>52</string>
-                        <string>57</string>
-                        <string>62</string>
-                  </StringData>
-                  <clef>F</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>33-74</aPitchRange>
-                  <pPitchRange>33-79</pPitchRange>
-                  <Channel name="arco">
-                        <!--MIDI: Bank 0, Prog 42; MS General: Cello-->
-                        <program value="42"/> <!--Cello-->
-                  </Channel>
-                  <Channel name="pizzicato">
-                        <!--MIDI: Bank 0, Prog 45; MS General: Strings Pizzicato-->
-                        <program value="45"/> <!--Pizzicato Strings-->
-                  </Channel>
-                  <Channel name="tremolo">
-                        <!--MIDI: Bank 0, Prog 44; MS General: Strings Tremolo-->
-                        <program value="44"/> <!--Tremolo Strings-->
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
             <Instrument id="violone">
+                  <family>viols</family>
                   <longName>Violone</longName>
                   <shortName>Vne.</shortName>
-                  <description>Violone</description>
+                  <description>Large viol with lowest string tuned to G (written in C, non-transposing).</description>
                   <musicXMLid>strings.viol.violone</musicXMLid>
                   <StringData>
                         <frets>13</frets>
@@ -12677,9 +13025,10 @@
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="d-violone">
+                  <family>viols</family>
                   <longName>D Violone</longName>
                   <shortName>D Vne.</shortName>
-                  <description>Violone</description>
+                  <description>Large viol with lowest string tuned to D (written in C, non-transposing).</description>
                   <musicXMLid>strings.viol.violone</musicXMLid>
                   <StringData>
                         <frets>13</frets>
@@ -12707,6 +13056,85 @@
                         <program value="44"/> <!--Tremolo Strings-->
                   </Channel>
                   <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="octobass">
+                  <family>octobasses</family>
+                  <longName>Octobass</longName>
+                  <shortName>Otb.</shortName>
+                  <description>Octobass</description>
+                  <musicXMLid>strings.octobass</musicXMLid>
+                  <transposingClef>F</transposingClef>
+                  <concertClef>F15mb</concertClef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>21-31</aPitchRange>
+                  <pPitchRange>12-33</pPitchRange>
+                  <transposeDiatonic>-14</transposeDiatonic>
+                  <transposeChromatic>-24</transposeChromatic>
+                  <Channel name="arco">
+                        <!--MIDI: Bank 0, Prog 43; MS General: Contrabass-->
+                        <program value="43"/> <!--Contrabass-->
+                  </Channel>
+                  <Channel name="pizzicato">
+                        <!--MIDI: Bank 0, Prog 32; MS General: Acoustic Bass-->
+                        <program value="32"/> <!--Acoustic Bass-->
+                  </Channel>
+                  <Channel name="tremolo">
+                        <!--MIDI: Bank 0, Prog 44; MS General: Strings Tremolo-->
+                        <program value="44"/> <!--Tremolo Strings-->
+                  </Channel>
+            </Instrument>
+            <Instrument id="erhu">
+                  <family>erhus</family>
+                  <longName>Erhu</longName>
+                  <shortName>Eh.</shortName>
+                  <description>Erhu</description>
+                  <musicXMLid>strings.erhu</musicXMLid>
+                  <StringData>
+                        <frets>24</frets>
+                        <string>62</string>
+                        <string>69</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>62-93</aPitchRange>
+                  <pPitchRange>62-105</pPitchRange>
+                  <Channel name="arco">
+                        <!--MIDI: Bank 0, Prog 110; MS General: Fiddle-->
+                        <program value="110"/> <!--Fiddle-->
+                  </Channel>
+                  <Channel name="pizzicato">
+                        <!--MIDI: Bank 0, Prog 45; MS General: Strings Pizzicato-->
+                        <program value="45"/> <!--Pizzicato Strings-->
+                  </Channel>
+                  <Channel name="tremolo">
+                        <!--MIDI: Bank 0, Prog 44; MS General: Strings Tremolo-->
+                        <program value="44"/> <!--Tremolo Strings-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="nyckelharpa">
+                  <family>nyckelharpas</family>
+                  <longName>Nyckelharpa</longName>
+                  <shortName>Nyh.</shortName>
+                  <description>Nyckelharpa</description>
+                  <musicXMLid>strings.nyckelharpa</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>48-79</aPitchRange>
+                  <pPitchRange>48-93</pPitchRange>
+                  <Channel name="arco">
+                        <!--MIDI: Bank 0, Prog 41; MS General: Viola-->
+                        <program value="41"/> <!--Viola-->
+                  </Channel>
+                  <Channel name="pizzicato">
+                        <!--MIDI: Bank 0, Prog 45; MS General: Strings Pizzicato-->
+                        <program value="45"/> <!--Pizzicato Strings-->
+                  </Channel>
+                  <Channel name="tremolo">
+                        <!--MIDI: Bank 0, Prog 44; MS General: Strings Tremolo-->
+                        <program value="44"/> <!--Tremolo Strings-->
+                  </Channel>
+                  <genre>world</genre>
             </Instrument>
       </InstrumentGroup>
 </museScore>

--- a/share/instruments/update_instruments_xml.py
+++ b/share/instruments/update_instruments_xml.py
@@ -7,10 +7,6 @@ import requests
 import sys
 import xml.etree.ElementTree as ET
 
-parser = argparse.ArgumentParser(description='Fetch the latest spreadsheet and generate instruments.xml.')
-parser.add_argument('-c', '--cached', action='store_true', help='Use cached version instead of downloading')
-args = parser.parse_args()
-
 spreadsheet_id = '1SwqZb8lq5rfv5regPSA10drWjUAoi65EuMoYtG-4k5s'
 
 sheet_ids = {
@@ -27,6 +23,11 @@ sheet_ids = {
     'GM+GS_Percussion':         '1216482735',
 }
 
+parser = argparse.ArgumentParser(description='Fetch the latest spreadsheet and generate instruments.xml.')
+parser.add_argument('-c', '--cached', action='store_true', help='Use cached version instead of downloading')
+parser.add_argument('-d', '--download', action='append', choices=sheet_ids.keys(), help='Override cached option for a specific sheet')
+args = parser.parse_args()
+
 null='[null]' # value used in TSV when attributes or tags are to be omitted in XML
 list_sep=';' # character used as separator in TSV when a cell contains multiple values
 
@@ -36,7 +37,7 @@ def eprint(*args, **kwargs):
 def download_google_spreadsheet(sheet):
     assert sheet in sheet_ids.keys()
     path = 'tsv/download/{sheet}.tsv'.format(sheet=sheet)
-    if args.cached and os.path.isfile(path):
+    if args.cached and os.path.isfile(path) and (args.download is None or sheet not in args.download):
         eprint('Using cached spreadsheet:', path)
     else:
         eprint('Downloading spreadsheet: ', sheet)
@@ -159,12 +160,20 @@ for group in groups.values():
     for instrument in instruments[group['id']].values():
         el = ET.SubElement(g_el, 'Instrument')
         to_attribute(el, instrument, 'id')
+        to_subelement(el, instrument, 'init') # must be first subelement
         to_subelement(el, instrument, 'family')
         to_comment(el, instrument, 'comment')
         to_subelement(el, instrument, 'trackName')
         to_subelement(el, instrument, 'longName')
         to_subelement(el, instrument, 'shortName')
-        to_subelement(el, instrument, 'init')
+        # if instrument["ddName"] != '[hide]':
+        #     to_subelement(el, instrument, 'trackName')
+        #     to_subelement(el, instrument, 'longName')
+        #     to_subelement(el, instrument, 'shortName')
+        #     if instrument["ddName"]:
+        #         dd_el = ET.SubElement(el, 'dropdownName')
+        #         dd_el.text = instrument["ddName"]
+        #         to_attribute(dd_el, instrument, 'ddMeaning', 'meaning')
         to_subelement(el, instrument, 'description')
         to_subelement(el, instrument, 'musicXMLid')
 

--- a/src/engraving/libmscore/instrtemplate.cpp
+++ b/src/engraving/libmscore/instrtemplate.cpp
@@ -706,18 +706,28 @@ InstrumentTemplate* searchTemplateForMusicXmlId(const QString& mxmlId)
 
 InstrumentTemplate* searchTemplateForInstrNameList(const QList<QString>& nameList)
 {
+    InstrumentTemplate* bestMatch = nullptr; // default if no matches
+    int bestMatchStrength = 0; // higher for better matches
     for (InstrumentGroup* g : qAsConst(instrumentGroups)) {
         for (InstrumentTemplate* it : qAsConst(g->instrumentTemplates)) {
             for (const QString& name : nameList) {
-                if (it->trackName == name
-                    || it->longNames.contains(StaffName(name))
-                    || it->shortNames.contains(StaffName(name))) {
-                    return it;
+                int matchStrength = 0
+                                    + (4 * (it->trackName == name)) // most weight to track name since there are fewer duplicates
+                                    + (2 * it->longNames.contains(StaffName(name)))
+                                    + (1 * it->shortNames.contains(StaffName(name))); // least weight to short name
+                const int perfectMatchStrength = 7;
+                Q_ASSERT(matchStrength <= perfectMatchStrength);
+                if (matchStrength > bestMatchStrength) {
+                    bestMatch = it;
+                    bestMatchStrength = matchStrength;
+                    if (bestMatchStrength == perfectMatchStrength) {
+                        break; // stop looking for matches
+                    }
                 }
             }
         }
     }
-    return nullptr;
+    return bestMatch; // nullptr if no matches found
 }
 
 InstrumentTemplate* searchTemplateForMidiProgram(int midiProgram, const bool useDrumSet)

--- a/src/engraving/libmscore/instrument.cpp
+++ b/src/engraving/libmscore/instrument.cpp
@@ -1730,31 +1730,53 @@ void Instrument::updateInstrumentId()
     // because there are multiple instrument using this same id.
     // For these instruments, use the value of controller 32 of the "arco"
     // channel to find the correct instrument.
+    // There are some duplicate MusicXML IDs among other instruments too. In
+    // that case we check the pitch range and use the shortest ID that matches.
     const QString arco = QString("arco");
     const bool groupHack = instrumentId() == QString("strings.group");
     const int idxref = channelIdx(arco);
     const int val32ref = (idxref < 0) ? -1 : channel(idxref)->bank();
     QString fallback;
+    int bestMatchStrength = 0; // higher when fallback ID provides better match for instrument data
 
     for (InstrumentGroup* g : qAsConst(instrumentGroups)) {
         for (InstrumentTemplate* it : qAsConst(g->instrumentTemplates)) {
-            if (it->musicXMLid == instrumentId()) {
-                if (groupHack) {
-                    if (fallback.isEmpty()) {
-                        // Instrument "Strings" doesn't have bank defined so
-                        // if no "strings.group" instrument with requested bank
-                        // is found, assume "Strings".
-                        fallback = it->id;
+            if (it->musicXMLid != instrumentId()) {
+                continue;
+            }
+            if (groupHack) {
+                if (fallback.isEmpty()) {
+                    // Instrument "Strings" doesn't have bank defined so
+                    // if no "strings.group" instrument with requested bank
+                    // is found, assume "Strings".
+                    fallback = it->id;
+                }
+                foreach (const Channel& chan, it->channel) {
+                    if ((chan.name() == arco) && (chan.bank() == val32ref)) {
+                        _id = it->id;
+                        return;
                     }
-                    for (const Channel& chan : it->channel) {
-                        if ((chan.name() == arco) && (chan.bank() == val32ref)) {
-                            _id = it->id;
-                            return;
-                        }
+                }
+            } else {
+                int matchStrength = 0
+                                    + (minPitchP() == it->minPitchP)
+                                    + (minPitchA() == it->minPitchA)
+                                    + (maxPitchA() == it->maxPitchA)
+                                    + (maxPitchP() == it->maxPitchP);
+                const int perfectMatchStrength = 4;
+                Q_ASSERT(matchStrength <= perfectMatchStrength);
+                if (fallback.isEmpty() || matchStrength > bestMatchStrength) {
+                    // Set a fallback ID or update it because we've found a better one.
+                    fallback = it->id;
+                    bestMatchStrength = matchStrength;
+                    if (bestMatchStrength == perfectMatchStrength) {
+                        break; // stop looking for matches
                     }
-                } else {
-                    _id = it->id;
-                    return;
+                } else if ((matchStrength == bestMatchStrength) && (it->id.length() < fallback.length())) {
+                    // Update fallback ID because we've found a shorter one that is equally good.
+                    // Shorter IDs tend to correspond to more generic instruments (e.g. "piano"
+                    // vs. "grand-piano") so it's better to use a shorter one if unsure.
+                    fallback = it->id;
                 }
             }
         }


### PR DESCRIPTION
Run share/instruments/update_instruments_xml.py to fetch the latest version of the online spreadsheet. In this version, every instrument has been assigned a family. Also, instruments are now sorted based on their group, family and minimum professional pitch, among other things. This ensures they appear roughly in score order according to standard orchestral layout. Finally, descriptions have been improved and a few small fixed made to fix incorrect or missing data.

In addition, some compatibility code was changed to improve instrument recognition in older MSCX score files that lack the appropriate MuseScore or MusicXML instrument IDs. The old code returned the *first* instrument that matched a given criteria (e.g. same trackName), whereas the new code returns the instrument that gives the *best* match according to multiple criteria. This means the return value is less dependent on the order in which instruments are defined within instruments.xml.