### PR TITLE
[MU4] fix #7819 - don't draw page elements outside page bounding box

### DIFF
--- a/src/engraving/draw/ipaintprovider.h
+++ b/src/engraving/draw/ipaintprovider.h
@@ -80,6 +80,9 @@ public:
 
     virtual void drawPixmap(const PointF& point, const QPixmap& pm) = 0;
     virtual void drawTiledPixmap(const RectF& rect, const QPixmap& pm, const PointF& offset = PointF()) = 0;
+
+    virtual void setClipRect(const RectF& rect) = 0;
+    virtual void setClipping(bool enable) = 0;
 };
 
 using IPaintProviderPtr = std::shared_ptr<IPaintProvider>;

--- a/src/engraving/draw/painter.cpp
+++ b/src/engraving/draw/painter.cpp
@@ -498,3 +498,13 @@ void Painter::updateMatrix()
         extended->setTransform(st.transform);
     }
 }
+
+void Painter::setClipRect(const RectF& rect)
+{
+    m_provider->setClipRect(rect);
+}
+
+void Painter::setClipping(bool enable)
+{
+    m_provider->setClipping(enable);
+}

--- a/src/engraving/draw/painter.h
+++ b/src/engraving/draw/painter.h
@@ -164,6 +164,9 @@ public:
     void drawPixmap(const PointF& point, const QPixmap& pm);
     void drawTiledPixmap(const RectF& rect, const QPixmap& pm, const PointF& offset = PointF());
 
+    void setClipRect(const RectF& rect);
+    void setClipping(bool enable);
+
     //! NOTE Provider for tests.
     //! We're not ready to use DI (ModuleIoC) here yet
     static IPaintProviderPtr extended;

--- a/src/engraving/draw/qpainterprovider.cpp
+++ b/src/engraving/draw/qpainterprovider.cpp
@@ -304,3 +304,13 @@ void QPainterProvider::drawTiledPixmap(const RectF& rect, const QPixmap& pm, con
 {
     m_painter->drawTiledPixmap(rect.toQRectF(), pm, QPointF(offset.x(), offset.y()));
 }
+
+void QPainterProvider::setClipRect(const RectF& rect)
+{
+    m_painter->setClipRect(rect.toQRectF());
+}
+
+void QPainterProvider::setClipping(bool enable)
+{
+    m_painter->setClipping(enable);
+}

--- a/src/engraving/draw/qpainterprovider.h
+++ b/src/engraving/draw/qpainterprovider.h
@@ -81,6 +81,9 @@ public:
     void drawPixmap(const PointF& point, const QPixmap& pm) override;
     void drawTiledPixmap(const RectF& rect, const QPixmap& pm, const PointF& offset = PointF()) override;
 
+    void setClipRect(const RectF& rect) override;
+    void setClipping(bool enable) override;
+
 private:
     QPainter* m_painter = nullptr;
     bool m_overship = false;

--- a/src/notation/internal/notation.cpp
+++ b/src/notation/internal/notation.cpp
@@ -326,11 +326,14 @@ void Notation::paintPages(draw::Painter* painter, const RectF& frameRect, const 
         PointF pagePosition(page->pos());
         painter->translate(pagePosition);
         paintForeground(painter, page->bbox());
+        painter->setClipping(true);
+        painter->setClipRect(page->bbox());
 
         QList<Element*> elements = page->items(frameRect.translated(-page->pos()));
         Ms::paintElements(*painter, elements);
 
         painter->translate(-pagePosition);
+        painter->setClipping(false);
     }
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/7819

Ensures that score elements aren't drawn onto background (outside page bounding box)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
