### PR TITLE
[MU4] Fix (MinGW) compiler warnings

### DIFF
--- a/src/engraving/draw/transform.cpp
+++ b/src/engraving/draw/transform.cpp
@@ -427,8 +427,8 @@ Transform& Transform::rotate(double a)
         double tm23 = -sina * m_13 + cosa * m_23;
         m_13 = tm13;
         m_23 = tm23;
-        // fallthrough
     }
+    // fallthrough
     case TransformationType::Rotate:
     case TransformationType::Shear: {
         double tm11 = cosa * m_affine.m_11 + sina * m_affine.m_21;
@@ -483,8 +483,8 @@ Transform& Transform::rotateRadians(double a)
         double tm23 = -sina * m_13 + cosa * m_23;
         m_13 = tm13;
         m_23 = tm23;
-        // fallthrough
     }
+    // fallthrough
     case TransformationType::Rotate:
     case TransformationType::Shear: {
         double tm11 = cosa * m_affine.m_11 + sina * m_affine.m_21;
@@ -564,6 +564,7 @@ Transform& Transform::scale(double sx, double sy)
     case TransformationType::Project:
         m_13 *= sx;
         m_23 *= sy;
+    // fall through
     case TransformationType::Rotate:
     case TransformationType::Shear:
         m_affine.m_12 *= sx;

--- a/src/palette/internal/palette.cpp
+++ b/src/palette/internal/palette.cpp
@@ -130,7 +130,7 @@ PaletteCellPtr Palette::appendActionIcon(Ms::ActionIconType type, actions::Actio
 
 bool Palette::insertCell(size_t idx, PaletteCellPtr cell)
 {
-    if (idx < 0 || idx > m_cells.size()) {
+    if (idx > m_cells.size()) {
         return false;
     }
 
@@ -141,7 +141,7 @@ bool Palette::insertCell(size_t idx, PaletteCellPtr cell)
 
 bool Palette::insertCells(size_t idx, std::vector<PaletteCellPtr> cells)
 {
-    if (idx < 0 || idx > m_cells.size()) {
+    if (idx > m_cells.size()) {
         return false;
     }
 
@@ -153,7 +153,7 @@ bool Palette::insertCells(size_t idx, std::vector<PaletteCellPtr> cells)
 
 PaletteCellPtr Palette::takeCell(size_t idx)
 {
-    if (idx < 0 || idx >= m_cells.size()) {
+    if (idx >= m_cells.size()) {
         return nullptr;
     }
 
@@ -165,7 +165,7 @@ std::vector<PaletteCellPtr> Palette::takeCells(size_t idx, size_t count)
     std::vector<PaletteCellPtr> removedCells;
     removedCells.reserve(count);
 
-    if (idx < 0 || idx + count > m_cells.size()) {
+    if (idx + count > m_cells.size()) {
         return removedCells;
     }
 

--- a/src/palette/view/widgets/palettewidget.cpp
+++ b/src/palette/view/widgets/palettewidget.cpp
@@ -112,7 +112,7 @@ int PaletteWidget::actualCellCount() const
 
 PaletteCellPtr PaletteWidget::cellAt(size_t index) const
 {
-    if (index < 0 || index >= actualCellsList().size()) {
+    if (index >= actualCellsList().size()) {
         return nullptr;
     }
 


### PR DESCRIPTION
Leaves one more warning:
```
.../src/framework/ui/internal/platform/windows/windowsplatformtheme.cpp:44:126: warning: cast between incompatible function types from 'FARPROC' {aka 'long long int (*)()'} to 'fnRtlGetNtVersionNumbers' {aka 'void (*)(long unsigned int*, long unsigned int*, long unsigned int*)'} [-Wcast-function-type]
         = reinterpret_cast<fnRtlGetNtVersionNumbers>(GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "RtlGetNtVersionNumbers"));
                                                                                                                              ^
```
This one seems above my pay grade :-/