### PR TITLE
[MU4] Alsa midi input fix

### DIFF
--- a/src/appshell/view/preferences/iopreferencesmodel.cpp
+++ b/src/appshell/view/preferences/iopreferencesmodel.cpp
@@ -87,12 +87,6 @@ void IOPreferencesModel::setCurrentMidiInputDeviceIndex(int index)
         return;
     }
 
-    ret = midiInPort()->run();
-    if (!ret) {
-        showMidiError(deviceId, ret.text());
-        return;
-    }
-
     midiConfiguration()->setMidiInputDeviceId(deviceId);
 
     emit currentMidiInputDeviceIndexChanged();

--- a/src/framework/midi/imidiinport.h
+++ b/src/framework/midi/imidiinport.h
@@ -45,9 +45,6 @@ public:
     virtual bool isConnected() const = 0;
     virtual MidiDeviceID deviceID() const = 0;
 
-    virtual Ret run() = 0;
-    virtual void stop() = 0;
-    virtual bool isRunning() const = 0;
     virtual async::Channel<tick_t, Event> eventReceived() const = 0;
 };
 }

--- a/src/framework/midi/internal/dummymidiinport.cpp
+++ b/src/framework/midi/internal/dummymidiinport.cpp
@@ -57,22 +57,6 @@ MidiDeviceID DummyMidiInPort::deviceID() const
     return m_deviceID;
 }
 
-Ret DummyMidiInPort::run()
-{
-    m_running = true;
-    return true;
-}
-
-void DummyMidiInPort::stop()
-{
-    m_running = false;
-}
-
-bool DummyMidiInPort::isRunning() const
-{
-    return m_running;
-}
-
 async::Channel<tick_t, Event> DummyMidiInPort::eventReceived() const
 {
     return m_eventReceived;

--- a/src/framework/midi/internal/dummymidiinport.h
+++ b/src/framework/midi/internal/dummymidiinport.h
@@ -38,15 +38,10 @@ public:
     bool isConnected() const override;
     MidiDeviceID deviceID() const override;
 
-    Ret run() override;
-    void stop() override;
-    bool isRunning() const override;
     async::Channel<tick_t, Event> eventReceived() const override;
 
 private:
-
     MidiDeviceID m_deviceID;
-    bool m_running = false;
     async::Channel<tick_t, Event> m_eventReceived;
 };
 }

--- a/src/framework/midi/internal/platform/lin/alsamidiinport.cpp
+++ b/src/framework/midi/internal/platform/lin/alsamidiinport.cpp
@@ -159,7 +159,8 @@ mu::Ret AlsaMidiInPort::connect(const MidiDeviceID& deviceID)
     }
 
     m_deviceID = deviceID;
-    return Ret(true);
+
+    return run();
 }
 
 void AlsaMidiInPort::disconnect()
@@ -203,6 +204,18 @@ mu::Ret AlsaMidiInPort::run()
     m_running.store(true);
     m_thread = std::make_shared<std::thread>(process, this);
     return Ret(true);
+}
+
+void AlsaMidiInPort::stop()
+{
+    if (!m_thread) {
+        LOGW() << "already stoped";
+        return;
+    }
+
+    m_running.store(false);
+    m_thread->join();
+    m_thread = nullptr;
 }
 
 void AlsaMidiInPort::process(AlsaMidiInPort* self)
@@ -290,26 +303,6 @@ void AlsaMidiInPort::doProcess()
 
         sleep();
     }
-}
-
-void AlsaMidiInPort::stop()
-{
-    if (!m_thread) {
-        LOGW() << "already stoped";
-        return;
-    }
-
-    m_running.store(false);
-    m_thread->join();
-    m_thread = nullptr;
-}
-
-bool AlsaMidiInPort::isRunning() const
-{
-    if (m_thread) {
-        return true;
-    }
-    return false;
 }
 
 mu::async::Channel<tick_t, Event> AlsaMidiInPort::eventReceived() const

--- a/src/framework/midi/internal/platform/lin/alsamidiinport.h
+++ b/src/framework/midi/internal/platform/lin/alsamidiinport.h
@@ -46,12 +46,12 @@ public:
     bool isConnected() const override;
     MidiDeviceID deviceID() const override;
 
-    Ret run() override;
-    void stop() override;
-    bool isRunning() const override;
     async::Channel<tick_t, Event> eventReceived() const override;
 
 private:
+    Ret run();
+    void stop();
+
     static void process(AlsaMidiInPort* self);
     void doProcess();
 

--- a/src/framework/midi/internal/platform/osx/coremidiinport.cpp
+++ b/src/framework/midi/internal/platform/osx/coremidiinport.cpp
@@ -206,7 +206,7 @@ Ret CoreMidiInPort::connect(const MidiDeviceID& deviceID)
     }
 
     m_deviceID = deviceID;
-    return Ret(true);
+    return run();
 }
 
 void CoreMidiInPort::disconnect()
@@ -215,10 +215,10 @@ void CoreMidiInPort::disconnect()
         return;
     }
 
+    stop();
+
     m_core->sourceId = 0;
     m_deviceID.clear();
-
-    stop();
 }
 
 bool CoreMidiInPort::isConnected() const
@@ -263,11 +263,6 @@ void CoreMidiInPort::stop()
         LOGE() << "can't disconnect midi port " << result;
     }
     m_running = false;
-}
-
-bool CoreMidiInPort::isRunning() const
-{
-    return m_running;
 }
 
 async::Channel<tick_t, Event> CoreMidiInPort::eventReceived() const

--- a/src/framework/midi/internal/platform/osx/coremidiinport.h
+++ b/src/framework/midi/internal/platform/osx/coremidiinport.h
@@ -43,15 +43,15 @@ public:
     bool isConnected() const override;
     MidiDeviceID deviceID() const override;
 
-    Ret run() override;
-    void stop() override;
-    bool isRunning() const override;
     async::Channel<tick_t, Event> eventReceived() const override;
 
     //internal
     void doProcess(uint32_t message, tick_t timing);
 
 private:
+    Ret run();
+    void stop();
+
     void initCore();
 
     struct Core;

--- a/src/framework/midi/internal/platform/win/winmidiinport.cpp
+++ b/src/framework/midi/internal/platform/win/winmidiinport.cpp
@@ -149,7 +149,7 @@ mu::Ret WinMidiInPort::connect(const MidiDeviceID& deviceID)
     }
 
     m_deviceID = deviceID;
-    return Ret(true);
+    return run();
 }
 
 void WinMidiInPort::disconnect()
@@ -160,12 +160,12 @@ void WinMidiInPort::disconnect()
 
     midiInClose(m_win->midiIn);
 
+    stop();
+
     m_win->midiIn = nullptr;
     m_win->deviceID = -1;
 
     m_deviceID.clear();
-
-    stop();
 }
 
 bool WinMidiInPort::isConnected() const
@@ -208,11 +208,6 @@ void WinMidiInPort::stop()
 
     midiInStop(m_win->midiIn);
     m_running = false;
-}
-
-bool WinMidiInPort::isRunning() const
-{
-    return m_running;
 }
 
 mu::async::Channel<tick_t, Event> WinMidiInPort::eventReceived() const

--- a/src/framework/midi/internal/platform/win/winmidiinport.h
+++ b/src/framework/midi/internal/platform/win/winmidiinport.h
@@ -45,15 +45,15 @@ public:
     bool isConnected() const override;
     MidiDeviceID deviceID() const override;
 
-    Ret run() override;
-    void stop() override;
-    bool isRunning() const override;
     async::Channel<tick_t, Event> eventReceived() const override;
 
     // internal;
     void doProcess(uint32_t message, tick_t timing);
 
 private:
+    Ret run();
+    void stop();
+
     struct Win;
     std::unique_ptr<Win> m_win;
     MidiDeviceID m_deviceID;

--- a/src/framework/midi/view/devtools/midiportdevmodel.cpp
+++ b/src/framework/midi/view/devtools/midiportdevmodel.cpp
@@ -95,7 +95,6 @@ QVariantList MidiPortDevModel::inputDevices() const
 void MidiPortDevModel::inputDeviceAction(const QString& deviceID, const QString& action)
 {
     LOGI() << "deviceID: " << deviceID << ", action: " << action;
-    midiInPort()->stop();
     midiInPort()->disconnect();
 
     if (action == "Connect") {
@@ -103,14 +102,6 @@ void MidiPortDevModel::inputDeviceAction(const QString& deviceID, const QString&
         if (!ret) {
             LOGE() << "failed connect, deviceID: " << deviceID << ", err: " << ret.text();
             m_connectionErrors[deviceID] = QString::fromStdString(ret.text());
-        }
-
-        if (ret) {
-            ret = midiInPort()->run();
-            if (!ret) {
-                LOGE() << "failed connect, deviceID: " << deviceID << ", err: " << ret.text();
-                m_connectionErrors[deviceID] = QString::fromStdString(ret.text());
-            }
         }
     }
 
@@ -210,19 +201,7 @@ void MidiPortDevModel::generateMIDI20()
     emit inputEventsChanged();
 }
 
-void MidiPortDevModel::stopInput()
+bool MidiPortDevModel::isInputConnected() const
 {
-    midiInPort()->stop();
-    emit isInputRunningChanged();
-}
-
-void MidiPortDevModel::runInput()
-{
-    midiInPort()->run();
-    emit isInputRunningChanged();
-}
-
-bool MidiPortDevModel::isInputRunning() const
-{
-    return midiInPort()->isRunning();
+    return midiInPort()->isConnected();
 }

--- a/src/framework/midi/view/devtools/midiportdevmodel.h
+++ b/src/framework/midi/view/devtools/midiportdevmodel.h
@@ -38,12 +38,12 @@ class MidiPortDevModel : public QObject, public async::Asyncable
     INJECT(midi, IMidiOutPort, midiOutPort)
     INJECT(midi, IMidiInPort, midiInPort)
 
-    Q_PROPERTY(bool isInputRunning READ isInputRunning NOTIFY isInputRunningChanged)
+    Q_PROPERTY(bool isInputConnected READ isInputConnected NOTIFY isInputConnectedChanged)
 
 public:
     explicit MidiPortDevModel(QObject* parent = nullptr);
 
-    bool isInputRunning() const;
+    bool isInputConnected() const;
 
     Q_INVOKABLE QVariantList outputDevices() const;
     Q_INVOKABLE void outputDeviceAction(const QString& deviceID, const QString& action);
@@ -51,8 +51,6 @@ public:
     Q_INVOKABLE QVariantList inputDevices() const;
     Q_INVOKABLE void inputDeviceAction(const QString& deviceID, const QString& action);
 
-    Q_INVOKABLE void stopInput();
-    Q_INVOKABLE void runInput();
     Q_INVOKABLE QVariantList inputEvents() const;
     Q_INVOKABLE void generateMIDI20();
 
@@ -60,10 +58,9 @@ signals:
     void outputDevicesChanged();
     void inputDevicesChanged();
     void inputEventsChanged();
-    void isInputRunningChanged();
+    void isInputConnectedChanged();
 
 private:
-
     QMap<QString, QString> m_connectionErrors;
     QVariantList m_inputEvents;
 };

--- a/src/notation/internal/midiinputcontroller.cpp
+++ b/src/notation/internal/midiinputcontroller.cpp
@@ -58,9 +58,7 @@ void MidiInputController::connectCurrentInputDevice()
     }
 
     Ret ret = midiInPort()->connect(deviceId);
-    if (ret) {
-        ret = midiInPort()->run();
-    } else {
+    if (!ret) {
         LOGW() << "failed connect to input device, deviceID: " << deviceId << ", err: " << ret.text();
     }
 }


### PR DESCRIPTION
Resolves: #7663

From [dock](https://www.alsa-project.org/alsa-doc/alsa-lib/group___seq_event.html#ga6421feafcd6f116d34531d6b54177c17)
If there is no input from sequencer, function falls into sleep in blocking mode until an event is received, or returns -EAGAIN error in non-blocking mode.