### PR TITLE
[MU4] fix #7633 - ensure that adding elements from palette in search mode works

### DIFF
--- a/src/palette/internal/palette/paletteworkspace.cpp
+++ b/src/palette/internal/palette/paletteworkspace.cpp
@@ -661,6 +661,7 @@ void PaletteWorkspace::setSearching(bool searching)
     m_searching = searching;
 
     mainPalette = nullptr;
+    mainPaletteController = nullptr;
     emit mainPaletteChanged();
 }
 
@@ -684,7 +685,6 @@ AbstractPaletteController* PaletteWorkspace::getMainPaletteController()
     if (!mainPaletteController) {
         mainPaletteController = new UserPaletteController(mainPaletteModel(), userPalette, this);
     }
-//             mainPaletteController = new PaletteController(mainPaletteModel(), this, this);
     return mainPaletteController;
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/7633

The issue reported was originally around searching not displaying the expected palette items but while that seems OK now, adding items to the score when in search mode wasn't working

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
