### PR TITLE
Added read/write to dir

### DIFF
--- a/src/engraving/io/msczreader.h
+++ b/src/engraving/io/msczreader.h
@@ -32,13 +32,20 @@ namespace mu::engraving {
 class MsczReader
 {
 public:
-    MsczReader(const QString& filePath = QString());
+    enum class Mode {
+        Zip,
+        Dir
+    };
+
+    MsczReader(const QString& filePath = QString(), Mode mode = Mode::Zip);
     MsczReader(QIODevice* device);
     ~MsczReader();
 
     void setDevice(QIODevice* device);
     void setFilePath(const QString& filePath);
     QString filePath() const;
+    void setMode(Mode m);
+    Mode mode() const;
 
     bool open();
     void close();
@@ -60,11 +67,13 @@ private:
         bool isValid() const { return !mscxFileName.isEmpty(); }
     };
 
+    QString rootPath() const;
     MQZipReader* reader() const;
     const Meta& meta() const;
     QByteArray fileData(const QString& fileName) const;
 
     QString m_filePath;
+    Mode m_mode = Mode::Zip;
     QIODevice* m_device = nullptr;
     bool m_selfDeviceOwner = false;
     mutable MQZipReader* m_reader = nullptr;

--- a/src/engraving/io/msczwriter.h
+++ b/src/engraving/io/msczwriter.h
@@ -32,13 +32,20 @@ namespace mu::engraving {
 class MsczWriter
 {
 public:
-    MsczWriter(const QString& filePath = QString());
+    enum class Mode {
+        Zip,
+        Dir
+    };
+
+    MsczWriter(const QString& filePath = QString(), Mode mode = Mode::Zip);
     MsczWriter(QIODevice* device);
     ~MsczWriter();
 
     void setDevice(QIODevice* device);
     void setFilePath(const QString& filePath);
     QString filePath() const;
+    void setMode(Mode m);
+    Mode mode() const;
 
     bool open();
     void close();
@@ -72,6 +79,8 @@ private:
         }
     };
 
+    QString rootPath() const;
+
     MQZipWriter* writer() const;
     bool addFileData(const QString& fileName, const QByteArray& data);
 
@@ -79,6 +88,7 @@ private:
     void writeContainer(const std::vector<QString>& paths);
 
     QString m_filePath;
+    Mode m_mode = Mode::Zip;
     QIODevice* m_device = nullptr;
     bool m_selfDeviceOwner = false;
     mutable MQZipWriter* m_writer = nullptr;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -68,7 +68,7 @@ using namespace mu::notation;
 
 NotationInteraction::NotationInteraction(Notation* notation, INotationUndoStackPtr undoStack)
     : m_notation(notation), m_undoStack(undoStack), m_gripEditData(&m_scoreCallbacks),
-    m_lasso(new Ms::Lasso(notation->score())), m_textEditData(&m_scoreCallbacks)
+    m_textEditData(&m_scoreCallbacks), m_lasso(new Ms::Lasso(notation->score()))
 {
     m_noteInput = std::make_shared<NotationNoteInput>(notation, this, m_undoStack);
     m_selection = std::make_shared<NotationSelection>(notation);

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -36,6 +36,7 @@
 
 namespace mu::engraving {
 class MsczReader;
+class MsczWriter;
 }
 
 namespace mu::project {
@@ -74,7 +75,7 @@ private:
     Ret saveSelectionOnScore(const io::path& path = io::path());
     Ret exportProject(const io::path& path, const std::string& suffix);
     Ret doSave(bool generateBackup);
-    Ret writeProject(io::Device* device, bool onlySelection);
+    Ret writeProject(engraving::MsczWriter& msczWriter, bool onlySelection);
 
     mu::engraving::EngravingProjectPtr m_engravingProject = nullptr;
     notation::MasterNotationPtr m_masterNotation = nullptr;

--- a/src/userscores/internal/filescorecontroller.cpp
+++ b/src/userscores/internal/filescorecontroller.cpp
@@ -351,7 +351,7 @@ void FileScoreController::exportScore()
 io::path FileScoreController::selectScoreOpeningFile()
 {
     QString allExt = "*.mscz *.mxl *.musicxml *.xml *.mid *.midi *.kar *.md *.mgu *.sgu *.cap *.capx"
-                     "*.ove *.scw *.bmw *.bww *.gtp *.gp3 *.gp4 *.gp5 *.gpx *.gp *.ptb *.mscz,";
+                     "*.ove *.scw *.bmw *.bww *.gtp *.gp3 *.gp4 *.gp5 *.gpx *.gp *.ptb *.mscx *.mscz,";
 
     QStringList filter;
     filter << QObject::tr("All Supported Files") + " (" + allExt + ")"
@@ -365,6 +365,7 @@ io::path FileScoreController::selectScoreOpeningFile()
            << QObject::tr("Bagpipe Music Writer Files (experimental)") + " (*.bmw *.bww)"
            << QObject::tr("Guitar Pro Files") + " (*.gtp *.gp3 *.gp4 *.gp5 *.gpx *.gp)"
            << QObject::tr("Power Tab Editor Files (experimental)") + " (*.ptb)"
+           << QObject::tr("MuseScore Unpack Dir") + " (*.mscx)"
            << QObject::tr("MuseScore Backup Files") + " (*.mscz,)";
 
     return interactive()->selectOpeningFile(qtrc("userscores", "Score"), "", filter.join(";;"));

--- a/src/userscores/view/templatepaintview.cpp
+++ b/src/userscores/view/templatepaintview.cpp
@@ -68,6 +68,7 @@ void TemplatePaintView::load()
 
     if (!ret) {
         LOGE() << ret.toString();
+        return;
     }
 
     setNotation(notationProject->masterNotation()->notation());


### PR DESCRIPTION
Now we can specify the `mscx` format when saving, in this case a folder will be created in which all files will be written as in `mscz`.
We can also open `mscx`, in this case the system will try to get other files relative to the current one as from  `mscz`.