### PR TITLE
[MU4] temporarily_disabled_mixer_panel

### DIFF
--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -248,6 +248,9 @@ DockPage {
             visible: false
 
             Loader {
+                //!Note Temporarily disabled the mixer panel,
+                // since it's waiting for a couple of important tasks in the instruments/parts workflow
+                active: false
                 asynchronous: true
                 sourceComponent: MixerPanel {}
             }


### PR DESCRIPTION
Temporarily disabled the mixer panel, since it's waiting for a couple of important tasks in the instruments/parts workflow

Will be turned on soon