### PR TITLE
[MU3 Backend] Make dynList const

### DIFF
--- a/libmscore/dynamic.h
+++ b/libmscore/dynamic.h
@@ -36,7 +36,7 @@ struct Dyn {
 
 // variant with ligatures, works for both emmentaler and bravura:
 
-static Dyn dynList[] = {
+static const Dyn dynList[] = {
       // dynamic:
       {  -1,  true,  "other-dynamics", "", 0 },
       {   1,  false, "pppppp", "<sym>dynamicPiano</sym><sym>dynamicPiano</sym><sym>dynamicPiano</sym><sym>dynamicPiano</sym><sym>dynamicPiano</sym><sym>dynamicPiano</sym>", 0 },


### PR DESCRIPTION
Resolves: Compiler warnings from #8347

See discussion in the above-mentioned PR. This simple fix avoids some compiler warnings without any evident regressions.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
