### PR TITLE
[MU4] playback_stabilisation

### DIFF
--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -268,6 +268,8 @@ DockPage {
 
             tabifyPanel: pianoRollPanel
 
+            // TODO: Temporarily disabled on startup, but can be enabled via the app menu, see:
+            // https://github.com/musescore/MuseScore/pull/8593
             visible: false
 
             Loader {

--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -268,14 +268,9 @@ DockPage {
 
             tabifyPanel: pianoRollPanel
 
-            // TODO: Temporarily disabled on startup, but can be enabled via the app menu, see:
-            // https://github.com/musescore/MuseScore/pull/8593
             visible: false
 
             Loader {
-                //!Note Temporarily disabled the mixer panel,
-                // since it's waiting for a couple of important tasks in the instruments/parts workflow
-                active: false
                 asynchronous: true
                 sourceComponent: MixerPanel {}
             }

--- a/src/engraving/libmscore/rendermidi.cpp
+++ b/src/engraving/libmscore/rendermidi.cpp
@@ -2676,58 +2676,16 @@ void MidiRenderer::updateChunksPartition()
     }
 }
 
-//---------------------------------------------------------
-//   MidiRenderer::getChunkAt
-//---------------------------------------------------------
-
-MidiRenderer::Chunk MidiRenderer::getChunkAt(int utick)
-{
-    updateState();
-
-    auto it = std::upper_bound(chunks.begin(), chunks.end(), utick, [](int utick, const Chunk& ch) {
-        return utick < ch.utick1();
-    });
-    if (it == chunks.begin()) {
-        return Chunk();
-    }
-    --it;
-    const Chunk& ch = *it;
-    if (ch.utick2() <= utick) {
-        return Chunk();
-    }
-    return ch;
-}
-
-MidiRenderer::Chunk MidiRenderer::chunkAt(int utick)
-{
-    updateState();
-    auto it = std::upper_bound(chunks.begin(), chunks.end(), utick, [](int utick, const Chunk& ch) {
-        return utick <= ch.utick1();
-    });
-
-    if (it == chunks.end()) {
-        return Chunk();
-    }
-
-    const Chunk& ch = *it;
-    return ch;
-}
-
 std::vector<MidiRenderer::Chunk> MidiRenderer::chunksFromRange(const int fromTick, const int toTick)
 {
     std::vector<Chunk> result;
 
-    Chunk currentChunk = chunkAt(fromTick);
+    updateState();
 
-    if (fromTick == toTick) {
-        result.push_back(std::move(currentChunk));
-        return result;
-    }
-
-    while (currentChunk.utick2() <= toTick) {
-        result.push_back(currentChunk);
-
-        currentChunk = chunkAt(currentChunk.utick2());
+    for (const Chunk& chunk : chunks) {
+        if (chunk.utick2() >= fromTick && chunk.utick1() <= toTick) {
+            result.push_back(chunk);
+        }
     }
 
     return result;

--- a/src/engraving/libmscore/rendermidi.h
+++ b/src/engraving/libmscore/rendermidi.h
@@ -141,11 +141,8 @@ public:
     void setScoreChanged() { needUpdate = true; }
     void setMinChunkSize(int sizeMeasures) { minChunkSize = sizeMeasures; needUpdate = true; }
 
-    Chunk getChunkAt(int utick);
-
     static const int ARTICULATION_CONV_FACTOR { 100000 };
 
-    Chunk chunkAt(int utick);
     std::vector<Chunk> chunksFromRange(const int fromTick, const int toTick);
 };
 

--- a/src/framework/audio/internal/worker/audiooutputhandler.cpp
+++ b/src/framework/audio/internal/worker/audiooutputhandler.cpp
@@ -190,9 +190,11 @@ void AudioOutputHandler::ensureSeqSubscriptions(const ITrackSequencePtr s) const
         return;
     }
 
+    TrackSequenceId sequenceId = s->id();
+
     if (!s->audioIO()->outputParamsChanged().isConnected()) {
-        s->audioIO()->outputParamsChanged().onReceive(this, [this, s](const TrackId trackId, const AudioOutputParams& params) {
-            m_outputParamsChanged.send(s->id(), trackId, params);
+        s->audioIO()->outputParamsChanged().onReceive(this, [this, sequenceId](const TrackId trackId, const AudioOutputParams& params) {
+            m_outputParamsChanged.send(sequenceId, trackId, params);
         });
     }
 }

--- a/src/framework/audio/internal/worker/clock.h
+++ b/src/framework/audio/internal/worker/clock.h
@@ -43,6 +43,7 @@ public:
     void resume() override;
     void seek(const msecs_t msecs) override;
 
+    void setTimeDuration(const msecs_t duration) override;
     Ret setTimeLoop(const msecs_t fromMsec, const msecs_t toMsec) override;
     void resetTimeLoop() override;
 
@@ -55,7 +56,8 @@ public:
 private:
 
     ValCh<PlaybackStatus> m_status;
-    msecs_t m_time = 0;
+    msecs_t m_currentTime = 0;
+    msecs_t m_timeDuration = 0;
     msecs_t m_timeLoopStart = 0;
     msecs_t m_timeLoopEnd = 0;
 

--- a/src/framework/audio/internal/worker/iclock.h
+++ b/src/framework/audio/internal/worker/iclock.h
@@ -48,6 +48,7 @@ public:
     virtual void resume() = 0;
     virtual void seek(const msecs_t msecs) = 0;
 
+    virtual void setTimeDuration(const msecs_t duration) = 0;
     virtual Ret setTimeLoop(const msecs_t fromMsec, const msecs_t toMsec) = 0;
     virtual void resetTimeLoop() = 0;
 

--- a/src/framework/audio/internal/worker/isequenceplayer.h
+++ b/src/framework/audio/internal/worker/isequenceplayer.h
@@ -40,6 +40,7 @@ public:
     virtual void pause() = 0;
     virtual void resume() = 0;
 
+    virtual void setDuration(const msecs_t duration) = 0;
     virtual Ret setLoop(const msecs_t fromMsec, const msecs_t toMsec) = 0;
     virtual void resetLoop() = 0;
 

--- a/src/framework/audio/internal/worker/itracksequence.h
+++ b/src/framework/audio/internal/worker/itracksequence.h
@@ -45,6 +45,7 @@ public:
     virtual TrackIdList trackIdList() const = 0;
 
     virtual Ret removeTrack(const TrackId id) = 0;
+    virtual void removeAllTracks() = 0;
 
     virtual async::Channel<TrackId> trackAdded() const = 0;
     virtual async::Channel<TrackId> trackRemoved() const = 0;

--- a/src/framework/audio/internal/worker/midiaudiosource.h
+++ b/src/framework/audio/internal/worker/midiaudiosource.h
@@ -45,7 +45,7 @@ class MidiAudioSource : public IAudioSource, public async::Asyncable
 public:
     explicit MidiAudioSource(const TrackId trackId, const midi::MidiData& midiData, const AudioInputParams& params,
                              async::Channel<AudioInputParams> paramsChanged);
-    ~MidiAudioSource() = default;
+    ~MidiAudioSource() override;
 
     bool isActive() const override;
     void setIsActive(const bool active) override;
@@ -110,6 +110,7 @@ private:
     void findAndSendNextEvents(EventsBuffer& eventsBuffer, const midi::tick_t nextTicks);
     bool sendEvents(const std::vector<midi::Event>& events);
     void requestNextEvents(const midi::tick_t nextTicksNumber);
+    void sendRequestFromTick(const midi::tick_t from);
 
     void resolveSynth(const AudioInputParams& inputParams);
     void buildTempoMap();
@@ -126,8 +127,8 @@ private:
     midi::MidiStream m_stream;
     midi::MidiMapping m_mapping;
 
-    EventsBuffer m_mainStreamEvents;
-    EventsBuffer m_backgroundStreamEvents;
+    EventsBuffer m_mainStreamEventsBuffer;
+    EventsBuffer m_backgroundStreamEventsBuffer;
 
     unsigned int m_sampleRate = 0;
 

--- a/src/framework/audio/internal/worker/playerhandler.cpp
+++ b/src/framework/audio/internal/worker/playerhandler.cpp
@@ -102,6 +102,18 @@ void PlayerHandler::resume(const TrackSequenceId sequenceId)
     }, AudioThread::ID);
 }
 
+void PlayerHandler::setDuration(const TrackSequenceId sequenceId, const msecs_t durationMsec)
+{
+    Async::call(this, [this, sequenceId, durationMsec]() {
+        ONLY_AUDIO_WORKER_THREAD;
+
+        ITrackSequencePtr s = sequence(sequenceId);
+        if (s) {
+            s->player()->setDuration(durationMsec);
+        }
+    }, AudioThread::ID);
+}
+
 Promise<bool> PlayerHandler::setLoop(const TrackSequenceId sequenceId, const msecs_t fromMsec, const msecs_t toMsec)
 {
     return Promise<bool>([this, sequenceId, fromMsec, toMsec](Promise<bool>::Resolve resolve, Promise<bool>::Reject reject) {

--- a/src/framework/audio/internal/worker/playerhandler.cpp
+++ b/src/framework/audio/internal/worker/playerhandler.cpp
@@ -171,11 +171,13 @@ void PlayerHandler::ensureSubscriptions(const ITrackSequencePtr s) const
         return;
     }
 
-    s->player()->playbackPositionMSecs().onReceive(this, [this, s](const msecs_t newPosMsecs) {
-        m_playbackPositionMsecsChanged.send(s->id(), newPosMsecs);
+    TrackSequenceId sequenceId = s->id();
+
+    s->player()->playbackPositionMSecs().onReceive(this, [this, sequenceId](const msecs_t newPosMsecs) {
+        m_playbackPositionMsecsChanged.send(sequenceId, newPosMsecs);
     });
 
-    s->player()->playbackStatusChanged().onReceive(this, [this, s](const PlaybackStatus newStatus) {
-        m_playbackStatusChanged.send(s->id(), newStatus);
+    s->player()->playbackStatusChanged().onReceive(this, [this, sequenceId](const PlaybackStatus newStatus) {
+        m_playbackStatusChanged.send(sequenceId, newStatus);
     });
 }

--- a/src/framework/audio/internal/worker/playerhandler.h
+++ b/src/framework/audio/internal/worker/playerhandler.h
@@ -41,6 +41,7 @@ public:
     void pause(const TrackSequenceId sequenceId) override;
     void resume(const TrackSequenceId sequenceId) override;
 
+    void setDuration(const TrackSequenceId sequenceId, const msecs_t durationMsec) override;
     async::Promise<bool> setLoop(const TrackSequenceId sequenceId, const msecs_t fromMsec, const msecs_t toMsec) override;
     void resetLoop(const TrackSequenceId sequenceId) override;
 

--- a/src/framework/audio/internal/worker/sequenceplayer.cpp
+++ b/src/framework/audio/internal/worker/sequenceplayer.cpp
@@ -95,6 +95,13 @@ void SequencePlayer::resume()
     }
 }
 
+void SequencePlayer::setDuration(const msecs_t duration)
+{
+    ONLY_AUDIO_WORKER_THREAD;
+
+    m_clock->setTimeDuration(duration);
+}
+
 Ret SequencePlayer::setLoop(const msecs_t fromMsec, const msecs_t toMsec)
 {
     ONLY_AUDIO_WORKER_THREAD;

--- a/src/framework/audio/internal/worker/sequenceplayer.h
+++ b/src/framework/audio/internal/worker/sequenceplayer.h
@@ -41,6 +41,7 @@ public:
     void pause() override;
     void resume() override;
 
+    void setDuration(const msecs_t duration) override;
     Ret setLoop(const msecs_t fromMsec, const msecs_t toMsec) override;
     void resetLoop() override;
 

--- a/src/framework/audio/internal/worker/tracksequence.cpp
+++ b/src/framework/audio/internal/worker/tracksequence.cpp
@@ -56,11 +56,7 @@ TrackSequence::~TrackSequence()
 
     mixer()->removeClock(m_clock);
 
-    for (const auto& pair : m_tracks) {
-        if (pair.second && pair.second->mixerChannel) {
-            mixer()->removeChannel(pair.second->mixerChannel->id());
-        }
-    }
+    removeAllTracks();
 }
 
 TrackSequenceId TrackSequence::id() const
@@ -167,6 +163,15 @@ Ret TrackSequence::removeTrack(const TrackId id)
     }
 
     return make_ret(Err::InvalidTrackId);
+}
+
+void TrackSequence::removeAllTracks()
+{
+    ONLY_AUDIO_WORKER_THREAD;
+
+    for (const TrackId& id : trackIdList()) {
+        removeTrack(id);
+    }
 }
 
 Channel<TrackId> TrackSequence::trackAdded() const

--- a/src/framework/audio/internal/worker/tracksequence.h
+++ b/src/framework/audio/internal/worker/tracksequence.h
@@ -51,6 +51,7 @@ public:
     TrackIdList trackIdList() const override;
 
     Ret removeTrack(const TrackId id) override;
+    void removeAllTracks() override;
 
     async::Channel<TrackId> trackAdded() const override;
     async::Channel<TrackId> trackRemoved() const override;

--- a/src/framework/audio/internal/worker/trackshandler.cpp
+++ b/src/framework/audio/internal/worker/trackshandler.cpp
@@ -228,21 +228,23 @@ void TracksHandler::ensureSubscriptions(const ITrackSequencePtr s) const
         return;
     }
 
+    TrackSequenceId sequenceId = s->id();
+
     if (!s->audioIO()->inputParamsChanged().isConnected()) {
-        s->audioIO()->inputParamsChanged().onReceive(this, [this, s](const TrackId trackId, const AudioInputParams& params) {
-            m_inputParamsChanged.send(s->id(), trackId, params);
+        s->audioIO()->inputParamsChanged().onReceive(this, [this, sequenceId](const TrackId trackId, const AudioInputParams& params) {
+            m_inputParamsChanged.send(sequenceId, trackId, params);
         });
     }
 
     if (!s->trackAdded().isConnected()) {
-        s->trackAdded().onReceive(this, [this, s](const TrackId trackId) {
-            m_trackAdded.send(s->id(), trackId);
+        s->trackAdded().onReceive(this, [this, sequenceId](const TrackId trackId) {
+            m_trackAdded.send(sequenceId, trackId);
         });
     }
 
     if (!s->trackRemoved().isConnected()) {
-        s->trackRemoved().onReceive(this, [this, s](const TrackId trackId) {
-            m_trackRemoved.send(s->id(), trackId);
+        s->trackRemoved().onReceive(this, [this, sequenceId](const TrackId trackId) {
+            m_trackRemoved.send(sequenceId, trackId);
         });
     }
 }

--- a/src/framework/audio/iplayer.h
+++ b/src/framework/audio/iplayer.h
@@ -42,6 +42,7 @@ public:
     virtual void pause(const TrackSequenceId sequenceId) = 0;
     virtual void resume(const TrackSequenceId sequenceId) = 0;
 
+    virtual void setDuration(const TrackSequenceId sequenceId, const msecs_t durationMsec) = 0;
     virtual async::Promise<bool> setLoop(const TrackSequenceId sequenceId, const msecs_t fromMsec, const msecs_t toMsec) = 0;
     virtual void resetLoop(const TrackSequenceId sequenceId) = 0;
 

--- a/src/notation/inotationplayback.h
+++ b/src/notation/inotationplayback.h
@@ -27,6 +27,7 @@
 #include "retval.h"
 #include "midi/miditypes.h"
 
+#include "audio/audiotypes.h"
 #include "notationtypes.h"
 
 namespace mu::notation {
@@ -35,7 +36,7 @@ class INotationPlayback
 public:
     virtual ~INotationPlayback() = default;
 
-    virtual QTime totalPlayTime() const = 0;
+    virtual audio::msecs_t totalPlayTime() const = 0;
 
     virtual float tickToSec(midi::tick_t tick) const = 0;
     virtual midi::tick_t secToTick(float sec) const = 0;

--- a/src/notation/internal/notationplayback.cpp
+++ b/src/notation/internal/notationplayback.cpp
@@ -98,19 +98,17 @@ void NotationPlayback::updateLoopBoundaries()
     }
 }
 
-QTime NotationPlayback::totalPlayTime() const
+audio::msecs_t NotationPlayback::totalPlayTime() const
 {
-    QTime time(0, 0, 0, 0);
-
     Ms::Score* score = m_getScore->score();
     if (!score) {
-        return time;
+        return 0;
     }
 
     int lastTick = score->repeatList().ticks();
-    int secs = score->utick2utime(lastTick);
+    qreal secs = score->utick2utime(lastTick);
 
-    return time.addSecs(secs);
+    return secs * 1000.f;
 }
 
 float NotationPlayback::tickToSec(tick_t tick) const

--- a/src/notation/internal/notationplayback.h
+++ b/src/notation/internal/notationplayback.h
@@ -47,7 +47,7 @@ public:
 
     void init();
 
-    QTime totalPlayTime() const override;
+    audio::msecs_t totalPlayTime() const override;
 
     float tickToSec(midi::tick_t tick) const override;
     midi::tick_t secToTick(float sec) const override;

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -321,14 +321,15 @@ void NotationViewInputController::mousePressEvent(QMouseEvent* event)
         hitStaffIndex = context.staff ? context.staff->idx() : -1;
     }
 
-    if (playbackController()->isPlaying()) {
-        if (hitElement) {
-            RetVal<midi::tick_t> tick = m_view->notationPlayback()->playPositionTickByElement(hitElement);
+    if (hitElement) {
+        RetVal<midi::tick_t> tick = m_view->notationPlayback()->playPositionTickByElement(hitElement);
 
-            if (tick.ret) {
-                playbackController()->seek(tick.val);
-            }
+        if (tick.ret) {
+            playbackController()->seek(tick.val);
         }
+    }
+
+    if (playbackController()->isPlaying()) {
         return;
     }
 

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -120,6 +120,7 @@ private:
 
     void notifyActionCheckedChanged(const actions::ActionCode& actionCode);
 
+    void resetCurrentSequence();
     void setupNewCurrentSequence(const audio::TrackSequenceId sequenceId);
     void setupSequenceTracks();
     void setCurrentTick(const midi::tick_t tick);

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -123,6 +123,8 @@ private:
     void resetCurrentSequence();
     void setupNewCurrentSequence(const audio::TrackSequenceId sequenceId);
     void setupSequenceTracks();
+    void setupSequencePlayer();
+
     void setCurrentTick(const midi::tick_t tick);
     void addTrack(const ID& partId, const std::string& title);
     void removeTrack(const ID& partId);

--- a/src/playback/view/mixerpanelmodel.cpp
+++ b/src/playback/view/mixerpanelmodel.cpp
@@ -111,9 +111,9 @@ void MixerPanelModel::removeItem(const audio::TrackId trackId)
 {
     beginResetModel();
 
-    (void)std::remove_if(m_mixerChannelList.begin(), m_mixerChannelList.end(), [&trackId](const MixerChannelItem* item) {
+    m_mixerChannelList.erase(std::remove_if(m_mixerChannelList.begin(), m_mixerChannelList.end(), [&trackId](const MixerChannelItem* item) {
         return item->id() == trackId;
-    });
+    }));
 
     sortItems();
 


### PR DESCRIPTION
- Ensured a proper removing of TrackSequence when score has been closed
- Fixed an issue with a seeking mechanism after the selection of specific notes
- Fixed an issue with MidiRendering when it was not possible to properly find chunks from a specific range
- Ensured that  a non-looping track sequence would be stopped by the end of the track
- Refined the algorithms of requesting new midi events during the playback

closing #8661 #8648


