### PR TITLE
[MU4] Change user visible "..." to ellipsis

### DIFF
--- a/src/appshell/internal/applicationuiactions.cpp
+++ b/src/appshell/internal/applicationuiactions.cpp
@@ -42,15 +42,15 @@ const UiActionList ApplicationUiActions::m_actions = {
              ),
     UiAction("about",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "About...")
+             QT_TRANSLATE_NOOP("action", "About…")
              ),
     UiAction("about-qt",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "About Qt...")
+             QT_TRANSLATE_NOOP("action", "About Qt…")
              ),
     UiAction("about-musicxml",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "About MusicXML...")
+             QT_TRANSLATE_NOOP("action", "About MusicXML…")
              ),
     UiAction("online-handbook",
              mu::context::UiCtxAny,

--- a/src/diagnostics/internal/diagnosticsactions.cpp
+++ b/src/diagnostics/internal/diagnosticsactions.cpp
@@ -30,15 +30,15 @@ using namespace mu::diagnostics;
 const UiActionList DiagnosticsActions::m_actions = {
     UiAction("diagnostic-show-paths",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Show paths...")
+             QT_TRANSLATE_NOOP("action", "Show paths…")
              ),
     UiAction("diagnostic-show-navigation-tree",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Show navigation tree...")
+             QT_TRANSLATE_NOOP("action", "Show navigation tree…")
              ),
     UiAction("diagnostic-show-accessible-tree",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Show accessible tree...")
+             QT_TRANSLATE_NOOP("action", "Show accessible tree…")
              ),
     UiAction("diagnostic-accessible-tree-dump",
              mu::context::UiCtxAny,

--- a/src/extensions/internal/extensionsservice.cpp
+++ b/src/extensions/internal/extensionsservice.cpp
@@ -38,12 +38,12 @@ using namespace mu::network;
 namespace mu::extensions {
 QString analysingStatusTitle()
 {
-    return qtrc("extensions", "Analysing...");
+    return qtrc("extensions", "Analysing…");
 }
 
 QString downloadingStatusTitle()
 {
-    return qtrc("extensions", "Downloading...");
+    return qtrc("extensions", "Downloading…");
 }
 }
 

--- a/src/framework/shortcuts/view/editmidimappingmodel.cpp
+++ b/src/framework/shortcuts/view/editmidimappingmodel.cpp
@@ -58,7 +58,7 @@ QString EditMidiMappingModel::mappingTitle() const
 {
     MidiDeviceID currentMidiInDeviceId = midiInPort()->deviceID();
     if (currentMidiInDeviceId.empty() || !m_event.isValid()) {
-        return qtrc("shortcuts", "Waiting...");
+        return qtrc("shortcuts", "Waiting…");
     }
 
     return deviceName(currentMidiInDeviceId) + " > " + eventName(m_event);

--- a/src/instrumentsscene/internal/instrumentsuiactions.cpp
+++ b/src/instrumentsscene/internal/instrumentsuiactions.cpp
@@ -31,7 +31,7 @@ using namespace mu::ui;
 const UiActionList InstrumentsUiActions::m_actions = {
     UiAction("instruments",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Instruments...")
+             QT_TRANSLATE_NOOP("action", "Instruments…")
              )
 };
 

--- a/src/languages/internal/languagesservice.cpp
+++ b/src/languages/internal/languagesservice.cpp
@@ -48,12 +48,12 @@ static const QStringList languageFileTypes = {
 namespace mu::languages {
 static QString analysingStatusTitle()
 {
-    return qtrc("languages", "Analysing...");
+    return qtrc("languages", "Analysing…");
 }
 
 static QString downloadingStatusTitle()
 {
-    return qtrc("languages", "Downloading...");
+    return qtrc("languages", "Downloading…");
 }
 }
 

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -233,22 +233,22 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("edit-style",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Style..."),
+             QT_TRANSLATE_NOOP("action", "Style…"),
              QT_TRANSLATE_NOOP("action", "Edit style")
              ),
     UiAction("page-settings",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Page settings..."),
+             QT_TRANSLATE_NOOP("action", "Page settings…"),
              QT_TRANSLATE_NOOP("action", "Page settings")
              ),
     UiAction("load-style",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Load style..."),
+             QT_TRANSLATE_NOOP("action", "Load style…"),
              QT_TRANSLATE_NOOP("action", "Load style")
              ),
     UiAction("transpose",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "&Transpose..."),
+             QT_TRANSLATE_NOOP("action", "&Transpose…"),
              QT_TRANSLATE_NOOP("action", "Transpose")
              ),
     UiAction("explode",

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -5867,7 +5867,7 @@ By default, they will be placed such as that their right end are at the same lev
               <item row="1" column="5">
                <widget class="QToolButton" name="resetMRNumberSeriesWithParentheses">
                 <property name="text">
-                 <string>...</string>
+                 <string notr="true">…</string>
                 </property>
                 <property name="icon">
                  <iconset>
@@ -5878,7 +5878,7 @@ By default, they will be placed such as that their right end are at the same lev
               <item row="0" column="5">
                <widget class="QToolButton" name="resetMRNumberEveryXMeasures">
                 <property name="text">
-                 <string>...</string>
+                 <string notr="true">…</string>
                 </property>
                 <property name="icon">
                  <iconset>
@@ -5943,7 +5943,7 @@ By default, they will be placed such as that their right end are at the same lev
            <item row="1" column="2">
             <widget class="QToolButton" name="resetMeasureRepeatNumberPos">
              <property name="text">
-              <string>...</string>
+              <string notr="true">…</string>
              </property>
              <property name="icon">
               <iconset>
@@ -5954,7 +5954,7 @@ By default, they will be placed such as that their right end are at the same lev
            <item row="2" column="2">
             <widget class="QToolButton" name="resetOneMeasureRepeatShow1">
              <property name="text">
-              <string>...</string>
+              <string notr="true">…</string>
              </property>
              <property name="icon">
               <iconset>

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -27,12 +27,12 @@ using namespace mu::ui;
 const UiActionList ProjectUiActions::m_actions = {
     UiAction("file-open",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Open..."),
+             QT_TRANSLATE_NOOP("action", "Open…"),
              QT_TRANSLATE_NOOP("action", "Load score from file")
              ),
     UiAction("file-new",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "New..."),
+             QT_TRANSLATE_NOOP("action", "New…"),
              QT_TRANSLATE_NOOP("action", "Create new score")
              ),
     UiAction("file-close",
@@ -53,17 +53,17 @@ const UiActionList ProjectUiActions::m_actions = {
              ),
     UiAction("file-save-as",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Save as..."),
+             QT_TRANSLATE_NOOP("action", "Save as…"),
              QT_TRANSLATE_NOOP("action", "Save score under a new file name")
              ),
     UiAction("file-save-a-copy",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Save a copy..."),
+             QT_TRANSLATE_NOOP("action", "Save a copy…"),
              QT_TRANSLATE_NOOP("action", "Save a copy of the score in addition to the current file")
              ),
     UiAction("file-save-selection",
              mu::context::UiCtxNotationFocused,
-             QT_TRANSLATE_NOOP("action", "Save selection..."),
+             QT_TRANSLATE_NOOP("action", "Save selection…"),
              QT_TRANSLATE_NOOP("action", "Save current selection as new score")
              ),
     UiAction("file-export",
@@ -74,12 +74,12 @@ const UiActionList ProjectUiActions::m_actions = {
              ),
     UiAction("file-import-pdf",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Import PDF..."),
+             QT_TRANSLATE_NOOP("action", "Import PDF…"),
              QT_TRANSLATE_NOOP("action", "Import a PDF file with an experimental service on musescore.com")
              ),
     UiAction("print",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Print..."),
+             QT_TRANSLATE_NOOP("action", "Print…"),
              QT_TRANSLATE_NOOP("action", "Print score/part")
              ),
     UiAction("clear-recent",


### PR DESCRIPTION
... except for one only seen on the commandline (in the usage message), and those in `qDebug()` statements.
Used to be that way in MuseScore 3 and before too.

See discussion in https://github.com/musescore/MuseScore/pull/8908#discussion_r694715645 ff.
There's some overlap with that PR, but in the very same way, so should not cause merge conflicts.