### PR TITLE
Fixed SMuFL anchors

### DIFF
--- a/src/engraving/engravingmodule.h
+++ b/src/engraving/engravingmodule.h
@@ -35,7 +35,7 @@ public:
     void registerResources() override;
     void registerUiTypes() override;
     void onInit(const framework::IApplication::RunMode& mode) override;
-    void onDeinit();
+    void onDeinit() override;
 };
 }
 

--- a/src/engraving/libmscore/mscoreview.cpp
+++ b/src/engraving/libmscore/mscoreview.cpp
@@ -62,7 +62,7 @@ Element* MuseScoreView::elementAt(const mu::PointF& p)
 
 Page* MuseScoreView::point2page(const mu::PointF& p)
 {
-    if (score()->layoutMode() == LayoutMode::LINE) {
+    if (score()->layoutMode() == mu::engraving::LayoutMode::LINE) {
         return score()->pages().isEmpty() ? 0 : score()->pages().front();
     }
     foreach (Page* page, score()->pages()) {

--- a/src/engraving/libmscore/scorefont.cpp
+++ b/src/engraving/libmscore/scorefont.cpp
@@ -274,7 +274,6 @@ void ScoreFont::load()
 void ScoreFont::loadGlyphsWithAnchors(const QJsonObject& glyphsWithAnchors)
 {
     for (const QString& symName : glyphsWithAnchors.keys()) {
-        constexpr qreal scale = SPATIUM20;
         QJsonObject anchors = glyphsWithAnchors.value(symName).toObject();
 
         SymId symId = Sym::nameToSymIdHash.value(symName, SymId::noSym);
@@ -284,42 +283,31 @@ void ScoreFont::loadGlyphsWithAnchors(const QJsonObject& glyphsWithAnchors)
             continue;
         }
 
-        Sym* sym = &m_symbols[int(symId)];
+        Sym& sym = m_symbols[size_t(symId)];
 
-        for (const QString& anchorKey : anchors.keys()) {
-            if (anchorKey == "stemDownNW") {
-                qreal x = anchors.value(anchorKey).toArray().at(0).toDouble();
-                qreal y = anchors.value(anchorKey).toArray().at(1).toDouble();
-                sym->setSmuflAnchor(SmuflAnchorId::stemDownNW, PointF(x, -y) * 4.0 * DPI_F);
-            } else if (anchorKey == "stemUpSE") {
-                qreal x = anchors.value(anchorKey).toArray().at(0).toDouble();
-                qreal y = anchors.value(anchorKey).toArray().at(1).toDouble();
-                sym->setSmuflAnchor(SmuflAnchorId::stemUpSE, PointF(x, -y) * 4.0 * DPI_F);
-            } else if (anchorKey == "stemDownSW") {
-                qreal x = anchors.value(anchorKey).toArray().at(0).toDouble();
-                qreal y = anchors.value(anchorKey).toArray().at(1).toDouble();
-                sym->setSmuflAnchor(SmuflAnchorId::stemDownSW, PointF(x, -y) * 4.0 * DPI_F);
-            } else if (anchorKey == "stemUpNW") {
-                qreal x = anchors.value(anchorKey).toArray().at(0).toDouble();
-                qreal y = anchors.value(anchorKey).toArray().at(1).toDouble();
-                sym->setSmuflAnchor(SmuflAnchorId::stemUpNW, PointF(x, -y) * 4.0 * DPI_F);
-            } else if (anchorKey == "cutOutNE") {
-                qreal x = anchors.value(anchorKey).toArray().at(0).toDouble();
-                qreal y = anchors.value(anchorKey).toArray().at(1).toDouble();
-                sym->setSmuflAnchor(SmuflAnchorId::cutOutNE, PointF(x, -y) * scale);
-            } else if (anchorKey == "cutOutNW") {
-                qreal x = anchors.value(anchorKey).toArray().at(0).toDouble();
-                qreal y = anchors.value(anchorKey).toArray().at(1).toDouble();
-                sym->setSmuflAnchor(SmuflAnchorId::cutOutNW, PointF(x, -y) * scale);
-            } else if (anchorKey == "cutOutSE") {
-                qreal x = anchors.value(anchorKey).toArray().at(0).toDouble();
-                qreal y = anchors.value(anchorKey).toArray().at(1).toDouble();
-                sym->setSmuflAnchor(SmuflAnchorId::cutOutSE, PointF(x, -y) * scale);
-            } else if (anchorKey == "cutOutSW") {
-                qreal x = anchors.value(anchorKey).toArray().at(0).toDouble();
-                qreal y = anchors.value(anchorKey).toArray().at(1).toDouble();
-                sym->setSmuflAnchor(SmuflAnchorId::cutOutSW, PointF(x, -y) * scale);
+        static const std::unordered_map<QString, SmuflAnchorId> smuflAnchorIdNames {
+            { "stemDownNW", SmuflAnchorId::stemDownNW },
+            { "stemUpSE", SmuflAnchorId::stemUpSE },
+            { "stemDownSW", SmuflAnchorId::stemDownSW },
+            { "stemUpNW", SmuflAnchorId::stemUpNW },
+            { "cutOutNE", SmuflAnchorId::cutOutNE },
+            { "cutOutNW", SmuflAnchorId::cutOutNW },
+            { "cutOutSE", SmuflAnchorId::cutOutSE },
+            { "cutOutSW", SmuflAnchorId::cutOutSW }
+        };
+
+        for (const QString& anchorId : anchors.keys()) {
+            auto search = smuflAnchorIdNames.find(anchorId);
+            if (search == smuflAnchorIdNames.cend()) {
+                //LOGD() << "Unhandled SMuFL anchorId: " << anchorId;
+                continue;
             }
+
+            QJsonArray arr = anchors.value(anchorId).toArray();
+            double x = arr.at(0).toDouble();
+            double y = arr.at(1).toDouble();
+
+            sym.setSmuflAnchor(search->second, PointF(x, -y) * SPATIUM20);
         }
     }
 }

--- a/src/framework/fonts/fonts_Petaluma.qrc
+++ b/src/framework/fonts/fonts_Petaluma.qrc
@@ -1,5 +1,6 @@
 <RCC>
     <qresource prefix="/">
+        <file alias="fonts/petaluma/metadata.json">../../../fonts/petaluma/petaluma_metadata.json</file>
         <file alias="fonts/petaluma/Petaluma.otf">../../../fonts/petaluma/Petaluma.otf</file>
         <file alias="fonts/petaluma/PetalumaText.otf">../../../fonts/petaluma/PetalumaText.otf</file>
         <file alias="fonts/petaluma/PetalumaScript.otf">../../../fonts/petaluma/PetalumaScript.otf</file>

--- a/src/importexport/musicxml/internal/musicxml/importxmlfirstpass.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importxmlfirstpass.cpp
@@ -22,6 +22,8 @@
 
 #include "importxmlfirstpass.h"
 
+#include "log.h"
+
 namespace Ms {
 // TODO: move somewhere else
 


### PR DESCRIPTION
Resolves: 
- https://github.com/musescore/MuseScore/issues/8952#issuecomment-907587882 (only @oktophonie's comment, not yet the whole issue)
- https://trello.com/c/86Ks7zZX/58-stemdownnw-stemupse-not-honoured-for-x-notehead

While working on #8952, I wrote some extra drawing code for debugging bboxes, positioning, anchors etc.. This revealed that the SMuFL anchors were hardly ever in the correct place, so stems were not attached correctly to noteheads. They always seemed to be at 80% of their correct position from the origin. And exactly that was the case. Now it looks like this: 
<img width="1451" alt="Schermafbeelding 2021-08-29 om 18 02 08" src="https://user-images.githubusercontent.com/48658420/131257919-ea051975-39a5-480c-be72-01aa0e4a63d7.png">
(red `+` means origin of element; orange `+` is flag anchor point; yellow `+` is notehead anchor point; the green rect is the bounding box. Please don't mind the badly-placed and purple-coloured stems in this picture.)

Here is it without those extra things:
<img width="1451" alt="Schermafbeelding 2021-08-29 om 18 38 26" src="https://user-images.githubusercontent.com/48658420/131258187-7b61ae2b-a0e4-4700-a085-5b404e77fb67.png">

It also turned out that the metadata file for Petaluma was not added to the application, so for Petaluma the anchors did not work at all. That's fixed too with this PR.