### PR TITLE
[MU4] Mixer crashes fix

### DIFF
--- a/src/playback/view/mixerpanelmodel.h
+++ b/src/playback/view/mixerpanelmodel.h
@@ -31,7 +31,6 @@
 #include "audio/itracks.h"
 #include "audio/iplayback.h"
 
-#include "iplaybackcontroller.h"
 #include "internal/mixerchannelitem.h"
 
 namespace mu::playback {
@@ -40,7 +39,6 @@ class MixerPanelModel : public QAbstractListModel, public async::Asyncable
     Q_OBJECT
 
     INJECT(playback, audio::IPlayback, playback)
-    INJECT(playback, IPlaybackController, controller)
 
 public:
     explicit MixerPanelModel(QObject* parent = nullptr);
@@ -56,7 +54,6 @@ private:
         ItemRole = Qt::UserRole + 1
     };
 
-    void loadItems(const audio::TrackSequenceId sequenceId, const audio::TrackIdList& trackIdList);
     void addItem(const audio::TrackSequenceId sequenceId, const audio::TrackId trackId);
     void removeItem(const audio::TrackId trackId);
     void sortItems();


### PR DESCRIPTION
The mixer panel is subscribed to changes tracks in the playback. When adding/deleting a track, a track item is also added/deleted in the model.
The mixer panel is also subscribed to change the current sequence. Changing the current sequence will delete all track items in the model.
In the playback, a signal is sent for each deletion of a track when the sequence was changed. As a result, the track is deleted twice in the model: removeItem and load(clear method)

Removed reloading tracks when changing the sequencer