### PR TITLE
Fix #312714: [Musicxml Export] - Hairpin export stops halfway

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -383,11 +383,11 @@ class ExportMusicXml
     void exportDefaultClef(const Part* const part, const Measure* const m);
     void writeElement(Element* el, const Measure* m, int sstaff, bool useDrumset);
     void writeMeasureTracks(const Measure* const m, const int partIndex, const int strack, const int partRelStaffNo, const bool useDrumset,
-                            const bool isLastStaffOfPart, FigBassMap& fbMap);
+                            const bool isLastStaffOfPart, FigBassMap& fbMap, QSet<const Spanner*>& spannersStopped);
     void writeMeasureStaves(const Measure* m, const int partIndex, const int startStaff, const int nstaves, const bool useDrumset,
-                            FigBassMap& fbMap);
+                            FigBassMap& fbMap, QSet<const Spanner*>& spannersStopped);
     void writeMeasure(const Measure* const m, const int idx, const int staffCount, MeasureNumberStateHandler& mnsh, FigBassMap& fbMap,
-                      const MeasurePrintContext& mpc);
+                      const MeasurePrintContext& mpc, QSet<const Spanner*>& spannersStopped);
     void repeatAtMeasureStart(Attributes& attr, const Measure* const m, int strack, int etrack, int track);
     void repeatAtMeasureStop(const Measure* const m, int strack, int etrack, int track);
     void writeParts();
@@ -6773,14 +6773,11 @@ void ExportMusicXml::writeMeasureTracks(const Measure* const m,
                                         const int partRelStaffNo,
                                         const bool useDrumset,
                                         const bool isLastStaffOfPart,
-                                        FigBassMap& fbMap)
+                                        FigBassMap& fbMap,
+                                        QSet<const Spanner*>& spannersStopped)
 {
     const auto tboxesAbove = findTextFramesToWriteAsWordsAbove(m);
     const auto tboxesBelow = findTextFramesToWriteAsWordsBelow(m);
-
-    // set of spanners already stopped in this measure
-    // required to prevent multiple spanner stops for the same spanner
-    QSet<const Spanner*> spannersStopped;
 
     int etrack = strack + VOICES;
     for (int track = strack; track < etrack; ++track) {
@@ -6873,7 +6870,8 @@ void ExportMusicXml::writeMeasureStaves(const Measure* m,
                                         const int startStaff,
                                         const int nstaves,
                                         const bool useDrumset,
-                                        FigBassMap& fbMap)
+                                        FigBassMap& fbMap,
+                                        QSet<const Spanner*>& spannersStopped)
 {
     const int endStaff = startStaff + nstaves;
     const Measure* const origM = m;
@@ -6904,7 +6902,7 @@ void ExportMusicXml::writeMeasureStaves(const Measure* m,
 
         bool isLastStaffOfPart = (endStaff - 1 <= staffIdx); // for writing tboxes below
 
-        writeMeasureTracks(m, partIndex, staff2track(staffIdx), partRelStaffNo, useDrumset, isLastStaffOfPart, fbMap);
+        writeMeasureTracks(m, partIndex, staff2track(staffIdx), partRelStaffNo, useDrumset, isLastStaffOfPart, fbMap, spannersStopped);
 
         // restore m and _tick before advancing to next staff in part
         m = origM;
@@ -6925,7 +6923,8 @@ void ExportMusicXml::writeMeasure(const Measure* const m,
                                   const int staffCount,
                                   MeasureNumberStateHandler& mnsh,
                                   FigBassMap& fbMap,
-                                  const MeasurePrintContext& mpc)
+                                  const MeasurePrintContext& mpc,
+                                  QSet<const Spanner*>& spannersStopped)
 {
     const auto part = _score->parts().at(partIndex);
     const int staves = part->nstaves();
@@ -6994,7 +6993,7 @@ void ExportMusicXml::writeMeasure(const Measure* const m,
     }
 
     // write data in the staves
-    writeMeasureStaves(m, partIndex, track2staff(strack), staves, part->instrument()->useDrumset(), fbMap);
+    writeMeasureStaves(m, partIndex, track2staff(strack), staves, part->instrument()->useDrumset(), fbMap, spannersStopped);
 
     // write the annotations that could not be attached to notes
     annotationsWithoutNote(this, strack, staves, m);
@@ -7050,6 +7049,10 @@ void ExportMusicXml::writeParts()
         MeasureNumberStateHandler mnsh;
         FigBassMap fbMap;                     // pending figured bass extends
 
+        // set of spanners already stopped in this part
+        // required to prevent multiple spanner stops for the same spanner
+        QSet<const Spanner*> spannersStopped;
+
         const auto& pages = _score->pages();
         MeasurePrintContext mpc;
 
@@ -7073,13 +7076,13 @@ void ExportMusicXml::writeParts()
                         const auto m2 = m->mmRestLast()->nextMeasure();
                         for (auto m1 = m->mmRestFirst(); m1 != m2; m1 = m1->nextMeasure()) {
                             if (m1->isMeasure()) {
-                                writeMeasure(m1, partIndex, staffCount, mnsh, fbMap, mpc);
+                                writeMeasure(m1, partIndex, staffCount, mnsh, fbMap, mpc, spannersStopped);
                                 mpc.measureWritten(m1);
                             }
                         }
                     } else {
                         // write the measure (or, if measure repeat, the "underlying" measure that it indicates for the musician to play)
-                        writeMeasure(m, partIndex, staffCount, mnsh, fbMap, mpc);
+                        writeMeasure(m, partIndex, staffCount, mnsh, fbMap, mpc, spannersStopped);
                         mpc.measureWritten(m);
                     }
                 }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/312714

The spanner stopped data structure was incorrectly at measure level instead of at part level.
This breaks spanners ending exactly at a measure end when the next measure starts with
a zero-sized rest (happens when the second track does not have a note at the neasure start).

This syncs 3.x https://github.com/musescore/MuseScore/pull/6869 to master

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
