### PR TITLE
[MU3 Backend] ENG-81: Fix fret spacer

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1305,7 +1305,9 @@ Shape ChordRest::shape() const
                   FretDiagram* fd = toFretDiagram(e);
                   qreal margin = styleP(Sid::fretMinDistance) * 0.5;
                   bool firstBeat = tick() == measure()->tick();
-                  if (fd->bbox().isEmpty())
+                  if (fd->pos().x() == 0)
+                        fd->layoutHorizontal();
+                  else if (fd->bbox().isEmpty())
                         fd->calculateBoundingRect();
                   qreal leftX = firstBeat ? 0 : e->bbox().x() - margin + e->pos().x();
                   qreal rightX = e->bbox().x() + e->bbox().width() + margin + e->pos().x();

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1303,17 +1303,24 @@ Shape ChordRest::shape() const
                   }
             else if (e->isFretDiagram()) {
                   FretDiagram* fd = toFretDiagram(e);
-                  if (fd->bbox().isEmpty()) fd->calculateBoundingRect();
                   qreal margin = styleP(Sid::fretMinDistance) * 0.5;
-                  x1 = qMin(x1, e->bbox().x() - margin + e->pos().x());
-                  x2 = qMax(x2, e->bbox().x() + e->bbox().width() + margin + e->pos().x());
+                  bool firstBeat = tick() == measure()->tick();
+                  if (fd->bbox().isEmpty())
+                        fd->calculateBoundingRect();
+                  qreal leftX = firstBeat ? 0 : e->bbox().x() - margin + e->pos().x();
+                  qreal rightX = e->bbox().x() + e->bbox().width() + margin + e->pos().x();
+                  x1 = qMin(x1, leftX);
+                  x2 = qMax(x2, rightX);
                   adjustWidth = true;
                   if (fd->harmony()) {
                         Harmony* h = fd->harmony();
-                        if (h->bbox().isEmpty()) h->layout1();
                         margin = styleP(Sid::minHarmonyDistance) * 0.5;
-                        x1 = qMin(x1, h->bbox().x() - margin + h->pos().x() + e->pos().x());
-                        x2 = qMax(x2, h->bbox().x() + h->bbox().width() + margin + h->pos().x() + e->pos().x());
+                        if (h->bbox().isEmpty())
+                              h->layout1();
+                        leftX = firstBeat ? 0 : h->bbox().x() - margin + h->pos().x() + e->pos().x();
+                        rightX = h->bbox().x() + h->bbox().width() + margin + h->pos().x() + e->pos().x();
+                        x1 = qMin(x1, leftX);
+                        x2 = qMax(x2, rightX);
                         adjustWidth = true;
                         }
                   }

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -495,10 +495,15 @@ void FretDiagram::calculateBoundingRect()
       }
 
 //---------------------------------------------------------
-//   layout
+//   layoutHorizontal
+//    Do initial setPos().
+//    This takes place before autoplaceSegmentElement() but
+//    reliably sets the x-value before the system has been
+//    created. This is useful for creating a horizontal
+//    spacer in ChordRest::shape().
 //---------------------------------------------------------
 
-void FretDiagram::layout()
+void FretDiagram::layoutHorizontal()
       {
       calculateBoundingRect();
       if (!parent() || !parent()->isSegment()) {
@@ -531,7 +536,15 @@ void FretDiagram::layout()
       else if (_orientation == Orientation::HORIZONTAL)
             mainWidth = fretDist * (_frets + 0.5);
       setPos((noteheadWidth - mainWidth)/2, -(bbox().height() + styleP(Sid::fretY)));
+      }
 
+//---------------------------------------------------------
+//   layout
+//---------------------------------------------------------
+
+void FretDiagram::layout()
+      {
+      layoutHorizontal();
       autoplaceSegmentElement();
 
       // don't display harmony in palette

--- a/libmscore/fret.h
+++ b/libmscore/fret.h
@@ -172,6 +172,7 @@ class FretDiagram final : public Element {
       static FretDiagram* fromString(Score* score, const QString &s);
 
       ElementType type() const override { return ElementType::FRET_DIAGRAM; }
+      void layoutHorizontal();
       void layout() override;
       void calculateBoundingRect();
       void write(XmlWriter& xml) const override;


### PR DESCRIPTION
Resolves: [ENG-81](https://mu--se.atlassian.net/jira/software/projects/ENG/boards/21?selectedIssue=ENG-81): Fret diagram spacers are incorrect on first render

This PR includes two fixes to FretDiagram spacers:

1. It prevents them from creating an unnecessary gap to the right of a barline (by omitting the left spacer if it is the first ChordRest of the measure
2. It partially lays out the FretDiagram before creating the spacer, correcting the initial creation of the spacer (which previously was incorrect upon user input).

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
