### PR TITLE
[MU4] Fix compiler warnings (again)

### DIFF
--- a/src/engraving/draw/painterpath.cpp
+++ b/src/engraving/draw/painterpath.cpp
@@ -147,7 +147,7 @@ size_t PainterPath::elementCount() const
     return m_elements.size();
 }
 
-PainterPath::Element PainterPath::elementAt(int i) const
+PainterPath::Element PainterPath::elementAt(size_t i) const
 {
     assert(i >= 0 && i < elementCount());
     return m_elements.at(i);

--- a/src/engraving/draw/painterpath.h
+++ b/src/engraving/draw/painterpath.h
@@ -95,7 +95,7 @@ public:
 
     bool isEmpty() const;
     size_t elementCount() const;
-    PainterPath::Element elementAt(int i) const;
+    PainterPath::Element elementAt(size_t i) const;
     void addRect(const RectF& r);
     inline void addRect(double x, double y, double w, double h)
     {

--- a/src/palette/internal/palette/palettecreator.cpp
+++ b/src/palette/internal/palette/palettecreator.cpp
@@ -1076,7 +1076,7 @@ PalettePanel* PaletteCreator::newBracketsPalettePanel()
 
     for (size_t i = 0; i < types.size(); ++i) {
         auto b1 = makeElement<Bracket>(gscore);
-        auto bi1 = bracketItemOwner.brackets()[i];
+        auto bi1 = bracketItemOwner.brackets()[static_cast<int>(i)];
         const auto& type = types[i];
         bi1->setBracketType(type.first);
         b1->setBracketItem(bi1);


### PR DESCRIPTION
Fixed earlier today, but these 2 seem to have been reverted by a later change.

Also slightly different than before, pventing warnings on macOS/Clang too