### PR TITLE
[MU4] Fix crash when pasting tie onto rest

### DIFF
--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -1863,7 +1863,7 @@ bool Note::acceptDrop(EditData& data) const
            || (type == ElementType::FRET_DIAGRAM)
            || (type == ElementType::FIGURED_BASS)
            || (type == ElementType::LYRICS)
-           || e->isSpanner();
+           || (type != ElementType::TIE && e->isSpanner());
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/rest.cpp
+++ b/src/engraving/libmscore/rest.cpp
@@ -188,7 +188,8 @@ bool Rest::acceptDrop(EditData& data) const
         ) {
         return true;
     }
-    return type != ElementType::SLUR && e->isSpanner();
+    // prevent 'hanging' slurs, avoid crash on tie
+    return type != ElementType::SLUR && type != ElementType::TIE && e->isSpanner();
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/tie.cpp
+++ b/src/engraving/libmscore/tie.cpp
@@ -98,12 +98,12 @@ bool TieSegment::edit(EditData& ed)
 {
     SlurTie* sl = tie();
 
-    if (ed.key == Qt::Key_X) {
+    if (ed.key == Qt::Key_X && !ed.modifiers) {
         sl->setSlurDirection(sl->up() ? Direction::DOWN : Direction::UP);
         sl->layout();
         return true;
     }
-    if (ed.key == Qt::Key_Home) {
+    if (ed.key == Qt::Key_Home && !ed.modifiers) {
         ups(ed.curGrip).off = PointF();
         sl->layout();
         return true;


### PR DESCRIPTION
Fixes a regression introduced with #8510

While at it (and being asked for it by @lyrra) also porting #8816 to master, to fix https://musescore.org/en/node/321809.
Edit: using a different and IMHO better fix now, see discussion in #8816., which only disables pasting a `NOTE`(head) onto a MMRest:
```
diff --git a/libmscore/rest.cpp b/libmscore/rest.cpp
index 4338d7f29..d93adb462 100644
--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -217,7 +214,7 @@ bool Rest::acceptDrop(EditData& data) const
          || (type == ElementType::BAR_LINE)
          || (type == ElementType::BREATH)
          || (type == ElementType::CHORD)
-         || (type == ElementType::NOTE)
+         || (type == ElementType::NOTE && !measure()->isMMRest()) // avoid crash
          || (type == ElementType::STAFF_STATE)
          || (type == ElementType::INSTRUMENT_CHANGE)
          || (type == ElementType::DYNAMIC)
```
Edit 2: #8825 fixes that even better, by actually making it work, so I'm removing that above mentioned change from this PR