### PR TITLE
[MU3] Fix #322759: Inputing Ottava Bassa via menu or shortcut shows it above staff

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1435,6 +1435,10 @@ void Score::cmdAddOttava(OttavaType type)
                        cr2 = cr1;
                   Ottava* ottava = new Ottava(this);
                   ottava->setOttavaType(type);
+                  if (type == OttavaType::OTTAVA_8VB/* || type == OttavaType::OTTAVA_15MB || type == OttavaType::OTTAVA_22MB*/) {
+                        ottava->setPlacement(Placement::BELOW);
+                        ottava->styleChanged();
+                        }
                   ottava->setTrack(cr1->track());
                   ottava->setTrack2(cr1->track());
                   ottava->setTick(cr1->tick());
@@ -1453,7 +1457,10 @@ void Score::cmdAddOttava(OttavaType type)
 
             Ottava* ottava = new Ottava(this);
             ottava->setOttavaType(type);
-
+            if (type == OttavaType::OTTAVA_8VB/* || type == OttavaType::OTTAVA_15MB || type == OttavaType::OTTAVA_22MB*/) {
+                  ottava->setPlacement(Placement::BELOW);
+                  ottava->styleChanged();
+                  }
             ottava->setTrack(cr1->track());
             ottava->setTrack2(cr1->track());
             ottava->setTick(cr1->tick());

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -1414,6 +1414,7 @@ PalettePanel* MuseScore::newLinesPalettePanel()
       ottava = new Ottava(gscore);
       ottava->setOttavaType(OttavaType::OTTAVA_22MB);
       ottava->setLen(w);
+      ottava->setPlacement(Placement::BELOW);
       ottava->styleChanged();
       sp->append(ottava, QT_TRANSLATE_NOOP("Palette", "22ma bassa"));
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/322759

PR for master in #8516 (merged already)