### PR TITLE
[MU3] Fix 304642#: inspector update on subtype change

### DIFF
--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -120,6 +120,7 @@ Inspector::Inspector(QWidget* parent)
       ie             = 0;
       oe             = 0;
       oSameTypes     = true;
+      oSameSubtypes  = true;
       _score         = 0;
 //      retranslate();
       setWindowTitle(tr("Inspector"));
@@ -201,11 +202,13 @@ void Inspector::update(Score* s)
                         sameSubtypes = false;
                   }
             }
-      if (oe != element() || oSameTypes != sameTypes || (sameTypes && !sameSubtypes)) {
-            delete ie;
+      if (oe != element() ||
+          (oSameTypes != sameTypes) ||
+          (oSameSubtypes != sameSubtypes)) {
             ie  = 0;
             oe  = element();
             oSameTypes = sameTypes;
+            oSameSubtypes = sameSubtypes;
             if (!element())
                   ie = new InspectorEmpty(this);
             else if (!sameTypes)
@@ -324,6 +327,7 @@ void Inspector::update(Score* s)
                               else
                                     ie = new InspectorBreak(this);
 #endif
+                              //FIX: it looks as we might end up with ie = 0
                               break;
                         case ElementType::BEND:
                               ie = new InspectorBend(this);
@@ -399,8 +403,13 @@ void Inspector::update(Score* s)
                               break;
                         }
                   }
+            Q_ASSERT(ie);
             connect(ie, &InspectorBase::elementChanged, this, QOverload<>::of(&Inspector::update), Qt::QueuedConnection);
-            sa->setWidget(ie);      // will destroy previous set widget
+            if (sa->widget()) { // If old inspector exist
+                  QWidget *q = sa->takeWidget();
+                  q->deleteLater();
+                  }
+            sa->setWidget(ie);      // will destroy previous set widget, unless takeWidget() call
 
             //focus policies were set by hand in each inspector_*.ui. this code just helps keeping them like they are
             //also fixes mac problem. on Mac Qt::TabFocus doesn't work, but Qt::StrongFocus works

--- a/mscore/inspector/inspector.h
+++ b/mscore/inspector/inspector.h
@@ -392,6 +392,7 @@ class Inspector : public QDockWidget {
                               // within the inspector itself
       Element* oe;
       bool oSameTypes;
+      bool oSameSubtypes;
 
    public slots:
       void update();


### PR DESCRIPTION
- its not enough to only track element-type change when
  to consider if update inspector.
- use Qt deleteLater which is more safe if we have
  signals roaming to old deleted widgets.

Resolves: https://musescore.org/en/node/304642


The bug that, if you select a slur and tie and click in inspector leads to crash, Is fixed with this commit.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://musescore.org/en/cla)
- [ ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x ] I made sure the code compiles on my machine
- [x ] I made sure there are no unnecessary changes in the code
- [x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
