### PR TITLE
[MU4] Fix #8522 - ensure when cloning textbase we don't clone raw pointers

### DIFF
--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -1668,7 +1668,7 @@ TextBase::TextBase(Score* s, ElementFlags f)
 TextBase::TextBase(const TextBase& st)
     : Element(st)
 {
-    _cursor                      = st._cursor;
+    _cursor                      = new TextCursor(this);
     _text                        = st._text;
     _layout                      = st._layout;
     textInvalid                  = st.textInvalid;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issue/8522

Copying TextBase elements was leaving TextCursor pointing to wrong object

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
