### PR TITLE
fix GH#8937 and #8938: inspector setting for tremolo doesn't appear

### DIFF
--- a/src/inspector/models/abstractinspectormodel.cpp
+++ b/src/inspector/models/abstractinspectormodel.cpp
@@ -68,7 +68,7 @@ static const QMap<Ms::ElementType, AbstractInspectorModel::InspectorModelType> N
     { Ms::ElementType::MMREST, AbstractInspectorModel::InspectorModelType::TYPE_MMREST },
     { Ms::ElementType::BEND, AbstractInspectorModel::InspectorModelType::TYPE_BEND },
     { Ms::ElementType::TREMOLOBAR, AbstractInspectorModel::InspectorModelType::TYPE_TREMOLOBAR },
-    { Ms::ElementType::TREMOLO, AbstractInspectorModel::InspectorModelType::TYPE_TREMOLOBAR },
+    { Ms::ElementType::TREMOLO, AbstractInspectorModel::InspectorModelType::TYPE_TREMOLO },
     { Ms::ElementType::MEASURE_REPEAT, AbstractInspectorModel::InspectorModelType::TYPE_MEASURE_REPEAT }
 };
 

--- a/src/inspector/models/inspectorlistmodel.cpp
+++ b/src/inspector/models/inspectorlistmodel.cpp
@@ -27,6 +27,7 @@
 #include "score/scoredisplaysettingsmodel.h"
 #include "score/scoreappearancesettingsmodel.h"
 #include "notation/inotationinteraction.h"
+#include "engraving/libmscore/tremolo.h"
 
 using namespace mu::inspector;
 using namespace mu::notation;
@@ -86,6 +87,9 @@ void InspectorListModel::setElementList(const QList<Ms::Element*>& selectedEleme
     QSet<Ms::ElementType> newElementTypeSet;
 
     for (const Ms::Element* element : selectedElementList) {
+        if (element->isTremolo() && !Ms::toTremolo(element)->customStyleApplicable()) {
+            continue;
+        }
         newElementTypeSet << element->type();
     }
 


### PR DESCRIPTION
Fixes #8937 and fixes #8938.

The second commit is for a different issue (that has been kind of brought up in the linked issues as well). Not sure whether this kind of hack can be allowed or I can do it better in another way.