### PR TITLE
Add the possibility to have async::Promises that return multiple parameters

### DIFF
--- a/src/framework/global/async/promise.h
+++ b/src/framework/global/async/promise.h
@@ -24,8 +24,8 @@
 
 #include "thirdparty/deto_async/async/promise.h"
 namespace mu::async {
-template<typename T>
-using Promise = deto::async::Promise<T>;
+template<typename ... T>
+using Promise = deto::async::Promise<T...>;
 }
 
 #endif // MU_ASYNC_PROMISE_H

--- a/src/palette/internal/palette/palettecreator.cpp
+++ b/src/palette/internal/palette/palettecreator.cpp
@@ -1102,7 +1102,7 @@ PalettePanel* PaletteCreator::newBracketsPalettePanel()
     static Staff bracketItemOwner(nullptr);
     bracketItemOwner.setBracketType(types.size() - 1, BracketType::NORMAL);
 
-    for (int i = 0; i < types.size(); ++i) {
+    for (size_t i = 0; i < types.size(); ++i) {
         auto b1 = makeElement<Bracket>(gscore);
         auto bi1 = bracketItemOwner.brackets()[i];
         const auto& type = types[i];


### PR DESCRIPTION
Same trick again (as in #8258), now with async::Promise.

So now we can do:
```cpp
auto p = Promise<int, int>([](Promise<Int, Int>::Resolve resolve, Promise<Int, Int>::Reject reject) {
    resolve(0, 1);
});

p.onResolve(this, [this](int a, int b) {
    doSomethingWith(a, b);
});
```

If we will ever need to (which might not be very often...).