### PR TITLE
[MU4] fix #8569 fix crash when switching between parts

### DIFF
--- a/thirdparty/deto_async/async/internal/abstractinvoker.cpp
+++ b/thirdparty/deto_async/async/internal/abstractinvoker.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 
 #include "queuedinvoker.h"
+#include <qlogging.h>
 
 using namespace deto::async;
 
@@ -32,6 +33,10 @@ void AbstractInvoker::invoke(int type, const NotifyData& data)
     CallBacks callbacks = it->second;
 
     for (const CallBack& c : callbacks) {
+        if (!it->second.containsReceiver(c.receiver)) {
+            qDebug("Skipping removed receiver");
+            continue;
+        }
         if (c.threadID == threadID) {
             invokeCallback(type, c, data);
         } else {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8569

Fixes crashes that can happen when callbacks get uninstalled while enumerating/executing them
 
- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
