### PR TITLE
[MU4] fix #7823 - ensure keyboard navigation between lyrics works as …

### DIFF
--- a/src/engraving/libmscore/lyrics.cpp
+++ b/src/engraving/libmscore/lyrics.cpp
@@ -505,6 +505,27 @@ Element* Lyrics::drop(EditData& data)
 }
 
 //---------------------------------------------------------
+//   edit
+//---------------------------------------------------------
+
+bool Lyrics::edit(EditData& ed)
+{
+    if (ed.modifiers == 0 || ed.modifiers == Qt::ShiftModifier) {
+        switch (ed.key) {
+        case Qt::Key_Space:
+        case Qt::Key_Underscore:
+        case Qt::Key_Minus:
+        case Qt::Key_Enter:
+        case Qt::Key_Return:
+        case Qt::Key_Up:
+        case Qt::Key_Down:
+            return false; // allow shortcut key controller to handle
+        }
+    }
+    return TextBase::edit(ed);
+}
+
+//---------------------------------------------------------
 //   endEdit
 //---------------------------------------------------------
 

--- a/src/engraving/libmscore/lyrics.h
+++ b/src/engraving/libmscore/lyrics.h
@@ -97,6 +97,7 @@ public:
     Syllabic syllabic() const { return _syllabic; }
     void add(Element*) override;
     void remove(Element*) override;
+    bool edit(EditData&) override;
     void endEdit(EditData&) override;
 
     Fraction ticks() const { return _ticks; }

--- a/src/framework/shortcuts/data/shortcuts.xml
+++ b/src/framework/shortcuts/data/shortcuts.xml
@@ -883,9 +883,37 @@
     <seq>Space</seq>
     </SC>
   <SC>
+    <key>next-lyric</key>
+    <seq>Right</seq>
+    </SC>
+  <SC>
     <key>prev-lyric</key>
     <seq>Shift+Space</seq>
     </SC>
+  <SC>
+    <key>prev-lyric</key>
+    <seq>Left</seq>
+  </SC>
+  <SC>
+    <key>next-syllable</key>
+    <seq>-</seq>
+  </SC>
+  <SC>
+    <key>add-melisma</key>
+    <seq>_</seq>
+  </SC>
+  <SC>
+    <key>next-lyric-verse</key>
+    <seq>Down</seq>
+  </SC>
+  <SC>
+    <key>prev-lyric-verse</key>
+    <seq>Up</seq>
+  </SC>
+  <SC>
+    <key>add-lyric-verse</key>
+    <seq>Return</seq>
+  </SC>
   <SC>
     <key>toggle-visible</key>
     <seq>V</seq>

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -165,6 +165,12 @@ public:
 
     virtual ScoreConfig scoreConfig() const = 0;
     virtual void setScoreConfig(ScoreConfig config) = 0;
+
+    virtual void nextLyrics(bool = false, bool = false, bool = true) = 0;
+    virtual void nextLyricsVerse(bool = false) = 0;
+    virtual void nextSyllable() = 0;
+    virtual void addMelisma() = 0;
+    virtual void addLyricsVerse() = 0;
 };
 
 using INotationInteractionPtr = std::shared_ptr<INotationInteraction>;

--- a/src/notation/internal/instrumentsconverter.cpp
+++ b/src/notation/internal/instrumentsconverter.cpp
@@ -116,7 +116,7 @@ Instrument InstrumentsConverter::convertInstrument(const Ms::InstrumentTemplate&
     Ms::Instrument msInstrument = Ms::Instrument::fromTemplate(&templ);
     Instrument result = convertInstrument(msInstrument);
     result.templateId = templ.id;
-    result.familyId = templ.family->id;
+    result.familyId = templ.family ? templ.family->id : QString();
     result.sequenceOrder = templ.sequenceOrder;
 
     for (const Ms::InstrumentGenre* msGenre : templ.genres) {

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -41,7 +41,7 @@ void NotationActionController::init()
     //! NOTE For historical reasons, the name of the action does not match what needs to be done
     dispatcher()->reg(this, ESCAPE_ACTION_CODE, this, &NotationActionController::resetState);
 
-    registerAction("note-input", [this]() { toggleNoteInput(); }, &NotationActionController::isNotTextEditing);
+    registerAction("note-input", [this]() { toggleNoteInput(); }, &NotationActionController::isNotEditingText);
     registerNoteInputAction("note-input-steptime", NoteInputMethod::STEPTIME);
     registerNoteInputAction("note-input-rhythm", NoteInputMethod::RHYTHM);
     registerNoteInputAction("note-input-repitch", NoteInputMethod::REPITCH);
@@ -91,6 +91,14 @@ void NotationActionController::init()
     registerNoteAction("insert-g", NoteName::G, NoteAddingMode::InsertChord);
     registerNoteAction("insert-a", NoteName::A, NoteAddingMode::InsertChord);
     registerNoteAction("insert-b", NoteName::B, NoteAddingMode::InsertChord);
+
+    registerLyricsAction("next-lyric", &NotationActionController::nextLyrics);
+    registerLyricsAction("prev-lyric", &NotationActionController::previousLyrics);
+    registerLyricsAction("next-lyric-verse", &NotationActionController::nextLyricsVerse);
+    registerLyricsAction("prev-lyric-verse", &NotationActionController::previousLyricsVerse);
+    registerLyricsAction("next-syllable", &NotationActionController::nextSyllable);
+    registerLyricsAction("add-melisma", &NotationActionController::addMelisma);
+    registerLyricsAction("add-lyric-verse", &NotationActionController::addLyricsVerse);
 
     dispatcher()->reg(this, "flat2", [this]() { toggleAccidental(AccidentalType::FLAT2); });
     dispatcher()->reg(this, "flat", [this]() { toggleAccidental(AccidentalType::FLAT); });
@@ -170,9 +178,9 @@ void NotationActionController::init()
     dispatcher()->reg(this, "first-element", this, &NotationActionController::firstElement);
     dispatcher()->reg(this, "last-element", this, &NotationActionController::lastElement);
 
-    dispatcher()->reg(this, "system-break", [this]() { toggleLayoutBreak(LayoutBreakType::LINE); });
-    dispatcher()->reg(this, "page-break", [this]() { toggleLayoutBreak(LayoutBreakType::PAGE); });
-    dispatcher()->reg(this, "section-break", [this]() { toggleLayoutBreak(LayoutBreakType::SECTION); });
+    registerAction("system-break", [this]() { toggleLayoutBreak(LayoutBreakType::LINE); }, &NotationActionController::isNotEditingText);
+    registerAction("page-break", [this]() { toggleLayoutBreak(LayoutBreakType::PAGE); }, &NotationActionController::isNotEditingText);
+    registerAction("section-break", [this]() { toggleLayoutBreak(LayoutBreakType::SECTION); }, &NotationActionController::isNotEditingText);
 
     dispatcher()->reg(this, "split-measure", this, &NotationActionController::splitMeasure);
     dispatcher()->reg(this, "join-measures", this, &NotationActionController::joinSelectedMeasures);
@@ -1494,7 +1502,7 @@ FilterElementsOptions NotationActionController::elementsFilterOptions(const Elem
     return options;
 }
 
-bool NotationActionController::isTextEditing() const
+bool NotationActionController::isEditingText() const
 {
     auto interaction = currentNotationInteraction();
     if (!interaction) {
@@ -1502,6 +1510,17 @@ bool NotationActionController::isTextEditing() const
     }
 
     return interaction->isTextEditingStarted();
+}
+
+bool NotationActionController::isEditingLyrics() const
+{
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return false;
+    }
+
+    return interaction->isTextEditingStarted() && interaction->selection()->element()
+           && interaction->selection()->element()->isLyrics();
 }
 
 void NotationActionController::openTupletOtherDialog()
@@ -1611,17 +1630,52 @@ bool NotationActionController::isNotationPage() const
 
 bool NotationActionController::isStandardStaff() const
 {
-    return isNotTextEditing() && !isTablatureStaff();
+    return isNotEditingText() && !isTablatureStaff();
 }
 
 bool NotationActionController::isTablatureStaff() const
 {
-    return isNotTextEditing() && currentNotation()->elements()->msScore()->inputState().staffGroup() == Ms::StaffGroup::TAB;
+    return isNotEditingText() && currentNotation()->elements()->msScore()->inputState().staffGroup() == Ms::StaffGroup::TAB;
 }
 
-bool NotationActionController::isNotTextEditing() const
+bool NotationActionController::isNotEditingText() const
 {
-    return !isTextEditing();
+    return !isEditingText();
+}
+
+void NotationActionController::nextLyrics()
+{
+    currentNotationInteraction()->nextLyrics();
+}
+
+void NotationActionController::previousLyrics()
+{
+    currentNotationInteraction()->nextLyrics(true);
+}
+
+void NotationActionController::nextLyricsVerse()
+{
+    currentNotationInteraction()->nextLyricsVerse();
+}
+
+void NotationActionController::previousLyricsVerse()
+{
+    currentNotationInteraction()->nextLyricsVerse(true);
+}
+
+void NotationActionController::nextSyllable()
+{
+    currentNotationInteraction()->nextSyllable();
+}
+
+void NotationActionController::addMelisma()
+{
+    currentNotationInteraction()->addMelisma();
+}
+
+void NotationActionController::addLyricsVerse()
+{
+    currentNotationInteraction()->addLyricsVerse();
 }
 
 void NotationActionController::registerAction(const mu::actions::ActionCode& code,
@@ -1641,7 +1695,7 @@ void NotationActionController::registerAction(const mu::actions::ActionCode& cod
 
 void NotationActionController::registerNoteInputAction(const mu::actions::ActionCode& code, NoteInputMethod inputMethod)
 {
-    registerAction(code, [this, inputMethod]() { toggleNoteInputMethod(inputMethod); }, &NotationActionController::isNotTextEditing);
+    registerAction(code, [this, inputMethod]() { toggleNoteInputMethod(inputMethod); }, &NotationActionController::isNotEditingText);
 }
 
 void NotationActionController::registerNoteAction(const mu::actions::ActionCode& code, NoteName noteName, NoteAddingMode addingMode)
@@ -1651,5 +1705,10 @@ void NotationActionController::registerNoteAction(const mu::actions::ActionCode&
 
 void NotationActionController::registerPadNoteAction(const mu::actions::ActionCode& code, Pad padding)
 {
-    registerAction(code, [this, padding]() { padNote(padding); }, &NotationActionController::isNotTextEditing);
+    registerAction(code, [this, padding]() { padNote(padding); }, &NotationActionController::isNotEditingText);
+}
+
+void NotationActionController::registerLyricsAction(const mu::actions::ActionCode& code, void (NotationActionController::* handler)())
+{
+    registerAction(code, handler, &NotationActionController::isEditingLyrics);
 }

--- a/src/notation/internal/notationactioncontroller.h
+++ b/src/notation/internal/notationactioncontroller.h
@@ -120,6 +120,14 @@ private:
     void firstElement();
     void lastElement();
 
+    void nextLyrics();
+    void previousLyrics();
+    void nextLyricsVerse();
+    void previousLyricsVerse();
+    void nextSyllable();
+    void addMelisma();
+    void addLyricsVerse();
+
     void toggleLayoutBreak(LayoutBreakType breakType);
 
     void splitMeasure();
@@ -175,8 +183,9 @@ private:
 
     void playSelectedElement(bool playChord = true);
 
-    bool isTextEditing() const;
-    bool isNotTextEditing() const;
+    bool isEditingText() const;
+    bool isNotEditingText() const;
+    bool isEditingLyrics() const;
 
     void pasteSelection(PastingType type = PastingType::Default);
     Fraction resolvePastingScale(const INotationInteractionPtr& interaction, PastingType type) const;
@@ -196,6 +205,7 @@ private:
     void registerNoteInputAction(const mu::actions::ActionCode&, NoteInputMethod inputMethod);
     void registerNoteAction(const mu::actions::ActionCode&, NoteName, NoteAddingMode addingMode = NoteAddingMode::NextChord);
     void registerPadNoteAction(const mu::actions::ActionCode&, Pad padding);
+    void registerLyricsAction(const mu::actions::ActionCode&, void (NotationActionController::*)());
 
     async::Notification m_currentNotationNoteInputChanged;
 };

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -52,6 +52,7 @@
 #include "libmscore/instrchange.h"
 #include "libmscore/lasso.h"
 #include "libmscore/textedit.h"
+#include "libmscore/lyrics.h"
 
 #include "masternotation.h"
 #include "scorecallbacks.h"
@@ -66,7 +67,7 @@ using namespace mu::notation;
 
 NotationInteraction::NotationInteraction(Notation* notation, INotationUndoStackPtr undoStack)
     : m_notation(notation), m_undoStack(undoStack), m_gripEditData(&m_scoreCallbacks),
-    m_lasso(new Ms::Lasso(notation->score()))
+    m_lasso(new Ms::Lasso(notation->score())), m_textEditData(&m_scoreCallbacks)
 {
     m_noteInput = std::make_shared<NotationNoteInput>(notation, this, m_undoStack);
     m_selection = std::make_shared<NotationSelection>(notation);
@@ -79,6 +80,7 @@ NotationInteraction::NotationInteraction(Notation* notation, INotationUndoStackP
 
     m_dragData.ed = Ms::EditData(&m_scoreCallbacks);
     m_dropData.ed = Ms::EditData(&m_scoreCallbacks);
+    m_scoreCallbacks.setScore(notation->score());
 }
 
 NotationInteraction::~NotationInteraction()
@@ -697,15 +699,15 @@ void NotationInteraction::drag(const PointF& fromPos, const PointF& toPos, DragM
 
     notifyAboutDragChanged();
 
-    //    Element* e = _score->getSelectedElement();
+    //    Element* e = score()->getSelectedElement();
     //    if (e) {
-    //        if (_score->playNote()) {
+    //        if (score()->playNote()) {
     //            mscore->play(e);
-    //            _score->setPlayNote(false);
+    //            score()->setPlayNote(false);
     //        }
     //    }
     //    updateGrips();
-    //    _score->update();
+    //    score()->update();
 }
 
 void NotationInteraction::endDrag()
@@ -727,7 +729,7 @@ void NotationInteraction::endDrag()
     notifyAboutDragChanged();
     //    updateGrips();
     //    if (editData.element->normalModeEditBehavior() == Element::EditBehavior::Edit
-    //        && _score->selection().element() == editData.element) {
+    //        && score()->selection().element() == editData.element) {
     //        startEdit(/* editMode */ false);
     //    }
 }
@@ -2983,4 +2985,428 @@ void NotationInteraction::resetShapesAndPosition()
     apply();
 
     notifyAboutNotationChanged();
+}
+
+void NotationInteraction::nextLyrics(bool back, bool moveOnly, bool end)
+{
+    if (!m_textEditData.element || !m_textEditData.element->isLyrics()) {
+        qWarning("nextLyric called with invalid current element");
+        return;
+    }
+    Ms::Lyrics* lyrics = toLyrics(m_textEditData.element);
+    int track = lyrics->track();
+    Ms::Segment* segment = lyrics->segment();
+    int verse = lyrics->no();
+    Ms::Placement placement = lyrics->placement();
+    Ms::PropertyFlags pFlags = lyrics->propertyFlags(Ms::Pid::PLACEMENT);
+
+    Ms::Segment* nextSegment = segment;
+    if (back) {
+        // search prev chord
+        while ((nextSegment = nextSegment->prev1(Ms::SegmentType::ChordRest))) {
+            Element* el = nextSegment->element(track);
+            if (el && el->isChord()) {
+                break;
+            }
+        }
+    } else {
+        // search next chord
+        while ((nextSegment = nextSegment->next1(Ms::SegmentType::ChordRest))) {
+            Element* el = nextSegment->element(track);
+            if (el && el->isChord()) {
+                break;
+            }
+        }
+    }
+    if (nextSegment == 0) {
+        return;
+    }
+
+    endEditText();
+
+    // look for the lyrics we are moving from; may be the current lyrics or a previous one
+    // if we are skipping several chords with spaces
+    Ms::Lyrics* fromLyrics = 0;
+    if (!back) {
+        while (segment) {
+            ChordRest* cr = toChordRest(segment->element(track));
+            if (cr) {
+                fromLyrics = cr->lyrics(verse, placement);
+                if (fromLyrics) {
+                    break;
+                }
+            }
+            segment = segment->prev1(Ms::SegmentType::ChordRest);
+        }
+    }
+
+    ChordRest* cr = toChordRest(nextSegment->element(track));
+    if (!cr) {
+        qDebug("no next lyrics list: %s", nextSegment->element(track)->name());
+        return;
+    }
+    Ms::Lyrics* nextLyrics = cr->lyrics(verse, placement);
+
+    bool newLyrics = false;
+    if (!nextLyrics) {
+        nextLyrics = new Ms::Lyrics(score());
+        nextLyrics->setTrack(track);
+        cr = toChordRest(nextSegment->element(track));
+        nextLyrics->setParent(cr);
+        nextLyrics->setNo(verse);
+        nextLyrics->setPlacement(placement);
+        nextLyrics->setPropertyFlags(Ms::Pid::PLACEMENT, pFlags);
+        nextLyrics->setSyllabic(Ms::Lyrics::Syllabic::SINGLE);
+        newLyrics = true;
+    }
+
+    score()->startCmd();
+    if (fromLyrics && !moveOnly) {
+        switch (nextLyrics->syllabic()) {
+        // as we arrived at nextLyrics by a [Space], it can be the beginning
+        // of a multi-syllable, but cannot have syllabic dashes before
+        case Ms::Lyrics::Syllabic::SINGLE:
+        case Ms::Lyrics::Syllabic::BEGIN:
+            break;
+        case Ms::Lyrics::Syllabic::END:
+            nextLyrics->undoChangeProperty(Ms::Pid::SYLLABIC, int(Ms::Lyrics::Syllabic::SINGLE));
+            break;
+        case Ms::Lyrics::Syllabic::MIDDLE:
+            nextLyrics->undoChangeProperty(Ms::Pid::SYLLABIC, int(Ms::Lyrics::Syllabic::BEGIN));
+            break;
+        }
+        // as we moved away from fromLyrics by a [Space], it can be
+        // the end of a multi-syllable, but cannot have syllabic dashes after
+        switch (fromLyrics->syllabic()) {
+        case Ms::Lyrics::Syllabic::SINGLE:
+        case Ms::Lyrics::Syllabic::END:
+            break;
+        case Ms::Lyrics::Syllabic::BEGIN:
+            fromLyrics->undoChangeProperty(Ms::Pid::SYLLABIC, int(Ms::Lyrics::Syllabic::SINGLE));
+            break;
+        case Ms::Lyrics::Syllabic::MIDDLE:
+            fromLyrics->undoChangeProperty(Ms::Pid::SYLLABIC, int(Ms::Lyrics::Syllabic::END));
+            break;
+        }
+        // for the same reason, it cannot have a melisma
+        fromLyrics->undoChangeProperty(Ms::Pid::LYRIC_TICKS, 0);
+    }
+
+    if (newLyrics) {
+        score()->undoAddElement(nextLyrics);
+    }
+    score()->endCmd();
+    score()->select(nextLyrics, SelectType::SINGLE, 0);
+    score()->setLayoutAll();
+
+    startEditText(nextLyrics, PointF());
+
+    Ms::TextCursor* cursor = nextLyrics->cursor();
+    if (end) {
+        nextLyrics->selectAll(cursor);
+    } else {
+        cursor->movePosition(QTextCursor::End, QTextCursor::MoveAnchor);
+        cursor->movePosition(QTextCursor::Start, QTextCursor::KeepAnchor);
+    }
+}
+
+void NotationInteraction::nextSyllable()
+{
+    if (!m_textEditData.element || !m_textEditData.element->isLyrics()) {
+        qWarning("nextSyllable called with invalid current element");
+        return;
+    }
+    Ms::Lyrics* lyrics = toLyrics(m_textEditData.element);
+    int track = lyrics->track();
+    Ms::Segment* segment = lyrics->segment();
+    int verse = lyrics->no();
+    Ms::Placement placement = lyrics->placement();
+    Ms::PropertyFlags pFlags = lyrics->propertyFlags(Ms::Pid::PLACEMENT);
+
+    // search next chord
+    Ms::Segment* nextSegment = segment;
+    while ((nextSegment = nextSegment->next1(Ms::SegmentType::ChordRest))) {
+        Element* el = nextSegment->element(track);
+        if (el && el->isChord()) {
+            break;
+        }
+    }
+    if (nextSegment == 0) {
+        return;
+    }
+
+    // look for the lyrics we are moving from; may be the current lyrics or a previous one
+    // we are extending with several dashes
+    Ms::Lyrics* fromLyrics = 0;
+    while (segment) {
+        ChordRest* cr = toChordRest(segment->element(track));
+        if (!cr) {
+            segment = segment->prev1(Ms::SegmentType::ChordRest);
+            continue;
+        }
+        fromLyrics = cr->lyrics(verse, placement);
+        if (fromLyrics) {
+            break;
+        }
+        segment = segment->prev1(Ms::SegmentType::ChordRest);
+    }
+
+    endEditText();
+
+    score()->startCmd();
+    ChordRest* cr = toChordRest(nextSegment->element(track));
+    Ms::Lyrics* toLyrics = cr->lyrics(verse, placement);
+    bool newLyrics = (toLyrics == 0);
+    if (!toLyrics) {
+        toLyrics = new Ms::Lyrics(score());
+        toLyrics->setTrack(track);
+        toLyrics->setParent(nextSegment->element(track));
+        toLyrics->setNo(verse);
+        toLyrics->setPlacement(placement);
+        toLyrics->setPropertyFlags(Ms::Pid::PLACEMENT, pFlags);
+        toLyrics->setSyllabic(Ms::Lyrics::Syllabic::END);
+    } else {
+        // as we arrived at toLyrics by a dash, it cannot be initial or isolated
+        if (toLyrics->syllabic() == Ms::Lyrics::Syllabic::BEGIN) {
+            toLyrics->undoChangeProperty(Ms::Pid::SYLLABIC, int(Ms::Lyrics::Syllabic::MIDDLE));
+        } else if (toLyrics->syllabic() == Ms::Lyrics::Syllabic::SINGLE) {
+            toLyrics->undoChangeProperty(Ms::Pid::SYLLABIC, int(Ms::Lyrics::Syllabic::END));
+        }
+    }
+
+    if (fromLyrics) {
+        // as we moved away from fromLyrics by a dash,
+        // it can have syll. dashes before and after but cannot be isolated or terminal
+        switch (fromLyrics->syllabic()) {
+        case Ms::Lyrics::Syllabic::BEGIN:
+        case Ms::Lyrics::Syllabic::MIDDLE:
+            break;
+        case Ms::Lyrics::Syllabic::SINGLE:
+            fromLyrics->undoChangeProperty(Ms::Pid::SYLLABIC, int(Ms::Lyrics::Syllabic::BEGIN));
+            break;
+        case Ms::Lyrics::Syllabic::END:
+            fromLyrics->undoChangeProperty(Ms::Pid::SYLLABIC, int(Ms::Lyrics::Syllabic::MIDDLE));
+            break;
+        }
+        // for the same reason, it cannot have a melisma
+        fromLyrics->undoChangeProperty(Ms::Pid::LYRIC_TICKS, 0);
+    }
+
+    if (newLyrics) {
+        score()->undoAddElement(toLyrics);
+    }
+
+    score()->endCmd();
+    score()->select(toLyrics, SelectType::SINGLE, 0);
+    score()->setLayoutAll();
+
+    startEditText(toLyrics, PointF());
+
+    toLyrics->selectAll(toLyrics->cursor());
+}
+
+void NotationInteraction::nextLyricsVerse(bool back)
+{
+    if (!m_textEditData.element || !m_textEditData.element->isLyrics()) {
+        qWarning("nextLyricVerse called with invalid current element");
+        return;
+    }
+    Ms::Lyrics* lyrics = toLyrics(m_textEditData.element);
+    int track = lyrics->track();
+    ChordRest* cr = lyrics->chordRest();
+    int verse = lyrics->no();
+    Ms::Placement placement = lyrics->placement();
+    Ms::PropertyFlags pFlags = lyrics->propertyFlags(Ms::Pid::PLACEMENT);
+
+    if (back) {
+        if (verse == 0) {
+            return;
+        }
+        --verse;
+    } else {
+        ++verse;
+        if (verse > cr->lastVerse(placement)) {
+            return;
+        }
+    }
+
+    endEditText();
+
+    lyrics = cr->lyrics(verse, placement);
+    if (!lyrics) {
+        lyrics = new Ms::Lyrics(score());
+        lyrics->setTrack(track);
+        lyrics->setParent(cr);
+        lyrics->setNo(verse);
+        lyrics->setPlacement(placement);
+        lyrics->setPropertyFlags(Ms::Pid::PLACEMENT, pFlags);
+        score()->startCmd();
+        score()->undoAddElement(lyrics);
+        score()->endCmd();
+    }
+
+    score()->select(lyrics, SelectType::SINGLE, 0);
+    startEditText(lyrics, PointF());
+
+    lyrics = toLyrics(m_textEditData.element);
+
+    score()->setLayoutAll();
+    score()->update();
+
+    lyrics->selectAll(lyrics->cursor());
+}
+
+void NotationInteraction::addMelisma()
+{
+    if (!m_textEditData.element || !m_textEditData.element->isLyrics()) {
+        qWarning("addMelisma called with invalid current element");
+        return;
+    }
+    Ms::Lyrics* lyrics = toLyrics(m_textEditData.element);
+    int track = lyrics->track();
+    Ms::Segment* segment = lyrics->segment();
+    int verse = lyrics->no();
+    Ms::Placement placement = lyrics->placement();
+    Ms::PropertyFlags pFlags = lyrics->propertyFlags(Ms::Pid::PLACEMENT);
+    Fraction endTick = segment->tick(); // a previous melisma cannot extend beyond this point
+
+    endEditText();
+
+    // search next chord
+    Ms::Segment* nextSegment = segment;
+    while ((nextSegment = nextSegment->next1(Ms::SegmentType::ChordRest))) {
+        Element* el = nextSegment->element(track);
+        if (el && el->isChord()) {
+            break;
+        }
+    }
+
+    // look for the lyrics we are moving from; may be the current lyrics or a previous one
+    // we are extending with several underscores
+    Ms::Lyrics* fromLyrics = 0;
+    while (segment) {
+        ChordRest* cr = toChordRest(segment->element(track));
+        if (cr) {
+            fromLyrics = cr->lyrics(verse, placement);
+            if (fromLyrics) {
+                break;
+            }
+        }
+        segment = segment->prev1(Ms::SegmentType::ChordRest);
+        // if the segment has a rest in this track, stop going back
+        Element* e = segment ? segment->element(track) : 0;
+        if (e && !e->isChord()) {
+            break;
+        }
+    }
+
+    // one-chord melisma?
+    // if still at melisma initial chord and there is a valid next chord (if not,
+    // there will be no melisma anyway), set a temporary melisma duration
+    if (fromLyrics == lyrics && nextSegment) {
+        score()->startCmd();
+        lyrics->undoChangeProperty(Ms::Pid::LYRIC_TICKS, Fraction::fromTicks(Ms::Lyrics::TEMP_MELISMA_TICKS));
+        score()->setLayoutAll();
+        score()->endCmd();
+    }
+
+    if (nextSegment == 0) {
+        score()->startCmd();
+        if (fromLyrics) {
+            switch (fromLyrics->syllabic()) {
+            case Ms::Lyrics::Syllabic::SINGLE:
+            case Ms::Lyrics::Syllabic::END:
+                break;
+            default:
+                fromLyrics->undoChangeProperty(Ms::Pid::SYLLABIC, int(Ms::Lyrics::Syllabic::END));
+                break;
+            }
+            if (fromLyrics->segment()->tick() < endTick) {
+                fromLyrics->undoChangeProperty(Ms::Pid::LYRIC_TICKS, endTick - fromLyrics->segment()->tick());
+            }
+        }
+
+        if (fromLyrics) {
+            score()->select(fromLyrics, SelectType::SINGLE, 0);
+        }
+        score()->setLayoutAll();
+        score()->endCmd();
+        return;
+    }
+
+    // if a place for a new lyrics has been found, create a lyrics there
+
+    score()->startCmd();
+    ChordRest* cr = toChordRest(nextSegment->element(track));
+    Ms::Lyrics* toLyrics = cr->lyrics(verse, placement);
+    bool newLyrics = (toLyrics == 0);
+    if (!toLyrics) {
+        toLyrics = new Ms::Lyrics(score());
+        toLyrics->setTrack(track);
+        toLyrics->setParent(nextSegment->element(track));
+        toLyrics->setNo(verse);
+        toLyrics->setPlacement(placement);
+        toLyrics->setPropertyFlags(Ms::Pid::PLACEMENT, pFlags);
+        toLyrics->setSyllabic(Ms::Lyrics::Syllabic::SINGLE);
+    }
+    // as we arrived at toLyrics by an underscore, it cannot have syllabic dashes before
+    else if (toLyrics->syllabic() == Ms::Lyrics::Syllabic::MIDDLE) {
+        toLyrics->undoChangeProperty(Ms::Pid::SYLLABIC, int(Ms::Lyrics::Syllabic::BEGIN));
+    } else if (toLyrics->syllabic() == Ms::Lyrics::Syllabic::END) {
+        toLyrics->undoChangeProperty(Ms::Pid::SYLLABIC, int(Ms::Lyrics::Syllabic::SINGLE));
+    }
+    if (fromLyrics) {
+        // as we moved away from fromLyrics by an underscore,
+        // it can be isolated or terminal but cannot have dashes after
+        switch (fromLyrics->syllabic()) {
+        case Ms::Lyrics::Syllabic::SINGLE:
+        case Ms::Lyrics::Syllabic::END:
+            break;
+        default:
+            fromLyrics->undoChangeProperty(Ms::Pid::SYLLABIC, int(Ms::Lyrics::Syllabic::END));
+            break;
+        }
+        // for the same reason, if it has a melisma, this cannot extend beyond toLyrics
+        if (fromLyrics->segment()->tick() < endTick) {
+            fromLyrics->undoChangeProperty(Ms::Pid::LYRIC_TICKS, endTick - fromLyrics->segment()->tick());
+        }
+    }
+    if (newLyrics) {
+        score()->undoAddElement(toLyrics);
+    }
+    score()->endCmd();
+
+    score()->select(toLyrics, SelectType::SINGLE, 0);
+    startEditText(toLyrics, PointF());
+
+    toLyrics->selectAll(toLyrics->cursor());
+}
+
+void NotationInteraction::addLyricsVerse()
+{
+    if (!m_textEditData.element || !m_textEditData.element->isLyrics()) {
+        qWarning("nextLyricVerse called with invalid current element");
+        return;
+    }
+    Ms::Lyrics* lyrics = toLyrics(m_textEditData.element);
+
+    endEditText();
+
+    score()->startCmd();
+    int newVerse;
+    newVerse = lyrics->no() + 1;
+
+    Ms::Lyrics* oldLyrics = lyrics;
+    lyrics = new Ms::Lyrics(score());
+    lyrics->setTrack(oldLyrics->track());
+    lyrics->setParent(oldLyrics->segment()->element(oldLyrics->track()));
+    lyrics->setPlacement(oldLyrics->placement());
+    lyrics->setPropertyFlags(Ms::Pid::PLACEMENT, oldLyrics->propertyFlags(Ms::Pid::PLACEMENT));
+    lyrics->setNo(newVerse);
+
+    score()->undoAddElement(lyrics);
+    score()->endCmd();
+
+    score()->select(lyrics, SelectType::SINGLE, 0);
+    startEditText(lyrics, PointF());
 }

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -182,6 +182,12 @@ public:
     void setScoreConfig(ScoreConfig config) override;
     async::Channel<ScoreConfigType> scoreConfigChanged() const override;
 
+    void nextLyrics(bool = false, bool = false, bool = true) override;
+    void nextLyricsVerse(bool = false) override;
+    void nextSyllable() override;
+    void addMelisma() override;
+    void addLyricsVerse() override;
+
 private:
     Ms::Score* score() const;
 

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -1368,6 +1368,48 @@ const UiActionList NotationUiActions::m_scoreConfigActions = {
              QT_TRANSLATE_NOOP("action", "Documents Stacked"),
              QT_TRANSLATE_NOOP("action", "Display documents stacked"),
              Checkable::Yes
+             ),
+    UiAction("next-lyric",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Next lyric"),
+             QT_TRANSLATE_NOOP("action", "Move to lyric on next note"),
+             Checkable::Yes
+             ),
+    UiAction("prev-lyric",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Previous lyric"),
+             QT_TRANSLATE_NOOP("action", "Move to lyric on previous note"),
+             Checkable::Yes
+             ),
+    UiAction("next-lyric-verse",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Next lyric verse"),
+             QT_TRANSLATE_NOOP("action", "Move to lyric in the next verse"),
+             Checkable::Yes
+             ),
+    UiAction("prev-lyric-verse",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Previous lyric verse"),
+             QT_TRANSLATE_NOOP("action", "Move to lyric in the previous verse"),
+             Checkable::Yes
+             ),
+    UiAction("next-syllable",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Next syllable"),
+             QT_TRANSLATE_NOOP("action", "Add hyphen and move to lyric on next note"),
+             Checkable::Yes
+             ),
+    UiAction("add-melisma",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Add melisma"),
+             QT_TRANSLATE_NOOP("action", "Add melisma line and move to lyric on next note"),
+             Checkable::Yes
+             ),
+    UiAction("add-lyric-verse",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Add lyric verse"),
+             QT_TRANSLATE_NOOP("action", "Adds a new verse and starts editing"),
+             Checkable::Yes
              )
 };
 

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -73,7 +73,7 @@ int PlaybackController::currentTick() const
 
 bool PlaybackController::isPlayAllowed() const
 {
-    return m_notation != nullptr;
+    return m_notation != nullptr && !m_notation->interaction()->isTextEditingStarted();
 }
 
 Notification PlaybackController::isPlayAllowedChanged() const


### PR DESCRIPTION
…expected

Resolves: https://github.com/musescore/MuseScore/issues/7823

None of the code to handle navigating between Lyrics using the keyboard in MU3 had been ported to MU4 yet.
The implementation is somewhat different now - in MU3 only space for "next lyric" (which is weirdly called "Next Syllable" in the preferences dialog) was set up as command with a customisable shortcut, all the other cases were handled via special case code.
There didn't seem to be any reason all the possible navigation commands shouldn't all be treated the same way, so that's the implementation here (which prevents the need for using the MuseScoreView/ScoreCallbacks interface - it's possible we'll never need this).

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
