### PR TITLE
[MU3 Backend] ENG-31 Coda and Segno symbol sizing manual override

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -3672,6 +3672,15 @@ void MusicXMLParserDirection::handleRepeats(Measure* measure, const int track, c
                   if (!_wordsText.isEmpty()) {
                         tb->setXmlText(_wordsText);
                         _wordsText = "";
+
+                        // Temporary fix for symbol sizing issues
+                        qreal symSize = _score->style().value(Sid::repeatLeftFontSize).toReal();
+                        qreal textSize = _score->style().value(Sid::repeatRightFontSize).toReal();
+                        if (tb->xmlText() != "<sym>coda</sym>" && tb->xmlText() != "<sym>segno</sym>")
+                              tb->setSize(textSize);
+                        else
+                              tb->setSize(symSize);
+                        tb->setPropertyFlags(Pid::FONT_SIZE, PropertyFlags::UNSTYLED);
                         }
                   else tb->setVisible(false);
 

--- a/mtest/musicxml/io/testDSalCoda.xml
+++ b/mtest/musicxml/io/testDSalCoda.xml
@@ -37,8 +37,6 @@
         <bottom-margin>85.7143</bottom-margin>
         </page-margins>
       </page-layout>
-    <word-font font-family="Edwin" font-size="10"/>
-    <lyric-font font-family="Edwin" font-size="10"/>
     </defaults>
   <credit page="1">
     <credit-type>title</credit-type>
@@ -311,6 +309,7 @@
         </note>
       </measure>
     <measure number="9" width="107.29">
+      <print new-system="yes" />
       <note default-x="13.00" default-y="-40.00">
         <pitch>
           <step>E</step>

--- a/mtest/musicxml/io/testDSalCoda_ref.mscx
+++ b/mtest/musicxml/io/testDSalCoda_ref.mscx
@@ -13,27 +13,6 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
-      <chordSymbolAFontSize>10</chordSymbolAFontSize>
-      <chordSymbolBFontSize>10</chordSymbolBFontSize>
-      <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
-      <tupletFontSize>10</tupletFontSize>
-      <fingeringFontSize>10</fingeringFontSize>
-      <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
-      <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
-      <stringNumberFontSize>10</stringNumberFontSize>
-      <partInstrumentFontSize>10</partInstrumentFontSize>
-      <dynamicsFontSize>10</dynamicsFontSize>
-      <tempoFontSize>10</tempoFontSize>
-      <metronomeFontSize>10</metronomeFontSize>
-      <measureNumberFontSize>10</measureNumberFontSize>
-      <mmRestRangeFontSize>10</mmRestRangeFontSize>
-      <rehearsalMarkFontSize>10</rehearsalMarkFontSize>
-      <repeatLeftFontSize>10</repeatLeftFontSize>
-      <repeatRightFontSize>10</repeatRightFontSize>
-      <glissandoFontSize>10</glissandoFontSize>
-      <bendFontSize>10</bendFontSize>
-      <headerFontSize>10</headerFontSize>
-      <footerFontSize>10</footerFontSize>
       <Spatium>1.75</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
@@ -293,6 +272,9 @@
           </voice>
         </Measure>
       <Measure>
+        <LayoutBreak>
+          <subtype>line</subtype>
+          </LayoutBreak>
         <voice>
           <Chord>
             <durationType>quarter</durationType>


### PR DESCRIPTION
Resolves: [ENG-31](https://mu--se.atlassian.net/browse/ENG-31): Correct handling of Coda symbols (sizing issue follow-up)

The sizing of REPEAT_LEFT and REPEAT_RIGHT text is inconsistent due to
the inconsistent sizing of the coda and segno symbols. This commit adds
an override on MusicXML import based on the presence of non-symbol text
as a temporary fixup for this sizing inconsistency


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
