### PR TITLE
[MU4] Fix #7767 - ensure undo works properly for staff properties dialog

### DIFF
--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -706,8 +706,8 @@ void NotationParts::replaceInstrument(const ID& instrumentId, const ID& fromPart
         return;
     }
 
-    part->setInstrument(InstrumentsConverter::convertInstrument(newInstrument), oldInstrumentInfo.fraction);
-    doSetPartName(part, formatPartName(part));
+    score()->undo(new Ms::ChangePart(part, new Ms::Instrument(InstrumentsConverter::convertInstrument(newInstrument)),
+                                     formatPartName(part)));
     updateScore();
 
     ChangedNotifier<mu::instruments::Instrument>* notifier = partNotifier(part->id());

--- a/src/notation/view/widgets/editstaff.cpp
+++ b/src/notation/view/widgets/editstaff.cpp
@@ -31,6 +31,7 @@
 #include "libmscore/stringdata.h"
 #include "libmscore/text.h"
 #include "libmscore/utils.h"
+#include "libmscore/undo.h"
 
 #include "log.h"
 #include "translation.h"
@@ -303,8 +304,10 @@ void EditStaff::bboxClicked(QAbstractButton* button)
 
 void EditStaff::apply()
 {
+    int index = m_staff->score()->undoStack()->getCurIdx();
     applyStaffProperties();
     applyPartProperties();
+    m_staff->score()->undoStack()->mergeCommands(index);
 }
 
 void EditStaff::minPitchAClicked()


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/7767

Undo wasn't correctly working for changing various staff properties

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
