### PR TITLE
Allow pasting all spanners 

### DIFF
--- a/src/engraving/libmscore/chordrest.cpp
+++ b/src/engraving/libmscore/chordrest.cpp
@@ -639,17 +639,15 @@ Element* ChordRest::drop(EditData& data)
     }
     break;
 
-    case ElementType::HAIRPIN:
-    {
-        Hairpin* hairpin = toHairpin(e);
-        hairpin->setTick(tick());
-        hairpin->setTrack(track());
-        hairpin->setTrack2(track());
-        score()->undoAddElement(hairpin);
-    }
-        return e;
-
     default:
+        if (e->isSpanner()) {
+            Spanner* spanner = toSpanner(e);
+            spanner->setTick(tick());
+            spanner->setTrack(track());
+            spanner->setTrack2(track());
+            score()->undoAddElement(spanner);
+            return e;
+        }
         qDebug("cannot drop %s", e->name());
         delete e;
         return 0;

--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -1981,10 +1981,10 @@ void Score::addNoteLine()
     TextLine* line = new TextLine(this);
     line->setParent(firstNote);
     line->setStartElement(firstNote);
-    line->setEndElement(lastNote);
     line->setDiagonal(true);
     line->setAnchor(Spanner::Anchor::NOTE);
     line->setTick(firstNote->chord()->tick());
+    line->setEndElement(lastNote);
 
     undoAddElement(line);
 }

--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -1854,8 +1854,6 @@ bool Note::acceptDrop(EditData& data) const
            || (type == ElementType::KEYSIG)
            || (type == ElementType::TIMESIG)
            || (type == ElementType::BAR_LINE)
-           || (type == ElementType::SLUR)
-           || (type == ElementType::HAIRPIN)
            || (type == ElementType::STAFF_TEXT)
            || (type == ElementType::SYSTEM_TEXT)
            || (type == ElementType::STICKING)
@@ -1864,7 +1862,8 @@ bool Note::acceptDrop(EditData& data) const
            || (type == ElementType::TREMOLOBAR)
            || (type == ElementType::FRET_DIAGRAM)
            || (type == ElementType::FIGURED_BASS)
-           || (type == ElementType::LYRICS);
+           || (type == ElementType::LYRICS)
+           || e->isSpanner();
 }
 
 //---------------------------------------------------------
@@ -1899,15 +1898,6 @@ Element* Note::drop(EditData& data)
             delete e;
         }
         return 0;
-
-    case ElementType::SLUR:
-        data.view()->addSlur(chord(), nullptr, toSlur(e));
-        delete e;
-        return 0;
-
-    case ElementType::HAIRPIN:
-        // forward this event to a chord
-        return chord()->drop(data);
 
     case ElementType::LYRICS:
         e->setParent(ch);
@@ -2089,6 +2079,17 @@ Element* Note::drop(EditData& data)
     break;
 
     default:
+        Spanner* spanner;
+        if (e->isSpanner() && (spanner = toSpanner(e))->anchor() == Spanner::Anchor::NOTE) {
+            spanner->setParent(this);
+            spanner->setStartElement(this);
+            spanner->setTick(tick());
+            spanner->setTrack(track());
+            spanner->setTrack2(track());
+            spanner->computeEndElement();
+            score()->undoAddElement(spanner);
+            return e;
+        }
         return ch->drop(data);
     }
     return 0;

--- a/src/engraving/libmscore/rest.cpp
+++ b/src/engraving/libmscore/rest.cpp
@@ -176,7 +176,6 @@ bool Rest::acceptDrop(EditData& data) const
         || (type == ElementType::STAFF_STATE)
         || (type == ElementType::INSTRUMENT_CHANGE)
         || (type == ElementType::DYNAMIC)
-        || (type == ElementType::HAIRPIN)
         || (type == ElementType::HARMONY)
         || (type == ElementType::TEMPO_TEXT)
         || (type == ElementType::REHEARSAL_MARK)
@@ -188,7 +187,7 @@ bool Rest::acceptDrop(EditData& data) const
         ) {
         return true;
     }
-    return false;
+    return type != ElementType::SLUR && e->isSpanner();
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/slur.h
+++ b/src/engraving/libmscore/slur.h
@@ -65,14 +65,17 @@ public:
 class Slur final : public SlurTie
 {
     void slurPosChord(SlurPos*);
+    int _sourceStemArrangement = -1;
 
 public:
     Slur(Score* = 0);
+    Slur(const Slur&);
     ~Slur() {}
 
     Slur* clone() const override { return new Slur(*this); }
     ElementType type() const override { return ElementType::SLUR; }
     void write(XmlWriter& xml) const override;
+    bool readProperties(XmlReader&) override;
     void layout() override;
     SpannerSegment* layoutSystem(System*) override;
     void setTrack(int val) override;

--- a/src/engraving/libmscore/slurtie.cpp
+++ b/src/engraving/libmscore/slurtie.cpp
@@ -383,7 +383,7 @@ void SlurTieSegment::read(XmlReader& e)
             ups(Grip::BEZIER2).off = e.readPoint() * _spatium;
         } else if (tag == "o4") {
             ups(Grip::END).off = e.readPoint() * _spatium;
-        } else if (!Element::readProperties(e)) {
+        } else if (!readProperties(e)) {
             e.unknown();
         }
     }
@@ -460,7 +460,7 @@ SlurTie::~SlurTie()
 
 void SlurTie::writeProperties(XmlWriter& xml) const
 {
-    Element::writeProperties(xml);
+    Spanner::writeProperties(xml);
     int idx = 0;
     for (const SpannerSegment* ss : spannerSegments()) {
         ((SlurTieSegment*)ss)->writeSlur(xml, idx++);
@@ -489,7 +489,7 @@ bool SlurTie::readProperties(XmlReader& e)
         SlurTieSegment* s = newSlurTieSegment();
         s->read(e);
         add(s);
-    } else if (!Element::readProperties(e)) {
+    } else if (!Spanner::readProperties(e)) {
         return false;
     }
     return true;
@@ -501,11 +501,7 @@ bool SlurTie::readProperties(XmlReader& e)
 
 void SlurTie::read(XmlReader& e)
 {
-    while (e.readNextStartElement()) {
-        if (!SlurTie::readProperties(e)) {
-            e.unknown();
-        }
-    }
+    Spanner::read(e);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -1668,10 +1668,10 @@ TextBase::TextBase(Score* s, ElementFlags f)
 TextBase::TextBase(const TextBase& st)
     : Element(st)
 {
-    _cursor                      = st._cursor;
+    _cursor                      = new TextCursor(this);
     _text                        = st._text;
-    _layout                      = st._layout;
     textInvalid                  = st.textInvalid;
+    _layout                      = st._layout;
     layoutInvalid                = st.layoutInvalid;
     frame                        = st.frame;
     _layoutToParentWidth         = st._layoutToParentWidth;
@@ -1694,6 +1694,11 @@ TextBase::TextBase(const TextBase& st)
         _propertyFlagsList[i] = st._propertyFlagsList[i];
     }
     _links = 0;
+}
+
+TextBase::~TextBase()
+{
+    delete _cursor;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/textbase.h
+++ b/src/engraving/libmscore/textbase.h
@@ -302,6 +302,7 @@ public:
     TextBase(Score* = 0, Tid tid = Tid::DEFAULT, ElementFlags = ElementFlag::NOTHING);
     TextBase(Score*, ElementFlags);
     TextBase(const TextBase&);
+    ~TextBase();
 
     virtual bool mousePress(EditData&) override;
 

--- a/src/engraving/libmscore/textlinebase.cpp
+++ b/src/engraving/libmscore/textlinebase.cpp
@@ -56,8 +56,8 @@ TextLineBaseSegment::TextLineBaseSegment(Spanner* sp, Score* score, ElementFlags
 TextLineBaseSegment::TextLineBaseSegment(const TextLineBaseSegment& seg)
     : LineSegment(seg)
 {
-    _text    = new Text(*seg._text);
-    _endText = new Text(*seg._endText);
+    _text    = seg._text->clone();
+    _endText = seg._endText->clone();
     _text->setParent(this);
     _endText->setParent(this);
     layout();      // set the right _text


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/2861

The behavior when cutting/copying lines (spanners) to the clipboard and pasting was very inconsistent for no good reason - basically only hairpins worked as expected. There are still some points for discussion here and some things that don't quite work as well as they could but it's a vast improvement on the current arbitrary limitations. Largely this involved getting rid of a lot of special case logic, though some had to be re-instated for slurs and note-anchored lines.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
