### PR TITLE
[DAISY] Accessibility: Improve speech for various elements

### DIFF
--- a/src/engraving/libmscore/chordrest.cpp
+++ b/src/engraving/libmscore/chordrest.cpp
@@ -728,7 +728,8 @@ QString ChordRest::durationUserName() const
             tupletType = QObject::tr("Nonuplet");
             break;
         default:
-            tupletType = QObject::tr("Custom tuplet");
+            //: %1 is tuplet ratio numerator (i.e. the number of notes in the tuplet)
+            tupletType = QObject::tr("%1 note tuplet").arg(tuplet()->ratio().numerator());
         }
     }
     QString dotString = "";

--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -3279,7 +3279,9 @@ QString Note::screenReaderInfo() const
     } else if (staff()->isTabStaff(tick())) {
         pitchName = QObject::tr("%1; String: %2; Fret: %3").arg(tpcUserName(true), QString::number(string() + 1), QString::number(fret()));
     } else {
-        pitchName = tpcUserName(true);
+        pitchName = _headGroup == NoteHead::Group::HEAD_NORMAL
+                    ? tpcUserName(true)
+                    : QObject::tr("%1 head %2").arg(subtypeName()).arg(tpcUserName(true));
     }
     return QString("%1 %2 %3%4").arg(noteTypeUserName(), pitchName, duration, (chord()->isGrace() ? "" : QString("; %1").arg(voice)));
 }


### PR DESCRIPTION
Resolves:

- [MS#307442 Tuplet more than 9 seems not to be announced correctly](https://musescore.org/en/node/307442)
- [MS#312625 Notehead types not read](https://musescore.org/en/node/312625)

Improve screen reader speech output for various score elements in libmscore.