### PR TITLE
[MU4] Fix #324232: after a MIDI export without expanding repeats, those are not played in the current session anymore either

### DIFF
--- a/src/engraving/libmscore/masterscore.h
+++ b/src/engraving/libmscore/masterscore.h
@@ -151,6 +151,7 @@ public:
     void setPlaylistClean() { _playlistDirty = false; }
 
     void setExpandRepeats(bool expandRepeats);
+    bool expandRepeats() const { return _expandRepeats; }
     void updateRepeatListTempo();
     const RepeatList& repeatList() const override;
     const RepeatList& repeatList2() const override;

--- a/src/engraving/libmscore/rendermidi.cpp
+++ b/src/engraving/libmscore/rendermidi.cpp
@@ -2468,12 +2468,14 @@ void Score::renderMidi(EventMap* events, const SynthesizerState& synthState)
 
 void Score::renderMidi(EventMap* events, bool metronome, bool expandRepeats, const SynthesizerState& synthState)
 {
+    bool expandRepeatsBackup = masterScore()->expandRepeats();
     masterScore()->setExpandRepeats(expandRepeats);
     MidiRenderer::Context ctx;
     ctx.synthState = synthState;
     ctx.metronome = metronome;
     ctx.renderHarmony = true;
     MidiRenderer(this).renderScore(events, ctx);
+    masterScore()->setExpandRepeats(expandRepeatsBackup);
 }
 
 void MidiRenderer::renderScore(EventMap* events, const Context& ctx)


### PR DESCRIPTION
Resolves: https://musescore.org/de/node/324232

To reproduce: Have "Play Repeats" enabled, export a score to MIDI, disable "Expand repeats", then play the still open score: it won't repeat, but the Play Repeats button is still active.

Very same fix would apply to 3.x too