### PR TITLE
Implement accessible descriptions

### DIFF
--- a/src/engraving/accessibility/accessibleelement.cpp
+++ b/src/engraving/accessibility/accessibleelement.cpp
@@ -180,6 +180,11 @@ QString AccessibleElement::accessibleName() const
     return m_element->accessibleInfo();
 }
 
+QString AccessibleElement::accessibleDescription() const
+{
+    return m_element->accessibleExtraInfo();
+}
+
 bool AccessibleElement::accessibleState(State st) const
 {
     if (!isAvalaible()) {

--- a/src/engraving/accessibility/accessibleelement.h
+++ b/src/engraving/accessibility/accessibleelement.h
@@ -50,6 +50,7 @@ public:
 
     Role accessibleRole() const override;
     QString accessibleName() const override;
+    QString accessibleDescription() const override;
     bool accessibleState(State st) const override;
     QRect accessibleRect() const override;
 

--- a/src/framework/accessibility/iaccessible.h
+++ b/src/framework/accessibility/iaccessible.h
@@ -68,7 +68,8 @@ public:
     enum class Property {
         Undefined = 0,
         Parent,
-        Name
+        Name,
+        Description
     };
 
     virtual const IAccessible* accessibleParent() const = 0;
@@ -77,6 +78,7 @@ public:
 
     virtual IAccessible::Role accessibleRole() const = 0;
     virtual QString accessibleName() const = 0;
+    virtual QString accessibleDescription() const = 0;
     virtual bool accessibleState(State st) const = 0;
     virtual QRect accessibleRect() const = 0;
 

--- a/src/framework/accessibility/internal/accessibilitycontroller.cpp
+++ b/src/framework/accessibility/internal/accessibilitycontroller.cpp
@@ -326,6 +326,11 @@ QString AccessibilityController::accessibleName() const
     return QString("AccessibilityController");
 }
 
+QString AccessibilityController::accessibleDescription() const
+{
+    return QString();
+}
+
 bool AccessibilityController::accessibleState(State st) const
 {
     switch (st) {

--- a/src/framework/accessibility/internal/accessibilitycontroller.h
+++ b/src/framework/accessibility/internal/accessibilitycontroller.h
@@ -70,6 +70,7 @@ public:
 
     Role accessibleRole() const override;
     QString accessibleName() const override;
+    QString accessibleDescription() const override;
     bool accessibleState(State st) const override;
     QRect accessibleRect() const override;
 

--- a/src/framework/accessibility/internal/accessibleiteminterface.cpp
+++ b/src/framework/accessibility/internal/accessibleiteminterface.cpp
@@ -213,6 +213,7 @@ QString AccessibleItemInterface::text(QAccessible::Text textType) const
 {
     switch (textType) {
     case QAccessible::Name: return m_object->item()->accessibleName();
+    case QAccessible::Description: return m_object->item()->accessibleDescription();
     default: break;
     }
 

--- a/src/framework/ui/view/qmlaccessible.cpp
+++ b/src/framework/ui/view/qmlaccessible.cpp
@@ -85,6 +85,11 @@ QString AccessibleItem::accessibleName() const
     return m_name;
 }
 
+QString AccessibleItem::accessibleDescription() const
+{
+    return m_description;
+}
+
 bool AccessibleItem::accessibleState(State st) const
 {
     return m_state.value(st, false);
@@ -217,9 +222,25 @@ void AccessibleItem::setName(QString name)
     m_accessiblePropertyChanged.send(IAccessible::Property::Name);
 }
 
+void AccessibleItem::setDescription(QString description)
+{
+    if (m_description == description) {
+        return;
+    }
+
+    m_description = description;
+    emit descriptionChanged(m_description);
+    m_accessiblePropertyChanged.send(IAccessible::Property::Description);
+}
+
 QString AccessibleItem::name() const
 {
     return m_name;
+}
+
+QString AccessibleItem::description() const
+{
+    return m_description;
 }
 
 void AccessibleItem::setIgnored(bool ignored)

--- a/src/framework/ui/view/qmlaccessible.h
+++ b/src/framework/ui/view/qmlaccessible.h
@@ -69,6 +69,7 @@ class AccessibleItem : public QObject, public QQmlParserStatus, public accessibi
     Q_PROPERTY(AccessibleItem * accessibleParent READ accessibleParent_property WRITE setAccessibleParent NOTIFY accessiblePrnChanged)
     Q_PROPERTY(mu::ui::MUAccessible::Role role READ role WRITE setRole NOTIFY roleChanged)
     Q_PROPERTY(QString name READ name WRITE setName NOTIFY nameChanged)
+    Q_PROPERTY(QString description READ description WRITE setDescription NOTIFY descriptionChanged)
     Q_PROPERTY(bool ignored READ ignored WRITE setIgnored NOTIFY ignoredChanged)
     Q_PROPERTY(QQuickItem * visualItem READ visualItem WRITE setVisualItem NOTIFY visualItemChanged)
 
@@ -86,6 +87,7 @@ public:
 
     MUAccessible::Role role() const;
     QString name() const;
+    QString description() const;
     bool ignored() const;
     QQuickItem* visualItem() const;
 
@@ -104,6 +106,7 @@ public:
 
     IAccessible::Role accessibleRole() const override;
     QString accessibleName() const override;
+    QString accessibleDescription() const override;
     bool accessibleState(State st) const override;
     QRect accessibleRect() const override;
 
@@ -118,6 +121,7 @@ public:
 public slots:
     void setRole(MUAccessible::Role role);
     void setName(QString name);
+    void setDescription(QString description);
     void setIgnored(bool ignored);
     void setVisualItem(QQuickItem* item);
 
@@ -125,6 +129,7 @@ signals:
     void accessiblePrnChanged();
     void roleChanged(MUAccessible::Role role);
     void nameChanged(QString name);
+    void descriptionChanged(QString description);
     void ignoredChanged(bool ignored);
     void visualItemChanged(QQuickItem* item);
     void stateChanged();
@@ -138,6 +143,7 @@ private:
     QList<AccessibleItem*> m_children;
     MUAccessible::Role m_role = MUAccessible::NoRole;
     QString m_name;
+    QString m_description;
     bool m_ignored = false;
     QQuickItem* m_visualItem = nullptr;
     QMap<State, bool> m_state;

--- a/src/playback/qml/MuseScore/Playback/PlaybackToolBar.qml
+++ b/src/playback/qml/MuseScore/Playback/PlaybackToolBar.qml
@@ -102,6 +102,8 @@ Rectangle {
                             toolTipTitle: modelData.title
                             toolTipDescription: modelData.description
                             toolTipShortcut: modelData.shortcut
+                            accessible.name: modelData.title
+                            accessible.description: modelData.description;
 
                             iconFont: ui.theme.toolbarIconsFont
 


### PR DESCRIPTION
UI controls were previously given names but not descriptions. Now they can have both a name and a description.

Demonstrates adding descriptions to the Playback Toolbar. The description announced by the screen reader is the same as the description displayed in the tooltip for sighted users.

![image](https://user-images.githubusercontent.com/11011881/130601881-b227b08b-2849-4271-8c78-031903503975.png)

Windows Narrator says: *"Metronome, button. Play metronome during playback."*
