### PR TITLE
Fix git error in Packaging.cmake (Windows)

### DIFF
--- a/build/Packaging.cmake
+++ b/build/Packaging.cmake
@@ -22,6 +22,7 @@ if (MSCORE_UNSTABLE)
       if (GIT_EXECUTABLE)
             execute_process(
                   COMMAND "${GIT_EXECUTABLE}" log -1 --date=short --format=%cd
+                  WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
                   OUTPUT_VARIABLE git_date
                   OUTPUT_STRIP_TRAILING_WHITESPACE)
       endif (GIT_EXECUTABLE)


### PR DESCRIPTION
The git command was run in the wrong working directory.

I don't see the error in logs on CI, but on my own machine, in Qt Creator, it has always been there. Anyway, this fix won't harm.