### PR TITLE
[MU4] Fix qml import errors pointed out by QtCreator 5

### DIFF
--- a/src/project/qml/MuseScore/Project/internal/Export/AudioSettingsPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/AudioSettingsPage.qml
@@ -19,11 +19,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2
-import QtQuick.Layouts 1
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
-import MuseScore.UiComponents 1
-import MuseScore.Project 1
+import MuseScore.UiComponents 1.0
+import MuseScore.Project 1.0
 
 ColumnLayout {
     id: root

--- a/src/project/qml/MuseScore/Project/internal/Export/ExportOptionItem.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/ExportOptionItem.qml
@@ -19,10 +19,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2
-import QtQuick.Layouts 1
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
-import MuseScore.UiComponents 1
+import MuseScore.UiComponents 1.0
 
 RowLayout {
     id: root

--- a/src/project/qml/MuseScore/Project/internal/Export/ExportOptionsView.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/ExportOptionsView.qml
@@ -19,12 +19,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2
-import QtQuick.Controls 2
-import QtQuick.Layouts 1
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
-import MuseScore.Project 1
-import MuseScore.UiComponents 1
+import MuseScore.Project 1.0
+import MuseScore.UiComponents 1.0
 
 ColumnLayout {
     id: root

--- a/src/project/qml/MuseScore/Project/internal/Export/MidiSettingsPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/MidiSettingsPage.qml
@@ -19,11 +19,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2
-import QtQuick.Layouts 1
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
-import MuseScore.UiComponents 1
-import MuseScore.Project 1
+import MuseScore.UiComponents 1.0
+import MuseScore.Project 1.0
 
 ColumnLayout {
     id: root

--- a/src/project/qml/MuseScore/Project/internal/Export/Mp3SettingsPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/Mp3SettingsPage.qml
@@ -19,11 +19,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2
-import QtQuick.Layouts 1
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
-import MuseScore.UiComponents 1
-import MuseScore.Project 1
+import MuseScore.UiComponents 1.0
+import MuseScore.Project 1.0
 
 AudioSettingsPage {
     showBitRateControl: true

--- a/src/project/qml/MuseScore/Project/internal/Export/MusicXmlSettingsPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/MusicXmlSettingsPage.qml
@@ -19,11 +19,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2
-import QtQuick.Layouts 1
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
-import MuseScore.UiComponents 1
-import MuseScore.Project 1
+import MuseScore.UiComponents 1.0
+import MuseScore.Project 1.0
 
 ColumnLayout {
     id: root

--- a/src/project/qml/MuseScore/Project/internal/Export/PdfSettingsPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/PdfSettingsPage.qml
@@ -19,11 +19,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2
-import QtQuick.Layouts 1
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
-import MuseScore.UiComponents 1
-import MuseScore.Project 1
+import MuseScore.UiComponents 1.0
+import MuseScore.Project 1.0
 
 ColumnLayout {
     id: root

--- a/src/project/qml/MuseScore/Project/internal/Export/PngSettingsPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/PngSettingsPage.qml
@@ -19,11 +19,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2
-import QtQuick.Layouts 1
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
-import MuseScore.UiComponents 1
-import MuseScore.Project 1
+import MuseScore.UiComponents 1.0
+import MuseScore.Project 1.0
 
 ColumnLayout {
     id: root

--- a/src/project/qml/MuseScore/Project/internal/Export/SvgSettingsPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/SvgSettingsPage.qml
@@ -19,11 +19,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2
-import QtQuick.Layouts 1
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
-import MuseScore.UiComponents 1
-import MuseScore.Project 1
+import MuseScore.UiComponents 1.0
+import MuseScore.Project 1.0
 
 StyledTextLabel {
     property ExportDialogModel model


### PR DESCRIPTION
It seems the new QtCreator 5(.0.0) is very picky when it comes to QML import statements and the version number of the to be imported module.

It reports the missing (or rather incomplete) version numbers as errors, but builds MuseScore nonetheless