### PR TITLE
Fix issues discovered while moving grip handles around on trills

### DIFF
--- a/src/engraving/libmscore/layout.cpp
+++ b/src/engraving/libmscore/layout.cpp
@@ -2156,6 +2156,9 @@ System* Score::getNextSystem(LayoutContext& lc)
     if (!isVBox) {
         int nstaves = Score::nstaves();
         system->adjustStavesNumber(nstaves);
+        for (int i = 0; i < nstaves; ++i) {
+            system->staff(i)->setShow(score()->staff(i)->show());
+        }
     }
     return system;
 }

--- a/src/engraving/libmscore/line.cpp
+++ b/src/engraving/libmscore/line.cpp
@@ -432,7 +432,7 @@ Segment* LineSegment::findSegmentForGrip(Grip grip, PointF pos) const
     System* sys = oldSeg->system();
     const QList<System*> foundSystems = score()->searchSystem(pos, sys, spacingFactor);
 
-    if (!foundSystems.empty() && !foundSystems.contains(sys)) {
+    if (!foundSystems.empty() && !foundSystems.contains(sys) && foundSystems[0]->staves()->size()) {
         sys = foundSystems[0];
     }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/322957 https://github.com/musescore/MuseScore/issues/8592

Two unrelated issues, neither really to do with trill lines specifically at all but both discovered at the same time:

a) if you drag the grip handle from any line into a 0-stave system (e.g. for a V-frame, as new scores have by default at the top of the score), it crashes
b) a bug in the layout engine where it reused cached information from a previous layout caused erratic behaviour when dragging grip handles around, though it could be triggered in other ways,

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x ] I signed [CLA](https://musescore.org/en/cla)
- [ x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x ] I made sure the code compiles on my machine
- [ x ] I made sure there are no unnecessary changes in the code
- [ x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
