### PR TITLE
Fix #8630: Update the menu bar item and the "Find / Go To" popup

### DIFF
--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -334,7 +334,7 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("find",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Find")
+             QT_TRANSLATE_NOOP("action", "Find / Go To")
              ),
     UiAction("staff-properties",
              mu::context::UiCtxNotationOpened,

--- a/src/notation/qml/MuseScore/NotationScene/internal/SearchPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/SearchPopup.qml
@@ -72,6 +72,10 @@ Rectangle {
                 privateProperties.hide()
             }
         }
+        
+        StyledTextLabel {
+            text: qsTrc("notation", "Find / Go to:")
+        }
 
         TextInputField {
             id: textInputField


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8630

- Add a text label to the "Find / Go To" popup panel
- Change "Edit > Find" to "Edit > Find / Go To"

- [ ] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
