### PR TITLE
8381 workspacesdialog

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/FlatRadioButton.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/FlatRadioButton.qml
@@ -34,6 +34,8 @@ RadioDelegate {
     //!      It can't be overridden either, as it is marked `FINAL`.
     property int iconCode: IconCode.NONE
 
+    property int keynavRow: 0
+
     property alias radius: backgroundRect.radius
 
     property color normalStateColor: ui.theme.buttonColor
@@ -65,6 +67,14 @@ RadioDelegate {
         accessible.selected: root.checked
 
         onTriggered: root.checked = !root.checked
+
+        row: root.keynavRow
+
+        onActiveChanged: {
+            if (active) {
+                root.clicked()
+            }
+        }
     }
 
     background: Rectangle {

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/RoundedRadioButton.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/RoundedRadioButton.qml
@@ -22,7 +22,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
-import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
 
 RadioButton {

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/RoundedRadioButton.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/RoundedRadioButton.qml
@@ -22,6 +22,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
+import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
 
 RadioButton {

--- a/src/workspace/qml/MuseScore/Workspace/WorkspacesDialog.qml
+++ b/src/workspace/qml/MuseScore/Workspace/WorkspacesDialog.qml
@@ -31,6 +31,8 @@ import "internal"
 StyledDialogView {
     id: root
 
+    signal requestActiveFocus()
+
     contentWidth: 552
     contentHeight: 286
 
@@ -42,10 +44,54 @@ StyledDialogView {
         workspacesModel.load()
     }
 
+    NavigationSection {
+        id: navTopSec
+        name: "WorkspacesTop"
+        enabled: root.visible
+        order: 10
+        onActiveChanged: {
+            if (active) {
+                root.requestActiveFocus()
+            }
+        }
+    }
+
+    NavigationSection {
+        id: navWorkspacesSec
+        name: "Workspaces"
+        enabled: root.visible
+        order: 11
+        onActiveChanged: {
+            if (active) {
+                root.requestActiveFocus()
+            }
+        }
+    }
+
+    NavigationSection {
+        id: navBottomSec
+        name: "WorkspacesBottom"
+        enabled: root.visible
+        order: 12
+        onActiveChanged: {
+            if (active) {
+                root.requestActiveFocus()
+            }
+        }
+    }
+
     ColumnLayout {
         anchors.fill: parent
         anchors.margins: 24
         spacing: 0
+
+        NavigationPanel {
+            id: navTopPanel
+            name: "Workspaces Top"
+            section: navTopSec
+            direction: NavigationPanel.Horizontal
+            order: 1
+        }
 
         Item {
             Layout.fillWidth: true
@@ -59,6 +105,10 @@ StyledDialogView {
             }
 
             FlatButton {
+                navigation.name: "New Workspace"
+                navigation.panel: navTopPanel
+                navigation.column: 1
+
                 text: qsTrc("workspace", "Create new workspace")
 
                 anchors.right: deleteButton.left
@@ -70,6 +120,10 @@ StyledDialogView {
             }
 
             FlatButton {
+                navigation.name: "Delete Workspace"
+                navigation.panel: navTopPanel
+                navigation.column: 2
+
                 id: deleteButton
 
                 anchors.right: parent.right
@@ -106,7 +160,18 @@ StyledDialogView {
             Layout.rightMargin: -parent.anchors.rightMargin
             leftPadding: parent.anchors.leftMargin
 
+            navigation.section: navWorkspacesSec
+            navigation.order: 1
+
             model: workspacesModel
+        }
+
+        NavigationPanel {
+            id: navBottomPanel
+            name: "Workspaces Bottom"
+            section: navBottomSec
+            direction: NavigationPanel.Horizontal
+            order: 1
         }
 
         Row {
@@ -117,6 +182,10 @@ StyledDialogView {
             spacing: 12
 
             FlatButton {
+                navigation.name: "Cancel"
+                navigation.panel: navBottomPanel
+                navigation.column: 1
+
                 text: qsTrc("global", "Cancel")
 
                 onClicked: {
@@ -125,6 +194,10 @@ StyledDialogView {
             }
 
             FlatButton {
+                navigation.name: "Select"
+                navigation.panel: navBottomPanel
+                navigation.column: 2
+                
                 text: qsTrc("global", "Select")
 
                 enabled: Boolean(workspacesModel.selectedWorkspace)

--- a/src/workspace/qml/MuseScore/Workspace/internal/WorkspacesView.qml
+++ b/src/workspace/qml/MuseScore/Workspace/internal/WorkspacesView.qml
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2.12
+import QtQuick 2.15
 import QtQuick.Controls 2.2
 
 import MuseScore.Ui 1.0
@@ -35,6 +35,15 @@ RadioButtonGroup {
     orientation: Qt.Vertical
 
     property int leftPadding: 0
+
+    property alias navigation: navPanel
+
+    NavigationPanel {
+        id: navPanel
+        name: "Workspaces List"
+        direction: NavigationPanel.Vertical
+        order: 1
+    }
 
     Connections {
         target: model
@@ -60,6 +69,9 @@ RadioButtonGroup {
 
         background: FlatRadioButton {
             anchors.fill: parent
+
+            navigation.panel: navPanel
+            keynavRow: model ? model.index : 0
 
             ButtonGroup.group: root.radioButtonGroup
             normalStateColor: "transparent"


### PR DESCRIPTION
Implemented: https://github.com/musescore/MuseScore/issues/8381?fbclid=IwAR3aipaI4TbcJUOgVy2HJTIj69DYep-8lgolKYUcesecLkXq3KrOzotKDKg

Summary: Key navigation added for the workspaces dialog, not including the "new workspaces" dialog that opens when you press "create new workspace."