### PR TITLE
Fix MusicXML export tests

### DIFF
--- a/src/importexport/musicxml/tests/data/testCueNotes2_ref.xml
+++ b/src/importexport/musicxml/tests/data/testCueNotes2_ref.xml
@@ -155,11 +155,11 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
-        </note>
         <lyric number="1">
           <syllabic>single</syllabic>
           <text>cue</text>
           </lyric>
+        </note>
       <note>
         <cue/>
         <pitch>
@@ -189,7 +189,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>1</duration>
+        <duration>2</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>

--- a/src/importexport/musicxml/tests/data/testInstrumentChangeMIDIportExport_ref.xml
+++ b/src/importexport/musicxml/tests/data/testInstrumentChangeMIDIportExport_ref.xml
@@ -1062,7 +1062,7 @@
     <measure number="2">
       <direction placement="above">
         <direction-type>
-          <words font-weight="bold">Voice</words>
+          <words font-weight="bold" font-size="12">Voice</words>
           </direction-type>
         <staff>1</staff>
         </direction>

--- a/src/importexport/musicxml/tests/testbase.cpp
+++ b/src/importexport/musicxml/tests/testbase.cpp
@@ -51,16 +51,15 @@ MasterScore* MTest::readScore(const QString& name)
 
 MasterScore* MTest::readCreatedScore(const QString& name)
 {
-    QString path = root + "/" + name;
     MasterScore* score = new MasterScore(mscore->baseStyle());
-    QFileInfo fi(path);
+    QFileInfo fi(name);
     score->setName(fi.completeBaseName());
     QString csl  = fi.suffix().toLower();
 
     ScoreLoad sl;
     Score::FileError rv;
     if (csl == "mscz" || csl == "mscx") {
-        rv = score->loadMsc(path, false);
+        rv = score->loadMsc(name, false);
     } else if (csl == "xml" || csl == "musicxml") {
         rv = importMusicXml(score, name);
     } else if (csl == "mxl") {
@@ -70,7 +69,7 @@ MasterScore* MTest::readCreatedScore(const QString& name)
     }
 
     if (rv != Score::FileError::FILE_NO_ERROR) {
-        QWARN(qPrintable(QString("readScore: cannot load <%1> type <%2>\n").arg(path).arg(csl)));
+        QWARN(qPrintable(QString("readScore: cannot load <%1> type <%2>\n").arg(name).arg(csl)));
         delete score;
         score = 0;
     } else {

--- a/src/importexport/musicxml/tests/tst_mxml_io.cpp
+++ b/src/importexport/musicxml/tests/tst_mxml_io.cpp
@@ -87,7 +87,7 @@ private slots:
     void arpGliss1() { mxmlIoTest("testArpGliss1"); }
     void arpGliss2() { mxmlIoTest("testArpGliss2"); }
     void arpGliss3() { mxmlIoTest("testArpGliss3"); }
-    // void barlineFermatas() { mxmlMscxExportTestRef("testBarlineFermatas"); } fail after sync with 3.x
+    void barlineFermatas() { mxmlMscxExportTestRef("testBarlineFermatas"); }
     void barStyles() { mxmlIoTest("testBarStyles"); }
     void barStyles2() { mxmlIoTest("testBarStyles2"); }
     void barStyles3() { mxmlIoTest("testBarStyles3"); }
@@ -101,7 +101,7 @@ private slots:
     void clefs1() { mxmlIoTest("testClefs1"); }
     void completeMeasureRests() { mxmlIoTest("testCompleteMeasureRests"); }
     void cueNotes() { mxmlIoTest("testCueNotes"); }
-    // void cueNotes2() { mxmlMscxExportTestRef("testCueNotes2"); } fail after sync with 3.x
+    void cueNotes2() { mxmlMscxExportTestRef("testCueNotes2"); }
     void dalSegno() { mxmlIoTest("testDalSegno"); }
     void dcalCoda() { mxmlIoTest("testDCalCoda"); }
     void dcalFine() { mxmlIoTest("testDCalFine"); }
@@ -128,20 +128,20 @@ private slots:
     void fractionTicks() { mxmlIoTestRef("testFractionTicks"); }
     void grace1() { mxmlIoTest("testGrace1"); }
     void grace2() { mxmlIoTest("testGrace2"); }
-    // void hairpinDynamics() { mxmlMscxExportTestRef("testHairpinDynamics"); } fail after sync with 3.x
+    void hairpinDynamics() { mxmlMscxExportTestRef("testHairpinDynamics"); }
     void harmony1() { mxmlIoTest("testHarmony1"); }
     void harmony2() { mxmlIoTest("testHarmony2"); }
     void harmony3() { mxmlIoTest("testHarmony3"); }
     void harmony4() { mxmlIoTest("testHarmony4"); }
     void harmony5() { mxmlIoTest("testHarmony5"); }   // chordnames without chordrest
-    // void harmony6() { mxmlMscxExportTestRef("testHarmony6"); } fail after sync with 3.x
+    void harmony6() { mxmlMscxExportTestRef("testHarmony6"); }
     void hello() { mxmlIoTest("testHello"); }
     void helloReadCompr() { mxmlReadTestCompr("testHello"); }
     void helloReadWriteCompr() { mxmlReadWriteTestCompr("testHello"); }
     void implicitMeasure1() { mxmlIoTest("testImplicitMeasure1"); }
     void incorrectStaffNumber1() { mxmlIoTestRef("testIncorrectStaffNumber1"); }
     void incorrectStaffNumber2() { mxmlIoTestRef("testIncorrectStaffNumber2"); }
-    // void instrumentChangeMIDIportExport() { mxmlMscxExportTestRef("testInstrumentChangeMIDIportExport"); } fail after sync with 3.x
+    void instrumentChangeMIDIportExport() { mxmlMscxExportTestRef("testInstrumentChangeMIDIportExport"); }
     //void instrumentSound() { mxmlIoTestRef("testInstrumentSound"); } fail XML parsing failed. (3) Opening and ending tag mismatch.
     void invalidTimesig() { mxmlIoTestRef("testInvalidTimesig"); }
     void invisibleElements() { mxmlIoTest("testInvisibleElements"); }
@@ -151,7 +151,7 @@ private slots:
     void lines1() { mxmlIoTest("testLines1"); }
     void lines2() { mxmlIoTest("testLines2"); }
     void lines3() { mxmlIoTest("testLines3"); }
-    // void lines4() { mxmlMscxExportTestRef("testLines4"); } fail after sync with 3.x
+    void lines4() { mxmlMscxExportTestRef("testLines4"); }
     void lyricColor() { mxmlIoTest("testLyricColor"); }
     void lyrics1() { mxmlIoTestRef("testLyrics1"); }
     void lyricsVoice2a() { mxmlIoTest("testLyricsVoice2a"); }
@@ -160,7 +160,7 @@ private slots:
     //void measureRepeats1() { mxmlIoTestRef("testMeasureRepeats1"); } fail libmscore/style.cpp Q_ASSERT(idx == textStyles[int(idx)].tid);
     //void measureRepeats2() { mxmlIoTestRef("testMeasureRepeats2"); } fail libmscore/style.cpp Q_ASSERT(idx == textStyles[int(idx)].tid);
     void measureRepeats3() { mxmlIoTest("testMeasureRepeats3"); }
-    // void midiPortExport() { mxmlMscxExportTestRef("testMidiPortExport"); } fail after sync with 3.x
+    void midiPortExport() { mxmlMscxExportTestRef("testMidiPortExport"); }
     void multiInstrumentPart1() { mxmlIoTest("testMultiInstrumentPart1"); }
     void multiInstrumentPart2() { mxmlIoTest("testMultiInstrumentPart2"); }
     void multiMeasureRest1() { mxmlIoTestRef("testMultiMeasureRest1"); }
@@ -205,12 +205,12 @@ private slots:
     void tablature3() { mxmlIoTest("testTablature3"); }
     void tablature4() { mxmlIoTest("testTablature4"); }
     void tablature5() { mxmlIoTestRef("testTablature5"); }
-    // void tboxAboveBelow1() { mxmlMscxExportTestRef("testTboxAboveBelow1"); } fail after sync with 3.x
-    // void tboxAboveBelow2() { mxmlMscxExportTestRef("testTboxAboveBelow2"); } fail after sync with 3.x
-    // void tboxAboveBelow3() { mxmlMscxExportTestRef("testTboxAboveBelow3"); } fail after sync with 3.x
-    // void tboxMultiPage1() { mxmlMscxExportTestRef("testTboxMultiPage1"); } fail after sync with 3.x
-    // void tboxVbox1() { mxmlMscxExportTestRef("testTboxVbox1"); } fail after sync with 3.x
-    // void tboxWords1() { mxmlMscxExportTestRef("testTboxWords1"); } fail after sync with 3.x
+    void tboxAboveBelow1() { mxmlMscxExportTestRef("testTboxAboveBelow1"); }
+    void tboxAboveBelow2() { mxmlMscxExportTestRef("testTboxAboveBelow2"); }
+    void tboxAboveBelow3() { mxmlMscxExportTestRef("testTboxAboveBelow3"); }
+    void tboxMultiPage1() { mxmlMscxExportTestRef("testTboxMultiPage1"); }
+    void tboxVbox1() { mxmlMscxExportTestRef("testTboxVbox1"); }
+    void tboxWords1() { mxmlMscxExportTestRef("testTboxWords1"); }
     void tempo1() { mxmlIoTest("testTempo1"); }
     void tempo2() { mxmlIoTestRef("testTempo2"); }
     void tempo3() { mxmlIoTestRef("testTempo3"); }
@@ -226,7 +226,7 @@ private slots:
     void tuplets5() { mxmlIoTestRef("testTuplets5"); }
     void tuplets6() { mxmlIoTestRef("testTuplets6"); }
     void tuplets7() { mxmlIoTest("testTuplets7"); }
-    // void tuplets8() { mxmlMscxExportTestRef("testTuplets8"); } fail after sync with 3.x
+    void tuplets8() { mxmlMscxExportTestRef("testTuplets8"); }
     void twoNoteTremoloTuplet() { mxmlIoTest("testTwoNoteTremoloTuplet"); }
     void uninitializedDivisions() { mxmlIoTestRef("testUninitializedDivisions"); }
     void unusualDurations() { mxmlIoTestRef("testUnusualDurations"); }


### PR DESCRIPTION
Fixes and re-enables tests on MusicXML export which were among the tests disabled in 3e7f8510f7313b88df6f495b024f2026ca309add. This commit is extracted from #8273 since multiple other pull requests would also benefit from this change, so it might be useful to be able to review and potentially merge it separately.