### PR TITLE
[MU4] Fix more compiler warnings

### DIFF
--- a/src/engraving/draw/painterpath.cpp
+++ b/src/engraving/draw/painterpath.cpp
@@ -55,7 +55,7 @@ void PainterPath::moveTo(const PointF& p)
     } else {
         m_elements.push_back({ p.x(), p.y(), ElementType::MoveToElement });
     }
-    m_cStart = m_elements.size() - 1;
+    m_cStart = static_cast<int>(m_elements.size() - 1);
 }
 
 void PainterPath::lineTo(const PointF& p)
@@ -109,7 +109,7 @@ void PainterPath::translate(double dx, double dy)
     if (qFuzzyIsNull(dx) && qFuzzyIsNull(dy)) {
         return;
     }
-    int m_elementsLeft = m_elements.size();
+    auto m_elementsLeft = m_elements.size();
     if (m_elementsLeft <= 0) {
         return;
     }
@@ -142,7 +142,7 @@ bool PainterPath::isEmpty() const
     return m_elements.empty() || (m_elements.size() == 1 && m_elements.front().type == ElementType::MoveToElement);
 }
 
-int PainterPath::elementCount() const
+size_t PainterPath::elementCount() const
 {
     return m_elements.size();
 }

--- a/src/engraving/draw/painterpath.h
+++ b/src/engraving/draw/painterpath.h
@@ -94,7 +94,7 @@ public:
     RectF boundingRect() const;
 
     bool isEmpty() const;
-    int elementCount() const;
+    size_t elementCount() const;
     PainterPath::Element elementAt(int i) const;
     void addRect(const RectF& r);
     inline void addRect(double x, double y, double w, double h)

--- a/src/engraving/libmscore/articulation.cpp
+++ b/src/engraving/libmscore/articulation.cpp
@@ -796,8 +796,8 @@ std::set<SymId> splitArticulations(const std::set<SymId>& articulationSymbolIds)
 {
     std::set<SymId> result;
     for (const SymId& articulationSymbolId: articulationSymbolIds) {
-        auto articulation = articulationAboveSplitGroups.find(articulationSymbolId);
-        if (articulation != articulationAboveSplitGroups.end()) {
+        auto artic = articulationAboveSplitGroups.find(articulationSymbolId);
+        if (artic != articulationAboveSplitGroups.end()) {
             ArticulationGroup group = articulationAboveSplitGroups[articulationSymbolId];
             result.insert(group.first);
             result.insert(group.second);

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -2945,9 +2945,9 @@ Articulation* Chord::hasArticulation(const Articulation* aa)
 void Chord::updateArticulations(const std::set<SymId>& newArticulationIds, ArticulationsUpdateMode updateMode)
 {
     std::set<SymId> currentArticulationIds;
-    for (Articulation* articulation: _articulations) {
-        currentArticulationIds.insert(articulation->symId());
-        score()->undoRemoveElement(articulation);
+    for (Articulation* artic: _articulations) {
+        currentArticulationIds.insert(artic->symId());
+        score()->undoRemoveElement(artic);
     }
 
     std::set<SymId> articulationIds = flipArticulations(currentArticulationIds, Placement::ABOVE);
@@ -3932,8 +3932,8 @@ void Chord::layoutArticulations3(Slur* slur)
 std::set<SymId> Chord::articulationSymbolIds() const
 {
     std::set<SymId> result;
-    for (const Articulation* articulation: _articulations) {
-        result.insert(articulation->symId());
+    for (const Articulation* artic: _articulations) {
+        result.insert(artic->symId());
     }
 
     return result;

--- a/src/engraving/libmscore/chordline.cpp
+++ b/src/engraving/libmscore/chordline.cpp
@@ -228,7 +228,7 @@ void ChordLine::write(XmlWriter& xml) const
     xml.tag("lengthY", _lengthY, 0.0);
     Element::writeProperties(xml);
     if (modified) {
-        int n = path.elementCount();
+        auto n = path.elementCount();
         xml.stag("Path");
         for (int i = 0; i < n; ++i) {
             const PainterPath::Element& e = path.elementAt(i);
@@ -296,7 +296,7 @@ void ChordLine::startEditDrag(EditData& ed)
 
 void ChordLine::editDrag(EditData& ed)
 {
-    int n = path.elementCount();
+    auto n = path.elementCount();
     PainterPath p;
     qreal sp = spatium();
     _lengthX += ed.delta.x();
@@ -377,7 +377,7 @@ void ChordLine::editDrag(EditData& ed)
 std::vector<PointF> ChordLine::gripsPositions(const EditData&) const
 {
     qreal sp = spatium();
-    int n    = path.elementCount();
+    auto n   = path.elementCount();
     PointF cp(pagePos());
     if (_straight) {
         // limit the number of grips to one

--- a/src/engraving/libmscore/chordline.h
+++ b/src/engraving/libmscore/chordline.h
@@ -82,7 +82,7 @@ public:
     Pid propertyId(const QStringRef& xmlName) const override;
 
     Element::EditBehavior normalModeEditBehavior() const override { return Element::EditBehavior::Edit; }
-    int gripsCount() const override { return _straight ? 1 : path.elementCount(); }
+    int gripsCount() const override { return _straight ? 1 : static_cast<int>(path.elementCount()); }
     Grip initialEditModeGrip() const override { return Grip(gripsCount() - 1); }
     Grip defaultGrip() const override { return initialEditModeGrip(); }
     std::vector<mu::PointF> gripsPositions(const EditData&) const override;

--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -2060,9 +2060,9 @@ void Score::cmdFlip()
                 slurTieSegment->undoChangeProperty(Pid::SLUR_DIRECTION, QVariant::fromValue<Direction>(dir));
             });
         } else if (e->isArticulation()) {
-            auto articulation = toArticulation(e);
-            flipOnce(articulation, [articulation]() {
-                ArticulationAnchor articAnchor = articulation->anchor();
+            auto artic = toArticulation(e);
+            flipOnce(artic, [artic]() {
+                ArticulationAnchor articAnchor = artic->anchor();
                 switch (articAnchor) {
                 case ArticulationAnchor::TOP_CHORD:
                     articAnchor = ArticulationAnchor::BOTTOM_CHORD;
@@ -2071,7 +2071,7 @@ void Score::cmdFlip()
                     articAnchor = ArticulationAnchor::TOP_CHORD;
                     break;
                 case ArticulationAnchor::CHORD:
-                    articAnchor = articulation->up() ? ArticulationAnchor::BOTTOM_CHORD : ArticulationAnchor::TOP_CHORD;
+                    articAnchor = artic->up() ? ArticulationAnchor::BOTTOM_CHORD : ArticulationAnchor::TOP_CHORD;
                     break;
                 case ArticulationAnchor::TOP_STAFF:
                     articAnchor = ArticulationAnchor::BOTTOM_STAFF;
@@ -2080,11 +2080,11 @@ void Score::cmdFlip()
                     articAnchor = ArticulationAnchor::TOP_STAFF;
                     break;
                 }
-                PropertyFlags pf = articulation->propertyFlags(Pid::ARTICULATION_ANCHOR);
+                PropertyFlags pf = artic->propertyFlags(Pid::ARTICULATION_ANCHOR);
                 if (pf == PropertyFlags::STYLED) {
                     pf = PropertyFlags::UNSTYLED;
                 }
-                articulation->undoChangeProperty(Pid::ARTICULATION_ANCHOR, int(articAnchor), pf);
+                artic->undoChangeProperty(Pid::ARTICULATION_ANCHOR, int(articAnchor), pf);
             });
         } else if (e->isTuplet()) {
             auto tuplet = toTuplet(e);

--- a/src/engraving/libmscore/input.cpp
+++ b/src/engraving/libmscore/input.cpp
@@ -161,8 +161,8 @@ void InputState::update(Selection& selection)
                 }
 
                 std::set<SymId> articulationsIds;
-                for (Articulation* articulation: n->chord()->articulations()) {
-                    articulationsIds.insert(articulation->symId());
+                for (Articulation* artic: n->chord()->articulations()) {
+                    articulationsIds.insert(artic->symId());
                 }
 
                 articulationsIds = Ms::splitArticulations(articulationsIds);
@@ -177,8 +177,8 @@ void InputState::update(Selection& selection)
                 setAccidentalType(n->accidentalType());
 
                 std::set<SymId> articulationsIds;
-                for (Articulation* articulation: n->chord()->articulations()) {
-                    articulationsIds.insert(articulation->symId());
+                for (Articulation* artic: n->chord()->articulations()) {
+                    articulationsIds.insert(artic->symId());
                 }
                 articulationSymbolIds = Ms::flipArticulations(articulationsIds, Ms::Placement::ABOVE);
 

--- a/src/engraving/libmscore/instrtemplate.cpp
+++ b/src/engraving/libmscore/instrtemplate.cpp
@@ -500,7 +500,7 @@ void InstrumentTemplate::read(XmlReader& e)
             QString traitName = qtrc("InstrumentsXML", e.readElementText().toUtf8().data());
             trait.isDefault = traitName.contains("*");
             trait.isHiddenOnScore = traitName.contains("(") && traitName.contains(")");
-            trait.name = traitName.remove("\*").remove("(").remove(")");
+            trait.name = traitName.remove("*").remove("(").remove(")");
         } else if (tag == "StringData") {
             stringData.read(e);
         } else if (tag == "drumset") {

--- a/src/engraving/libmscore/read302.cpp
+++ b/src/engraving/libmscore/read302.cpp
@@ -177,9 +177,9 @@ bool Score::read(XmlReader& e, compat::ReadScoreHook& hooks)
                 e.tracks().clear();             // ???
                 MasterScore* m = masterScore();
                 Score* s = m->createScore();
-                compat::ReadScoreHook hooks;
-                hooks.installReadStyleHook(s);
-                hooks.setupDefaultStyle();
+                compat::ReadScoreHook compatHooks;
+                compatHooks.installReadStyleHook(s);
+                compatHooks.setupDefaultStyle();
 
                 Excerpt* ex = new Excerpt(m);
                 ex->setPartScore(s);

--- a/src/engraving/libmscore/scoreorder.cpp
+++ b/src/engraving/libmscore/scoreorder.cpp
@@ -42,18 +42,18 @@ static const QString UNSORTED_ID("<unsorted>");
 //   readBoolAttribute
 //---------------------------------------------------------
 
-bool ScoreOrder::readBoolAttribute(Ms::XmlReader& reader, const char* name, bool defvalue)
+bool ScoreOrder::readBoolAttribute(Ms::XmlReader& reader, const char* attrName, bool defvalue)
 {
-    if (!reader.hasAttribute(name)) {
+    if (!reader.hasAttribute(attrName)) {
         return defvalue;
     }
-    QString attr { reader.attribute(name) };
+    QString attr { reader.attribute(attrName) };
     if (attr.toLower() == "false") {
         return false;
     } else if (attr.toLower() == "true") {
         return true;
     }
-    qDebug("invalid value \"%s\" for attribute \"%s\", using default \"%d\"", qPrintable(attr), qPrintable(name), defvalue);
+    qDebug("invalid value \"%s\" for attribute \"%s\", using default \"%d\"", qPrintable(attr), qPrintable(attrName), defvalue);
     return defvalue;
 }
 
@@ -145,10 +145,10 @@ void ScoreOrder::readSection(Ms::XmlReader& reader)
 //   hasGroup
 //---------------------------------------------------------
 
-bool ScoreOrder::hasGroup(const QString& id, const QString& group) const
+bool ScoreOrder::hasGroup(const QString& familyId, const QString& group) const
 {
     for (const ScoreGroup& sg: groups) {
-        if ((sg.family == id) && (group == sg.unsorted)) {
+        if ((sg.family == familyId) && (group == sg.unsorted)) {
             return true;
         }
     }

--- a/src/engraving/libmscore/shadownote.cpp
+++ b/src/engraving/libmscore/shadownote.cpp
@@ -242,18 +242,18 @@ void ShadowNote::drawArticulations(mu::draw::Painter* painter) const
 
     RectF boundRect = RectF(PointF(x1, y1), PointF(x2, y2));
 
-    for (const SymId& articulation: score()->inputState().articulationIds()) {
-        bool isMarcato = QString(Articulation::symId2ArticulationName(articulation)).contains("marcato");
+    for (const SymId& artic: score()->inputState().articulationIds()) {
+        bool isMarcato = QString(Articulation::symId2ArticulationName(artic)).contains("marcato");
 
         if (isMarcato) {
-            drawMarcato(painter, articulation, boundRect);
+            drawMarcato(painter, artic, boundRect);
         } else {
-            drawArticulation(painter, articulation, boundRect);
+            drawArticulation(painter, artic, boundRect);
         }
     }
 }
 
-void ShadowNote::drawMarcato(mu::draw::Painter* painter, const SymId& articulation, RectF& boundRect) const
+void ShadowNote::drawMarcato(mu::draw::Painter* painter, const SymId& artic, RectF& boundRect) const
 {
     PointF coord;
     qreal spacing = spatium();
@@ -262,13 +262,13 @@ void ShadowNote::drawMarcato(mu::draw::Painter* painter, const SymId& articulati
     if (topY > 0) {
         topY = 0;
     }
-    coord.ry() = topY - symHeight(articulation);
+    coord.ry() = topY - symHeight(artic);
 
-    boundRect.setY(boundRect.y() - symHeight(articulation) - spacing);
-    drawSymbol(articulation, painter, coord);
+    boundRect.setY(boundRect.y() - symHeight(artic) - spacing);
+    drawSymbol(artic, painter, coord);
 }
 
-void ShadowNote::drawArticulation(mu::draw::Painter* painter, const SymId& articulation, RectF& boundRect) const
+void ShadowNote::drawArticulation(mu::draw::Painter* painter, const SymId& artic, RectF& boundRect) const
 {
     PointF coord;
     qreal spacing = spatium();
@@ -279,18 +279,18 @@ void ShadowNote::drawArticulation(mu::draw::Painter* painter, const SymId& artic
         if (topY > 0) {
             topY = 0;
         }
-        coord.ry() = topY - symHeight(articulation);
-        boundRect.setY(topY - symHeight(articulation) - spacing);
+        coord.ry() = topY - symHeight(artic);
+        boundRect.setY(topY - symHeight(artic) - spacing);
     } else {
         qreal bottomY = boundRect.bottomLeft().y();
         if (bottomY < 0) {
             bottomY = symHeight(m_noteheadSymbol);
         }
-        coord.ry() = bottomY + symHeight(articulation);
-        boundRect.setHeight(bottomY + symHeight(articulation) + spacing);
+        coord.ry() = bottomY + symHeight(artic);
+        boundRect.setHeight(bottomY + symHeight(artic) + spacing);
     }
 
-    drawSymbol(articulation, painter, coord);
+    drawSymbol(artic, painter, coord);
 }
 
 //---------------------------------------------------------

--- a/src/framework/audio/internal/audiobuffer.cpp
+++ b/src/framework/audio/internal/audiobuffer.cpp
@@ -121,5 +121,5 @@ unsigned int AudioBuffer::sampleLag() const
         lag = m_writeIndex + m_data.size() - m_readIndex;
     }
 
-    return lag / m_audioChannelsCount;
+    return static_cast<unsigned int>(lag / m_audioChannelsCount);
 }

--- a/src/framework/audio/internal/worker/audiostream.cpp
+++ b/src/framework/audio/internal/worker/audiostream.cpp
@@ -88,7 +88,7 @@ unsigned int AudioStream::copySamplesToBuffer(float* buffer, unsigned int fromSa
     }
 
     if (to >= m_data.size()) {
-        to = m_data.size() - 1;
+        to = static_cast<unsigned int>(m_data.size() - 1);
         count = to - from;
     }
 

--- a/src/framework/audio/internal/worker/mixer.cpp
+++ b/src/framework/audio/internal/worker/mixer.cpp
@@ -64,7 +64,7 @@ RetVal<IMixerChannelPtr> Mixer::addChannel(IAudioSourcePtr source, const AudioOu
         return result;
     }
 
-    MixerChannelId newId = m_mixerChannels.size();
+    MixerChannelId newId = static_cast<MixerChannelId>(m_mixerChannels.size());
     m_mixerChannels.emplace(newId, std::make_shared<MixerChannel>(newId, std::move(source), params, paramsChanged, m_sampleRate));
 
     result.val = m_mixerChannels[newId];

--- a/src/framework/audio/internal/worker/playback.cpp
+++ b/src/framework/audio/internal/worker/playback.cpp
@@ -52,7 +52,7 @@ Promise<TrackSequenceId> Playback::addSequence()
     return Promise<TrackSequenceId>([this](Promise<TrackSequenceId>::Resolve resolve, Promise<TrackSequenceId>::Reject /*reject*/) {
         ONLY_AUDIO_WORKER_THREAD;
 
-        TrackSequenceId newId = m_sequences.size();
+        TrackSequenceId newId = static_cast<TrackSequenceId>(m_sequences.size());
 
         m_sequences.emplace(newId, std::make_shared<TrackSequence>(newId));
         m_sequenceAdded.send(newId);

--- a/src/framework/audio/internal/worker/tracksequence.cpp
+++ b/src/framework/audio/internal/worker/tracksequence.cpp
@@ -87,7 +87,7 @@ RetVal<TrackId> TrackSequence::addTrack(const std::string& trackName, const midi
         return result;
     }
 
-    TrackId newId = m_tracks.size();
+    TrackId newId = static_cast<TrackId>(m_tracks.size());
 
     MidiTrack track;
     track.id = newId;
@@ -119,7 +119,7 @@ RetVal<TrackId> TrackSequence::addTrack(const std::string& trackName, io::Device
         return result;
     }
 
-    TrackId newId = m_tracks.size();
+    TrackId newId = static_cast<TrackId>(m_tracks.size());
 
     AudioTrack track;
     track.id = newId;

--- a/src/framework/audio/synthtypes.h
+++ b/src/framework/audio/synthtypes.h
@@ -56,9 +56,9 @@ struct SynthUri : public UriQuery
         : UriQuery("musescore://audio/" + synthTypeToString(type)), type(type) {}
 
 private:
-    std::string synthTypeToString(const SynthType& type)
+    std::string synthTypeToString(const SynthType& synthType)
     {
-        switch (type) {
+        switch (synthType) {
         case SynthType::Fluid: {
             static std::string fluid("fluid");
             return fluid;

--- a/src/framework/ui/internal/uiarrangement.cpp
+++ b/src/framework/ui/internal/uiarrangement.cpp
@@ -58,9 +58,9 @@ void UiArrangement::updateData(DataKey key, QJsonObject& obj, Notifications& not
 
     Notifications::Iterator it = notifications.begin();
     for (; it != notifications.end(); ++it) {
-        const QString& key = it.key();
+        const QString& k = it.key();
 
-        if (oldObj.value(key) != obj.value(key)) {
+        if (oldObj.value(k) != obj.value(k)) {
             it.value().notify();
         }
     }

--- a/src/instrumentsscene/view/instrumentlistmodel.h
+++ b/src/instrumentsscene/view/instrumentlistmodel.h
@@ -104,7 +104,7 @@ private:
         bool customized = false;
         notation::ScoreOrder info;
 
-        bool operator==(const ScoreOrderInfo& info) const { return id == info.id; }
+        bool operator==(const ScoreOrderInfo& orderInfo) const { return id == orderInfo.id; }
     };
 
     void initSelectedInstruments(const notation::IDList& selectedPartIds);

--- a/src/notation/view/widgets/selectdialog.cpp
+++ b/src/notation/view/widgets/selectdialog.cpp
@@ -60,8 +60,8 @@ SelectDialog::SelectDialog(QWidget* parent)
         subtype->setText(qApp->translate("TextStyle", m_element->subtypeName().toUtf8()));
         break;
     case ElementType::ARTICULATION: { // comes translated, but from a different method
-        const Articulation* articulation = dynamic_cast<const Articulation*>(m_element);
-        subtype->setText(articulation->userName());
+        const Articulation* artic = dynamic_cast<const Articulation*>(m_element);
+        subtype->setText(artic->userName());
         break;
     }
     // other come translated or don't need any or are too difficult to implement

--- a/src/palette/internal/palette/palettecreator.cpp
+++ b/src/palette/internal/palette/palettecreator.cpp
@@ -1072,9 +1072,9 @@ PalettePanel* PaletteCreator::newBracketsPalettePanel()
     };
 
     static Staff bracketItemOwner(gscore);
-    bracketItemOwner.setBracketType(types.size() - 1, BracketType::NORMAL);
+    bracketItemOwner.setBracketType(static_cast<int>(types.size()) - 1, BracketType::NORMAL);
 
-    for (size_t i = 0; i < types.size(); ++i) {
+    for (int i = 0; i < types.size(); ++i) {
         auto b1 = makeElement<Bracket>(gscore);
         auto bi1 = bracketItemOwner.brackets()[i];
         const auto& type = types[i];

--- a/src/playback/view/mixerpanelmodel.cpp
+++ b/src/playback/view/mixerpanelmodel.cpp
@@ -111,7 +111,7 @@ void MixerPanelModel::removeItem(const audio::TrackId trackId)
 {
     beginResetModel();
 
-    std::remove_if(m_mixerChannelList.begin(), m_mixerChannelList.end(), [&trackId](const MixerChannelItem* item) {
+    (void)std::remove_if(m_mixerChannelList.begin(), m_mixerChannelList.end(), [&trackId](const MixerChannelItem* item) {
         return item->id() == trackId;
     });
 

--- a/thirdparty/KDDockWidgets/src/private/WidgetResizeHandler.cpp
+++ b/thirdparty/KDDockWidgets/src/private/WidgetResizeHandler.cpp
@@ -310,9 +310,6 @@ bool WidgetResizeHandler::handleWindowsNativeEvent(FloatingWindow *fw, const QBy
 
             return true;
         }
-
-        const bool ret = handleWindowsNativeEvent(fw->windowHandle(), msg, result, {});
-        return ret;
     }
 
     return handleWindowsNativeEvent(fw->windowHandle(), msg, result, {});
@@ -566,8 +563,8 @@ bool WidgetResizeHandler::isInterestingNativeEvent(int nativeEvent)
      }
 #else
     Q_UNUSED(nativeEvent);
+    return false;
 #endif
-     return false;
 }
 
 #if defined(Q_OS_WIN) && defined(KDDOCKWIDGETS_QTWIDGETS)


### PR DESCRIPTION
as seen in MS VS2019

Now just 11 warnings remaining:
7 in third party code, stb_vorbis.c (6 times C4457, once C4701), probably best disable these warnings there?
One about en empty telemetry.qrc, delete that file?
One (C4505) in moc_DockWidgetQuick.cpp, also third party and on top a generated file, maybe disable that warning?
2 (C4573 about `QObject::disconnect` not being able to gather `this` for in dockframemodel.cpp, lines 99 and 100, no idea what this is about, way above my pay grade ;-)