### PR TITLE
Changed type virtual method to type field

### DIFF
--- a/src/engraving/libmscore/accidental.cpp
+++ b/src/engraving/libmscore/accidental.cpp
@@ -241,7 +241,7 @@ AccidentalVal sym2accidentalVal(SymId id)
 //---------------------------------------------------------
 
 Accidental::Accidental(Score* s)
-    : Element(s, ElementFlag::MOVABLE)
+    : Element(ElementType::ACCIDENTAL, s, ElementFlag::MOVABLE)
 {
 }
 

--- a/src/engraving/libmscore/accidental.h
+++ b/src/engraving/libmscore/accidental.h
@@ -90,7 +90,6 @@ public:
     Accidental(Score* s = 0);
 
     Accidental* clone() const override { return new Accidental(*this); }
-    ElementType type() const override { return ElementType::ACCIDENTAL; }
 
     // Score Tree functions
     ScoreElement* treeParent() const override;

--- a/src/engraving/libmscore/actionicon.cpp
+++ b/src/engraving/libmscore/actionicon.cpp
@@ -28,18 +28,13 @@ using namespace mu;
 
 namespace Ms {
 ActionIcon::ActionIcon(Score* score)
-    : Element(score)
+    : Element(ElementType::ACTION_ICON, score)
 {
 }
 
 ActionIcon* ActionIcon::clone() const
 {
     return new ActionIcon(*this);
-}
-
-ElementType ActionIcon::type() const
-{
-    return ElementType::ACTION_ICON;
 }
 
 ActionIconType ActionIcon::actionType() const

--- a/src/engraving/libmscore/actionicon.h
+++ b/src/engraving/libmscore/actionicon.h
@@ -67,7 +67,6 @@ public:
     ~ActionIcon() override = default;
 
     ActionIcon* clone() const override;
-    ElementType type() const override;
 
     ActionIconType actionType() const;
     const std::string& actionCode() const;

--- a/src/engraving/libmscore/ambitus.cpp
+++ b/src/engraving/libmscore/ambitus.cpp
@@ -51,7 +51,7 @@ static const qreal LINEOFFSET_DEFAULT      = 0.8;               // the distance 
 //---------------------------------------------------------
 
 Ambitus::Ambitus(Score* s)
-    : Element(s, ElementFlag::ON_STAFF), _topAccid(s), _bottomAccid(s)
+    : Element(ElementType::AMBITUS, s, ElementFlag::ON_STAFF), _topAccid(s), _bottomAccid(s)
 {
     _noteHeadGroup    = NOTEHEADGROUP_DEFAULT;
     _noteHeadType     = NOTEHEADTYPE_DEFAULT;

--- a/src/engraving/libmscore/ambitus.h
+++ b/src/engraving/libmscore/ambitus.h
@@ -53,7 +53,6 @@ class Ambitus final : public Element
 public:
     Ambitus(Score* s);
 
-    ElementType type() const override { return ElementType::AMBITUS; }
     Ambitus* clone() const override { return new Ambitus(*this); }
 
     // Score Tree functions

--- a/src/engraving/libmscore/arpeggio.cpp
+++ b/src/engraving/libmscore/arpeggio.cpp
@@ -54,7 +54,7 @@ const std::array<const char*, 6> Arpeggio::arpeggioTypeNames = {
 //---------------------------------------------------------
 
 Arpeggio::Arpeggio(Score* s)
-    : Element(s, ElementFlag::MOVABLE)
+    : Element(ElementType::ARPEGGIO, s, ElementFlag::MOVABLE)
 {
     _arpeggioType = ArpeggioType::NORMAL;
     setHeight(spatium() * 4);        // for use in palettes

--- a/src/engraving/libmscore/arpeggio.h
+++ b/src/engraving/libmscore/arpeggio.h
@@ -64,7 +64,6 @@ public:
     Arpeggio(Score* s);
 
     Arpeggio* clone() const override { return new Arpeggio(*this); }
-    ElementType type() const override { return ElementType::ARPEGGIO; }
 
     ArpeggioType arpeggioType() const { return _arpeggioType; }
     void setArpeggioType(ArpeggioType v) { _arpeggioType = v; }

--- a/src/engraving/libmscore/articulation.cpp
+++ b/src/engraving/libmscore/articulation.cpp
@@ -56,7 +56,7 @@ static const ElementStyle articulationStyle {
 //---------------------------------------------------------
 
 Articulation::Articulation(Score* s)
-    : Element(s, ElementFlag::MOVABLE)
+    : Element(ElementType::ARTICULATION, s, ElementFlag::MOVABLE)
 {
     _symId         = SymId::noSym;
     _anchor        = ArticulationAnchor::TOP_STAFF;

--- a/src/engraving/libmscore/articulation.h
+++ b/src/engraving/libmscore/articulation.h
@@ -107,7 +107,6 @@ public:
     Articulation& operator=(const Articulation&) = delete;
 
     Articulation* clone() const override { return new Articulation(*this); }
-    ElementType type() const override { return ElementType::ARTICULATION; }
 
     qreal mag() const override;
 

--- a/src/engraving/libmscore/bagpembell.h
+++ b/src/engraving/libmscore/bagpembell.h
@@ -64,10 +64,9 @@ class BagpipeEmbellishment final : public Element
 
 public:
     BagpipeEmbellishment(Score* s)
-        : Element(s), _embelType(0) { }
+        : Element(ElementType::BAGPIPE_EMBELLISHMENT, s), _embelType(0) { }
 
     BagpipeEmbellishment* clone() const override { return new BagpipeEmbellishment(*this); }
-    ElementType type() const override { return ElementType::BAGPIPE_EMBELLISHMENT; }
 
     int embelType() const { return _embelType; }
     void setEmbelType(int val) { _embelType = val; }

--- a/src/engraving/libmscore/barline.cpp
+++ b/src/engraving/libmscore/barline.cpp
@@ -336,7 +336,7 @@ BarLineType BarLine::barLineType(const QString& s)
 //---------------------------------------------------------
 
 BarLine::BarLine(Score* s)
-    : Element(s)
+    : Element(ElementType::BAR_LINE, s)
 {
     setHeight(4 * spatium());   // for use in palettes
 }

--- a/src/engraving/libmscore/barline.h
+++ b/src/engraving/libmscore/barline.h
@@ -92,7 +92,6 @@ public:
     int treeChildCount() const override;
 
     BarLine* clone() const override { return new BarLine(*this); }
-    ElementType type() const override { return ElementType::BAR_LINE; }
     Fraction playTick() const override;
     void write(XmlWriter& xml) const override;
     void read(XmlReader&) override;

--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -76,7 +76,7 @@ struct BeamFragment {
 //---------------------------------------------------------
 
 Beam::Beam(Score* s)
-    : Element(s)
+    : Element(ElementType::BEAM, s)
 {
     initElementStyle(&beamStyle);
 }

--- a/src/engraving/libmscore/beam.h
+++ b/src/engraving/libmscore/beam.h
@@ -100,7 +100,6 @@ public:
     void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
 
     Beam* clone() const override { return new Beam(*this); }
-    ElementType type() const override { return ElementType::BEAM; }
     mu::PointF pagePos() const override;      ///< position in page coordinates
     mu::PointF canvasPos() const override;    ///< position in page coordinates
 

--- a/src/engraving/libmscore/bend.cpp
+++ b/src/engraving/libmscore/bend.cpp
@@ -85,7 +85,7 @@ static const QList<PitchValue> PREBEND_RELEASE_CURVE = { PitchValue(0, 100),
 //---------------------------------------------------------
 
 Bend::Bend(Score* s)
-    : Element(s, ElementFlag::MOVABLE)
+    : Element(ElementType::BEND, s, ElementFlag::MOVABLE)
 {
     initElementStyle(&bendStyle);
 }

--- a/src/engraving/libmscore/bend.h
+++ b/src/engraving/libmscore/bend.h
@@ -55,7 +55,7 @@ public:
     Bend(Score* s);
 
     Bend* clone() const override { return new Bend(*this); }
-    ElementType type() const override { return ElementType::BEND; }
+
     void layout() override;
     void draw(mu::draw::Painter*) const override;
     void write(XmlWriter&) const override;

--- a/src/engraving/libmscore/box.cpp
+++ b/src/engraving/libmscore/box.cpp
@@ -58,8 +58,8 @@ static const ElementStyle hBoxStyle {
 //   Box
 //---------------------------------------------------------
 
-Box::Box(Score* score)
-    : MeasureBase(score)
+Box::Box(const ElementType& type, Score* score)
+    : MeasureBase(type, score)
 {
 }
 
@@ -476,7 +476,7 @@ void Box::copyValues(Box* origin)
 //---------------------------------------------------------
 
 HBox::HBox(Score* score)
-    : Box(score)
+    : Box(ElementType::HBOX, score)
 {
     initElementStyle(&hBoxStyle);
     setBoxWidth(Spatium(5.0));
@@ -757,12 +757,17 @@ QVariant HBox::propertyDefault(Pid id) const
 //   VBox
 //---------------------------------------------------------
 
-VBox::VBox(Score* score)
-    : Box(score)
+VBox::VBox(const ElementType& type, Score* score)
+    : Box(type, score)
 {
     initElementStyle(&boxStyle);
     setBoxHeight(Spatium(10.0));
     setLineBreak(true);
+}
+
+VBox::VBox(Score* score)
+    : VBox(ElementType::VBOX, score)
+{
 }
 
 qreal VBox::minHeight() const

--- a/src/engraving/libmscore/box.h
+++ b/src/engraving/libmscore/box.h
@@ -52,7 +52,7 @@ class Box : public MeasureBase
     bool _isAutoSizeEnabled       { true };
 
 public:
-    Box(Score*);
+    Box(const ElementType& type, Score*);
 
     void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
 
@@ -122,7 +122,6 @@ public:
     virtual ~HBox() {}
 
     HBox* clone() const override { return new HBox(*this); }
-    ElementType type() const override { return ElementType::HBOX; }
 
     void layout() override;
     void writeProperties(XmlWriter&) const override;
@@ -152,11 +151,11 @@ public:
 class VBox : public Box
 {
 public:
+    VBox(const ElementType& type, Score* score);
     VBox(Score* score);
     virtual ~VBox() {}
 
     VBox* clone() const override { return new VBox(*this); }
-    ElementType type() const override { return ElementType::VBOX; }
 
     qreal minHeight() const;
     qreal maxHeight() const;
@@ -178,11 +177,10 @@ class FBox : public VBox
 {
 public:
     FBox(Score* score)
-        : VBox(score) {}
+        : VBox(ElementType::FBOX, score) {}
     virtual ~FBox() {}
 
     FBox* clone() const override { return new FBox(*this); }
-    ElementType type() const override { return ElementType::FBOX; }
 
     void layout() override;
     void add(Element*) override;

--- a/src/engraving/libmscore/bracket.cpp
+++ b/src/engraving/libmscore/bracket.cpp
@@ -44,7 +44,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 Bracket::Bracket(Score* s)
-    : Element(s)
+    : Element(ElementType::BRACKET, s)
 {
     ay1          = 0;
     h2           = 3.5 * spatium();

--- a/src/engraving/libmscore/bracket.h
+++ b/src/engraving/libmscore/bracket.h
@@ -59,7 +59,6 @@ public:
     ~Bracket();
 
     Bracket* clone() const override { return new Bracket(*this); }
-    ElementType type() const override { return ElementType::BRACKET; }
 
     void setBracketItem(BracketItem* i) { _bi = i; }
     BracketItem* bracketItem() const { return _bi; }

--- a/src/engraving/libmscore/bracketItem.h
+++ b/src/engraving/libmscore/bracketItem.h
@@ -40,10 +40,10 @@ class BracketItem final : public ScoreElement
 
 public:
     BracketItem(Score* s)
-        : ScoreElement(s) {}
+        : ScoreElement(ElementType::BRACKET_ITEM, s) {}
     BracketItem(Score* s, BracketType a, int b)
-        : ScoreElement(s), _bracketType(a), _bracketSpan(b) { }
-    virtual ElementType type() const override { return ElementType::BRACKET_ITEM; }
+        : ScoreElement(ElementType::BRACKET_ITEM, s), _bracketType(a), _bracketSpan(b) { }
+
     virtual QVariant getProperty(Pid) const override;
     virtual bool setProperty(Pid, const QVariant&) override;
     virtual QVariant propertyDefault(Pid id) const override;

--- a/src/engraving/libmscore/breath.cpp
+++ b/src/engraving/libmscore/breath.cpp
@@ -51,7 +51,7 @@ const std::vector<BreathType> Breath::breathList {
 //---------------------------------------------------------
 
 Breath::Breath(Score* s)
-    : Element(s, ElementFlag::MOVABLE)
+    : Element(ElementType::BREATH, s, ElementFlag::MOVABLE)
 {
     _symId = SymId::breathMarkComma;
     _pause = 0.0;

--- a/src/engraving/libmscore/breath.h
+++ b/src/engraving/libmscore/breath.h
@@ -50,7 +50,6 @@ class Breath final : public Element
 public:
     Breath(Score* s);
 
-    ElementType type() const override { return ElementType::BREATH; }
     Breath* clone() const override { return new Breath(*this); }
 
     qreal mag() const override;

--- a/src/engraving/libmscore/bsymbol.cpp
+++ b/src/engraving/libmscore/bsymbol.cpp
@@ -39,8 +39,8 @@ namespace Ms {
 //   BSymbol
 //---------------------------------------------------------
 
-BSymbol::BSymbol(Score* s, ElementFlags f)
-    : Element(s, f)
+BSymbol::BSymbol(const Ms::ElementType& type, Score* s, ElementFlags f)
+    : Element(type, s, f)
 {
     _align = Align::LEFT | Align::BASELINE;
 }

--- a/src/engraving/libmscore/bsymbol.h
+++ b/src/engraving/libmscore/bsymbol.h
@@ -37,7 +37,7 @@ class BSymbol : public Element
     Align _align;
 
 public:
-    BSymbol(Score* s, ElementFlags f = ElementFlag::NOTHING);
+    BSymbol(const ElementType& type, Score* s, ElementFlags f = ElementFlag::NOTHING);
     BSymbol(const BSymbol&);
 
     // Score Tree functions

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -231,7 +231,7 @@ int Chord::downString() const
 //---------------------------------------------------------
 
 Chord::Chord(Score* s)
-    : ChordRest(s)
+    : ChordRest(ElementType::CHORD, s)
 {
     _ledgerLines      = 0;
     _stem             = 0;

--- a/src/engraving/libmscore/chord.h
+++ b/src/engraving/libmscore/chord.h
@@ -118,7 +118,6 @@ public:
     void undoUnlink() override;
 
     void setScore(Score* s) override;
-    ElementType type() const override { return ElementType::CHORD; }
     qreal chordMag() const;
     qreal mag() const override;
 

--- a/src/engraving/libmscore/chordline.cpp
+++ b/src/engraving/libmscore/chordline.cpp
@@ -43,7 +43,7 @@ const char* scorelineNames[] = {
 //---------------------------------------------------------
 
 ChordLine::ChordLine(Score* s)
-    : Element(s, ElementFlag::MOVABLE)
+    : Element(ElementType::CHORDLINE, s, ElementFlag::MOVABLE)
 {
     modified = false;
     _chordLineType = ChordLineType::NOTYPE;

--- a/src/engraving/libmscore/chordline.h
+++ b/src/engraving/libmscore/chordline.h
@@ -56,7 +56,6 @@ public:
     ChordLine(const ChordLine&);
 
     ChordLine* clone() const override { return new ChordLine(*this); }
-    ElementType type() const override { return ElementType::CHORDLINE; }
 
     void setChordLineType(ChordLineType);
     ChordLineType chordLineType() const { return _chordLineType; }

--- a/src/engraving/libmscore/chordrest.cpp
+++ b/src/engraving/libmscore/chordrest.cpp
@@ -69,8 +69,8 @@ namespace Ms {
 //   ChordRest
 //---------------------------------------------------------
 
-ChordRest::ChordRest(Score* s)
-    : DurationElement(s)
+ChordRest::ChordRest(const ElementType& type, Score* s)
+    : DurationElement(type, s)
 {
     _staffMove    = 0;
     _beam         = 0;

--- a/src/engraving/libmscore/chordrest.h
+++ b/src/engraving/libmscore/chordrest.h
@@ -78,7 +78,7 @@ protected:
     TDuration _crossMeasureTDur;          ///< the total Duration type of the combined notes
 
 public:
-    ChordRest(Score*);
+    ChordRest(const ElementType& type, Score*);
     ChordRest(const ChordRest&, bool link = false);
     ChordRest& operator=(const ChordRest&) = delete;
     ~ChordRest();

--- a/src/engraving/libmscore/clef.cpp
+++ b/src/engraving/libmscore/clef.cpp
@@ -139,7 +139,7 @@ ClefType ClefInfo::tag2type(const QString& s)
 //---------------------------------------------------------
 
 Clef::Clef(Score* s)
-    : Element(s, ElementFlag::ON_STAFF), symId(SymId::noSym)
+    : Element(ElementType::CLEF, s, ElementFlag::ON_STAFF), symId(SymId::noSym)
 {}
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/clef.h
+++ b/src/engraving/libmscore/clef.h
@@ -152,7 +152,6 @@ class Clef final : public Element
 public:
     Clef(Score*);
     Clef* clone() const override { return new Clef(*this); }
-    ElementType type() const override { return ElementType::CLEF; }
     qreal mag() const override;
 
     Segment* segment() const { return (Segment*)parent(); }

--- a/src/engraving/libmscore/duration.cpp
+++ b/src/engraving/libmscore/duration.cpp
@@ -36,8 +36,8 @@ namespace Ms {
 //   DurationElement
 //---------------------------------------------------------
 
-DurationElement::DurationElement(Score* s, ElementFlags f)
-    : Element(s, f)
+DurationElement::DurationElement(const ElementType& type, Score* s, ElementFlags f)
+    : Element(type, s, f)
 {
     _tuplet = 0;
 }

--- a/src/engraving/libmscore/duration.h
+++ b/src/engraving/libmscore/duration.h
@@ -46,7 +46,7 @@ class DurationElement : public Element
     Tuplet* _tuplet;
 
 public:
-    DurationElement(Score* = 0, ElementFlags = ElementFlag::MOVABLE | ElementFlag::ON_STAFF);
+    DurationElement(const ElementType& type, Score* = 0, ElementFlags = ElementFlag::MOVABLE | ElementFlag::ON_STAFF);
     DurationElement(const DurationElement& e);
     ~DurationElement();
 

--- a/src/engraving/libmscore/dynamic.cpp
+++ b/src/engraving/libmscore/dynamic.cpp
@@ -158,7 +158,7 @@ int Dynamic::findInString(const QString& s, int& length, QString& type)
 //---------------------------------------------------------
 
 Dynamic::Dynamic(Score* s)
-    : TextBase(s, Tid::DYNAMICS, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+    : TextBase(ElementType::DYNAMIC, s, Tid::DYNAMICS, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     _velocity    = -1;
     _dynRange    = Range::PART;

--- a/src/engraving/libmscore/dynamic.h
+++ b/src/engraving/libmscore/dynamic.h
@@ -104,7 +104,6 @@ public:
     Dynamic(Score*);
     Dynamic(const Dynamic&);
     Dynamic* clone() const override { return new Dynamic(*this); }
-    ElementType type() const override { return ElementType::DYNAMIC; }
     Segment* segment() const { return (Segment*)parent(); }
     Measure* measure() const { return (Measure*)parent()->parent(); }
 

--- a/src/engraving/libmscore/element.cpp
+++ b/src/engraving/libmscore/element.cpp
@@ -211,8 +211,8 @@ QString Element::subtypeName() const
 //   Element
 //---------------------------------------------------------
 
-Element::Element(Score* s, ElementFlags f, mu::engraving::AccessibleElement* access)
-    : ScoreElement(s)
+Element::Element(const ElementType& type, Score* s, ElementFlags f, mu::engraving::AccessibleElement* access)
+    : ScoreElement(type, s)
 {
     _flags         = f;
     _track         = -1;
@@ -976,8 +976,8 @@ void ElementList::write(XmlWriter& xml) const
 //   Compound
 //---------------------------------------------------------
 
-Compound::Compound(Score* s)
-    : Element(s)
+Compound::Compound(const ElementType& type, Score* s)
+    : Element(type, s)
 {
 }
 

--- a/src/engraving/libmscore/element.h
+++ b/src/engraving/libmscore/element.h
@@ -212,7 +212,7 @@ protected:
     mu::draw::Color _color;                ///< element color attribute
 
 public:
-    Element(Score* = 0, ElementFlags = ElementFlag::NOTHING, mu::engraving::AccessibleElement* access = nullptr);
+    Element(const ElementType& type, Score* = 0, ElementFlags = ElementFlag::NOTHING, mu::engraving::AccessibleElement* access = nullptr);
     Element(const Element&);
     virtual ~Element();
 
@@ -647,7 +647,7 @@ protected:
     const QList<Element*>& getElements() const { return elements; }
 
 public:
-    Compound(Score*);
+    Compound(const ElementType& type, Score*);
     Compound(const Compound&);
 
     virtual void draw(mu::draw::Painter*) const;

--- a/src/engraving/libmscore/fermata.cpp
+++ b/src/engraving/libmscore/fermata.cpp
@@ -50,7 +50,7 @@ static const ElementStyle fermataStyle {
 //---------------------------------------------------------
 
 Fermata::Fermata(Score* s)
-    : Element(s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+    : Element(ElementType::FERMATA, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     setPlacement(Placement::ABOVE);
     _symId         = SymId::noSym;

--- a/src/engraving/libmscore/fermata.h
+++ b/src/engraving/libmscore/fermata.h
@@ -53,7 +53,6 @@ public:
     Fermata& operator=(const Fermata&) = delete;
 
     Fermata* clone() const override { return new Fermata(*this); }
-    ElementType type() const override { return ElementType::FERMATA; }
 
     qreal mag() const override;
 

--- a/src/engraving/libmscore/figuredbass.cpp
+++ b/src/engraving/libmscore/figuredbass.cpp
@@ -76,7 +76,7 @@ const QChar FiguredBassItem::normParenthToChar[int(FiguredBassItem::Parenthesis:
 { 0, '(', ')', '[', ']' };
 
 FiguredBassItem::FiguredBassItem(Score* s, int l)
-    : Element(s), ord(l)
+    : Element(ElementType::INVALID, s), ord(l)
 {
     _prefix     = _suffix = Modifier::NONE;
     _digit      = FBIDigitNone;
@@ -998,7 +998,7 @@ bool FiguredBassItem::startsWithParenthesis() const
 //---------------------------------------------------------
 
 FiguredBass::FiguredBass(Score* s)
-    : TextBase(s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+    : TextBase(ElementType::FIGURED_BASS, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&figuredBassStyle);
     // figured bass inherits from TextBase for layout purposes

--- a/src/engraving/libmscore/figuredbass.h
+++ b/src/engraving/libmscore/figuredbass.h
@@ -163,7 +163,7 @@ public:
 
     // standard re-implemented virtual functions
     FiguredBassItem* clone() const override { return new FiguredBassItem(*this); }
-    ElementType       type() const override { return ElementType::INVALID; }
+
     void              draw(mu::draw::Painter* painter) const override;
     void              layout() override;
     void              read(XmlReader&) override;
@@ -267,7 +267,7 @@ public:
 
     // standard re-implemented virtual functions
     FiguredBass* clone() const override { return new FiguredBass(*this); }
-    ElementType   type() const override { return ElementType::FIGURED_BASS; }
+
     void      draw(mu::draw::Painter* painter) const override;
     void      endEdit(EditData&) override;
     void      layout() override;

--- a/src/engraving/libmscore/fingering.cpp
+++ b/src/engraving/libmscore/fingering.cpp
@@ -52,7 +52,7 @@ static const ElementStyle fingeringStyle {
 //---------------------------------------------------------
 
 Fingering::Fingering(Score* s, Tid tid, ElementFlags ef)
-    : TextBase(s, tid, ef)
+    : TextBase(ElementType::FINGERING, s, tid, ef)
 {
     setPlacement(Placement::ABOVE);
     initElementStyle(&fingeringStyle);

--- a/src/engraving/libmscore/fingering.h
+++ b/src/engraving/libmscore/fingering.h
@@ -37,7 +37,6 @@ public:
     Fingering(Score* s, ElementFlags ef = ElementFlag::HAS_TAG);
 
     Fingering* clone() const override { return new Fingering(*this); }
-    ElementType type() const override { return ElementType::FINGERING; }
 
     Note* note() const { return toNote(parent()); }
     ElementType layoutType();

--- a/src/engraving/libmscore/fret.cpp
+++ b/src/engraving/libmscore/fret.cpp
@@ -65,7 +65,7 @@ static const ElementStyle fretStyle {
 //---------------------------------------------------------
 
 FretDiagram::FretDiagram(Score* score)
-    : Element(score, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+    : Element(ElementType::FRET_DIAGRAM, score, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     font.setFamily("FreeSans");
     font.setPointSizeF(4.0 * mag());

--- a/src/engraving/libmscore/fret.h
+++ b/src/engraving/libmscore/fret.h
@@ -189,7 +189,6 @@ public:
 
     static std::shared_ptr<FretDiagram> createFromString(Score* score, const QString& s);
 
-    ElementType type() const override { return ElementType::FRET_DIAGRAM; }
     void layout() override;
     void write(XmlWriter& xml) const override;
     void writeNew(XmlWriter& xml) const;

--- a/src/engraving/libmscore/glissando.cpp
+++ b/src/engraving/libmscore/glissando.cpp
@@ -181,7 +181,7 @@ Element* GlissandoSegment::propertyDelegate(Pid pid)
 //=========================================================
 
 Glissando::Glissando(Score* s)
-    : SLine(s, ElementFlag::MOVABLE)
+    : SLine(ElementType::GLISSANDO, s, ElementFlag::MOVABLE)
 {
     setAnchor(Spanner::Anchor::NOTE);
     setDiagonal(true);

--- a/src/engraving/libmscore/glissando.h
+++ b/src/engraving/libmscore/glissando.h
@@ -43,10 +43,9 @@ class GlissandoSegment final : public LineSegment
 {
 public:
     GlissandoSegment(Spanner* sp, Score* s)
-        : LineSegment(sp, s) {}
+        : LineSegment(ElementType::GLISSANDO_SEGMENT, sp, s) {}
     Glissando* glissando() const { return toGlissando(spanner()); }
 
-    ElementType type() const override { return ElementType::GLISSANDO_SEGMENT; }
     GlissandoSegment* clone() const override { return new GlissandoSegment(*this); }
     void draw(mu::draw::Painter*) const override;
     void layout() override;
@@ -84,7 +83,7 @@ public:
 
     // overridden inherited methods
     Glissando* clone() const override { return new Glissando(*this); }
-    ElementType type() const override { return ElementType::GLISSANDO; }
+
     LineSegment* createLineSegment() override;
 
     void layout() override;

--- a/src/engraving/libmscore/hairpin.cpp
+++ b/src/engraving/libmscore/hairpin.cpp
@@ -76,7 +76,7 @@ static const ElementStyle hairpinStyle {
 //---------------------------------------------------------
 
 HairpinSegment::HairpinSegment(Spanner* sp, Score* s)
-    : TextLineBaseSegment(sp, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+    : TextLineBaseSegment(ElementType::HAIRPIN_SEGMENT, sp, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
 }
 
@@ -604,7 +604,7 @@ Sid Hairpin::getPropertyStyle(Pid pid) const
 //---------------------------------------------------------
 
 Hairpin::Hairpin(Score* s)
-    : TextLineBase(s)
+    : TextLineBase(ElementType::HAIRPIN, s)
 {
     initElementStyle(&hairpinStyle);
 

--- a/src/engraving/libmscore/hairpin.h
+++ b/src/engraving/libmscore/hairpin.h
@@ -66,7 +66,6 @@ public:
     HairpinSegment(Spanner* sp, Score* s);
 
     HairpinSegment* clone() const override { return new HairpinSegment(*this); }
-    ElementType type() const override { return ElementType::HAIRPIN_SEGMENT; }
 
     Hairpin* hairpin() const { return (Hairpin*)spanner(); }
 
@@ -106,7 +105,6 @@ public:
     Hairpin(Score* s);
 
     Hairpin* clone() const override { return new Hairpin(*this); }
-    ElementType type() const override { return ElementType::HAIRPIN; }
 
     HairpinType hairpinType() const { return _hairpinType; }
     void setHairpinType(HairpinType val);

--- a/src/engraving/libmscore/harmony.cpp
+++ b/src/engraving/libmscore/harmony.cpp
@@ -187,7 +187,7 @@ const ElementStyle chordSymbolStyle {
 //---------------------------------------------------------
 
 Harmony::Harmony(Score* s)
-    : TextBase(s, Tid::HARMONY_A, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+    : TextBase(ElementType::HARMONY, s, Tid::HARMONY_A, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     _rootTpc    = Tpc::TPC_INVALID;
     _baseTpc    = Tpc::TPC_INVALID;

--- a/src/engraving/libmscore/harmony.h
+++ b/src/engraving/libmscore/harmony.h
@@ -125,7 +125,6 @@ public:
     ~Harmony();
 
     Harmony* clone() const override { return new Harmony(*this); }
-    ElementType type() const override { return ElementType::HARMONY; }
 
     void setId(int d) { _id = d; }
     int id() const { return _id; }

--- a/src/engraving/libmscore/hook.cpp
+++ b/src/engraving/libmscore/hook.cpp
@@ -33,7 +33,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 Hook::Hook(Score* s)
-    : Symbol(s, ElementFlag::NOTHING)
+    : Symbol(ElementType::HOOK, s, ElementFlag::NOTHING)
 {
     setZ(int(type()) * 100);
 }

--- a/src/engraving/libmscore/hook.h
+++ b/src/engraving/libmscore/hook.h
@@ -42,7 +42,7 @@ public:
     Hook* clone() const override { return new Hook(*this); }
     qreal mag() const override { return parent()->mag(); }
     Element* elementBase() const override;
-    ElementType type() const override { return ElementType::HOOK; }
+
     void setHookType(int v);
     int hookType() const { return _hookType; }
     void layout() override;

--- a/src/engraving/libmscore/image.cpp
+++ b/src/engraving/libmscore/image.cpp
@@ -50,7 +50,7 @@ static bool defaultSizeIsSpatium    = true;
 //---------------------------------------------------------
 
 Image::Image(Score* s)
-    : BSymbol(s, ElementFlag::MOVABLE)
+    : BSymbol(ElementType::IMAGE, s, ElementFlag::MOVABLE)
 {
     imageType        = ImageType::NONE;
     rasterDoc        = 0;

--- a/src/engraving/libmscore/image.h
+++ b/src/engraving/libmscore/image.h
@@ -79,7 +79,7 @@ public:
     ~Image();
 
     Image* clone() const override { return new Image(*this); }
-    ElementType type() const override { return ElementType::IMAGE; }
+
     void write(XmlWriter& xml) const override;
     void read(XmlReader&) override;
     bool load(const QString& s);

--- a/src/engraving/libmscore/iname.cpp
+++ b/src/engraving/libmscore/iname.cpp
@@ -50,7 +50,7 @@ static const ElementStyle shortInstrumentStyle {
 //---------------------------------------------------------
 
 InstrumentName::InstrumentName(Score* s)
-    : TextBase(s, Tid::INSTRUMENT_LONG, ElementFlag::NOTHING)
+    : TextBase(ElementType::INSTRUMENT_NAME, s, Tid::INSTRUMENT_LONG, ElementFlag::NOTHING)
 {
     setFlag(ElementFlag::MOVABLE, false);
     setInstrumentNameType(InstrumentNameType::LONG);

--- a/src/engraving/libmscore/iname.h
+++ b/src/engraving/libmscore/iname.h
@@ -47,7 +47,6 @@ public:
     InstrumentName(Score*);
 
     InstrumentName* clone() const override { return new InstrumentName(*this); }
-    ElementType type() const override { return ElementType::INSTRUMENT_NAME; }
 
     int layoutPos() const { return _layoutPos; }
     void setLayoutPos(int val) { _layoutPos = val; }

--- a/src/engraving/libmscore/instrchange.cpp
+++ b/src/engraving/libmscore/instrchange.cpp
@@ -52,14 +52,14 @@ static const ElementStyle instrumentChangeStyle {
 //---------------------------------------------------------
 
 InstrumentChange::InstrumentChange(Score* s)
-    : TextBase(s, Tid::INSTRUMENT_CHANGE, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+    : TextBase(ElementType::INSTRUMENT_CHANGE, s, Tid::INSTRUMENT_CHANGE, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&instrumentChangeStyle);
     _instrument = new Instrument();
 }
 
 InstrumentChange::InstrumentChange(const Instrument& i, Score* s)
-    : TextBase(s, Tid::INSTRUMENT_CHANGE, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+    : TextBase(ElementType::INSTRUMENT_CHANGE, s, Tid::INSTRUMENT_CHANGE, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&instrumentChangeStyle);
     _instrument = new Instrument(i);

--- a/src/engraving/libmscore/instrchange.h
+++ b/src/engraving/libmscore/instrchange.h
@@ -47,7 +47,6 @@ public:
     ~InstrumentChange();
 
     InstrumentChange* clone() const override { return new InstrumentChange(*this); }
-    ElementType type() const override { return ElementType::INSTRUMENT_CHANGE; }
 
     void write(XmlWriter& xml) const override;
     void read(XmlReader&) override;

--- a/src/engraving/libmscore/jump.cpp
+++ b/src/engraving/libmscore/jump.cpp
@@ -63,7 +63,7 @@ int jumpTypeTableSize()
 //---------------------------------------------------------
 
 Jump::Jump(Score* s)
-    : TextBase(s, Tid::REPEAT_RIGHT, ElementFlag::MOVABLE | ElementFlag::SYSTEM)
+    : TextBase(ElementType::JUMP, s, Tid::REPEAT_RIGHT, ElementFlag::MOVABLE | ElementFlag::SYSTEM)
 {
     initElementStyle(&jumpStyle);
     setLayoutToParentWidth(true);

--- a/src/engraving/libmscore/jump.h
+++ b/src/engraving/libmscore/jump.h
@@ -62,7 +62,7 @@ public:
     QString jumpTypeUserName() const;
 
     Jump* clone() const override { return new Jump(*this); }
-    ElementType type() const override { return ElementType::JUMP; }
+
     int subtype() const override { return int(jumpType()); }
 
     Measure* measure() const { return toMeasure(parent()); }

--- a/src/engraving/libmscore/keysig.cpp
+++ b/src/engraving/libmscore/keysig.cpp
@@ -62,7 +62,7 @@ const char* keyNames[] = {
 //---------------------------------------------------------
 
 KeySig::KeySig(Score* s)
-    : Element(s, ElementFlag::ON_STAFF)
+    : Element(ElementType::KEYSIG, s, ElementFlag::ON_STAFF)
 {
     _showCourtesy = true;
     _hideNaturals = false;

--- a/src/engraving/libmscore/keysig.h
+++ b/src/engraving/libmscore/keysig.h
@@ -50,7 +50,7 @@ public:
 
     KeySig* clone() const override { return new KeySig(*this); }
     void draw(mu::draw::Painter*) const override;
-    ElementType type() const override { return ElementType::KEYSIG; }
+
     bool acceptDrop(EditData&) const override;
     Element* drop(EditData&) override;
     void layout() override;

--- a/src/engraving/libmscore/lasso.cpp
+++ b/src/engraving/libmscore/lasso.cpp
@@ -32,7 +32,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 Lasso::Lasso(Score* s)
-    : Element(s)
+    : Element(ElementType::LASSO, s)
 {
     setVisible(false);
 }

--- a/src/engraving/libmscore/lasso.h
+++ b/src/engraving/libmscore/lasso.h
@@ -40,7 +40,7 @@ public:
 
     Lasso(Score*);
     virtual Lasso* clone() const override { return new Lasso(*this); }
-    ElementType type() const final { return ElementType::LASSO; }
+
     virtual void draw(mu::draw::Painter*) const override;
     virtual bool isEditable() const override { return true; }
     virtual void editDrag(EditData&) override;

--- a/src/engraving/libmscore/layoutbreak.cpp
+++ b/src/engraving/libmscore/layoutbreak.cpp
@@ -41,7 +41,7 @@ static const ElementStyle sectionBreakStyle {
 //---------------------------------------------------------
 
 LayoutBreak::LayoutBreak(Score* score)
-    : Element(score, ElementFlag::SYSTEM | ElementFlag::HAS_TAG)
+    : Element(ElementType::LAYOUT_BREAK, score, ElementFlag::SYSTEM | ElementFlag::HAS_TAG)
 {
     _pause = 0.;
     _startWithLongNames = false;

--- a/src/engraving/libmscore/layoutbreak.h
+++ b/src/engraving/libmscore/layoutbreak.h
@@ -61,7 +61,6 @@ public:
     LayoutBreak(const LayoutBreak&);
 
     LayoutBreak* clone() const override { return new LayoutBreak(*this); }
-    ElementType type() const override { return ElementType::LAYOUT_BREAK; }
     int subtype() const override { return static_cast<int>(_layoutBreakType); }
 
     void setLayoutBreakType(Type);

--- a/src/engraving/libmscore/ledgerline.cpp
+++ b/src/engraving/libmscore/ledgerline.cpp
@@ -38,7 +38,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 LedgerLine::LedgerLine(Score* s)
-    : Element(s)
+    : Element(ElementType::LEDGER_LINE, s)
 {
     setSelectable(false);
     _width      = 0.;

--- a/src/engraving/libmscore/ledgerline.h
+++ b/src/engraving/libmscore/ledgerline.h
@@ -49,7 +49,7 @@ public:
     LedgerLine& operator=(const LedgerLine&) = delete;
 
     LedgerLine* clone() const override { return new LedgerLine(*this); }
-    ElementType type() const override { return ElementType::LEDGER_LINE; }
+
     mu::PointF pagePos() const override;        ///< position in page coordinates
     Chord* chord() const { return toChord(parent()); }
 

--- a/src/engraving/libmscore/letring.cpp
+++ b/src/engraving/libmscore/letring.cpp
@@ -68,7 +68,7 @@ void LetRingSegment::layout()
 //---------------------------------------------------------
 
 LetRing::LetRing(Score* s)
-    : TextLineBase(s)
+    : TextLineBase(ElementType::LET_RING, s)
 {
     initElementStyle(&letRingStyle);
     resetProperty(Pid::LINE_VISIBLE);

--- a/src/engraving/libmscore/letring.h
+++ b/src/engraving/libmscore/letring.h
@@ -36,9 +36,8 @@ class LetRingSegment final : public TextLineBaseSegment
 {
 public:
     LetRingSegment(Spanner* sp, Score* s)
-        : TextLineBaseSegment(sp, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF) { }
+        : TextLineBaseSegment(ElementType::LET_RING_SEGMENT, sp, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF) { }
 
-    ElementType type() const override { return ElementType::LET_RING_SEGMENT; }
     LetRingSegment* clone() const override { return new LetRingSegment(*this); }
 
     LetRing* letRing() const { return (LetRing*)spanner(); }
@@ -61,7 +60,6 @@ public:
     LetRing(Score* s);
 
     LetRing* clone() const override { return new LetRing(*this); }
-    ElementType type() const override { return ElementType::LET_RING; }
 
     void read(XmlReader&) override;
 //      virtual void write(XmlWriter& xml) const override;

--- a/src/engraving/libmscore/line.cpp
+++ b/src/engraving/libmscore/line.cpp
@@ -785,8 +785,8 @@ RectF LineSegment::drag(EditData& ed)
 //   SLine
 //---------------------------------------------------------
 
-SLine::SLine(Score* s, ElementFlags f)
-    : Spanner(s, f)
+SLine::SLine(const ElementType& type, Score* s, ElementFlags f)
+    : Spanner(type, s, f)
 {
     setTrack(0);
     _lineWidth = 0.15 * spatium();

--- a/src/engraving/libmscore/line.h
+++ b/src/engraving/libmscore/line.h
@@ -51,10 +51,10 @@ protected:
     void startDrag(EditData&) override;
 
 public:
-    LineSegment(Spanner* sp, Score* s, ElementFlags f = ElementFlag::NOTHING)
-        : SpannerSegment(sp, s, f) {}
-    LineSegment(Score* s, ElementFlags f = ElementFlag::NOTHING)
-        : SpannerSegment(s, f) {}
+    LineSegment(const ElementType& type, Spanner* sp, Score* s, ElementFlags f = ElementFlag::NOTHING)
+        : SpannerSegment(type, sp, s, f) {}
+    LineSegment(const ElementType& type, Score* s, ElementFlags f = ElementFlag::NOTHING)
+        : SpannerSegment(type, s, f) {}
     LineSegment(const LineSegment&);
     SLine* line() const { return (SLine*)spanner(); }
     virtual void spatiumChanged(qreal, qreal) override;
@@ -104,7 +104,7 @@ protected:
     virtual mu::PointF linePos(Grip, System** system) const;
 
 public:
-    SLine(Score* s, ElementFlags = ElementFlag::NOTHING);
+    SLine(const ElementType& type, Score* s, ElementFlags = ElementFlag::NOTHING);
     SLine(const SLine&);
 
     virtual void layout() override;

--- a/src/engraving/libmscore/lyrics.cpp
+++ b/src/engraving/libmscore/lyrics.cpp
@@ -52,7 +52,7 @@ static const ElementStyle lyricsElementStyle {
 //---------------------------------------------------------
 
 Lyrics::Lyrics(Score* s)
-    : TextBase(s, Tid::LYRICS_ODD)
+    : TextBase(ElementType::LYRICS, s, Tid::LYRICS_ODD)
 {
     _even       = false;
     initElementStyle(&lyricsElementStyle);

--- a/src/engraving/libmscore/lyrics.h
+++ b/src/engraving/libmscore/lyrics.h
@@ -74,7 +74,6 @@ public:
     ~Lyrics();
 
     Lyrics* clone() const override { return new Lyrics(*this); }
-    ElementType type() const override { return ElementType::LYRICS; }
     bool acceptDrop(EditData&) const override;
     Element* drop(EditData&) override;
 
@@ -128,7 +127,6 @@ public:
     LyricsLine(const LyricsLine&);
 
     LyricsLine* clone() const override { return new LyricsLine(*this); }
-    ElementType type() const override { return ElementType::LYRICSLINE; }
     void layout() override;
     LineSegment* createLineSegment() override;
     void removeUnmanaged() override;
@@ -157,7 +155,6 @@ public:
     LyricsLineSegment(Spanner*, Score*);
 
     LyricsLineSegment* clone() const override { return new LyricsLineSegment(*this); }
-    ElementType type() const override { return ElementType::LYRICSLINE_SEGMENT; }
     void draw(mu::draw::Painter*) const override;
     void layout() override;
     // helper functions

--- a/src/engraving/libmscore/lyricsline.cpp
+++ b/src/engraving/libmscore/lyricsline.cpp
@@ -70,7 +70,7 @@ static Lyrics* searchNextLyrics(Segment* s, int staffIdx, int verse, Placement p
 //---------------------------------------------------------
 
 LyricsLine::LyricsLine(Score* s)
-    : SLine(s, ElementFlag::NOT_SELECTABLE)
+    : SLine(ElementType::LYRICSLINE, s, ElementFlag::NOT_SELECTABLE)
 {
     setGenerated(true);             // no need to save it, as it can be re-generated
     setDiagonal(false);
@@ -335,7 +335,7 @@ bool LyricsLine::setProperty(Pid propertyId, const QVariant& v)
 //=========================================================
 
 LyricsLineSegment::LyricsLineSegment(Spanner* sp, Score* s)
-    : LineSegment(sp, s, ElementFlag::ON_STAFF | ElementFlag::NOT_SELECTABLE)
+    : LineSegment(ElementType::LYRICSLINE_SEGMENT, sp, s, ElementFlag::ON_STAFF | ElementFlag::NOT_SELECTABLE)
 {
     setGenerated(true);
 }

--- a/src/engraving/libmscore/marker.cpp
+++ b/src/engraving/libmscore/marker.cpp
@@ -68,7 +68,7 @@ Marker::Marker(Score* s)
 }
 
 Marker::Marker(Score* s, Tid tid)
-    : TextBase(s, tid, ElementFlag::MOVABLE | ElementFlag::ON_STAFF | ElementFlag::SYSTEM)
+    : TextBase(ElementType::MARKER, s, tid, ElementFlag::MOVABLE | ElementFlag::ON_STAFF | ElementFlag::SYSTEM)
 {
     initElementStyle(&markerStyle);
     _markerType = Type::FINE;

--- a/src/engraving/libmscore/marker.h
+++ b/src/engraving/libmscore/marker.h
@@ -62,7 +62,7 @@ public:
     Type markerType(const QString&) const;
 
     Marker* clone() const override { return new Marker(*this); }
-    ElementType type() const override { return ElementType::MARKER; }
+
     int subtype() const override { return int(_markerType); }
 
     Measure* measure() const { return (Measure*)parent(); }

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -181,7 +181,7 @@ void MStaff::setTrack(int track)
 //---------------------------------------------------------
 
 Measure::Measure(Score* s)
-    : MeasureBase(s), m_timesig(4, 4)
+    : MeasureBase(ElementType::MEASURE, s), m_timesig(4, 4)
 {
     setTicks(Fraction(4, 4));
     m_repeatCount = 2;

--- a/src/engraving/libmscore/measure.h
+++ b/src/engraving/libmscore/measure.h
@@ -141,7 +141,6 @@ public:
     ~Measure();
 
     Measure* clone() const override { return new Measure(*this); }
-    ElementType type() const override { return ElementType::MEASURE; }
     void setScore(Score* s) override;
     Measure* cloneMeasure(Score*, const Fraction& tick, TieMap*);
 

--- a/src/engraving/libmscore/measurebase.cpp
+++ b/src/engraving/libmscore/measurebase.cpp
@@ -41,8 +41,8 @@ namespace Ms {
 //   MeasureBase
 //---------------------------------------------------------
 
-MeasureBase::MeasureBase(Score* score)
-    : Element(score)
+MeasureBase::MeasureBase(const ElementType& type, Score* score)
+    : Element(type, score)
 {
     setIrregular(true);
 }

--- a/src/engraving/libmscore/measurebase.h
+++ b/src/engraving/libmscore/measurebase.h
@@ -87,7 +87,7 @@ protected:
     void cleanupLayoutBreaks(bool undo);
 
 public:
-    MeasureBase(Score* score = 0);
+    MeasureBase(const ElementType& type, Score* score = 0);
     ~MeasureBase();
     MeasureBase(const MeasureBase&);
 

--- a/src/engraving/libmscore/measurenumber.cpp
+++ b/src/engraving/libmscore/measurenumber.cpp
@@ -41,7 +41,7 @@ static const ElementStyle measureNumberStyle {
 //---------------------------------------------------------
 
 MeasureNumber::MeasureNumber(Score* s, Tid tid)
-    : MeasureNumberBase(s, tid)
+    : MeasureNumberBase(ElementType::MEASURE_NUMBER, s, tid)
 {
     initElementStyle(&measureNumberStyle);
 

--- a/src/engraving/libmscore/measurenumber.h
+++ b/src/engraving/libmscore/measurenumber.h
@@ -36,7 +36,6 @@ public:
     MeasureNumber(Score* = nullptr, Tid tid = Tid::MEASURE_NUMBER);
     MeasureNumber(const MeasureNumber& other);
 
-    virtual ElementType type() const override { return ElementType::MEASURE_NUMBER; }
     virtual MeasureNumber* clone() const override { return new MeasureNumber(*this); }
 
     virtual QVariant propertyDefault(Pid id) const override;

--- a/src/engraving/libmscore/measurenumberbase.cpp
+++ b/src/engraving/libmscore/measurenumberbase.cpp
@@ -33,8 +33,8 @@ namespace Ms {
 //   MeasureNumberBase
 //---------------------------------------------------------
 
-MeasureNumberBase::MeasureNumberBase(Score* s, Tid tid)
-    : TextBase(s, tid)
+MeasureNumberBase::MeasureNumberBase(const ElementType& type, Score* s, Tid tid)
+    : TextBase(type, s, tid)
 {
     setFlag(ElementFlag::ON_STAFF, true);
 }

--- a/src/engraving/libmscore/measurenumberbase.h
+++ b/src/engraving/libmscore/measurenumberbase.h
@@ -37,7 +37,7 @@ class MeasureNumberBase : public TextBase
     M_PROPERTY(HPlacement, hPlacement, setHPlacement)    // Horizontal Placement
 
 public:
-    MeasureNumberBase(Score* = nullptr, Tid = Tid::DEFAULT);
+    MeasureNumberBase(const ElementType& type, Score* = nullptr, Tid = Tid::DEFAULT);
     MeasureNumberBase(const MeasureNumberBase& other);
 
     virtual QVariant getProperty(Pid id) const override;

--- a/src/engraving/libmscore/measurerepeat.cpp
+++ b/src/engraving/libmscore/measurerepeat.cpp
@@ -43,7 +43,7 @@ static const ElementStyle measureRepeatStyle {
 //---------------------------------------------------------
 
 MeasureRepeat::MeasureRepeat(Score* score)
-    : Rest(score), m_numMeasures(0), m_symId(SymId::noSym)
+    : Rest(ElementType::MEASURE_REPEAT, score), m_numMeasures(0), m_symId(SymId::noSym)
 {
     // however many measures the group, the element itself is always exactly the duration of its containing measure
     setDurationType(TDuration::DurationType::V_MEASURE);

--- a/src/engraving/libmscore/measurerepeat.h
+++ b/src/engraving/libmscore/measurerepeat.h
@@ -43,7 +43,6 @@ public:
 
     MeasureRepeat* clone() const override { return new MeasureRepeat(*this); }
     Element* linkedClone() override { return Element::linkedClone(); }
-    ElementType type() const override { return ElementType::MEASURE_REPEAT; }
 
     void setNumMeasures(int n) { m_numMeasures = n; }
     int numMeasures() const { return m_numMeasures; }

--- a/src/engraving/libmscore/mmrest.cpp
+++ b/src/engraving/libmscore/mmrest.cpp
@@ -43,7 +43,7 @@ static const ElementStyle mmRestStyle {
 //--------------------------------------------------------
 
 MMRest::MMRest(Score* s)
-    : Rest(s)
+    : Rest(ElementType::MMREST, s)
 {
     m_width = 0;
     m_symsWidth = 0;

--- a/src/engraving/libmscore/mmrest.h
+++ b/src/engraving/libmscore/mmrest.h
@@ -40,8 +40,6 @@ public:
     {
     }
 
-    ElementType type() const override { return ElementType::MMREST; }
-
     MMRest* clone() const override { return new MMRest(*this, false); }
     Element* linkedClone() override { return new MMRest(*this, true); }
 

--- a/src/engraving/libmscore/mmrestrange.cpp
+++ b/src/engraving/libmscore/mmrestrange.cpp
@@ -39,7 +39,7 @@ static const ElementStyle mmRestRangeStyle {
 };
 
 MMRestRange::MMRestRange(Score* s)
-    : MeasureNumberBase(s, Tid::MMREST_RANGE)
+    : MeasureNumberBase(ElementType::MMREST_RANGE, s, Tid::MMREST_RANGE)
 {
     initElementStyle(&mmRestRangeStyle);
 }

--- a/src/engraving/libmscore/mmrestrange.h
+++ b/src/engraving/libmscore/mmrestrange.h
@@ -40,7 +40,6 @@ public:
     MMRestRange(Score* s = nullptr);
     MMRestRange(const MMRestRange& other);
 
-    virtual ElementType type()   const override { return ElementType::MMREST_RANGE; }
     virtual MMRestRange* clone() const override { return new MMRestRange(*this); }
 
     virtual QVariant getProperty(Pid id) const override;

--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -687,7 +687,7 @@ NoteHead::Group NoteHead::headGroup() const
 //---------------------------------------------------------
 
 Note::Note(Score* s)
-    : Element(s, ElementFlag::MOVABLE
+    : Element(ElementType::NOTE, s, ElementFlag::MOVABLE
 #ifdef ENGRAVING_BUILD_ACCESSIBLE_TREE
               , new mu::engraving::AccessibleNote())
 #else

--- a/src/engraving/libmscore/note.h
+++ b/src/engraving/libmscore/note.h
@@ -172,10 +172,9 @@ public:
     Q_ENUM(Type);
 
     NoteHead(Score* s = 0)
-        : Symbol(s) {}
+        : Symbol(ElementType::NOTEHEAD, s) {}
     NoteHead& operator=(const NoteHead&) = delete;
     NoteHead* clone() const override { return new NoteHead(*this); }
-    ElementType type() const override { return ElementType::NOTEHEAD; }
 
     Group headGroup() const;
 
@@ -342,7 +341,6 @@ public:
 
     Note& operator=(const Note&) = delete;
     virtual Note* clone() const override { return new Note(*this, false); }
-    ElementType type() const override { return ElementType::NOTE; }
 
     void undoUnlink() override;
 

--- a/src/engraving/libmscore/notedot.cpp
+++ b/src/engraving/libmscore/notedot.cpp
@@ -35,7 +35,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 NoteDot::NoteDot(Score* s)
-    : Element(s)
+    : Element(ElementType::NOTEDOT, s)
 {
     setFlag(ElementFlag::MOVABLE, false);
 }

--- a/src/engraving/libmscore/notedot.h
+++ b/src/engraving/libmscore/notedot.h
@@ -39,7 +39,6 @@ public:
     NoteDot(Score* = 0);
 
     NoteDot* clone() const override { return new NoteDot(*this); }
-    ElementType type() const override { return ElementType::NOTEDOT; }
     qreal mag() const override;
 
     void draw(mu::draw::Painter*) const override;

--- a/src/engraving/libmscore/noteline.cpp
+++ b/src/engraving/libmscore/noteline.cpp
@@ -25,7 +25,7 @@
 
 namespace Ms {
 NoteLine::NoteLine(Score* s)
-    : TextLineBase(s)
+    : TextLineBase(ElementType::NOTELINE, s)
 {
 //TODO-ws      init();
 }

--- a/src/engraving/libmscore/noteline.h
+++ b/src/engraving/libmscore/noteline.h
@@ -43,7 +43,6 @@ public:
     ~NoteLine() {}
 
     NoteLine* clone() const override { return new NoteLine(*this); }
-    ElementType type() const override { return ElementType::NOTELINE; }
 
     void setStartNote(Note* n) { _startNote = n; }
     Note* startNote() const { return _startNote; }

--- a/src/engraving/libmscore/ossia.cpp
+++ b/src/engraving/libmscore/ossia.cpp
@@ -28,7 +28,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 Ossia::Ossia(Score* score)
-    : Element(score)
+    : Element(ElementType::OSSIA, score)
 {
 }
 

--- a/src/engraving/libmscore/ossia.h
+++ b/src/engraving/libmscore/ossia.h
@@ -38,7 +38,6 @@ public:
     Ossia(const Ossia&);
 
     Ossia* clone() const override { return new Ossia(*this); }
-    ElementType type() const override { return ElementType::OSSIA; }
 };
 }     // namespace Ms
 #endif

--- a/src/engraving/libmscore/ottava.cpp
+++ b/src/engraving/libmscore/ottava.cpp
@@ -220,7 +220,7 @@ Sid Ottava::getPropertyStyle(Pid pid) const
 //---------------------------------------------------------
 
 Ottava::Ottava(Score* s)
-    : TextLineBase(s, ElementFlag::ON_STAFF | ElementFlag::MOVABLE)
+    : TextLineBase(ElementType::OTTAVA, s, ElementFlag::ON_STAFF | ElementFlag::MOVABLE)
 {
     _ottavaType  = OttavaType::OTTAVA_8VA;
     _numbersOnly = false;

--- a/src/engraving/libmscore/ottava.h
+++ b/src/engraving/libmscore/ottava.h
@@ -83,9 +83,8 @@ class OttavaSegment final : public TextLineBaseSegment
 
 public:
     OttavaSegment(Spanner* sp, Score* s)
-        : TextLineBaseSegment(sp, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF) { }
+        : TextLineBaseSegment(ElementType::OTTAVA_SEGMENT, sp, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF) { }
 
-    ElementType type() const override { return ElementType::OTTAVA_SEGMENT; }
     OttavaSegment* clone() const override { return new OttavaSegment(*this); }
     Ottava* ottava() const { return (Ottava*)spanner(); }
     void layout() override;
@@ -114,7 +113,6 @@ public:
     Ottava(const Ottava&);
 
     Ottava* clone() const override { return new Ottava(*this); }
-    ElementType type() const override { return ElementType::OTTAVA; }
 
     void setOttavaType(OttavaType val);
     OttavaType ottavaType() const { return _ottavaType; }

--- a/src/engraving/libmscore/page.cpp
+++ b/src/engraving/libmscore/page.cpp
@@ -58,7 +58,7 @@ static QString revision;
 //---------------------------------------------------------
 
 Page::Page(Score* s)
-    : Element(s, ElementFlag::NOT_SELECTABLE), _no(0)
+    : Element(ElementType::PAGE, s, ElementFlag::NOT_SELECTABLE), _no(0)
 {
     bspTreeValid = false;
 }

--- a/src/engraving/libmscore/page.h
+++ b/src/engraving/libmscore/page.h
@@ -63,7 +63,6 @@ public:
     int treeChildCount() const override;
 
     Page* clone() const override { return new Page(*this); }
-    ElementType type() const override { return ElementType::PAGE; }
     const QList<System*>& systems() const { return _systems; }
     QList<System*>& systems() { return _systems; }
     System* system(int idx) { return _systems[idx]; }

--- a/src/engraving/libmscore/palmmute.cpp
+++ b/src/engraving/libmscore/palmmute.cpp
@@ -89,7 +89,7 @@ Sid PalmMute::getPropertyStyle(Pid pid) const
 //---------------------------------------------------------
 
 PalmMute::PalmMute(Score* s)
-    : TextLineBase(s)
+    : TextLineBase(ElementType::PALM_MUTE, s)
 {
     initElementStyle(&palmMuteStyle);
     resetProperty(Pid::LINE_VISIBLE);

--- a/src/engraving/libmscore/palmmute.h
+++ b/src/engraving/libmscore/palmmute.h
@@ -38,9 +38,8 @@ class PalmMuteSegment final : public TextLineBaseSegment
 
 public:
     PalmMuteSegment(Spanner* sp, Score* s)
-        : TextLineBaseSegment(sp, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF) { }
+        : TextLineBaseSegment(ElementType::PALM_MUTE_SEGMENT, sp, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF) { }
 
-    ElementType type() const override { return ElementType::PALM_MUTE_SEGMENT; }
     PalmMuteSegment* clone() const override { return new PalmMuteSegment(*this); }
 
     PalmMute* palmMute() const { return (PalmMute*)spanner(); }
@@ -65,7 +64,6 @@ public:
     PalmMute(Score* s);
 
     PalmMute* clone() const override { return new PalmMute(*this); }
-    ElementType type() const override { return ElementType::PALM_MUTE; }
 
     void read(XmlReader&) override;
 //      virtual void write(XmlWriter& xml) const override;

--- a/src/engraving/libmscore/part.cpp
+++ b/src/engraving/libmscore/part.cpp
@@ -46,7 +46,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 Part::Part(Score* s)
-    : ScoreElement(s)
+    : ScoreElement(ElementType::PART, s)
 {
     _color   = DEFAULT_COLOR;
     _show    = true;

--- a/src/engraving/libmscore/part.h
+++ b/src/engraving/libmscore/part.h
@@ -90,8 +90,6 @@ public:
 
     Part* clone() const;
 
-    ElementType type() const override { return ElementType::PART; }
-
     void read(XmlReader&);
     bool readProperties(XmlReader&);
     void write(XmlWriter& xml) const;

--- a/src/engraving/libmscore/pedal.cpp
+++ b/src/engraving/libmscore/pedal.cpp
@@ -93,7 +93,7 @@ Sid Pedal::getPropertyStyle(Pid pid) const
 //---------------------------------------------------------
 
 Pedal::Pedal(Score* s)
-    : TextLineBase(s)
+    : TextLineBase(ElementType::PEDAL, s)
 {
     initElementStyle(&pedalStyle);
     setLineVisible(true);

--- a/src/engraving/libmscore/pedal.h
+++ b/src/engraving/libmscore/pedal.h
@@ -38,9 +38,8 @@ class PedalSegment final : public TextLineBaseSegment
 
 public:
     PedalSegment(Spanner* sp, Score* s)
-        : TextLineBaseSegment(sp, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF) {}
+        : TextLineBaseSegment(ElementType::PEDAL_SEGMENT, sp, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF) {}
 
-    ElementType type() const override { return ElementType::PEDAL_SEGMENT; }
     PedalSegment* clone() const override { return new PedalSegment(*this); }
     Pedal* pedal() const { return toPedal(spanner()); }
     void layout() override;
@@ -63,7 +62,6 @@ public:
     Pedal(Score* s);
 
     Pedal* clone() const override { return new Pedal(*this); }
-    ElementType type() const override { return ElementType::PEDAL; }
 
     void read(XmlReader&) override;
     void write(XmlWriter& xml) const override;

--- a/src/engraving/libmscore/range.cpp
+++ b/src/engraving/libmscore/range.cpp
@@ -292,6 +292,10 @@ void TrackList::read(const Segment* fs, const Segment* es)
             // TODO: copy previous measure contents?
             MeasureRepeat* rm = toMeasureRepeat(e);
             Rest r(*rm);
+            //! TODO Perhaps there is a bug.
+            //! Previously, the element changed its type (because there was a virtual method that returned the type).
+            //! This code has been added for compatibility reasons to maintain the same behavior.
+            r.hack_toRestType();
             r.reset();
             append(&r);
             tick += r.ticks();

--- a/src/engraving/libmscore/rehearsalmark.cpp
+++ b/src/engraving/libmscore/rehearsalmark.cpp
@@ -42,7 +42,7 @@ static const ElementStyle rehearsalMarkStyle {
 //---------------------------------------------------------
 
 RehearsalMark::RehearsalMark(Score* s)
-    : TextBase(s, Tid::REHEARSAL_MARK)
+    : TextBase(ElementType::REHEARSAL_MARK, s, Tid::REHEARSAL_MARK)
 {
     initElementStyle(&rehearsalMarkStyle);
     setSystemFlag(true);

--- a/src/engraving/libmscore/rehearsalmark.h
+++ b/src/engraving/libmscore/rehearsalmark.h
@@ -36,7 +36,7 @@ public:
     RehearsalMark(Score* score);
 
     RehearsalMark* clone() const override { return new RehearsalMark(*this); }
-    ElementType type() const override { return ElementType::REHEARSAL_MARK; }
+
     Segment* segment() const { return (Segment*)parent(); }
     void layout() override;
     QVariant propertyDefault(Pid id) const override;

--- a/src/engraving/libmscore/rest.cpp
+++ b/src/engraving/libmscore/rest.cpp
@@ -53,14 +53,24 @@ namespace Ms {
 //--------------------------------------------------------
 
 Rest::Rest(Score* s)
-    : ChordRest(s)
+    : Rest(ElementType::REST, s)
+{
+}
+
+Rest::Rest(const ElementType& type, Score* s)
+    : ChordRest(type, s)
 {
     _beamMode  = Beam::Mode::NONE;
     m_sym      = SymId::restQuarter;
 }
 
 Rest::Rest(Score* s, const TDuration& d)
-    : ChordRest(s)
+    : Rest(ElementType::REST, s, d)
+{
+}
+
+Rest::Rest(const ElementType& type, Score* s, const TDuration& d)
+    : ChordRest(type, s)
 {
     _beamMode  = Beam::Mode::NONE;
     m_sym      = SymId::restQuarter;
@@ -83,6 +93,11 @@ Rest::Rest(const Rest& r, bool link)
     for (NoteDot* dot : r.m_dots) {
         add(new NoteDot(*dot));
     }
+}
+
+void Rest::hack_toRestType()
+{
+    hack_setType(ElementType::REST);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/rest.h
+++ b/src/engraving/libmscore/rest.h
@@ -39,16 +39,19 @@ class Rest : public ChordRest
 {
 public:
     Rest(Score* s = 0);
+    Rest(const ElementType& type, Score* s = 0);
     Rest(Score*, const TDuration&);
+    Rest(const ElementType& type, Score*, const TDuration&);
     Rest(const Rest&, bool link = false);
     ~Rest() { qDeleteAll(m_dots); }
+
+    void hack_toRestType();
 
     // Score Tree functions
     ScoreElement* treeParent() const override;
     ScoreElement* treeChild(int idx) const override;
     int treeChildCount() const override;
 
-    virtual ElementType type() const override { return ElementType::REST; }
     Rest& operator=(const Rest&) = delete;
 
     Rest* clone() const override { return new Rest(*this, false); }

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -310,7 +310,8 @@ void MeasureBaseList::fixupSystems()
 //---------------------------------------------------------
 
 Score::Score()
-    : ScoreElement(this), _headersText(MAX_HEADERS, nullptr), _footersText(MAX_FOOTERS, nullptr), _selection(this), m_layout(this)
+    : ScoreElement(ElementType::SCORE, this), _headersText(MAX_HEADERS, nullptr), _footersText(MAX_FOOTERS, nullptr), _selection(this),
+    m_layout(this)
 {
     Score::validScores.insert(this);
     _masterScore = 0;

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -603,8 +603,6 @@ public:
     int treeChildCount() const override;
     void dumpScoreTree();  // for debugging purposes
 
-    virtual ElementType type() const override { return ElementType::SCORE; }
-
     void rebuildBspTree();
     bool noStaves() const { return _staves.empty(); }
     void insertPart(Part*, int);

--- a/src/engraving/libmscore/scoreElement.cpp
+++ b/src/engraving/libmscore/scoreElement.cpp
@@ -159,8 +159,8 @@ static const ElementName elementNames[] = {
 //   ScoreElement
 //---------------------------------------------------------
 
-ScoreElement::ScoreElement(Score* s)
-    : _score(s)
+ScoreElement::ScoreElement(const ElementType& type, Score* s)
+    : m_type(type), _score(s)
 {
     if (elementsProvider()) {
         elementsProvider()->reg(this);
@@ -169,7 +169,8 @@ ScoreElement::ScoreElement(Score* s)
 
 ScoreElement::ScoreElement(const ScoreElement& se)
 {
-    _score        = se._score;
+    m_type = se.m_type;
+    _score = se._score;
     _elementStyle = se._elementStyle;
     if (_elementStyle) {
         size_t n = _elementStyle->size();

--- a/src/engraving/libmscore/scoreElement.h
+++ b/src/engraving/libmscore/scoreElement.h
@@ -191,6 +191,7 @@ class ScoreElement
 {
     INJECT_STATIC(engraving, mu::diagnostics::IEngravingElementsProvider, elementsProvider)
 
+    ElementType m_type = ElementType::INVALID;
     Score* _score;
     static ElementStyle const emptyStyle;
 
@@ -200,11 +201,16 @@ protected:
     LinkedElements* _links            { 0 };
     virtual int getPropertyFlagsIdx(Pid id) const;
 
+    //! NOTE For compatibility reasons, hope, we will remove the need for this method.
+    void hack_setType(const ElementType& t) { m_type = t; }
+
 public:
-    ScoreElement(Score* s);
+    ScoreElement(const ElementType& type, Score* s);
     ScoreElement(const ScoreElement& se);
 
     virtual ~ScoreElement();
+
+    inline ElementType type() const { return m_type; }
 
     // Score Tree functions
     virtual ScoreElement* treeParent() const { return nullptr; }
@@ -248,7 +254,6 @@ public:
     virtual void setScore(Score* s) { _score = s; }
     const char* name() const;
     virtual QString userName() const;
-    virtual ElementType type() const = 0;
 
     static ElementType name2type(const QStringRef&, bool silent = false);
     static ElementType name2type(const QString& s) { return name2type(QStringRef(&s)); }

--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -126,14 +126,14 @@ void Segment::removeElement(int track)
 //---------------------------------------------------------
 
 Segment::Segment(Measure* m)
-    : Element(m->score(), ElementFlag::EMPTY | ElementFlag::ENABLED | ElementFlag::NOT_SELECTABLE)
+    : Element(ElementType::SEGMENT, m->score(), ElementFlag::EMPTY | ElementFlag::ENABLED | ElementFlag::NOT_SELECTABLE)
 {
     setParent(m);
     init();
 }
 
 Segment::Segment(Measure* m, SegmentType st, const Fraction& t)
-    : Element(m->score(), ElementFlag::EMPTY | ElementFlag::ENABLED | ElementFlag::NOT_SELECTABLE)
+    : Element(ElementType::SEGMENT, m->score(), ElementFlag::EMPTY | ElementFlag::ENABLED | ElementFlag::NOT_SELECTABLE)
 {
     setParent(m);
 //      Q_ASSERT(t >= Fraction(0,1));

--- a/src/engraving/libmscore/segment.h
+++ b/src/engraving/libmscore/segment.h
@@ -92,7 +92,6 @@ public:
     int treeChildCount() const override;
 
     Segment* clone() const override { return new Segment(*this); }
-    ElementType type() const override { return ElementType::SEGMENT; }
 
     void setScore(Score*) override;
 

--- a/src/engraving/libmscore/shadownote.cpp
+++ b/src/engraving/libmscore/shadownote.cpp
@@ -38,7 +38,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 ShadowNote::ShadowNote(Score* s)
-    : Element(s), m_noteheadSymbol(SymId::noSym)
+    : Element(ElementType::SHADOW_NOTE, s), m_noteheadSymbol(SymId::noSym)
 {
     m_lineIndex = 1000;
     m_duration = TDuration(TDuration::DurationType::V_INVALID);

--- a/src/engraving/libmscore/shadownote.h
+++ b/src/engraving/libmscore/shadownote.h
@@ -56,7 +56,6 @@ public:
     ShadowNote(Score*);
 
     ShadowNote* clone() const override { return new ShadowNote(*this); }
-    ElementType type() const override { return ElementType::SHADOW_NOTE; }
 
     bool isValid() const;
 

--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -960,7 +960,7 @@ void Slur::slurPos(SlurPos* sp)
 //---------------------------------------------------------
 
 Slur::Slur(Score* s)
-    : SlurTie(s)
+    : SlurTie(ElementType::SLUR, s)
 {
     setAnchor(Anchor::CHORD);
 }

--- a/src/engraving/libmscore/slur.h
+++ b/src/engraving/libmscore/slur.h
@@ -39,12 +39,11 @@ protected:
 
 public:
     SlurSegment(Score* s)
-        : SlurTieSegment(s) {}
+        : SlurTieSegment(ElementType::SLUR_SEGMENT, s) {}
     SlurSegment(const SlurSegment& ss)
         : SlurTieSegment(ss) {}
 
     SlurSegment* clone() const override { return new SlurSegment(*this); }
-    ElementType type() const override { return ElementType::SLUR_SEGMENT; }
     int subtype() const override { return static_cast<int>(spanner()->type()); }
     void draw(mu::draw::Painter*) const override;
 
@@ -73,7 +72,7 @@ public:
     ~Slur() {}
 
     Slur* clone() const override { return new Slur(*this); }
-    ElementType type() const override { return ElementType::SLUR; }
+
     void write(XmlWriter& xml) const override;
     bool readProperties(XmlReader&) override;
     void layout() override;

--- a/src/engraving/libmscore/slurtie.cpp
+++ b/src/engraving/libmscore/slurtie.cpp
@@ -41,8 +41,8 @@ namespace Ms {
 //   SlurTieSegment
 //---------------------------------------------------------
 
-SlurTieSegment::SlurTieSegment(Score* score)
-    : SpannerSegment(score)
+SlurTieSegment::SlurTieSegment(const ElementType& type, Score* score)
+    : SpannerSegment(type, score)
 {
     setFlag(ElementFlag::ON_STAFF, true);
 }
@@ -423,8 +423,8 @@ void SlurTieSegment::drawEditMode(mu::draw::Painter* p, EditData& ed)
 //   SlurTie
 //---------------------------------------------------------
 
-SlurTie::SlurTie(Score* s)
-    : Spanner(s)
+SlurTie::SlurTie(const ElementType& type, Score* s)
+    : Spanner(type, s)
 {
     _slurDirection = Direction::AUTO;
     _up            = true;

--- a/src/engraving/libmscore/slurtie.h
+++ b/src/engraving/libmscore/slurtie.h
@@ -101,7 +101,7 @@ protected:
     QVector<mu::LineF> gripAnchorLines(Grip grip) const override;
 
 public:
-    SlurTieSegment(Score*);
+    SlurTieSegment(const ElementType& type, Score*);
     SlurTieSegment(const SlurTieSegment&);
     virtual void spatiumChanged(qreal, qreal) override;
     SlurTie* slurTie() const { return (SlurTie*)spanner(); }
@@ -152,7 +152,7 @@ protected:
     void fixupSegments(unsigned nsegs);
 
 public:
-    SlurTie(Score*);
+    SlurTie(const ElementType& type, Score*);
     SlurTie(const SlurTie&);
     ~SlurTie();
 

--- a/src/engraving/libmscore/spacer.cpp
+++ b/src/engraving/libmscore/spacer.cpp
@@ -36,7 +36,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 Spacer::Spacer(Score* score)
-    : Element(score)
+    : Element(ElementType::SPACER, score)
 {
     _spacerType = SpacerType::UP;
     _gap = 0.0;

--- a/src/engraving/libmscore/spacer.h
+++ b/src/engraving/libmscore/spacer.h
@@ -54,7 +54,6 @@ public:
     Spacer(const Spacer&);
 
     Spacer* clone() const override { return new Spacer(*this); }
-    ElementType type() const override { return ElementType::SPACER; }
     Measure* measure() const { return toMeasure(parent()); }
 
     SpacerType spacerType() const { return _spacerType; }

--- a/src/engraving/libmscore/spanner.cpp
+++ b/src/engraving/libmscore/spanner.cpp
@@ -57,15 +57,15 @@ public:
 //   SpannerSegment
 //---------------------------------------------------------
 
-SpannerSegment::SpannerSegment(Spanner* sp, Score* s, ElementFlags f)
-    : Element(s, f)
+SpannerSegment::SpannerSegment(const ElementType& type, Spanner* sp, Score* s, ElementFlags f)
+    : Element(type, s, f)
 {
     _spanner = sp;
     setSpannerSegmentType(SpannerSegmentType::SINGLE);
 }
 
-SpannerSegment::SpannerSegment(Score* s, ElementFlags f)
-    : Element(s, f)
+SpannerSegment::SpannerSegment(const ElementType& type, Score* s, ElementFlags f)
+    : Element(type, s, f)
 {
     setSpannerSegmentType(SpannerSegmentType::SINGLE);
     _spanner = 0;
@@ -373,8 +373,8 @@ void SpannerSegment::scanElements(void* data, void (* func)(void*, Element*), bo
 //   Spanner
 //---------------------------------------------------------
 
-Spanner::Spanner(Score* s, ElementFlags f)
-    : Element(s, f)
+Spanner::Spanner(const ElementType& type, Score* s, ElementFlags f)
+    : Element(type, s, f)
 {
 }
 

--- a/src/engraving/libmscore/spanner.h
+++ b/src/engraving/libmscore/spanner.h
@@ -54,8 +54,8 @@ protected:
     mu::PointF _offset2;
 
 public:
-    SpannerSegment(Spanner*, Score*, ElementFlags f = ElementFlag::ON_STAFF | ElementFlag::MOVABLE);
-    SpannerSegment(Score* s, ElementFlags f = ElementFlag::ON_STAFF | ElementFlag::MOVABLE);
+    SpannerSegment(const ElementType& type, Spanner*, Score*, ElementFlags f = ElementFlag::ON_STAFF | ElementFlag::MOVABLE);
+    SpannerSegment(const ElementType& type, Score* s, ElementFlags f = ElementFlag::ON_STAFF | ElementFlag::MOVABLE);
     SpannerSegment(const SpannerSegment&);
 
     // Score Tree functions
@@ -175,7 +175,7 @@ protected:
     const std::vector<SpannerSegment*> spannerSegments() const { return segments; }
 
 public:
-    Spanner(Score* s, ElementFlags = ElementFlag::NOTHING);
+    Spanner(const ElementType& type, Score* s, ElementFlags = ElementFlag::NOTHING);
     Spanner(const Spanner&);
     ~Spanner();
 

--- a/src/engraving/libmscore/staff.cpp
+++ b/src/engraving/libmscore/staff.cpp
@@ -61,7 +61,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 Staff::Staff(Score* score)
-    : Element(score)
+    : Element(ElementType::STAFF, score)
 {
     initFromStaffType(0);
 }

--- a/src/engraving/libmscore/staff.h
+++ b/src/engraving/libmscore/staff.h
@@ -130,8 +130,6 @@ public:
     ID id() const;
     void setId(const ID& id);
 
-    ElementType type() const override { return ElementType::STAFF; }
-
     void setScore(Score* score) override;
 
     bool isTop() const;

--- a/src/engraving/libmscore/stafflines.cpp
+++ b/src/engraving/libmscore/stafflines.cpp
@@ -49,7 +49,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 StaffLines::StaffLines(Score* s)
-    : Element(s)
+    : Element(ElementType::STAFF_LINES, s)
 {
     setSelectable(false);
 }

--- a/src/engraving/libmscore/stafflines.h
+++ b/src/engraving/libmscore/stafflines.h
@@ -43,7 +43,7 @@ public:
     StaffLines(Score*);
 
     StaffLines* clone() const override { return new StaffLines(*this); }
-    ElementType type() const override { return ElementType::STAFF_LINES; }
+
     void layout() override;
     void draw(mu::draw::Painter*) const override;
     mu::PointF pagePos() const override;      ///< position in page coordinates

--- a/src/engraving/libmscore/staffstate.cpp
+++ b/src/engraving/libmscore/staffstate.cpp
@@ -38,7 +38,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 StaffState::StaffState(Score* score)
-    : Element(score)
+    : Element(ElementType::STAFF_STATE, score)
 {
     _staffStateType = StaffStateType::INSTRUMENT;
     _instrument = new Instrument;

--- a/src/engraving/libmscore/staffstate.h
+++ b/src/engraving/libmscore/staffstate.h
@@ -56,7 +56,6 @@ public:
     ~StaffState();
 
     StaffState* clone() const override { return new StaffState(*this); }
-    ElementType type() const override { return ElementType::STAFF_STATE; }
 
     void setStaffStateType(const QString&);
     void setStaffStateType(StaffStateType st) { _staffStateType = st; }

--- a/src/engraving/libmscore/stafftext.cpp
+++ b/src/engraving/libmscore/stafftext.cpp
@@ -44,7 +44,7 @@ static const ElementStyle staffStyle {
 //---------------------------------------------------------
 
 StaffText::StaffText(Score* s, Tid tid)
-    : StaffTextBase(s, tid, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+    : StaffTextBase(ElementType::STAFF_TEXT, s, tid, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&staffStyle);
 }

--- a/src/engraving/libmscore/stafftext.h
+++ b/src/engraving/libmscore/stafftext.h
@@ -41,7 +41,6 @@ public:
     StaffText(Score* s = 0, Tid = Tid::STAFF);
 
     StaffText* clone() const override { return new StaffText(*this); }
-    ElementType type() const override { return ElementType::STAFF_TEXT; }
     void layout() override;
 };
 }     // namespace Ms

--- a/src/engraving/libmscore/stafftextbase.cpp
+++ b/src/engraving/libmscore/stafftextbase.cpp
@@ -34,8 +34,8 @@ namespace Ms {
 //   StaffTextBase
 //---------------------------------------------------------
 
-StaffTextBase::StaffTextBase(Score* s, Tid tid, ElementFlags flags)
-    : TextBase(s, tid, flags)
+StaffTextBase::StaffTextBase(const ElementType& type, Score* s, Tid tid, ElementFlags flags)
+    : TextBase(type, s, tid, flags)
 {
     setSwingParameters(MScore::division / 2, 60);
 }

--- a/src/engraving/libmscore/stafftextbase.h
+++ b/src/engraving/libmscore/stafftextbase.h
@@ -52,7 +52,7 @@ class StaffTextBase : public TextBase
     int _capo            { 0 };
 
 public:
-    StaffTextBase(Score*, Tid tid, ElementFlags = ElementFlag::NOTHING);
+    StaffTextBase(const ElementType& type, Score*, Tid tid, ElementFlags = ElementFlag::NOTHING);
 
     virtual void write(XmlWriter& xml) const override;
     virtual void read(XmlReader&) override;

--- a/src/engraving/libmscore/stafftype.cpp
+++ b/src/engraving/libmscore/stafftype.cpp
@@ -844,7 +844,7 @@ qreal StaffType::physStringToYOffset(int strg) const
 //---------------------------------------------------------
 
 TabDurationSymbol::TabDurationSymbol(Score* s)
-    : Element(s, ElementFlag::NOT_SELECTABLE)
+    : Element(ElementType::TAB_DURATION_SYMBOL, s, ElementFlag::NOT_SELECTABLE)
 {
     setGenerated(true);
     _beamGrid   = TabBeamGrid::NONE;
@@ -854,7 +854,7 @@ TabDurationSymbol::TabDurationSymbol(Score* s)
 }
 
 TabDurationSymbol::TabDurationSymbol(Score* s, const StaffType* tab, TDuration::DurationType type, int dots)
-    : Element(s, ElementFlag::NOT_SELECTABLE)
+    : Element(ElementType::TAB_DURATION_SYMBOL, s, ElementFlag::NOT_SELECTABLE)
 {
     setGenerated(true);
     _beamGrid   = TabBeamGrid::NONE;

--- a/src/engraving/libmscore/stafftype.h
+++ b/src/engraving/libmscore/stafftype.h
@@ -456,7 +456,6 @@ public:
     void draw(mu::draw::Painter*) const override;
     bool isEditable() const override { return false; }
     void layout() override;
-    ElementType type() const override { return ElementType::TAB_DURATION_SYMBOL; }
 
     TabBeamGrid beamGrid() { return _beamGrid; }
     void layout2();                 // second step of layout: after horiz. pos. are defined, compute width of 'grid beams'

--- a/src/engraving/libmscore/stafftypechange.cpp
+++ b/src/engraving/libmscore/stafftypechange.cpp
@@ -35,7 +35,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 StaffTypeChange::StaffTypeChange(Score* score)
-    : Element(score, ElementFlag::HAS_TAG)
+    : Element(ElementType::STAFFTYPE_CHANGE, score, ElementFlag::HAS_TAG)
 {
     lw = spatium() * 0.3;
 }

--- a/src/engraving/libmscore/stafftypechange.h
+++ b/src/engraving/libmscore/stafftypechange.h
@@ -46,7 +46,6 @@ public:
     StaffTypeChange(const StaffTypeChange&);
 
     StaffTypeChange* clone() const override { return new StaffTypeChange(*this); }
-    ElementType type() const override { return ElementType::STAFFTYPE_CHANGE; }
 
     void write(XmlWriter&) const override;
     void read(XmlReader&) override;

--- a/src/engraving/libmscore/stem.cpp
+++ b/src/engraving/libmscore/stem.cpp
@@ -52,7 +52,7 @@ static const ElementStyle stemStyle {
 //---------------------------------------------------------
 
 Stem::Stem(Score* s)
-    : Element(s)
+    : Element(ElementType::STEM, s)
 {
     initElementStyle(&stemStyle);
     resetProperty(Pid::USER_LEN);

--- a/src/engraving/libmscore/stem.h
+++ b/src/engraving/libmscore/stem.h
@@ -45,7 +45,6 @@ public:
     Stem& operator=(const Stem&) = delete;
 
     Stem* clone() const override { return new Stem(*this); }
-    ElementType type() const override { return ElementType::STEM; }
     void draw(mu::draw::Painter*) const override;
     bool isEditable() const override { return true; }
     void layout() override;

--- a/src/engraving/libmscore/stemslash.h
+++ b/src/engraving/libmscore/stemslash.h
@@ -38,13 +38,12 @@ class StemSlash final : public Element
 
 public:
     StemSlash(Score* s = 0)
-        : Element(s) {}
+        : Element(ElementType::STEM_SLASH, s) {}
 
     qreal mag() const override { return parent()->mag(); }
     void setLine(const mu::LineF& l);
 
     StemSlash* clone() const override { return new StemSlash(*this); }
-    ElementType type() const override { return ElementType::STEM_SLASH; }
     void draw(mu::draw::Painter*) const override;
     void layout() override;
     Chord* chord() const { return (Chord*)parent(); }

--- a/src/engraving/libmscore/sticking.cpp
+++ b/src/engraving/libmscore/sticking.cpp
@@ -40,7 +40,7 @@ static const ElementStyle stickingStyle {
 //---------------------------------------------------------
 
 Sticking::Sticking(Score* s)
-    : TextBase(s, Tid::STICKING, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+    : TextBase(ElementType::STICKING, s, Tid::STICKING, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&stickingStyle);
 }

--- a/src/engraving/libmscore/sticking.h
+++ b/src/engraving/libmscore/sticking.h
@@ -39,7 +39,6 @@ public:
     Sticking(Score*);
 
     Sticking* clone() const override { return new Sticking(*this); }
-    ElementType type() const override { return ElementType::STICKING; }
 
     Segment* segment() const { return (Segment*)parent(); }
     Measure* measure() const { return (Measure*)parent()->parent(); }

--- a/src/engraving/libmscore/symbol.cpp
+++ b/src/engraving/libmscore/symbol.cpp
@@ -41,10 +41,15 @@ namespace Ms {
 //   Symbol
 //---------------------------------------------------------
 
-Symbol::Symbol(Score* s, ElementFlags f)
-    : BSymbol(s, f)
+Symbol::Symbol(const ElementType& type, Score* s, ElementFlags f)
+    : BSymbol(type, s, f)
 {
     _sym = SymId::accidentalSharp;          // arbitrary valid default
+}
+
+Symbol::Symbol(Score* s, ElementFlags f)
+    : Symbol(ElementType::SYMBOL, s, f)
+{
 }
 
 Symbol::Symbol(const Symbol& s)
@@ -208,7 +213,7 @@ bool Symbol::setProperty(Pid propertyId, const QVariant& v)
 //---------------------------------------------------------
 
 FSymbol::FSymbol(Score* s)
-    : BSymbol(s)
+    : BSymbol(ElementType::FSYMBOL, s)
 {
     _code = 0;
     _font.setNoFontMerging(true);

--- a/src/engraving/libmscore/symbol.h
+++ b/src/engraving/libmscore/symbol.h
@@ -46,13 +46,13 @@ protected:
     const ScoreFont* _scoreFont = nullptr;
 
 public:
+    Symbol(const ElementType& type, Score* s, ElementFlags f = ElementFlag::MOVABLE);
     Symbol(Score* s, ElementFlags f = ElementFlag::MOVABLE);
     Symbol(const Symbol&);
 
     Symbol& operator=(const Symbol&) = delete;
 
     Symbol* clone() const override { return new Symbol(*this); }
-    ElementType type() const override { return ElementType::SYMBOL; }
 
     void setSym(SymId s, const ScoreFont* sf = nullptr) { _sym  = s; _scoreFont = sf; }
     SymId sym() const { return _sym; }
@@ -85,7 +85,6 @@ public:
     FSymbol(const FSymbol&);
 
     FSymbol* clone() const override { return new FSymbol(*this); }
-    ElementType type() const override { return ElementType::FSYMBOL; }
 
     void draw(mu::draw::Painter*) const override;
     void write(XmlWriter& xml) const override;

--- a/src/engraving/libmscore/system.cpp
+++ b/src/engraving/libmscore/system.cpp
@@ -104,7 +104,7 @@ void SysStaff::restoreLayout()
 //---------------------------------------------------------
 
 System::System(Score* s)
-    : Element(s)
+    : Element(ElementType::SYSTEM, s)
 {
 }
 

--- a/src/engraving/libmscore/system.h
+++ b/src/engraving/libmscore/system.h
@@ -129,7 +129,6 @@ public:
     int treeChildCount() const override;
 
     System* clone() const override { return new System(*this); }
-    ElementType type() const override { return ElementType::SYSTEM; }
 
     void add(Element*) override;
     void remove(Element*) override;

--- a/src/engraving/libmscore/systemdivider.cpp
+++ b/src/engraving/libmscore/systemdivider.cpp
@@ -35,7 +35,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 SystemDivider::SystemDivider(Score* s)
-    : Symbol(s, ElementFlag::SYSTEM | ElementFlag::NOT_SELECTABLE)
+    : Symbol(ElementType::SYSTEM_DIVIDER, s, ElementFlag::SYSTEM | ElementFlag::NOT_SELECTABLE)
 {
     // default value, but not valid until setDividerType()
     _dividerType = SystemDivider::Type::LEFT;

--- a/src/engraving/libmscore/systemdivider.h
+++ b/src/engraving/libmscore/systemdivider.h
@@ -45,7 +45,6 @@ public:
     SystemDivider(const SystemDivider&);
 
     SystemDivider* clone() const override { return new SystemDivider(*this); }
-    ElementType type() const override { return ElementType::SYSTEM_DIVIDER; }
 
     Type dividerType() const { return _dividerType; }
     void setDividerType(Type v);

--- a/src/engraving/libmscore/systemtext.cpp
+++ b/src/engraving/libmscore/systemtext.cpp
@@ -39,7 +39,7 @@ static const ElementStyle systemStyle {
 //---------------------------------------------------------
 
 SystemText::SystemText(Score* s, Tid tid)
-    : StaffTextBase(s, tid, ElementFlag::SYSTEM | ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+    : StaffTextBase(ElementType::SYSTEM_TEXT, s, tid, ElementFlag::SYSTEM | ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&systemStyle);
 }

--- a/src/engraving/libmscore/systemtext.h
+++ b/src/engraving/libmscore/systemtext.h
@@ -39,7 +39,6 @@ public:
     SystemText(Score* = 0, Tid = Tid::SYSTEM);
 
     SystemText* clone() const override { return new SystemText(*this); }
-    ElementType type() const override { return ElementType::SYSTEM_TEXT; }
     Segment* segment() const { return (Segment*)parent(); }
 };
 }     // namespace Ms

--- a/src/engraving/libmscore/tempotext.cpp
+++ b/src/engraving/libmscore/tempotext.cpp
@@ -57,7 +57,7 @@ static const ElementStyle tempoStyle {
 //---------------------------------------------------------
 
 TempoText::TempoText(Score* s)
-    : TextBase(s, Tid::TEMPO, ElementFlags(ElementFlag::SYSTEM))
+    : TextBase(ElementType::TEMPO_TEXT, s, Tid::TEMPO, ElementFlags(ElementFlag::SYSTEM))
 {
     initElementStyle(&tempoStyle);
     _tempo      = 2.0;        // propertyDefault(P_TEMPO).toDouble();

--- a/src/engraving/libmscore/tempotext.h
+++ b/src/engraving/libmscore/tempotext.h
@@ -51,7 +51,6 @@ public:
     TempoText(Score*);
 
     TempoText* clone() const override { return new TempoText(*this); }
-    ElementType type() const override { return ElementType::TEMPO_TEXT; }
 
     void write(XmlWriter& xml) const override;
     void read(XmlReader&) override;

--- a/src/engraving/libmscore/text.cpp
+++ b/src/engraving/libmscore/text.cpp
@@ -40,7 +40,7 @@ static const ElementStyle defaultStyle {
 //---------------------------------------------------------
 
 Text::Text(Score* s, Tid tid)
-    : TextBase(s, tid)
+    : TextBase(ElementType::TEXT, s, tid)
 {
     initElementStyle(&defaultStyle);
 }

--- a/src/engraving/libmscore/text.h
+++ b/src/engraving/libmscore/text.h
@@ -35,7 +35,6 @@ class Text final : public TextBase
 public:
     Text(Score* s = 0, Tid tid = Tid::DEFAULT);
 
-    ElementType type() const override { return ElementType::TEXT; }
     Text* clone() const override { return new Text(*this); }
     void read(XmlReader&) override;
     QVariant propertyDefault(Pid id) const override;

--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -1674,8 +1674,8 @@ QString TextBlock::text(int col1, int len, bool withFormat) const
 //   Text
 //---------------------------------------------------------
 
-TextBase::TextBase(Score* s, Tid tid, ElementFlags f)
-    : Element(s, f | ElementFlag::MOVABLE)
+TextBase::TextBase(const Ms::ElementType& type, Score* s, Tid tid, ElementFlags f)
+    : Element(type, s, f | ElementFlag::MOVABLE)
 {
     _cursor                 = new TextCursor(this);
     _cursor->init();
@@ -1691,8 +1691,8 @@ TextBase::TextBase(Score* s, Tid tid, ElementFlags f)
     _frameRound             = 0;
 }
 
-TextBase::TextBase(Score* s, ElementFlags f)
-    : TextBase(s, Tid::DEFAULT, f)
+TextBase::TextBase(const ElementType& type, Score* s, ElementFlags f)
+    : TextBase(type, s, Tid::DEFAULT, f)
 {
 }
 

--- a/src/engraving/libmscore/textbase.h
+++ b/src/engraving/libmscore/textbase.h
@@ -311,8 +311,8 @@ protected:
     bool prepareFormat(const QString& token, Ms::CharFormat& format);
 
 public:
-    TextBase(Score* = 0, Tid tid = Tid::DEFAULT, ElementFlags = ElementFlag::NOTHING);
-    TextBase(Score*, ElementFlags);
+    TextBase(const ElementType& type, Score* = 0, Tid tid = Tid::DEFAULT, ElementFlags = ElementFlag::NOTHING);
+    TextBase(const ElementType& type, Score*, ElementFlags);
     TextBase(const TextBase&);
     ~TextBase();
 

--- a/src/engraving/libmscore/textframe.cpp
+++ b/src/engraving/libmscore/textframe.cpp
@@ -44,7 +44,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 TBox::TBox(Score* score)
-    : VBox(score)
+    : VBox(ElementType::TBOX, score)
 {
     setBoxHeight(Spatium(1));
     _text  = new Text(score, Tid::FRAME);

--- a/src/engraving/libmscore/textframe.h
+++ b/src/engraving/libmscore/textframe.h
@@ -48,7 +48,7 @@ public:
     int treeChildCount() const override;
 
     virtual TBox* clone() const override { return new TBox(*this); }
-    virtual ElementType type() const override { return ElementType::TBOX; }
+
     virtual void write(XmlWriter&) const override;
     using VBox::write;
     virtual void read(XmlReader&) override;

--- a/src/engraving/libmscore/textline.cpp
+++ b/src/engraving/libmscore/textline.cpp
@@ -99,7 +99,7 @@ static const ElementStyle systemTextLineStyle {
 //---------------------------------------------------------
 
 TextLineSegment::TextLineSegment(Spanner* sp, Score* s, bool system)
-    : TextLineBaseSegment(sp, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+    : TextLineBaseSegment(ElementType::TEXTLINE_SEGMENT, sp, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     setSystemFlag(system);
     if (systemFlag()) {
@@ -139,7 +139,7 @@ void TextLineSegment::layout()
 //---------------------------------------------------------
 
 TextLine::TextLine(Score* s, bool system)
-    : TextLineBase(s)
+    : TextLineBase(ElementType::TEXTLINE, s)
 {
     setSystemFlag(system);
 

--- a/src/engraving/libmscore/textline.h
+++ b/src/engraving/libmscore/textline.h
@@ -40,7 +40,6 @@ class TextLineSegment final : public TextLineBaseSegment
 public:
     TextLineSegment(Spanner* sp, Score* s, bool system=false);
 
-    ElementType type() const override { return ElementType::TEXTLINE_SEGMENT; }
     TextLineSegment* clone() const override { return new TextLineSegment(*this); }
 
     virtual Element* propertyDelegate(Pid) override;
@@ -67,7 +66,6 @@ public:
     virtual SpannerSegment* layoutSystem(System*) override;
 
     TextLine* clone() const override { return new TextLine(*this); }
-    ElementType type() const override { return ElementType::TEXTLINE; }
 
     void write(XmlWriter&) const override;
     void read(XmlReader&) override;

--- a/src/engraving/libmscore/textlinebase.cpp
+++ b/src/engraving/libmscore/textlinebase.cpp
@@ -43,8 +43,8 @@ namespace Ms {
 //   TextLineBaseSegment
 //---------------------------------------------------------
 
-TextLineBaseSegment::TextLineBaseSegment(Spanner* sp, Score* score, ElementFlags f)
-    : LineSegment(sp, score, f)
+TextLineBaseSegment::TextLineBaseSegment(const ElementType& type, Spanner* sp, Score* score, ElementFlags f)
+    : LineSegment(type, sp, score, f)
 {
     _text    = new Text(score);
     _endText = new Text(score);
@@ -505,8 +505,8 @@ Element* TextLineBaseSegment::propertyDelegate(Pid pid)
 //   TextLineBase
 //---------------------------------------------------------
 
-TextLineBase::TextLineBase(Score* s, ElementFlags f)
-    : SLine(s, f)
+TextLineBase::TextLineBase(const ElementType& type, Score* s, ElementFlags f)
+    : SLine(type, s, f)
 {
     setBeginHookHeight(Spatium(1.9));
     setEndHookHeight(Spatium(1.9));

--- a/src/engraving/libmscore/textlinebase.h
+++ b/src/engraving/libmscore/textlinebase.h
@@ -49,7 +49,7 @@ protected:
     bool twoLines { false };
 
 public:
-    TextLineBaseSegment(Spanner*, Score* s, ElementFlags f = ElementFlag::NOTHING);
+    TextLineBaseSegment(const ElementType& type, Spanner*, Score* s, ElementFlags f = ElementFlag::NOTHING);
     TextLineBaseSegment(const TextLineBaseSegment&);
     ~TextLineBaseSegment();
 
@@ -120,7 +120,7 @@ protected:
     friend class TextLineBaseSegment;
 
 public:
-    TextLineBase(Score* s, ElementFlags = ElementFlag::NOTHING);
+    TextLineBase(const ElementType& type, Score* s, ElementFlags = ElementFlag::NOTHING);
 
     virtual void write(XmlWriter& xml) const override;
     virtual void read(XmlReader&) override;

--- a/src/engraving/libmscore/tie.cpp
+++ b/src/engraving/libmscore/tie.cpp
@@ -552,7 +552,7 @@ void Tie::slurPos(SlurPos* sp)
 //---------------------------------------------------------
 
 Tie::Tie(Score* s)
-    : SlurTie(s)
+    : SlurTie(ElementType::TIE, s)
 {
     setAnchor(Anchor::NOTE);
 }

--- a/src/engraving/libmscore/tie.h
+++ b/src/engraving/libmscore/tie.h
@@ -44,12 +44,12 @@ protected:
 
 public:
     TieSegment(Score* s)
-        : SlurTieSegment(s) { autoAdjustOffset = mu::PointF(); }
+        : SlurTieSegment(ElementType::TIE_SEGMENT, s) { autoAdjustOffset = mu::PointF(); }
     TieSegment(const TieSegment& s)
         : SlurTieSegment(s) { autoAdjustOffset = mu::PointF(); }
 
     TieSegment* clone() const override { return new TieSegment(*this); }
-    ElementType type() const override { return ElementType::TIE_SEGMENT; }
+
     int subtype() const override { return static_cast<int>(spanner()->type()); }
     void draw(mu::draw::Painter*) const override;
 
@@ -78,7 +78,6 @@ public:
     Tie(Score* = 0);
 
     Tie* clone() const override { return new Tie(*this); }
-    ElementType type() const override { return ElementType::TIE; }
 
     void setStartNote(Note* note);
     void setEndNote(Note* note) { setEndElement((Element*)note); }

--- a/src/engraving/libmscore/timesig.cpp
+++ b/src/engraving/libmscore/timesig.cpp
@@ -51,7 +51,7 @@ static const ElementStyle timesigStyle {
 //---------------------------------------------------------
 
 TimeSig::TimeSig(Score* s)
-    : Element(s, ElementFlag::ON_STAFF | ElementFlag::MOVABLE)
+    : Element(ElementType::TIMESIG, s, ElementFlag::ON_STAFF | ElementFlag::MOVABLE)
 {
     initElementStyle(&timesigStyle);
 

--- a/src/engraving/libmscore/timesig.h
+++ b/src/engraving/libmscore/timesig.h
@@ -77,7 +77,6 @@ public:
     void setSSig(const QString&);
 
     TimeSig* clone() const override { return new TimeSig(*this); }
-    ElementType type() const override { return ElementType::TIMESIG; }
 
     TimeSigType timeSigType() const { return _timeSigType; }
 

--- a/src/engraving/libmscore/tremolo.cpp
+++ b/src/engraving/libmscore/tremolo.cpp
@@ -68,7 +68,7 @@ static const char* tremoloName[] = {
 };
 
 Tremolo::Tremolo(Score* score)
-    : Element(score, ElementFlag::MOVABLE)
+    : Element(ElementType::TREMOLO, score, ElementFlag::MOVABLE)
 {
     initElementStyle(&tremoloStyle);
 }

--- a/src/engraving/libmscore/tremolo.h
+++ b/src/engraving/libmscore/tremolo.h
@@ -67,7 +67,6 @@ public:
     Tremolo(const Tremolo&);
     Tremolo& operator=(const Tremolo&) = delete;
     Tremolo* clone() const override { return new Tremolo(*this); }
-    ElementType type() const override { return ElementType::TREMOLO; }
     int subtype() const override { return static_cast<int>(_tremoloType); }
     QString subtypeName() const override;
 

--- a/src/engraving/libmscore/tremolobar.cpp
+++ b/src/engraving/libmscore/tremolobar.cpp
@@ -65,7 +65,7 @@ static const QList<PitchValue> RELEASE_DOWN_CURVE = { PitchValue(0, 150),
 //---------------------------------------------------------
 
 TremoloBar::TremoloBar(Score* s)
-    : Element(s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+    : Element(ElementType::TREMOLOBAR, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&tremoloBarStyle);
 }

--- a/src/engraving/libmscore/tremolobar.h
+++ b/src/engraving/libmscore/tremolobar.h
@@ -51,7 +51,6 @@ public:
     TremoloBar(Score* s);
 
     TremoloBar* clone() const override { return new TremoloBar(*this); }
-    ElementType type() const override { return ElementType::TREMOLOBAR; }
 
     void layout() override;
     void draw(mu::draw::Painter*) const override;

--- a/src/engraving/libmscore/trill.cpp
+++ b/src/engraving/libmscore/trill.cpp
@@ -275,7 +275,7 @@ Sid Trill::getPropertyStyle(Pid pid) const
 //---------------------------------------------------------
 
 Trill::Trill(Score* s)
-    : SLine(s)
+    : SLine(ElementType::TRILL, s)
 {
     _trillType     = Type::TRILL_LINE;
     _accidental    = 0;
@@ -285,7 +285,7 @@ Trill::Trill(Score* s)
 }
 
 Trill::Trill(const Trill& t)
-    : SLine(t.score())
+    : SLine(ElementType::TRILL, t.score())
 {
     _trillType = t._trillType;
     _accidental = t._accidental ? t._accidental->clone() : nullptr;

--- a/src/engraving/libmscore/trill.h
+++ b/src/engraving/libmscore/trill.h
@@ -44,12 +44,12 @@ class TrillSegment final : public LineSegment
 protected:
 public:
     TrillSegment(Spanner* sp, Score* s)
-        : LineSegment(sp, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF) {}
+        : LineSegment(ElementType::TRILL_SEGMENT, sp, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF) {}
     TrillSegment(Score* s)
-        : LineSegment(s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF) {}
+        : LineSegment(ElementType::TRILL_SEGMENT, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF) {}
 
     Trill* trill() const { return (Trill*)spanner(); }
-    ElementType type() const override { return ElementType::TRILL_SEGMENT; }
+
     TrillSegment* clone() const override { return new TrillSegment(*this); }
     void draw(mu::draw::Painter*) const override;
     bool acceptDrop(EditData&) const override;
@@ -97,7 +97,6 @@ public:
     int treeChildCount() const override;
 
     Trill* clone() const override { return new Trill(*this); }
-    ElementType type() const override { return ElementType::TRILL; }
 
     void layout() override;
     LineSegment* createLineSegment() override;

--- a/src/engraving/libmscore/tuplet.cpp
+++ b/src/engraving/libmscore/tuplet.cpp
@@ -63,7 +63,7 @@ static const ElementStyle tupletStyle {
 //---------------------------------------------------------
 
 Tuplet::Tuplet(Score* s)
-    : DurationElement(s)
+    : DurationElement(ElementType::TUPLET, s)
 {
     _direction    = Direction::AUTO;
     _numberType   = TupletNumberType::SHOW_NUMBER;

--- a/src/engraving/libmscore/tuplet.h
+++ b/src/engraving/libmscore/tuplet.h
@@ -79,7 +79,6 @@ public:
     int treeChildCount() const override;
 
     Tuplet* clone() const override { return new Tuplet(*this); }
-    ElementType type() const override { return ElementType::TUPLET; }
     void setTrack(int val) override;
 
     void add(Element*) override;

--- a/src/engraving/libmscore/vibrato.cpp
+++ b/src/engraving/libmscore/vibrato.cpp
@@ -186,7 +186,7 @@ static const ElementStyle vibratoStyle {
 //---------------------------------------------------------
 
 Vibrato::Vibrato(Score* s)
-    : SLine(s)
+    : SLine(ElementType::VIBRATO, s)
 {
     initElementStyle(&vibratoStyle);
     _vibratoType = Type::GUITAR_VIBRATO;

--- a/src/engraving/libmscore/vibrato.h
+++ b/src/engraving/libmscore/vibrato.h
@@ -44,9 +44,8 @@ class VibratoSegment final : public LineSegment
 protected:
 public:
     VibratoSegment(Spanner* sp, Score* s)
-        : LineSegment(sp, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF) {}
+        : LineSegment(ElementType::VIBRATO_SEGMENT, sp, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF) {}
 
-    ElementType type() const override { return ElementType::VIBRATO_SEGMENT; }
     VibratoSegment* clone() const override { return new VibratoSegment(*this); }
 
     Vibrato* vibrato() const { return toVibrato(spanner()); }
@@ -82,7 +81,6 @@ public:
     ~Vibrato();
 
     Vibrato* clone() const override { return new Vibrato(*this); }
-    ElementType type() const override { return ElementType::VIBRATO; }
 
     void layout() override;
     LineSegment* createLineSegment() override;

--- a/src/engraving/libmscore/volta.cpp
+++ b/src/engraving/libmscore/volta.cpp
@@ -66,7 +66,7 @@ static const ElementStyle voltaStyle {
 //---------------------------------------------------------
 
 VoltaSegment::VoltaSegment(Spanner* sp, Score* s)
-    : TextLineBaseSegment(sp, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF | ElementFlag::SYSTEM)
+    : TextLineBaseSegment(ElementType::VOLTA_SEGMENT, sp, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF | ElementFlag::SYSTEM)
 {
 }
 
@@ -97,7 +97,7 @@ Element* VoltaSegment::propertyDelegate(Pid pid)
 //---------------------------------------------------------
 
 Volta::Volta(Score* s)
-    : TextLineBase(s, ElementFlag::SYSTEM)
+    : TextLineBase(ElementType::VOLTA, s, ElementFlag::SYSTEM)
 {
     setPlacement(Placement::ABOVE);
     initElementStyle(&voltaStyle);

--- a/src/engraving/libmscore/volta.h
+++ b/src/engraving/libmscore/volta.h
@@ -43,7 +43,6 @@ class VoltaSegment final : public TextLineBaseSegment
 public:
     VoltaSegment(Spanner*, Score*);
 
-    ElementType type() const override { return ElementType::VOLTA_SEGMENT; }
     VoltaSegment* clone() const override { return new VoltaSegment(*this); }
 
     Volta* volta() const { return (Volta*)spanner(); }
@@ -70,7 +69,6 @@ public:
     Volta(Score* s);
 
     Volta* clone() const override { return new Volta(*this); }
-    ElementType type() const override { return ElementType::VOLTA; }
 
     LineSegment* createLineSegment() override;
 


### PR DESCRIPTION
This is made for two reasons:
1. A virtual method cannot be called in the constructor and destructor, sometimes it is necessary (directly or indirectly)
2. It is difficult to debug with a virtual method in the debugger - the type of the element is not visible. With the type field, we see the type of the element in the debugger.