### PR TITLE
[MU4] audio_refactoring_p4

### DIFF
--- a/src/framework/audio/audiotypes.h
+++ b/src/framework/audio/audiotypes.h
@@ -79,6 +79,12 @@ struct VolumePressureDbfsBoundaries {
     volume_dbfs_t max = 0;
     volume_dbfs_t min = -60;
 };
+
+enum class PlaybackStatus {
+    Stopped = 0,
+    Paused,
+    Running
+};
 }
 
 #endif // MU_AUDIO_AUDIOTYPES_H

--- a/src/framework/audio/devtools/waveformmodel.cpp
+++ b/src/framework/audio/devtools/waveformmodel.cpp
@@ -38,7 +38,7 @@ WaveFormModel::WaveFormModel(QObject* parent)
         if (pressure < MIN_DISPLAYED_DBFS) {
             setCurrentVolumePressure(MIN_DISPLAYED_DBFS);
         } else if (pressure > MAX_DISPLAYED_DBFS) {
-            setCurrentVolumePressure(MIN_DISPLAYED_DBFS);
+            setCurrentVolumePressure(MAX_DISPLAYED_DBFS);
         } else {
             setCurrentVolumePressure(pressure);
         }

--- a/src/framework/audio/devtools/waveformmodel.h
+++ b/src/framework/audio/devtools/waveformmodel.h
@@ -28,6 +28,7 @@
 #include "modularity/ioc.h"
 #include "async/asyncable.h"
 
+#include "iaudiooutput.h"
 #include "iplayback.h"
 
 namespace mu::audio {

--- a/src/framework/audio/internal/worker/audioengine.cpp
+++ b/src/framework/audio/internal/worker/audioengine.cpp
@@ -127,14 +127,14 @@ IAudioBufferPtr AudioEngine::buffer() const
 
 IMixerPtr AudioEngine::mixer() const
 {
-    ONLY_AUDIO_MAIN_OR_WORKER_THREAD;
+    ONLY_AUDIO_WORKER_THREAD;
 
     return m_mixer;
 }
 
 void AudioEngine::setMixer(IMixerPtr mixerPtr)
 {
-    ONLY_AUDIO_MAIN_OR_WORKER_THREAD;
+    ONLY_AUDIO_WORKER_THREAD;
 
     m_mixer = mixerPtr;
 }

--- a/src/framework/audio/internal/worker/audioengine.h
+++ b/src/framework/audio/internal/worker/audioengine.h
@@ -42,7 +42,7 @@ class AudioEngine : public async::Asyncable
     INJECT(audio, synth::ISoundFontsProvider, soundFontsProvider)
     INJECT(audio, synth::ISynthesizersRegister, synthesizersRegister)
 public:
-    ~AudioEngine();
+    ~AudioEngine() = default;
 
     static AudioEngine* instance();
 

--- a/src/framework/audio/internal/worker/audioengine.h
+++ b/src/framework/audio/internal/worker/audioengine.h
@@ -42,7 +42,7 @@ class AudioEngine : public async::Asyncable
     INJECT(audio, synth::ISoundFontsProvider, soundFontsProvider)
     INJECT(audio, synth::ISynthesizersRegister, synthesizersRegister)
 public:
-    ~AudioEngine() = default;
+    ~AudioEngine();
 
     static AudioEngine* instance();
 

--- a/src/framework/audio/internal/worker/clock.cpp
+++ b/src/framework/audio/internal/worker/clock.cpp
@@ -26,6 +26,11 @@
 using namespace mu;
 using namespace mu::audio;
 
+Clock::Clock()
+{
+    m_status.set(PlaybackStatus::Stopped);
+}
+
 msecs_t Clock::currentTime() const
 {
     return m_time;
@@ -48,7 +53,7 @@ void Clock::forward(const msecs_t nextMsecs)
 
 void Clock::start()
 {
-    m_status = Running;
+    m_status.set(PlaybackStatus::Running);
 }
 
 void Clock::reset()
@@ -59,13 +64,19 @@ void Clock::reset()
 
 void Clock::stop()
 {
-    m_status = Stoped;
+    m_status.set(PlaybackStatus::Stopped);
     seek(0);
 }
 
 void Clock::pause()
 {
-    m_status = Paused;
+    m_status.set(PlaybackStatus::Paused);
+}
+
+void Clock::resume()
+{
+    m_status.set(PlaybackStatus::Running);
+    seek(m_time);
 }
 
 void Clock::seek(const msecs_t msecs)
@@ -95,7 +106,7 @@ void Clock::resetTimeLoop()
 
 bool Clock::isRunning() const
 {
-    return m_status == Running;
+    return m_status.val == PlaybackStatus::Running;
 }
 
 async::Channel<msecs_t> Clock::timeChanged() const
@@ -106,4 +117,9 @@ async::Channel<msecs_t> Clock::timeChanged() const
 async::Notification Clock::seekOccurred() const
 {
     return m_seekOccurred;
+}
+
+async::Channel<PlaybackStatus> Clock::statusChanged() const
+{
+    return m_status.ch;
 }

--- a/src/framework/audio/internal/worker/clock.h
+++ b/src/framework/audio/internal/worker/clock.h
@@ -30,6 +30,8 @@ namespace mu::audio {
 class Clock : public IClock, public async::Asyncable
 {
 public:
+    Clock();
+
     msecs_t currentTime() const override;
 
     void forward(const msecs_t nextMsecs) override;
@@ -38,6 +40,7 @@ public:
     void reset() override;
     void stop() override;
     void pause() override;
+    void resume() override;
     void seek(const msecs_t msecs) override;
 
     Ret setTimeLoop(const msecs_t fromMsec, const msecs_t toMsec) override;
@@ -47,15 +50,11 @@ public:
 
     async::Channel<msecs_t> timeChanged() const override;
     async::Notification seekOccurred() const override;
+    async::Channel<PlaybackStatus> statusChanged() const override;
 
 private:
-    enum Status {
-        Stoped = 0,
-        Paused,
-        Running
-    };
 
-    Status m_status = Stoped;
+    ValCh<PlaybackStatus> m_status;
     msecs_t m_time = 0;
     msecs_t m_timeLoopStart = 0;
     msecs_t m_timeLoopEnd = 0;

--- a/src/framework/audio/internal/worker/iclock.h
+++ b/src/framework/audio/internal/worker/iclock.h
@@ -45,6 +45,7 @@ public:
     virtual void reset() = 0;
     virtual void stop() = 0;
     virtual void pause() = 0;
+    virtual void resume() = 0;
     virtual void seek(const msecs_t msecs) = 0;
 
     virtual Ret setTimeLoop(const msecs_t fromMsec, const msecs_t toMsec) = 0;
@@ -54,6 +55,7 @@ public:
 
     virtual async::Channel<msecs_t> timeChanged() const = 0;
     virtual async::Notification seekOccurred() const = 0;
+    virtual async::Channel<PlaybackStatus> statusChanged() const = 0;
 };
 
 using IClockPtr = std::shared_ptr<IClock>;

--- a/src/framework/audio/internal/worker/isequenceplayer.h
+++ b/src/framework/audio/internal/worker/isequenceplayer.h
@@ -38,11 +38,13 @@ public:
     virtual void seek(const msecs_t newPositionMsecs) = 0;
     virtual void stop() = 0;
     virtual void pause() = 0;
+    virtual void resume() = 0;
 
     virtual Ret setLoop(const msecs_t fromMsec, const msecs_t toMsec) = 0;
     virtual void resetLoop() = 0;
 
     virtual async::Channel<msecs_t> playbackPositionMSecs() const = 0;
+    virtual async::Channel<PlaybackStatus> playbackStatusChanged() const = 0;
 };
 using ISequencePlayerPtr = std::shared_ptr<ISequencePlayer>;
 }

--- a/src/framework/audio/internal/worker/midiaudiosource.h
+++ b/src/framework/audio/internal/worker/midiaudiosource.h
@@ -86,7 +86,7 @@ private:
 
         bool isEmpty() const
         {
-            return m_eventsMap.empty() && endTick == 0;
+            return m_eventsMap.empty();
         }
 
         void reset()
@@ -114,6 +114,8 @@ private:
     void resolveSynth(const synth::SynthName& synthName);
     void buildTempoMap();
     void setupChannels();
+
+    void invalidateCaches(EventsBuffer& eventsBuffer);
 
     bool m_hasActiveRequest = false;
 

--- a/src/framework/audio/internal/worker/playback.cpp
+++ b/src/framework/audio/internal/worker/playback.cpp
@@ -48,6 +48,8 @@ Playback::Playback()
 Promise<TrackSequenceId> Playback::addSequence()
 {
     return Promise<TrackSequenceId>([this](Promise<TrackSequenceId>::Resolve resolve, Promise<TrackSequenceId>::Reject /*reject*/) {
+        ONLY_AUDIO_WORKER_THREAD;
+
         TrackSequenceId newId = m_sequences.size();
 
         m_sequences.emplace(newId, std::make_shared<TrackSequence>(newId));
@@ -60,6 +62,8 @@ Promise<TrackSequenceIdList> Playback::sequenceIdList() const
 {
     return Promise<TrackSequenceIdList>([this](Promise<TrackSequenceIdList>::Resolve resolve,
                                                Promise<TrackSequenceIdList>::Reject /*reject*/) {
+        ONLY_AUDIO_WORKER_THREAD;
+
         TrackSequenceIdList result(m_sequences.size());
 
         for (const auto& pair : m_sequences) {
@@ -85,16 +89,22 @@ void Playback::removeSequence(const TrackSequenceId id)
 
 IPlayerPtr Playback::player() const
 {
+    ONLY_AUDIO_MAIN_OR_WORKER_THREAD;
+
     return m_playerHandlersPtr;
 }
 
 ITracksPtr Playback::tracks() const
 {
+    ONLY_AUDIO_MAIN_OR_WORKER_THREAD;
+
     return m_trackHandlersPtr;
 }
 
 IAudioOutputPtr Playback::audioOutput() const
 {
+    ONLY_AUDIO_MAIN_OR_WORKER_THREAD;
+
     return m_audioOutputPtr;
 }
 

--- a/src/framework/audio/internal/worker/playerhandler.h
+++ b/src/framework/audio/internal/worker/playerhandler.h
@@ -39,11 +39,13 @@ public:
     void seek(const TrackSequenceId sequenceId, const msecs_t newPositionMsecs) override;
     void stop(const TrackSequenceId sequenceId) override;
     void pause(const TrackSequenceId sequenceId) override;
+    void resume(const TrackSequenceId sequenceId) override;
 
     async::Promise<bool> setLoop(const TrackSequenceId sequenceId, const msecs_t fromMsec, const msecs_t toMsec) override;
     void resetLoop(const TrackSequenceId sequenceId) override;
 
     async::Channel<TrackSequenceId, msecs_t> playbackPositionMsecs() const override;
+    async::Channel<TrackSequenceId, PlaybackStatus> playbackStatusChanged() const override;
 
 private:
     ITrackSequencePtr sequence(const TrackSequenceId id) const;
@@ -52,6 +54,7 @@ private:
     IGetTrackSequence* m_getSequence = nullptr;
 
     mutable async::Channel<TrackSequenceId, msecs_t> m_playbackPositionMsecsChanged;
+    mutable async::Channel<TrackSequenceId, PlaybackStatus> m_playbackStatusChanged;
 };
 }
 

--- a/src/framework/audio/internal/worker/sequenceplayer.cpp
+++ b/src/framework/audio/internal/worker/sequenceplayer.cpp
@@ -84,6 +84,17 @@ void SequencePlayer::pause()
     }
 }
 
+void SequencePlayer::resume()
+{
+    ONLY_AUDIO_WORKER_THREAD;
+
+    m_clock->resume();
+
+    for (auto& pair : tracks()) {
+        pair.second->audioSource->setIsActive(true);
+    }
+}
+
 Ret SequencePlayer::setLoop(const msecs_t fromMsec, const msecs_t toMsec)
 {
     ONLY_AUDIO_WORKER_THREAD;
@@ -103,6 +114,13 @@ Channel<msecs_t> SequencePlayer::playbackPositionMSecs() const
     ONLY_AUDIO_WORKER_THREAD;
 
     return m_clock->timeChanged();
+}
+
+Channel<PlaybackStatus> SequencePlayer::playbackStatusChanged() const
+{
+    ONLY_AUDIO_WORKER_THREAD;
+
+    return m_clock->statusChanged();
 }
 
 TracksMap SequencePlayer::tracks() const

--- a/src/framework/audio/internal/worker/sequenceplayer.h
+++ b/src/framework/audio/internal/worker/sequenceplayer.h
@@ -39,11 +39,13 @@ public:
     void seek(const msecs_t newPositionMsecs) override;
     void stop() override;
     void pause() override;
+    void resume() override;
 
     Ret setLoop(const msecs_t fromMsec, const msecs_t toMsec) override;
     void resetLoop() override;
 
     async::Channel<msecs_t> playbackPositionMSecs() const override;
+    async::Channel<PlaybackStatus> playbackStatusChanged() const override;
 
 private:
     TracksMap tracks() const;

--- a/src/framework/audio/iplayback.h
+++ b/src/framework/audio/iplayback.h
@@ -26,7 +26,6 @@
 #include "async/channel.h"
 #include "async/promise.h"
 
-
 #include "audiotypes.h"
 
 namespace mu::audio {

--- a/src/framework/audio/iplayback.h
+++ b/src/framework/audio/iplayback.h
@@ -26,12 +26,14 @@
 #include "async/channel.h"
 #include "async/promise.h"
 
-#include "iplayer.h"
-#include "itracks.h"
-#include "iaudiooutput.h"
+
 #include "audiotypes.h"
 
 namespace mu::audio {
+class ITracks;
+class IPlayer;
+class IAudioOutput;
+
 class IPlayback : MODULE_EXPORT_INTERFACE
 {
     INTERFACE_ID(IPlayback)
@@ -47,13 +49,13 @@ public:
     virtual void removeSequence(const TrackSequenceId id) = 0;
 
     // 2. Setup tracks for Sequence
-    virtual ITracksPtr tracks() const = 0;
+    virtual std::shared_ptr<ITracks> tracks() const = 0;
 
     // 3. Play Sequence
-    virtual IPlayerPtr player() const = 0;
+    virtual std::shared_ptr<IPlayer> player() const = 0;
 
     // 4. Adjust a Sequence output
-    virtual IAudioOutputPtr audioOutput() const = 0;
+    virtual std::shared_ptr<IAudioOutput> audioOutput() const = 0;
 };
 
 using IPlaybackPtr = std::shared_ptr<IPlayback>;

--- a/src/framework/audio/iplayer.h
+++ b/src/framework/audio/iplayer.h
@@ -40,11 +40,13 @@ public:
     virtual void seek(const TrackSequenceId sequenceId, const msecs_t newPositionMsecs) = 0;
     virtual void stop(const TrackSequenceId sequenceId) = 0;
     virtual void pause(const TrackSequenceId sequenceId) = 0;
+    virtual void resume(const TrackSequenceId sequenceId) = 0;
 
     virtual async::Promise<bool> setLoop(const TrackSequenceId sequenceId, const msecs_t fromMsec, const msecs_t toMsec) = 0;
     virtual void resetLoop(const TrackSequenceId sequenceId) = 0;
 
     virtual async::Channel<TrackSequenceId, msecs_t> playbackPositionMsecs() const = 0;
+    virtual async::Channel<TrackSequenceId, PlaybackStatus> playbackStatusChanged() const = 0;
 };
 
 using IPlayerPtr = std::shared_ptr<IPlayer>;

--- a/src/notation/internal/notationmidievents.cpp
+++ b/src/notation/internal/notationmidievents.cpp
@@ -78,7 +78,7 @@ std::vector<Event> NotationMidiEvents::retrieveSetupEvents(const std::list<Instr
     for (const InstrumentChannel* instrChannel : instrChannels) {
         Event e;
 
-        e.setMessageType(Event::MessageType::ChannelVoice20);
+        e.setMessageType(Event::MessageType::ChannelVoice10);
         e.setOpcode(Event::Opcode::ProgramChange);
         e.setProgram(instrChannel->program());
         e.setBank(instrChannel->bank());

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -285,7 +285,7 @@ void PlaybackController::resume()
         return;
     }
 
-    playback()->player()->play(m_currentSequenceId);
+    playback()->player()->resume(m_currentSequenceId);
 
     m_isPlaying = true;
     m_isPlayingChanged.notify();
@@ -486,6 +486,14 @@ void PlaybackController::setCurrentSequence(const TrackSequenceId sequenceId)
 
         setCurrentTick(tick);
         m_tickPlayed.send(std::move(tick));
+    });
+
+    playback()->player()->playbackStatusChanged().onReceive(this, [this](const TrackSequenceId id, const PlaybackStatus status) {
+        if (m_currentSequenceId != id) {
+            return;
+        }
+
+        m_currentPlaybackStatus = status;
     });
 }
 

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -129,6 +129,7 @@ private:
     bool m_isPlaying = false;
 
     audio::TrackSequenceId m_currentSequenceId = -1;
+    audio::PlaybackStatus m_currentPlaybackStatus = audio::PlaybackStatus::Stopped;
     midi::tick_t m_currentTick = 0;
     std::unordered_map<std::string /* score file path*/, audio::TrackSequenceId> m_sequenceIdMap;
     std::unordered_map<notation::INotationPlayback::InstrumentTrackId, audio::TrackId> m_trackIdMap;

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -33,6 +33,8 @@
 #include "notation/notationtypes.h"
 #include "notation/inotationconfiguration.h"
 #include "notation/inotationplayback.h"
+#include "audio/iplayer.h"
+#include "audio/itracks.h"
 #include "audio/iplayback.h"
 #include "audio/audiotypes.h"
 


### PR DESCRIPTION
Various fixes for the audio module

- Some instruments was unplayable because of the conversion from MIDI 2.0 onto MIDI 1.0
- Missing caches invalidation when you press "pause"
- Missing thread markers
- Dependencies from IPlayback facade are more clear now