### PR TITLE
Fix Utils.colorWithAlpha

### DIFF
--- a/src/framework/audio/qml/MuseScore/Audio/KnobControl.qml
+++ b/src/framework/audio/qml/MuseScore/Audio/KnobControl.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
-import MuseScore.Ui 1.0
+import MuseScore.UiComponents 1.0
 
 Dial {
     id: root
@@ -17,7 +17,7 @@ Dial {
         id: internal
 
         property real radius: 24
-        readonly property bool reversed: angle < 0
+        readonly property bool reversed: root.angle < 0
 
         property real handlerHeight: 8
         property real handlerWidth: 2
@@ -26,15 +26,8 @@ Dial {
         property real innerArcLineWidth: 3
 
         property color valueArcColor: ui.theme.accentColor
-        property color outerArcColor: {
-            var oc = ui.theme.buttonColor
-            return Qt.rgba(oc.r, oc.g, oc.b, 0.7)
-        }
-
-        property color innerArcColor: {
-            var ic = ui.theme.fontPrimaryColor
-            return Qt.rgba(ic.r, ic.g, ic.b, 0.5)
-        }
+        property color outerArcColor: Utils.colorWithAlpha(ui.theme.buttonColor, 0.7)
+        property color innerArcColor: Utils.colorWithAlpha(ui.theme.fontPrimaryColor, 0.5)
     }
 
     background: Canvas {

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/GradientTabButton.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/GradientTabButton.qml
@@ -87,7 +87,7 @@ RadioDelegate {
             anchors.fill: parent
             anchors.margins: 2 //! NOTE margin needed to show focus border
 
-            property bool isVertical: orientation === Qt.Vertical
+            readonly property bool isVertical: root.orientation === Qt.Vertical
             visible: false
 
             LinearGradient {
@@ -95,13 +95,17 @@ RadioDelegate {
                 anchors.fill: parent
 
                 start: Qt.point(0, 0)
-                end: backgroundGradientRect.isVertical ? Qt.point(0, root.width) : Qt.point(root.width, 0)
+                end: backgroundGradientRect.isVertical ? Qt.point(0, root.height) : Qt.point(root.width, 0)
                 gradient: Gradient {
-                    GradientStop { position: 0.0; color: "transparent" }
-                    GradientStop { position: 1.0; color: Qt.rgba(ui.theme.accentColor.r,
-                                                                 ui.theme.accentColor.g,
-                                                                 ui.theme.accentColor.b,
-                                                                 backgroundGradientRect.isVertical ? 0.2 : 0.1) }
+                    GradientStop {
+                        position: 0.0
+                        color: "transparent"
+                    }
+                    GradientStop {
+                        position: 1.0
+                        color: Utils.colorWithAlpha(ui.theme.accentColor,
+                                                    backgroundGradientRect.isVertical ? 0.2 : 0.1)
+                    }
                 }
             }
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/RoundedRadioButton.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/RoundedRadioButton.qml
@@ -19,10 +19,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2.7
-import QtQuick.Controls 2.0
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
-import "internal/Utils.js" as Utils
+import MuseScore.UiComponents 1.0
 
 RadioButton {
     id: root
@@ -48,7 +48,7 @@ RadioButton {
 
             anchors.fill: parent
 
-            sourceComponent: Boolean(contentComponent) ? contentComponent : textLabel
+            sourceComponent: Boolean(root.contentComponent) ? root.contentComponent : textLabel
 
             Component {
                 id: textLabel

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/TextInputField.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/TextInputField.qml
@@ -24,6 +24,7 @@ import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 
 import MuseScore.Ui 1.0
+import MuseScore.UiComponents 1.0
 
 FocusScope {
     id: root
@@ -135,7 +136,7 @@ FocusScope {
             focus: false
             activeFocusOnPress: false
             selectByMouse: true
-            selectionColor: Qt.rgba(ui.theme.accentColor.r, ui.theme.accentColor.g, ui.theme.accentColor.b, ui.theme.accentOpacityNormal)
+            selectionColor: Utils.colorWithAlpha(ui.theme.accentColor, ui.theme.accentOpacityNormal)
             selectedTextColor: ui.theme.fontPrimaryColor
             visible: !root.isIndeterminate || activeFocus
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/Utils.js
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/Utils.js
@@ -22,5 +22,5 @@
 .pragma library
 
 function colorWithAlpha(color, alpha) {
-    return Qt.rgba(color.red, color.green, color.blue, alpha)
+    return Qt.rgba(color.r, color.g, color.b, alpha)
 }

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/qmldir
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/qmldir
@@ -47,3 +47,4 @@ FilePicker 1.0 FilePicker.qml
 ValueList 1.0 ValueList.qml
 StyledDropShadow 1.0 StyledDropShadow.qml
 VisibilityBox 1.0 VisibilityBox.qml
+Utils 1.0 Utils.js

--- a/src/framework/uicomponents/uicomponents.qrc
+++ b/src/framework/uicomponents/uicomponents.qrc
@@ -52,7 +52,7 @@
         <file>qml/MuseScore/UiComponents/TabItem.qml</file>
         <file>qml/MuseScore/UiComponents/StyledDropShadow.qml</file>
         <file>qml/MuseScore/UiComponents/StyledToolTip.qml</file>
-        <file>qml/MuseScore/UiComponents/internal/Utils.js</file>
+        <file>qml/MuseScore/UiComponents/Utils.js</file>
         <file>qml/MuseScore/UiComponents/Dropdown.qml</file>
         <file>qml/MuseScore/UiComponents/internal/DropdownItem.qml</file>
         <file>qml/MuseScore/UiComponents/VisibilityBox.qml</file>


### PR DESCRIPTION
The wrong name for the rgb properties of the color was used (like `red` instead of `r`), so the returned color was always black with the given alpha component. Now that's fixed.