### PR TITLE
Fix #8387: Add keyboard navigation for '...' button on Dock Panel Tabs

### DIFF
--- a/src/appshell/qml/dockwindow/DockFrame.qml
+++ b/src/appshell/qml/dockwindow/DockFrame.qml
@@ -147,7 +147,7 @@ Rectangle {
             delegate: DockPanelTab {
                 navigation.name: title
                 navigation.panel: navPanel
-                navigation.order: model.index
+                navigation.order: model.index * 2 // NOTE '...' button will have +1 order
                 onNavigationTriggered: tabsPanel.currentIndex = model.index
 
                 text: title

--- a/src/appshell/qml/dockwindow/DockPanelTab.qml
+++ b/src/appshell/qml/dockwindow/DockPanelTab.qml
@@ -57,8 +57,10 @@ StyledTabButton {
 
         MenuButton {
             anchors.verticalCenter: parent.verticalCenter
-
             visible: root.isCurrent
+
+            navigation.panel: root.navigation.panel
+            navigation.order: root.navigation.order + 1
 
             menuModel: root.menuModel
         }

--- a/src/framework/ui/inavigation.h
+++ b/src/framework/ui/inavigation.h
@@ -38,8 +38,8 @@ class INavigationSection;
 class INavigationPanel;
 class INavigationControl;
 
-using PanelControl = std::tuple<INavigationPanel*, INavigationControl*>;
-using SectionPanelControl = std::tuple<INavigationSection*, INavigationPanel*, INavigationControl*>;
+using PanelControlChannel = async::Channel<INavigationPanel*, INavigationControl*>;
+using SectionPanelControlChannel = async::Channel<INavigationSection*, INavigationPanel*, INavigationControl*>;
 
 class INavigation
 {
@@ -130,7 +130,7 @@ public:
     virtual Direction direction() const = 0;
     virtual const std::set<INavigationControl*>& controls() const = 0;
     virtual async::Notification controlsListChanged() const = 0;
-    virtual async::Channel<PanelControl> activeRequested() const = 0;
+    virtual PanelControlChannel activeRequested() const = 0;
 };
 
 class INavigationSection : public INavigation
@@ -149,7 +149,7 @@ public:
     virtual Type type() const = 0;
     virtual const std::set<INavigationPanel*>& panels() const = 0;
     virtual async::Notification panelsListChanged() const = 0;
-    virtual async::Channel<SectionPanelControl> activeRequested() const = 0;
+    virtual SectionPanelControlChannel activeRequested() const = 0;
 };
 }
 

--- a/src/framework/ui/internal/navigationcontroller.cpp
+++ b/src/framework/ui/internal/navigationcontroller.cpp
@@ -305,8 +305,8 @@ void NavigationController::reg(INavigationSection* section)
     TRACEFUNC;
     m_sections.insert(section);
 
-    section->activeRequested().onReceive(this, [this](const SectionPanelControl& ssc) {
-        onActiveRequested(std::get<0>(ssc), std::get<1>(ssc), std::get<2>(ssc));
+    section->activeRequested().onReceive(this, [this](INavigationSection* section, INavigationPanel* panel, INavigationControl* control) {
+        onActiveRequested(section, panel, control);
     });
 }
 

--- a/src/framework/ui/tests/mocks/navigationmocks.h
+++ b/src/framework/ui/tests/mocks/navigationmocks.h
@@ -48,7 +48,7 @@ public:
 
     MOCK_METHOD(const std::set<INavigationPanel*>&, panels, (), (const, override));
     MOCK_METHOD(async::Notification, panelsListChanged, (), (const, override));
-    MOCK_METHOD(async::Channel<SectionPanelControl>, activeRequested, (), (const, override));
+    MOCK_METHOD(SectionPanelControlChannel, activeRequested, (), (const, override));
 };
 
 class NavigationPanelMock : public INavigationPanel
@@ -73,7 +73,7 @@ public:
     MOCK_METHOD(Direction, direction, (), (const, override));
     MOCK_METHOD(const std::set<INavigationControl*>&, controls, (), (const, override));
     MOCK_METHOD(async::Notification, controlsListChanged, (), (const, override));
-    MOCK_METHOD(async::Channel<PanelControl>, activeRequested, (), (const, override));
+    MOCK_METHOD(PanelControlChannel, activeRequested, (), (const, override));
 };
 
 class NavigationControlMock : public INavigationControl

--- a/src/framework/ui/tests/navigationcontroller_tests.cpp
+++ b/src/framework/ui/tests/navigationcontroller_tests.cpp
@@ -132,7 +132,7 @@ public:
         p->panel = new NiceMock<NavigationPanelMock>();
         ON_CALL(*p->panel, enabled()).WillByDefault(Return(true));
         ON_CALL(*p->panel, active()).WillByDefault(Return(false));
-        ON_CALL(*p->panel, activeRequested()).WillByDefault(Return(async::Channel<PanelControl>()));
+        ON_CALL(*p->panel, activeRequested()).WillByDefault(Return(PanelControlChannel()));
         ON_CALL(*p->panel, controls()).WillByDefault(ReturnRef(p->icontrols));
 
         INavigation::Index& idx = make_idx(env);
@@ -156,7 +156,7 @@ public:
         ON_CALL(*s->section, type()).WillByDefault(Return(INavigationSection::Type::Regular));
         ON_CALL(*s->section, enabled()).WillByDefault(Return(true));
         ON_CALL(*s->section, active()).WillByDefault(Return(false));
-        ON_CALL(*s->section, activeRequested()).WillByDefault(Return(async::Channel<SectionPanelControl>()));
+        ON_CALL(*s->section, activeRequested()).WillByDefault(Return(SectionPanelControlChannel()));
         ON_CALL(*s->section, panels()).WillByDefault(ReturnRef(s->ipanels));
 
         INavigation::Index& idx = make_idx(env);

--- a/src/framework/ui/view/navigationpanel.cpp
+++ b/src/framework/ui/view/navigationpanel.cpp
@@ -141,7 +141,7 @@ mu::async::Notification NavigationPanel::controlsListChanged() const
     return m_controlsListChanged;
 }
 
-mu::async::Channel<PanelControl> NavigationPanel::activeRequested() const
+PanelControlChannel NavigationPanel::activeRequested() const
 {
     return m_forceActiveRequested;
 }
@@ -197,8 +197,8 @@ void NavigationPanel::addControl(NavigationControl* control)
 
     m_controls.insert(control);
 
-    control->activeRequested().onReceive(this, [this](INavigationControl* c) {
-        m_forceActiveRequested.send(std::make_tuple(this, c));
+    control->activeRequested().onReceive(this, [this](INavigationControl* control) {
+        m_forceActiveRequested.send(this, control);
     });
 
     if (m_controlsListChanged.isConnected()) {

--- a/src/framework/ui/view/navigationpanel.h
+++ b/src/framework/ui/view/navigationpanel.h
@@ -71,7 +71,7 @@ public:
     const std::set<INavigationControl*>& controls() const override;
     async::Notification controlsListChanged() const override;
 
-    async::Channel<PanelControl> activeRequested() const override;
+    PanelControlChannel activeRequested() const override;
 
     INavigationSection* section() const override;
     NavigationSection* section_property() const;
@@ -95,7 +95,7 @@ private:
     NavigationSection* m_section = nullptr;
     std::set<INavigationControl*> m_controls;
     async::Notification m_controlsListChanged;
-    async::Channel<PanelControl> m_forceActiveRequested;
+    PanelControlChannel m_forceActiveRequested;
     QmlDirection m_direction = QmlDirection::Horizontal;
 };
 }

--- a/src/framework/ui/view/navigationsection.cpp
+++ b/src/framework/ui/view/navigationsection.cpp
@@ -116,8 +116,8 @@ void NavigationSection::addPanel(NavigationPanel* panel)
 
     m_panels.insert(panel);
 
-    panel->activeRequested().onReceive(this, [this](const PanelControl& subcon) {
-        m_forceActiveRequested.send(std::make_tuple(this, std::get<0>(subcon), std::get<1>(subcon)));
+    panel->activeRequested().onReceive(this, [this](INavigationPanel* panel, INavigationControl* control) {
+        m_forceActiveRequested.send(this, panel, control);
     });
 
     if (m_panelsListChanged.isConnected()) {
@@ -125,7 +125,7 @@ void NavigationSection::addPanel(NavigationPanel* panel)
     }
 }
 
-mu::async::Channel<SectionPanelControl> NavigationSection::activeRequested() const
+SectionPanelControlChannel NavigationSection::activeRequested() const
 {
     return m_forceActiveRequested;
 }

--- a/src/framework/ui/view/navigationsection.h
+++ b/src/framework/ui/view/navigationsection.h
@@ -70,7 +70,7 @@ public:
     const std::set<INavigationPanel*>& panels() const override;
     async::Notification panelsListChanged() const override;
 
-    async::Channel<SectionPanelControl> activeRequested() const override;
+    SectionPanelControlChannel activeRequested() const override;
 
     void componentComplete() override;
 
@@ -87,7 +87,7 @@ private:
 
     std::set<INavigationPanel*> m_panels;
     async::Notification m_panelsListChanged;
-    async::Channel<SectionPanelControl> m_forceActiveRequested;
+    SectionPanelControlChannel m_forceActiveRequested;
     QmlType m_type = Regular;
 };
 }


### PR DESCRIPTION
Resolves: #8387 

Also lets NavigationController make use of multi-arg async::Channels (because they are cool 😄).