### PR TITLE
Fix #8499: Move "Select" actions in NotationContextMenu to submenu

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/NotationView.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NotationView.qml
@@ -43,14 +43,22 @@ FocusScope {
         enabled: root.visible
     }
 
+    QtObject {
+        id: prv
+        readonly property int scrollbarMargin: 4
+    }
+
+    Component.onCompleted: {
+        notationView.load()
+        notationNavigator.load()
+    }
+
     ColumnLayout {
         anchors.fill: parent
-
         spacing: 0
 
         NotationSwitchPanel {
             id: tabPanel
-
             Layout.fillWidth: true
 
             navigationSection: navSec
@@ -78,8 +86,9 @@ FocusScope {
                     root.textEdittingStarted()
                 }
 
-                onOpenContextMenuRequested: {
-                    privateProperties.showNotationMenu(items)
+                onOpenContextMenuRequested: function (items, pos) {
+                    // TODO: replace `null` with a NavigationControl
+                    contextMenuLoader.toggleOpened(items, null, pos.x, pos.y)
                 }
 
                 onViewportChanged: {
@@ -98,15 +107,11 @@ FocusScope {
                     }
                 }
 
-                ContextMenu {
-                    id: contextMenu
-                }
-
                 StyledScrollBar {
                     id: verticalScrollBar
 
                     anchors.top: parent.top
-                    anchors.bottomMargin: privateProperties.scrollbarMargin
+                    anchors.bottomMargin: prv.scrollbarMargin
                     anchors.bottom: parent.bottom
                     anchors.right: parent.right
 
@@ -131,7 +136,7 @@ FocusScope {
                     anchors.bottom: parent.bottom
                     anchors.left: parent.left
                     anchors.right: parent.right
-                    anchors.rightMargin: privateProperties.scrollbarMargin
+                    anchors.rightMargin: prv.scrollbarMargin
 
                     orientation: Qt.Horizontal
 
@@ -147,6 +152,14 @@ FocusScope {
                         }
                     }
                 }
+
+                StyledMenuLoader {
+                    id: contextMenuLoader
+
+                    onHandleAction: function (actionCode) {
+                        notationView.handleAction(actionCode)
+                    }
+                }
             }
 
             NotationNavigator {
@@ -159,7 +172,7 @@ FocusScope {
                 SplitView.preferredHeight: 100
                 SplitView.preferredWidth: 100
 
-                onMoveNotationRequested: {
+                onMoveNotationRequested: function (dx, dy) {
                     notationView.moveCanvas(dx, dy)
                 }
             }
@@ -197,50 +210,6 @@ FocusScope {
             id: searchPopup
 
             Layout.fillWidth: true
-        }
-    }
-
-    Component.onCompleted: {
-        notationView.load()
-        notationNavigator.load()
-    }
-
-    QtObject {
-        id: privateProperties
-
-        property int scrollbarMargin: 4
-
-        function showNotationMenu(items) {
-            contextMenu.clear()
-
-            for (var i in items) {
-                var item = items[i]
-
-                var action = notationMenuAction.createObject(notationView, {
-                                                                 code: item.code,
-                                                                 text: item.title,
-                                                                 hintIcon: item.icon,
-                                                                 shortcut: item.shortcut
-                                                             })
-                contextMenu.addMenuItem(action)
-            }
-
-            contextMenu.popup()
-        }
-    }
-
-    Component {
-        id: notationMenuAction
-
-        Action {
-            property string code: ""
-            property string hintIcon: ""
-
-            icon.name: hintIcon
-
-            onTriggered: {
-                Qt.callLater(notationView.handleAction, code)
-            }
         }
     }
 }

--- a/src/notation/view/notationcontextmenu.cpp
+++ b/src/notation/view/notationcontextmenu.cpp
@@ -34,33 +34,51 @@ MenuItemList NotationContextMenu::items(const ElementType& elementType) const
     case ElementType::PAGE:
         return pageItems();
     default:
-        return elementItems();
+        break;
     }
-}
 
-MenuItem NotationContextMenu::makeItem(const UiAction& action, const QString& section, bool enabled, bool checked) const
-{
-    MenuItem item = action;
-    item.section = section;
-    item.state.enabled = enabled;
-    item.state.checked = checked;
-    return item;
-}
-
-MenuItemList NotationContextMenu::measureItems() const
-{
-    MenuItemList items = defaultCopyPasteItems();
-    items << makeItem(actionsRegister()->action("staff-properties"));
-
-    return items;
+    return elementItems();
 }
 
 MenuItemList NotationContextMenu::pageItems() const
 {
     MenuItemList items {
-        makeItem(actionsRegister()->action("edit-style")),
-        makeItem(actionsRegister()->action("page-settings")),
-        makeItem(actionsRegister()->action("load-style"))
+        makeMenuItem("edit-style"),
+        makeMenuItem("page-settings"),
+        makeMenuItem("load-style"),
+    };
+
+    return items;
+}
+
+MenuItemList NotationContextMenu::defaultCopyPasteItems() const
+{
+    MenuItemList items {
+        makeMenuItem("cut"),
+        makeMenuItem("copy"),
+        makeMenuItem("paste"),
+        makeMenuItem("swap"),
+        makeMenuItem("delete"),
+    };
+
+    return items;
+}
+
+MenuItemList NotationContextMenu::measureItems() const
+{
+    MenuItemList items = defaultCopyPasteItems();
+    items << makeMenuItem("staff-properties");
+
+    return items;
+}
+
+MenuItemList NotationContextMenu::selectItems() const
+{
+    MenuItemList items {
+        makeMenuItem("select-similar"),
+        makeMenuItem("select-similar-staff"),
+        makeMenuItem("select-similar-range"),
+        makeMenuItem("select-dialog"),
     };
 
     return items;
@@ -69,23 +87,7 @@ MenuItemList NotationContextMenu::pageItems() const
 MenuItemList NotationContextMenu::elementItems() const
 {
     MenuItemList items = defaultCopyPasteItems();
-    items << makeItem(actionsRegister()->action("select-similar"))
-          << makeItem(actionsRegister()->action("select-similar-staff"))
-          << makeItem(actionsRegister()->action("select-similar-range"))
-          << makeItem(actionsRegister()->action("select-dialog"));
-
-    return items;
-}
-
-MenuItemList NotationContextMenu::defaultCopyPasteItems() const
-{
-    MenuItemList items {
-        makeItem(actionsRegister()->action("cut")),
-        makeItem(actionsRegister()->action("copy")),
-        makeItem(actionsRegister()->action("paste")),
-        makeItem(actionsRegister()->action("swap")),
-        makeItem(actionsRegister()->action("delete")),
-    };
+    items << makeMenu(qtrc("notation", "Select"), selectItems());
 
     return items;
 }

--- a/src/notation/view/notationcontextmenu.h
+++ b/src/notation/view/notationcontextmenu.h
@@ -22,29 +22,23 @@
 #ifndef MU_NOTATION_NOTATIONCONTEXTMENU_H
 #define MU_NOTATION_NOTATIONCONTEXTMENU_H
 
-#include "modularity/ioc.h"
-
-#include "shortcuts/ishortcutsregister.h"
-#include "ui/iuiactionsregister.h"
-
+#include "ui/view/abstractmenumodel.h"
 #include "inotationcontextmenu.h"
 
 namespace mu::notation {
-class NotationContextMenu : public INotationContextMenu
+class NotationContextMenu : public ui::AbstractMenuModel, public INotationContextMenu
 {
-    INJECT(notation, ui::IUiActionsRegister, actionsRegister)
+    Q_OBJECT
 
 public:
     ui::MenuItemList items(const ElementType& elementType) const override;
 
 private:
-    ui::MenuItem makeItem(const ui::UiAction& action, const QString& section = "", bool enabled = true, bool checked = false) const;
-
-    ui::MenuItemList measureItems() const;
     ui::MenuItemList pageItems() const;
-    ui::MenuItemList elementItems() const;
-
     ui::MenuItemList defaultCopyPasteItems() const;
+    ui::MenuItemList measureItems() const;
+    ui::MenuItemList selectItems() const;
+    ui::MenuItemList elementItems() const;
 };
 }
 


### PR DESCRIPTION
Resolves: #8499 
<img width="836" alt="Schermafbeelding 2021-07-07 om 16 12 34" src="https://user-images.githubusercontent.com/48658420/124775909-4cd6a080-df3f-11eb-8e35-db92c1c7f4c2.png">