### PR TITLE
[MU4] fix #8159 (partial), implement move-up/move-down/up-chord/down-chord/top-chord/bottom-chord

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -3142,7 +3142,11 @@ void Score::cmdDeleteSelection()
     deselectAll();
     // make new selection if appropriate
     if (noteEntryMode()) {
-        cr = _is.cr();
+        if (cr) {
+            _is.setSegment(cr->segment());
+        } else {
+            cr = _is.cr();
+        }
     }
     if (cr) {
         if (cr->isChord()) {

--- a/src/framework/shortcuts/internal/shortcutsregister.h
+++ b/src/framework/shortcuts/internal/shortcutsregister.h
@@ -65,7 +65,7 @@ private:
     bool writeToFile(const ShortcutList& shortcuts, const io::path& path) const;
     void writeShortcut(framework::XmlWriter& writer, const Shortcut& shortcut) const;
 
-    void mergeSortcuts(ShortcutList& shortcuts, const ShortcutList& defaultShortcuts) const;
+    void mergeShortcuts(ShortcutList& shortcuts, const ShortcutList& defaultShortcuts) const;
     void expandStandardKeys(ShortcutList& shortcuts) const;
 
     ShortcutList m_shortcuts;

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -71,6 +71,7 @@ public:
     virtual INotationSelectionPtr selection() const = 0;
     virtual void clearSelection() = 0;
     virtual async::Notification selectionChanged() const = 0;
+    virtual void selectTopOrBottomOfChord(MoveDirection d) = 0;
 
     // SelectionFilter
     virtual bool isSelectionTypeFiltered(SelectionFilterType type) const = 0;
@@ -101,6 +102,7 @@ public:
     virtual void moveSelection(MoveDirection d, MoveSelectionType type) = 0;
     virtual void movePitch(MoveDirection d, PitchMode mode) = 0;  //! NOTE Requires a note to be selected
     virtual void moveText(MoveDirection d, bool quickly) = 0;     //! NOTE Requires a text element to be selected
+    virtual void moveChordRestToStaff(MoveDirection d) = 0;
 
     // Text edit
     virtual bool isTextEditingStarted() const = 0;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -143,8 +143,8 @@ void NotationActionController::init()
     registerMoveAction("pitch-down");
     registerMoveAction("pitch-up-octave");
     registerMoveAction("pitch-down-octave");
-    registerMoveAction("up-chord");
-    registerMoveAction("down-chord");
+    registerAction("move-up", [this]() { moveChordRestToStaff(MoveDirection::Up); }, &NotationActionController::hasSelection);
+    registerAction("move-down", [this]() { moveChordRestToStaff(MoveDirection::Down); }, &NotationActionController::hasSelection);
 
     registerAction("double-duration", [this]() { increaseDecreaseDuration(-1, /*stepByDots*/ false); });
     registerAction("half-duration", [this]() { increaseDecreaseDuration(1, false); });
@@ -177,6 +177,10 @@ void NotationActionController::init()
     registerAction("select-section", &NotationActionController::selectSection);
     registerAction("first-element", &NotationActionController::firstElement);
     registerAction("last-element", &NotationActionController::lastElement);
+    registerAction("up-chord", [this]() { moveWithinChord(MoveDirection::Up); }, &NotationActionController::hasSelection);
+    registerAction("down-chord", [this]() { moveWithinChord(MoveDirection::Down); }, &NotationActionController::hasSelection);
+    registerAction("top-chord", [this]() { selectTopOrBottomOfChord(MoveDirection::Up); }, &NotationActionController::hasSelection);
+    registerAction("bottom-chord", [this]() { selectTopOrBottomOfChord(MoveDirection::Down); }, &NotationActionController::hasSelection);
 
     registerAction("system-break", [this]() { toggleLayoutBreak(LayoutBreakType::LINE); });
     registerAction("page-break", [this]() { toggleLayoutBreak(LayoutBreakType::PAGE); });
@@ -649,6 +653,15 @@ void NotationActionController::addBracketsToSelection(BracketsType type)
     interaction->addBracketsToSelection(type);
 }
 
+void NotationActionController::moveChordRestToStaff(MoveDirection direction)
+{
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+    interaction->moveChordRestToStaff(direction);
+}
+
 void NotationActionController::moveAction(const actions::ActionCode& actionCode)
 {
     auto interaction = currentNotationInteraction();
@@ -714,7 +727,7 @@ void NotationActionController::moveAction(const actions::ActionCode& actionCode)
     }
 }
 
-void NotationActionController::moveChord(MoveDirection direction)
+void NotationActionController::moveWithinChord(MoveDirection direction)
 {
     auto interaction = currentNotationInteraction();
     if (!interaction) {
@@ -722,6 +735,18 @@ void NotationActionController::moveChord(MoveDirection direction)
     }
 
     interaction->moveChordNoteSelection(direction);
+
+    playSelectedElement(false);
+}
+
+void NotationActionController::selectTopOrBottomOfChord(MoveDirection direction)
+{
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+
+    interaction->selectTopOrBottomOfChord(direction);
 
     playSelectedElement(false);
 }

--- a/src/notation/internal/notationactioncontroller.h
+++ b/src/notation/internal/notationactioncontroller.h
@@ -88,8 +88,10 @@ private:
     void addBracketsToSelection(BracketsType type);
 
     void moveAction(const actions::ActionCode& actionCode);
-    void moveChord(MoveDirection direction);
+    void moveWithinChord(MoveDirection direction);
     void moveText(INotationInteractionPtr interaction, const actions::ActionCode& actionCode);
+    void moveChordRestToStaff(MoveDirection direction);
+    void selectTopOrBottomOfChord(MoveDirection direction);
 
     void increaseDecreaseDuration(int steps, bool stepByDots);
 

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -83,6 +83,7 @@ public:
     INotationSelectionPtr selection() const override;
     void clearSelection() override;
     async::Notification selectionChanged() const override;
+    void selectTopOrBottomOfChord(MoveDirection d) override;
 
     // SelectionFilter
     bool isSelectionTypeFiltered(SelectionFilterType type) const override;
@@ -111,6 +112,7 @@ public:
     void moveSelection(MoveDirection d, MoveSelectionType type) override;
     void movePitch(MoveDirection d, PitchMode mode) override; //! NOTE Requires a note to be selected
     void moveText(MoveDirection d, bool quickly) override;    //! NOTE Requires a text element to be selected
+    void moveChordRestToStaff(MoveDirection d) override;
 
     // Text edit
     bool isTextEditingStarted() const override;

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -88,6 +88,16 @@ const UiActionList NotationUiActions::m_actions = {
              QT_TRANSLATE_NOOP("action", "Down note in chord"),
              QT_TRANSLATE_NOOP("action", "Go to lower pitched note in chord")
              ),
+    UiAction("top-chord",
+             mu::context::UiCtxNotationFocused,
+             QT_TRANSLATE_NOOP("action", "Top note in chord"),
+             QT_TRANSLATE_NOOP("action", "Go to top note in chord")
+             ),
+    UiAction("bottom-chord",
+             mu::context::UiCtxNotationFocused,
+             QT_TRANSLATE_NOOP("action", "Bottom note in chord"),
+             QT_TRANSLATE_NOOP("action", "Go bottom note in chord")
+             ),
     UiAction("first-element",
              mu::context::UiCtxNotationFocused,
              QT_TRANSLATE_NOOP("action", "First element"),
@@ -97,6 +107,16 @@ const UiActionList NotationUiActions::m_actions = {
              mu::context::UiCtxNotationFocused,
              QT_TRANSLATE_NOOP("action", "Last element"),
              QT_TRANSLATE_NOOP("action", "Go to last element in score")
+             ),
+    UiAction("move-up",
+             mu::context::UiCtxNotationFocused,
+             QT_TRANSLATE_NOOP("action", "Move up"),
+             QT_TRANSLATE_NOOP("action", "Move chord/rest to staff above")
+             ),
+    UiAction("move-down",
+             mu::context::UiCtxNotationFocused,
+             QT_TRANSLATE_NOOP("action", "Move down"),
+             QT_TRANSLATE_NOOP("action", "Move chord/rest to staff below")
              ),
     UiAction("next-track",
              mu::context::UiCtxNotationFocused,


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8159 (partially)

Various score manipulation/navigation commands not implemented

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
