### PR TITLE
Fix some compiler warnings

### DIFF
--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -85,6 +85,7 @@
 #include "tremolo.h"
 #include "rehearsalmark.h"
 #include "sym.h"
+#include "log.h"
 
 using namespace mu;
 
@@ -273,13 +274,14 @@ void Score::undoRedo(bool undo, EditData* ed)
 ///   and (always) updating the redraw area.
 //---------------------------------------------------------
 
-void Score::endCmd(const bool isCmdFromInspector, bool rollback)
+void Score::endCmd(bool rollback)
 {
     if (!undoStack()->active()) {
-        qDebug("Score::endCmd(): no cmd active");
+        LOGW() << "no command active";
         update();
         return;
     }
+
     if (readOnly() || MScore::_error != MsError::MS_NO_ERROR) {
         rollback = true;
     }
@@ -290,16 +292,16 @@ void Score::endCmd(const bool isCmdFromInspector, bool rollback)
 
     update(false);
 
-    if (MScore::debugMode) {
-        qDebug("===endCmd() %d", undoStack()->current()->childCount());
-    }
-    const bool noUndo = undoStack()->current()->empty();         // nothing to undo?
+    LOGD() << "Undo stack current macro child count: " << undoStack()->current()->childCount();
+
+    const bool noUndo = undoStack()->current()->empty(); // nothing to undo?
     undoStack()->endMacro(noUndo);
 
     if (dirty()) {
-        masterScore()->setPlaylistDirty();      // TODO: flag individual operations
+        masterScore()->setPlaylistDirty(); // TODO: flag individual operations
         masterScore()->setAutosaveDirty(true);
     }
+
     cmdState().reset();
 }
 

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -805,8 +805,8 @@ public:
     bool checkTimeDelete(Segment*, Segment*);
     void timeDelete(Measure*, Segment*, const Fraction&);
 
-    void startCmd();                            // start undoable command
-    void endCmd(const bool isCmdFromInspector = false, bool rollback = false);       // end undoable command
+    void startCmd();                    // start undoable command
+    void endCmd(bool rollback = false); // end undoable command
     void update() { update(true); }
     void undoRedo(bool undo, EditData*);
 

--- a/src/framework/uicomponents/view/itemmultiselectionmodel.h
+++ b/src/framework/uicomponents/view/itemmultiselectionmodel.h
@@ -34,6 +34,8 @@ public:
 
     void setAllowedModifiers(Qt::KeyboardModifiers modifiers);
 
+    using QItemSelectionModel::select;
+
 public slots:
     Q_INVOKABLE void select(const QModelIndex& index);
 

--- a/src/learn/learnmodule.h
+++ b/src/learn/learnmodule.h
@@ -25,7 +25,7 @@
 #include "modularity/imodulesetup.h"
 
 namespace mu::learn {
-class LearnModule : public framework::IModuleSetup
+class LearnModule : public modularity::IModuleSetup
 {
 public:
     std::string moduleName() const override;

--- a/src/notation/internal/notationundostack.cpp
+++ b/src/notation/internal/notationundostack.cpp
@@ -106,7 +106,7 @@ void NotationUndoStack::rollbackChanges()
         return;
     }
 
-    score()->endCmd(false, true);
+    score()->endCmd(true);
     masterScore()->setSaved(isStackClean());
 
     notifyAboutStateChanged();

--- a/src/plugins/api/qmlpluginapi.h
+++ b/src/plugins/api/qmlpluginapi.h
@@ -281,7 +281,7 @@ public:
     Q_INVOKABLE Ms::PluginAPI::FractionWrapper* fraction(int numerator, int denominator) const;
 
 protected:
-    virtual MuseScoreCore* msc() const;
+    virtual MuseScoreCore* msc() const override;
 };
 
 #undef DECLARE_API_ENUM

--- a/src/stubs/learn/learnmodule.h
+++ b/src/stubs/learn/learnmodule.h
@@ -25,7 +25,7 @@
 #include "modularity/imodulesetup.h"
 
 namespace mu::learn {
-class LearnModule : public framework::IModuleSetup
+class LearnModule : public modularity::IModuleSetup
 {
 public:
     std::string moduleName() const override;

--- a/src/workspace/internal/workspace.h
+++ b/src/workspace/internal/workspace.h
@@ -33,6 +33,7 @@ namespace mu::workspace {
 class Workspace : public IWorkspace
 {
     INJECT(workspace, mi::IMultiInstancesProvider, multiInstancesProvider)
+
 public:
     Workspace(const io::path& filePath);
 
@@ -51,9 +52,7 @@ public:
     Ret save();
 
 private:
-
     WorkspaceFile m_file;
-    bool m_hasUnsavedChanges = false;
 };
 
 using WorkspacePtr = std::shared_ptr<Workspace>;


### PR DESCRIPTION
NOTE: please review if the changes in the third commit will work correctly together with scorefile.cpp:279. 
I have a feeling that these changes _fix_ a bug there, but I'm not 100% sure. In MU3, there was no `isCmdFromInspector` parameter, and the code in scorefile.cpp is the same as in MU4, so that makes me assume that it was a bug in MU4. 