### PR TITLE
Fixed Clang warning

### DIFF
--- a/thirdparty/deto_async/async/notifylist.h
+++ b/thirdparty/deto_async/async/notifylist.h
@@ -11,6 +11,7 @@ class NotifyList : public std::vector<T>
 {
 public:
     NotifyList() {}
+    NotifyList(const NotifyList&) = default;
     NotifyList(ChangedNotify<T>* n)
         : m_notify(n) {}
     NotifyList(const std::vector<T>& l, ChangedNotify<T>* n)


### PR DESCRIPTION
When compiling, I get a "deprecated implicitly-defined copy constructor" warning.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
