### PR TITLE
Fix #8385, #8386: Add basic keyboard navigation for Notation Status Bar

### DIFF
--- a/src/appshell/qml/MainToolBar.qml
+++ b/src/appshell/qml/MainToolBar.qml
@@ -35,7 +35,7 @@ Rectangle {
 
     property alias navigation: keynavSub
 
-    property var currentUri: "musescore://home"
+    property string currentUri: "musescore://home"
     property var items: [
         {
             title: qsTrc("appshell", "Home"),
@@ -64,6 +64,7 @@ Rectangle {
     NavigationPanel {
         id: keynavSub
         name: "MainToolBar"
+        enabled: root.enabled && root.visible
         accessible.name: qsTrc("appshell", "Main tool bar") + " " + keynavSub.directionInfo
     }
 

--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -143,7 +143,10 @@ DockPage {
 
             movable: false
 
-            contentComponent: UndoRedoToolBar {}
+            contentComponent: UndoRedoToolBar {
+                navigation.section: root.topToolKeyNavSec
+                navigation.order: 4
+            }
         }
     ]
 

--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -41,9 +41,6 @@ DockPage {
     objectName: "Notation"
     uri: "musescore://notation"
 
-    property var color: ui.theme.backgroundPrimaryColor
-    property var borderColor: ui.theme.strokeColor
-
     property DockWindow dockWindow: null
 
     property var topToolKeyNavSec
@@ -299,8 +296,6 @@ DockPage {
 
         objectName: "notationStatusBar"
 
-        NotationStatusBar {
-            color: root.color
-        }
+        NotationStatusBar {}
     }
 }

--- a/src/appshell/qml/NotationPage/NotationStatusBar.qml
+++ b/src/appshell/qml/NotationPage/NotationStatusBar.qml
@@ -24,13 +24,32 @@ import QtQuick.Window 2.15
 
 import MuseScore.AppShell 1.0
 import MuseScore.UiComponents 1.0
+import MuseScore.Ui 1.0
 import MuseScore.NotationScene 1.0
 
 Rectangle {
     id: root
 
+    color: ui.theme.backgroundPrimaryColor
+
     NotationStatusBarModel {
         id: model
+    }
+
+    NavigationSection {
+        id: navSec
+        name: "NotationStatusBar"
+        enabled: root.visible
+        order: 7
+    }
+
+    NavigationPanel {
+        id: navPanel
+        name: "NotationStatusBar"
+        enabled: root.visible
+        order: 0
+        direction: NavigationPanel.Horizontal
+        section: navSec
     }
 
     Component.onCompleted: {
@@ -39,7 +58,6 @@ Rectangle {
 
     MouseArea {
         anchors.fill: parent
-
         onClicked: root.forceActiveFocus()
     }
 
@@ -77,13 +95,14 @@ Rectangle {
 
         FlatButton {
             id: workspaceControl
-
             anchors.verticalCenter: parent.verticalCenter
 
             text: model.currentWorkspaceAction.title
             normalStateColor: "transparent"
-
             visible: statusBarRow.remainingSpace > width + concertPitchControl.width
+
+            navigation.panel: navPanel
+            navigation.order: 1
 
             onClicked: {
                 Qt.callLater(model.selectWorkspace)
@@ -94,15 +113,16 @@ Rectangle {
 
         ConcertPitchControl {
             id: concertPitchControl
-
             anchors.verticalCenter: parent.verticalCenter
 
             text: model.concertPitchAction.title
             icon: model.concertPitchAction.icon
             checked: model.concertPitchAction.checked
             enabled: model.concertPitchAction.enabled
-
             visible: statusBarRow.remainingSpace > width
+
+            navigation.panel: navPanel
+            navigation.order: 2
 
             onToggleConcertPitchRequested: {
                 model.toggleConcertPitch()
@@ -113,11 +133,13 @@ Rectangle {
 
         ViewModeControl {
             id: viewModeControl
-
             anchors.verticalCenter: parent.verticalCenter
 
             currentViewMode: model.currentViewMode
             availableViewModeList: model.availableViewModeList
+
+            navigation.panel: navPanel
+            navigation.order: 3
 
             onChangeCurrentViewModeRequested: {
                 model.setCurrentViewMode(newViewMode)
@@ -134,6 +156,9 @@ Rectangle {
             minZoomPercentage: model.minZoomPercentage()
             maxZoomPercentage: model.maxZoomPercentage()
             availableZoomList: model.availableZoomList
+
+            navigationPanel: navPanel
+            navigationOrderMin: 4
 
             onChangeZoomPercentageRequested: {
                 model.currentZoomPercentage = newZoomPercentage
@@ -161,6 +186,9 @@ Rectangle {
 
             visible: !concertPitchControl.visible ||
                      !workspaceControl.visible
+
+            navigation.panel: navPanel
+            navigation.order: zoomControl.navigationOrderMax + 1
 
             menuModel: {
                 var result = []

--- a/src/appshell/qml/PublishPage/PublishPage.qml
+++ b/src/appshell/qml/PublishPage/PublishPage.qml
@@ -35,11 +35,10 @@ import "../NotationPage"
 DockPage {
     id: root
 
-    property var color: ui.theme.backgroundPrimaryColor
-    property var topToolKeyNavSec
-
     objectName: "Publish"
     uri: "musescore://publish"
+
+    property var topToolKeyNavSec
 
     property NavigationSection publishToolBarKeyNavSec: NavigationSection {
         id: keynavSec
@@ -122,8 +121,6 @@ DockPage {
     statusBar: DockStatusBar {
         objectName: "publishStatusBar"
 
-        NotationStatusBar {
-            color: root.color
-        }
+        NotationStatusBar {}
     }
 }

--- a/src/appshell/qml/PublishPage/PublishPage.qml
+++ b/src/appshell/qml/PublishPage/PublishPage.qml
@@ -98,7 +98,10 @@ DockPage {
 
             movable: false
 
-            contentComponent: UndoRedoToolBar {}
+            contentComponent: UndoRedoToolBar {
+                navigation.section: root.topToolKeyNavSec
+                navigation.order: 4
+            }
         }
     ]
 

--- a/src/appshell/qml/PublishPage/PublishPage.qml
+++ b/src/appshell/qml/PublishPage/PublishPage.qml
@@ -59,6 +59,7 @@ DockPage {
             minimumWidth: 198
 
             contentComponent: NotationToolBar {
+                navigation.section: root.topToolKeyNavSec
                 navigation.order: 2
 
                 onActiveFocusRequested: {

--- a/src/appshell/qml/PublishPage/PublishToolBar.qml
+++ b/src/appshell/qml/PublishPage/PublishToolBar.qml
@@ -34,8 +34,8 @@ Rectangle {
 
     NavigationPanel {
         id: keynavSub
-
         name: "PublishToolBar"
+        enabled: root.enabled && root.visible
     }
 
     PublishToolBarModel {

--- a/src/appshell/qml/PublishPage/PublishToolBar.qml
+++ b/src/appshell/qml/PublishPage/PublishToolBar.qml
@@ -28,12 +28,12 @@ import MuseScore.AppShell 1.0
 Rectangle {
     id: root
 
-    property alias navigation: keynavSub
+    property alias navigation: navPanel
 
     color: ui.theme.backgroundPrimaryColor
 
     NavigationPanel {
-        id: keynavSub
+        id: navPanel
         name: "PublishToolBar"
         enabled: root.enabled && root.visible
     }
@@ -71,6 +71,9 @@ Rectangle {
 
             orientation: Qt.Horizontal
             normalStateColor: "transparent"
+
+            navigation.panel: navPanel
+            navigation.order: model.index
 
             onClicked: {
                 toolBarModel.handleAction(model.code)

--- a/src/appshell/qml/PublishPage/PublishToolBar.qml
+++ b/src/appshell/qml/PublishPage/PublishToolBar.qml
@@ -75,6 +75,9 @@ Rectangle {
             navigation.panel: navPanel
             navigation.order: model.index
 
+            iconFont: ui.theme.toolbarIconsFont
+            height: 36
+
             onClicked: {
                 toolBarModel.handleAction(model.code)
             }

--- a/src/framework/audio/internal/worker/track.h
+++ b/src/framework/audio/internal/worker/track.h
@@ -45,6 +45,7 @@ struct Track
 public:
     Track(const TrackType trackType = Undefined)
         : type(trackType) {}
+    virtual ~Track() = default;
 
     TrackId id = -1;
     TrackType type = Undefined;

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/NumberInputField.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/NumberInputField.qml
@@ -36,6 +36,9 @@ Item {
 
     property alias font: textField.font
 
+    property alias navigation: navCtrl
+    property alias accessible: navCtrl.accessible
+
     signal valueEdited(var newValue)
 
     implicitWidth: textField.contentWidth
@@ -43,13 +46,25 @@ Item {
 
     opacity: enabled ? 1 : ui.theme.itemOpacityDisabled
 
+    function ensureActiveFocus() {
+        if (!root.activeFocus) {
+            root.forceActiveFocus()
+        }
+    }
+
+    onActiveFocusChanged: {
+        if (activeFocus) {
+            textField.forceActiveFocus()
+        }
+    }
+
     QtObject {
         id: privateProperties
 
         function pad(value) {
             var str = value.toString()
 
-            if (!addLeadingZeros) {
+            if (!root.addLeadingZeros) {
                 return str;
             }
 
@@ -63,6 +78,22 @@ Item {
 
     onValueChanged: {
         textField.text = privateProperties.pad(value)
+    }
+
+    NavigationControl {
+        id: navCtrl
+        name: root.objectName !== "" ? root.objectName : "NumberInputField"
+        enabled: root.enabled && root.visible
+
+        accessible.role: MUAccessible.EditableText
+        accessible.name: textField.text
+        accessible.visualItem: root
+
+        onActiveChanged: {
+            if (navCtrl.active) {
+                root.ensureActiveFocus()
+            }
+        }
     }
 
     TextField {

--- a/src/notation/qml/MuseScore/NotationScene/NotationToolBar.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NotationToolBar.qml
@@ -40,6 +40,7 @@ Rectangle {
     NavigationPanel {
         id: keynavSub
         name: "NotationToolBar"
+        enabled: root.enabled && root.visible
         onActiveChanged: {
             if (active) {
                 root.activeFocusRequested()

--- a/src/notation/qml/MuseScore/NotationScene/NoteInputBar.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NoteInputBar.qml
@@ -38,12 +38,13 @@ Rectangle {
     QtObject {
         id: privatesProperties
 
-        property bool isHorizontal: orientation === Qt.Horizontal
+        property bool isHorizontal: root.orientation === Qt.Horizontal
     }
 
     NavigationPanel {
         id: keynavSub
         name: "NoteInputBar"
+        enabled: root.enabled && root.visible
     }
 
     NoteInputBarModel {

--- a/src/notation/qml/MuseScore/NotationScene/UndoRedoToolBar.qml
+++ b/src/notation/qml/MuseScore/NotationScene/UndoRedoToolBar.qml
@@ -39,6 +39,7 @@ Rectangle {
     NavigationPanel {
         id: navPanel
         name: "UndoRedoToolBar"
+        enabled: root.enabled && root.visible
     }
 
     UndoRedoModel {

--- a/src/notation/qml/MuseScore/NotationScene/UndoRedoToolBar.qml
+++ b/src/notation/qml/MuseScore/NotationScene/UndoRedoToolBar.qml
@@ -22,15 +22,23 @@
 import QtQuick 2.15
 
 import MuseScore.UiComponents 1.0
+import MuseScore.Ui 1.0
 import MuseScore.NotationScene 1.0
 
 Rectangle {
     id: root
 
+    property alias navigation: navPanel
+
     color: ui.theme.backgroundPrimaryColor
 
     Component.onCompleted: {
         model.load()
+    }
+
+    NavigationPanel {
+        id: navPanel
+        name: "UndoRedoToolBar"
     }
 
     UndoRedoModel {
@@ -54,6 +62,9 @@ Rectangle {
             enabled: model.undoItem.enabled
             normalStateColor: "transparent"
 
+            navigation.panel: navPanel
+            navigation.order: 1
+
             onClicked: {
                 model.undo()
             }
@@ -69,6 +80,9 @@ Rectangle {
 
             enabled: model.redoItem.enabled
             normalStateColor: "transparent"
+
+            navigation.panel: navPanel
+            navigation.order: 2
 
             onClicked: {
                 model.redo()

--- a/src/notation/qml/MuseScore/NotationScene/ZoomControl.qml
+++ b/src/notation/qml/MuseScore/NotationScene/ZoomControl.qml
@@ -33,6 +33,10 @@ RowLayout {
     property alias maxZoomPercentage: zoomInputField.maxValue
     property var availableZoomList: []
 
+    property NavigationPanel navigationPanel: null
+    property int navigationOrderMin: 0
+    readonly property int navigationOrderMax: menuButton.navigation.order
+
     signal changeZoomPercentageRequested(var newZoomPercentage)
     signal changeZoomRequested(var newZoomIndex)
     signal zoomInRequested()
@@ -41,10 +45,14 @@ RowLayout {
     spacing: 0
 
     FlatButton {
+        id: zoomInButton
         icon: IconCode.ZOOM_IN
         iconFont: ui.theme.toolbarIconsFont
 
         normalStateColor: "transparent"
+
+        navigation.panel: root.navigationPanel
+        navigation.order: root.navigationOrderMin
 
         onClicked: {
             root.zoomInRequested()
@@ -52,12 +60,16 @@ RowLayout {
     }
 
     FlatButton {
+        id: zoomOutButton
         Layout.leftMargin: 4
 
         icon: IconCode.ZOOM_OUT
         iconFont: ui.theme.toolbarIconsFont
 
         normalStateColor: "transparent"
+
+        navigation.panel: root.navigationPanel
+        navigation.order: zoomInButton.navigation.order + 1
 
         onClicked: {
             root.zoomOutRequested()
@@ -78,6 +90,9 @@ RowLayout {
             addLeadingZeros: false
             font: ui.theme.bodyFont
 
+            navigation.panel: root.navigationPanel
+            navigation.order: zoomOutButton.navigation.order + 1
+
             onValueEdited: {
                 root.changeZoomPercentageRequested(newValue)
             }
@@ -91,12 +106,16 @@ RowLayout {
     }
 
     FlatButton {
+        id: menuButton
         Layout.leftMargin: 4
         Layout.preferredWidth: 20
 
         icon: IconCode.SMALL_ARROW_DOWN
 
         normalStateColor: menuLoader.isMenuOpened ? ui.theme.accentColor : "transparent"
+
+        navigation.panel: root.navigationPanel
+        navigation.order: zoomInputField.navigation.order + 1
 
         StyledMenuLoader {
             id: menuLoader

--- a/src/playback/qml/MuseScore/Playback/PlaybackToolBar.qml
+++ b/src/playback/qml/MuseScore/Playback/PlaybackToolBar.qml
@@ -33,14 +33,15 @@ import "internal"
 Rectangle {
     id: root
 
-    property alias navigation: keynavSub
+    property alias navigation: navPanel
     property bool floating: false
 
     color: ui.theme.backgroundPrimaryColor
 
     NavigationPanel {
-        id: keynavSub
+        id: navPanel
         name: "PlaybackToolBar"
+        enabled: root.enabled && root.visible
     }
 
     PlaybackToolBarModel {
@@ -94,7 +95,7 @@ Rectangle {
                         FlatButton {
                             id: btn
                             property var modelData
-                            property var hasSubitems: modelData.subitems.length !== 0
+                            property bool hasSubitems: modelData.subitems.length !== 0
 
                             icon: modelData.icon
 
@@ -108,7 +109,7 @@ Rectangle {
                                               ? ui.theme.accentColor : "transparent"
                             accentButton: modelData.checked || menuLoader.isMenuOpened
 
-                            navigation.panel: keynavSub
+                            navigation.panel: navPanel
                             navigation.name: modelData.title
                             navigation.order: modelData.index
                             navigation.enabled: playbackModel.isPlayAllowed


### PR DESCRIPTION
Resolves: #8385 
Resolves: #8386 

Todo:
- Pressing tab to move from the Zoom NumberInputField to the next control
- Pressing up/down to open a menu