### PR TITLE
[MU3 Backend] ENG-18-adjacent Remove left FretDiagram spacer if first beat of measure

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1303,17 +1303,24 @@ Shape ChordRest::shape() const
                   }
             else if (e->isFretDiagram()) {
                   FretDiagram* fd = toFretDiagram(e);
-                  if (fd->bbox().isEmpty()) fd->calculateBoundingRect();
                   qreal margin = styleP(Sid::fretMinDistance) * 0.5;
-                  x1 = qMin(x1, e->bbox().x() - margin + e->pos().x());
-                  x2 = qMax(x2, e->bbox().x() + e->bbox().width() + margin + e->pos().x());
+                  bool firstBeat = tick() == measure()->tick();
+                  if (fd->bbox().isEmpty())
+                        fd->calculateBoundingRect();
+                  qreal leftX = firstBeat ? 0 : e->bbox().x() - margin + e->pos().x();
+                  qreal rightX = e->bbox().x() + e->bbox().width() + margin + e->pos().x();
+                  x1 = qMin(x1, leftX);
+                  x2 = qMax(x2, rightX);
                   adjustWidth = true;
                   if (fd->harmony()) {
                         Harmony* h = fd->harmony();
-                        if (h->bbox().isEmpty()) h->layout1();
                         margin = styleP(Sid::minHarmonyDistance) * 0.5;
-                        x1 = qMin(x1, h->bbox().x() - margin + h->pos().x() + e->pos().x());
-                        x2 = qMax(x2, h->bbox().x() + h->bbox().width() + margin + h->pos().x() + e->pos().x());
+                        if (h->bbox().isEmpty())
+                              h->layout1();
+                        leftX = firstBeat ? 0 : h->bbox().x() - margin + h->pos().x() + e->pos().x();
+                        rightX = h->bbox().x() + h->bbox().width() + margin + h->pos().x() + e->pos().x();
+                        x1 = qMin(x1, leftX);
+                        x2 = qMax(x2, rightX);
                         adjustWidth = true;
                         }
                   }


### PR DESCRIPTION
Resolves: [ENG-18](https://mu--se.atlassian.net/browse/ENG-18): Fretboard diagrams need much improvement

This commit changes the spacer code in ChordRest::shape to prevent a
left space from being created in the first beat of a measure. This
spacer was causing an unnecessary gap between the barline and the first
beat.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
