### PR TITLE
[MU4] instruments_converter_issue

### DIFF
--- a/src/notation/internal/instrumentsconverter.cpp
+++ b/src/notation/internal/instrumentsconverter.cpp
@@ -57,6 +57,8 @@ Ms::Instrument InstrumentsConverter::convertInstrument(const mu::instruments::In
     result.setMidiActions(convertMidiActions(instrument.midiActions));
     result.setArticulation(instrument.midiArticulations);
 
+    result.clearChannels();
+
     for (const instruments::Channel& channel : instrument.channels) {
         result.appendChannel(new instruments::Channel(channel));
     }


### PR DESCRIPTION
In fact, we were getting 2 instrument channels during the conversions in instrumentsconverter.cpp
One of them was a default one (with midiProgram - 1) and the second (valid one) was appended on the top of existing one
