### PR TITLE
[MU3 Backend] ENG-68: Fix pedal endpoints on other tracks

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -2033,9 +2033,20 @@ void MusicXMLParserPass2::part()
             auto sp = i.key();
             Fraction tick1 = Fraction::fromTicks(i.value().first);
             Fraction tick2 = Fraction::fromTicks(i.value().second);
-            if (sp->isPedal() && toPedal(sp)->endHookType() == HookType::HOOK_45)
+            if (sp->isPedal() && toPedal(sp)->endHookType() == HookType::HOOK_45) {
                   // Handle pedal change end tick (slightly hacky)
-                  tick2 += _score->findCR(tick2, sp->track())->ticks();
+                  // Find CR on the end tick of 
+                  ChordRest* terminatingCR = _score->findCR(tick2, sp->effectiveTrack2());
+                  for (int track = _pass1.getPart(id)->startTrack(); track <= _pass1.getPart(id)->endTrack(); ++track) {
+                        ChordRest* tempCR = _score->findCR(tick2, track);
+                        if (!terminatingCR
+                        || (tempCR && tempCR->tick() > terminatingCR->tick())
+                        || (tempCR && tempCR->tick() == terminatingCR->tick() && tempCR->ticks() < terminatingCR->ticks()))
+                              terminatingCR = tempCR;
+                        }
+                  tick2 += terminatingCR->ticks();
+                  sp->setTrack2(terminatingCR->track());
+                  }
             //qDebug("spanner %p tp %d tick1 %s tick2 %s track1 %d track2 %d",
             //       sp, sp->type(), qPrintable(tick1.print()), qPrintable(tick2.print()), sp->track(), sp->track2());
             if (incompleteSpanners.find(sp) == incompleteSpanners.end()) {

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -18,6 +18,7 @@
 #include "chord.h"
 #include "segment.h"
 #include "measure.h"
+#include "part.h"
 #include "undo.h"
 #include "staff.h"
 #include "lyrics.h"
@@ -579,14 +580,18 @@ void Spanner::computeStartElement()
       switch (_anchor) {
             case Anchor::SEGMENT: {
                   Segment* seg = score()->tick2segmentMM(tick(), false, SegmentType::ChordRest);
-                  int strack = (track() / VOICES) * VOICES;
-                  int etrack = strack + VOICES;
+                  int strack = part()->startTrack();
+                  int etrack = part()->endTrack();
                   _startElement = 0;
                   if (seg) {
-                        for (int t = strack; t < etrack; ++t) {
-                              if (seg->element(t)) {
-                                    _startElement = seg->element(t);
-                                    break;
+                        if (seg->element(track()))
+                              _startElement = seg->element(track());
+                        else {
+                              for (int t = strack; t < etrack; ++t) {
+                                    if (seg->element(t)) {
+                                          _startElement = seg->element(t);
+                                          break;
+                                          }
                                     }
                               }
                         }

--- a/mtest/musicxml/io/testPedalChanges.xml
+++ b/mtest/musicxml/io/testPedalChanges.xml
@@ -42,19 +42,19 @@
     </defaults>
   <credit page="1">
     <credit-type>title</credit-type>
-    <credit-words default-x="600" default-y="1611.43" justify="center" valign="top" font-size="22">Pedal Changes</credit-words>
+    <credit-words default-x="600" default-y="1611.86" justify="center" valign="top" font-size="22">Pedal Changes</credit-words>
     </credit>
   <credit page="1">
     <credit-type>subtitle</credit-type>
-    <credit-words default-x="600" default-y="1554.29" justify="center" valign="top" font-size="16">MuseScore Testcase</credit-words>
+    <credit-words default-x="600" default-y="1554.72" justify="center" valign="top" font-size="16">MuseScore Testcase</credit-words>
     </credit>
   <credit page="1">
     <credit-type>composer</credit-type>
-    <credit-words default-x="1114.29" default-y="1511.43" justify="right" valign="bottom">Henry Ives</credit-words>
+    <credit-words default-x="1114.29" default-y="1511.86" justify="right" valign="top">Henry Ives</credit-words>
     </credit>
   <part-list>
     <part-group type="start" number="1">
-      <group-symbol>brace</group-symbol>
+      <group-symbol>none</group-symbol>
       </part-group>
     <score-part id="P1">
       <part-name>Piano</part-name>
@@ -70,9 +70,10 @@
         <pan>0</pan>
         </midi-instrument>
       </score-part>
+    <part-group type="stop" number="1"/>
     </part-list>
   <part id="P1">
-    <measure number="1" width="202.25">
+    <measure number="1" width="208.61">
       <print>
         <system-layout>
           <system-margins>
@@ -81,27 +82,30 @@
             </system-margins>
           <top-system-distance>170.00</top-system-distance>
           </system-layout>
+        <staff-layout number="2">
+          <staff-distance>65.00</staff-distance>
+          </staff-layout>
         </print>
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key number="2">
           <fifths>0</fifths>
           </key>
         <time>
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>
-        <clef>
+        <staves>2</staves>
+        <clef number="1">
           <sign>G</sign>
           <line>2</line>
           </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
         </attributes>
-      <direction placement="below">
-        <direction-type>
-          <pedal type="start" line="yes" default-y="-74.95"/>
-          </direction-type>
-        </direction>
-      <note default-x="84.22" default-y="-50.00">
+      <note default-x="86.99" default-y="-50.00">
         <pitch>
           <step>C</step>
           <octave>4</octave>
@@ -110,8 +114,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <staff>1</staff>
         </note>
-      <note default-x="113.28" default-y="-45.00">
+      <note default-x="116.94" default-y="-45.00">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -120,8 +125,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <staff>1</staff>
         </note>
-      <note default-x="142.34" default-y="-40.00">
+      <note default-x="146.90" default-y="-40.00">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -130,8 +136,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <staff>1</staff>
         </note>
-      <note default-x="171.39" default-y="-35.00">
+      <note default-x="176.85" default-y="-35.00">
         <pitch>
           <step>F</step>
           <octave>4</octave>
@@ -140,14 +147,60 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <direction placement="below">
+        <direction-type>
+          <pedal type="start" line="yes" sign="yes" default-y="-67.94"/>
+          </direction-type>
+        <staff>2</staff>
+        </direction>
+      <note default-x="91.09" default-y="-140.00">
+        <pitch>
+          <step>A</step>
+          <octave>2</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>5</voice>
+        <type>whole</type>
+        <staff>2</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="86.99" default-y="-115.00">
+        <pitch>
+          <step>F</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>6</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <staff>2</staff>
         </note>
       <direction placement="below">
         <direction-type>
-          <pedal type="stop" line="yes"/>
+          <pedal type="stop" line="yes" sign="yes" relative-x="7.76"/>
           </direction-type>
+        <staff>2</staff>
         </direction>
+      <note default-x="146.90" default-y="-110.00">
+        <pitch>
+          <step>G</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>6</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        </note>
       </measure>
-    <measure number="2" width="126.83">
+    <measure number="2" width="130.42">
       <note default-x="13.00" default-y="-30.00">
         <pitch>
           <step>G</step>
@@ -157,8 +210,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <staff>1</staff>
         </note>
-      <note default-x="41.01" default-y="-25.00">
+      <note default-x="41.91" default-y="-25.00">
         <pitch>
           <step>A</step>
           <octave>4</octave>
@@ -167,13 +221,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <staff>1</staff>
         </note>
-      <direction placement="below">
-        <direction-type>
-          <pedal type="start" line="yes" default-y="-74.95"/>
-          </direction-type>
-        </direction>
-      <note default-x="69.01" default-y="-20.00">
+      <note default-x="70.81" default-y="-20.00">
         <pitch>
           <step>B</step>
           <octave>4</octave>
@@ -182,8 +232,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
+        <staff>1</staff>
         </note>
-      <note default-x="97.02" default-y="-15.00">
+      <note default-x="99.72" default-y="-15.00">
         <pitch>
           <step>C</step>
           <octave>5</octave>
@@ -192,15 +243,61 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="17.10" default-y="-125.00">
+        <pitch>
+          <step>D</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>5</voice>
+        <type>whole</type>
+        <staff>2</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="13.00" default-y="-105.00">
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>6</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <staff>2</staff>
         </note>
       <direction placement="below">
         <direction-type>
-          <pedal type="stop" line="yes"/>
+          <pedal type="start" line="yes" sign="yes" default-y="-67.94"/>
           </direction-type>
+        <staff>2</staff>
+        </direction>
+      <note default-x="70.81" default-y="-100.00">
+        <pitch>
+          <step>B</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>6</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <pedal type="stop" line="yes" sign="yes"/>
+          </direction-type>
+        <staff>2</staff>
         </direction>
       </measure>
-    <measure number="3" width="126.83">
-      <note default-x="13.00" default-y="-10.00">
+    <measure number="3" width="131.38">
+      <note default-x="13.96" default-y="-10.00">
         <pitch>
           <step>D</step>
           <octave>5</octave>
@@ -209,8 +306,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
+        <staff>1</staff>
         </note>
-      <note default-x="41.01" default-y="-5.00">
+      <note default-x="42.87" default-y="-5.00">
         <pitch>
           <step>E</step>
           <octave>5</octave>
@@ -219,8 +317,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
+        <staff>1</staff>
         </note>
-      <note default-x="69.01" default-y="0.00">
+      <note default-x="71.77" default-y="0.00">
         <pitch>
           <step>F</step>
           <octave>5</octave>
@@ -229,8 +328,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
+        <staff>1</staff>
         </note>
-      <note default-x="97.02" default-y="5.00">
+      <note default-x="100.68" default-y="5.00">
         <pitch>
           <step>G</step>
           <octave>5</octave>
@@ -239,13 +339,28 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="13.00" default-y="-130.00">
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>5</voice>
+        <type>whole</type>
+        <staff>2</staff>
         </note>
       </measure>
-    <measure number="4" width="151.33">
+    <measure number="4" width="154.92">
       <direction placement="below">
         <direction-type>
-          <pedal type="start" line="yes" default-y="-74.95"/>
+          <pedal type="start" line="yes" sign="yes" default-y="-65.00"/>
           </direction-type>
+        <staff>2</staff>
         </direction>
       <note default-x="16.50" default-y="10.00">
         <pitch>
@@ -256,8 +371,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
+        <staff>1</staff>
         </note>
-      <note default-x="49.76" default-y="15.00">
+      <note default-x="50.66" default-y="15.00">
         <pitch>
           <step>B</step>
           <octave>5</octave>
@@ -266,13 +382,15 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
+        <staff>1</staff>
         </note>
       <direction placement="below">
         <direction-type>
-          <pedal type="change" line="yes" default-y="-74.95"/>
+          <pedal type="change" line="yes" sign="no" default-y="-65.00" relative-x="68.51"/>
           </direction-type>
+        <staff>2</staff>
         </direction>
-      <note default-x="83.01" default-y="10.00">
+      <note default-x="84.81" default-y="10.00">
         <pitch>
           <step>A</step>
           <octave>5</octave>
@@ -281,8 +399,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
+        <staff>1</staff>
         </note>
-      <note default-x="116.27" default-y="5.00">
+      <note default-x="118.97" default-y="5.00">
         <pitch>
           <step>G</step>
           <octave>5</octave>
@@ -291,15 +410,24 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="15.54" default-y="-135.00">
+        <pitch>
+          <step>B</step>
+          <octave>2</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>5</voice>
+        <type>whole</type>
+        <staff>2</staff>
         </note>
       </measure>
-    <measure number="5" width="126.83">
-      <direction placement="below">
-        <direction-type>
-          <pedal type="change" line="yes" default-y="-74.95"/>
-          </direction-type>
-        </direction>
-      <note default-x="13.00" default-y="0.00">
+    <measure number="5" width="131.38">
+      <note default-x="13.96" default-y="0.00">
         <pitch>
           <step>F</step>
           <octave>5</octave>
@@ -308,8 +436,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
+        <staff>1</staff>
         </note>
-      <note default-x="41.01" default-y="-5.00">
+      <note default-x="42.87" default-y="-5.00">
         <pitch>
           <step>E</step>
           <octave>5</octave>
@@ -318,8 +447,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
+        <staff>1</staff>
         </note>
-      <note default-x="69.01" default-y="-10.00">
+      <note default-x="71.77" default-y="-10.00">
         <pitch>
           <step>D</step>
           <octave>5</octave>
@@ -328,8 +458,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
+        <staff>1</staff>
         </note>
-      <note default-x="97.02" default-y="-15.00">
+      <note default-x="100.68" default-y="-15.00">
         <pitch>
           <step>C</step>
           <octave>5</octave>
@@ -338,15 +469,36 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <direction placement="below">
+        <direction-type>
+          <pedal type="change" line="yes" sign="no" default-y="-67.94"/>
+          </direction-type>
+        <staff>2</staff>
+        </direction>
+      <note default-x="13.00" default-y="-140.00">
+        <pitch>
+          <step>A</step>
+          <octave>2</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>5</voice>
+        <type>whole</type>
+        <staff>2</staff>
         </note>
       <direction placement="below">
         <direction-type>
-          <pedal type="stop" line="yes"/>
+          <pedal type="stop" line="yes" sign="no"/>
           </direction-type>
+        <staff>2</staff>
         </direction>
       </measure>
-    <measure number="6" width="126.83">
-      <note default-x="13.00" default-y="-20.00">
+    <measure number="6" width="132.34">
+      <note default-x="14.92" default-y="-20.00">
         <pitch>
           <step>B</step>
           <octave>4</octave>
@@ -355,8 +507,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
+        <staff>1</staff>
         </note>
-      <note default-x="41.01" default-y="-25.00">
+      <note default-x="43.83" default-y="-25.00">
         <pitch>
           <step>A</step>
           <octave>4</octave>
@@ -365,8 +518,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <staff>1</staff>
         </note>
-      <note default-x="69.01" default-y="-30.00">
+      <note default-x="72.73" default-y="-30.00">
         <pitch>
           <step>G</step>
           <octave>4</octave>
@@ -375,8 +529,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <staff>1</staff>
         </note>
-      <note default-x="97.02" default-y="-35.00">
+      <note default-x="101.64" default-y="-35.00">
         <pitch>
           <step>F</step>
           <octave>4</octave>
@@ -385,44 +540,57 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="13.96" default-y="-105.00">
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>5</voice>
+        <type>whole</type>
+        <staff>2</staff>
         </note>
       </measure>
-    <measure number="7" width="117.68">
-      <direction placement="below">
-        <direction-type>
-          <pedal type="start" line="yes" default-y="-74.95"/>
-          </direction-type>
-        </direction>
-      <note default-x="13.00" default-y="-40.00">
+    <measure number="7" width="89.51">
+      <note default-x="13.96" default-y="-40.00">
         <pitch>
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>1</duration>
+        <duration>4</duration>
         <voice>1</voice>
-        <type>quarter</type>
-        <stem>up</stem>
+        <type>whole</type>
+        <staff>1</staff>
         </note>
-      <note default-x="39.12" default-y="-45.00">
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <direction placement="below">
+        <direction-type>
+          <pedal type="start" line="yes" sign="yes" default-y="-67.94"/>
+          </direction-type>
+        <staff>2</staff>
+        </direction>
+      <note default-x="13.96" default-y="-110.00">
         <pitch>
-          <step>D</step>
-          <octave>4</octave>
+          <step>G</step>
+          <octave>3</octave>
           </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>quarter</type>
-        <stem>up</stem>
-        </note>
-      <note>
-        <rest/>
-        <duration>2</duration>
-        <voice>1</voice>
-        <type>half</type>
+        <duration>4</duration>
+        <voice>5</voice>
+        <type>whole</type>
+        <staff>2</staff>
         </note>
       <direction placement="below">
         <direction-type>
-          <pedal type="stop" line="yes"/>
+          <pedal type="stop" line="yes" sign="yes"/>
           </direction-type>
+        <staff>2</staff>
         </direction>
       <barline location="right">
         <bar-style>light-heavy</bar-style>

--- a/mtest/musicxml/io/testPedalChanges_ref.mscx
+++ b/mtest/musicxml/io/testPedalChanges_ref.mscx
@@ -57,6 +57,13 @@
           <name>stdNormal</name>
           </StaffType>
         <hideWhenEmpty>3</hideWhenEmpty>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <Staff id="2">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
         </Staff>
       <trackName>Piano</trackName>
       <Instrument id="piano">
@@ -120,18 +127,18 @@
         <height>12.5</height>
         <Text>
           <style>Title</style>
-          <offset x="0" y="-0.07525"/>
+          <offset x="0" y="-0.1505"/>
           <text><font size="22"/>Pedal Changes</text>
           </Text>
         <Text>
           <style>Subtitle</style>
-          <offset x="0" y="9.92425"/>
+          <offset x="0" y="9.849"/>
           <text><font size="16"/>MuseScore Testcase</text>
           </Text>
         <Text>
           <style>Composer</style>
           <align>right,top</align>
-          <offset x="0" y="17.4247"/>
+          <offset x="0" y="17.3495"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>
@@ -145,17 +152,6 @@
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
-          <Spanner type="Pedal">
-            <Pedal>
-              <endHookType>1</endHookType>
-              <beginText>&lt;sym&gt;keyboardPedalPed&lt;/sym&gt;</beginText>
-              </Pedal>
-            <next>
-              <location>
-                <measures>1</measures>
-                </location>
-              </next>
-            </Spanner>
           <Chord>
             <durationType>quarter</durationType>
             <StemDirection>up</StemDirection>
@@ -192,13 +188,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Spanner type="Pedal">
-            <prev>
-              <location>
-                <measures>-1</measures>
-                </location>
-              </prev>
-            </Spanner>
           <Chord>
             <durationType>quarter</durationType>
             <StemDirection>up</StemDirection>
@@ -215,18 +204,6 @@
               <tpc>17</tpc>
               </Note>
             </Chord>
-          <Spanner type="Pedal">
-            <Pedal>
-              <endHookType>1</endHookType>
-              <beginText>&lt;sym&gt;keyboardPedalPed&lt;/sym&gt;</beginText>
-              </Pedal>
-            <next>
-              <location>
-                <measures>1</measures>
-                <fractions>-1/2</fractions>
-                </location>
-              </next>
-            </Spanner>
           <Chord>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
@@ -247,14 +224,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Spanner type="Pedal">
-            <prev>
-              <location>
-                <measures>-1</measures>
-                <fractions>1/2</fractions>
-                </location>
-              </prev>
-            </Spanner>
           <Chord>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
@@ -291,17 +260,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Spanner type="Pedal">
-            <Pedal>
-              <endHookType>2</endHookType>
-              <beginText>&lt;sym&gt;keyboardPedalPed&lt;/sym&gt;</beginText>
-              </Pedal>
-            <next>
-              <location>
-                <fractions>3/4</fractions>
-                </location>
-              </next>
-            </Spanner>
           <Chord>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
@@ -318,18 +276,6 @@
               <tpc>19</tpc>
               </Note>
             </Chord>
-          <Spanner type="Pedal">
-            <Pedal>
-              <endHookType>2</endHookType>
-              <beginHookType>2</beginHookType>
-              </Pedal>
-            <next>
-              <location>
-                <measures>1</measures>
-                <fractions>-1/4</fractions>
-                </location>
-              </next>
-            </Spanner>
           <Chord>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
@@ -341,6 +287,7 @@
           <Spanner type="Pedal">
             <prev>
               <location>
+                <staves>1</staves>
                 <fractions>-3/4</fractions>
                 </location>
               </prev>
@@ -357,17 +304,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Spanner type="Pedal">
-            <Pedal>
-              <endHookType>1</endHookType>
-              <beginHookType>2</beginHookType>
-              </Pedal>
-            <next>
-              <location>
-                <measures>1</measures>
-                </location>
-              </next>
-            </Spanner>
           <Chord>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
@@ -379,6 +315,7 @@
           <Spanner type="Pedal">
             <prev>
               <location>
+                <staves>1</staves>
                 <measures>-1</measures>
                 <fractions>1/4</fractions>
                 </location>
@@ -412,13 +349,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Spanner type="Pedal">
-            <prev>
-              <location>
-                <measures>-1</measures>
-                </location>
-              </prev>
-            </Spanner>
           <Chord>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
@@ -455,6 +385,222 @@
         </Measure>
       <Measure>
         <voice>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>64</pitch>
+              <tpc>18</tpc>
+              </Note>
+            </Chord>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="2">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>F</concertClefType>
+            <transposingClefType>F</transposingClefType>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Spanner type="Pedal">
+            <Pedal>
+              <endHookType>1</endHookType>
+              <beginText>&lt;sym&gt;keyboardPedalPed&lt;/sym&gt;</beginText>
+              </Pedal>
+            <next>
+              <location>
+                <fractions>1/2</fractions>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>45</pitch>
+              <tpc>17</tpc>
+              </Note>
+            </Chord>
+          <location>
+            <fractions>-1/2</fractions>
+            </location>
+          <Spanner type="Pedal">
+            <prev>
+              <location>
+                <fractions>-1/2</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          </voice>
+        <voice>
+          <Chord>
+            <durationType>half</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <pitch>53</pitch>
+              <tpc>13</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>half</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <pitch>55</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>50</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          <location>
+            <fractions>-1/2</fractions>
+            </location>
+          <Spanner type="Pedal">
+            <Pedal>
+              <endHookType>1</endHookType>
+              <beginText>&lt;sym&gt;keyboardPedalPed&lt;/sym&gt;</beginText>
+              </Pedal>
+            <next>
+              <location>
+                <measures>1</measures>
+                <fractions>-1/2</fractions>
+                </location>
+              </next>
+            </Spanner>
+          </voice>
+        <voice>
+          <Chord>
+            <durationType>half</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>half</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <pitch>59</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Spanner type="Pedal">
+            <prev>
+              <location>
+                <measures>-1</measures>
+                <fractions>1/2</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>48</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Spanner type="Pedal">
+            <Pedal>
+              <endHookType>2</endHookType>
+              <beginText>&lt;sym&gt;keyboardPedalPed&lt;/sym&gt;</beginText>
+              </Pedal>
+            <next>
+              <location>
+                <staves>-1</staves>
+                <fractions>3/4</fractions>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>47</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          <location>
+            <fractions>-1/2</fractions>
+            </location>
+          <Spanner type="Pedal">
+            <Pedal>
+              <endHookType>2</endHookType>
+              <beginHookType>2</beginHookType>
+              </Pedal>
+            <next>
+              <location>
+                <staves>-1</staves>
+                <measures>1</measures>
+                <fractions>-1/4</fractions>
+                </location>
+              </next>
+            </Spanner>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Spanner type="Pedal">
+            <Pedal>
+              <endHookType>1</endHookType>
+              <beginHookType>2</beginHookType>
+              </Pedal>
+            <next>
+              <location>
+                <measures>1</measures>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>45</pitch>
+              <tpc>17</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Spanner type="Pedal">
+            <prev>
+              <location>
+                <measures>-1</measures>
+                </location>
+              </prev>
+            </Spanner>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
           <Spanner type="Pedal">
             <Pedal>
               <endHookType>1</endHookType>
@@ -467,27 +613,12 @@
               </next>
             </Spanner>
           <Chord>
-            <durationType>quarter</durationType>
-            <StemDirection>up</StemDirection>
+            <durationType>whole</durationType>
             <Note>
-              <pitch>64</pitch>
-              <tpc>18</tpc>
+              <pitch>55</pitch>
+              <tpc>15</tpc>
               </Note>
             </Chord>
-          <Chord>
-            <durationType>quarter</durationType>
-            <StemDirection>up</StemDirection>
-            <Note>
-              <pitch>62</pitch>
-              <tpc>16</tpc>
-              </Note>
-            </Chord>
-          <Rest>
-            <durationType>half</durationType>
-            </Rest>
-          <BarLine>
-            <subtype>end</subtype>
-            </BarLine>
           <Spanner type="Pedal">
             <prev>
               <location>


### PR DESCRIPTION
Resolves: [ENG-68](https://mu--se.atlassian.net/jira/software/projects/ENG/boards/21?selectedIssue=ENG-68): Pedals anchored to staff 1 or voice 2 terminate incorrectly

Sometimes pedals are imported that begin or end on segments that have
notes on tracks (or staves) other than the track the spanner is on.
Previously, this would cause incorrect tick adjustments on "change"
type pedals, and it would result in some pedals not being able to
compute a start or end element. This commit fixes these issues by
considering all tracks of a part when assessing pedal change tick
adjustments and when computing start elements.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
