### PR TITLE
[MU4] Fix more warnings

### DIFF
--- a/src/appshell/view/dockwindow/internal/dockframemodel.cpp
+++ b/src/appshell/view/dockwindow/internal/dockframemodel.cpp
@@ -95,7 +95,7 @@ void DockFrameModel::listenChangesInFrame()
         emit currentDockUniqueNameChanged();
     });
 
-    connect(qApp, &QApplication::aboutToQuit, [numDocksChangedCon, currentDockWidgetChangedCon]() {
+    connect(qApp, &QApplication::aboutToQuit, [numDocksChangedCon, currentDockWidgetChangedCon, this]() {
         disconnect(numDocksChangedCon);
         disconnect(currentDockWidgetChangedCon);
     });


### PR DESCRIPTION
Fix warnings reg. `this` not being captured (in a lambda)
Fix compiler warnings in 3rd part code, stb_vorbis.c

Leaves only 2:

    Warning: No resources in '.../src/framework/telemetry/telemetry.qrc'
    Warning: C4505 'checkNotifySignalValidity_KDDockWidgets__DockWidgetQuick': unreferenced local function has been removed (compiling source file 
    ...\msvc.build_x64\thirdparty\KDDockWidgets\src\kddockwidgets_autogen\mocs_compilation.cpp)
