### PR TITLE
Added engraving and notation project concept

### DIFF
--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -73,7 +73,7 @@ mu::ValCh<bool> ApplicationActionController::isFullScreen() const
 
 void ApplicationActionController::quit()
 {
-    if (fileScoreController()->closeOpenedScore()) {
+    if (fileScoreController()->closeOpenedProject()) {
         QCoreApplication::quit();
     }
 }

--- a/src/context/contextmodule.cpp
+++ b/src/context/contextmodule.cpp
@@ -52,5 +52,5 @@ void ContextModule::onInit(const framework::IApplication::RunMode& mode)
 
 void ContextModule::onDeinit()
 {
-    s_globalContext->setCurrentMasterNotation(nullptr);
+    s_globalContext->setCurrentNotationProject(nullptr);
 }

--- a/src/context/iglobalcontext.h
+++ b/src/context/iglobalcontext.h
@@ -23,8 +23,9 @@
 #define MU_CONTEXT_IGLOBALCONTEXT_H
 
 #include "modularity/imoduleexport.h"
-#include "notation/imasternotation.h"
+#include "notation/inotationproject.h"
 #include "async/notification.h"
+#include "io/path.h"
 
 namespace mu::context {
 class IGlobalContext : MODULE_EXPORT_INTERFACE
@@ -34,12 +35,15 @@ class IGlobalContext : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IGlobalContext() = default;
 
-    virtual void addMasterNotation(const notation::IMasterNotationPtr& notation) = 0;
-    virtual void removeMasterNotation(const notation::IMasterNotationPtr& notation) = 0;
-    virtual const std::vector<notation::IMasterNotationPtr>& masterNotations() const = 0;
-    virtual bool containsMasterNotation(const io::path& path) const = 0;
+    virtual void addNotationProject(const notation::INotationProjectPtr& project) = 0;
+    virtual void removeNotationProject(const notation::INotationProjectPtr& project) = 0;
+    virtual const std::vector<notation::INotationProjectPtr>& notationProjects() const = 0;
+    virtual bool containsNotationProject(const io::path& path) const = 0;
 
-    virtual void setCurrentMasterNotation(const notation::IMasterNotationPtr& notation) = 0;
+    virtual void setCurrentNotationProject(const notation::INotationProjectPtr& project) = 0;
+    virtual notation::INotationProjectPtr currentNotationProject() const = 0;
+    virtual async::Notification currentNotationProjectChanged() const = 0;
+
     virtual notation::IMasterNotationPtr currentMasterNotation() const = 0;
     virtual async::Notification currentMasterNotationChanged() const = 0;
 

--- a/src/context/internal/globalcontext.cpp
+++ b/src/context/internal/globalcontext.cpp
@@ -21,58 +21,71 @@
  */
 #include "globalcontext.h"
 
+#include "notation/imasternotation.h"
+
 using namespace mu::context;
 using namespace mu::notation;
 using namespace mu::async;
 
-void GlobalContext::addMasterNotation(const IMasterNotationPtr& notation)
+void GlobalContext::addNotationProject(const INotationProjectPtr& project)
 {
-    m_masterNotations.push_back(notation);
+    m_projects.push_back(project);
 }
 
-void GlobalContext::removeMasterNotation(const IMasterNotationPtr& notation)
+void GlobalContext::removeNotationProject(const INotationProjectPtr& project)
 {
-    m_masterNotations.erase(std::remove(m_masterNotations.begin(), m_masterNotations.end(), notation), m_masterNotations.end());
+    m_projects.erase(std::remove(m_projects.begin(), m_projects.end(), project), m_projects.end());
 }
 
-const std::vector<IMasterNotationPtr>& GlobalContext::masterNotations() const
+const std::vector<INotationProjectPtr>& GlobalContext::notationProjects() const
 {
-    return m_masterNotations;
+    return m_projects;
 }
 
-bool GlobalContext::containsMasterNotation(const io::path& path) const
+bool GlobalContext::containsNotationProject(const io::path& path) const
 {
-    for (const auto& n : m_masterNotations) {
-        if (n->path() == path) {
+    for (const auto& p : m_projects) {
+        if (p->path() == path) {
             return true;
         }
     }
     return false;
 }
 
-void GlobalContext::setCurrentMasterNotation(const IMasterNotationPtr& masterNotation)
+void GlobalContext::setCurrentNotationProject(const INotationProjectPtr& project)
 {
-    if (m_currentMasterNotation == masterNotation) {
+    if (m_currentNotationProject == project) {
         return;
     }
 
-    m_currentMasterNotation = masterNotation;
+    m_currentNotationProject = project;
 
-    INotationPtr notation = masterNotation ? masterNotation->notation() : nullptr;
+    INotationPtr notation = project ? project->masterNotation()->notation() : nullptr;
     doSetCurrentNotation(notation);
 
-    m_currentMasterNotationChanged.notify();
+    m_currentNotationProjectChanged.notify();
     m_currentNotationChanged.notify();
+}
+
+INotationProjectPtr GlobalContext::currentNotationProject() const
+{
+    return m_currentNotationProject;
+}
+
+Notification GlobalContext::currentNotationProjectChanged() const
+{
+    return m_currentNotationProjectChanged;
 }
 
 IMasterNotationPtr GlobalContext::currentMasterNotation() const
 {
-    return m_currentMasterNotation;
+    return m_currentNotationProject ? m_currentNotationProject->masterNotation() : nullptr;
 }
 
 Notification GlobalContext::currentMasterNotationChanged() const
 {
-    return m_currentMasterNotationChanged;
+    //! NOTE Same as project
+    return m_currentNotationProjectChanged;
 }
 
 void GlobalContext::setCurrentNotation(const INotationPtr& notation)

--- a/src/context/internal/globalcontext.h
+++ b/src/context/internal/globalcontext.h
@@ -28,12 +28,15 @@ namespace mu::context {
 class GlobalContext : public IGlobalContext
 {
 public:
-    void addMasterNotation(const notation::IMasterNotationPtr& notation) override;
-    void removeMasterNotation(const notation::IMasterNotationPtr& notation) override;
-    const std::vector<notation::IMasterNotationPtr>& masterNotations() const override;
-    bool containsMasterNotation(const io::path& path) const override;
+    void addNotationProject(const notation::INotationProjectPtr& project) override;
+    void removeNotationProject(const notation::INotationProjectPtr& project) override;
+    const std::vector<notation::INotationProjectPtr>& notationProjects() const override;
+    bool containsNotationProject(const io::path& path) const override;
 
-    void setCurrentMasterNotation(const notation::IMasterNotationPtr& notation) override;
+    void setCurrentNotationProject(const notation::INotationProjectPtr& project) override;
+    notation::INotationProjectPtr currentNotationProject() const override;
+    async::Notification currentNotationProjectChanged() const override;
+
     notation::IMasterNotationPtr currentMasterNotation() const override;
     async::Notification currentMasterNotationChanged() const override;
 
@@ -44,10 +47,10 @@ public:
 private:
     void doSetCurrentNotation(const notation::INotationPtr& notation);
 
-    std::vector<notation::IMasterNotationPtr> m_masterNotations;
+    std::vector<notation::INotationProjectPtr> m_projects;
 
-    notation::IMasterNotationPtr m_currentMasterNotation;
-    async::Notification m_currentMasterNotationChanged;
+    notation::INotationProjectPtr m_currentNotationProject;
+    async::Notification m_currentNotationProjectChanged;
 
     notation::INotationPtr m_currentNotation;
     async::Notification m_currentNotationChanged;

--- a/src/converter/internal/compat/backendapi.h
+++ b/src/converter/internal/compat/backendapi.h
@@ -58,6 +58,9 @@ public:
 private:
     static Ret openOutputFile(QFile& file, const io::path& out);
 
+    static RetVal<notation::INotationProjectPtr> openProject(const io::path& path,
+                                                             const io::path& stylePath = io::path(), bool forceMode = false);
+
     static RetVal<notation::IMasterNotationPtr> openScore(const io::path& path,
                                                           const io::path& stylePath = io::path(), bool forceMode = false);
 

--- a/src/converter/internal/convertercontroller.cpp
+++ b/src/converter/internal/convertercontroller.cpp
@@ -65,8 +65,8 @@ mu::Ret ConverterController::fileConvert(const io::path& in, const io::path& out
     TRACEFUNC;
 
     LOGI() << "in: " << in << ", out: " << out;
-    auto masterNotation = notationCreator()->newMasterNotation();
-    IF_ASSERT_FAILED(masterNotation) {
+    auto notationProject = notationCreator()->newNotationProject();
+    IF_ASSERT_FAILED(notationProject) {
         return make_ret(Err::UnknownError);
     }
 
@@ -76,16 +76,16 @@ mu::Ret ConverterController::fileConvert(const io::path& in, const io::path& out
         return make_ret(Err::ConvertTypeUnknown);
     }
 
-    Ret ret = masterNotation->load(in, stylePath, forceMode);
+    Ret ret = notationProject->load(in, stylePath, forceMode);
     if (!ret) {
         LOGE() << "failed load notation, err: " << ret.toString() << ", path: " << in;
         return make_ret(Err::InFileFailedLoad);
     }
 
     if (isConvertPageByPage(suffix)) {
-        ret = convertPageByPage(writer, masterNotation->notation(), out);
+        ret = convertPageByPage(writer, notationProject->masterNotation()->notation(), out);
     } else {
-        ret = convertFullNotation(writer, masterNotation->notation(), out);
+        ret = convertFullNotation(writer, notationProject->masterNotation()->notation(), out);
     }
 
     return make_ret(Ret::Code::Ok);
@@ -96,8 +96,8 @@ mu::Ret ConverterController::convertScoreParts(const mu::io::path& in, const mu:
 {
     TRACEFUNC;
 
-    auto masterNotation = notationCreator()->newMasterNotation();
-    IF_ASSERT_FAILED(masterNotation) {
+    auto notationProject = notationCreator()->newNotationProject();
+    IF_ASSERT_FAILED(notationProject) {
         return make_ret(Err::UnknownError);
     }
 
@@ -107,16 +107,16 @@ mu::Ret ConverterController::convertScoreParts(const mu::io::path& in, const mu:
         return make_ret(Err::ConvertTypeUnknown);
     }
 
-    Ret ret = masterNotation->load(in, stylePath, forceMode);
+    Ret ret = notationProject->load(in, stylePath, forceMode);
     if (!ret) {
         LOGE() << "failed load notation, err: " << ret.toString() << ", path: " << in;
         return make_ret(Err::InFileFailedLoad);
     }
 
     if (suffix == PDF_SUFFIX) {
-        ret = convertScorePartsToPdf(writer, masterNotation, out);
+        ret = convertScorePartsToPdf(writer, notationProject->masterNotation(), out);
     } else if (suffix == PNG_SUFFIX) {
-        ret = convertScorePartsToPngs(writer, masterNotation, out);
+        ret = convertScorePartsToPngs(writer, notationProject->masterNotation(), out);
     } else {
         ret = make_ret(Ret::Code::NotSupported);
     }

--- a/src/engraving/CMakeLists.txt
+++ b/src/engraving/CMakeLists.txt
@@ -26,6 +26,11 @@ set(MODULE_SRC
 
     ${CMAKE_CURRENT_LIST_DIR}/engravingmodule.cpp
     ${CMAKE_CURRENT_LIST_DIR}/engravingmodule.h
+    ${CMAKE_CURRENT_LIST_DIR}/engravingerrors.h
+    ${CMAKE_CURRENT_LIST_DIR}/engravingproject.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/engravingproject.h
+    ${CMAKE_CURRENT_LIST_DIR}/scoreaccess.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/scoreaccess.h
 
     ${LIBMSCORE_SRC}
 

--- a/src/engraving/compat/mscxcompat.cpp
+++ b/src/engraving/compat/mscxcompat.cpp
@@ -24,6 +24,8 @@
 #include <QFile>
 #include <QBuffer>
 
+#include "scoreaccess.h"
+
 #include "log.h"
 
 Ms::Score::FileError mu::engraving::compat::loadMsczOrMscx(Ms::MasterScore* score, const QString& path, bool ignoreVersionError)
@@ -65,6 +67,6 @@ Ms::Score::FileError mu::engraving::compat::loadMsczOrMscx(Ms::MasterScore* scor
     reader.setFilePath(filePath);
     reader.open();
 
-    Ms::Score::FileError err = score->loadMscz(reader, ignoreVersionError);
+    Ms::Score::FileError err = ScoreAccess::loadMscz(score, reader, ignoreVersionError);
     return err;
 }

--- a/src/engraving/engravingerrors.h
+++ b/src/engraving/engravingerrors.h
@@ -19,19 +19,30 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include "notationcreator.h"
 
-#include "notationproject.h"
-#include "excerptnotation.h"
+#ifndef MU_ENGRAVING_ENGRAVINGERRORS_H
+#define MU_ENGRAVING_ENGRAVINGERRORS_H
 
-using namespace mu::notation;
+namespace mu::engraving {
+enum class Err {
+    Undefined       = -1,
+    NoError         = 0,
+    UnknownError    = 2000,
 
-INotationProjectPtr NotationCreator::newNotationProject() const
-{
-    return std::make_shared<NotationProject>();
+    // file
+    FileUnknownError = 2001,
+    FileNotFound = 2002,
+    FileOpenFailed = 2003,
+    FileBadFormat = 2004,
+    FileUnknownType = 2005,
+    FileTooOld = 2006,
+    FileTooNew = 2007,
+    FileOld300Format = 2008,
+    FileCorrupted = 2009,
+    FileCriticallyCorrupated = 2010,
+    FileUserAbort = 2011,
+    FileIgnoreError = 2012
+};
 }
 
-IExcerptNotationPtr NotationCreator::newExcerptNotation() const
-{
-    return std::make_shared<ExcerptNotation>();
-}
+#endif // MU_ENGRAVING_ENGRAVINGERRORS_H

--- a/src/engraving/engravingmodule.cpp
+++ b/src/engraving/engravingmodule.cpp
@@ -33,6 +33,8 @@
 
 #include "notation/inotationconfiguration.h"
 
+#include "scoreaccess.h"
+
 using namespace mu::engraving;
 using namespace mu::modularity;
 
@@ -69,7 +71,7 @@ void EngravingModule::onInit(const framework::IApplication::RunMode&)
     Ms::MScore::setNudgeStep10(1.0); // Ctrl + cursor key (default 1.0)
     Ms::MScore::setNudgeStep50(0.01); // Alt  + cursor key (default 0.01)
 
-    Ms::gscore = new Ms::MasterScore();
+    Ms::gscore = ScoreAccess::createMasterScore();
     Ms::gscore->setPaletteMode(true);
     Ms::gscore->setMovements(new Ms::Movements());
     Ms::gscore->setStyle(Ms::MScore::baseStyle());

--- a/src/engraving/engravingproject.cpp
+++ b/src/engraving/engravingproject.cpp
@@ -1,0 +1,116 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "engravingproject.h"
+
+#include <QFileInfo>
+
+#include "libmscore/score.h"
+#include "libmscore/part.h"
+
+using namespace mu::engraving;
+
+std::shared_ptr<EngravingProject> EngravingProject::create()
+{
+    return std::shared_ptr<EngravingProject>(new EngravingProject(Ms::MScore::defaultStyle()));
+}
+
+std::shared_ptr<EngravingProject> EngravingProject::create(const Ms::MStyle& style)
+{
+    return std::shared_ptr<EngravingProject>(new EngravingProject(style));
+}
+
+EngravingProject::EngravingProject(const Ms::MStyle& style)
+{
+    m_masterScore = new Ms::MasterScore(style);
+}
+
+EngravingProject::~EngravingProject()
+{
+    delete m_masterScore;
+}
+
+void EngravingProject::setPath(const QString& path)
+{
+    QFileInfo fi(path);
+    m_masterScore->setName(fi.completeBaseName());
+    m_masterScore->setImportedFilePath(fi.filePath());
+    m_masterScore->setMetaTag("originalFormat", fi.suffix().toLower());
+
+    m_path = path;
+}
+
+QString EngravingProject::path() const
+{
+    return m_path;
+}
+
+Err EngravingProject::setupMasterScore()
+{
+    return doSetupMasterScore(m_masterScore);
+}
+
+Err EngravingProject::doSetupMasterScore(Ms::MasterScore* score)
+{
+    score->connectTies();
+
+    for (Ms::Part* p : score->parts()) {
+        p->updateHarmonyChannels(false);
+    }
+    score->rebuildMidiMapping();
+    score->setSoloMute();
+    for (Ms::Score* s : score->scoreList()) {
+        s->setPlaylistDirty();
+        s->addLayoutFlags(Ms::LayoutFlag::FIX_PITCH_VELO);
+        s->setLayoutAll();
+    }
+    score->updateChannel();
+    //score->updateExpressive(MuseScore::synthesizer("Fluid"));
+    score->setSaved(true);
+    score->setCreated(false);
+    score->update();
+
+    if (!score->sanityCheck(QString())) {
+        return Err::FileCorrupted;
+    }
+
+    return Err::NoError;
+}
+
+Ms::MasterScore* EngravingProject::masterScore() const
+{
+    return m_masterScore;
+}
+
+bool EngravingProject::saveFile(bool generateBackup)
+{
+    return m_masterScore->saveFile(generateBackup);
+}
+
+bool EngravingProject::saveSelectionOnScore(const QString& filePath)
+{
+    return m_masterScore->writeMscz(filePath, true);
+}
+
+bool EngravingProject::writeMscz(QIODevice* device, const QString& filePath)
+{
+    return m_masterScore->writeMscz(device, filePath);
+}

--- a/src/engraving/engravingproject.h
+++ b/src/engraving/engravingproject.h
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_ENGRAVING_ENGRAVINGPROJECT_H
+#define MU_ENGRAVING_ENGRAVINGPROJECT_H
+
+#include <memory>
+
+#include "engravingerrors.h"
+#include "io/msczreader.h"
+
+//! NOTE In addition to the score itself, the mscz file also stores other data,
+//! such as synthesizer, mixer settings, omr, etc.
+//! We should talk not just about the score, but about the Project.
+//! So, the Engraving Project contains the score and all other data,
+//! such as additional styles, sound settings, sound samples, and others.
+//!
+//! To simplify logic and reduce combinatorics,
+//! we need to strive to ensure that there is work with the project everywhere;
+//! accordingly, only the project should create and load the master score.
+
+namespace Ms {
+class MasterScore;
+class MStyle;
+}
+
+namespace mu::engraving {
+class EngravingProject
+{
+public:
+    ~EngravingProject();
+
+    static std::shared_ptr<EngravingProject> create();
+    static std::shared_ptr<EngravingProject> create(const Ms::MStyle& style);
+
+    void setPath(const QString& path);
+    QString path() const;
+
+    Ms::MasterScore* masterScore() const;
+    Err setupMasterScore();
+
+    bool saveFile(bool generateBackup = true);
+    bool saveSelectionOnScore(const QString& filePath);
+
+    bool writeMscz(QIODevice* device, const QString& filePath);
+
+private:
+    EngravingProject(const Ms::MStyle& style);
+
+    Err doSetupMasterScore(Ms::MasterScore* score);
+
+    QString m_path;
+    Ms::MasterScore* m_masterScore = nullptr;
+};
+
+using EngravingProjectPtr = std::shared_ptr<EngravingProject>;
+}
+
+#endif // MU_ENGRAVING_PROJECT_H

--- a/src/engraving/libmscore/mcursor.cpp
+++ b/src/engraving/libmscore/mcursor.cpp
@@ -21,6 +21,9 @@
  */
 
 #include "libmscore/mcursor.h"
+
+#include "engraving/scoreaccess.h"
+
 #include "libmscore/part.h"
 #include "libmscore/staff.h"
 #include "libmscore/note.h"
@@ -143,7 +146,7 @@ TimeSig* MCursor::addTimeSig(const Fraction& f)
 void MCursor::createScore(const QString& name)
 {
     delete _score;
-    _score = new MasterScore(mscore->baseStyle());
+    _score = mu::engraving::ScoreAccess::createMasterScore(mscore->baseStyle());
     _score->setName(name);
     move(0, Fraction(0, 1));
 }

--- a/src/engraving/libmscore/read206.cpp
+++ b/src/engraving/libmscore/read206.cpp
@@ -3588,7 +3588,7 @@ static bool readScore(Score* score, XmlReader& e)
                 e.tracks().clear();
                 e.clearUserTextStyles();
                 MasterScore* m = score->masterScore();
-                Score* s = new Score(m, MScore::baseStyle());
+                Score* s = m->createScore(MScore::baseStyle());
                 int defaultsVersion = m->style().defaultStyleVersion();
                 s->setStyle(*MStyle::resolveStyleDefaults(defaultsVersion));
                 s->style().setDefaultStyleVersion(defaultsVersion);

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -2136,6 +2136,16 @@ MasterScore* MasterScore::clone()
     return score;
 }
 
+Score* MasterScore::createScore()
+{
+    return new Score(this, MScore::baseStyle());
+}
+
+Score* MasterScore::createScore(const MStyle& s)
+{
+    return new Score(this, s);
+}
+
 //---------------------------------------------------------
 //   setSynthesizerState
 //---------------------------------------------------------

--- a/src/engraving/libmscore/unrollrepeats.cpp
+++ b/src/engraving/libmscore/unrollrepeats.cpp
@@ -127,7 +127,7 @@ static void createExcerpts(MasterScore* cs, QList<Excerpt*> excerpts)
 {
     // borrowed from musescore.cpp endsWith(".pdf")
     for (Excerpt* e: excerpts) {
-        Score* nscore = new Score(e->oscore());
+        Score* nscore = e->oscore()->createScore();
         e->setPartScore(nscore);
         nscore->style().set(Sid::createMultiMeasureRests, true);
         cs->startCmd();

--- a/src/engraving/scoreaccess.cpp
+++ b/src/engraving/scoreaccess.cpp
@@ -19,19 +19,21 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include "notationcreator.h"
+#include "scoreaccess.h"
 
-#include "notationproject.h"
-#include "excerptnotation.h"
+using namespace mu::engraving;
 
-using namespace mu::notation;
-
-INotationProjectPtr NotationCreator::newNotationProject() const
+Ms::MasterScore* ScoreAccess::createMasterScore()
 {
-    return std::make_shared<NotationProject>();
+    return new Ms::MasterScore();
 }
 
-IExcerptNotationPtr NotationCreator::newExcerptNotation() const
+Ms::MasterScore* ScoreAccess::createMasterScore(const Ms::MStyle& style)
 {
-    return std::make_shared<ExcerptNotation>();
+    return new Ms::MasterScore(style);
+}
+
+Ms::Score::FileError ScoreAccess::loadMscz(Ms::MasterScore* masterScore, mu::engraving::MsczReader& msczFile, bool ignoreVersionError)
+{
+    return masterScore->loadMscz(msczFile, ignoreVersionError);
 }

--- a/src/engraving/scoreaccess.h
+++ b/src/engraving/scoreaccess.h
@@ -19,19 +19,24 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include "notationcreator.h"
+#ifndef MU_ENGRAVING_SCOREACCESS_H
+#define MU_ENGRAVING_SCOREACCESS_H
 
-#include "notationproject.h"
-#include "excerptnotation.h"
+#include "libmscore/score.h"
 
-using namespace mu::notation;
+//! NOTE This is a temporary class for controlling (master)score access
+//! See Project class description for detail
 
-INotationProjectPtr NotationCreator::newNotationProject() const
+namespace mu::engraving {
+class ScoreAccess
 {
-    return std::make_shared<NotationProject>();
+public:
+
+    static Ms::MasterScore* createMasterScore();
+    static Ms::MasterScore* createMasterScore(const Ms::MStyle& style);
+
+    static Ms::Score::FileError loadMscz(Ms::MasterScore* masterScore, mu::engraving::MsczReader& msczFile, bool ignoreVersionError);
+};
 }
 
-IExcerptNotationPtr NotationCreator::newExcerptNotation() const
-{
-    return std::make_shared<ExcerptNotation>();
-}
+#endif // MU_ENGRAVING_SCOREACCESS_H

--- a/src/engraving/tests/testbase.cpp
+++ b/src/engraving/tests/testbase.cpp
@@ -37,6 +37,7 @@
 #include "thirdparty/qzip/qzipreader_p.h"
 
 #include "engraving/compat/mscxcompat.h"
+#include "engraving/scoreaccess.h"
 
 #include "framework/global/globalmodule.h"
 #include "framework/fonts/fontsmodule.h"
@@ -103,7 +104,7 @@ MasterScore* MTest::readScore(const QString& name)
 
 MasterScore* MTest::readCreatedScore(const QString& name)
 {
-    MasterScore* score = new MasterScore(mscore->baseStyle());
+    MasterScore* score = mu::engraving::ScoreAccess::createMasterScore(mscore->baseStyle());
     QFileInfo fi(name);
     score->setName(fi.completeBaseName());
     QString csl  = fi.suffix().toLower();

--- a/src/engraving/tests/tst_chordsymbol.cpp
+++ b/src/engraving/tests/tst_chordsymbol.cpp
@@ -200,7 +200,7 @@ void TestChordSymbol::testNoSystem()
     //
     QList<Part*> parts;
     parts.append(score->parts().at(0));
-    Score* nscore = new Score(score);
+    Score* nscore = score->createScore();
 
     Excerpt* ex = new Excerpt(score);
     ex->setPartScore(nscore);
@@ -219,7 +219,7 @@ void TestChordSymbol::testNoSystem()
     //
     parts.clear();
     parts.append(score->parts().at(1));
-    nscore = new Score(score);
+    nscore = score->createScore();
 
     ex = new Excerpt(score);
     ex->setPartScore(nscore);

--- a/src/engraving/tests/tst_layout_benchmark.cpp
+++ b/src/engraving/tests/tst_layout_benchmark.cpp
@@ -25,6 +25,7 @@
 #include "libmscore/score.h"
 
 #include "engraving/compat/mscxcompat.h"
+#include "engraving/scoreaccess.h"
 
 using namespace mu::engraving;
 
@@ -71,7 +72,7 @@ void TestLayoutBenchmark::initTestCase()
 void TestLayoutBenchmark::benchmark3()
 {
     QString path = root + "/" + LAYOUT_DATA_DIR + "goldberg.mscx";
-    score = new MasterScore(mscore->baseStyle());
+    score = mu::engraving::ScoreAccess::createMasterScore(mscore->baseStyle());
     score->setName(path);
     MScore::testMode = true;
     QBENCHMARK {

--- a/src/framework/global/ret.h
+++ b/src/framework/global/ret.h
@@ -64,8 +64,8 @@ public:
         MidiFirst       = 600,
         MidiLast        = 699,
 
-        LanguagesFirst = 700,
-        LanguagesLast  = 799,
+        LanguagesFirst  = 700,
+        LanguagesLast   = 799,
 
         NotationFirst   = 1000,
         NotationLast    = 1299,
@@ -80,7 +80,10 @@ public:
         WorkspaceLast   = 1599,
 
         LearnFirst      = 1600,
-        LearnLast       = 1699
+        LearnLast       = 1699,
+
+        EngravingFirst  = 2000,
+        EngravingLast   = 2999,
     };
 
     Ret() = default;

--- a/src/importexport/bb/tests/testbase.cpp
+++ b/src/importexport/bb/tests/testbase.cpp
@@ -31,6 +31,7 @@
 #include "libmscore/musescoreCore.h"
 
 #include "engraving/compat/mscxcompat.h"
+#include "engraving/scoreaccess.h"
 
 using namespace mu::engraving;
 
@@ -47,7 +48,7 @@ MTest::MTest()
 MasterScore* MTest::readScore(const QString& name)
 {
     QString path = root + "/" + name;
-    MasterScore* score = new MasterScore(mscore->baseStyle());
+    MasterScore* score = ScoreAccess::createMasterScore(mscore->baseStyle());
     QFileInfo fi(path);
     score->setName(fi.completeBaseName());
     QString csl  = fi.suffix().toLower();

--- a/src/importexport/braille/tests/testbase.cpp
+++ b/src/importexport/braille/tests/testbase.cpp
@@ -31,6 +31,7 @@
 #include "libmscore/musescoreCore.h"
 
 #include "engraving/compat/mscxcompat.h"
+#include "engraving/scoreaccess.h"
 
 using namespace mu::engraving;
 
@@ -47,7 +48,7 @@ MTest::MTest()
 MasterScore* MTest::readScore(const QString& name)
 {
     QString path = root + "/" + name;
-    MasterScore* score = new MasterScore(mscore->baseStyle());
+    MasterScore* score = mu::engraving::ScoreAccess::createMasterScore(mscore->baseStyle());
     QFileInfo fi(path);
     score->setName(fi.completeBaseName());
     QString csl  = fi.suffix().toLower();

--- a/src/importexport/bww/tests/testbase.cpp
+++ b/src/importexport/bww/tests/testbase.cpp
@@ -31,6 +31,7 @@
 #include "libmscore/musescoreCore.h"
 
 #include "engraving/compat/mscxcompat.h"
+#include "engraving/scoreaccess.h"
 
 using namespace mu::engraving;
 
@@ -43,7 +44,7 @@ MTest::MTest()
 MasterScore* MTest::readScore(const QString& name)
 {
     QString path = root + "/" + name;
-    MasterScore* score = new MasterScore(mscore->baseStyle());
+    MasterScore* score = mu::engraving::ScoreAccess::createMasterScore(mscore->baseStyle());
     QFileInfo fi(path);
     score->setName(fi.completeBaseName());
     QString csl  = fi.suffix().toLower();

--- a/src/importexport/capella/tests/testbase.cpp
+++ b/src/importexport/capella/tests/testbase.cpp
@@ -31,6 +31,7 @@
 #include "libmscore/musescoreCore.h"
 
 #include "engraving/compat/mscxcompat.h"
+#include "engraving/scoreaccess.h"
 
 using namespace mu::engraving;
 
@@ -48,7 +49,7 @@ MTest::MTest()
 MasterScore* MTest::readScore(const QString& name)
 {
     QString path = root + "/" + name;
-    MasterScore* score = new MasterScore(mscore->baseStyle());
+    MasterScore* score = mu::engraving::ScoreAccess::createMasterScore(mscore->baseStyle());
     QFileInfo fi(path);
     score->setName(fi.completeBaseName());
     QString csl  = fi.suffix().toLower();

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -2975,7 +2975,7 @@ Score::FileError importGTP(MasterScore* score, const QString& name)
             continue;
         }
         QMultiMap<int, int> tracks;
-        Score* pscore = new Score(score);
+        Score* pscore = score->createScore();
         //TODO-ws		pscore->showLyrics = score->showLyrics;
         pscore->style().set(Sid::createMultiMeasureRests, false);
         pscore->style().set(Sid::ArpeggioHiddenInStdIfTab, true);

--- a/src/importexport/guitarpro/internal/importptb.cpp
+++ b/src/importexport/guitarpro/internal/importptb.cpp
@@ -1289,7 +1289,7 @@ Score::FileError PowerTab::read()
     int id = 0;
     for (Part* part : score->parts()) {
         QMultiMap<int, int> tracks;
-        Score* pscore = new Score(score);
+        Score* pscore = score->createScore();
 
 //TODO-ws            pscore->tuning.clear();
         auto& info = song.track1.infos[id++];

--- a/src/importexport/midi/tests/testbase.cpp
+++ b/src/importexport/midi/tests/testbase.cpp
@@ -31,6 +31,7 @@
 #include "libmscore/musescoreCore.h"
 
 #include "engraving/compat/mscxcompat.h"
+#include "engraving/scoreaccess.h"
 
 using namespace mu::engraving;
 
@@ -46,7 +47,7 @@ MTest::MTest()
 MasterScore* MTest::readScore(const QString& name)
 {
     QString path = root + "/" + name;
-    MasterScore* score = new MasterScore(mscore->baseStyle());
+    MasterScore* score = ScoreAccess::createMasterScore(mscore->baseStyle());
     QFileInfo fi(path);
     score->setName(fi.completeBaseName());
     QString csl  = fi.suffix().toLower();

--- a/src/importexport/musicxml/tests/testbase.cpp
+++ b/src/importexport/musicxml/tests/testbase.cpp
@@ -31,6 +31,7 @@
 #include "libmscore/musescoreCore.h"
 
 #include "engraving/compat/mscxcompat.h"
+#include "engraving/scoreaccess.h"
 
 #include "importexport/musicxml/internal/musicxml/exportxml.h"
 
@@ -55,7 +56,7 @@ MasterScore* MTest::readScore(const QString& name)
 
 MasterScore* MTest::readCreatedScore(const QString& name)
 {
-    MasterScore* score = new MasterScore(mscore->baseStyle());
+    MasterScore* score = ScoreAccess::createMasterScore(mscore->baseStyle());
     QFileInfo fi(name);
     score->setName(fi.completeBaseName());
     QString csl  = fi.suffix().toLower();

--- a/src/inspector/models/abstractinspectormodel.cpp
+++ b/src/inspector/models/abstractinspectormodel.cpp
@@ -453,7 +453,7 @@ void AbstractInspectorModel::loadPropertyItem(PropertyItem* propertyItem, std::f
 
 bool AbstractInspectorModel::isNotationExisting() const
 {
-    return !context()->masterNotations().empty();
+    return !context()->notationProjects().empty();
 }
 
 bool AbstractInspectorModel::hasAcceptableElements() const

--- a/src/multiinstances/internal/multiinstancesprovider.cpp
+++ b/src/multiinstances/internal/multiinstancesprovider.cpp
@@ -78,12 +78,12 @@ void MultiInstancesProvider::onMsg(const Msg& msg)
     if (msg.type == MsgType::Request && msg.method == METHOD_SCORE_IS_OPENED) {
         CHECK_ARGS_COUNT(1);
         io::path scorePath = io::path(msg.args.at(0));
-        bool isOpened = fileScoreController()->isScoreOpened(scorePath);
+        bool isOpened = fileScoreController()->isProjectOpened(scorePath);
         m_ipcChannel->response(METHOD_SCORE_IS_OPENED, { QString::number(isOpened) }, msg.srcID);
     } else if (msg.method == METHOD_ACTIVATE_WINDOW_WITH_SCORE) {
         CHECK_ARGS_COUNT(1);
         io::path scorePath = io::path(msg.args.at(0));
-        bool isOpened = fileScoreController()->isScoreOpened(scorePath);
+        bool isOpened = fileScoreController()->isProjectOpened(scorePath);
         if (isOpened) {
             mainWindow()->requestShowOnFront();
         }

--- a/src/notation/CMakeLists.txt
+++ b/src/notation/CMakeLists.txt
@@ -31,6 +31,7 @@ set(MODULE_SRC
     ${WIDGETS_SRC}
     ${CMAKE_CURRENT_LIST_DIR}/notationmodule.cpp
     ${CMAKE_CURRENT_LIST_DIR}/notationmodule.h
+    ${CMAKE_CURRENT_LIST_DIR}/inotationproject.h
     ${CMAKE_CURRENT_LIST_DIR}/imasternotation.h
     ${CMAKE_CURRENT_LIST_DIR}/iexcerptnotation.h
     ${CMAKE_CURRENT_LIST_DIR}/inotation.h
@@ -54,9 +55,12 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/inotationplayback.h
     ${CMAKE_CURRENT_LIST_DIR}/inotationelements.h
     ${CMAKE_CURRENT_LIST_DIR}/inotationparts.h
+
     ${CMAKE_CURRENT_LIST_DIR}/internal/notationuiactions.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/notationuiactions.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/igetscore.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/notationproject.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/notationproject.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/masternotation.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/masternotation.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/excerptnotation.cpp

--- a/src/notation/inotationcreator.h
+++ b/src/notation/inotationcreator.h
@@ -22,7 +22,7 @@
 #ifndef MU_NOTATION_INOTATIONCREATOR_H
 #define MU_NOTATION_INOTATIONCREATOR_H
 
-#include "imasternotation.h"
+#include "inotationproject.h"
 #include "iexcerptnotation.h"
 
 #include "modularity/imoduleexport.h"
@@ -35,7 +35,7 @@ class INotationCreator : MODULE_EXPORT_INTERFACE
 public:
     virtual ~INotationCreator() = default;
 
-    virtual IMasterNotationPtr newMasterNotation() const = 0;
+    virtual INotationProjectPtr newNotationProject() const = 0;
     virtual IExcerptNotationPtr newExcerptNotation() const = 0;
 };
 }

--- a/src/notation/inotationproject.h
+++ b/src/notation/inotationproject.h
@@ -19,38 +19,40 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_NOTATION_IMASTERNOTATION_H
-#define MU_NOTATION_IMASTERNOTATION_H
+#ifndef MU_NOTATION_INOTATIONPROJECT_H
+#define MU_NOTATION_INOTATIONPROJECT_H
 
-#include "modularity/imoduleexport.h"
-#include "inotation.h"
-#include "iexcerptnotation.h"
-#include "retval.h"
+#include <memory>
+
 #include "io/path.h"
-#include "io/device.h"
+#include "ret.h"
+
+#include "imasternotation.h"
 
 namespace mu::notation {
-using ExcerptNotationList = std::vector<IExcerptNotationPtr>;
-
-class IMasterNotation
+class INotationProject
 {
 public:
-    virtual INotationPtr notation() = 0;
+    virtual ~INotationProject() = default;
 
-    virtual Meta metaInfo() const = 0;
-    virtual void setMetaInfo(const Meta& meta) = 0;
+    virtual io::path path() const = 0;
+
+    virtual Ret load(const io::path& path, const io::path& stylePath = io::path(), bool forceMode = false) = 0;
+    virtual Ret createNew(const ScoreCreateOptions& scoreInfo) = 0;
 
     virtual RetVal<bool> created() const = 0;
     virtual ValNt<bool> needSave() const = 0;
 
-    virtual ValCh<ExcerptNotationList> excerpts() const = 0;
-    virtual void setExcerpts(const ExcerptNotationList& excerpts) = 0;
+    virtual Ret save(const io::path& path = io::path(), SaveMode saveMode = SaveMode::Save) = 0;
+    virtual Ret writeToDevice(io::Device& destinationDevice) = 0;
 
-    virtual INotationPartsPtr parts() const = 0;
-    virtual INotationPtr clone() const = 0;
+    virtual Meta metaInfo() const = 0;
+    virtual void setMetaInfo(const Meta& meta) = 0;
+
+    virtual IMasterNotationPtr masterNotation() const = 0;
 };
 
-using IMasterNotationPtr = std::shared_ptr<IMasterNotation>;
+using INotationProjectPtr = std::shared_ptr<INotationProject>;
 }
 
-#endif // MU_NOTATION_IMASTERNOTATION_H
+#endif // MU_NOTATION_INOTATIONPROJECT_H

--- a/src/notation/internal/masternotation.h
+++ b/src/notation/internal/masternotation.h
@@ -25,8 +25,6 @@
 #include <memory>
 
 #include "../imasternotation.h"
-#include "../inotationreadersregister.h"
-#include "../inotationwritersregister.h"
 
 #include "modularity/ioc.h"
 #include "notation.h"
@@ -37,27 +35,23 @@ class MasterScore;
 }
 
 namespace mu::notation {
+class NotationProject;
 class MasterNotation : public IMasterNotation, public Notation, public std::enable_shared_from_this<MasterNotation>
 {
-    INJECT(notation, INotationReadersRegister, readers)
-    INJECT(notation, INotationWritersRegister, writers)
-
 public:
-    explicit MasterNotation();
     ~MasterNotation();
+
+    void setMasterScore(Ms::MasterScore* masterScore);
+    Ret setupNewScore(Ms::MasterScore* score, Ms::MasterScore* templateScore, const ScoreCreateOptions& scoreOptions);
+    void onSaveCopy();
 
     INotationPtr notation() override;
 
     Meta metaInfo() const override;
     void setMetaInfo(const Meta& meta) override;
 
-    Ret load(const io::path& path, const io::path& stylePath = io::path(), bool forceMode = false) override;
-    io::path path() const override;
-
-    Ret createNew(const ScoreCreateOptions& scoreOptions) override;
     RetVal<bool> created() const override;
 
-    Ret save(const io::path& path = io::path(), SaveMode saveMode = SaveMode::Save) override;
     mu::ValNt<bool> needSave() const override;
 
     ValCh<ExcerptNotationList> excerpts() const override;
@@ -66,16 +60,12 @@ public:
     INotationPartsPtr parts() const override;
     INotationPtr clone() const override;
 
-    Ret writeToDevice(io::Device& destinationDevice) override;
-
 private:
-    Ret exportScore(const io::path& path, const std::string& suffix);
+
+    friend class NotationProject;
+    explicit MasterNotation();
 
     Ms::MasterScore* masterScore() const;
-
-    Ret load(const io::path& path, const io::path& stylePath, const INotationReaderPtr& reader, bool forceMode = false);
-    Ret doLoadScore(Ms::MasterScore* score, const io::path& path, const INotationReaderPtr& reader, bool forceMode = false) const;
-    mu::RetVal<Ms::MasterScore*> newScore(const ScoreCreateOptions& scoreInfo);
 
     void doSetExcerpts(ExcerptNotationList excerpts);
 
@@ -85,9 +75,6 @@ private:
 
     void updateExcerpts();
     IExcerptNotationPtr createExcerpt(Ms::Part* part);
-
-    Ret saveScore(const io::path& path = io::path(), SaveMode saveMode = SaveMode::Save);
-    Ret saveSelectionOnScore(const io::path& path = io::path());
 
     ValCh<ExcerptNotationList> m_excerpts;
 };

--- a/src/notation/internal/notationcreator.h
+++ b/src/notation/internal/notationcreator.h
@@ -28,7 +28,7 @@ namespace mu::notation {
 class NotationCreator : public INotationCreator
 {
 public:
-    IMasterNotationPtr newMasterNotation() const override;
+    INotationProjectPtr newNotationProject() const override;
     IExcerptNotationPtr newExcerptNotation() const override;
 };
 }

--- a/src/notation/internal/notationproject.cpp
+++ b/src/notation/internal/notationproject.cpp
@@ -1,0 +1,236 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "notationproject.h"
+
+#include "engraving/engravingproject.h"
+#include "engraving/scoreaccess.h"
+
+#include "notationerrors.h"
+#include "masternotation.h"
+
+#include "log.h"
+
+using namespace mu::notation;
+using namespace mu::engraving;
+
+NotationProject::NotationProject()
+{
+    m_engravingProject = EngravingProject::create();
+    m_masterNotation = std::shared_ptr<MasterNotation>(new MasterNotation());
+}
+
+mu::io::path NotationProject::path() const
+{
+    return m_engravingProject->path();
+}
+
+mu::Ret NotationProject::load(const io::path& path, const io::path& stylePath, bool forceMode)
+{
+    TRACEFUNC;
+
+    std::string syffix = io::syffix(path);
+
+    //! NOTE For "mscz", "mscx" see MsczNotationReader
+    //! for others see readers in importexport module
+    auto reader = readers()->reader(syffix);
+    if (!reader) {
+        return make_ret(notation::Err::FileUnknownType, path);
+    }
+
+    return load(path, stylePath, reader, forceMode);
+}
+
+mu::Ret NotationProject::load(const io::path& path, const io::path& stylePath, const INotationReaderPtr& reader, bool forceMode)
+{
+    EngravingProjectPtr project = EngravingProject::create();
+    project->setPath(path.toQString());
+
+    INotationReader::Options options;
+    if (forceMode) {
+        options[INotationReader::OptionKey::ForceMode] = forceMode;
+    }
+
+    Ms::ScoreLoad sl;
+
+    Ms::MasterScore* score = project->masterScore();
+    Ret ret = reader->read(score, path, options);
+    if (!ret) {
+        return ret;
+    }
+
+    if (!Ms::MScore::lastError.isEmpty()) {
+        LOGE() << Ms::MScore::lastError;
+    }
+
+    project->setupMasterScore();
+    if (!Ms::MScore::lastError.isEmpty()) {
+        LOGE() << Ms::MScore::lastError;
+    }
+
+    if (!stylePath.empty()) {
+        score->loadStyle(stylePath.toQString());
+
+        if (!Ms::MScore::lastError.isEmpty()) {
+            LOGE() << Ms::MScore::lastError;
+        }
+    }
+
+    m_engravingProject = project;
+    m_masterNotation->setMasterScore(project->masterScore());
+
+    return make_ret(Ret::Code::Ok);
+}
+
+IMasterNotationPtr NotationProject::masterNotation() const
+{
+    return m_masterNotation;
+}
+
+mu::Ret NotationProject::createNew(const ScoreCreateOptions& scoreOptions)
+{
+    EngravingProjectPtr project = EngravingProject::create();
+    Ms::MasterScore* masterScore = project->masterScore();
+
+    io::path templatePath = scoreOptions.templatePath;
+    Ms::MasterScore* templateScore = nullptr;
+    if (!templatePath.empty()) {
+        std::string syffix = io::syffix(templatePath);
+        auto reader = readers()->reader(syffix);
+        if (!reader) {
+            LOGE() << "not found reader for file: " << templatePath;
+            return make_ret(Ret::Code::InternalError);
+        }
+
+        EngravingProjectPtr templateProject = EngravingProject::create(Ms::MScore::baseStyle());
+        templateScore = templateProject->masterScore();
+        Ret ret = reader->read(templateScore, templatePath);
+        if (!ret) {
+            return ret;
+        }
+
+        templateProject->setupMasterScore();
+        if (!ret) {
+            return ret;
+        }
+    }
+
+    Ret ret = m_masterNotation->setupNewScore(masterScore, templateScore, scoreOptions);
+    if (!ret) {
+        //! NOTE Return old
+        m_masterNotation->setMasterScore(m_engravingProject->masterScore());
+        return ret;
+    }
+
+    m_engravingProject = project;
+
+    return make_ret(Ret::Code::Ok);
+}
+
+mu::RetVal<bool> NotationProject::created() const
+{
+    return m_masterNotation->created();
+}
+
+mu::ValNt<bool> NotationProject::needSave() const
+{
+    return m_masterNotation->needSave();
+}
+
+mu::Ret NotationProject::save(const io::path& path, SaveMode saveMode)
+{
+    switch (saveMode) {
+    case SaveMode::SaveSelection:
+        return saveSelectionOnScore(path);
+    case SaveMode::Save:
+    case SaveMode::SaveAs:
+    case SaveMode::SaveCopy:
+        return saveScore(path);
+    }
+
+    return make_ret(Err::UnknownError);
+}
+
+mu::Ret NotationProject::writeToDevice(io::Device& destinationDevice)
+{
+    bool ok = m_engravingProject->writeMscz(&destinationDevice, m_masterNotation->metaInfo().title + ".mscx");
+    return ok;
+}
+
+mu::Ret NotationProject::saveScore(const io::path& path, SaveMode saveMode)
+{
+    std::string suffix = io::syffix(path);
+    if (suffix != "mscz" && !suffix.empty()) {
+        return exportProject(path, suffix);
+    }
+
+    io::path oldFilePath = m_engravingProject->path();
+
+    if (!path.empty()) {
+        m_engravingProject->setPath(path.toQString());
+    }
+
+    Ret ret = m_engravingProject->saveFile(true);
+    if (!ret) {
+        ret.setText(Ms::MScore::lastError.toStdString());
+    } else if (saveMode != SaveMode::SaveCopy || oldFilePath == path) {
+        m_masterNotation->onSaveCopy();
+    }
+
+    return make_ret(Ret::Code::Ok);
+}
+
+mu::Ret NotationProject::exportProject(const io::path& path, const std::string& suffix)
+{
+    QFile file(path.toQString());
+    file.open(QFile::WriteOnly);
+
+    auto writer = writers()->writer(suffix);
+    if (!writer) {
+        LOGE() << "Unknown export format:" << suffix;
+        return false;
+    }
+
+    Ret ret = writer->write(m_masterNotation, file);
+    file.close();
+
+    return ret;
+}
+
+mu::Ret NotationProject::saveSelectionOnScore(const mu::io::path& path)
+{
+    Ret ret = m_engravingProject->saveSelectionOnScore(path.toQString());
+    if (!ret) {
+        ret.setText(Ms::MScore::lastError.toStdString());
+    }
+
+    return ret;
+}
+
+Meta NotationProject::metaInfo() const
+{
+    return m_masterNotation->metaInfo();
+}
+
+void NotationProject::setMetaInfo(const Meta& meta)
+{
+    m_masterNotation->setMetaInfo(meta);
+}

--- a/src/notation/internal/notationproject.h
+++ b/src/notation/internal/notationproject.h
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_NOTATION_NOTATIONPROJECT_H
+#define MU_NOTATION_NOTATIONPROJECT_H
+
+#include "../inotationproject.h"
+#include "engraving/engravingproject.h"
+
+#include "../inotationreadersregister.h"
+#include "../inotationwritersregister.h"
+
+namespace mu::notation {
+class MasterNotation;
+class NotationProject : public INotationProject
+{
+    INJECT(notation, INotationReadersRegister, readers)
+    INJECT(notation, INotationWritersRegister, writers)
+
+public:
+    NotationProject();
+
+    io::path path() const override;
+
+    Ret load(const io::path& path, const io::path& stylePath = io::path(), bool forceMode = false) override;
+    Ret createNew(const ScoreCreateOptions& scoreInfo) override;
+
+    RetVal<bool> created() const override;
+    ValNt<bool> needSave() const override;
+
+    Ret save(const io::path& path = io::path(), SaveMode saveMode = SaveMode::Save) override;
+    Ret writeToDevice(io::Device& destinationDevice) override;
+
+    Meta metaInfo() const override;
+    void setMetaInfo(const Meta& meta) override;
+
+    IMasterNotationPtr masterNotation() const override;
+
+private:
+
+    Ret load(const io::path& path, const io::path& stylePath, const INotationReaderPtr& reader, bool forceMode);
+
+    Ret saveScore(const io::path& path = io::path(), SaveMode saveMode = SaveMode::Save);
+    Ret saveSelectionOnScore(const io::path& path = io::path());
+    Ret exportProject(const io::path& path, const std::string& suffix);
+
+    mu::engraving::EngravingProjectPtr m_engravingProject = nullptr;
+    std::shared_ptr<MasterNotation> m_masterNotation = nullptr;
+};
+}
+
+#endif // MU_NOTATION_NOTATIONPROJECT_H

--- a/src/notation/notationerrors.h
+++ b/src/notation/notationerrors.h
@@ -26,6 +26,7 @@
 #include "translation.h"
 #include "io/path.h"
 #include "libmscore/score.h"
+#include "engraving/engravingerrors.h"
 
 namespace mu::notation {
 // 1000 - 1299
@@ -122,6 +123,11 @@ inline Ret make_ret(Err err, const io::path& filePath = "")
     }
 
     return Ret(code, text.toStdString());
+}
+
+inline Ret make_ret(engraving::Err e)
+{
+    return Ret(static_cast<int>(e));
 }
 
 inline Ret scoreFileErrorToRet(Ms::Score::FileError err, const io::path& filePath)

--- a/src/notation/view/widgets/editstafftype.cpp
+++ b/src/notation/view/widgets/editstafftype.cpp
@@ -27,11 +27,14 @@
 #include "libmscore/staff.h"
 #include "libmscore/stringdata.h"
 
+#include "engraving/scoreaccess.h"
+
 #include "widgetstatestore.h"
 #include "internal/mscznotationreader.h"
 
-#include "log.h"
 #include "notationerrors.h"
+
+#include "log.h"
 
 using namespace mu::notation;
 
@@ -85,7 +88,7 @@ EditStaffType::EditStaffType(QWidget* parent)
     }
 
     // load a sample standard score in preview
-    Ms::MasterScore* sc = new Ms::MasterScore(Ms::MScore::defaultStyle());
+    Ms::MasterScore* sc = mu::engraving::ScoreAccess::createMasterScore(Ms::MScore::defaultStyle());
     if (loadScore(sc, ":/view/resources/data/std_sample.mscx")) {
         standardPreview->setScore(sc);
     } else {
@@ -93,7 +96,7 @@ EditStaffType::EditStaffType(QWidget* parent)
     }
 
     // load a sample tabulature score in preview
-    sc = new Ms::MasterScore(Ms::MScore::defaultStyle());
+    sc = mu::engraving::ScoreAccess::createMasterScore(Ms::MScore::defaultStyle());
     if (loadScore(sc, ":/view/resources/data/tab_sample.mscx")) {
         tabPreview->setScore(sc);
     } else {

--- a/src/plugins/api/qmlpluginapi.cpp
+++ b/src/plugins/api/qmlpluginapi.cpp
@@ -32,6 +32,7 @@
 #include "tie.h"
 
 #include "libmscore/musescoreCore.h"
+#include "engraving/scoreaccess.h"
 
 #include <QQmlEngine>
 
@@ -188,7 +189,7 @@ Score* PluginAPI::newScore(const QString& name, const QString& part, int measure
     if (msc()->currentScore()) {
         msc()->currentScore()->endCmd();
     }
-    MasterScore* score = new MasterScore(MScore::defaultStyle());
+    MasterScore* score = mu::engraving::ScoreAccess::createMasterScore(MScore::defaultStyle());
     score->setName(name);
     score->appendPart(Score::instrTemplateFromName(part));
     score->appendMeasures(measures);

--- a/src/userscores/ifilescorecontroller.h
+++ b/src/userscores/ifilescorecontroller.h
@@ -34,9 +34,9 @@ class IFileScoreController : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IFileScoreController() = default;
 
-    virtual Ret openScore(const io::path& scorePath) = 0;
-    virtual bool closeOpenedScore() = 0;
-    virtual bool isScoreOpened(const io::path& scorePath) const = 0;
+    virtual Ret openProject(const io::path& scorePath) = 0;
+    virtual bool closeOpenedProject() = 0;
+    virtual bool isProjectOpened(const io::path& scorePath) const = 0;
 };
 }
 

--- a/src/userscores/internal/exportscorescenario.cpp
+++ b/src/userscores/internal/exportscorescenario.cpp
@@ -151,15 +151,15 @@ bool ExportScoreScenario::isMainNotation(INotationPtr notation) const
 
 mu::io::path ExportScoreScenario::askExportPath(const INotationPtrList& notations, const ExportType& exportType, UnitType unitType) const
 {
-    IMasterNotationPtr currentMasterNotation = context()->currentMasterNotation();
+    INotationProjectPtr currentNotationProject = context()->currentNotationProject();
 
     io::path suggestedPath = configuration()->userScoresPath();
-    io::path masterNotationDirPath = io::dirpath(currentMasterNotation->path());
-    if (masterNotationDirPath != "") {
-        suggestedPath = masterNotationDirPath;
+    io::path notationProjectDirPath = io::dirpath(currentNotationProject->path());
+    if (notationProjectDirPath != "") {
+        suggestedPath = notationProjectDirPath;
     }
 
-    suggestedPath += "/" + currentMasterNotation->metaInfo().title;
+    suggestedPath += "/" + currentNotationProject->metaInfo().title;
 
     // If only one file will be created, the filename will be exactly what the user
     // types in the save dialog and therefore we can put the file dialog in charge of

--- a/src/userscores/internal/filescorecontroller.h
+++ b/src/userscores/internal/filescorecontroller.h
@@ -50,21 +50,22 @@ class FileScoreController : public IFileScoreController, public actions::Actiona
 public:
     void init();
 
-    Ret openScore(const io::path& scorePath) override;
-    bool closeOpenedScore() override;
-    bool isScoreOpened(const io::path& scorePath) const override;
+    Ret openProject(const io::path& projectPath) override;
+    bool closeOpenedProject() override;
+    bool isProjectOpened(const io::path& scorePath) const override;
 
 private:
     void setupConnections();
 
+    notation::INotationProjectPtr currentNotationProject() const;
     notation::IMasterNotationPtr currentMasterNotation() const;
     notation::INotationPtr currentNotation() const;
     notation::INotationInteractionPtr currentInteraction() const;
     notation::INotationSelectionPtr currentNotationSelection() const;
 
-    void openScore(const actions::ActionData& args);
+    void openProject(const actions::ActionData& args);
     void importScore();
-    void newScore();
+    void newProject();
 
     bool checkCanIgnoreError(const Ret& ret, const io::path& filePath);
     framework::IInteractive::Button askAboutSavingScore(const io::path& filePath);
@@ -84,7 +85,7 @@ private:
     io::path selectScoreOpeningFile();
     io::path selectScoreSavingFile(const io::path& defaultFilePath, const QString& saveTitle);
 
-    Ret doOpenScore(const io::path& filePath);
+    Ret doOpenProject(const io::path& filePath);
     void doSaveScore(const io::path& filePath = io::path(), notation::SaveMode saveMode = notation::SaveMode::Save);
 
     void exportScore();
@@ -93,7 +94,7 @@ private:
 
     void prependToRecentScoreList(const io::path& filePath);
 
-    bool isScoreOpened() const;
+    bool isProjectOpened() const;
     bool isNeedSaveScore() const;
     bool hasSelection() const;
 };

--- a/src/userscores/view/newscoremodel.cpp
+++ b/src/userscores/view/newscoremodel.cpp
@@ -51,19 +51,19 @@ bool NewScoreModel::createScore(const QVariant& info)
 {
     ScoreCreateOptions options = parseOptions(info.toMap());
 
-    auto notation = notationCreator()->newMasterNotation();
-    Ret ret = notation->createNew(options);
+    auto project = notationCreator()->newNotationProject();
+    Ret ret = project->createNew(options);
 
     if (!ret) {
         LOGE() << ret.toString();
         return false;
     }
 
-    if (!globalContext()->containsMasterNotation(notation->path())) {
-        globalContext()->addMasterNotation(notation);
+    if (!globalContext()->containsNotationProject(project->path())) {
+        globalContext()->addNotationProject(project);
     }
 
-    globalContext()->setCurrentMasterNotation(notation);
+    globalContext()->setCurrentNotationProject(project);
 
     bool isScoreCreatedFromInstruments = options.templatePath.empty();
     updatePreferredScoreCreationMode(isScoreCreatedFromInstruments);

--- a/src/userscores/view/templatepaintview.cpp
+++ b/src/userscores/view/templatepaintview.cpp
@@ -63,16 +63,16 @@ QString TemplatePaintView::zoomOutSequence() const
 
 void TemplatePaintView::load()
 {
-    IMasterNotationPtr masterNotation = notationCreator()->newMasterNotation();
-    Ret ret = masterNotation->load(m_templatePath);
+    INotationProjectPtr notationProject = notationCreator()->newNotationProject();
+    Ret ret = notationProject->load(m_templatePath);
 
     if (!ret) {
         LOGE() << ret.toString();
     }
 
-    setNotation(masterNotation->notation());
+    setNotation(notationProject->masterNotation()->notation());
 
-    if (masterNotation) {
+    if (notationProject) {
         adjustCanvas();
     }
 }


### PR DESCRIPTION
In addition to the score itself, a mscz file also stores other data, for example, settings for a synthesizer, mixer, omr, etc.
So, we should talk not just about a score, but about a Project.
To some extent, the project functions are performed by MasterScore, but this is not its responsibility, this functionality only overloads it and confuses what, where and why.

I add explicitly the concept of a project.