### PR TITLE
[MU3 Backend] Fix more compiler warnings

### DIFF
--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -4347,6 +4347,9 @@ void ExportMusicXml::pedal(Pedal const* const pd, int staff, const Fraction& tic
                               pedalType = "resume";
                               break;
                               }
+                        else {
+                              // FALLTHROUGH
+                              }
                   default:
                         pedalType = "start";
                   }

--- a/importexport/musicxml/importmxmlpass1.cpp
+++ b/importexport/musicxml/importmxmlpass1.cpp
@@ -1101,11 +1101,12 @@ void MusicXMLParserPass1::identification()
             else if (_e.name() == "encoding") {
                   // TODO
                   while (_e.readNextStartElement()) {
-                        if (_e.name() == "supports" )
+                        if (_e.name() == "supports" ) {
                               if (_e.attributes().value("element") == "beam" && _e.attributes().value("type") == "yes")
                                     _hasBeamingInfo = true;
                               else if (_e.attributes().value("element") == "transpose")
                                     _supportsTranspose = _e.attributes().value("type").toString();
+                              }
                         _e.skipCurrentElement();
                         }
                   // _score->setMetaTag("encoding", _e.readElementText()); works with DOM but not with pull parser

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -2993,7 +2993,7 @@ MusicXMLInferredFingering::MusicXMLInferredFingering(qreal totalY,
                                                      QString placement,
                                                      Measure* measure,
                                                      Fraction tick)
-      : _totalY(totalY),  _text(text), _element(element), _track(track), _placement(placement), _measure(measure), _tick(tick)
+      : _totalY(totalY), _element(element), _text(text), _track(track), _placement(placement), _measure(measure), _tick(tick)
       {
       _fingerings = _text.simplified().split(" ");
       }


### PR DESCRIPTION
Resolves: Further compiler warnings mentioned in #8275, #8358, and #8298

This commit adds a // FALLTHROUGH in exportxml.cpp and adds missing
brackets in importmxmlpass1.cpp, and reorders an initializer list,
both for clarity and to remedy compiler warnings.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
