### PR TITLE
[MU4] Fix compiler warnings

### DIFF
--- a/src/appshell/view/dockwindow/internal/dockframemodel.cpp
+++ b/src/appshell/view/dockwindow/internal/dockframemodel.cpp
@@ -155,7 +155,11 @@ void DockFrameModel::listenChangesInFrame()
         emit currentDockChanged();
     });
 
-    connect(qApp, &QApplication::aboutToQuit, [numDocksChangedCon, currentDockWidgetChangedCon, this]() {
+    connect(qApp, &QApplication::aboutToQuit, [numDocksChangedCon, currentDockWidgetChangedCon
+#if (defined (_MSCVER) || defined (_MSC_VER)) // prevent bogus compiler warning with MSVC
+                                               , this
+#endif
+            ]() {
         disconnect(numDocksChangedCon);
         disconnect(currentDockWidgetChangedCon);
     });

--- a/src/engraving/CMakeLists.txt
+++ b/src/engraving/CMakeLists.txt
@@ -153,6 +153,8 @@ else()
 endif()
 
 set_source_files_properties( # For these files, Unity Build does not work
+    ${CMAKE_CURRENT_LIST_DIR}/libmscore/chordlist.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/compat/chordlist.cpp
     ${CMAKE_CURRENT_LIST_DIR}/compat/read114.cpp
     ${CMAKE_CURRENT_LIST_DIR}/compat/read206.cpp
     PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON

--- a/src/engraving/internal/fontengineft.cpp
+++ b/src/engraving/internal/fontengineft.cpp
@@ -97,7 +97,7 @@ bool FontEngineFT::load(const QString& path)
     return true;
 }
 
-QRectF FontEngineFT::bbox(uint ucs4, qreal DPI_F) const
+QRectF FontEngineFT::bbox(uint ucs4, qreal dpi_f) const
 {
     FTGlyphMetrics* gm = glyphMetrics(ucs4);
     if (!gm) {
@@ -106,13 +106,13 @@ QRectF FontEngineFT::bbox(uint ucs4, qreal DPI_F) const
 
     const FT_BBox& bb = gm->bb;
     //! NOTE Moved form sym.cpp ScoreFont::computeMetrics as is
-    double m = 640.0 / DPI_F;
+    double m = 640.0 / dpi_f;
     QRectF bbox;
     bbox.setCoords(bb.xMin / m, -bb.yMax / m, bb.xMax / m, -bb.yMin / m);
     return bbox;
 }
 
-qreal FontEngineFT::advance(uint ucs4, qreal DPI_F) const
+qreal FontEngineFT::advance(uint ucs4, qreal dpi_f) const
 {
     FTGlyphMetrics* gm = glyphMetrics(ucs4);
     if (!gm) {
@@ -120,7 +120,7 @@ qreal FontEngineFT::advance(uint ucs4, qreal DPI_F) const
     }
 
     //! NOTE Moved form sym.cpp ScoreFont::computeMetrics as is
-    return gm->linearHoriAdvance * DPI_F / 655360.0;
+    return gm->linearHoriAdvance * dpi_f / 655360.0;
 }
 
 FTGlyphMetrics* FontEngineFT::glyphMetrics(uint ucs4) const

--- a/src/engraving/internal/qfontprovider.cpp
+++ b/src/engraving/internal/qfontprovider.cpp
@@ -129,22 +129,22 @@ RectF QFontProvider::tightBoundingRect(const Font& f, const QString& string) con
 }
 
 // Score symbols
-RectF QFontProvider::symBBox(const Font& f, uint ucs4, qreal DPI_F) const
+RectF QFontProvider::symBBox(const Font& f, uint ucs4, qreal dpi_f) const
 {
     FontEngineFT* engine = symEngine(f);
     if (!engine) {
         return RectF();
     }
-    return RectF::fromQRectF(engine->bbox(ucs4, DPI_F));
+    return RectF::fromQRectF(engine->bbox(ucs4, dpi_f));
 }
 
-qreal QFontProvider::symAdvance(const Font& f, uint ucs4, qreal DPI_F) const
+qreal QFontProvider::symAdvance(const Font& f, uint ucs4, qreal dpi_f) const
 {
     FontEngineFT* engine = symEngine(f);
     if (!engine) {
         return 0.0;
     }
-    return engine->advance(ucs4, DPI_F);
+    return engine->advance(ucs4, dpi_f);
 }
 
 FontEngineFT* QFontProvider::symEngine(const Font& f) const

--- a/src/engraving/libmscore/layout/layoutcontext.cpp
+++ b/src/engraving/libmscore/layout/layoutcontext.cpp
@@ -1738,10 +1738,10 @@ System* LayoutContext::collectSystem()
                     }
                 }
                 const MeasureBase* pbmb = lc.prevMeasure->findPotentialSectionBreak();
-                bool firstSystem = pbmb->sectionBreak() && score->_layoutMode != LayoutMode::FLOAT;
+                bool localFirstSystem = pbmb->sectionBreak() && score->_layoutMode != LayoutMode::FLOAT;
                 MeasureBase* nm = breakMeasure ? breakMeasure : m;
                 if (curHeader) {
-                    m->addSystemHeader(firstSystem);
+                    m->addSystemHeader(localFirstSystem);
                 } else {
                     m->removeSystemHeader();
                 }

--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -2430,7 +2430,7 @@ void TextBase::writeProperties(XmlWriter& xml, bool writeText, bool /*writeStyle
     }
 }
 
-static constexpr std::array<Pid, 18> pids { {
+static constexpr std::array<Pid, 18> TextBasePropertyId { {
     Pid::SUB_STYLE,
     Pid::FONT_FACE,
     Pid::FONT_SIZE,
@@ -2453,7 +2453,7 @@ static constexpr std::array<Pid, 18> pids { {
 bool TextBase::readProperties(XmlReader& e)
 {
     const QStringRef& tag(e.name());
-    for (Pid i :pids) {
+    for (Pid i : TextBasePropertyId) {
         if (readProperty(tag, e, i)) {
             return true;
         }
@@ -2505,7 +2505,7 @@ Pid TextBase::propertyId(const QStringRef& name) const
     if (name == "text") {
         return Pid::TEXT;
     }
-    for (Pid pid : pids) {
+    for (Pid pid : TextBasePropertyId) {
         if (propertyName(pid) == name) {
             return pid;
         }

--- a/src/engraving/libmscore/textlinebase.cpp
+++ b/src/engraving/libmscore/textlinebase.cpp
@@ -466,7 +466,7 @@ void TextLineBaseSegment::spatiumChanged(qreal ov, qreal nv)
     _endText->spatiumChanged(ov, nv);
 }
 
-static constexpr std::array<Pid, 26> pids = { {
+static constexpr std::array<Pid, 26> TextLineBasePropertyId = { {
     Pid::LINE_VISIBLE,
     Pid::BEGIN_HOOK_TYPE,
     Pid::BEGIN_HOOK_HEIGHT,
@@ -501,7 +501,7 @@ static constexpr std::array<Pid, 26> pids = { {
 
 Element* TextLineBaseSegment::propertyDelegate(Pid pid)
 {
-    for (Pid id : pids) {
+    for (Pid id : TextLineBasePropertyId) {
         if (pid == id) {
             return spanner();
         }
@@ -568,7 +568,7 @@ void TextLineBase::spatiumChanged(qreal /*ov*/, qreal /*nv*/)
 
 void TextLineBase::writeProperties(XmlWriter& xml) const
 {
-    for (Pid pid : pids) {
+    for (Pid pid : TextLineBasePropertyId) {
         if (!isStyled(pid)) {
             writeProperty(xml, pid);
         }
@@ -583,7 +583,7 @@ void TextLineBase::writeProperties(XmlWriter& xml) const
 bool TextLineBase::readProperties(XmlReader& e)
 {
     const QStringRef& tag(e.name());
-    for (Pid i : pids) {
+    for (Pid i : TextLineBasePropertyId) {
         if (readProperty(tag, e, i)) {
             setPropertyFlags(i, PropertyFlags::UNSTYLED);
             return true;
@@ -598,7 +598,7 @@ bool TextLineBase::readProperties(XmlReader& e)
 
 Pid TextLineBase::propertyId(const QStringRef& name) const
 {
-    for (Pid pid : pids) {
+    for (Pid pid : TextLineBasePropertyId) {
         if (propertyName(pid) == name) {
             return pid;
         }

--- a/src/framework/ui/internal/platform/windows/windowsplatformtheme.cpp
+++ b/src/framework/ui/internal/platform/windows/windowsplatformtheme.cpp
@@ -40,12 +40,16 @@ HANDLE hStopListeningEvent = nullptr;
 WindowsPlatformTheme::WindowsPlatformTheme()
 {
     using fnRtlGetNtVersionNumbers = void(WINAPI*)(LPDWORD major, LPDWORD minor, LPDWORD build);
+
+    // The (void*) cast silences an unnecessary MinGW warning about incompatible function cast
     auto rtlGetNtVersionNumbers
-        = reinterpret_cast<fnRtlGetNtVersionNumbers>(GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "RtlGetNtVersionNumbers"));
+        = reinterpret_cast<fnRtlGetNtVersionNumbers>((void*)GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "RtlGetNtVersionNumbers"));
     if (rtlGetNtVersionNumbers) {
-        DWORD major, minor, buildNumber;
-        rtlGetNtVersionNumbers(&major, &minor, &buildNumber);
+        DWORD buildNumber;
+        rtlGetNtVersionNumbers(NULL, NULL, &buildNumber);
         m_buildNumber = buildNumber & ~0xF0000000;
+    } else {
+        LOGE() << "Could not get Windows build number";
     }
 }
 

--- a/src/framework/vst/internal/vstaudioclient.cpp
+++ b/src/framework/vst/internal/vstaudioclient.cpp
@@ -155,7 +155,7 @@ void VstAudioClient::updateProcessSetup()
 
 void VstAudioClient::fillOutputBuffer(unsigned int samples, float* output)
 {
-    int audioChannels = config()->audioChannelsCount();
+    unsigned int audioChannels = config()->audioChannelsCount();
 
     for (unsigned int i = 0; i < samples; ++i) {
         for (unsigned int s = 0; s < audioChannels; ++s) {

--- a/thirdparty/KDDockWidgets/src/CMakeLists.txt
+++ b/thirdparty/KDDockWidgets/src/CMakeLists.txt
@@ -367,3 +367,9 @@ if(${PROJECT_NAME}_DEVELOPER_MODE)
   endif()
 
 endif()
+
+if (MSVC)
+  set_target_properties(kddockwidgets PROPERTIES
+    COMPILE_FLAGS "/wd4505"
+  )
+endif (MSVC)


### PR DESCRIPTION
* Fix a compiler warning for MSVC only as it otherwise causes a warning with Clang
    See discussion at https://github.com/musescore/MuseScore/pull/8712#pullrequestreview-722681599
* Fix compiler warning and subsequent error on MSCV and MinGW after enabling Unity build for engraving
    See https://github.com/musescore/MuseScore/pull/8765#issuecomment-889667391 and https://github.com/musescore/MuseScore/pull/8765#issuecomment-894631281.
    Issue apparently is not seen in a Ninja build.
* Fix MinGW warning about "incompatible function cast" and a very small optimization and added an error logging statement.
* Fix an MSVC compiler warning seen on GitHub CI
* Fix MSVC compiler warnings reg. clash between function parameter and marco/constexpr of same name and a clash between a local variable and a class member
* Disable an MSVC compiler warning in a third party part
