### PR TITLE
[MU4] Fix compiler warnings

### DIFF
--- a/src/appshell/view/dockwindow/docktypes.h
+++ b/src/appshell/view/dockwindow/docktypes.h
@@ -27,8 +27,8 @@
 #include <QVariant>
 
 namespace mu::dock {
-static const char* CONTEXT_MENU_MODEL_PROPERTY("contextMenuModel");
-static const char* DOCK_PANEL_PROPERY("dockPanel");
+inline const char* CONTEXT_MENU_MODEL_PROPERTY("contextMenuModel");
+inline const char* DOCK_PANEL_PROPERY("dockPanel");
 
 enum class DockType {
     Undefined = -1,

--- a/src/engraving/layout/layout.h
+++ b/src/engraving/layout/layout.h
@@ -32,7 +32,7 @@ class Tremolo;
 }
 
 namespace mu::engraving {
-class LayoutContext;
+struct LayoutContext;
 class Layout
 {
 public:

--- a/src/engraving/layout/layoutbeams.h
+++ b/src/engraving/layout/layoutbeams.h
@@ -30,14 +30,14 @@ class ChordRest;
 }
 
 namespace mu::engraving {
-class LayoutContext;
+struct LayoutContext;
 class LayoutBeams
 {
 public:
 
     static bool isTopBeam(Ms::ChordRest* cr);
     static bool notTopBeam(Ms::ChordRest* cr);
-    static void createBeams(Ms::Score* score, LayoutContext& lc, Ms::Measure* measure);
+    static void createBeams(Ms::Score* score, struct LayoutContext& lc, Ms::Measure* measure);
     static void restoreBeams(Ms::Measure* m);
     static void breakCrossMeasureBeams(Ms::Measure* measure);
     static void respace(std::vector<Ms::ChordRest*>* elements);

--- a/src/engraving/layout/layoutmeasure.h
+++ b/src/engraving/layout/layoutmeasure.h
@@ -32,7 +32,7 @@ class MeasureBase;
 }
 
 namespace mu::engraving {
-class LayoutContext;
+struct LayoutContext;
 class LayoutMeasure
 {
 public:

--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -2683,14 +2683,11 @@ void Score::deleteMeasures(MeasureBase* mbStart, MeasureBase* mbEnd, bool preser
 {
     select(0, SelectType::SINGLE, 0);
 
-    // createEndBar if last measure is deleted
-    bool createEndBar = false;
     if (mbEnd->isMeasure()) {
         Measure* mbEndMeasure = toMeasure(mbEnd);
         if (mbEndMeasure->isMMRest()) {
             mbEnd = mbEndMeasure->mmRestLast();
         }
-        createEndBar = false;
     }
 
     // get the last deleted timesig & keysig in order to restore after deletion

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -55,8 +55,6 @@ class QMimeData;
 
 namespace mu::engraving {
 class EngravingProject;
-class LayoutContext;
-class LayoutMeasure;
 class AccessibleScore;
 }
 
@@ -428,8 +426,6 @@ private:
     friend class mu::engraving::compat::ReadScoreHook;
     friend class mu::engraving::compat::Read302;
     friend class mu::engraving::Layout;
-    friend class mu::engraving::LayoutContext;
-    friend class mu::engraving::LayoutMeasure;
 
     static std::set<Score*> validScores;
     int _linkId { 0 };

--- a/src/framework/accessibility/internal/accessibilitycontroller.cpp
+++ b/src/framework/accessibility/internal/accessibilitycontroller.cpp
@@ -154,6 +154,8 @@ void AccessibilityController::propertyChanged(IAccessible* item, IAccessible::Pr
         break;
     case IAccessible::Property::Name: etype = QAccessible::NameChanged;
         break;
+    case IAccessible::Property::Description: etype = QAccessible::DescriptionChanged;
+        break;
     }
 
     QAccessibleEvent ev(it.object, etype);

--- a/src/instrumentsscene/view/instrumentsonscorelistmodel.cpp
+++ b/src/instrumentsscene/view/instrumentsonscorelistmodel.cpp
@@ -71,10 +71,10 @@ QVariant InstrumentsOnScoreListModel::data(const QModelIndex& index, int role) c
     case RoleIsSoloist:
         return instrument->isSoloist;
     default:
-        return SelectableItemListModel::data(index, role);
+        break;
     }
 
-    return QVariant();
+    return SelectableItemListModel::data(index, role);
 }
 
 bool InstrumentsOnScoreListModel::setData(const QModelIndex& index, const QVariant& value, int role)

--- a/src/notation/view/noteinputbarcustomisemodel.cpp
+++ b/src/notation/view/noteinputbarcustomisemodel.cpp
@@ -71,10 +71,10 @@ QVariant NoteInputBarCustomiseModel::data(const QModelIndex& index, int role) co
 
     switch (role) {
     case ItemRole: return QVariant::fromValue(item);
-    default: return SelectableItemListModel::data(index, role);
+    default: break;
     }
 
-    return QVariant();
+    return SelectableItemListModel::data(index, role);
 }
 
 QHash<int, QByteArray> NoteInputBarCustomiseModel::roleNames() const


### PR DESCRIPTION
One more remaining:
```
Warning	C4505	'checkNotifySignalValidity_mu__notation__NoteInputBarCustomiseModel': unreferenced function with internal linkage has been removed (compiling source file ...\src\notation\notation_autogen\mocs_compilation_RelWithDebInfo.cpp)
```
Last time we had a similar one, but in thirdparty and there just disabled it, see bee94112, here however it is 'our' code.