### PR TITLE
[MU4] fix MU3 issue #323402, accidentals not shown as expected for altered unisons

### DIFF
--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -2322,6 +2322,16 @@ bool Note::dotIsUp() const
     }
 }
 
+static bool hasAlteredUnison(Note* note)
+{
+    const auto& chordNotes = note->chord()->notes();
+    AccidentalVal accVal = tpc2alter(note->tpc());
+    int relLine = absStep(note->tpc(), note->epitch());
+    return std::find_if(chordNotes.begin(), chordNotes.end(), [note, accVal, relLine](Note* n) {
+        return n != note && !n->hidden() && absStep(n->tpc(), n->epitch()) == relLine && tpc2alter(n->tpc()) != accVal;
+    }) != chordNotes.end();
+}
+
 //---------------------------------------------------------
 //   updateAccidental
 //    set _accidental and _line depending on tpc
@@ -2352,6 +2362,10 @@ void Note::updateAccidental(AccidentalState* as)
             if (_tieBack && _tieBack->startNote()->tpc1() == tpc1()) {
                 acci = AccidentalType::NONE;
             } else if (acci == AccidentalType::NONE) {
+                acci = AccidentalType::NATURAL;
+            }
+        } else if (hasAlteredUnison(this)) {
+            if ((acci = Accidental::value2subtype(accVal)) == AccidentalType::NONE) {
                 acci = AccidentalType::NATURAL;
             }
         }

--- a/src/engraving/tests/note_data/altered-unison.mscx
+++ b/src/engraving/tests/note_data/altered-unison.mscx
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.02">
+  <programVersion>3.6.2</programVersion>
+  <programRevision>3224f34</programRevision>
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <enableVerticalSpread>1</enableVerticalSpread>
+      <useStandardNoteNames>0</useStandardNoteNames>
+      <Spatium>1.75</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2021-07-31</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Microsoft Windows</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">x</metaTag>
+    <Order id="orchestral" customized="1">
+      <name>Orchestral</name>
+      <instrument id="piano">
+        <family id="keyboards">Keyboards</family>
+        </instrument>
+      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
+        <family>flutes</family>
+        <family>oboes</family>
+        <family>clarinets</family>
+        <family>saxophones</family>
+        <family>bassoons</family>
+        <unsorted group="woodwinds"/>
+        </section>
+      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+        <family>horns</family>
+        <family>trumpets</family>
+        <family>cornets</family>
+        <family>flugelhorns</family>
+        <family>trombones</family>
+        <family>tubas</family>
+        </section>
+      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+        <family>timpani</family>
+        </section>
+      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+        <family>keyboard-percussion</family>
+        <family>drums</family>
+        <family>unpitched-metal-percussion</family>
+        <family>unpitched-wooden-percussion</family>
+        <family>other-percussion</family>
+        </section>
+      <family>keyboards</family>
+      <family>harps</family>
+      <family>organs</family>
+      <family>synths</family>
+      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+        <family>plucked-strings</family>
+        </section>
+      <soloists/>
+      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+        <family>voices</family>
+        </section>
+      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
+        <family>orchestral-strings</family>
+        </section>
+      <unsorted/>
+      </Order>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <bracket type="1" span="2" col="2"/>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument id="piano">
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>Title</style>
+          <text>x</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <Accidental><subtype>accidentalFlat</subtype></Accidental>
+              <pitch>70</pitch><tpc>12</tpc>
+              </Note>
+            <Note>
+              <Accidental><subtype>accidentalNatural</subtype></Accidental>
+              <pitch>71</pitch><tpc>19</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <Accidental><subtype>accidentalSharp</subtype></Accidental>
+              <pitch>73</pitch><tpc>21</tpc>
+              </Note>
+            <Note>
+              <Accidental><subtype>accidentalNatural</subtype></Accidental>
+              <pitch>72</pitch><tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/engraving/tests/tst_note.cpp
+++ b/src/engraving/tests/tst_note.cpp
@@ -58,6 +58,7 @@ private slots:
     void tpcTranspose2();
     void noteLimits();
     void tpcDegrees();
+    void alteredUnison();
     void LongNoteAfterShort_183746();
 };
 
@@ -511,6 +512,18 @@ void TestNote::tpcDegrees()
     QCOMPARE(tpc2degree(Tpc::TPC_B,   Key::C_S), 6);
     QCOMPARE(tpc2degree(Tpc::TPC_B_B, Key::C_S), 6);
     //QCOMPARE(tpc2degree(Tpc::TPC_B_S, Key::C_S), 7);
+}
+
+void TestNote::alteredUnison()
+{
+    MasterScore* score = readScore(NOTE_DATA_DIR + "altered-unison.mscx");
+    Measure* m = score->firstMeasure();
+    Chord* c = m->findChord(Fraction(0, 1), 0);
+    QVERIFY(c->downNote()->accidental() && c->downNote()->accidental()->accidentalType() == Ms::AccidentalType::FLAT);
+    QVERIFY(c->upNote()->accidental() && c->upNote()->accidental()->accidentalType() == Ms::AccidentalType::NATURAL);
+    c = m->findChord(Fraction(1, 4), 0);
+    QVERIFY(c->downNote()->accidental() && c->downNote()->accidental()->accidentalType() == Ms::AccidentalType::NATURAL);
+    QVERIFY(c->upNote()->accidental() && c->upNote()->accidental()->accidentalType() == Ms::AccidentalType::SHARP);
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/323402

Altered unisons where the same note occurs twice in one chord but with different accidentals need to ensure that the accidentals for both notes are always correctly shown (currently they appear and disappear somewhat randomly)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
