### PR TITLE
[MU4] Temporarily disabled a redundant loading of soundfonts

### DIFF
--- a/src/framework/audio/internal/synthesizers/synthesizercontroller.cpp
+++ b/src/framework/audio/internal/synthesizers/synthesizercontroller.cpp
@@ -50,11 +50,13 @@ void SynthesizerController::init()
     for (ISynthesizerPtr& synth : synthesizers) {
         synth->init();
 
-        reloadSoundFonts(synth);
+        // !Note Temporarily disabled a loading of soundfonts during the startup time
+        //       This part of the system will be reworked soon, see a task - https://github.com/musescore/MuseScore/issues/8539
+        /*reloadSoundFonts(synth);
         auto notification = m_soundFontProvider->soundFontPathsForSynthChanged(synth->name());
         notification.onNotify(this, [this, synth]() {
             reloadSoundFonts(synth);
-        });
+        });*/
     }
 }
 

--- a/src/framework/audio/internal/worker/audioengine.cpp
+++ b/src/framework/audio/internal/worker/audioengine.cpp
@@ -46,7 +46,7 @@ AudioEngine::AudioEngine()
 
 AudioEngine::~AudioEngine()
 {
-    ONLY_AUDIO_WORKER_THREAD;
+    ONLY_AUDIO_MAIN_OR_WORKER_THREAD;
 }
 
 mu::Ret AudioEngine::init(IAudioBufferPtr bufferPtr)


### PR DESCRIPTION
Temporarily disabled a loading of soundfonts during the startup time
The rest part of the system will be reworked soon, see a task - https://github.com/musescore/MuseScore/issues/8539

Also fixed an assert failure during the close of the application, I've missed the fact that AudioEngine is a static instance and have put incorrect thread-marker