### PR TITLE
[MU4] Fix #322759: Inputing Ottava Bassa via menu or shortcut shows it above staff

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -1869,6 +1869,10 @@ void Score::cmdAddOttava(OttavaType type)
             }
             Ottava* ottava = new Ottava(this);
             ottava->setOttavaType(type);
+            if (type == OttavaType::OTTAVA_8VB /*|| type == OttavaType::OTTAVA_15MB || type == OttavaType::OTTAVA_22MB*/) {
+                ottava->setPlacement(Placement::BELOW);
+                ottava->styleChanged();
+            }
             ottava->setTrack(cr1->track());
             ottava->setTrack2(cr1->track());
             ottava->setTick(cr1->tick());
@@ -1888,7 +1892,10 @@ void Score::cmdAddOttava(OttavaType type)
 
         Ottava* ottava = new Ottava(this);
         ottava->setOttavaType(type);
-
+        if (type == OttavaType::OTTAVA_8VB /*|| type == OttavaType::OTTAVA_15MB || type == OttavaType::OTTAVA_22MB*/) {
+            ottava->setPlacement(Placement::BELOW);
+            ottava->styleChanged();
+        }
         ottava->setTrack(cr1->track());
         ottava->setTrack2(cr1->track());
         ottava->setTick(cr1->tick());

--- a/src/palette/internal/palette/palettecreator.cpp
+++ b/src/palette/internal/palette/palettecreator.cpp
@@ -1423,6 +1423,7 @@ PalettePanel* PaletteCreator::newLinesPalettePanel()
 
     ottava = makeElement<Ottava>(gscore);
     ottava->setOttavaType(OttavaType::OTTAVA_22MB);
+    ottava->setPlacement(Placement::BELOW);
     ottava->setLen(w);
     ottava->styleChanged();
     sp->append(ottava, QT_TRANSLATE_NOOP("palette", "22ma bassa"));


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/322759

This is for master what #8515 is for 3.x
