### PR TITLE
[MU4] fix #8615 fix #8638 - fix vertical positioning of lyrics inc. hyphens

### DIFF
--- a/src/engraving/libmscore/lyricsline.cpp
+++ b/src/engraving/libmscore/lyricsline.cpp
@@ -424,7 +424,7 @@ void LyricsLineSegment::layout()
         }
     } else {                              // dash(es)
         // set conventional dash Y pos
-        rypos() -= MScore::pixelRatio * lyr->fontMetrics().xHeight() * score()->styleD(Sid::lyricsDashYposRatio);
+        rypos() -= lyr->fontMetrics().xHeight() * score()->styleD(Sid::lyricsDashYposRatio);
         _dashLength = score()->styleP(Sid::lyricsDashMaxLength) * mag();      // and dash length
         qreal len         = pos2().x();
         qreal minDashLen  = score()->styleS(Sid::lyricsDashMinLength).val() * sp;

--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -2100,7 +2100,7 @@ void TextBase::layoutFrame()
 
 qreal TextBase::lineSpacing() const
 {
-    return fontMetrics().lineSpacing() * MScore::pixelRatio;
+    return fontMetrics().lineSpacing();
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8615

Vertical positioning for lyrics secondary verses and hyphens was incorrect

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
