### PR TITLE
[MU4] fix #8773, "change enharmonic spelling" commands not implemented

### DIFF
--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -923,6 +923,8 @@ public:
     void spell();
     void spell(int startStaff, int endStaff, Segment* startSegment, Segment* endSegment);
     void spell(Note*);
+    void changeEnharmonicSpelling(bool both);
+
     Fraction nextSeg(const Fraction& tick, int track);
 
     ChordList* chordList() { return &_chordList; }

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -170,6 +170,7 @@ public:
     virtual void fillSelectionWithSlashes() = 0;
     virtual void replaceSelectedNotesWithSlashes() = 0;
 
+    virtual void changeEnharmonicSpelling(bool both) = 0;
     virtual void spellPitches() = 0;
     virtual void regroupNotesAndRests() = 0;
     virtual void resequenceRehearsalMarks() = 0;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -287,6 +287,9 @@ void NotationActionController::init()
     dispatcher()->reg(this, "add-parentheses", [this]() { addBracketsToSelection(BracketsType::Parentheses); });
     dispatcher()->reg(this, "add-braces", [this]() { addBracketsToSelection(BracketsType::Braces); });
 
+    registerAction("enh-both", &NotationActionController::changeEnharmonicSpellingBoth, &NotationActionController::isNotEditingText);
+    registerAction("enh-current", &NotationActionController::changeEnharmonicSpellingCurrent, &NotationActionController::isNotEditingText);
+
     for (int i = MIN_NOTES_INTERVAL; i <= MAX_NOTES_INTERVAL; ++i) {
         if (isNotesIntervalValid(i)) {
             dispatcher()->reg(this, "interval" + std::to_string(i), [this, i]() { addInterval(i); });
@@ -1343,6 +1346,26 @@ void NotationActionController::addGraceNotesToSelectedNotes(GraceNoteType type)
     }
 
     interaction->addGraceNotesToSelectedNotes(type);
+}
+
+void NotationActionController::changeEnharmonicSpellingBoth()
+{
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+
+    interaction->changeEnharmonicSpelling(true);
+}
+
+void NotationActionController::changeEnharmonicSpellingCurrent()
+{
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+
+    interaction->changeEnharmonicSpelling(false);
 }
 
 void NotationActionController::addStretch(qreal value)

--- a/src/notation/internal/notationactioncontroller.h
+++ b/src/notation/internal/notationactioncontroller.h
@@ -160,6 +160,8 @@ private:
     void unrollRepeats();
     void copyLyrics();
     void addGraceNotesToSelectedNotes(GraceNoteType type);
+    void changeEnharmonicSpellingBoth();
+    void changeEnharmonicSpellingCurrent();
 
     void resetState();
     void resetStretch();

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -438,11 +438,11 @@ bool NotationInteraction::elementIsLess(const Ms::Element* e1, const Ms::Element
             }
         }
         // different types, or same type but nothing hidden - use track
-        return e1->track() <= e2->track();
+        return e1->track() < e2->track();
     }
 
     // default case, use stacking order
-    return e1->z() <= e2->z();
+    return e1->z() < e2->z();
 }
 
 const NotationInteraction::HitElementContext& NotationInteraction::hitElementContext() const
@@ -2827,6 +2827,15 @@ void NotationInteraction::replaceSelectedNotesWithSlashes()
 
     startEdit();
     score()->cmdSlashRhythm();
+    apply();
+
+    notifyAboutNotationChanged();
+}
+
+void mu::notation::NotationInteraction::changeEnharmonicSpelling(bool both)
+{
+    startEdit();
+    score()->changeEnharmonicSpelling(both);
     apply();
 
     notifyAboutNotationChanged();

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -178,6 +178,7 @@ public:
     void fillSelectionWithSlashes() override;
     void replaceSelectedNotesWithSlashes() override;
 
+    void changeEnharmonicSpelling(bool) override;
     void spellPitches() override;
     void regroupNotesAndRests() override;
     void resequenceRehearsalMarks() override;

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -1317,6 +1317,18 @@ const UiActionList NotationUiActions::m_noteInputActions = {
              QT_TRANSLATE_NOOP("action", "Voice 4"),
              IconCode::Code::VOICE_4
              ),
+    UiAction("enh-both",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Change enharmonic spelling (both modes)"),
+             QT_TRANSLATE_NOOP("action", "Change enharmonic spelling (both modes)"),
+             IconCode::Code::NONE
+             ),
+    UiAction("enh-current",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Change enharmonic spelling (both modes)"),
+             QT_TRANSLATE_NOOP("action", "Change enharmonic spelling (current mode)"),
+             IconCode::Code::NONE
+             ),
     UiAction("flip",
              mu::context::UiCtxNotationOpened,
              QT_TRANSLATE_NOOP("action", "Flip direction"),


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8773

Ensures "change enharmonic spelling" commands available in MU3 are ported to MU4, and ensures "Respell pitches" only applies to selected notes

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
