### PR TITLE
Engraving elements tree refactoring

### DIFF
--- a/src/commonscene/exampleview.cpp
+++ b/src/commonscene/exampleview.cpp
@@ -236,9 +236,9 @@ void ExampleView::dragEnterEvent(QDragEnterEvent* event)
         Fraction duration;      // dummy
         ElementType type = Element::readType(e, &dragOffset, &duration);
 
-        dragElement = Element::create(type, _score);
+        dragElement = Element::create(type, _score->dummy());
         if (dragElement) {
-            dragElement->setParent(0);
+            dragElement->moveToDummy();
             dragElement->read(e);
             dragElement->layout();
         }

--- a/src/engraving/CMakeLists.txt
+++ b/src/engraving/CMakeLists.txt
@@ -67,6 +67,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/compat/read206.h
     ${CMAKE_CURRENT_LIST_DIR}/compat/read302.cpp
     ${CMAKE_CURRENT_LIST_DIR}/compat/read302.h
+    ${CMAKE_CURRENT_LIST_DIR}/compat/dummyelement.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/compat/dummyelement.h
 
     ${COMPAT_MIDI_SRC}
 

--- a/src/engraving/compat/dummyelement.cpp
+++ b/src/engraving/compat/dummyelement.cpp
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "dummyelement.h"
+
+#include "libmscore/score.h"
+#include "libmscore/page.h"
+#include "libmscore/system.h"
+#include "libmscore/measure.h"
+#include "libmscore/segment.h"
+#include "libmscore/chord.h"
+#include "libmscore/note.h"
+
+using namespace mu::engraving::compat;
+
+DummyElement::DummyElement(Ms::Score* s)
+    : Ms::Element(Ms::ElementType::INVALID, s)
+{
+    m_page = new Ms::Page(this);
+    m_system = new Ms::System(m_page);
+    m_measure = new Ms::Measure(m_system);
+    m_segment = new Ms::Segment(m_measure);
+    m_chord = new Ms::Chord(m_segment);
+    m_note = new Ms::Note(m_chord);
+
+    setIsDummy(true);
+    m_page->setIsDummy(true);
+    m_system->setIsDummy(true);
+    m_measure->setIsDummy(true);
+    m_segment->setIsDummy(true);
+    m_chord->setIsDummy(true);
+    m_note->setIsDummy(true);
+}
+
+DummyElement::~DummyElement()
+{
+}
+
+Ms::Score* DummyElement::score()
+{
+    return static_cast<Ms::Score*>(parent());
+}
+
+Ms::Page* DummyElement::page()
+{
+    return m_page;
+}
+
+Ms::System* DummyElement::system()
+{
+    return m_system;
+}
+
+Ms::Measure* DummyElement::measure()
+{
+    return m_measure;
+}
+
+Ms::Segment* DummyElement::segment()
+{
+    return m_segment;
+}
+
+Ms::Chord* DummyElement::chord()
+{
+    return m_chord;
+}
+
+Ms::Note* DummyElement::note()
+{
+    return m_note;
+}
+
+Ms::Element* DummyElement::clone() const
+{
+    return nullptr;
+}
+
+void DummyElement::add(Ms::ScoreElement* e)
+{
+    m_elements.push_back(e);
+}
+
+void DummyElement::remove(Ms::ScoreElement* e)
+{
+    m_elements.remove(e);
+}

--- a/src/engraving/compat/dummyelement.h
+++ b/src/engraving/compat/dummyelement.h
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_ENGRAVING_DUMMYELEMENT_H
+#define MU_ENGRAVING_DUMMYELEMENT_H
+
+#include <list>
+#include <QVariant>
+#include "libmscore/element.h"
+
+namespace Ms {
+enum class Pid : int;
+}
+
+namespace mu::engraving::compat {
+class DummyElement : public Ms::Element
+{
+public:
+    DummyElement(Ms::Score* s);
+    ~DummyElement();
+
+    Ms::Page* page();
+    Ms::System* system();
+    Ms::Measure* measure();
+    Ms::Segment* segment();
+    Ms::Chord* chord();
+    Ms::Note* note();
+
+    Ms::Element* clone() const override;
+    void add(Ms::ScoreElement* e);
+    void remove(Ms::ScoreElement* e);
+
+    QVariant getProperty(Ms::Pid) const override { return QVariant(); }
+    bool setProperty(Ms::Pid, const QVariant&) override { return false; }
+
+private:
+    Ms::Score* score();
+
+    Ms::Page* m_page = nullptr;
+    Ms::System* m_system = nullptr;
+    Ms::Measure* m_measure = nullptr;
+    Ms::Segment* m_segment = nullptr;
+    Ms::Chord* m_chord = nullptr;
+    Ms::Note* m_note = nullptr;
+    std::list<Ms::ScoreElement*> m_elements;
+};
+}
+
+#endif // MU_ENGRAVING_DUMMYELEMENT_H

--- a/src/engraving/compat/read206.cpp
+++ b/src/engraving/compat/read206.cpp
@@ -801,7 +801,7 @@ static void readNote(Note* note, XmlReader& e)
     while (e.readNextStartElement()) {
         const QStringRef& tag(e.name());
         if (tag == "Accidental") {
-            Accidental* a = new Accidental(note->score());
+            Accidental* a = new Accidental(note);
             a->setTrack(note->track());
             Read206::readAccidental206(a, e);
             note->add(a);
@@ -963,12 +963,12 @@ bool Read206::readNoteProperties206(Note* note, XmlReader& e)
     } else if (tag == "track") {          // for performance
         note->setTrack(e.readInt());
     } else if (tag == "Accidental") {
-        Accidental* a = new Accidental(note->score());
+        Accidental* a = new Accidental(note);
         a->setTrack(note->track());
         a->read(e);
         note->add(a);
     } else if (tag == "Tie") {
-        Tie* tie = new Tie(note->score());
+        Tie* tie = new Tie(note);
         tie->setParent(note);
         tie->setTrack(note->track());
         readTie206(e, tie);
@@ -1007,12 +1007,12 @@ bool Read206::readNoteProperties206(Note* note, XmlReader& e)
     } else if (tag == "line") {
         note->setLine(e.readInt());
     } else if (tag == "Fingering") {
-        Fingering* f = new Fingering(note->score());
+        Fingering* f = new Fingering(note);
         f->setTrack(note->track());
         readText206(e, f, note);
         note->add(f);
     } else if (tag == "Symbol") {
-        Symbol* s = new Symbol(note->score());
+        Symbol* s = new Symbol(note);
         s->setTrack(note->track());
         s->read(e);
         note->add(s);
@@ -1020,18 +1020,18 @@ bool Read206::readNoteProperties206(Note* note, XmlReader& e)
         if (MScore::noImages) {
             e.skipCurrentElement();
         } else {
-            Image* image = new Image(note->score());
+            Image* image = new Image(note);
             image->setTrack(note->track());
             image->read(e);
             note->add(image);
         }
     } else if (tag == "Bend") {
-        Bend* b = new Bend(note->score());
+        Bend* b = new Bend(note);
         b->setTrack(note->track());
         b->read(e);
         note->add(b);
     } else if (tag == "NoteDot") {
-        NoteDot* dot = new NoteDot(note->score());
+        NoteDot* dot = new NoteDot(note);
         dot->read(e);
         note->add(dot);
     } else if (tag == "Events") {
@@ -1076,7 +1076,7 @@ bool Read206::readNoteProperties206(Note* note, XmlReader& e)
                 &&            // DISABLE if pasting into a staff with linked staves
                               // because the glissando is not properly cloned into the linked staves
                 staff && (!e.pasteMode() || !staff->links() || staff->links()->empty())) {
-                Spanner* placeholder = new TextLine(note->score());
+                Spanner* placeholder = new TextLine(note->score()->dummy());
                 placeholder->setAnchor(Spanner::Anchor::NOTE);
                 placeholder->setEndElement(note);
                 placeholder->setTrack2(note->track());
@@ -1088,7 +1088,7 @@ bool Read206::readNoteProperties206(Note* note, XmlReader& e)
         e.readNext();
     } else if (tag == "TextLine"
                || tag == "Glissando") {
-        Spanner* sp = toSpanner(Element::name2Element(tag, note->score()));
+        Spanner* sp = toSpanner(Element::name2Element(tag, note->score()->dummy()));
         // check this is not a lower-to-higher cross-staff spanner we already got
         int id = e.intAttribute("id");
         Spanner* placeholder = e.findSpanner(id);
@@ -1444,7 +1444,7 @@ static void readTuplet(Tuplet* tuplet, XmlReader& e)
     while (e.readNextStartElement()) {
         const QStringRef& tag(e.name());
         if (tag == "Number") {
-            Text* _number = new Text(tuplet->score());
+            Text* _number = new Text(tuplet);
             _number->setParent(tuplet);
             _number->setComposition(true);
             tuplet->setNumber(_number);
@@ -1482,7 +1482,7 @@ static void readLyrics(Lyrics* lyrics, XmlReader& e)
             // which positions this lyrics element in the score
             iEndTick = e.readInt();
         } else if (tag == "Number") {
-            _verseNumber = new Text(lyrics->score());
+            _verseNumber = new Text(lyrics);
             readText206(e, _verseNumber, lyrics);
             _verseNumber->setParent(lyrics);
         } else if (tag == "style") {
@@ -1555,7 +1555,7 @@ bool Read206::readTupletProperties206(XmlReader& e, Tuplet* de)
     } else if (tag == "baseNote") {
         de->setBaseLen(TDuration(e.readElementText()));
     } else if (tag == "Number") {
-        Text* _number = new Text(de->score());
+        Text* _number = new Text(de);
         de->setNumber(_number);
         _number->setComposition(true);
         _number->setParent(de);
@@ -1749,7 +1749,7 @@ bool Read206::readChordRestProperties206(XmlReader& e, ChordRest* ch)
         }
         e.readNext();
     } else if (tag == "Lyrics") {
-        Lyrics* l = new Lyrics(ch->score());
+        Lyrics* l = new Lyrics(ch);
         l->setTrack(e.track());
         readLyrics(l, e);
         ch->add(l);
@@ -1760,7 +1760,7 @@ bool Read206::readChordRestProperties206(XmlReader& e, ChordRest* ch)
         if (MScore::noImages) {
             e.skipCurrentElement();
         } else {
-            Image* image = new Image(ch->score());
+            Image* image = new Image(ch);
             image->setTrack(e.track());
             image->read(e);
             ch->add(image);
@@ -1776,19 +1776,18 @@ bool Read206::readChordProperties206(XmlReader& e, Chord* ch)
     const QStringRef& tag(e.name());
 
     if (tag == "Note") {
-        Note* note = new Note(ch->score());
+        Note* note = new Note(ch);
         // the note needs to know the properties of the track it belongs to
         note->setTrack(ch->track());
-        note->setChord(ch);
         readNote(note, e);
         ch->add(note);
     } else if (readChordRestProperties206(e, ch)) {
     } else if (tag == "Stem") {
-        Stem* s = new Stem(ch->score());
+        Stem* s = new Stem(ch);
         s->read(e);
         ch->add(s);
     } else if (tag == "Hook") {
-        Hook* hook = new Hook(ch->score());
+        Hook* hook = new Hook(ch);
         hook->read(e);
         ch->add(hook);
     } else if (tag == "appoggiatura") {
@@ -1816,14 +1815,14 @@ bool Read206::readChordProperties206(XmlReader& e, Chord* ch)
         ch->setNoteType(NoteType::GRACE32_AFTER);
         e.readNext();
     } else if (tag == "StemSlash") {
-        StemSlash* ss = new StemSlash(ch->score());
+        StemSlash* ss = new StemSlash(ch);
         ss->read(e);
         ch->add(ss);
     } else if (ch->readProperty(tag, e, Pid::STEM_DIRECTION)) {
     } else if (tag == "noStem") {
         ch->setNoStem(e.readInt());
     } else if (tag == "Arpeggio") {
-        Arpeggio* arpeggio = new Arpeggio(ch->score());
+        Arpeggio* arpeggio = new Arpeggio(ch);
         arpeggio->setTrack(ch->track());
         arpeggio->read(e);
         arpeggio->setParent(ch);
@@ -1838,7 +1837,7 @@ bool Read206::readChordProperties206(XmlReader& e, Chord* ch)
         // after the whole score is read, Score::connectTies() will look for
         // the suitable initial note
         Note* finalNote = ch->upNote();
-        Glissando* gliss = new Glissando(ch->score());
+        Glissando* gliss = new Glissando(ch->score()->dummy());
         gliss->read(e);
         gliss->setAnchor(Spanner::Anchor::NOTE);
         gliss->setStartElement(nullptr);
@@ -1850,7 +1849,7 @@ bool Read206::readChordProperties206(XmlReader& e, Chord* ch)
         }
         finalNote->addSpannerBack(gliss);
     } else if (tag == "Tremolo") {
-        Tremolo* tremolo = new Tremolo(ch->score());
+        Tremolo* tremolo = new Tremolo(ch);
         tremolo->setTrack(ch->track());
         tremolo->read(e);
         tremolo->setParent(ch);
@@ -1858,7 +1857,7 @@ bool Read206::readChordProperties206(XmlReader& e, Chord* ch)
         ch->setTremolo(tremolo);
     } else if (tag == "tickOffset") {     // obsolete
     } else if (tag == "ChordLine") {
-        ChordLine* cl = new ChordLine(ch->score());
+        ChordLine* cl = new ChordLine(ch);
         cl->read(e);
         PointF o = cl->offset();
         cl->setOffset(0.0, 0.0);
@@ -1964,14 +1963,13 @@ static void readChord(Chord* chord, XmlReader& e)
     while (e.readNextStartElement()) {
         const QStringRef& tag(e.name());
         if (tag == "Note") {
-            Note* note = new Note(chord->score());
+            Note* note = new Note(chord);
             // the note needs to know the properties of the track it belongs to
             note->setTrack(chord->track());
-            note->setChord(chord);
             readNote(note, e);
             chord->add(note);
         } else if (tag == "Stem") {
-            Stem* stem = new Stem(chord->score());
+            Stem* stem = new Stem(chord);
             while (e.readNextStartElement()) {
                 const QStringRef& t(e.name());
                 if (t == "subtype") {              // obsolete
@@ -1982,7 +1980,7 @@ static void readChord(Chord* chord, XmlReader& e)
             }
             chord->add(stem);
         } else if (tag == "Lyrics") {
-            Lyrics* lyrics = new Lyrics(chord->score());
+            Lyrics* lyrics = new Lyrics(chord);
             lyrics->setTrack(e.track());
             readLyrics(lyrics, e);
             chord->add(lyrics);
@@ -2167,7 +2165,7 @@ void Read206::readTrill206(XmlReader& e, Trill* t)
         if (tag == "subtype") {
             t->setTrillType(e.readElementText());
         } else if (tag == "Accidental") {
-            Accidental* _accidental = new Accidental(t->score());
+            Accidental* _accidental = new Accidental(t);
             readAccidental206(_accidental, e);
             _accidental->setParent(t);
             t->setAccidental(_accidental);
@@ -2305,10 +2303,10 @@ Element* Read206::readArticulation(Element* parent, XmlReader& e)
             case SymId::fermataLongBelow:
             case SymId::fermataVeryLongAbove:
             case SymId::fermataVeryLongBelow:
-                el = new Fermata(sym, score);
+                el = new Fermata(sym, score->dummy());
                 break;
             default:
-                el = new Articulation(sym, score);
+                el = new Articulation(sym, score->dummy()->chord());
                 toArticulation(el)->setDirection(direction);
                 break;
             }
@@ -2339,7 +2337,7 @@ Element* Read206::readArticulation(Element* parent, XmlReader& e)
     }
     // Special case for "no type" = ufermata, with missing subtype tag
     if (!el) {
-        el = new Fermata(sym, score);
+        el = new Fermata(sym, score->dummy());
     }
     if (el->isFermata()) {
         if (timeStretch != 0.0) {
@@ -2474,7 +2472,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
         } else if (tag == "BarLine") {
             Fermata* fermataAbove = nullptr;
             Fermata* fermataBelow = nullptr;
-            BarLine* bl = new BarLine(score);
+            BarLine* bl = new BarLine(score->dummy()->segment());
             bl->setTrack(e.track());
             while (e.readNextStartElement()) {
                 const QStringRef& t(e.name());
@@ -2534,9 +2532,9 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                 segment->add(fermataBelow);
             }
         } else if (tag == "Chord") {
-            Chord* chord = new Chord(score);
-            chord->setTrack(e.track());
             segment = m->getSegment(SegmentType::ChordRest, e.tick());
+            Chord* chord = new Chord(segment);
+            chord->setTrack(e.track());
             chord->setParent(segment);
             readChord(chord, e);
             if (chord->noteType() != NoteType::NORMAL) {
@@ -2555,19 +2553,19 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
             }
         } else if (tag == "Rest") {
             if (m->isMMRest()) {
-                MMRest* mmr = new MMRest(score);
+                segment = m->getSegment(SegmentType::ChordRest, e.tick());
+                MMRest* mmr = new MMRest(segment);
                 mmr->setTrack(e.track());
                 mmr->read(e);
-                segment = m->getSegment(SegmentType::ChordRest, e.tick());
                 segment->add(mmr);
                 lastTick = e.tick();
                 e.incTick(mmr->actualTicks());
             } else {
-                Rest* rest = new Rest(score);
+                segment = m->getSegment(SegmentType::ChordRest, e.tick());
+                Rest* rest = new Rest(segment);
                 rest->setDurationType(TDuration::DurationType::V_MEASURE);
                 rest->setTicks(m->timesig() / timeStretch);
                 rest->setTrack(e.track());
-                segment = m->getSegment(SegmentType::ChordRest, e.tick());
                 rest->setParent(segment);
                 readRest(rest, e);
                 segment->add(rest);
@@ -2580,7 +2578,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                 e.incTick(rest->actualTicks());
             }
         } else if (tag == "Breath") {
-            Breath* breath = new Breath(score);
+            Breath* breath = new Breath(score->dummy()->segment());
             breath->setTrack(e.track());
             breath->setPlacement(Placement::ABOVE);
             Fraction tick = e.tick();
@@ -2627,7 +2625,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
             }
             e.readNext();
         } else if (tag == "Slur") {
-            Slur* sl = new Slur(score);
+            Slur* sl = new Slur(score->dummy());
             sl->setTick(e.tick());
             Read206::readSlur206(e, sl);
             //
@@ -2646,7 +2644,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                    || tag == "Trill"
                    || tag == "TextLine"
                    || tag == "Volta") {
-            Spanner* sp = toSpanner(Element::name2Element(tag, score));
+            Spanner* sp = toSpanner(Element::name2Element(tag, score->dummy()));
             sp->setTrack(e.track());
             sp->setTick(e.tick());
             sp->eraseSpannerSegments();
@@ -2676,17 +2674,17 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                 sp->setTrack2(sv->track2);
             }
         } else if (tag == "RepeatMeasure") {
-            MeasureRepeat* rm = new MeasureRepeat(score);
+            segment = m->getSegment(SegmentType::ChordRest, e.tick());
+            MeasureRepeat* rm = new MeasureRepeat(segment);
             rm->setTrack(e.track());
             readRest(rm, e);
             rm->setNumMeasures(1);
             m->setMeasureRepeatCount(1, staffIdx);
-            segment = m->getSegment(SegmentType::ChordRest, e.tick());
             segment->add(rm);
             lastTick = e.tick();
             e.incTick(m->ticks());
         } else if (tag == "Clef") {
-            Clef* clef = new Clef(score);
+            Clef* clef = new Clef(score->dummy()->segment());
             clef->setTrack(e.track());
             clef->read(e);
             clef->setGenerated(false);
@@ -2747,7 +2745,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
             }
             segment->add(clef);
         } else if (tag == "TimeSig") {
-            TimeSig* ts = new TimeSig(score);
+            TimeSig* ts = new TimeSig(score->dummy()->segment());
             ts->setTrack(e.track());
             ts->read(e);
             // if time sig not at beginning of measure => courtesy time sig
@@ -2774,7 +2772,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                 }
             }
         } else if (tag == "KeySig") {
-            KeySig* ks = new KeySig(score);
+            KeySig* ks = new KeySig(score->dummy()->segment());
             ks->setTrack(e.track());
             ks->read(e);
             Fraction curTick = e.tick();
@@ -2806,9 +2804,9 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
             if (styleName == "System" || styleName == "Tempo"
                 || styleName == "Marker" || styleName == "Jump"
                 || styleName == "Volta") {    // TODO: is it possible to get it from style?
-                t = new SystemText(score);
+                t = new SystemText(score->dummy()->segment());
             } else {
-                t = new StaffText(score);
+                t = new StaffText(score->dummy()->segment());
             }
             t->setTrack(e.track());
             readTextPropertyStyle206(ctx.tag(), e, t, t);
@@ -2833,16 +2831,16 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
         //----------------------------------------------------
         // Annotation
         else if (tag == "Dynamic") {
-            Dynamic* dyn = new Dynamic(score);
+            segment = m->getSegment(SegmentType::ChordRest, e.tick());
+            Dynamic* dyn = new Dynamic(segment);
             dyn->setTrack(e.track());
             readDynamic(dyn, e);
-            segment = m->getSegment(SegmentType::ChordRest, e.tick());
             segment->add(dyn);
         } else if (tag == "RehearsalMark") {
-            RehearsalMark* el = new RehearsalMark(score);
+            segment = m->getSegment(SegmentType::ChordRest, e.tick());
+            RehearsalMark* el = new RehearsalMark(segment);
             el->setTrack(e.track());
             readText206(e, el, el);
-            segment = m->getSegment(SegmentType::ChordRest, e.tick());
             segment->add(el);
         } else if (tag == "Harmony"
                    || tag == "FretDiagram"
@@ -2852,7 +2850,8 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                    || tag == "StaffState"
                    || tag == "FiguredBass"
                    ) {
-            Element* el = Element::name2Element(tag, score);
+            segment = m->getSegment(SegmentType::ChordRest, e.tick());
+            Element* el = Element::name2Element(tag, segment);
             // hack - needed because tick tags are unreliable in 1.3 scores
             // for symbols attached to anything but a measure
             el->setTrack(e.track());
@@ -2860,18 +2859,18 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
             if (el->staff() && (el->isHarmony() || el->isFretDiagram() || el->isInstrumentChange())) {
                 adjustPlacement(el);
             }
-            segment = m->getSegment(SegmentType::ChordRest, e.tick());
+
             segment->add(el);
         } else if (tag == "Tempo") {
-            TempoText* tt = new TempoText(score);
+            segment = m->getSegment(SegmentType::ChordRest, e.tick());
+            TempoText* tt = new TempoText(segment);
             // hack - needed because tick tags are unreliable in 1.3 scores
             // for symbols attached to anything but a measure
             tt->setTrack(e.track());
             readTempoText(tt, e);
-            segment = m->getSegment(SegmentType::ChordRest, e.tick());
             segment->add(tt);
         } else if (tag == "Marker" || tag == "Jump") {
-            Element* el = Element::name2Element(tag, score);
+            Element* el = Element::name2Element(tag, score->dummy());
             el->setTrack(e.track());
             if (tag == "Marker") {
                 Marker* ma = toMarker(el);
@@ -2886,10 +2885,10 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
             if (MScore::noImages) {
                 e.skipCurrentElement();
             } else {
-                Element* el = Element::name2Element(tag, score);
+                segment = m->getSegment(SegmentType::ChordRest, e.tick());
+                Element* el = Element::name2Element(tag, segment);
                 el->setTrack(e.track());
                 el->read(e);
-                segment = m->getSegment(SegmentType::ChordRest, e.tick());
                 segment->add(el);
             }
         }
@@ -2910,13 +2909,13 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
             m->setBreakMultiMeasureRest(e.readBool());
         } else if (tag == "sysInitBarLineType") {
             const QString& val(e.readElementText());
-            BarLine* barLine = new BarLine(score);
+            segment = m->getSegment(SegmentType::BeginBarLine, m->tick());
+            BarLine* barLine = new BarLine(segment);
             barLine->setTrack(e.track());
             barLine->setBarLineType(val);
-            segment = m->getSegment(SegmentType::BeginBarLine, m->tick());
             segment->add(barLine);
         } else if (tag == "Tuplet") {
-            Tuplet* tuplet = new Tuplet(score);
+            Tuplet* tuplet = new Tuplet(m);
             tuplet->setTrack(e.track());
             tuplet->setTick(e.tick());
             tuplet->setParent(m);
@@ -2930,7 +2929,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
             m->setRepeatEnd(true);
         } else if (tag == "vspacer" || tag == "vspacerDown") {
             if (!m->vspacerDown(staffIdx)) {
-                Spacer* spacer = new Spacer(score);
+                Spacer* spacer = new Spacer(m);
                 spacer->setSpacerType(SpacerType::DOWN);
                 spacer->setTrack(staffIdx * VOICES);
                 m->add(spacer);
@@ -2938,7 +2937,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
             m->vspacerDown(staffIdx)->setGap(e.readDouble() * _spatium);
         } else if (tag == "vspacer" || tag == "vspacerUp") {
             if (!m->vspacerUp(staffIdx)) {
-                Spacer* spacer = new Spacer(score);
+                Spacer* spacer = new Spacer(m);
                 spacer->setSpacerType(SpacerType::UP);
                 spacer->setTrack(staffIdx * VOICES);
                 m->add(spacer);
@@ -2949,10 +2948,10 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
         } else if (tag == "slashStyle") {
             m->setStaffStemless(staffIdx, e.readInt());
         } else if (tag == "Beam") {
-            Beam* beam = new Beam(score);
+            Beam* beam = new Beam(score->dummy(), score);
             beam->setTrack(e.track());
             beam->read(e);
-            beam->setParent(0);
+            beam->moveToDummy();
             e.addBeam(beam);
         } else if (tag == "Segment") {
             if (segment) {
@@ -2961,19 +2960,19 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                 e.unknown();
             }
         } else if (tag == "MeasureNumber") {
-            MeasureNumber* noText = new MeasureNumber(score);
+            MeasureNumber* noText = new MeasureNumber(m);
             readText206(e, noText, m);
             noText->setTrack(e.track());
             noText->setParent(m);
             m->setNoText(noText->staffIdx(), noText);
         } else if (tag == "SystemDivider") {
-            SystemDivider* sd = new SystemDivider(score);
+            SystemDivider* sd = new SystemDivider(score->dummy()->system());
             sd->read(e);
             m->add(sd);
         } else if (tag == "Ambitus") {
-            Ambitus* range = new Ambitus(score);
-            readAmbitus(range, e);
             segment = m->getSegment(SegmentType::Ambitus, e.tick());
+            Ambitus* range = new Ambitus(segment);
+            readAmbitus(range, e);
             range->setParent(segment);                // a parent segment is needed for setTrack() to work
             range->setTrack(trackZeroVoice(e.track()));
             segment->add(range);
@@ -3014,12 +3013,12 @@ static void readBox(Box* b, XmlReader& e)
     while (e.readNextStartElement()) {
         const QStringRef& tag(e.name());
         if (tag == "HBox") {
-            HBox* hb = new HBox(b->score());
+            HBox* hb = new HBox(b->system());
             hb->read(e);
             b->add(hb);
             keepMargins = true;           // in old file, box nesting used outer box margins
         } else if (tag == "VBox") {
-            VBox* vb = new VBox(b->score());
+            VBox* vb = new VBox(b->system());
             vb->read(e);
             b->add(vb);
             keepMargins = true;           // in old file, box nesting used outer box margins
@@ -3077,7 +3076,7 @@ static void readStaffContent(Score* score, XmlReader& e)
                 readMeasureLast = true;
 
                 Measure* measure = nullptr;
-                measure = new Measure(score);
+                measure = new Measure(score->dummy()->system());
                 measure->setTick(e.tick());
                 //
                 // inherit timesig from previous measure
@@ -3104,7 +3103,7 @@ static void readStaffContent(Score* score, XmlReader& e)
                     }
                 }
             } else if (tag == "HBox" || tag == "VBox" || tag == "TBox" || tag == "FBox") {
-                Box* b = toBox(Element::name2Element(tag, score));
+                Box* b = toBox(Element::name2Element(tag, score->dummy()));
                 readBox(b, e);
                 b->setTick(e.tick());
                 score->measures()->add(b);
@@ -3134,7 +3133,7 @@ static void readStaffContent(Score* score, XmlReader& e)
             if (tag == "Measure") {
                 if (measure == 0) {
                     qDebug("Score::readStaff(): missing measure!");
-                    measure = new Measure(score);
+                    measure = new Measure(score->dummy()->system());
                     measure->setTick(e.tick());
                     score->measures()->add(measure);
                 }
@@ -3313,7 +3312,7 @@ bool Read206::readScore206(Score* score, XmlReader& e)
                    || (tag == "Trill")
                    || (tag == "Slur")
                    || (tag == "Pedal")) {
-            Spanner* s = toSpanner(Element::name2Element(tag, score));
+            Spanner* s = toSpanner(Element::name2Element(tag, score->dummy()));
             if (tag == "HairPin") {
                 readHairpin206(e, toHairpin(s));
             } else if (tag == "Ottava") {

--- a/src/engraving/compat/read302.cpp
+++ b/src/engraving/compat/read302.cpp
@@ -121,7 +121,7 @@ bool Read302::readScore302(Ms::Score* score, XmlReader& e)
             }
             score->_scoreFont = ScoreFont::fontByName(score->style().value(Sid::MusicalSymbolFont).toString());
         } else if (tag == "copyright" || tag == "rights") {
-            Text* text = new Text(score);
+            Text* text = new Text(score->dummy());
             text->read(e);
             score->setMetaTag("copyright", text->xmlText());
             delete text;
@@ -155,7 +155,7 @@ bool Read302::readScore302(Ms::Score* score, XmlReader& e)
                    || (tag == "Trill")
                    || (tag == "Slur")
                    || (tag == "Pedal")) {
-            Spanner* s = toSpanner(Element::name2Element(tag, score));
+            Spanner* s = toSpanner(Element::name2Element(tag, score->dummy()));
             s->read(e);
             score->addSpanner(s);
         } else if (tag == "Excerpt") {

--- a/src/engraving/layout/layout.cpp
+++ b/src/engraving/layout/layout.cpp
@@ -191,12 +191,12 @@ void Layout::doLayoutRange(const LayoutOptions& options, const Fraction& st, con
                     m_score->setSelectionChanged(true);
                 }
             }
-            s->setParent(nullptr);
+            s->moveToDummy();
         }
         for (MeasureBase* mb = m_score->first(); mb; mb = mb->next()) {
-            mb->setSystem(0);
+            mb->moveToDummy();
             if (mb->isMeasure() && toMeasure(mb)->mmRest()) {
-                toMeasure(mb)->mmRest()->setSystem(0);
+                toMeasure(mb)->mmRest()->moveToDummy();
             }
         }
         qDeleteAll(m_score->_systems);
@@ -284,7 +284,7 @@ void Layout::resetSystems(bool layoutAll, const LayoutOptions& options, LayoutCo
     if (layoutAll) {
         for (System* s : qAsConst(m_score->_systems)) {
             for (SpannerSegment* ss : s->spannerSegments()) {
-                ss->setParent(0);
+                ss->moveToDummy();
             }
         }
         qDeleteAll(m_score->_systems);
@@ -297,7 +297,7 @@ void Layout::resetSystems(bool layoutAll, const LayoutOptions& options, LayoutCo
         }
 
         for (MeasureBase* mb = m_score->first(); mb; mb = mb->next()) {
-            mb->setSystem(0);
+            mb->moveToDummy();
         }
 
         page = new Page(m_score);
@@ -305,7 +305,7 @@ void Layout::resetSystems(bool layoutAll, const LayoutOptions& options, LayoutCo
         page->bbox().setRect(0.0, 0.0, options.loWidth, options.loHeight);
         page->setNo(0);
 
-        System* system = new System(m_score);
+        System* system = new System(page);
         m_score->_systems.push_back(system);
         page->appendSystem(system);
         system->adjustStavesNumber(m_score->nstaves());
@@ -343,7 +343,7 @@ void Layout::collectLinearSystem(const LayoutOptions& options, LayoutContext& lc
     while (lc.curMeasure) {
         qreal ww = 0.0;
         if (lc.curMeasure->isVBox() || lc.curMeasure->isTBox()) {
-            lc.curMeasure->setParent(nullptr);
+            lc.curMeasure->moveToDummy();
             LayoutMeasure::getNextMeasure(options, m_score, lc);
             continue;
         }
@@ -351,7 +351,7 @@ void Layout::collectLinearSystem(const LayoutOptions& options, LayoutContext& lc
         if (lc.curMeasure->isMeasure()) {
             Measure* m = toMeasure(lc.curMeasure);
             if (m->mmRest()) {
-                m->mmRest()->setSystem(nullptr);
+                m->mmRest()->moveToDummy();
             }
             if (firstMeasure) {
                 system->layoutSystem(pos.rx());

--- a/src/engraving/layout/layoutbeams.cpp
+++ b/src/engraving/layout/layoutbeams.cpp
@@ -169,7 +169,7 @@ void LayoutBeams::breakCrossMeasureBeams(Measure* measure)
 
         Beam* newBeam = nullptr;
         if (nextElements.size() > 1) {
-            newBeam = new Beam(score);
+            newBeam = new Beam(score->dummy(), score);
             newBeam->setGenerated(true);
             newBeam->setTrack(track);
         }
@@ -244,7 +244,7 @@ void LayoutBeams::beamGraceNotes(Score* score, Chord* mainNote, bool after)
             } else {
                 beam = a1->beam();
                 if (beam == 0 || beam->elements().front() != a1) {
-                    beam = new Beam(score);
+                    beam = new Beam(score->dummy(), score);
                     beam->setGenerated(true);
                     beam->setTrack(mainNote->track());
                     a1->replaceBeam(beam);
@@ -431,7 +431,7 @@ void LayoutBeams::createBeams(Score* score, LayoutContext& lc, Measure* measure)
                 } else {
                     beam = a1->beam();
                     if (beam == 0 || beam->elements().front() != a1) {
-                        beam = new Beam(score);
+                        beam = new Beam(score->dummy(), score);
                         beam->setGenerated(true);
                         beam->setTrack(track);
                         a1->replaceBeam(beam);

--- a/src/engraving/layout/layoutmeasure.cpp
+++ b/src/engraving/layout/layoutmeasure.cpp
@@ -80,7 +80,7 @@ void LayoutMeasure::createMMRest(const LayoutOptions& options, Score* score, Mea
         }
         mmrMeasure->removeSystemTrailer();
     } else {
-        mmrMeasure = new Measure(score);
+        mmrMeasure = new Measure(score->dummy()->system());
         mmrMeasure->setTicks(len);
         mmrMeasure->setTick(firstMeasure->tick());
         score->undo(new ChangeMMRest(firstMeasure, mmrMeasure));
@@ -188,7 +188,7 @@ void LayoutMeasure::createMMRest(const LayoutOptions& options, Score* score, Mea
     for (int staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
         int track = staffIdx * VOICES;
         if (s->element(track) == 0) {
-            MMRest* mmr = new MMRest(score);
+            MMRest* mmr = new MMRest(s);
             mmr->setDurationType(TDuration::DurationType::V_MEASURE);
             mmr->setTicks(mmrMeasure->ticks());
             mmr->setTrack(track);

--- a/src/engraving/layout/layoutpage.cpp
+++ b/src/engraving/layout/layoutpage.cpp
@@ -428,7 +428,7 @@ void LayoutPage::checkDivider(bool left, System* s, qreal yOffset, bool remove)
     SystemDivider* divider = left ? s->systemDividerLeft() : s->systemDividerRight();
     if ((s->score()->styleB(left ? Sid::dividerLeft : Sid::dividerRight)) && !remove) {
         if (!divider) {
-            divider = new SystemDivider(s->score());
+            divider = new SystemDivider(s);
             divider->setDividerType(left ? SystemDivider::Type::LEFT : SystemDivider::Type::RIGHT);
             divider->setGenerated(true);
             s->add(divider);

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -142,7 +142,7 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
         if (doBreak) {
             breakMeasure = lc.curMeasure;
             system->removeLastMeasure();
-            lc.curMeasure->setSystem(oldSystem);
+            lc.curMeasure->setParent(oldSystem);
             while (lc.prevMeasure && lc.prevMeasure->noBreak() && system->measures().size() > 1) {
                 // remove however many measures are grouped with nobreak, working backwards
                 // but if too many are grouped, stop before we get 0 measures left on system
@@ -156,7 +156,7 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
 
                 minWidth -= system->lastMeasure()->width();
                 system->removeLastMeasure();
-                lc.curMeasure->setSystem(oldSystem);
+                lc.curMeasure->setParent(oldSystem);
             }
             break;
         }
@@ -426,7 +426,7 @@ System* LayoutSystem::getNextSystem(LayoutContext& lc, Ms::Score* score)
     bool isVBox = lc.curMeasure->isVBox();
     System* system;
     if (lc.systemList.empty()) {
-        system = new System(score);
+        system = new System(score->dummy()->page());
         lc.systemOldMeasure = 0;
     } else {
         system = lc.systemList.takeFirst();
@@ -583,7 +583,7 @@ void LayoutSystem::layoutSystemElements(const LayoutOptions& options, LayoutCont
                 // the beam and its system may still be referenced when selecting all,
                 // even if the staff is invisible. The old system is invalid and does cause problems in #284012
                 if (e && e->isChordRest() && !score->score()->staff(e->staffIdx())->show() && toChordRest(e)->beam()) {
-                    toChordRest(e)->beam()->setParent(nullptr);
+                    toChordRest(e)->beam()->moveToDummy();
                 }
                 continue;
             }

--- a/src/engraving/libmscore/accidental.cpp
+++ b/src/engraving/libmscore/accidental.cpp
@@ -240,8 +240,8 @@ AccidentalVal sym2accidentalVal(SymId id)
 //   Accidental
 //---------------------------------------------------------
 
-Accidental::Accidental(Score* s)
-    : Element(ElementType::ACCIDENTAL, s, ElementFlag::MOVABLE)
+Accidental::Accidental(Element* parent)
+    : Element(ElementType::ACCIDENTAL, parent, ElementFlag::MOVABLE)
 {
 }
 
@@ -380,7 +380,7 @@ void Accidental::layout()
         return;
     }
 
-    qreal m = parent() ? parent()->mag() : 1.0;
+    qreal m = parent() ? parentElement()->mag() : 1.0;
     if (m_isSmall) {
         m *= score()->styleD(Sid::smallNoteMag);
     }

--- a/src/engraving/libmscore/accidental.h
+++ b/src/engraving/libmscore/accidental.h
@@ -87,7 +87,7 @@ class Accidental final : public Element
     AccidentalRole _role           { AccidentalRole::AUTO };
 
 public:
-    Accidental(Score* s = 0);
+    Accidental(Element* parent = 0);
 
     Accidental* clone() const override { return new Accidental(*this); }
 

--- a/src/engraving/libmscore/actionicon.cpp
+++ b/src/engraving/libmscore/actionicon.cpp
@@ -27,7 +27,7 @@
 using namespace mu;
 
 namespace Ms {
-ActionIcon::ActionIcon(Score* score)
+ActionIcon::ActionIcon(Element* score)
     : Element(ElementType::ACTION_ICON, score)
 {
 }

--- a/src/engraving/libmscore/actionicon.h
+++ b/src/engraving/libmscore/actionicon.h
@@ -63,7 +63,7 @@ enum class ActionIconType {
 class ActionIcon final : public Element
 {
 public:
-    ActionIcon(Score* score);
+    ActionIcon(Element* score);
     ~ActionIcon() override = default;
 
     ActionIcon* clone() const override;

--- a/src/engraving/libmscore/ambitus.cpp
+++ b/src/engraving/libmscore/ambitus.cpp
@@ -50,8 +50,8 @@ static const qreal LINEOFFSET_DEFAULT      = 0.8;               // the distance 
 //   Ambitus
 //---------------------------------------------------------
 
-Ambitus::Ambitus(Score* s)
-    : Element(ElementType::AMBITUS, s, ElementFlag::ON_STAFF), _topAccid(s), _bottomAccid(s)
+Ambitus::Ambitus(Segment* parent)
+    : Element(ElementType::AMBITUS, parent, ElementFlag::ON_STAFF), _topAccid(parent), _bottomAccid(parent)
 {
     _noteHeadGroup    = NOTEHEADGROUP_DEFAULT;
     _noteHeadType     = NOTEHEADTYPE_DEFAULT;

--- a/src/engraving/libmscore/ambitus.h
+++ b/src/engraving/libmscore/ambitus.h
@@ -51,7 +51,7 @@ class Ambitus final : public Element
     void normalize();
 
 public:
-    Ambitus(Score* s);
+    Ambitus(Segment* parent);
 
     Ambitus* clone() const override { return new Ambitus(*this); }
 

--- a/src/engraving/libmscore/arpeggio.cpp
+++ b/src/engraving/libmscore/arpeggio.cpp
@@ -53,8 +53,8 @@ const std::array<const char*, 6> Arpeggio::arpeggioTypeNames = {
 //   Arpeggio
 //---------------------------------------------------------
 
-Arpeggio::Arpeggio(Score* s)
-    : Element(ElementType::ARPEGGIO, s, ElementFlag::MOVABLE)
+Arpeggio::Arpeggio(Chord* parent)
+    : Element(ElementType::ARPEGGIO, parent, ElementFlag::MOVABLE)
 {
     _arpeggioType = ArpeggioType::NORMAL;
     setHeight(spatium() * 4);        // for use in palettes

--- a/src/engraving/libmscore/arpeggio.h
+++ b/src/engraving/libmscore/arpeggio.h
@@ -61,7 +61,7 @@ class Arpeggio final : public Element
     static const std::array<const char*, 6> arpeggioTypeNames;
 
 public:
-    Arpeggio(Score* s);
+    Arpeggio(Chord* parent);
 
     Arpeggio* clone() const override { return new Arpeggio(*this); }
 

--- a/src/engraving/libmscore/articulation.cpp
+++ b/src/engraving/libmscore/articulation.cpp
@@ -55,8 +55,8 @@ static const ElementStyle articulationStyle {
 //   Articulation
 //---------------------------------------------------------
 
-Articulation::Articulation(Score* s)
-    : Element(ElementType::ARTICULATION, s, ElementFlag::MOVABLE)
+Articulation::Articulation(ChordRest* parent)
+    : Element(ElementType::ARTICULATION, parent, ElementFlag::MOVABLE)
 {
     _symId         = SymId::noSym;
     _anchor        = ArticulationAnchor::TOP_STAFF;
@@ -67,8 +67,8 @@ Articulation::Articulation(Score* s)
     initElementStyle(&articulationStyle);
 }
 
-Articulation::Articulation(SymId id, Score* s)
-    : Articulation(s)
+Articulation::Articulation(SymId id, ChordRest* parent)
+    : Articulation(parent)
 {
     setSymId(id);
 }
@@ -307,7 +307,7 @@ bool Articulation::layoutCloseToNote() const
 QVector<mu::LineF> Articulation::dragAnchorLines() const
 {
     QVector<LineF> result;
-    result << LineF(canvasPos(), parent()->canvasPos());
+    result << LineF(canvasPos(), parentElement()->canvasPos());
     return result;
 }
 
@@ -592,7 +592,7 @@ void Articulation::resetProperty(Pid id)
 
 qreal Articulation::mag() const
 {
-    return parent() ? parent()->mag() * score()->styleD(Sid::articulationMag) : 1.0;
+    return parent() ? parentElement()->mag() * score()->styleD(Sid::articulationMag) : 1.0;
 }
 
 bool Articulation::isTenuto() const

--- a/src/engraving/libmscore/articulation.h
+++ b/src/engraving/libmscore/articulation.h
@@ -102,8 +102,8 @@ class Articulation final : public Element
     static AnchorGroup anchorGroup(SymId);
 
 public:
-    Articulation(Score*);
-    Articulation(SymId, Score*);
+    Articulation(ChordRest* parent);
+    Articulation(SymId, ChordRest* parent);
     Articulation& operator=(const Articulation&) = delete;
 
     Articulation* clone() const override { return new Articulation(*this); }

--- a/src/engraving/libmscore/bagpembell.h
+++ b/src/engraving/libmscore/bagpembell.h
@@ -63,8 +63,8 @@ class BagpipeEmbellishment final : public Element
     void drawGraceNote(mu::draw::Painter*, const BEDrawingDataX&, const BEDrawingDataY&, SymId, const qreal x, const bool drawFlag) const;
 
 public:
-    BagpipeEmbellishment(Score* s)
-        : Element(ElementType::BAGPIPE_EMBELLISHMENT, s), _embelType(0) { }
+    BagpipeEmbellishment(Element* parent)
+        : Element(ElementType::BAGPIPE_EMBELLISHMENT, parent), _embelType(0) { }
 
     BagpipeEmbellishment* clone() const override { return new BagpipeEmbellishment(*this); }
 

--- a/src/engraving/libmscore/barline.cpp
+++ b/src/engraving/libmscore/barline.cpp
@@ -134,7 +134,7 @@ static void undoChangeBarLineType(BarLine* bl, BarLineType barType, bool allStav
                     Segment* lsegment = lmeasure->undoGetSegmentR(SegmentType::EndBarLine, lmeasure->ticks());
                     BarLine* lbl = toBarLine(lsegment->element(ltrack));
                     if (!lbl) {
-                        lbl = new BarLine(lscore);
+                        lbl = new BarLine(lsegment);
                         lbl->setParent(lsegment);
                         lbl->setTrack(ltrack);
                         lbl->setSpanStaff(lstaff->barLineSpan());
@@ -335,8 +335,8 @@ BarLineType BarLine::barLineType(const QString& s)
 //   BarLine
 //---------------------------------------------------------
 
-BarLine::BarLine(Score* s)
-    : Element(ElementType::BAR_LINE, s)
+BarLine::BarLine(Segment* parent)
+    : Element(ElementType::BAR_LINE, parent)
 {
     setHeight(4 * spatium());   // for use in palettes
 }
@@ -359,6 +359,11 @@ BarLine::BarLine(const BarLine& bl)
 BarLine::~BarLine()
 {
     qDeleteAll(_el);
+}
+
+void BarLine::setParent(Segment* parent)
+{
+    Element::setParent(parent);
 }
 
 //---------------------------------------------------------
@@ -872,11 +877,11 @@ void BarLine::read(XmlReader& e)
         } else if (tag == "spanToOffset") {
             _spanTo = e.readInt();
         } else if (tag == "Articulation") {
-            Articulation* a = new Articulation(score());
+            Articulation* a = new Articulation(score()->dummy()->chord());
             a->read(e);
             add(a);
         } else if (tag == "Symbol") {
-            Symbol* s = new Symbol(score());
+            Symbol* s = new Symbol(this);
             s->setTrack(track());
             s->read(e);
             add(s);
@@ -884,7 +889,7 @@ void BarLine::read(XmlReader& e)
             if (MScore::noImages) {
                 e.skipCurrentElement();
             } else {
-                Image* image = new Image(score());
+                Image* image = new Image(this);
                 image->setTrack(track());
                 image->read(e);
                 add(image);

--- a/src/engraving/libmscore/barline.h
+++ b/src/engraving/libmscore/barline.h
@@ -81,10 +81,12 @@ class BarLine final : public Element
     void drawEditMode(mu::draw::Painter*, EditData&) override;
 
 public:
-    BarLine(Score* s = 0);
+    BarLine(Segment* parent);
     virtual ~BarLine();
     BarLine(const BarLine&);
     BarLine& operator=(const BarLine&) = delete;
+
+    void setParent(Segment* parent);
 
     // Score Tree functions
     ScoreElement* treeParent() const override;

--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -75,9 +75,10 @@ struct BeamFragment {
 //   Beam
 //---------------------------------------------------------
 
-Beam::Beam(Score* s)
-    : Element(ElementType::BEAM, s)
+Beam::Beam(Element* parent, Score* score)
+    : Element(ElementType::BEAM, parent)
 {
+    ScoreElement::setScore(score);
     initElementStyle(&beamStyle);
 }
 
@@ -150,7 +151,7 @@ PointF Beam::canvasPos() const
 {
     PointF p(pagePos());
     if (system() && system()->parent()) {
-        p += system()->parent()->pos();
+        p += system()->parentElement()->pos();
     }
     return p;
 }
@@ -339,11 +340,16 @@ void Beam::layout1()
     qDeleteAll(beamSegments);
     beamSegments.clear();
 
-    setParent(nullptr);   // parent is System
+    moveToDummy();  // parent is System
 
     maxDuration.setType(TDuration::DurationType::V_INVALID);
     Chord* c1 = 0;
     Chord* c2 = 0;
+
+    if (!staff()) {
+        int k = 0;
+        auto s = staff();
+    }
 
     // TAB's with stem beside staves have special layout
     if (staff()->isTabStaff(Fraction(0, 1)) && !staff()->staffType(Fraction(0, 1))->stemThrough()) {
@@ -1692,7 +1698,7 @@ void Beam::layout2(std::vector<ChordRest*> crl, SpannerSegmentType, int frag)
             }
             _up = crl.front()->up();
             if (relayoutGrace) {
-                c1->parent()->layout();
+                c1->parentElement()->layout();
             }
         } else if (_cross) {
             qreal beamY   = 0.0;        // y position of main beam start

--- a/src/engraving/libmscore/beam.h
+++ b/src/engraving/libmscore/beam.h
@@ -88,7 +88,7 @@ public:
     };
     Q_ENUM(Mode);
 
-    Beam(Score* = 0);
+    Beam(Element* parent, Ms::Score* score);
     Beam(const Beam&);
     ~Beam();
 

--- a/src/engraving/libmscore/bend.cpp
+++ b/src/engraving/libmscore/bend.cpp
@@ -84,8 +84,8 @@ static const QList<PitchValue> PREBEND_RELEASE_CURVE = { PitchValue(0, 100),
 //   Bend
 //---------------------------------------------------------
 
-Bend::Bend(Score* s)
-    : Element(ElementType::BEND, s, ElementFlag::MOVABLE)
+Bend::Bend(Note* parent)
+    : Element(ElementType::BEND, parent, ElementFlag::MOVABLE)
 {
     initElementStyle(&bendStyle);
 }

--- a/src/engraving/libmscore/bend.h
+++ b/src/engraving/libmscore/bend.h
@@ -52,7 +52,7 @@ class Bend final : public Element
     M_PROPERTY(qreal,     lineWidth, setLineWidth)
 
 public:
-    Bend(Score* s);
+    Bend(Note* parent);
 
     Bend* clone() const override { return new Bend(*this); }
 

--- a/src/engraving/libmscore/box.h
+++ b/src/engraving/libmscore/box.h
@@ -52,7 +52,7 @@ class Box : public MeasureBase
     bool _isAutoSizeEnabled       { true };
 
 public:
-    Box(const ElementType& type, Score*);
+    Box(const ElementType& type, System* parent);
 
     void scanElements(void* data, void (* func)(void*, Element*), bool all=true) override;
 
@@ -118,7 +118,7 @@ class HBox final : public Box
     bool _createSystemHeader { true };
 
 public:
-    HBox(Score* score);
+    HBox(System* parent);
     virtual ~HBox() {}
 
     HBox* clone() const override { return new HBox(*this); }
@@ -151,8 +151,8 @@ public:
 class VBox : public Box
 {
 public:
-    VBox(const ElementType& type, Score* score);
-    VBox(Score* score);
+    VBox(const ElementType& type, System* parent);
+    VBox(System* parent);
     virtual ~VBox() {}
 
     VBox* clone() const override { return new VBox(*this); }
@@ -176,8 +176,8 @@ public:
 class FBox : public VBox
 {
 public:
-    FBox(Score* score)
-        : VBox(ElementType::FBOX, score) {}
+    FBox(System* parent)
+        : VBox(ElementType::FBOX, parent) {}
     virtual ~FBox() {}
 
     FBox* clone() const override { return new FBox(*this); }

--- a/src/engraving/libmscore/bracket.cpp
+++ b/src/engraving/libmscore/bracket.cpp
@@ -43,8 +43,8 @@ namespace Ms {
 //   Bracket
 //---------------------------------------------------------
 
-Bracket::Bracket(Score* s)
-    : Element(ElementType::BRACKET, s)
+Bracket::Bracket(Element* parent)
+    : Element(ElementType::BRACKET, parent)
 {
     ay1          = 0;
     h2           = 3.5 * spatium();
@@ -370,7 +370,7 @@ void Bracket::endEditDrag(EditData&)
     if (staffIdx1 + 1 >= n) {
         staffIdx2 = staffIdx1;
     } else {
-        qreal ay  = parent()->pagePos().y();
+        qreal ay  = parentElement()->pagePos().y();
         System* s = system();
         qreal y   = s->staff(staffIdx1)->y() + ay;
         qreal h1  = staff()->height();

--- a/src/engraving/libmscore/bracket.h
+++ b/src/engraving/libmscore/bracket.h
@@ -55,7 +55,7 @@ class Bracket final : public Element
     Measure* _measure = nullptr;
 
 public:
-    Bracket(Score*);
+    Bracket(Element* parent);
     ~Bracket();
 
     Bracket* clone() const override { return new Bracket(*this); }

--- a/src/engraving/libmscore/bracketItem.cpp
+++ b/src/engraving/libmscore/bracketItem.cpp
@@ -28,6 +28,10 @@
 using namespace mu;
 
 namespace Ms {
+BracketItem::BracketItem(ScoreElement* parent)
+    : ScoreElement(ElementType::BRACKET_ITEM, parent) {}
+BracketItem::BracketItem(ScoreElement* parent, BracketType a, int b)
+    : ScoreElement(ElementType::BRACKET_ITEM, parent), _bracketType(a), _bracketSpan(b) { }
 //---------------------------------------------------------
 //   getProperty
 //---------------------------------------------------------

--- a/src/engraving/libmscore/bracketItem.h
+++ b/src/engraving/libmscore/bracketItem.h
@@ -39,10 +39,8 @@ class BracketItem final : public ScoreElement
     Staff* _staff            { 0 };
 
 public:
-    BracketItem(Score* s)
-        : ScoreElement(ElementType::BRACKET_ITEM, s) {}
-    BracketItem(Score* s, BracketType a, int b)
-        : ScoreElement(ElementType::BRACKET_ITEM, s), _bracketType(a), _bracketSpan(b) { }
+    BracketItem(ScoreElement* parent);
+    BracketItem(ScoreElement* parent, BracketType a, int b);
 
     virtual QVariant getProperty(Pid) const override;
     virtual bool setProperty(Pid, const QVariant&) override;

--- a/src/engraving/libmscore/breath.cpp
+++ b/src/engraving/libmscore/breath.cpp
@@ -50,8 +50,8 @@ const std::vector<BreathType> Breath::breathList {
 //   Breath
 //---------------------------------------------------------
 
-Breath::Breath(Score* s)
-    : Element(ElementType::BREATH, s, ElementFlag::MOVABLE)
+Breath::Breath(Segment* parent)
+    : Element(ElementType::BREATH, parent, ElementFlag::MOVABLE)
 {
     _symId = SymId::breathMarkComma;
     _pause = 0.0;

--- a/src/engraving/libmscore/breath.h
+++ b/src/engraving/libmscore/breath.h
@@ -48,7 +48,7 @@ class Breath final : public Element
     SymId _symId;
 
 public:
-    Breath(Score* s);
+    Breath(Segment* parent);
 
     Breath* clone() const override { return new Breath(*this); }
 

--- a/src/engraving/libmscore/bsymbol.cpp
+++ b/src/engraving/libmscore/bsymbol.cpp
@@ -39,8 +39,8 @@ namespace Ms {
 //   BSymbol
 //---------------------------------------------------------
 
-BSymbol::BSymbol(const Ms::ElementType& type, Score* s, ElementFlags f)
-    : Element(type, s, f)
+BSymbol::BSymbol(const Ms::ElementType& type, Ms::Element* parent, ElementFlags f)
+    : Element(type, parent, f)
 {
     _align = Align::LEFT | Align::BASELINE;
 }
@@ -81,14 +81,14 @@ bool BSymbol::readProperties(XmlReader& e)
     } else if (tag == "systemFlag") {
         setSystemFlag(e.readInt());
     } else if (tag == "Symbol" || tag == "FSymbol") {
-        Element* element = name2Element(tag, score());
+        Element* element = name2Element(tag, this);
         element->read(e);
         add(element);
     } else if (tag == "Image") {
         if (MScore::noImages) {
             e.skipCurrentElement();
         } else {
-            Element* element = name2Element(tag, score());
+            Element* element = name2Element(tag, this);
             element->read(e);
             add(element);
         }

--- a/src/engraving/libmscore/bsymbol.h
+++ b/src/engraving/libmscore/bsymbol.h
@@ -37,7 +37,7 @@ class BSymbol : public Element
     Align _align;
 
 public:
-    BSymbol(const ElementType& type, Score* s, ElementFlags f = ElementFlag::NOTHING);
+    BSymbol(const ElementType& type, Element* parent, ElementFlags f = ElementFlag::NOTHING);
     BSymbol(const BSymbol&);
 
     // Score Tree functions

--- a/src/engraving/libmscore/check.cpp
+++ b/src/engraving/libmscore/check.cpp
@@ -235,7 +235,7 @@ void Measure::fillGap(const Fraction& pos, const Fraction& len, int track, const
     TDuration d;
     d.setVal(len.ticks());
     if (d.isValid()) {
-        Rest* rest = new Rest(score());
+        Rest* rest = new Rest(score()->dummy()->segment());
         rest->setTicks(len);
         rest->setDurationType(d);
         rest->setTrack(track);

--- a/src/engraving/libmscore/chord.h
+++ b/src/engraving/libmscore/chord.h
@@ -103,7 +103,7 @@ class Chord final : public ChordRest
     qreal noteHeadWidth() const;
 
 public:
-    Chord(Score* s = 0);
+    Chord(Segment* parent = 0);
     Chord(const Chord&, bool link = false);
     ~Chord();
     Chord& operator=(const Chord&) = delete;

--- a/src/engraving/libmscore/chordline.cpp
+++ b/src/engraving/libmscore/chordline.cpp
@@ -42,8 +42,8 @@ const char* scorelineNames[] = {
 //   ChordLine
 //---------------------------------------------------------
 
-ChordLine::ChordLine(Score* s)
-    : Element(ElementType::CHORDLINE, s, ElementFlag::MOVABLE)
+ChordLine::ChordLine(Chord* parent)
+    : Element(ElementType::CHORDLINE, parent, ElementFlag::MOVABLE)
 {
     modified = false;
     _chordLineType = ChordLineType::NOTYPE;

--- a/src/engraving/libmscore/chordline.h
+++ b/src/engraving/libmscore/chordline.h
@@ -52,7 +52,7 @@ class ChordLine final : public Element
     const int _initialLength = 2;
 
 public:
-    ChordLine(Score*);
+    ChordLine(Chord* parent);
     ChordLine(const ChordLine&);
 
     ChordLine* clone() const override { return new ChordLine(*this); }

--- a/src/engraving/libmscore/chordrest.cpp
+++ b/src/engraving/libmscore/chordrest.cpp
@@ -69,8 +69,8 @@ namespace Ms {
 //   ChordRest
 //---------------------------------------------------------
 
-ChordRest::ChordRest(const ElementType& type, Score* s)
-    : DurationElement(type, s)
+ChordRest::ChordRest(const ElementType& type, Segment* parent)
+    : DurationElement(type, parent)
 {
     _staffMove    = 0;
     _beam         = 0;
@@ -268,7 +268,7 @@ bool ChordRest::readProperties(XmlReader& e)
         }
         _beamMode = Beam::Mode(bm);
     } else if (tag == "Articulation") {
-        Articulation* atr = new Articulation(score());
+        Articulation* atr = new Articulation(this);
         atr->setTrack(track());
         atr->read(e);
         add(atr);
@@ -303,7 +303,7 @@ bool ChordRest::readProperties(XmlReader& e)
     } else if (tag == "Spanner") {
         Spanner::readSpanner(e, this, track());
     } else if (tag == "Lyrics") {
-        Element* element = new Lyrics(score());
+        Element* element = new Lyrics(this);
         element->setTrack(e.track());
         element->read(e);
         add(element);
@@ -521,7 +521,7 @@ Element* ChordRest::drop(EditData& data)
         Note* note = toNote(e);
         Segment* seg = segment();
         score()->undoRemoveElement(this);
-        Chord* chord = new Chord(score());
+        Chord* chord = new Chord(score()->dummy()->segment());
         chord->setTrack(track());
         chord->setDurationType(durationType());
         chord->setTicks(ticks());

--- a/src/engraving/libmscore/chordrest.h
+++ b/src/engraving/libmscore/chordrest.h
@@ -78,7 +78,7 @@ protected:
     TDuration _crossMeasureTDur;          ///< the total Duration type of the combined notes
 
 public:
-    ChordRest(const ElementType& type, Score*);
+    ChordRest(const ElementType& type, Segment* parent);
     ChordRest(const ChordRest&, bool link = false);
     ChordRest& operator=(const ChordRest&) = delete;
     ~ChordRest();

--- a/src/engraving/libmscore/clef.cpp
+++ b/src/engraving/libmscore/clef.cpp
@@ -138,8 +138,8 @@ ClefType ClefInfo::tag2type(const QString& s)
 //   Clef
 //---------------------------------------------------------
 
-Clef::Clef(Score* s)
-    : Element(ElementType::CLEF, s, ElementFlag::ON_STAFF), symId(SymId::noSym)
+Clef::Clef(Segment* parent)
+    : Element(ElementType::CLEF, parent, ElementFlag::ON_STAFF), symId(SymId::noSym)
 {}
 
 //---------------------------------------------------------
@@ -311,7 +311,7 @@ Element* Clef::drop(EditData& data)
             if (segm->element(track())) {
                 score()->undoRemoveElement(segm->element(track()));
             }
-            Ambitus* r = new Ambitus(score());
+            Ambitus* r = new Ambitus(segm);
             r->setParent(segm);
             r->setTrack(track());
             score()->undoAddElement(r);

--- a/src/engraving/libmscore/clef.h
+++ b/src/engraving/libmscore/clef.h
@@ -150,7 +150,7 @@ class Clef final : public Element
     ClefTypeList _clefTypes { ClefType::INVALID };
 
 public:
-    Clef(Score*);
+    Clef(Segment* parent);
     Clef* clone() const override { return new Clef(*this); }
     qreal mag() const override;
 

--- a/src/engraving/libmscore/connector.cpp
+++ b/src/engraving/libmscore/connector.cpp
@@ -390,7 +390,7 @@ bool ConnectorInfoReader::read()
             readEndpointLocation(_nextLoc);
         } else {
             if (tag == name) {
-                _connector = Element::name2Element(tag, _connectorReceiver->score());
+                _connector = Element::name2Element(tag, _connectorReceiver->score()->dummy());
             } else {
                 qWarning("ConnectorInfoReader::read: element tag (%s) does not match connector type (%s). Is the file corrupted?",
                          tag.toLatin1().constData(), name.toLatin1().constData());

--- a/src/engraving/libmscore/duration.cpp
+++ b/src/engraving/libmscore/duration.cpp
@@ -36,8 +36,8 @@ namespace Ms {
 //   DurationElement
 //---------------------------------------------------------
 
-DurationElement::DurationElement(const ElementType& type, Score* s, ElementFlags f)
-    : Element(type, s, f)
+DurationElement::DurationElement(const ElementType& type, Element* parent, ElementFlags f)
+    : Element(type, parent, f)
 {
     _tuplet = 0;
 }

--- a/src/engraving/libmscore/duration.h
+++ b/src/engraving/libmscore/duration.h
@@ -46,7 +46,7 @@ class DurationElement : public Element
     Tuplet* _tuplet;
 
 public:
-    DurationElement(const ElementType& type, Score* = 0, ElementFlags = ElementFlag::MOVABLE | ElementFlag::ON_STAFF);
+    DurationElement(const ElementType& type, Element* parent = 0, ElementFlags = ElementFlag::MOVABLE | ElementFlag::ON_STAFF);
     DurationElement(const DurationElement& e);
     ~DurationElement();
 

--- a/src/engraving/libmscore/dynamic.cpp
+++ b/src/engraving/libmscore/dynamic.cpp
@@ -157,8 +157,8 @@ int Dynamic::findInString(const QString& s, int& length, QString& type)
 //   Dynamic
 //---------------------------------------------------------
 
-Dynamic::Dynamic(Score* s)
-    : TextBase(ElementType::DYNAMIC, s, Tid::DYNAMICS, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+Dynamic::Dynamic(Segment* parent)
+    : TextBase(ElementType::DYNAMIC, parent, Tid::DYNAMICS, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     _velocity    = -1;
     _dynRange    = Range::PART;

--- a/src/engraving/libmscore/dynamic.h
+++ b/src/engraving/libmscore/dynamic.h
@@ -101,7 +101,7 @@ private:
     mu::RectF drag(EditData&) override;
 
 public:
-    Dynamic(Score*);
+    Dynamic(Segment* parent);
     Dynamic(const Dynamic&);
     Dynamic* clone() const override { return new Dynamic(*this); }
     Segment* segment() const { return (Segment*)parent(); }

--- a/src/engraving/libmscore/element.h
+++ b/src/engraving/libmscore/element.h
@@ -186,7 +186,6 @@ class Element : public ScoreElement
 {
     INJECT(engraving, mu::engraving::IEngravingConfiguration, engravingConfiguration)
 
-    Element* _parent { 0 };
     mutable mu::RectF _bbox;  ///< Bounding box relative to _pos + _offset
     qreal _mag;                     ///< standard magnification (derived value)
     mu::PointF _pos;          ///< Reference position, relative to _parent, set by autoplace
@@ -212,7 +211,8 @@ protected:
     mu::draw::Color _color;                ///< element color attribute
 
 public:
-    Element(const ElementType& type, Score* = 0, ElementFlags = ElementFlag::NOTHING, mu::engraving::AccessibleElement* access = nullptr);
+    Element(const ElementType& type, ScoreElement* se = 0, ElementFlags = ElementFlag::NOTHING,
+            mu::engraving::AccessibleElement* access = nullptr);
     Element(const Element&);
     virtual ~Element();
 
@@ -223,10 +223,7 @@ public:
 
     void deleteLater();
 
-    Element* parent() const { return _parent; }
-    void setParent(Element* e) { _parent = e; }
-
-    virtual ScoreElement* treeParent() const override { return _parent; }
+    Element* parentElement() const { return static_cast<Element*>(parent()); }
 
     Element* findAncestor(ElementType t);
     const Element* findAncestor(ElementType t) const;
@@ -486,8 +483,8 @@ public:
     bool isPrintable() const;
     qreal point(const Spatium sp) const { return sp.val() * spatium(); }
 
-    static Ms::Element* create(Ms::ElementType type, Score*);
-    static Element* name2Element(const QStringRef&, Score*);
+    static Ms::Element* create(Ms::ElementType type, Ms::Element* parent);
+    static Element* name2Element(const QStringRef&, Ms::Element* parent);
 
     bool systemFlag() const { return flag(ElementFlag::SYSTEM); }
     void setSystemFlag(bool v) const { setFlag(ElementFlag::SYSTEM, v); }
@@ -661,9 +658,9 @@ public:
 extern bool elementLessThan(const Element* const, const Element* const);
 extern void collectElements(void* data, Element* e);
 
-template<typename T> std::shared_ptr<T> makeElement(Ms::Score* score)
+template<typename T> std::shared_ptr<T> makeElement(Ms::Element* parent)
 {
-    return std::make_shared<T>(score);
+    return std::make_shared<T>(parent);
 }
 }     // namespace Ms
 

--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -463,7 +463,7 @@ static void cloneSpanner(Spanner* s, Score* score, int dstTrack, int dstTrack2)
     }
     Spanner* ns = toSpanner(s->linkedClone());
     ns->setScore(score);
-    ns->setParent(0);
+    ns->moveToDummy();
     ns->setTrack(dstTrack);
     ns->setTrack2(dstTrack2);
 
@@ -571,18 +571,18 @@ void Excerpt::cloneStaves(Score* oscore, Score* score, const QList<int>& sourceS
     for (MeasureBase* mb = oscore->measures()->first(); mb; mb = mb->next()) {
         MeasureBase* nmb = 0;
         if (mb->isHBox()) {
-            nmb = new HBox(score);
+            nmb = new HBox(score->dummy()->system());
         } else if (mb->isVBox()) {
-            nmb = new VBox(score);
+            nmb = new VBox(score->dummy()->system());
         } else if (mb->isTBox()) {
-            nmb = new TBox(score);
+            nmb = new TBox(score->dummy()->system());
             Text* text = toTBox(mb)->text();
             Element* ne = text->linkedClone();
             ne->setScore(score);
             nmb->add(ne);
         } else if (mb->isMeasure()) {
             Measure* m  = toMeasure(mb);
-            Measure* nm = new Measure(score);
+            Measure* nm = new Measure(score->dummy()->system());
             nmb = nm;
             nm->setTick(m->tick());
             nm->setTicks(m->ticks());
@@ -816,11 +816,11 @@ void Excerpt::cloneStaves(Score* oscore, Score* score, const QList<int>& sourceS
 
                         Segment* tst = nm->segments().firstCRSegment();
                         if (srcTrack % VOICES && !(track % VOICES) && (!tst || (!tst->element(track)))) {
-                            Rest* rest = new Rest(score);
+                            Segment* segment = nm->getSegment(SegmentType::ChordRest, nm->tick());
+                            Rest* rest = new Rest(segment);
                             rest->setTicks(nm->ticks());
                             rest->setDurationType(nm->ticks());
                             rest->setTrack(track);
-                            Segment* segment = nm->getSegment(SegmentType::ChordRest, nm->tick());
                             segment->add(rest);
                         }
                     }

--- a/src/engraving/libmscore/fermata.cpp
+++ b/src/engraving/libmscore/fermata.cpp
@@ -49,8 +49,8 @@ static const ElementStyle fermataStyle {
 //   Fermata
 //---------------------------------------------------------
 
-Fermata::Fermata(Score* s)
-    : Element(ElementType::FERMATA, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+Fermata::Fermata(Element* parent)
+    : Element(ElementType::FERMATA, parent, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     setPlacement(Placement::ABOVE);
     _symId         = SymId::noSym;
@@ -59,8 +59,8 @@ Fermata::Fermata(Score* s)
     initElementStyle(&fermataStyle);
 }
 
-Fermata::Fermata(SymId id, Score* s)
-    : Fermata(s)
+Fermata::Fermata(SymId id, Element* parent)
+    : Fermata(parent)
 {
     setSymId(id);
 }
@@ -257,7 +257,7 @@ void Fermata::layout()
 QVector<mu::LineF> Fermata::dragAnchorLines() const
 {
     QVector<LineF> result;
-    result << LineF(canvasPos(), parent()->canvasPos());
+    result << LineF(canvasPos(), parentElement()->canvasPos());
     return result;
 }
 

--- a/src/engraving/libmscore/fermata.h
+++ b/src/engraving/libmscore/fermata.h
@@ -48,8 +48,8 @@ class Fermata final : public Element
     Sid getPropertyStyle(Pid) const override;
 
 public:
-    Fermata(Score*);
-    Fermata(SymId, Score*);
+    Fermata(Element* parent);
+    Fermata(SymId, Element* parent);
     Fermata& operator=(const Fermata&) = delete;
 
     Fermata* clone() const override { return new Fermata(*this); }

--- a/src/engraving/libmscore/figuredbass.cpp
+++ b/src/engraving/libmscore/figuredbass.cpp
@@ -75,8 +75,8 @@ static QList<FiguredBassFont> g_FBFonts;
 const QChar FiguredBassItem::normParenthToChar[int(FiguredBassItem::Parenthesis::NUMOF)] =
 { 0, '(', ')', '[', ']' };
 
-FiguredBassItem::FiguredBassItem(Score* s, int l)
-    : Element(ElementType::INVALID, s), ord(l)
+FiguredBassItem::FiguredBassItem(FiguredBass* parent, int l)
+    : Element(ElementType::INVALID, parent), ord(l)
 {
     _prefix     = _suffix = Modifier::NONE;
     _digit      = FBIDigitNone;
@@ -997,8 +997,8 @@ bool FiguredBassItem::startsWithParenthesis() const
 //   F I G U R E D   B A S S
 //---------------------------------------------------------
 
-FiguredBass::FiguredBass(Score* s)
-    : TextBase(ElementType::FIGURED_BASS, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+FiguredBass::FiguredBass(Segment* parent)
+    : TextBase(ElementType::FIGURED_BASS, parent, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&figuredBassStyle);
     // figured bass inherits from TextBase for layout purposes
@@ -1103,7 +1103,7 @@ void FiguredBass::read(XmlReader& e)
         } else if (tag == "onNote") {
             setOnNote(e.readInt() != 0l);
         } else if (tag == "FiguredBassItem") {
-            FiguredBassItem* pItem = new FiguredBassItem(score(), idx++);
+            FiguredBassItem* pItem = new FiguredBassItem(this, idx++);
             pItem->setTrack(track());
             pItem->setParent(this);
             pItem->read(e);
@@ -1333,7 +1333,7 @@ void FiguredBass::endEdit(EditData& ed)
     QString normalizedText = QString();
     idx = 0;
     for (QString str : qAsConst(list)) {
-        FiguredBassItem* pItem = new FiguredBassItem(score(), idx++);
+        FiguredBassItem* pItem = new FiguredBassItem(this, idx++);
         if (!pItem->parse(str)) {               // if any item fails parsing
             qDeleteAll(items);
             items.clear();                      // clear item list
@@ -1513,7 +1513,7 @@ FiguredBass* FiguredBass::addFiguredBassToSegment(Segment* seg, int track, const
         }
     }
     if (fb == 0) {                            // no FB at segment: create new
-        fb = new FiguredBass(seg->score());
+        fb = new FiguredBass(seg);
         fb->setTrack(track);
         fb->setParent(seg);
 

--- a/src/engraving/libmscore/figuredbass.h
+++ b/src/engraving/libmscore/figuredbass.h
@@ -153,7 +153,7 @@ private:
     QString                   Modifier2MusicXML(FiguredBassItem::Modifier prefix) const;
 
 public:
-    FiguredBassItem(Score* s = 0, int line = 0);
+    FiguredBassItem(FiguredBass* parent = 0, int line = 0);
     FiguredBassItem(const FiguredBassItem&);
     ~FiguredBassItem();
 
@@ -253,7 +253,7 @@ class FiguredBass final : public TextBase
     Sid getPropertyStyle(Pid) const override;
 
 public:
-    FiguredBass(Score* s = 0);
+    FiguredBass(Segment* parent = 0);
     FiguredBass(const FiguredBass&);
     ~FiguredBass();
 

--- a/src/engraving/libmscore/fingering.cpp
+++ b/src/engraving/libmscore/fingering.cpp
@@ -51,15 +51,15 @@ static const ElementStyle fingeringStyle {
 //      Element(Score* = 0, ElementFlags = ElementFlag::NOTHING);
 //---------------------------------------------------------
 
-Fingering::Fingering(Score* s, Tid tid, ElementFlags ef)
-    : TextBase(ElementType::FINGERING, s, tid, ef)
+Fingering::Fingering(Note* parent, Tid tid, ElementFlags ef)
+    : TextBase(ElementType::FINGERING, parent, tid, ef)
 {
     setPlacement(Placement::ABOVE);
     initElementStyle(&fingeringStyle);
 }
 
-Fingering::Fingering(Score* s, ElementFlags ef)
-    : Fingering(s, Tid::FINGERING, ef)
+Fingering::Fingering(Note* parent, ElementFlags ef)
+    : Fingering(parent, Tid::FINGERING, ef)
 {
 }
 
@@ -105,7 +105,7 @@ Placement Fingering::calculatePlacement() const
 void Fingering::layout()
 {
     if (parent()) {
-        Fraction tick = parent()->tick();
+        Fraction tick = parentElement()->tick();
         const Staff* st = staff();
         if (st && st->isTabStaff(tick) && !st->staffType(tick)->showTabFingering()) {
             setbbox(RectF());

--- a/src/engraving/libmscore/fingering.h
+++ b/src/engraving/libmscore/fingering.h
@@ -33,8 +33,8 @@ namespace Ms {
 class Fingering final : public TextBase
 {
 public:
-    Fingering(Score*, Tid tid, ElementFlags ef = ElementFlag::HAS_TAG);
-    Fingering(Score* s, ElementFlags ef = ElementFlag::HAS_TAG);
+    Fingering(Note* parent, Tid tid, ElementFlags ef = ElementFlag::HAS_TAG);
+    Fingering(Note* parent, ElementFlags ef = ElementFlag::HAS_TAG);
 
     Fingering* clone() const override { return new Fingering(*this); }
 

--- a/src/engraving/libmscore/fret.cpp
+++ b/src/engraving/libmscore/fret.cpp
@@ -64,8 +64,8 @@ static const ElementStyle fretStyle {
 //   FretDiagram
 //---------------------------------------------------------
 
-FretDiagram::FretDiagram(Score* score)
-    : Element(ElementType::FRET_DIAGRAM, score, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+FretDiagram::FretDiagram(Segment* parent)
+    : Element(ElementType::FRET_DIAGRAM, parent, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     font.setFamily("FreeSans");
     font.setPointSizeF(4.0 * mag());
@@ -125,7 +125,7 @@ Element* FretDiagram::linkedClone()
 
 std::shared_ptr<FretDiagram> FretDiagram::createFromString(Score* score, const QString& s)
 {
-    auto fd = makeElement<FretDiagram>(score);
+    auto fd = std::make_shared<FretDiagram>(score->dummy()->segment());
     int strings = s.size();
 
     fd->setStrings(strings);
@@ -822,7 +822,7 @@ void FretDiagram::read(XmlReader& e)
         } else if (tag == "mag") {
             readProperty(e, Pid::MAG);
         } else if (tag == "Harmony") {
-            Harmony* h = new Harmony(score());
+            Harmony* h = new Harmony(this->score()->dummy()->segment());
             h->read(e);
             add(h);
         } else if (!Element::readProperties(e)) {
@@ -1177,7 +1177,7 @@ FretItem::Barre FretDiagram::barre(int f) const
 void FretDiagram::setHarmony(QString harmonyText)
 {
     if (!_harmony) {
-        Harmony* h = new Harmony(score());
+        Harmony* h = new Harmony(this->score()->dummy()->segment());
         add(h);
     }
 

--- a/src/engraving/libmscore/fret.h
+++ b/src/engraving/libmscore/fret.h
@@ -172,7 +172,7 @@ class FretDiagram final : public Element
     void removeDotsMarkers(int ss, int es, int fret);
 
 public:
-    FretDiagram(Score* s = nullptr);
+    FretDiagram(Segment* parent = nullptr);
     FretDiagram(const FretDiagram&);
     ~FretDiagram();
 

--- a/src/engraving/libmscore/glissando.cpp
+++ b/src/engraving/libmscore/glissando.cpp
@@ -180,8 +180,8 @@ Element* GlissandoSegment::propertyDelegate(Pid pid)
 //   Glissando
 //=========================================================
 
-Glissando::Glissando(Score* s)
-    : SLine(ElementType::GLISSANDO, s, ElementFlag::MOVABLE)
+Glissando::Glissando(Element* parent)
+    : SLine(ElementType::GLISSANDO, parent, ElementFlag::MOVABLE)
 {
     setAnchor(Spanner::Anchor::NOTE);
     setDiagonal(true);

--- a/src/engraving/libmscore/glissando.h
+++ b/src/engraving/libmscore/glissando.h
@@ -73,7 +73,7 @@ class Glissando final : public SLine
     static const std::array<const char*, 2> glissandoTypeNames;
 
 public:
-    Glissando(Score* s);
+    Glissando(Element* parent);
     Glissando(const Glissando&);
 
     static Note* guessInitialNote(Chord* chord);

--- a/src/engraving/libmscore/hairpin.cpp
+++ b/src/engraving/libmscore/hairpin.cpp
@@ -603,8 +603,8 @@ Sid Hairpin::getPropertyStyle(Pid pid) const
 //   Hairpin
 //---------------------------------------------------------
 
-Hairpin::Hairpin(Score* s)
-    : TextLineBase(ElementType::HAIRPIN, s)
+Hairpin::Hairpin(Segment* parent)
+    : TextLineBase(ElementType::HAIRPIN, parent)
 {
     initElementStyle(&hairpinStyle);
 

--- a/src/engraving/libmscore/hairpin.h
+++ b/src/engraving/libmscore/hairpin.h
@@ -102,7 +102,7 @@ class Hairpin final : public TextLineBase
     Sid getPropertyStyle(Pid) const override;
 
 public:
-    Hairpin(Score* s);
+    Hairpin(Segment* parent);
 
     Hairpin* clone() const override { return new Hairpin(*this); }
 

--- a/src/engraving/libmscore/harmony.cpp
+++ b/src/engraving/libmscore/harmony.cpp
@@ -186,8 +186,8 @@ const ElementStyle chordSymbolStyle {
 //   Harmony
 //---------------------------------------------------------
 
-Harmony::Harmony(Score* s)
-    : TextBase(ElementType::HARMONY, s, Tid::HARMONY_A, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+Harmony::Harmony(Segment* parent)
+    : TextBase(ElementType::HARMONY, parent, Tid::HARMONY_A, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     _rootTpc    = Tpc::TPC_INVALID;
     _baseTpc    = Tpc::TPC_INVALID;

--- a/src/engraving/libmscore/harmony.h
+++ b/src/engraving/libmscore/harmony.h
@@ -120,7 +120,7 @@ class Harmony final : public TextBase
     Harmony* findInSeg(Segment* seg) const;
 
 public:
-    Harmony(Score* = 0);
+    Harmony(Segment* parent = 0);
     Harmony(const Harmony&);
     ~Harmony();
 

--- a/src/engraving/libmscore/hook.cpp
+++ b/src/engraving/libmscore/hook.cpp
@@ -32,8 +32,8 @@ namespace Ms {
 //   Hook
 //---------------------------------------------------------
 
-Hook::Hook(Score* s)
-    : Symbol(ElementType::HOOK, s, ElementFlag::NOTHING)
+Hook::Hook(Chord* parent)
+    : Symbol(ElementType::HOOK, parent, ElementFlag::NOTHING)
 {
     setZ(int(type()) * 100);
 }
@@ -44,7 +44,7 @@ Hook::Hook(Score* s)
 
 Element* Hook::elementBase() const
 {
-    return parent();
+    return parentElement();
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/hook.h
+++ b/src/engraving/libmscore/hook.h
@@ -37,10 +37,10 @@ class Hook final : public Symbol
     int _hookType { 0 };
 
 public:
-    Hook(Score* = 0);
+    Hook(Chord* parent = 0);
 
     Hook* clone() const override { return new Hook(*this); }
-    qreal mag() const override { return parent()->mag(); }
+    qreal mag() const override { return parentElement()->mag(); }
     Element* elementBase() const override;
 
     void setHookType(int v);

--- a/src/engraving/libmscore/image.cpp
+++ b/src/engraving/libmscore/image.cpp
@@ -49,8 +49,8 @@ static bool defaultSizeIsSpatium    = true;
 //   Image
 //---------------------------------------------------------
 
-Image::Image(Score* s)
-    : BSymbol(ElementType::IMAGE, s, ElementFlag::MOVABLE)
+Image::Image(Element* parent)
+    : BSymbol(ElementType::IMAGE, parent, ElementFlag::MOVABLE)
 {
     imageType        = ImageType::NONE;
     rasterDoc        = 0;
@@ -568,8 +568,8 @@ void Image::layout()
             qreal f = _sizeIsSpatium ? spatium() : DPMM;
             SizeF size(imageSize());
             qreal ratio = size.width() / size.height();
-            qreal w = parent()->width();
-            qreal h = parent()->height();
+            qreal w = parentElement()->width();
+            qreal h = parentElement()->height();
             if ((w / h) < ratio) {
                 _size.setWidth(w / f);
                 _size.setHeight((w / ratio) / f);
@@ -578,7 +578,7 @@ void Image::layout()
                 _size.setWidth(h * ratio / f);
             }
         } else {
-            _size = pixel2size(parent()->bbox().size());
+            _size = pixel2size(parentElement()->bbox().size());
         }
     }
 

--- a/src/engraving/libmscore/image.h
+++ b/src/engraving/libmscore/image.h
@@ -74,7 +74,7 @@ protected:
     QVector<mu::LineF> gripAnchorLines(Grip) const override { return QVector<mu::LineF>(); }
 
 public:
-    Image(Score* = 0);
+    Image(Element* parent = 0);
     Image(const Image&);
     ~Image();
 

--- a/src/engraving/libmscore/iname.cpp
+++ b/src/engraving/libmscore/iname.cpp
@@ -49,7 +49,7 @@ static const ElementStyle shortInstrumentStyle {
 //   InstrumentName
 //---------------------------------------------------------
 
-InstrumentName::InstrumentName(Score* s)
+InstrumentName::InstrumentName(System* s)
     : TextBase(ElementType::INSTRUMENT_NAME, s, Tid::INSTRUMENT_LONG, ElementFlag::NOTHING)
 {
     setFlag(ElementFlag::MOVABLE, false);

--- a/src/engraving/libmscore/iname.h
+++ b/src/engraving/libmscore/iname.h
@@ -44,7 +44,7 @@ class InstrumentName final : public TextBase
     SysStaff* _sysStaff { nullptr };
 
 public:
-    InstrumentName(Score*);
+    InstrumentName(System*);
 
     InstrumentName* clone() const override { return new InstrumentName(*this); }
 

--- a/src/engraving/libmscore/instrchange.cpp
+++ b/src/engraving/libmscore/instrchange.cpp
@@ -51,15 +51,15 @@ static const ElementStyle instrumentChangeStyle {
 //   InstrumentChange
 //---------------------------------------------------------
 
-InstrumentChange::InstrumentChange(Score* s)
-    : TextBase(ElementType::INSTRUMENT_CHANGE, s, Tid::INSTRUMENT_CHANGE, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+InstrumentChange::InstrumentChange(Element* parent)
+    : TextBase(ElementType::INSTRUMENT_CHANGE, parent, Tid::INSTRUMENT_CHANGE, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&instrumentChangeStyle);
     _instrument = new Instrument();
 }
 
-InstrumentChange::InstrumentChange(const Instrument& i, Score* s)
-    : TextBase(ElementType::INSTRUMENT_CHANGE, s, Tid::INSTRUMENT_CHANGE, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+InstrumentChange::InstrumentChange(const Instrument& i, Element* parent)
+    : TextBase(ElementType::INSTRUMENT_CHANGE, parent, Tid::INSTRUMENT_CHANGE, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&instrumentChangeStyle);
     _instrument = new Instrument(i);

--- a/src/engraving/libmscore/instrchange.h
+++ b/src/engraving/libmscore/instrchange.h
@@ -41,8 +41,8 @@ class InstrumentChange final : public TextBase
     bool _init = false;   // Set if the instrument has been set by the user, as there is no other way to tell.
 
 public:
-    InstrumentChange(Score*);
-    InstrumentChange(const Instrument&, Score*);
+    InstrumentChange(Element* parent);
+    InstrumentChange(const Instrument&, Element* parent);
     InstrumentChange(const InstrumentChange&);
     ~InstrumentChange();
 

--- a/src/engraving/libmscore/jump.cpp
+++ b/src/engraving/libmscore/jump.cpp
@@ -62,8 +62,8 @@ int jumpTypeTableSize()
 //   Jump
 //---------------------------------------------------------
 
-Jump::Jump(Score* s)
-    : TextBase(ElementType::JUMP, s, Tid::REPEAT_RIGHT, ElementFlag::MOVABLE | ElementFlag::SYSTEM)
+Jump::Jump(Measure* parent)
+    : TextBase(ElementType::JUMP, parent, Tid::REPEAT_RIGHT, ElementFlag::MOVABLE | ElementFlag::SYSTEM)
 {
     initElementStyle(&jumpStyle);
     setLayoutToParentWidth(true);

--- a/src/engraving/libmscore/jump.h
+++ b/src/engraving/libmscore/jump.h
@@ -55,7 +55,7 @@ public:
         USER
     };
 
-    Jump(Score*);
+    Jump(Measure* parent);
 
     void setJumpType(Type t);
     Type jumpType() const;

--- a/src/engraving/libmscore/keysig.cpp
+++ b/src/engraving/libmscore/keysig.cpp
@@ -61,7 +61,7 @@ const char* keyNames[] = {
 //   KeySig
 //---------------------------------------------------------
 
-KeySig::KeySig(Score* s)
+KeySig::KeySig(Segment* s)
     : Element(ElementType::KEYSIG, s, ElementFlag::ON_STAFF)
 {
     _showCourtesy = true;

--- a/src/engraving/libmscore/keysig.h
+++ b/src/engraving/libmscore/keysig.h
@@ -45,7 +45,7 @@ class KeySig final : public Element
     void addLayout(SymId sym, qreal x, int y);
 
 public:
-    KeySig(Score* = 0);
+    KeySig(Segment* = 0);
     KeySig(const KeySig&);
 
     KeySig* clone() const override { return new KeySig(*this); }

--- a/src/engraving/libmscore/layoutbreak.cpp
+++ b/src/engraving/libmscore/layoutbreak.cpp
@@ -40,8 +40,8 @@ static const ElementStyle sectionBreakStyle {
 //   LayoutBreak
 //---------------------------------------------------------
 
-LayoutBreak::LayoutBreak(Score* score)
-    : Element(ElementType::LAYOUT_BREAK, score, ElementFlag::SYSTEM | ElementFlag::HAS_TAG)
+LayoutBreak::LayoutBreak(MeasureBase* parent)
+    : Element(ElementType::LAYOUT_BREAK, parent, ElementFlag::SYSTEM | ElementFlag::HAS_TAG)
 {
     _pause = 0.;
     _startWithLongNames = false;
@@ -68,6 +68,11 @@ LayoutBreak::LayoutBreak(const LayoutBreak& lb)
     _startWithMeasureOne   = lb._startWithMeasureOne;
     _firstSystemIdentation = lb._firstSystemIdentation;
     layout0();
+}
+
+void LayoutBreak::setParent(MeasureBase* parent)
+{
+    Element::setParent(parent);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/layoutbreak.h
+++ b/src/engraving/libmscore/layoutbreak.h
@@ -57,8 +57,10 @@ private:
     void spatiumChanged(qreal oldValue, qreal newValue) override;
 
 public:
-    LayoutBreak(Score* = 0);
+    LayoutBreak(MeasureBase* parent = 0);
     LayoutBreak(const LayoutBreak&);
+
+    void setParent(MeasureBase* parent);
 
     LayoutBreak* clone() const override { return new LayoutBreak(*this); }
     int subtype() const override { return static_cast<int>(_layoutBreakType); }

--- a/src/engraving/libmscore/letring.cpp
+++ b/src/engraving/libmscore/letring.cpp
@@ -67,8 +67,8 @@ void LetRingSegment::layout()
 //   LetRing
 //---------------------------------------------------------
 
-LetRing::LetRing(Score* s)
-    : TextLineBase(ElementType::LET_RING, s)
+LetRing::LetRing(Element* parent)
+    : TextLineBase(ElementType::LET_RING, parent)
 {
     initElementStyle(&letRingStyle);
     resetProperty(Pid::LINE_VISIBLE);

--- a/src/engraving/libmscore/letring.h
+++ b/src/engraving/libmscore/letring.h
@@ -57,7 +57,7 @@ protected:
     mu::PointF linePos(Grip, System**) const override;
 
 public:
-    LetRing(Score* s);
+    LetRing(Element* parent);
 
     LetRing* clone() const override { return new LetRing(*this); }
 

--- a/src/engraving/libmscore/line.cpp
+++ b/src/engraving/libmscore/line.cpp
@@ -785,8 +785,8 @@ RectF LineSegment::drag(EditData& ed)
 //   SLine
 //---------------------------------------------------------
 
-SLine::SLine(const ElementType& type, Score* s, ElementFlags f)
-    : Spanner(type, s, f)
+SLine::SLine(const ElementType& type, Element* parent, ElementFlags f)
+    : Spanner(type, parent, f)
 {
     setTrack(0);
     _lineWidth = 0.15 * spatium();
@@ -920,7 +920,7 @@ PointF SLine::linePos(Grip grip, System** sys) const
                     Segment* seg = score()->tick2segmentMM(tick2(), false, SegmentType::ChordRest);
                     if (!seg) {
                         // no end segment found, use measure width
-                        x2 = endElement()->parent()->parent()->width() - sp;
+                        x2 = endElement()->parentElement()->parentElement()->width() - sp;
                     } else if (currentSeg->measure() == seg->measure()) {
                         // next chordrest found in same measure;
                         // end line 1sp to left
@@ -938,7 +938,7 @@ PointF SLine::linePos(Grip grip, System** sys) const
                         qreal x3 = seg->enabled() ? seg->x() : seg->measure()->width();
                         x2 = qMax(x2, x3 - gap);
                     }
-                    x = x2 - endElement()->parent()->x();
+                    x = x2 - endElement()->parentElement()->x();
                 }
             }
         }

--- a/src/engraving/libmscore/line.h
+++ b/src/engraving/libmscore/line.h
@@ -104,7 +104,7 @@ protected:
     virtual mu::PointF linePos(Grip, System** system) const;
 
 public:
-    SLine(const ElementType& type, Score* s, ElementFlags = ElementFlag::NOTHING);
+    SLine(const ElementType& type, Element* parent, ElementFlags = ElementFlag::NOTHING);
     SLine(const SLine&);
 
     virtual void layout() override;

--- a/src/engraving/libmscore/lyrics.cpp
+++ b/src/engraving/libmscore/lyrics.cpp
@@ -51,8 +51,8 @@ static const ElementStyle lyricsElementStyle {
 //   Lyrics
 //---------------------------------------------------------
 
-Lyrics::Lyrics(Score* s)
-    : TextBase(ElementType::LYRICS, s, Tid::LYRICS_ODD)
+Lyrics::Lyrics(Element* parent)
+    : TextBase(ElementType::LYRICS, parent, Tid::LYRICS_ODD)
 {
     _even       = false;
     initElementStyle(&lyricsElementStyle);
@@ -186,7 +186,7 @@ void Lyrics::remove(Element* el)
             // be sure each finds a clean context
             LyricsLine* separ = _separator;
             _separator = 0;
-            separ->setParent(0);
+            separ->moveToDummy();
             separ->removeUnmanaged();
         }
     } else {
@@ -337,7 +337,7 @@ void Lyrics::layout()
 
     if (_ticks > Fraction(0, 1) || _syllabic == Syllabic::BEGIN || _syllabic == Syllabic::MIDDLE) {
         if (!_separator) {
-            _separator = new LyricsLine(score());
+            _separator = new LyricsLine(score()->dummy());
             _separator->setTick(cr->tick());
             score()->addUnmanagedSpanner(_separator);
         }

--- a/src/engraving/libmscore/lyrics.h
+++ b/src/engraving/libmscore/lyrics.h
@@ -69,7 +69,7 @@ protected:
     bool _even;
 
 public:
-    Lyrics(Score* = 0);
+    Lyrics(Element* parent = 0);
     Lyrics(const Lyrics&);
     ~Lyrics();
 
@@ -123,7 +123,7 @@ protected:
     Lyrics* _nextLyrics;
 
 public:
-    LyricsLine(Score*);
+    LyricsLine(Element* parent);
     LyricsLine(const LyricsLine&);
 
     LyricsLine* clone() const override { return new LyricsLine(*this); }

--- a/src/engraving/libmscore/lyricsline.cpp
+++ b/src/engraving/libmscore/lyricsline.cpp
@@ -69,8 +69,8 @@ static Lyrics* searchNextLyrics(Segment* s, int staffIdx, int verse, Placement p
 //   LyricsLine
 //---------------------------------------------------------
 
-LyricsLine::LyricsLine(Score* s)
-    : SLine(ElementType::LYRICSLINE, s, ElementFlag::NOT_SELECTABLE)
+LyricsLine::LyricsLine(Element* parent)
+    : SLine(ElementType::LYRICSLINE, parent, ElementFlag::NOT_SELECTABLE)
 {
     setGenerated(true);             // no need to save it, as it can be re-generated
     setDiagonal(false);

--- a/src/engraving/libmscore/marker.cpp
+++ b/src/engraving/libmscore/marker.cpp
@@ -62,13 +62,13 @@ int markerTypeTableSize()
 //   Marker
 //---------------------------------------------------------
 
-Marker::Marker(Score* s)
-    : Marker(s, Tid::REPEAT_LEFT)
+Marker::Marker(Element* parent)
+    : Marker(parent, Tid::REPEAT_LEFT)
 {
 }
 
-Marker::Marker(Score* s, Tid tid)
-    : TextBase(ElementType::MARKER, s, tid, ElementFlag::MOVABLE | ElementFlag::ON_STAFF | ElementFlag::SYSTEM)
+Marker::Marker(Element* parent, Tid tid)
+    : TextBase(ElementType::MARKER, parent, tid, ElementFlag::MOVABLE | ElementFlag::ON_STAFF | ElementFlag::SYSTEM)
 {
     initElementStyle(&markerStyle);
     _markerType = Type::FINE;

--- a/src/engraving/libmscore/marker.h
+++ b/src/engraving/libmscore/marker.h
@@ -53,8 +53,8 @@ private:
     QString _label;                 ///< referenced from Jump() element
 
 public:
-    Marker(Score*);
-    Marker(Score*, Tid);
+    Marker(Element* parent);
+    Marker(Element* parent, Tid);
 
     void setMarkerType(Type t);
     Type markerType() const { return _markerType; }

--- a/src/engraving/libmscore/mcursor.cpp
+++ b/src/engraving/libmscore/mcursor.cpp
@@ -22,7 +22,7 @@
 
 #include "mcursor.h"
 
-#include "engraving/compat/scoreaccess.h"
+#include "compat/scoreaccess.h"
 
 #include "part.h"
 #include "staff.h"
@@ -68,7 +68,7 @@ void MCursor::createMeasures()
                 break;
             }
         }
-        measure = new Measure(_score);
+        measure = new Measure(_score->dummy()->system());
         measure->setTick(tick);
         measure->setTimesig(_sig);
         measure->setTicks(_sig);
@@ -87,13 +87,13 @@ Chord* MCursor::addChord(int pitch, const TDuration& duration)
     Segment* segment = measure->getSegment(SegmentType::ChordRest, _tick);
     Chord* chord = toChord(segment->element(_track));
     if (chord == 0) {
-        chord = new Chord(_score);
+        chord = new Chord(segment);
         chord->setTrack(_track);
         chord->setDurationType(duration);
         chord->setTicks(duration.fraction());
         segment->add(chord);
     }
-    Note* note = new Note(_score);
+    Note* note = new Note(chord);
     chord->add(note);
     note->setPitch(pitch);
     note->setTpcFromPitch();
@@ -112,7 +112,7 @@ void MCursor::addKeySig(Key key)
     Segment* segment = measure->getSegment(SegmentType::KeySig, _tick);
     int n = _score->nstaves();
     for (int i = 0; i < n; ++i) {
-        KeySig* ks = new KeySig(_score);
+        KeySig* ks = new KeySig(segment);
         ks->setKey(key);
         ks->setTrack(i * VOICES);
         segment->add(ks);
@@ -130,7 +130,7 @@ TimeSig* MCursor::addTimeSig(const Fraction& f)
     Segment* segment = measure->getSegment(SegmentType::TimeSig, _tick);
     TimeSig* ts = 0;
     for (int i = 0; i < _score->nstaves(); ++i) {
-        ts = new TimeSig(_score);
+        ts = new TimeSig(segment);
         ts->setSig(f, TimeSigType::NORMAL);
         ts->setTrack(i * VOICES);
         segment->add(ts);

--- a/src/engraving/libmscore/measure.h
+++ b/src/engraving/libmscore/measure.h
@@ -136,7 +136,7 @@ private:
 class Measure final : public MeasureBase
 {
 public:
-    Measure(Score* = 0);
+    Measure(System* parent = 0);
     Measure(const Measure&);
     ~Measure();
 

--- a/src/engraving/libmscore/measurebase.h
+++ b/src/engraving/libmscore/measurebase.h
@@ -87,9 +87,12 @@ protected:
     void cleanupLayoutBreaks(bool undo);
 
 public:
-    MeasureBase(const ElementType& type, Score* score = 0);
+    MeasureBase(const ElementType& type, System* system = 0);
     ~MeasureBase();
     MeasureBase(const MeasureBase&);
+
+    System* system() const { return (System*)parent(); }
+    void setParent(System* s) { Element::setParent((ScoreElement*)(s)); }
 
     // Score Tree functions
     ScoreElement* treeParent() const override;
@@ -118,8 +121,6 @@ public:
 
     ElementList& el() { return _el; }
     const ElementList& el() const { return _el; }
-    System* system() const { return (System*)parent(); }
-    void setSystem(System* s) { setParent((Element*)s); }
 
     const MeasureBase* findPotentialSectionBreak() const;
     LayoutBreak* sectionBreakElement() const;

--- a/src/engraving/libmscore/measurenumber.cpp
+++ b/src/engraving/libmscore/measurenumber.cpp
@@ -40,8 +40,8 @@ static const ElementStyle measureNumberStyle {
 //   MeasureNumber
 //---------------------------------------------------------
 
-MeasureNumber::MeasureNumber(Score* s, Tid tid)
-    : MeasureNumberBase(ElementType::MEASURE_NUMBER, s, tid)
+MeasureNumber::MeasureNumber(Measure* parent, Tid tid)
+    : MeasureNumberBase(ElementType::MEASURE_NUMBER, parent, tid)
 {
     initElementStyle(&measureNumberStyle);
 

--- a/src/engraving/libmscore/measurenumber.h
+++ b/src/engraving/libmscore/measurenumber.h
@@ -33,7 +33,7 @@ namespace Ms {
 class MeasureNumber : public MeasureNumberBase
 {
 public:
-    MeasureNumber(Score* = nullptr, Tid tid = Tid::MEASURE_NUMBER);
+    MeasureNumber(Measure* parent = nullptr, Tid tid = Tid::MEASURE_NUMBER);
     MeasureNumber(const MeasureNumber& other);
 
     virtual MeasureNumber* clone() const override { return new MeasureNumber(*this); }

--- a/src/engraving/libmscore/measurenumberbase.cpp
+++ b/src/engraving/libmscore/measurenumberbase.cpp
@@ -33,8 +33,8 @@ namespace Ms {
 //   MeasureNumberBase
 //---------------------------------------------------------
 
-MeasureNumberBase::MeasureNumberBase(const ElementType& type, Score* s, Tid tid)
-    : TextBase(type, s, tid)
+MeasureNumberBase::MeasureNumberBase(const ElementType& type, Measure* parent, Tid tid)
+    : TextBase(type, parent, tid)
 {
     setFlag(ElementFlag::ON_STAFF, true);
 }

--- a/src/engraving/libmscore/measurenumberbase.h
+++ b/src/engraving/libmscore/measurenumberbase.h
@@ -37,7 +37,7 @@ class MeasureNumberBase : public TextBase
     M_PROPERTY(HPlacement, hPlacement, setHPlacement)    // Horizontal Placement
 
 public:
-    MeasureNumberBase(const ElementType& type, Score* = nullptr, Tid = Tid::DEFAULT);
+    MeasureNumberBase(const ElementType& type, Measure* parent = nullptr, Tid = Tid::DEFAULT);
     MeasureNumberBase(const MeasureNumberBase& other);
 
     virtual QVariant getProperty(Pid id) const override;

--- a/src/engraving/libmscore/measurerepeat.cpp
+++ b/src/engraving/libmscore/measurerepeat.cpp
@@ -42,12 +42,12 @@ static const ElementStyle measureRepeatStyle {
 //   MeasureRepeat
 //---------------------------------------------------------
 
-MeasureRepeat::MeasureRepeat(Score* score)
-    : Rest(ElementType::MEASURE_REPEAT, score), m_numMeasures(0), m_symId(SymId::noSym)
+MeasureRepeat::MeasureRepeat(Segment* parent)
+    : Rest(ElementType::MEASURE_REPEAT, parent), m_numMeasures(0), m_symId(SymId::noSym)
 {
     // however many measures the group, the element itself is always exactly the duration of its containing measure
     setDurationType(TDuration::DurationType::V_MEASURE);
-    if (score) {
+    if (parent) {
         initElementStyle(&measureRepeatStyle);
     }
 }

--- a/src/engraving/libmscore/measurerepeat.h
+++ b/src/engraving/libmscore/measurerepeat.h
@@ -38,7 +38,7 @@ class Segment;
 class MeasureRepeat final : public Rest
 {
 public:
-    MeasureRepeat(Score*);
+    MeasureRepeat(Segment* parent);
     MeasureRepeat& operator=(const MeasureRepeat&) = delete;
 
     MeasureRepeat* clone() const override { return new MeasureRepeat(*this); }

--- a/src/engraving/libmscore/mmrest.cpp
+++ b/src/engraving/libmscore/mmrest.cpp
@@ -42,7 +42,7 @@ static const ElementStyle mmRestStyle {
 //    MMRest
 //--------------------------------------------------------
 
-MMRest::MMRest(Score* s)
+MMRest::MMRest(Segment* s)
     : Rest(ElementType::MMREST, s)
 {
     m_width = 0;

--- a/src/engraving/libmscore/mmrest.h
+++ b/src/engraving/libmscore/mmrest.h
@@ -34,7 +34,7 @@ namespace Ms {
 class MMRest final : public Rest
 {
 public:
-    MMRest(Score* s = 0);
+    MMRest(Segment* s = 0);
     MMRest(const MMRest&, bool link = false);
     ~MMRest()
     {

--- a/src/engraving/libmscore/mmrestrange.cpp
+++ b/src/engraving/libmscore/mmrestrange.cpp
@@ -38,8 +38,8 @@ static const ElementStyle mmRestRangeStyle {
     { Sid::mmRestRangeHPlacement,  Pid::HPLACEMENT }
 };
 
-MMRestRange::MMRestRange(Score* s)
-    : MeasureNumberBase(ElementType::MMREST_RANGE, s, Tid::MMREST_RANGE)
+MMRestRange::MMRestRange(Measure* parent)
+    : MeasureNumberBase(ElementType::MMREST_RANGE, parent, Tid::MMREST_RANGE)
 {
     initElementStyle(&mmRestRangeStyle);
 }

--- a/src/engraving/libmscore/mmrestrange.h
+++ b/src/engraving/libmscore/mmrestrange.h
@@ -37,7 +37,7 @@ class MMRestRange : public MeasureNumberBase
     M_PROPERTY(MMRestRangeBracketType, bracketType, setBracketType)
 
 public:
-    MMRestRange(Score* s = nullptr);
+    MMRestRange(Measure* parent = nullptr);
     MMRestRange(const MMRestRange& other);
 
     virtual MMRestRange* clone() const override { return new MMRestRange(*this); }

--- a/src/engraving/libmscore/navigate.cpp
+++ b/src/engraving/libmscore/navigate.cpp
@@ -635,7 +635,7 @@ Element* Score::nextElement()
         case ElementType::KEYSIG:
         case ElementType::TIMESIG:
         case ElementType::BAR_LINE: {
-            for (; e && e->type() != ElementType::SEGMENT; e = e->parent()) {
+            for (; e && e->type() != ElementType::SEGMENT; e = e->parentElement()) {
             }
             Segment* s = toSegment(e);
             Element* next = s->nextElement(staffId);
@@ -708,7 +708,7 @@ Element* Score::nextElement()
         default:
             break;
         }
-        e = e->parent();
+        e = e->parentElement();
     }
     return score()->lastElement();
 }
@@ -754,7 +754,7 @@ Element* Score::prevElement()
         case ElementType::KEYSIG:
         case ElementType::TIMESIG:
         case ElementType::BAR_LINE: {
-            for (; e && e->type() != ElementType::SEGMENT; e = e->parent()) {
+            for (; e && e->type() != ElementType::SEGMENT; e = e->parentElement()) {
             }
             Segment* s = toSegment(e);
             return s->prevElement(staffId);
@@ -841,7 +841,7 @@ Element* Score::prevElement()
         default:
             break;
         }
-        e = e->parent();
+        e = e->parentElement();
     }
     return score()->firstElement();
 }

--- a/src/engraving/libmscore/note.h
+++ b/src/engraving/libmscore/note.h
@@ -171,8 +171,7 @@ public:
     Q_ENUM(Group);
     Q_ENUM(Type);
 
-    NoteHead(Score* s = 0)
-        : Symbol(ElementType::NOTEHEAD, s) {}
+    NoteHead(Note* parent = 0);
     NoteHead& operator=(const NoteHead&) = delete;
     NoteHead* clone() const override { return new NoteHead(*this); }
 
@@ -330,17 +329,20 @@ private:
     static QString tpcUserName(int tpc, int pitch, bool explicitAccidental);
 
 public:
-    Note(Score* s = 0);
+    Note(Chord* ch = 0);
     Note(const Note&, bool link = false);
     ~Note();
+
+    Note& operator=(const Note&) = delete;
+    virtual Note* clone() const override { return new Note(*this, false); }
+
+    Chord* chord() const { return (Chord*)parent(); }
+    void setParent(Chord* ch);
 
     // Score Tree functions
     ScoreElement* treeParent() const override;
     ScoreElement* treeChild(int idx) const override;
     int treeChildCount() const override;
-
-    Note& operator=(const Note&) = delete;
-    virtual Note* clone() const override { return new Note(*this, false); }
 
     void undoUnlink() override;
 
@@ -450,8 +452,6 @@ public:
     void disconnectTiedNotes();
     void connectTiedNotes();
 
-    Chord* chord() const { return (Chord*)parent(); }
-    void setChord(Chord* a) { setParent((Element*)a); }
     void draw(mu::draw::Painter*) const override;
 
     void read(XmlReader&) override;

--- a/src/engraving/libmscore/notedot.cpp
+++ b/src/engraving/libmscore/notedot.cpp
@@ -34,8 +34,14 @@ namespace Ms {
 //   NoteDot
 //---------------------------------------------------------
 
-NoteDot::NoteDot(Score* s)
-    : Element(ElementType::NOTEDOT, s)
+NoteDot::NoteDot(Note* parent)
+    : Element(ElementType::NOTEDOT, parent)
+{
+    setFlag(ElementFlag::MOVABLE, false);
+}
+
+NoteDot::NoteDot(Rest* parent)
+    : Element(ElementType::NOTEDOT, parent)
 {
     setFlag(ElementFlag::MOVABLE, false);
 }
@@ -77,7 +83,7 @@ void NoteDot::layout()
 
 Element* NoteDot::elementBase() const
 {
-    return parent();
+    return parentElement();
 }
 
 //---------------------------------------------------------
@@ -103,6 +109,6 @@ void NoteDot::read(XmlReader& e)
 
 qreal NoteDot::mag() const
 {
-    return parent()->mag() * score()->styleD(Sid::dotMag);
+    return parentElement()->mag() * score()->styleD(Sid::dotMag);
 }
 }

--- a/src/engraving/libmscore/notedot.h
+++ b/src/engraving/libmscore/notedot.h
@@ -36,7 +36,8 @@ class Rest;
 class NoteDot final : public Element
 {
 public:
-    NoteDot(Score* = 0);
+    NoteDot(Note* parent);
+    NoteDot(Rest* parent);
 
     NoteDot* clone() const override { return new NoteDot(*this); }
     qreal mag() const override;

--- a/src/engraving/libmscore/noteentry.cpp
+++ b/src/engraving/libmscore/noteentry.cpp
@@ -214,7 +214,7 @@ Note* Score::addPitch(NoteVal& nval, bool addFlag, InputState* externalInputStat
         // for keyboard input (where we are given a staff position), there is a separate function Score::repitchNote()
         // the code is similar enough that it could possibly be refactored
         Chord* chord = toChord(is.cr());
-        note = new Note(this);
+        note = new Note(chord);
         note->setParent(chord);
         note->setTrack(chord->track());
         note->setNval(nval);
@@ -265,7 +265,7 @@ Note* Score::addPitch(NoteVal& nval, bool addFlag, InputState* externalInputStat
         // recreate tie forward if there is a note to tie to
         // one-sided ties will not be recreated
         if (firstTiedNote) {
-            Tie* tie = new Tie(this);
+            Tie* tie = new Tie(note);
             tie->setStartNote(note);
             tie->setEndNote(firstTiedNote);
             tie->setTick(tie->startNote()->tick());
@@ -547,7 +547,7 @@ void Score::repitchNote(const Position& p, bool replace)
     } else {
         chord = toChord(cr);
     }
-    Note* note = new Note(this);
+    Note* note = new Note(chord);
     note->setParent(chord);
     note->setTrack(chord->track());
     note->setNval(nval);
@@ -605,7 +605,7 @@ void Score::repitchNote(const Position& p, bool replace)
         int tpc = styleB(Sid::concertPitch) ? nval.tpc1 : nval.tpc2;
         AccidentalVal alter = tpc2alter(tpc);
         at = Accidental::value2subtype(alter);
-        Accidental* a = new Accidental(this);
+        Accidental* a = new Accidental(note);
         a->setAccidentalType(at);
         a->setRole(AccidentalRole::USER);
         a->setParent(note);
@@ -616,7 +616,7 @@ void Score::repitchNote(const Position& p, bool replace)
     // recreate tie forward if there is a note to tie to
     // one-sided ties will not be recreated
     if (firstTiedNote) {
-        Tie* tie = new Tie(this);
+        Tie* tie = new Tie(note);
         tie->setStartNote(note);
         tie->setEndNote(firstTiedNote);
         tie->setTick(tie->startNote()->tick());

--- a/src/engraving/libmscore/noteline.cpp
+++ b/src/engraving/libmscore/noteline.cpp
@@ -24,8 +24,8 @@
 #include "textline.h"
 
 namespace Ms {
-NoteLine::NoteLine(Score* s)
-    : TextLineBase(ElementType::NOTELINE, s)
+NoteLine::NoteLine(Element* parent)
+    : TextLineBase(ElementType::NOTELINE, parent)
 {
 //TODO-ws      init();
 }

--- a/src/engraving/libmscore/noteline.h
+++ b/src/engraving/libmscore/noteline.h
@@ -38,7 +38,7 @@ class NoteLine final : public TextLineBase
     Note* _endNote;
 
 public:
-    NoteLine(Score* s);
+    NoteLine(Element* parent);
     NoteLine(const NoteLine&);
     ~NoteLine() {}
 

--- a/src/engraving/libmscore/ossia.cpp
+++ b/src/engraving/libmscore/ossia.cpp
@@ -27,8 +27,8 @@ namespace Ms {
 //   Ossia
 //---------------------------------------------------------
 
-Ossia::Ossia(Score* score)
-    : Element(ElementType::OSSIA, score)
+Ossia::Ossia(Element* parent)
+    : Element(ElementType::OSSIA, parent)
 {
 }
 

--- a/src/engraving/libmscore/ossia.h
+++ b/src/engraving/libmscore/ossia.h
@@ -34,7 +34,7 @@ namespace Ms {
 class Ossia final : public Element
 {
 public:
-    Ossia(Score*);
+    Ossia(Element* parent);
     Ossia(const Ossia&);
 
     Ossia* clone() const override { return new Ossia(*this); }

--- a/src/engraving/libmscore/ottava.cpp
+++ b/src/engraving/libmscore/ottava.cpp
@@ -219,8 +219,8 @@ Sid Ottava::getPropertyStyle(Pid pid) const
 //   Ottava
 //---------------------------------------------------------
 
-Ottava::Ottava(Score* s)
-    : TextLineBase(ElementType::OTTAVA, s, ElementFlag::ON_STAFF | ElementFlag::MOVABLE)
+Ottava::Ottava(Element* parent)
+    : TextLineBase(ElementType::OTTAVA, parent, ElementFlag::ON_STAFF | ElementFlag::MOVABLE)
 {
     _ottavaType  = OttavaType::OTTAVA_8VA;
     _numbersOnly = false;

--- a/src/engraving/libmscore/ottava.h
+++ b/src/engraving/libmscore/ottava.h
@@ -109,7 +109,7 @@ protected:
     friend class OttavaSegment;
 
 public:
-    Ottava(Score* s);
+    Ottava(Element* parent);
     Ottava(const Ottava&);
 
     Ottava* clone() const override { return new Ottava(*this); }

--- a/src/engraving/libmscore/page.h
+++ b/src/engraving/libmscore/page.h
@@ -54,7 +54,7 @@ class Page final : public Element
     void drawHeaderFooter(mu::draw::Painter*, int area, const QString&) const;
 
 public:
-    Page(Score*);
+    Page(ScoreElement* parent);
     ~Page();
 
     // Score Tree functions

--- a/src/engraving/libmscore/palmmute.cpp
+++ b/src/engraving/libmscore/palmmute.cpp
@@ -88,8 +88,8 @@ Sid PalmMute::getPropertyStyle(Pid pid) const
 //   PalmMute
 //---------------------------------------------------------
 
-PalmMute::PalmMute(Score* s)
-    : TextLineBase(ElementType::PALM_MUTE, s)
+PalmMute::PalmMute(Element* parent)
+    : TextLineBase(ElementType::PALM_MUTE, parent)
 {
     initElementStyle(&palmMuteStyle);
     resetProperty(Pid::LINE_VISIBLE);

--- a/src/engraving/libmscore/palmmute.h
+++ b/src/engraving/libmscore/palmmute.h
@@ -61,7 +61,7 @@ protected:
     mu::PointF linePos(Grip, System**) const override;
 
 public:
-    PalmMute(Score* s);
+    PalmMute(Element* parent);
 
     PalmMute* clone() const override { return new PalmMute(*this); }
 

--- a/src/engraving/libmscore/pedal.cpp
+++ b/src/engraving/libmscore/pedal.cpp
@@ -92,8 +92,8 @@ Sid Pedal::getPropertyStyle(Pid pid) const
 //   Pedal
 //---------------------------------------------------------
 
-Pedal::Pedal(Score* s)
-    : TextLineBase(ElementType::PEDAL, s)
+Pedal::Pedal(Element* parent)
+    : TextLineBase(ElementType::PEDAL, parent)
 {
     initElementStyle(&pedalStyle);
     setLineVisible(true);

--- a/src/engraving/libmscore/pedal.h
+++ b/src/engraving/libmscore/pedal.h
@@ -59,7 +59,7 @@ protected:
     mu::PointF linePos(Grip, System**) const override;
 
 public:
-    Pedal(Score* s);
+    Pedal(Element* parent);
 
     Pedal* clone() const override { return new Pedal(*this); }
 

--- a/src/engraving/libmscore/range.h
+++ b/src/engraving/libmscore/range.h
@@ -63,7 +63,7 @@ public:
     void read(const Segment* fs, const Segment* ls);
     bool write(Score*, const Fraction&) const;
 
-    void appendGap(const Fraction&);
+    void appendGap(const Fraction&, Ms::Score* score);
     bool truncate(const Fraction&);
     void dump() const;
 };

--- a/src/engraving/libmscore/read400.cpp
+++ b/src/engraving/libmscore/read400.cpp
@@ -162,7 +162,7 @@ bool Score::readScore400(XmlReader& e)
                    || (tag == "Trill")
                    || (tag == "Slur")
                    || (tag == "Pedal")) {
-            Spanner* s = toSpanner(Element::name2Element(tag, this));
+            Spanner* s = toSpanner(Element::name2Element(tag, this->dummy()));
             s->read(e);
             addSpanner(s);
         } else if (tag == "Excerpt") {

--- a/src/engraving/libmscore/rehearsalmark.cpp
+++ b/src/engraving/libmscore/rehearsalmark.cpp
@@ -41,8 +41,8 @@ static const ElementStyle rehearsalMarkStyle {
 //   RehearsalMark
 //---------------------------------------------------------
 
-RehearsalMark::RehearsalMark(Score* s)
-    : TextBase(ElementType::REHEARSAL_MARK, s, Tid::REHEARSAL_MARK)
+RehearsalMark::RehearsalMark(Segment* parent)
+    : TextBase(ElementType::REHEARSAL_MARK, parent, Tid::REHEARSAL_MARK)
 {
     initElementStyle(&rehearsalMarkStyle);
     setSystemFlag(true);

--- a/src/engraving/libmscore/rehearsalmark.h
+++ b/src/engraving/libmscore/rehearsalmark.h
@@ -33,7 +33,7 @@ namespace Ms {
 class RehearsalMark final : public TextBase
 {
 public:
-    RehearsalMark(Score* score);
+    RehearsalMark(Segment* parent);
 
     RehearsalMark* clone() const override { return new RehearsalMark(*this); }
 

--- a/src/engraving/libmscore/rest.cpp
+++ b/src/engraving/libmscore/rest.cpp
@@ -52,25 +52,25 @@ namespace Ms {
 //    Rest
 //--------------------------------------------------------
 
-Rest::Rest(Score* s)
-    : Rest(ElementType::REST, s)
+Rest::Rest(Segment* parent)
+    : Rest(ElementType::REST, parent)
 {
 }
 
-Rest::Rest(const ElementType& type, Score* s)
-    : ChordRest(type, s)
+Rest::Rest(const ElementType& type, Segment* parent)
+    : ChordRest(type, parent)
 {
     _beamMode  = Beam::Mode::NONE;
     m_sym      = SymId::restQuarter;
 }
 
-Rest::Rest(Score* s, const TDuration& d)
-    : Rest(ElementType::REST, s, d)
+Rest::Rest(Segment* parent, const TDuration& d)
+    : Rest(ElementType::REST, parent, d)
 {
 }
 
-Rest::Rest(const ElementType& type, Score* s, const TDuration& d)
-    : ChordRest(type, s)
+Rest::Rest(const ElementType& type, Segment* parent, const TDuration& d)
+    : ChordRest(type, parent)
 {
     _beamMode  = Beam::Mode::NONE;
     m_sym      = SymId::restQuarter;
@@ -342,7 +342,7 @@ void Rest::layout()
             }
             // symbol needed; if not exist, create, if exists, update duration
             if (!_tabDur) {
-                _tabDur = new TabDurationSymbol(score(), stt, type, dots);
+                _tabDur = new TabDurationSymbol(this, stt, type, dots);
             } else {
                 _tabDur->setDuration(type, dots, stt);
             }
@@ -406,7 +406,7 @@ void Rest::checkDots()
 {
     int n = dots() - int(m_dots.size());
     for (int i = 0; i < n; ++i) {
-        NoteDot* dot = new NoteDot(score());
+        NoteDot* dot = new NoteDot(this);
         dot->setParent(this);
         dot->setVisible(visible());
         score()->undoAddElement(dot);
@@ -863,7 +863,9 @@ QString Rest::screenReaderInfo() const
 
 void Rest::add(Element* e)
 {
-    e->setParent(this);
+    if (e->parent() != this) {
+        e->setParent(this);
+    }
     e->setTrack(track());
 
     switch (e->type()) {
@@ -941,7 +943,7 @@ void Rest::read(XmlReader& e)
     while (e.readNextStartElement()) {
         const QStringRef& tag(e.name());
         if (tag == "Symbol") {
-            Symbol* s = new Symbol(score());
+            Symbol* s = new Symbol(this);
             s->setTrack(track());
             s->read(e);
             add(s);
@@ -949,13 +951,13 @@ void Rest::read(XmlReader& e)
             if (MScore::noImages) {
                 e.skipCurrentElement();
             } else {
-                Image* image = new Image(score());
+                Image* image = new Image(this);
                 image->setTrack(track());
                 image->read(e);
                 add(image);
             }
         } else if (tag == "NoteDot") {
-            NoteDot* dot = new NoteDot(score());
+            NoteDot* dot = new NoteDot(this);
             dot->read(e);
             add(dot);
         } else if (readStyledProperty(e, tag)) {

--- a/src/engraving/libmscore/rest.h
+++ b/src/engraving/libmscore/rest.h
@@ -38,10 +38,10 @@ class TDuration;
 class Rest : public ChordRest
 {
 public:
-    Rest(Score* s = 0);
-    Rest(const ElementType& type, Score* s = 0);
-    Rest(Score*, const TDuration&);
-    Rest(const ElementType& type, Score*, const TDuration&);
+    Rest(Segment* parent);
+    Rest(const ElementType& type, Segment* parent = 0);
+    Rest(Segment* parent, const TDuration&);
+    Rest(const ElementType& type, Segment* parent, const TDuration&);
     Rest(const Rest&, bool link = false);
     ~Rest() { qDeleteAll(m_dots); }
 

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -34,6 +34,7 @@
 #include "style/style.h"
 #include "style/defaultstyle.h"
 #include "compat/writescorehook.h"
+#include "compat/dummyelement.h"
 #include "io/xml.h"
 
 #include "fermata.h"
@@ -276,7 +277,7 @@ void MeasureBaseList::change(MeasureBase* ob, MeasureBase* nb)
     }
     if (nb->type() == ElementType::HBOX || nb->type() == ElementType::VBOX
         || nb->type() == ElementType::TBOX || nb->type() == ElementType::FBOX) {
-        nb->setSystem(ob->system());
+        nb->setParent(ob->system());
     }
     foreach (Element* e, nb->el()) {
         e->setParent(nb);
@@ -297,7 +298,7 @@ void MeasureBaseList::fixupSystems()
     while (m != _last) {
         m = m->next();
         if (m->prev()->system() && !m->system()) {
-            m->setSystem(m->prev()->system());
+            m->setParent(m->prev()->system());
             if (m->isMeasure() && !toMeasure(m)->hasMMRest()) {
                 m->system()->appendMeasure(m);
             }
@@ -310,7 +311,7 @@ void MeasureBaseList::fixupSystems()
 //---------------------------------------------------------
 
 Score::Score()
-    : ScoreElement(ElementType::SCORE, this), _headersText(MAX_HEADERS, nullptr), _footersText(MAX_FOOTERS, nullptr), _selection(this),
+    : ScoreElement(ElementType::SCORE, nullptr), _headersText(MAX_HEADERS, nullptr), _footersText(MAX_FOOTERS, nullptr), _selection(this),
     m_layout(this)
 {
     Score::validScores.insert(this);
@@ -327,6 +328,8 @@ Score::Score()
     _style  = DefaultStyle::defaultStyle();
 //      accInfo = tr("No selection");     // ??
     accInfo = "No selection";
+
+    m_dummyElement = new mu::engraving::compat::DummyElement(this);
 
 #ifdef ENGRAVING_BUILD_ACCESSIBLE_TREE
     m_accessible = new mu::engraving::AccessibleScore(this);
@@ -416,6 +419,8 @@ Score::~Score()
 
     imageStore.clearUnused();
 
+    delete m_dummyElement;
+
 #ifdef ENGRAVING_BUILD_ACCESSIBLE_TREE
     delete m_accessible;
 #endif
@@ -466,7 +471,7 @@ bool Score::isPaletteScore() const
 
 void Score::onElementDestruction(Element* e)
 {
-    Score* score = e->score();
+    Score* score = e->score(false);
     if (!score || Score::validScores.find(score) == Score::validScores.end()) {
         // No score or the score is already deleted
         return;
@@ -1426,7 +1431,7 @@ Measure* Score::getCreateMeasure(const Fraction& tick)
     if (last == 0 || ((last->tick() + last->ticks()) <= tick)) {
         Fraction lastTick  = last ? (last->tick() + last->ticks()) : Fraction(0, 1);
         while (tick >= lastTick) {
-            Measure* m = new Measure(this);
+            Measure* m = new Measure(this->dummy()->system());
             Fraction ts = sigmap()->timesig(lastTick).timesig();
             m->setTick(lastTick);
             m->setTimesig(ts);
@@ -1451,7 +1456,7 @@ Measure* Score::getCreateMeasure(const Fraction& tick)
 
 void Score::addElement(Element* element)
 {
-    Element* parent = element->parent();
+    Element* parent = element->parentElement();
     element->triggerLayout();
 
 //      qDebug("Score(%p) Element(%p)(%s) parent %p(%s)",
@@ -1577,7 +1582,7 @@ void Score::addElement(Element* element)
 
 void Score::removeElement(Element* element)
 {
-    Element* parent = element->parent();
+    Element* parent = element->parentElement();
     element->triggerLayout();
 
 //      qDebug("Score(%p) Element(%p)(%s) parent %p(%s)",
@@ -1607,7 +1612,7 @@ void Score::removeElement(Element* element)
         if (element->isBox() && system->measures().size() == 1) {
             auto i = std::find(page->systems().begin(), page->systems().end(), system);
             page->systems().erase(i);
-            mb->setSystem(0);
+            mb->moveToDummy();
             if (page->systems().isEmpty()) {
                 // Remove this page, since it is now empty.
                 // This involves renumbering and repositioning all subsequent pages.
@@ -1629,7 +1634,7 @@ void Score::removeElement(Element* element)
     }
 
     if (et == ElementType::BEAM) {            // beam parent does not survive layout
-        element->setParent(0);
+        element->moveToDummy();
         parent = 0;
     }
 
@@ -1711,7 +1716,7 @@ void Score::removeElement(Element* element)
     case ElementType::ARTICULATION:
     case ElementType::ARPEGGIO:
     {
-        Element* cr = element->parent();
+        Element* cr = element->parentElement();
         if (cr->isChord()) {
             createPlayEvents(toChord(cr));
         }
@@ -2136,7 +2141,7 @@ bool Score::appendMeasuresFromScore(Score* score, const Fraction& startTick, con
         if (ostaff->key(otick) != staff->key(ctick)) {
             Segment* ns = firstAppendedMeasure->undoGetSegment(SegmentType::KeySig, ctick);
             KeySigEvent nkse = KeySigEvent(ostaff->keySigEvent(otick));
-            KeySig* nks = new KeySig(this);
+            KeySig* nks = new KeySig(ns);
             nks->setScore(this);
             nks->setTrack(trackIdx);
 
@@ -2207,7 +2212,7 @@ bool Score::appendMeasuresFromScore(Score* score, const Fraction& startTick, con
         }
         Spanner* ns = toSpanner(spanner->clone());
         ns->setScore(this);
-        ns->setParent(0);
+        ns->moveToDummy();
         ns->setTick(spanner->tick() - startTick + tickOfAppend);
         ns->setTick2(spanner->tick2() - startTick + tickOfAppend);
         ns->computeStartElement();
@@ -2238,10 +2243,10 @@ void Score::splitStaff(int staffIdx, int splitPoint)
     int staffIdxPart = staffIdx - p->staff(0)->idx();
     undoInsertStaff(ns, staffIdxPart + 1, false);
 
-    Clef* clef = new Clef(this);
+    Segment* seg = firstMeasure()->getSegment(SegmentType::HeaderClef, Fraction(0, 1));
+    Clef* clef = new Clef(seg);
     clef->setClefType(ClefType::F);
     clef->setTrack((staffIdx + 1) * VOICES);
-    Segment* seg = firstMeasure()->getSegment(SegmentType::HeaderClef, Fraction(0, 1));
     clef->setParent(seg);
     undoAddElement(clef);
     clef->layout();
@@ -2658,10 +2663,11 @@ void Score::adjustKeySigs(int sidx, int eidx, KeyList km)
                 nKey.setKey(transposeKey(nKey.key(), diff, staff->part()->preferSharpFlat()));
             }
             staff->setKey(tick, nKey);
-            KeySig* keysig = new KeySig(this);
+
+            Segment* s = measure->getSegment(SegmentType::KeySig, tick);
+            KeySig* keysig = new KeySig(s);
             keysig->setTrack(staffIdx * VOICES);
             keysig->setKeySigEvent(nKey);
-            Segment* s = measure->getSegment(SegmentType::KeySig, tick);
             s->add(keysig);
         }
     }
@@ -3099,7 +3105,7 @@ void Score::padToggle(Pad p, const EditData& ed)
             changeCRlen(cr, _is.duration());
 
             for (const SymId& articulationId: _is.articulationIds()) {
-                Articulation* na = new Articulation(cr->score());
+                Articulation* na = new Articulation(cr);
                 na->setSymId(articulationId);
                 addArticulation(cr, na);
             }
@@ -3175,7 +3181,7 @@ void Score::selectSingle(Element* e, int staffIdx)
         _is.setTrack(e->track());
         selState = SelState::LIST;
         if (e->type() == ElementType::NOTE) {
-            e = e->parent();
+            e = e->parentElement();
         }
         if (e->isChordRest()) {
             _is.setLastSegment(_is.segment());
@@ -3265,7 +3271,7 @@ void Score::selectRange(Element* e, int staffIdx)
             Element* oe = selection().element();
             if (oe->isNote() || oe->isChordRest()) {
                 if (oe->isNote()) {
-                    oe = oe->parent();
+                    oe = oe->parentElement();
                 }
                 ChordRest* cr = toChordRest(oe);
                 Fraction oetick = cr->segment()->tick();
@@ -3296,7 +3302,7 @@ void Score::selectRange(Element* e, int staffIdx)
         }
     } else if (e->isNote() || e->isChordRest()) {
         if (e->isNote()) {
-            e = e->parent();
+            e = e->parentElement();
         }
         ChordRest* cr = toChordRest(e);
 
@@ -3311,7 +3317,7 @@ void Score::selectRange(Element* e, int staffIdx)
             Element* oe = _selection.element();
             if (oe && (oe->isNote() || oe->isRest() || oe->isMMRest())) {
                 if (oe->isNote()) {
-                    oe = oe->parent();
+                    oe = oe->parentElement();
                 }
                 ChordRest* ocr = toChordRest(oe);
 
@@ -3439,7 +3445,7 @@ void Score::collectMatch(void* data, Element* e)
                 }
                 break;
             }
-            ee = ee->parent();
+            ee = ee->parentElement();
         } while (ee);
     }
 
@@ -3700,7 +3706,7 @@ void Score::lassoSelectEnd(bool convertToRange)
         }
         ++noteRestCount;
         if (e->type() == ElementType::NOTE) {
-            e = e->parent();
+            e = e->parentElement();
         }
         Segment* seg = static_cast<const ChordRest*>(e)->segment();
         if ((startSegment == 0) || (*seg < *startSegment)) {
@@ -3753,7 +3759,7 @@ void Score::addLyrics(const Fraction& tick, int staffIdx, const QString& txt)
         int track = staffIdx * VOICES + voice;
         ChordRest* cr = toChordRest(seg->element(track));
         if (cr) {
-            Lyrics* l = new Lyrics(this);
+            Lyrics* l = new Lyrics(cr);
             l->setXmlText(txt);
             l->setTrack(track);
             cr->add(l);
@@ -4824,7 +4830,7 @@ void Score::changeSelectedNotesVoice(int voice)
                 // existing rest in destination with correct duration;
                 //   replace with chord, then move note in
                 //   this case allows for tuplets, unlike the more general case below
-                dstChord = new Chord(this);
+                dstChord = new Chord(s);
                 dstChord->setTrack(dstTrack);
                 dstChord->setDurationType(chord->durationType());
                 dstChord->setTicks(chord->ticks());
@@ -4857,7 +4863,7 @@ void Score::changeSelectedNotesVoice(int voice)
                 Fraction gapEnd   = ncr ? ncr->tick() : m->tick() + m->ticks();
                 if (gapStart <= s->tick() && gapEnd >= s->tick() + chord->actualTicks()) {
                     // big enough gap found
-                    dstChord = new Chord(this);
+                    dstChord = new Chord(s);
                     dstChord->setTrack(dstTrack);
                     dstChord->setDurationType(chord->durationType());
                     dstChord->setTicks(chord->ticks());
@@ -4897,7 +4903,7 @@ void Score::changeSelectedNotesVoice(int voice)
                     undoRemoveElement(note);
                 } else if (notes == 1) {
                     // create rest to leave behind
-                    Rest* r = new Rest(this);
+                    Rest* r = new Rest(s);
                     r->setTrack(chord->track());
                     r->setDurationType(chord->durationType());
                     r->setTicks(chord->ticks());

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -50,6 +50,7 @@
 #include "infrastructure/draw/iimageprovider.h"
 #include "layout/layout.h"
 #include "layout/layoutoptions.h"
+#include "compat/dummyelement.h"
 
 class QMimeData;
 
@@ -63,6 +64,7 @@ class ScoreAccess;
 class ReadScoreHook;
 class WriteScoreHook;
 class Read302;
+class DummyElement;
 }
 
 namespace Ms {
@@ -506,6 +508,7 @@ private:
 
     mu::engraving::Layout m_layout;
     mu::engraving::LayoutOptions m_layoutOptions;
+    mu::engraving::compat::DummyElement* m_dummyElement = nullptr;
 
     ChordRest* nextMeasure(ChordRest* element, bool selectBehavior = false, bool mmRest = false);
     ChordRest* prevMeasure(ChordRest* element, bool mmRest = false);
@@ -602,6 +605,8 @@ public:
     ScoreElement* treeChild(int idx) const override;
     int treeChildCount() const override;
     void dumpScoreTree();  // for debugging purposes
+
+    mu::engraving::compat::DummyElement* dummy() { return m_dummyElement; }
 
     void rebuildBspTree();
     bool noStaves() const { return _staves.empty(); }

--- a/src/engraving/libmscore/scorefile.cpp
+++ b/src/engraving/libmscore/scorefile.cpp
@@ -310,7 +310,7 @@ void Score::readStaff(XmlReader& e)
 
             if (tag == "Measure") {
                 Measure* measure = nullptr;
-                measure = new Measure(this);
+                measure = new Measure(this->dummy()->system());
                 measure->setTick(e.tick());
                 e.setCurrentMeasureIndex(measureIdx++);
                 //
@@ -338,7 +338,7 @@ void Score::readStaff(XmlReader& e)
                     }
                 }
             } else if (tag == "HBox" || tag == "VBox" || tag == "TBox" || tag == "FBox") {
-                MeasureBase* mb = toMeasureBase(Element::name2Element(tag, this));
+                MeasureBase* mb = toMeasureBase(Element::name2Element(tag, this->dummy()));
                 mb->read(e);
                 mb->setTick(e.tick());
                 measures()->add(mb);
@@ -356,7 +356,7 @@ void Score::readStaff(XmlReader& e)
             if (tag == "Measure") {
                 if (measure == 0) {
                     qDebug("Score::readStaff(): missing measure!");
-                    measure = new Measure(this);
+                    measure = new Measure(this->dummy()->system());
                     measure->setTick(e.tick());
                     measures()->add(measure);
                 }
@@ -717,7 +717,7 @@ void Score::writeSegments(XmlWriter& xml, int strack, int etrack,
                 // we will miss a key sig!
                 if (!keySigWritten) {
                     Key k = score()->staff(track2staff(track))->key(segment->tick());
-                    KeySig* ks = new KeySig(this);
+                    KeySig* ks = new KeySig(this->dummy()->segment());
                     ks->setKey(k);
                     ks->write(xml);
                     delete ks;
@@ -725,7 +725,7 @@ void Score::writeSegments(XmlWriter& xml, int strack, int etrack,
                 }
                 // we will miss a time sig!
                 Fraction tsf = sigmap()->timesig(segment->tick()).timesig();
-                TimeSig* ts = new TimeSig(this);
+                TimeSig* ts = new TimeSig(this->dummy()->segment());
                 ts->setSig(tsf);
                 ts->write(xml);
                 delete ts;

--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -171,6 +171,11 @@ Segment::Segment(const Segment& s)
     _shapes  = s._shapes;
 }
 
+void Segment::setParent(Measure* parent)
+{
+    Element::setParent(parent);
+}
+
 //---------------------------------------------------------
 //   setSegmentType
 //---------------------------------------------------------
@@ -537,7 +542,9 @@ void Segment::add(Element* el)
 {
 //      qDebug("%p segment %s add(%d, %d, %s)", this, subTypeName(), tick(), el->track(), el->name());
 
-    el->setParent(this);
+    if (el->parent() != this) {
+        el->setParent(this);
+    }
 
     int track = el->track();
     Q_ASSERT(track != -1);
@@ -1795,13 +1802,13 @@ Element* Segment::nextElement(int activeStaff)
             p = sp->startElement();
         } else {
             p = e;
-            Element* pp = p->parent();
+            Element* pp = p->parentElement();
             if (pp->isNote() || pp->isRest() || (pp->isChord() && !p->isNote())) {
                 p = pp;
             }
         }
         Element* el = p;
-        for (; p && p->type() != ElementType::SEGMENT; p = p->parent()) {
+        for (; p && p->type() != ElementType::SEGMENT; p = p->parentElement()) {
         }
         Segment* seg = toSegment(p);
         // next in _elist
@@ -1945,9 +1952,9 @@ Element* Segment::prevElement(int activeStaff)
             el = sp->startElement();
             seg = sp->startSegment();
         } else {
-            Element* ep = e->parent();
+            Element* ep = e->parentElement();
             if (ep->isNote() || ep->isRest() || (ep->isChord() && !e->isNote())) {
-                el = e->parent();
+                el = e->parentElement();
             }
         }
 

--- a/src/engraving/libmscore/segment.h
+++ b/src/engraving/libmscore/segment.h
@@ -86,6 +86,8 @@ public:
     Segment(const Segment&);
     ~Segment();
 
+    void setParent(Measure* parent);
+
     // Score Tree functions
     ScoreElement* treeParent() const override;
     ScoreElement* treeChild(int idx) const override;

--- a/src/engraving/libmscore/select.cpp
+++ b/src/engraving/libmscore/select.cpp
@@ -266,7 +266,7 @@ ChordRest* Selection::cr() const
         return 0;
     }
     if (e->isNote()) {
-        e = e->parent();
+        e = e->parentElement();
     }
     if (e->isChordRest()) {
         return toChordRest(e);
@@ -340,7 +340,7 @@ ChordRest* Selection::firstChordRest(int track) const
     ChordRest* cr = 0;
     for (Element* el : _el) {
         if (el->isNote()) {
-            el = el->parent();
+            el = el->parentElement();
         }
         if (el->isChordRest()) {
             if (track != -1 && el->track() != track) {

--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -959,8 +959,8 @@ void Slur::slurPos(SlurPos* sp)
 //   Slur
 //---------------------------------------------------------
 
-Slur::Slur(Score* s)
-    : SlurTie(ElementType::SLUR, s)
+Slur::Slur(Element* parent)
+    : SlurTie(ElementType::SLUR, parent)
 {
     setAnchor(Anchor::CHORD);
 }

--- a/src/engraving/libmscore/slur.h
+++ b/src/engraving/libmscore/slur.h
@@ -67,7 +67,7 @@ class Slur final : public SlurTie
     int _sourceStemArrangement = -1;
 
 public:
-    Slur(Score* = 0);
+    Slur(Element* parent);
     Slur(const Slur&);
     ~Slur() {}
 

--- a/src/engraving/libmscore/slurtie.cpp
+++ b/src/engraving/libmscore/slurtie.cpp
@@ -423,8 +423,8 @@ void SlurTieSegment::drawEditMode(mu::draw::Painter* p, EditData& ed)
 //   SlurTie
 //---------------------------------------------------------
 
-SlurTie::SlurTie(const ElementType& type, Score* s)
-    : Spanner(type, s)
+SlurTie::SlurTie(const ElementType& type, Element* parent)
+    : Spanner(type, parent)
 {
     _slurDirection = Direction::AUTO;
     _up            = true;

--- a/src/engraving/libmscore/slurtie.h
+++ b/src/engraving/libmscore/slurtie.h
@@ -152,7 +152,7 @@ protected:
     void fixupSegments(unsigned nsegs);
 
 public:
-    SlurTie(const ElementType& type, Score*);
+    SlurTie(const ElementType& type, Element* parent);
     SlurTie(const SlurTie&);
     ~SlurTie();
 

--- a/src/engraving/libmscore/spacer.cpp
+++ b/src/engraving/libmscore/spacer.cpp
@@ -35,8 +35,8 @@ namespace Ms {
 //   LayoutBreak
 //---------------------------------------------------------
 
-Spacer::Spacer(Score* score)
-    : Element(ElementType::SPACER, score)
+Spacer::Spacer(Measure* parent)
+    : Element(ElementType::SPACER, parent)
 {
     _spacerType = SpacerType::UP;
     _gap = 0.0;

--- a/src/engraving/libmscore/spacer.h
+++ b/src/engraving/libmscore/spacer.h
@@ -50,7 +50,7 @@ class Spacer final : public Element
     void layout0();
 
 public:
-    Spacer(Score*);
+    Spacer(Measure* parent);
     Spacer(const Spacer&);
 
     Spacer* clone() const override { return new Spacer(*this); }

--- a/src/engraving/libmscore/spanner.cpp
+++ b/src/engraving/libmscore/spanner.cpp
@@ -110,7 +110,7 @@ void SpannerSegment::setSystem(System* s)
         if (s) {
             s->add(this);
         } else {
-            setParent(0);
+            moveToDummy();
         }
     }
 }
@@ -373,8 +373,8 @@ void SpannerSegment::scanElements(void* data, void (* func)(void*, Element*), bo
 //   Spanner
 //---------------------------------------------------------
 
-Spanner::Spanner(const ElementType& type, Score* s, ElementFlags f)
-    : Element(type, s, f)
+Spanner::Spanner(const ElementType& type, Element* parent, ElementFlags f)
+    : Element(type, parent, f)
 {
 }
 
@@ -484,7 +484,7 @@ void Spanner::insertTimeUnmanaged(const Fraction& fromTick, const Fraction& len)
         if (tick() > fromTick) {          // start after beginning of removed time
             if (tick() < toTick) {        // start within removed time: bring start at removing point
                 if (parent()) {
-                    parent()->remove(this);
+                    parentElement()->remove(this);
                     return;
                 } else {
                     newTick1 = fromTick;
@@ -505,7 +505,7 @@ void Spanner::insertTimeUnmanaged(const Fraction& fromTick, const Fraction& len)
     // update properties as required
     if (newTick2 <= newTick1) {                 // if no longer any span: remove it
         if (parent()) {
-            parent()->remove(this);
+            parentElement()->remove(this);
         }
     } else {                                    // if either TICKS or TICK did change, update property
         if (newTick2 - newTick1 != tick2() - tick()) {

--- a/src/engraving/libmscore/spanner.h
+++ b/src/engraving/libmscore/spanner.h
@@ -175,7 +175,7 @@ protected:
     const std::vector<SpannerSegment*> spannerSegments() const { return segments; }
 
 public:
-    Spanner(const ElementType& type, Score* s, ElementFlags = ElementFlag::NOTHING);
+    Spanner(const ElementType& type, Element* parent, ElementFlags = ElementFlag::NOTHING);
     Spanner(const Spanner&);
     ~Spanner();
 

--- a/src/engraving/libmscore/stafflines.cpp
+++ b/src/engraving/libmscore/stafflines.cpp
@@ -48,8 +48,8 @@ namespace Ms {
 //   StaffLines
 //---------------------------------------------------------
 
-StaffLines::StaffLines(Score* s)
-    : Element(ElementType::STAFF_LINES, s)
+StaffLines::StaffLines(Measure* parent)
+    : Element(ElementType::STAFF_LINES, parent)
 {
     setSelectable(false);
 }
@@ -71,13 +71,13 @@ PointF StaffLines::pagePos() const
 PointF StaffLines::canvasPos() const
 {
     PointF p(pagePos());
-    Element* e = parent();
+    Element* e = parentElement();
     while (e) {
         if (e->type() == ElementType::PAGE) {
             p += e->pos();
             break;
         }
-        e = e->parent();
+        e = e->parentElement();
     }
     return p;
 }

--- a/src/engraving/libmscore/stafflines.h
+++ b/src/engraving/libmscore/stafflines.h
@@ -40,7 +40,7 @@ class StaffLines final : public Element
     std::vector<mu::LineF> lines;
 
 public:
-    StaffLines(Score*);
+    StaffLines(Measure* parent);
 
     StaffLines* clone() const override { return new StaffLines(*this); }
 

--- a/src/engraving/libmscore/staffstate.cpp
+++ b/src/engraving/libmscore/staffstate.cpp
@@ -37,8 +37,8 @@ namespace Ms {
 //   StaffState
 //---------------------------------------------------------
 
-StaffState::StaffState(Score* score)
-    : Element(ElementType::STAFF_STATE, score)
+StaffState::StaffState(Element* parent)
+    : Element(ElementType::STAFF_STATE, parent)
 {
     _staffStateType = StaffStateType::INSTRUMENT;
     _instrument = new Instrument;

--- a/src/engraving/libmscore/staffstate.h
+++ b/src/engraving/libmscore/staffstate.h
@@ -51,7 +51,7 @@ class StaffState final : public Element
     void layout() override;
 
 public:
-    StaffState(Score*);
+    StaffState(Element* parent);
     StaffState(const StaffState&);
     ~StaffState();
 

--- a/src/engraving/libmscore/stafftext.cpp
+++ b/src/engraving/libmscore/stafftext.cpp
@@ -43,8 +43,8 @@ static const ElementStyle staffStyle {
 //   StaffText
 //---------------------------------------------------------
 
-StaffText::StaffText(Score* s, Tid tid)
-    : StaffTextBase(ElementType::STAFF_TEXT, s, tid, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+StaffText::StaffText(Segment* parent, Tid tid)
+    : StaffTextBase(ElementType::STAFF_TEXT, parent, tid, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&staffStyle);
 }

--- a/src/engraving/libmscore/stafftext.h
+++ b/src/engraving/libmscore/stafftext.h
@@ -38,7 +38,7 @@ class StaffText final : public StaffTextBase
     QVariant propertyDefault(Pid id) const override;
 
 public:
-    StaffText(Score* s = 0, Tid = Tid::STAFF);
+    StaffText(Segment* parent = 0, Tid = Tid::STAFF);
 
     StaffText* clone() const override { return new StaffText(*this); }
     void layout() override;

--- a/src/engraving/libmscore/stafftextbase.cpp
+++ b/src/engraving/libmscore/stafftextbase.cpp
@@ -34,8 +34,8 @@ namespace Ms {
 //   StaffTextBase
 //---------------------------------------------------------
 
-StaffTextBase::StaffTextBase(const ElementType& type, Score* s, Tid tid, ElementFlags flags)
-    : TextBase(type, s, tid, flags)
+StaffTextBase::StaffTextBase(const ElementType& type, Segment* parent, Tid tid, ElementFlags flags)
+    : TextBase(type, parent, tid, flags)
 {
     setSwingParameters(MScore::division / 2, 60);
 }

--- a/src/engraving/libmscore/stafftextbase.h
+++ b/src/engraving/libmscore/stafftextbase.h
@@ -52,7 +52,7 @@ class StaffTextBase : public TextBase
     int _capo            { 0 };
 
 public:
-    StaffTextBase(const ElementType& type, Score*, Tid tid, ElementFlags = ElementFlag::NOTHING);
+    StaffTextBase(const ElementType& type, Segment* parent, Tid tid, ElementFlags = ElementFlag::NOTHING);
 
     virtual void write(XmlWriter& xml) const override;
     virtual void read(XmlReader&) override;

--- a/src/engraving/libmscore/stafftype.cpp
+++ b/src/engraving/libmscore/stafftype.cpp
@@ -843,8 +843,8 @@ qreal StaffType::physStringToYOffset(int strg) const
 //   TabDurationSymbol
 //---------------------------------------------------------
 
-TabDurationSymbol::TabDurationSymbol(Score* s)
-    : Element(ElementType::TAB_DURATION_SYMBOL, s, ElementFlag::NOT_SELECTABLE)
+TabDurationSymbol::TabDurationSymbol(ChordRest* parent)
+    : Element(ElementType::TAB_DURATION_SYMBOL, parent, ElementFlag::NOT_SELECTABLE)
 {
     setGenerated(true);
     _beamGrid   = TabBeamGrid::NONE;
@@ -853,8 +853,8 @@ TabDurationSymbol::TabDurationSymbol(Score* s)
     _text       = QString();
 }
 
-TabDurationSymbol::TabDurationSymbol(Score* s, const StaffType* tab, TDuration::DurationType type, int dots)
-    : Element(ElementType::TAB_DURATION_SYMBOL, s, ElementFlag::NOT_SELECTABLE)
+TabDurationSymbol::TabDurationSymbol(ChordRest* parent, const StaffType* tab, TDuration::DurationType type, int dots)
+    : Element(ElementType::TAB_DURATION_SYMBOL, parent, ElementFlag::NOT_SELECTABLE)
 {
     setGenerated(true);
     _beamGrid   = TabBeamGrid::NONE;

--- a/src/engraving/libmscore/stafftype.h
+++ b/src/engraving/libmscore/stafftype.h
@@ -449,8 +449,8 @@ class TabDurationSymbol final : public Element
     bool _repeat     { false };
 
 public:
-    TabDurationSymbol(Score* s);
-    TabDurationSymbol(Score* s, const StaffType* tab, TDuration::DurationType type, int dots);
+    TabDurationSymbol(ChordRest* parent);
+    TabDurationSymbol(ChordRest* parent, const StaffType* tab, TDuration::DurationType type, int dots);
     TabDurationSymbol(const TabDurationSymbol&);
     TabDurationSymbol* clone() const override { return new TabDurationSymbol(*this); }
     void draw(mu::draw::Painter*) const override;

--- a/src/engraving/libmscore/stafftypechange.cpp
+++ b/src/engraving/libmscore/stafftypechange.cpp
@@ -34,8 +34,8 @@ namespace Ms {
 //   StaffTypeChange
 //---------------------------------------------------------
 
-StaffTypeChange::StaffTypeChange(Score* score)
-    : Element(ElementType::STAFFTYPE_CHANGE, score, ElementFlag::HAS_TAG)
+StaffTypeChange::StaffTypeChange(MeasureBase* parent)
+    : Element(ElementType::STAFFTYPE_CHANGE, parent, ElementFlag::HAS_TAG)
 {
     lw = spatium() * 0.3;
 }

--- a/src/engraving/libmscore/stafftypechange.h
+++ b/src/engraving/libmscore/stafftypechange.h
@@ -42,7 +42,7 @@ class StaffTypeChange final : public Element
     void draw(mu::draw::Painter*) const override;
 
 public:
-    StaffTypeChange(Score* = 0);
+    StaffTypeChange(MeasureBase* parent = 0);
     StaffTypeChange(const StaffTypeChange&);
 
     StaffTypeChange* clone() const override { return new StaffTypeChange(*this); }

--- a/src/engraving/libmscore/stem.cpp
+++ b/src/engraving/libmscore/stem.cpp
@@ -51,8 +51,8 @@ static const ElementStyle stemStyle {
 //    Notenhals
 //---------------------------------------------------------
 
-Stem::Stem(Score* s)
-    : Element(ElementType::STEM, s)
+Stem::Stem(Chord* parent)
+    : Element(ElementType::STEM, parent)
 {
     initElementStyle(&stemStyle);
     resetProperty(Pid::USER_LEN);
@@ -63,7 +63,7 @@ Stem::Stem(Score* s)
 //---------------------------------------------------------
 Element* Stem::elementBase() const
 {
-    return parent();
+    return parentElement();
 }
 
 //---------------------------------------------------------
@@ -355,7 +355,7 @@ Element* Stem::drop(EditData& data)
 
     switch (e->type()) {
     case ElementType::TREMOLO:
-        e->setParent(ch);
+        toTremolo(e)->setParent(ch);
         score()->undoAddElement(e);
         return e;
     default:

--- a/src/engraving/libmscore/stem.h
+++ b/src/engraving/libmscore/stem.h
@@ -41,7 +41,7 @@ class Stem final : public Element
     qreal _len       { 0.0 };       // always positive
 
 public:
-    Stem(Score* = 0);
+    Stem(Chord* parent = 0);
     Stem& operator=(const Stem&) = delete;
 
     Stem* clone() const override { return new Stem(*this); }

--- a/src/engraving/libmscore/stemslash.h
+++ b/src/engraving/libmscore/stemslash.h
@@ -37,10 +37,10 @@ class StemSlash final : public Element
     mu::LineF line;
 
 public:
-    StemSlash(Score* s = 0)
-        : Element(ElementType::STEM_SLASH, s) {}
+    StemSlash(Chord* parent = 0)
+        : Element(ElementType::STEM_SLASH, parent) {}
 
-    qreal mag() const override { return parent()->mag(); }
+    qreal mag() const override { return parentElement()->mag(); }
     void setLine(const mu::LineF& l);
 
     StemSlash* clone() const override { return new StemSlash(*this); }

--- a/src/engraving/libmscore/sticking.cpp
+++ b/src/engraving/libmscore/sticking.cpp
@@ -39,8 +39,8 @@ static const ElementStyle stickingStyle {
 //   Sticking
 //---------------------------------------------------------
 
-Sticking::Sticking(Score* s)
-    : TextBase(ElementType::STICKING, s, Tid::STICKING, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+Sticking::Sticking(Segment* parent)
+    : TextBase(ElementType::STICKING, parent, Tid::STICKING, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&stickingStyle);
 }

--- a/src/engraving/libmscore/sticking.h
+++ b/src/engraving/libmscore/sticking.h
@@ -36,7 +36,7 @@ class Sticking final : public TextBase
     QVariant propertyDefault(Pid id) const override;
 
 public:
-    Sticking(Score*);
+    Sticking(Segment* parent);
 
     Sticking* clone() const override { return new Sticking(*this); }
 

--- a/src/engraving/libmscore/symbol.cpp
+++ b/src/engraving/libmscore/symbol.cpp
@@ -41,14 +41,14 @@ namespace Ms {
 //   Symbol
 //---------------------------------------------------------
 
-Symbol::Symbol(const ElementType& type, Score* s, ElementFlags f)
-    : BSymbol(type, s, f)
+Symbol::Symbol(const ElementType& type, Element* parent, ElementFlags f)
+    : BSymbol(type, parent, f)
 {
     _sym = SymId::accidentalSharp;          // arbitrary valid default
 }
 
-Symbol::Symbol(Score* s, ElementFlags f)
-    : Symbol(ElementType::SYMBOL, s, f)
+Symbol::Symbol(Element* parent, ElementFlags f)
+    : Symbol(ElementType::SYMBOL, parent, f)
 {
 }
 
@@ -157,14 +157,14 @@ void Symbol::read(XmlReader& e)
         } else if (tag == "font") {
             _scoreFont = ScoreFont::fontByName(e.readElementText());
         } else if (tag == "Symbol") {
-            Symbol* s = new Symbol(score());
+            Symbol* s = new Symbol(this);
             s->read(e);
             add(s);
         } else if (tag == "Image") {
             if (MScore::noImages) {
                 e.skipCurrentElement();
             } else {
-                Image* image = new Image(score());
+                Image* image = new Image(this);
                 image->read(e);
                 add(image);
             }
@@ -212,8 +212,8 @@ bool Symbol::setProperty(Pid propertyId, const QVariant& v)
 //   FSymbol
 //---------------------------------------------------------
 
-FSymbol::FSymbol(Score* s)
-    : BSymbol(ElementType::FSYMBOL, s)
+FSymbol::FSymbol(Element* parent)
+    : BSymbol(ElementType::FSYMBOL, parent)
 {
     _code = 0;
     _font.setNoFontMerging(true);

--- a/src/engraving/libmscore/symbol.h
+++ b/src/engraving/libmscore/symbol.h
@@ -46,8 +46,8 @@ protected:
     const ScoreFont* _scoreFont = nullptr;
 
 public:
-    Symbol(const ElementType& type, Score* s, ElementFlags f = ElementFlag::MOVABLE);
-    Symbol(Score* s, ElementFlags f = ElementFlag::MOVABLE);
+    Symbol(const ElementType& type, Element* parent, ElementFlags f = ElementFlag::MOVABLE);
+    Symbol(Element* parent, ElementFlags f = ElementFlag::MOVABLE);
     Symbol(const Symbol&);
 
     Symbol& operator=(const Symbol&) = delete;
@@ -81,7 +81,7 @@ class FSymbol final : public BSymbol
     int _code;
 
 public:
-    FSymbol(Score* s);
+    FSymbol(Element* parent);
     FSymbol(const FSymbol&);
 
     FSymbol* clone() const override { return new FSymbol(*this); }

--- a/src/engraving/libmscore/system.h
+++ b/src/engraving/libmscore/system.h
@@ -120,8 +120,10 @@ class System final : public Element
     Bracket* createBracket(Ms::BracketItem* bi, int column, int staffIdx, QList<Ms::Bracket*>& bl, Measure* measure);
 
 public:
-    System(Score*);
+    System(Page* parent);
     ~System();
+
+    void moveToPage(Page* parent);
 
     // Score Tree functions
     ScoreElement* treeParent() const override;

--- a/src/engraving/libmscore/systemdivider.cpp
+++ b/src/engraving/libmscore/systemdivider.cpp
@@ -34,8 +34,8 @@ namespace Ms {
 //   SystemDivider
 //---------------------------------------------------------
 
-SystemDivider::SystemDivider(Score* s)
-    : Symbol(ElementType::SYSTEM_DIVIDER, s, ElementFlag::SYSTEM | ElementFlag::NOT_SELECTABLE)
+SystemDivider::SystemDivider(System* parent)
+    : Symbol(ElementType::SYSTEM_DIVIDER, parent, ElementFlag::SYSTEM | ElementFlag::NOT_SELECTABLE)
 {
     // default value, but not valid until setDividerType()
     _dividerType = SystemDivider::Type::LEFT;

--- a/src/engraving/libmscore/systemdivider.h
+++ b/src/engraving/libmscore/systemdivider.h
@@ -41,7 +41,7 @@ private:
     Type _dividerType;
 
 public:
-    SystemDivider(Score* s = 0);
+    SystemDivider(System* parent = 0);
     SystemDivider(const SystemDivider&);
 
     SystemDivider* clone() const override { return new SystemDivider(*this); }

--- a/src/engraving/libmscore/systemtext.cpp
+++ b/src/engraving/libmscore/systemtext.cpp
@@ -38,8 +38,8 @@ static const ElementStyle systemStyle {
 //   SystemText
 //---------------------------------------------------------
 
-SystemText::SystemText(Score* s, Tid tid)
-    : StaffTextBase(ElementType::SYSTEM_TEXT, s, tid, ElementFlag::SYSTEM | ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+SystemText::SystemText(Segment* parent, Tid tid)
+    : StaffTextBase(ElementType::SYSTEM_TEXT, parent, tid, ElementFlag::SYSTEM | ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&systemStyle);
 }

--- a/src/engraving/libmscore/systemtext.h
+++ b/src/engraving/libmscore/systemtext.h
@@ -36,7 +36,7 @@ class SystemText final : public StaffTextBase
     QVariant propertyDefault(Pid id) const override;
 
 public:
-    SystemText(Score* = 0, Tid = Tid::SYSTEM);
+    SystemText(Segment* parent, Tid = Tid::SYSTEM);
 
     SystemText* clone() const override { return new SystemText(*this); }
     Segment* segment() const { return (Segment*)parent(); }

--- a/src/engraving/libmscore/tempotext.cpp
+++ b/src/engraving/libmscore/tempotext.cpp
@@ -56,8 +56,8 @@ static const ElementStyle tempoStyle {
 //   TempoText
 //---------------------------------------------------------
 
-TempoText::TempoText(Score* s)
-    : TextBase(ElementType::TEMPO_TEXT, s, Tid::TEMPO, ElementFlags(ElementFlag::SYSTEM))
+TempoText::TempoText(Segment* parent)
+    : TextBase(ElementType::TEMPO_TEXT, parent, Tid::TEMPO, ElementFlags(ElementFlag::SYSTEM))
 {
     initElementStyle(&tempoStyle);
     _tempo      = 2.0;        // propertyDefault(P_TEMPO).toDouble();

--- a/src/engraving/libmscore/tempotext.h
+++ b/src/engraving/libmscore/tempotext.h
@@ -48,7 +48,7 @@ class TempoText final : public TextBase
     void undoChangeProperty(Pid id, const QVariant&, PropertyFlags ps) override;
 
 public:
-    TempoText(Score*);
+    TempoText(Segment* parent);
 
     TempoText* clone() const override { return new TempoText(*this); }
 

--- a/src/engraving/libmscore/text.cpp
+++ b/src/engraving/libmscore/text.cpp
@@ -39,8 +39,8 @@ static const ElementStyle defaultStyle {
 //   Text
 //---------------------------------------------------------
 
-Text::Text(Score* s, Tid tid)
-    : TextBase(ElementType::TEXT, s, tid)
+Text::Text(ScoreElement* parent, Tid tid)
+    : TextBase(ElementType::TEXT, parent, tid)
 {
     initElementStyle(&defaultStyle);
 }

--- a/src/engraving/libmscore/text.h
+++ b/src/engraving/libmscore/text.h
@@ -33,7 +33,7 @@ namespace Ms {
 class Text final : public TextBase
 {
 public:
-    Text(Score* s = 0, Tid tid = Tid::DEFAULT);
+    Text(ScoreElement* parent = 0, Tid tid = Tid::DEFAULT);
 
     Text* clone() const override { return new Text(*this); }
     void read(XmlReader&) override;

--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -1028,7 +1028,7 @@ void TextBlock::layout(TextBase* t)
     qreal lm     = 0.0;
 
     qreal layoutWidth = 0;
-    Element* e = t->parent();
+    Element* e = t->parentElement();
     if (e && t->layoutToParentWidth()) {
         layoutWidth = e->width();
         switch (e->type()) {
@@ -1674,8 +1674,8 @@ QString TextBlock::text(int col1, int len, bool withFormat) const
 //   Text
 //---------------------------------------------------------
 
-TextBase::TextBase(const Ms::ElementType& type, Score* s, Tid tid, ElementFlags f)
-    : Element(type, s, f | ElementFlag::MOVABLE)
+TextBase::TextBase(const Ms::ElementType& type, Ms::ScoreElement* parent, Tid tid, ElementFlags f)
+    : Element(type, parent, f | ElementFlag::MOVABLE)
 {
     _cursor                 = new TextCursor(this);
     _cursor->init();
@@ -1691,8 +1691,8 @@ TextBase::TextBase(const Ms::ElementType& type, Score* s, Tid tid, ElementFlags 
     _frameRound             = 0;
 }
 
-TextBase::TextBase(const ElementType& type, Score* s, ElementFlags f)
-    : TextBase(type, s, Tid::DEFAULT, f)
+TextBase::TextBase(const ElementType& type, ScoreElement* parent, ElementFlags f)
+    : TextBase(type, parent, Tid::DEFAULT, f)
 {
 }
 
@@ -2043,7 +2043,7 @@ void TextBase::layout1()
                 yoff = p->tm();
             } else if (parent()->isMeasure()) {
             } else {
-                h  = parent()->height();
+                h  = parentElement()->height();
             }
         }
     } else {

--- a/src/engraving/libmscore/textbase.h
+++ b/src/engraving/libmscore/textbase.h
@@ -311,8 +311,8 @@ protected:
     bool prepareFormat(const QString& token, Ms::CharFormat& format);
 
 public:
-    TextBase(const ElementType& type, Score* = 0, Tid tid = Tid::DEFAULT, ElementFlags = ElementFlag::NOTHING);
-    TextBase(const ElementType& type, Score*, ElementFlags);
+    TextBase(const ElementType& type, ScoreElement* parent = 0, Tid tid = Tid::DEFAULT, ElementFlags = ElementFlag::NOTHING);
+    TextBase(const ElementType& type, ScoreElement* parent, ElementFlags);
     TextBase(const TextBase&);
     ~TextBase();
 

--- a/src/engraving/libmscore/textframe.cpp
+++ b/src/engraving/libmscore/textframe.cpp
@@ -43,11 +43,11 @@ namespace Ms {
 //   TBox
 //---------------------------------------------------------
 
-TBox::TBox(Score* score)
-    : VBox(ElementType::TBOX, score)
+TBox::TBox(System* parent)
+    : VBox(ElementType::TBOX, parent)
 {
     setBoxHeight(Spatium(1));
-    _text  = new Text(score, Tid::FRAME);
+    _text  = new Text(this, Tid::FRAME);
     _text->setLayoutToParentWidth(true);
     _text->setParent(this);
 }
@@ -162,7 +162,7 @@ void TBox::remove(Element* el)
         // replace with new empty text element
         // this keeps undo/redo happier than just clearing the text
         qDebug("TBox::remove() - replacing _text");
-        _text = new Text(score(), Tid::FRAME);
+        _text = new Text(this, Tid::FRAME);
         _text->setLayoutToParentWidth(true);
         _text->setParent(this);
     } else {

--- a/src/engraving/libmscore/textframe.h
+++ b/src/engraving/libmscore/textframe.h
@@ -38,7 +38,7 @@ class TBox : public VBox
     Text* _text;
 
 public:
-    TBox(Score* score);
+    TBox(System* parent);
     TBox(const TBox&);
     ~TBox();
 

--- a/src/engraving/libmscore/textline.cpp
+++ b/src/engraving/libmscore/textline.cpp
@@ -138,8 +138,8 @@ void TextLineSegment::layout()
 //   TextLine
 //---------------------------------------------------------
 
-TextLine::TextLine(Score* s, bool system)
-    : TextLineBase(ElementType::TEXTLINE, s)
+TextLine::TextLine(Element* parent, bool system)
+    : TextLineBase(ElementType::TEXTLINE, parent)
 {
     setSystemFlag(system);
 

--- a/src/engraving/libmscore/textline.h
+++ b/src/engraving/libmscore/textline.h
@@ -58,7 +58,7 @@ class TextLine final : public TextLineBase
     Sid getPropertyStyle(Pid) const override;
 
 public:
-    TextLine(Score* s, bool system=false);
+    TextLine(Element* parent, bool system=false);
     TextLine(const TextLine&);
     ~TextLine() {}
 

--- a/src/engraving/libmscore/textlinebase.cpp
+++ b/src/engraving/libmscore/textlinebase.cpp
@@ -46,8 +46,8 @@ namespace Ms {
 TextLineBaseSegment::TextLineBaseSegment(const ElementType& type, Spanner* sp, Score* score, ElementFlags f)
     : LineSegment(type, sp, score, f)
 {
-    _text    = new Text(score);
-    _endText = new Text(score);
+    _text    = new Text(this);
+    _endText = new Text(this);
     _text->setParent(this);
     _endText->setParent(this);
     _text->setFlag(ElementFlag::MOVABLE, false);
@@ -505,8 +505,8 @@ Element* TextLineBaseSegment::propertyDelegate(Pid pid)
 //   TextLineBase
 //---------------------------------------------------------
 
-TextLineBase::TextLineBase(const ElementType& type, Score* s, ElementFlags f)
-    : SLine(type, s, f)
+TextLineBase::TextLineBase(const ElementType& type, Element* parent, ElementFlags f)
+    : SLine(type, parent, f)
 {
     setBeginHookHeight(Spatium(1.9));
     setEndHookHeight(Spatium(1.9));

--- a/src/engraving/libmscore/textlinebase.h
+++ b/src/engraving/libmscore/textlinebase.h
@@ -120,7 +120,7 @@ protected:
     friend class TextLineBaseSegment;
 
 public:
-    TextLineBase(const ElementType& type, Score* s, ElementFlags = ElementFlag::NOTHING);
+    TextLineBase(const ElementType& type, Element* parent, ElementFlags = ElementFlag::NOTHING);
 
     virtual void write(XmlWriter& xml) const override;
     virtual void read(XmlReader&) override;

--- a/src/engraving/libmscore/tie.cpp
+++ b/src/engraving/libmscore/tie.cpp
@@ -551,8 +551,8 @@ void Tie::slurPos(SlurPos* sp)
 //   Tie
 //---------------------------------------------------------
 
-Tie::Tie(Score* s)
-    : SlurTie(ElementType::TIE, s)
+Tie::Tie(Element* parent)
+    : SlurTie(ElementType::TIE, parent)
 {
     setAnchor(Anchor::NOTE);
 }

--- a/src/engraving/libmscore/tie.h
+++ b/src/engraving/libmscore/tie.h
@@ -75,7 +75,7 @@ class Tie final : public SlurTie
     static Note* editEndNote;
 
 public:
-    Tie(Score* = 0);
+    Tie(Element* parent = 0);
 
     Tie* clone() const override { return new Tie(*this); }
 

--- a/src/engraving/libmscore/timesig.cpp
+++ b/src/engraving/libmscore/timesig.cpp
@@ -50,8 +50,8 @@ static const ElementStyle timesigStyle {
 //    Layout() is static and called in setSig().
 //---------------------------------------------------------
 
-TimeSig::TimeSig(Score* s)
-    : Element(ElementType::TIMESIG, s, ElementFlag::ON_STAFF | ElementFlag::MOVABLE)
+TimeSig::TimeSig(Segment* parent)
+    : Element(ElementType::TIMESIG, parent, ElementFlag::ON_STAFF | ElementFlag::MOVABLE)
 {
     initElementStyle(&timesigStyle);
 
@@ -60,6 +60,11 @@ TimeSig::TimeSig(Score* s)
     _sig.set(0, 1);                 // initialize to invalid
     _timeSigType      = TimeSigType::NORMAL;
     _largeParentheses = false;
+}
+
+void TimeSig::setParent(Segment* parent)
+{
+    Element::setParent(parent);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/timesig.h
+++ b/src/engraving/libmscore/timesig.h
@@ -71,7 +71,9 @@ class TimeSig final : public Element
     bool _largeParentheses;
 
 public:
-    TimeSig(Score* = 0);
+    TimeSig(Segment* parent = 0);
+
+    void setParent(Segment* parent);
 
     QString ssig() const;
     void setSSig(const QString&);

--- a/src/engraving/libmscore/transpose.cpp
+++ b/src/engraving/libmscore/transpose.cpp
@@ -531,7 +531,7 @@ bool Score::transpose(TransposeMode mode, TransposeDirection direction, Key trKe
             Segment* seg = firstMeasure()->undoGetSegmentR(SegmentType::KeySig, Fraction(0, 1));
             KeySig* ks = toKeySig(seg->element(track));
             if (!ks) {
-                ks = new KeySig(this);
+                ks = new KeySig(seg);
                 ks->setTrack(track);
                 Key nKey = transposeKey(Key::C, interval, ks->part()->preferSharpFlat());
                 ks->setKey(nKey);
@@ -619,14 +619,14 @@ void Score::transposeKeys(int staffStart, int staffEnd, const Fraction& ts, cons
             }
         }
         if (createKey && firstMeasure()) {
-            KeySig* ks = new KeySig(this);
+            Segment* seg = firstMeasure()->undoGetSegmentR(SegmentType::KeySig, Fraction(0, 1));
+            seg->setHeader(true);
+            KeySig* ks = new KeySig(seg);
             ks->setTrack(staffIdx * VOICES);
             Key nKey = transposeKey(Key::C, firstInterval, ks->part()->preferSharpFlat());
             KeySigEvent ke;
             ke.setKey(nKey);
             ks->setKeySigEvent(ke);
-            Segment* seg = firstMeasure()->undoGetSegmentR(SegmentType::KeySig, Fraction(0, 1));
-            seg->setHeader(true);
             ks->setParent(seg);
             undoAddElement(ks);
         }

--- a/src/engraving/libmscore/tremolo.cpp
+++ b/src/engraving/libmscore/tremolo.cpp
@@ -67,8 +67,8 @@ static const char* tremoloName[] = {
     QT_TRANSLATE_NOOP("Tremolo", "64th between notes")
 };
 
-Tremolo::Tremolo(Score* score)
-    : Element(ElementType::TREMOLO, score, ElementFlag::MOVABLE)
+Tremolo::Tremolo(Chord* parent)
+    : Element(ElementType::TREMOLO, parent, ElementFlag::MOVABLE)
 {
     initElementStyle(&tremoloStyle);
 }
@@ -80,6 +80,11 @@ Tremolo::Tremolo(const Tremolo& t)
     _chord1       = t.chord1();
     _chord2       = t.chord2();
     _durationType = t._durationType;
+}
+
+void Tremolo::setParent(Chord* ch)
+{
+    Element::setParent(ch);
 }
 
 //---------------------------------------------------------
@@ -97,7 +102,7 @@ qreal Tremolo::chordMag() const
 
 qreal Tremolo::mag() const
 {
-    return parent() ? parent()->mag() : 1.0;
+    return parentElement() ? parentElement()->mag() : 1.0;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/tremolo.h
+++ b/src/engraving/libmscore/tremolo.h
@@ -63,10 +63,15 @@ class Tremolo final : public Element
     void layoutTwoNotesTremolo(qreal x, qreal y, qreal h, qreal spatium);
 
 public:
-    Tremolo(Score*);
+    Tremolo(Chord* parent);
     Tremolo(const Tremolo&);
+
     Tremolo& operator=(const Tremolo&) = delete;
     Tremolo* clone() const override { return new Tremolo(*this); }
+
+    Chord* chord() const { return toChord(parent()); }
+    void setParent(Chord* ch);
+
     int subtype() const override { return static_cast<int>(_tremoloType); }
     QString subtypeName() const override;
 
@@ -76,8 +81,6 @@ public:
     void setTremoloType(const QString& s);
     static TremoloType name2Type(const QString& s);
     static QString type2name(TremoloType t);
-
-    Chord* chord() const { return toChord(parent()); }
 
     void setTremoloType(TremoloType t);
     TremoloType tremoloType() const { return _tremoloType; }

--- a/src/engraving/libmscore/tremolobar.cpp
+++ b/src/engraving/libmscore/tremolobar.cpp
@@ -64,8 +64,8 @@ static const QList<PitchValue> RELEASE_DOWN_CURVE = { PitchValue(0, 150),
 //   TremoloBar
 //---------------------------------------------------------
 
-TremoloBar::TremoloBar(Score* s)
-    : Element(ElementType::TREMOLOBAR, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+TremoloBar::TremoloBar(Element* parent)
+    : Element(ElementType::TREMOLOBAR, parent, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
     initElementStyle(&tremoloBarStyle);
 }

--- a/src/engraving/libmscore/tremolobar.h
+++ b/src/engraving/libmscore/tremolobar.h
@@ -48,7 +48,7 @@ enum class TremoloBarType {
 class TremoloBar final : public Element
 {
 public:
-    TremoloBar(Score* s);
+    TremoloBar(Element* parent);
 
     TremoloBar* clone() const override { return new TremoloBar(*this); }
 

--- a/src/engraving/libmscore/trill.cpp
+++ b/src/engraving/libmscore/trill.cpp
@@ -274,8 +274,8 @@ Sid Trill::getPropertyStyle(Pid pid) const
 //   Trill
 //---------------------------------------------------------
 
-Trill::Trill(Score* s)
-    : SLine(ElementType::TRILL, s)
+Trill::Trill(Element* parent)
+    : SLine(ElementType::TRILL, parent)
 {
     _trillType     = Type::TRILL_LINE;
     _accidental    = 0;
@@ -285,7 +285,7 @@ Trill::Trill(Score* s)
 }
 
 Trill::Trill(const Trill& t)
-    : SLine(ElementType::TRILL, t.score())
+    : SLine(ElementType::TRILL, t.parentElement())
 {
     _trillType = t._trillType;
     _accidental = t._accidental ? t._accidental->clone() : nullptr;
@@ -398,7 +398,7 @@ void Trill::read(XmlReader& e)
         if (tag == "subtype") {
             setTrillType(e.readElementText());
         } else if (tag == "Accidental") {
-            _accidental = new Accidental(score());
+            _accidental = new Accidental(this);
             _accidental->read(e);
             _accidental->setParent(this);
         } else if (tag == "ornamentStyle") {

--- a/src/engraving/libmscore/trill.h
+++ b/src/engraving/libmscore/trill.h
@@ -87,7 +87,7 @@ private:
     bool _playArticulation;
 
 public:
-    Trill(Score* s);
+    Trill(Element* parent);
     Trill(const Trill& t);
     ~Trill();
 

--- a/src/engraving/libmscore/tuplet.h
+++ b/src/engraving/libmscore/tuplet.h
@@ -69,9 +69,11 @@ class Tuplet final : public DurationElement
     Fraction addMissingElement(const Fraction& startTick, const Fraction& endTick);
 
 public:
-    Tuplet(Score*);
+    Tuplet(Measure* parent);
     Tuplet(const Tuplet&);
     ~Tuplet();
+
+    void setParent(Measure* parent);
 
     // Score Tree functions
     ScoreElement* treeParent() const override;

--- a/src/engraving/libmscore/undo.cpp
+++ b/src/engraving/libmscore/undo.cpp
@@ -1301,7 +1301,7 @@ void ChangeElement::flip(EditData*)
         score->removeElement(oldElement);
         score->addElement(newElement);
     } else {
-        oldElement->parent()->change(oldElement, newElement);
+        oldElement->parentElement()->change(oldElement, newElement);
     }
 
     if (newElement->isKeySig()) {
@@ -2496,7 +2496,7 @@ void ChangeSpannerElements::flip(EditData*)
 
 void ChangeParent::flip(EditData*)
 {
-    Element* p = element->parent();
+    Element* p = element->parentElement();
     int si = element->staffIdx();
     p->remove(element);
     element->setParent(parent);

--- a/src/engraving/libmscore/vibrato.cpp
+++ b/src/engraving/libmscore/vibrato.cpp
@@ -185,8 +185,8 @@ static const ElementStyle vibratoStyle {
 //   Vibrato
 //---------------------------------------------------------
 
-Vibrato::Vibrato(Score* s)
-    : SLine(ElementType::VIBRATO, s)
+Vibrato::Vibrato(Element* parent)
+    : SLine(ElementType::VIBRATO, parent)
 {
     initElementStyle(&vibratoStyle);
     _vibratoType = Type::GUITAR_VIBRATO;

--- a/src/engraving/libmscore/vibrato.h
+++ b/src/engraving/libmscore/vibrato.h
@@ -77,7 +77,7 @@ private:
     bool _playArticulation;
 
 public:
-    Vibrato(Score* s);
+    Vibrato(Element* parent);
     ~Vibrato();
 
     Vibrato* clone() const override { return new Vibrato(*this); }

--- a/src/engraving/libmscore/volta.cpp
+++ b/src/engraving/libmscore/volta.cpp
@@ -96,8 +96,8 @@ Element* VoltaSegment::propertyDelegate(Pid pid)
 //   Volta
 //---------------------------------------------------------
 
-Volta::Volta(Score* s)
-    : TextLineBase(ElementType::VOLTA, s, ElementFlag::SYSTEM)
+Volta::Volta(Element* parent)
+    : TextLineBase(ElementType::VOLTA, parent, ElementFlag::SYSTEM)
 {
     setPlacement(Placement::ABOVE);
     initElementStyle(&voltaStyle);

--- a/src/engraving/libmscore/volta.h
+++ b/src/engraving/libmscore/volta.h
@@ -66,7 +66,7 @@ public:
         OPEN, CLOSED
     };
 
-    Volta(Score* s);
+    Volta(Element* parent);
 
     Volta* clone() const override { return new Volta(*this); }
 

--- a/src/engraving/tests/testbase.cpp
+++ b/src/engraving/tests/testbase.cpp
@@ -74,7 +74,7 @@ Element* MTest::writeReadElement(Element* element)
 
     XmlReader e(buffer.buffer());
     e.readNextStartElement();
-    element = Element::name2Element(e.name(), score);
+    element = Element::name2Element(e.name(), score->dummy());
     element->read(e);
     return element;
 }

--- a/src/engraving/tests/tst_barline.cpp
+++ b/src/engraving/tests/tst_barline.cpp
@@ -147,7 +147,7 @@ void TestBarline::barline02()
     Score* score = readScore(BARLINE_DATA_DIR + "barline02.mscx");
     QVERIFY(score);
     Measure* msr = score->firstMeasure()->nextMeasure();
-    TimeSig* ts  = new TimeSig(score);
+    TimeSig* ts  = new TimeSig(score->dummy()->segment());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
     score->cmdAddTimeSig(msr, 0, ts, false);
@@ -278,7 +278,7 @@ void TestBarline::barline05()
         msr = msr->nextMeasure();
     }
     // create and add a LineBreak element
-    LayoutBreak* lb = new LayoutBreak(score);
+    LayoutBreak* lb = new LayoutBreak(msr);
     lb->setLayoutBreakType(LayoutBreak::Type::LINE);
     lb->setTrack(-1);               // system-level element
     lb->setParent(msr);
@@ -368,7 +368,7 @@ void TestBarline::barline06()
 void dropNormalBarline(Element* e)
 {
     EditData dropData(0);
-    BarLine* barLine = new BarLine(e->score());
+    BarLine* barLine = new BarLine(e->score()->dummy()->segment());
     barLine->setBarLineType(BarLineType::NORMAL);
     dropData.dropElement = barLine;
 

--- a/src/engraving/tests/tst_breath.cpp
+++ b/src/engraving/tests/tst_breath.cpp
@@ -76,7 +76,7 @@ void TestBreath::breath()
     score->cmdSelectAll();
     for (Element* e : score->selection().elements()) {
         EditData dd(0);
-        Breath* b = new Breath(score);
+        Breath* b = new Breath(score->dummy()->segment());
         b->setSymId(SymId::breathMarkComma);
         dd.dropElement = b;
         if (e->acceptDrop(dd)) {

--- a/src/engraving/tests/tst_chordsymbol.cpp
+++ b/src/engraving/tests/tst_chordsymbol.cpp
@@ -168,7 +168,7 @@ void TestChordSymbol::testAddLink()
     MasterScore* score = test_pre("add-link");
     Segment* seg = score->firstSegment(SegmentType::ChordRest);
     ChordRest* cr = seg->cr(0);
-    Harmony* harmony = new Harmony(score);
+    Harmony* harmony = new Harmony(cr->segment());
     harmony->setHarmony("C7");
     harmony->setTrack(cr->track());
     harmony->setParent(cr->segment());
@@ -182,7 +182,7 @@ void TestChordSymbol::testAddPart()
     MasterScore* score = test_pre("add-part");
     Segment* seg = score->firstSegment(SegmentType::ChordRest);
     ChordRest* cr = seg->cr(0);
-    Harmony* harmony = new Harmony(score);
+    Harmony* harmony = new Harmony(cr->segment());
     harmony->setHarmony("C7");
     harmony->setTrack(cr->track());
     harmony->setParent(cr->segment());

--- a/src/engraving/tests/tst_clef.cpp
+++ b/src/engraving/tests/tst_clef.cpp
@@ -79,7 +79,7 @@ void TestClef::clef2()
     Measure* m = score->firstMeasure();
     m = m->nextMeasure();
     m = m->nextMeasure();
-    TimeSig* ts = new TimeSig(score);
+    TimeSig* ts = new TimeSig(score->dummy()->segment());
     ts->setSig(Fraction(2, 4));
     score->cmdAddTimeSig(m, 0, ts, false);
 

--- a/src/engraving/tests/tst_clef_courtesy.cpp
+++ b/src/engraving/tests/tst_clef_courtesy.cpp
@@ -70,7 +70,7 @@ static Measure* getMeasure(Score* score, int idx)
 
 static void dropClef(Element* m, ClefType t)
 {
-    Clef* clef = new Clef(m->score());   // create a new element, as Measure::drop() will eventually delete it
+    Clef* clef = new Clef(m->score()->dummy()->segment());   // create a new element, as Measure::drop() will eventually delete it
     clef->setClefType(t);
     EditData dropData(0);
     dropData.pos = m->pagePos();
@@ -165,7 +165,7 @@ void TestClefCourtesy::clef_courtesy02()
         m1 = m1->nextMeasure();
     }
     // make a clef-drop object and drop it to the measure
-    Clef* clef = new Clef(score);   // create a new element, as Measure::drop() will eventually delete it
+    Clef* clef = new Clef(score->dummy()->segment());   // create a new element, as Measure::drop() will eventually delete it
     clef->setClefType(ClefType::G8_VA);
     EditData dropData(0);
     dropData.pos = m1->pagePos();
@@ -178,7 +178,7 @@ void TestClefCourtesy::clef_courtesy02()
         m2 = m2->nextMeasure();
     }
     // make a clef-drop object and drop it to the measure
-    clef = new Clef(score);   // create a new element, as Measure::drop() will eventually delete it
+    clef = new Clef(score->dummy()->segment());   // create a new element, as Measure::drop() will eventually delete it
     clef->setClefType(ClefType::G);
     dropData.pos = m2->pagePos();
     dropData.dropElement = clef;
@@ -221,7 +221,7 @@ void TestClefCourtesy::clef_courtesy03()
     Measure* m2 = m1->nextMeasure();
 
     // make a clef-drop object and drop it to the 2nd measure
-    Clef* clef = new Clef(score);   // create a new element, as Measure::drop() will eventually delete it
+    Clef* clef = new Clef(score->dummy()->segment());   // create a new element, as Measure::drop() will eventually delete it
     clef->setClefType(ClefType::G8_VA);
     EditData dropData(0);
     dropData.pos = m2->pagePos();

--- a/src/engraving/tests/tst_copypastesymbollist.cpp
+++ b/src/engraving/tests/tst_copypastesymbollist.cpp
@@ -121,7 +121,7 @@ void TestCopyPasteSymbolList::copypaste(const char* name, ElementType type)
     MasterScore* score = readScore(CPSYMBOLLIST_DATA_DIR + QString("copypastesymbollist-%1.mscx").arg(name));
     // score->doLayout();
 
-    Element* el = Element::create(type, score);
+    Element* el = Element::create(type, score->dummy());
     score->selectSimilar(el, false);
     delete el;
 
@@ -143,7 +143,7 @@ void TestCopyPasteSymbolList::copypastepart(const char* name, ElementType type)
     score->select(score->firstMeasure());
     score->select(score->firstMeasure()->nextMeasure(), SelectType::RANGE);
 
-    Element* el = Element::create(type, score);
+    Element* el = Element::create(type, score->dummy());
     score->selectSimilarInRange(el);
     delete el;
 
@@ -165,7 +165,7 @@ void TestCopyPasteSymbolList::copypastedifferentvoice(const char* name, ElementT
     score->select(score->firstMeasure());
     score->select(score->firstMeasure()->nextMeasure(), SelectType::RANGE, 1);
 
-    Element* el = Element::create(type, score);
+    Element* el = Element::create(type, score->dummy());
     score->selectSimilarInRange(el);
     delete el;
 

--- a/src/engraving/tests/tst_dynamic.cpp
+++ b/src/engraving/tests/tst_dynamic.cpp
@@ -56,7 +56,7 @@ void TestDynamic::initTestCase()
 
 void TestDynamic::test1()
 {
-    Dynamic* dynamic = new Dynamic(score);
+    Dynamic* dynamic = new Dynamic(score->dummy()->segment());
     dynamic->setDynamicType(Dynamic::Type(1));
 
     Dynamic* d;

--- a/src/engraving/tests/tst_element.cpp
+++ b/src/engraving/tests/tst_element.cpp
@@ -105,7 +105,7 @@ void TestElement::testIds()
     };
 
     for (ElementType t : ids) {
-        Element* e = Element::create(t, score);
+        Element* e = Element::create(t, score->dummy());
         Element* ee = writeReadElement(e);
         QCOMPARE(e->type(), ee->type());
         delete e;

--- a/src/engraving/tests/tst_hairpin.cpp
+++ b/src/engraving/tests/tst_hairpin.cpp
@@ -55,7 +55,7 @@ void TestHairpin::initTestCase()
 
 void TestHairpin::hairpin()
 {
-    Hairpin* hp = new Hairpin(score);
+    Hairpin* hp = new Hairpin(score->dummy()->segment());
 
     // subtype
     hp->setHairpinType(HairpinType::DECRESC_HAIRPIN);

--- a/src/engraving/tests/tst_instrumentchange.cpp
+++ b/src/engraving/tests/tst_instrumentchange.cpp
@@ -91,7 +91,7 @@ void TestInstrumentChange::testAdd()
     MasterScore* score = test_pre("add");
     Measure* m = score->firstMeasure()->nextMeasure();
     Segment* s = m->first(SegmentType::ChordRest);
-    InstrumentChange* ic = new InstrumentChange(score);
+    InstrumentChange* ic = new InstrumentChange(s);
     ic->setParent(s);
     ic->setTrack(0);
     ic->setXmlText("Instrument");

--- a/src/engraving/tests/tst_measure.cpp
+++ b/src/engraving/tests/tst_measure.cpp
@@ -543,7 +543,7 @@ void TestMeasure::mmrest()
 
 void TestMeasure::measureNumbers()
 {
-    MeasureNumber* measureNumber = new MeasureNumber(score);
+    MeasureNumber* measureNumber = new MeasureNumber(score->dummy()->measure());
 
     // horizontal placement
     measureNumber->setHPlacement(HPlacement::CENTER);

--- a/src/engraving/tests/tst_note.cpp
+++ b/src/engraving/tests/tst_note.cpp
@@ -78,8 +78,8 @@ void TestNote::initTestCase()
 
 void TestNote::note()
 {
-    Ms::Chord* chord = new Ms::Chord(score);
-    Note* note = new Note(score);
+    Ms::Chord* chord = new Ms::Chord(score->dummy()->segment());
+    Note* note = new Note(chord);
     chord->add(note);
 
     // pitch
@@ -354,7 +354,7 @@ void TestNote::grace()
 
     // tremolo
     score->startCmd();
-    Tremolo* tr = new Tremolo(score);
+    Tremolo* tr = new Tremolo(gc);
     tr->setTremoloType(TremoloType::R16);
     tr->setParent(gc);
     tr->setTrack(gc->track());
@@ -366,7 +366,7 @@ void TestNote::grace()
 
     // articulation
     score->startCmd();
-    Articulation* ar = new Articulation(SymId::articAccentAbove, score);
+    Articulation* ar = new Articulation(SymId::articAccentAbove, gc);
     ar->setParent(gc);
     ar->setTrack(gc->track());
     score->undoAddElement(ar);

--- a/src/engraving/tests/tst_spanners.cpp
+++ b/src/engraving/tests/tst_spanners.cpp
@@ -101,7 +101,7 @@ void TestSpanners::spanners01()
     Note* note  = chord->upNote();
     QVERIFY(note);
     // drop a glissando on note
-    gliss             = new Glissando(score);   // create a new element each time, as drop() will eventually delete it
+    gliss             = new Glissando(score->dummy());   // create a new element each time, as drop() will eventually delete it
     dropData.pos      = note->pagePos();
     dropData.dropElement  = gliss;
     note->drop(dropData);
@@ -117,7 +117,7 @@ void TestSpanners::spanners01()
     note  = chord->upNote();
     QVERIFY(note);
     // drop a glissando on note
-    gliss             = new Glissando(score);
+    gliss             = new Glissando(score->dummy());
     dropData.pos      = note->pagePos();
     dropData.dropElement  = gliss;
     note->drop(dropData);
@@ -133,7 +133,7 @@ void TestSpanners::spanners01()
     note  = chord->upNote();
     QVERIFY(note);
     // drop a glissando on note
-    gliss             = new Glissando(score);
+    gliss             = new Glissando(score->dummy());
     dropData.pos      = note->pagePos();
     dropData.dropElement  = gliss;
     note->drop(dropData);
@@ -149,7 +149,7 @@ void TestSpanners::spanners01()
     note  = chord->upNote();
     QVERIFY(note);
     // drop a glissando on note
-    gliss             = new Glissando(score);
+    gliss             = new Glissando(score->dummy());
     dropData.pos      = note->pagePos();
     dropData.dropElement  = gliss;
     note->drop(dropData);
@@ -165,7 +165,7 @@ void TestSpanners::spanners01()
     note  = chord->upNote();
     QVERIFY(note);
     // drop a glissando on note
-    gliss             = new Glissando(score);
+    gliss             = new Glissando(score->dummy());
     dropData.pos      = note->pagePos();
     dropData.dropElement  = gliss;
     note->drop(dropData);
@@ -216,7 +216,7 @@ void TestSpanners::spanners03()
     Note* note  = chord->upNote();
     QVERIFY(note);
     // drop a glissando on note
-    gliss             = new Glissando(score);   // create a new element each time, as drop() will eventually delete it
+    gliss             = new Glissando(score->dummy());   // create a new element each time, as drop() will eventually delete it
     dropData.pos      = note->pagePos();
     dropData.dropElement  = gliss;
     note->drop(dropData);
@@ -227,7 +227,7 @@ void TestSpanners::spanners03()
     QVERIFY(grace && grace->type() == ElementType::CHORD);
     note              = grace->upNote();
     QVERIFY(note);
-    gliss             = new Glissando(score);
+    gliss             = new Glissando(score->dummy());
     dropData.pos      = note->pagePos();
     dropData.dropElement  = gliss;
     note->drop(dropData);
@@ -240,7 +240,7 @@ void TestSpanners::spanners03()
     QVERIFY(chord && chord->type() == ElementType::CHORD);
     note              = chord->upNote();
     QVERIFY(note);
-    gliss             = new Glissando(score);
+    gliss             = new Glissando(score->dummy());
     dropData.pos      = note->pagePos();
     dropData.dropElement  = gliss;
     note->drop(dropData);
@@ -256,7 +256,7 @@ void TestSpanners::spanners03()
     QVERIFY(grace && grace->type() == ElementType::CHORD);
     note              = grace->upNote();
     QVERIFY(note);
-    gliss             = new Glissando(score);
+    gliss             = new Glissando(score->dummy());
     dropData.pos      = note->pagePos();
     dropData.dropElement  = gliss;
     note->drop(dropData);
@@ -346,7 +346,7 @@ void TestSpanners::spanners06()
     Note* note  = chord->upNote();
     QVERIFY(note);
     // drop a glissando on note
-    gliss             = new Glissando(score);
+    gliss             = new Glissando(score->dummy());
     dropData.pos      = note->pagePos();
     dropData.dropElement  = gliss;
     note->drop(dropData);
@@ -378,7 +378,7 @@ void TestSpanners::spanners07()
     Note* note  = chord->upNote();
     QVERIFY(note);
     // drop a glissando on note
-    gliss             = new Glissando(score);
+    gliss             = new Glissando(score->dummy());
     dropData.pos      = note->pagePos();
     dropData.dropElement  = gliss;
     note->drop(dropData);

--- a/src/engraving/tests/tst_textbase.cpp
+++ b/src/engraving/tests/tst_textbase.cpp
@@ -173,7 +173,7 @@ void TestTextBase::musicalSymbolsNotItalic()
 Dynamic* TestTextBase::addDynamic()
 {
     score = readScore("test.mscx");
-    Dynamic* dynamic = new Dynamic(score);
+    Dynamic* dynamic = new Dynamic(score->dummy()->segment());
     dynamic->setXmlText("<sym>dynamicForte</sym>");
     ChordRest* chordRest = score->firstSegment(SegmentType::ChordRest)->nextChordRest(0);
     ed.dropElement = dynamic;
@@ -184,7 +184,7 @@ Dynamic* TestTextBase::addDynamic()
 StaffText* TestTextBase::addStaffText()
 {
     score = readScore("test.mscx");
-    StaffText* staffText = new StaffText(score);
+    StaffText* staffText = new StaffText(score->dummy()->segment());
     ChordRest* chordRest = score->firstSegment(SegmentType::ChordRest)->nextChordRest(0);
     ed.dropElement = staffText;
     chordRest->drop(ed);

--- a/src/engraving/tests/tst_timesig.cpp
+++ b/src/engraving/tests/tst_timesig.cpp
@@ -64,7 +64,7 @@ void TestTimesig::timesig01()
     MasterScore* score = readScore(TIMESIG_DATA_DIR + "timesig01.mscx");
     QVERIFY(score);
     Measure* m  = score->firstMeasure()->nextMeasure();
-    TimeSig* ts = new TimeSig(score);
+    TimeSig* ts = new TimeSig(score->dummy()->segment());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
     score->startCmd();
@@ -88,7 +88,7 @@ void TestTimesig::timesig02()
     MasterScore* score = readScore(TIMESIG_DATA_DIR + "timesig-02.mscx");
     QVERIFY(score);
     Measure* m = score->firstMeasure();
-    TimeSig* ts = new TimeSig(score);
+    TimeSig* ts = new TimeSig(score->dummy()->segment());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
     score->startCmd();
@@ -114,7 +114,7 @@ void TestTimesig::timesig03()
     MasterScore* score = readScore(TIMESIG_DATA_DIR + "timesig-03.mscx");
     QVERIFY(score);
     Measure* m = score->firstMeasure()->nextMeasure();
-    TimeSig* ts = new TimeSig(score);
+    TimeSig* ts = new TimeSig(score->dummy()->segment());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
     score->cmdAddTimeSig(m, 0, ts, false);
@@ -135,7 +135,7 @@ void TestTimesig::timesig04()
     MasterScore* score = readScore(TIMESIG_DATA_DIR + "timesig-04.mscx");
     QVERIFY(score);
     Measure* m = score->firstMeasure()->nextMeasure();
-    TimeSig* ts = new TimeSig(score);
+    TimeSig* ts = new TimeSig(score->dummy()->segment());
     ts->setSig(Fraction(6, 4), TimeSigType::NORMAL);
 
     score->cmdAddTimeSig(m, 0, ts, false);
@@ -159,7 +159,7 @@ void TestTimesig::timesig05()
     MasterScore* score = readScore(TIMESIG_DATA_DIR + "timesig-05.mscx");
     QVERIFY(score);
     Measure* m = score->firstMeasure();
-    TimeSig* ts = new TimeSig(score);
+    TimeSig* ts = new TimeSig(score->dummy()->segment());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
     score->cmdAddTimeSig(m, 0, ts, false);
@@ -179,7 +179,7 @@ void TestTimesig::timesig06()
     MasterScore* score = readScore(TIMESIG_DATA_DIR + "timesig-06.mscx");
     QVERIFY(score);
     Measure* m = score->firstMeasure();
-    TimeSig* ts = new TimeSig(score);
+    TimeSig* ts = new TimeSig(score->dummy()->segment());
     ts->setSig(Fraction(5, 4), TimeSigType::NORMAL);
 
     score->startCmd();
@@ -205,7 +205,7 @@ void TestTimesig::timesig07()
     MasterScore* score = readScore(TIMESIG_DATA_DIR + "timesig-07.mscx");
     QVERIFY(score);
     Measure* m = score->firstMeasure();
-    TimeSig* ts = new TimeSig(score);
+    TimeSig* ts = new TimeSig(score->dummy()->segment());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
     score->startCmd();
@@ -250,7 +250,7 @@ void TestTimesig::timesig09()
     MasterScore* score = readScore(TIMESIG_DATA_DIR + "timesig-09.mscx");
     QVERIFY(score);
     Measure* m = score->firstMeasure();
-    TimeSig* ts = new TimeSig(score);
+    TimeSig* ts = new TimeSig(score->dummy()->segment());
     ts->setSig(Fraction(9, 8), TimeSigType::NORMAL);
 
     score->startCmd();
@@ -277,16 +277,16 @@ void TestTimesig::timesig10()
     MasterScore* score = readScore(TIMESIG_DATA_DIR + "timesig-10.mscx");
 
     Measure* m1 = score->firstMeasure();
-    TimeSig* ts1 = new TimeSig(score);
+    TimeSig* ts1 = new TimeSig(score->dummy()->segment());
     ts1->setSig(Fraction(2, 2), TimeSigType::ALLA_BREVE);
 
     score->startCmd();
     score->cmdAddTimeSig(m1, 0, ts1, false);
 
     Measure* m2 = m1->nextMeasure();
-    TimeSig* ts2 = new TimeSig(score);
+    TimeSig* ts2 = new TimeSig(score->dummy()->segment());
     ts2->setSig(Fraction(2, 2), TimeSigType::NORMAL);
-    TimeSig* ts3 = new TimeSig(score);
+    TimeSig* ts3 = new TimeSig(score->dummy()->segment());
     ts3->setSig(Fraction(4, 4), TimeSigType::FOUR_FOUR);
 
     score->cmdAddTimeSig(m2, 0, ts2, false);

--- a/src/engraving/tests/tst_tuplet.cpp
+++ b/src/engraving/tests/tst_tuplet.cpp
@@ -87,7 +87,7 @@ bool TestTuplet::createTuplet(int n, ChordRest* cr)
         fr    *= Fraction(1, 2);
     }
 
-    Tuplet* tuplet = new Tuplet(cr->score());
+    Tuplet* tuplet = new Tuplet(cr->score()->dummy()->measure());
     tuplet->setRatio(ratio);
 
     //
@@ -150,7 +150,7 @@ void TestTuplet::split(const char* p1, const char* p2)
 {
     MasterScore* score = readScore(TUPLET_DATA_DIR + p1);
     Measure* m         = score->firstMeasure();
-    TimeSig* ts        = new TimeSig(score);
+    TimeSig* ts        = new TimeSig(score->dummy()->segment());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
     score->startCmd();

--- a/src/importexport/midi/internal/midiimport/importmidi_chordname.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_chordname.cpp
@@ -230,7 +230,7 @@ void setChordNames(QList<MTrack>& tracks)
             Segment* seg = measure->getSegment(SegmentType::ChordRest, onTime.fraction());
             const int t = staff->idx() * VOICES;
 
-            Harmony* h = new Harmony(score);
+            Harmony* h = new Harmony(seg);
             h->setHarmony(chordName);
             h->setTrack(t);
             seg->add(h);

--- a/src/importexport/midi/internal/midiimport/importmidi_clef.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_clef.cpp
@@ -117,15 +117,15 @@ void createClef(ClefType clefType, Staff* staff, int tick, bool isSmall = false)
     if (tick == 0) {
         staff->setDefaultClefType(ClefTypeList(clefType, clefType));
     } else {
-        Clef* clef = new Clef(staff->score());
+        Measure* m = staff->score()->tick2measure(Fraction::fromTicks(tick));
+        Segment* seg = m->getSegment(SegmentType::Clef, Fraction::fromTicks(tick));
+        Clef* clef = new Clef(seg);
         clef->setClefType(clefType);
         const int track = staff->idx() * VOICES;
         clef->setTrack(track);
         clef->setGenerated(false);
         clef->setMag(staff->staffMag(Fraction::fromTicks(tick)));
         clef->setSmall(isSmall);
-        Measure* m = staff->score()->tick2measure(Fraction::fromTicks(tick));
-        Segment* seg = m->getSegment(SegmentType::Clef, Fraction::fromTicks(tick));
         seg->add(clef);
     }
 }

--- a/src/importexport/midi/internal/midiimport/importmidi_key.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_key.cpp
@@ -75,16 +75,16 @@ void assignKeyListToStaff(const KeyList& kl, Staff* staff)
             continue;
         }
         pkey = key;
-        KeySig* ks = new KeySig(score);
-        ks->setTrack(track);
-        ks->setGenerated(false);
-        ks->setKey(key);
-        ks->setMag(staff->staffMag(Fraction::fromTicks(tick)));
         Measure* m = score->tick2measure(Fraction::fromTicks(tick));
         if (!m) {
             continue;
         }
         Segment* seg = m->getSegment(SegmentType::KeySig, Fraction::fromTicks(tick));
+        KeySig* ks = new KeySig(seg);
+        ks->setTrack(track);
+        ks->setGenerated(false);
+        ks->setKey(key);
+        ks->setMag(staff->staffMag(Fraction::fromTicks(tick)));
         seg->add(ks);
     }
 }

--- a/src/importexport/midi/internal/midiimport/importmidi_lyrics.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_lyrics.cpp
@@ -171,7 +171,7 @@ void addTitleToScore(Score* score, const QString& string, int textCounter)
 
     MeasureBase* measure = score->first();
     if (!measure->isVBox()) {
-        measure = new VBox(score);
+        measure = new VBox(score->dummy()->system());
         measure->setTick(Fraction(0, 1));
         measure->setNext(score->first());
         score->measures()->add(measure);

--- a/src/importexport/midi/internal/midiimport/importmidi_swing.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_swing.cpp
@@ -246,9 +246,9 @@ void detectSwing(Staff* staff, MidiOperations::Swing swingType)
     }
     if (swingDetector.wasSwingApplied()) {
         // add swing label to the score
-        StaffText* st = new StaffText(score, Tid::STAFF);
-        st->setPlainText(swingCaption(swingType));
         Segment* seg = score->firstSegment(SegmentType::ChordRest);
+        StaffText* st = new StaffText(seg, Tid::STAFF);
+        st->setPlainText(swingCaption(swingType));
         st->setParent(seg);
         st->setTrack(strack);       // voice == 0
         score->addElement(st);

--- a/src/importexport/midi/internal/midiimport/importmidi_tempo.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_tempo.cpp
@@ -75,11 +75,6 @@ void setTempoToScore(Score* score, int tick, double beatsPerSecond)
     if (data->trackOpers.showTempoText.value()) {
         const int tempoInBpm = qRound(beatsPerSecond * 60.0);
 
-        TempoText* tempoText = new TempoText(score);
-        tempoText->setTempo(beatsPerSecond);
-        tempoText->setXmlText(QString("<sym>metNoteQuarterUp</sym> = %1").arg(tempoInBpm));
-        tempoText->setTrack(0);
-
         Measure* measure = score->tick2measure(Fraction::fromTicks(tick));
         if (!measure) {
             qDebug("MidiTempo::setTempoToScore: no measure for tick %d", tick);
@@ -90,6 +85,11 @@ void setTempoToScore(Score* score, int tick, double beatsPerSecond)
             qDebug("MidiTempo::setTempoToScore: no chord/rest segment for tempo at %d", tick);
             return;
         }
+
+        TempoText* tempoText = new TempoText(segment);
+        tempoText->setTempo(beatsPerSecond);
+        tempoText->setXmlText(QString("<sym>metNoteQuarterUp</sym> = %1").arg(tempoInBpm));
+        tempoText->setTrack(0);
         segment->add(tempoText);
         data->hasTempoText = true;          // to show tempo text column in the MIDI import panel
     }

--- a/src/importexport/midi/internal/midiimport/importmidi_tuplet_tonotes.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_tuplet_tonotes.cpp
@@ -74,7 +74,8 @@ void createTupletNotes(
             continue;
         }
 
-        Tuplet* tuplet = new Tuplet(score);
+        Measure* measure = score->tick2measure(tupletData.onTime.fraction());
+        Tuplet* tuplet = new Tuplet(measure);
         const auto& tupletRatio = tupletLimits(tupletData.tupletNumber).ratio;
         tuplet->setRatio(tupletRatio.fraction());
 
@@ -85,7 +86,6 @@ void createTupletNotes(
         tuplet->setTrack(track);
 //            tuplet->setTick(tupletData.onTime.ticks());
         tuplet->setVoice(tupletData.voice);
-        Measure* measure = score->tick2measure(tupletData.onTime.fraction());
         tuplet->setParent(measure);
 
         for (DurationElement* el: tupletData.elements) {

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -1362,7 +1362,7 @@ static void creditWords(XmlWriter& xml, const Score* const s, const int pageNr,
 
 static double parentHeight(const Element* element)
 {
-    const Element* parent = element->parent();
+    const Element* parent = element->parentElement();
 
     if (!parent) {
         return 0;
@@ -3901,7 +3901,7 @@ static void directionTag(XmlWriter& xml, Attributes& attr, Element const* const 
                         seg->pagePos().x(), seg->pagePos().y(),
                         seg->offset().y());
                  */
-                pel = seg->parent();
+                pel = seg->parentElement();
             }
         } else if (el->type() == ElementType::DYNAMIC
                    || el->type() == ElementType::INSTRUMENT_CHANGE
@@ -3911,7 +3911,7 @@ static void directionTag(XmlWriter& xml, Attributes& attr, Element const* const 
                    || el->type() == ElementType::TEXT) {
             // handle other elements attached (e.g. via Segment / Measure) to a system
             // find the system containing this element
-            for (const Element* e = el; e; e = e->parent()) {
+            for (const Element* e = el; e; e = e->parentElement()) {
                 if (e->type() == ElementType::SYSTEM) {
                     pel = e;
                 }
@@ -5779,7 +5779,7 @@ void ExportMusicXml::keysigTimesig(const Measure* m, const Part* p)
         if (m->tick().isZero()) {
             //KeySigEvent kse;
             //kse.setKey(Key::C);
-            KeySig* ks = new KeySig(_score);
+            KeySig* ks = new KeySig(_score->dummy()->segment());
             ks->setKey(Key::C);
             keysig(ks, p->staff(0)->clef(m->tick()));
             delete ks;

--- a/src/importexport/musicxml/internal/musicxml/importmxmlnotepitch.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlnotepitch.cpp
@@ -24,6 +24,8 @@
 #include "importmxmlnotepitch.h"
 #include "musicxmlsupport.h"
 
+#include "libmscore/score.h"
+
 namespace Ms {
 //---------------------------------------------------------
 //   accidental
@@ -46,7 +48,7 @@ static Accidental* accidental(QXmlStreamReader& e, Score* score)
     const auto type = mxmlString2accidentalType(s);
 
     if (type != AccidentalType::NONE) {
-        auto a = new Accidental(score);
+        auto a = new Accidental(score->dummy());
         a->setAccidentalType(type);
         if (editorial || cautionary || parentheses) {
             a->setBracket(AccidentalBracket(cautionary || parentheses));

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -513,9 +513,9 @@ void MusicXMLParserPass1::skipLogCurrElem()
 //   addBreak
 //---------------------------------------------------------
 
-static void addBreak(Score* const score, MeasureBase* const mb, const LayoutBreak::Type type)
+static void addBreak(Score* const, MeasureBase* const mb, const LayoutBreak::Type type)
 {
-    LayoutBreak* lb = new LayoutBreak(score);
+    LayoutBreak* lb = new LayoutBreak(mb);
     lb->setLayoutBreakType(type);
     mb->add(lb);
 }
@@ -698,7 +698,7 @@ static Tid tidForCreditWords(const CreditWords* const word, std::vector<const Cr
 
 static VBox* createAndAddVBoxForCreditWords(Score* const score, const int miny = 0, const int maxy = 75)
 {
-    auto vbox = new VBox(score);
+    auto vbox = new VBox(score->dummy()->system());
     qreal vboxHeight = 10;                           // default height in tenths
     double diff = maxy - miny;                       // calculate height in tenths
     if (diff > vboxHeight) {                         // and size is reasonable
@@ -860,7 +860,7 @@ static void createMeasuresAndVboxes(Score* const score,
         }
 
         // create and add the measure
-        Measure* measure  = new Measure(score);
+        Measure* measure  = new Measure(score->dummy()->system());
         measure->setTick(ms.at(i));
         measure->setTicks(ml.at(i));
         measure->setNo(i);

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
@@ -284,7 +284,7 @@ private:
                Fraction& dura, Fraction& missingCurr, QString& currentVoice, GraceChordList& gcl, int& gac, Beam*& beam,
                FiguredBassList& fbl, int& alt, MxmlTupletStates& tupletStates, Tuplets& tuplets);
     void notePrintSpacingNo(Fraction& dura);
-    FiguredBassItem* figure(const int idx, const bool paren);
+    FiguredBassItem* figure(const int idx, const bool paren, FiguredBass* parent);
     FiguredBass* figuredBass();
     FretDiagram* frame();
     void harmony(const QString& partId, Measure* measure, const Fraction sTime);

--- a/src/notation/internal/notationaccessibility.cpp
+++ b/src/notation/internal/notationaccessibility.cpp
@@ -198,7 +198,7 @@ std::pair<int, float> NotationAccessibility::barbeat(const Element* element) con
 
     const Element* parent = element;
     while (parent && parent->type() != ElementType::SEGMENT && parent->type() != ElementType::MEASURE) {
-        parent = parent->parent();
+        parent = parent->parentElement();
     }
 
     if (!parent) {

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -67,7 +67,7 @@ using namespace mu::notation;
 
 NotationInteraction::NotationInteraction(Notation* notation, INotationUndoStackPtr undoStack)
     : m_notation(notation), m_undoStack(undoStack), m_gripEditData(&m_scoreCallbacks),
-    m_textEditData(&m_scoreCallbacks), m_lasso(new Ms::Lasso(notation->score()))
+    m_textEditData(&m_scoreCallbacks)
 {
     m_noteInput = std::make_shared<NotationNoteInput>(notation, this, m_undoStack);
     m_selection = std::make_shared<NotationSelection>(notation);
@@ -152,7 +152,7 @@ void NotationInteraction::paint(mu::draw::Painter* painter)
     drawTextEditMode(painter);
     drawSelectionRange(painter);
     drawGripPoints(painter);
-    if (!m_lasso->bbox().isEmpty()) {
+    if (m_lasso && !m_lasso->bbox().isEmpty()) {
         m_lasso->draw(painter);
     }
 }
@@ -225,7 +225,7 @@ void NotationInteraction::showShadowNote(const PointF& pos)
 
     if (inputState.rest()) {
         int yo = 0;
-        Ms::Rest rest(Ms::gpaletteScore, duration.type());
+        Ms::Rest rest(Ms::gpaletteScore->dummy()->segment(), duration.type());
         rest.setTicks(duration.fraction());
         symNotehead = rest.getSymbol(inputState.duration().type(), 0, staff->lines(position.segment->tick()), &yo);
         m_shadowNote->setState(symNotehead, duration, true, segmentSkylineTopY, segmentSkylineBottomY);
@@ -666,6 +666,10 @@ void NotationInteraction::startDrag(const std::vector<Element*>& elems,
 
 void NotationInteraction::doDragLasso(const PointF& pt)
 {
+    if (!m_lasso) {
+        m_lasso = new Ms::Lasso(score());
+    }
+
     score()->addRefresh(m_lasso->canvasBoundingRect());
     RectF r;
     r.setCoords(m_dragData.beginMove.x(), m_dragData.beginMove.y(), pt.x(), pt.y());
@@ -677,6 +681,10 @@ void NotationInteraction::doDragLasso(const PointF& pt)
 
 void NotationInteraction::endLasso()
 {
+    if (!m_lasso) {
+        return;
+    }
+
     score()->addRefresh(m_lasso->canvasBoundingRect());
     m_lasso->setbbox(RectF());
     score()->lassoSelectEnd(m_dragData.mode != DragMode::LassoList);
@@ -815,7 +823,7 @@ void NotationInteraction::startDrop(const QByteArray& edata)
     Fraction duration;      // dummy
     ElementType type = Element::readType(e, &m_dropData.ed.dragOffset, &duration);
 
-    Element* el = Element::create(type, score());
+    Element* el = Element::create(type, score()->dummy());
     if (el) {
         if (type == ElementType::BAR_LINE || type == ElementType::ARPEGGIO || type == ElementType::BRACKET) {
             double spatium = score()->spatium();
@@ -1232,7 +1240,7 @@ bool NotationInteraction::applyPaletteElement(Ms::Element* element, Qt::Keyboard
             Ms::Fraction duration;        // dummy
             PointF dragOffset;
             Ms::ElementType type = Ms::Element::readType(e, &dragOffset, &duration);
-            Ms::Spanner* spanner = static_cast<Ms::Spanner*>(Ms::Element::create(type, score));
+            Ms::Spanner* spanner = static_cast<Ms::Spanner*>(Ms::Element::create(type, score->dummy()));
             spanner->read(e);
             spanner->styleChanged();
             score->cmdAddSpanner(spanner, idx, startSegment, endSegment);
@@ -1314,14 +1322,14 @@ bool NotationInteraction::applyPaletteElement(Ms::Element* element, Qt::Keyboard
                     switch (element->type()) {
                     case Ms::ElementType::CLEF:
                     {
-                        Ms::Clef* oclef = new Ms::Clef(score);
+                        Ms::Clef* oclef = new Ms::Clef(score->dummy()->segment());
                         oclef->setClefType(staff->clef(tick1));
                         oelement = oclef;
                         break;
                     }
                     case Ms::ElementType::KEYSIG:
                     {
-                        Ms::KeySig* okeysig = new Ms::KeySig(score);
+                        Ms::KeySig* okeysig = new Ms::KeySig(score->dummy()->segment());
                         okeysig->setKeySigEvent(staff->keySigEvent(tick1));
                         if (!score->styleB(Ms::Sid::concertPitch) && !okeysig->isCustom() && !okeysig->isAtonal()) {
                             Ms::Interval v = staff->part()->instrument(tick1)->transpose();
@@ -1335,7 +1343,7 @@ bool NotationInteraction::applyPaletteElement(Ms::Element* element, Qt::Keyboard
                     }
                     case Ms::ElementType::TIMESIG:
                     {
-                        Ms::TimeSig* otimesig = new Ms::TimeSig(score);
+                        Ms::TimeSig* otimesig = new Ms::TimeSig(score->dummy()->segment());
                         otimesig->setFrom(staff->timeSig(tick1));
                         oelement = otimesig;
                         break;
@@ -1450,7 +1458,7 @@ void NotationInteraction::applyDropPaletteElement(Ms::Score* score, Ms::Element*
         Fraction duration;      // dummy
         PointF dragOffset;
         ElementType type = Element::readType(n, &dragOffset, &duration);
-        dropData->dropElement = Element::create(type, score);
+        dropData->dropElement = Element::create(type, score->dummy());
 
         dropData->dropElement->read(n);
         dropData->dropElement->styleChanged();       // update to local style
@@ -3155,7 +3163,7 @@ void NotationInteraction::nextLyrics(bool back, bool moveOnly, bool end)
 
     bool newLyrics = false;
     if (!nextLyrics) {
-        nextLyrics = new Ms::Lyrics(score());
+        nextLyrics = new Ms::Lyrics(cr);
         nextLyrics->setTrack(track);
         cr = toChordRest(nextSegment->element(track));
         nextLyrics->setParent(cr);
@@ -3264,7 +3272,7 @@ void NotationInteraction::nextSyllable()
     Ms::Lyrics* toLyrics = cr->lyrics(verse, placement);
     bool newLyrics = (toLyrics == 0);
     if (!toLyrics) {
-        toLyrics = new Ms::Lyrics(score());
+        toLyrics = new Ms::Lyrics(nextSegment->element(track));
         toLyrics->setTrack(track);
         toLyrics->setParent(nextSegment->element(track));
         toLyrics->setNo(verse);
@@ -3340,7 +3348,7 @@ void NotationInteraction::nextLyricsVerse(bool back)
 
     lyrics = cr->lyrics(verse, placement);
     if (!lyrics) {
-        lyrics = new Ms::Lyrics(score());
+        lyrics = new Ms::Lyrics(cr);
         lyrics->setTrack(track);
         lyrics->setParent(cr);
         lyrics->setNo(verse);
@@ -3447,7 +3455,7 @@ void NotationInteraction::addMelisma()
     Ms::Lyrics* toLyrics = cr->lyrics(verse, placement);
     bool newLyrics = (toLyrics == 0);
     if (!toLyrics) {
-        toLyrics = new Ms::Lyrics(score());
+        toLyrics = new Ms::Lyrics(nextSegment->element(track));
         toLyrics->setTrack(track);
         toLyrics->setParent(nextSegment->element(track));
         toLyrics->setNo(verse);
@@ -3503,7 +3511,7 @@ void NotationInteraction::addLyricsVerse()
     newVerse = lyrics->no() + 1;
 
     Ms::Lyrics* oldLyrics = lyrics;
-    lyrics = new Ms::Lyrics(score());
+    lyrics = new Ms::Lyrics(oldLyrics->segment()->element(oldLyrics->track()));
     lyrics->setTrack(oldLyrics->track());
     lyrics->setParent(oldLyrics->segment()->element(oldLyrics->track()));
     lyrics->setPlacement(oldLyrics->placement());

--- a/src/notation/internal/notationplayback.cpp
+++ b/src/notation/internal/notationplayback.cpp
@@ -222,7 +222,7 @@ RetVal<midi::tick_t> NotationPlayback::playPositionTickByElement(const Element* 
     }
 
     if (element->isNote()) {
-        element = element->parent();
+        element = element->parentElement();
     }
 
     const Ms::ChordRest* cr = Ms::toChordRest(element);

--- a/src/notation/view/widgets/selectdialog.cpp
+++ b/src/notation/view/widgets/selectdialog.cpp
@@ -138,7 +138,7 @@ Ms::System* SelectDialog::elementSystem(const Element* element) const
         if (_element->type() == ElementType::SYSTEM) {
             return dynamic_cast<Ms::System*>(_element);
         }
-        _element = _element->parent();
+        _element = _element->parentElement();
     } while (element);
 
     return nullptr;

--- a/src/palette/internal/palettecell.cpp
+++ b/src/palette/internal/palettecell.cpp
@@ -184,7 +184,7 @@ bool PaletteCell::read(XmlReader& e)
         } else if (s == "visible") {
             visible = e.readBool();
         } else {
-            element.reset(Element::name2Element(s, gpaletteScore));
+            element.reset(Element::name2Element(s, gpaletteScore->dummy()));
             if (!element) {
                 e.unknown();
             } else {

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -84,6 +84,43 @@
 using namespace mu::palette;
 using namespace Ms;
 
+template<typename T> std::shared_ptr<T> makeElement(Ms::Score* score)
+{
+    return std::make_shared<T>(score->dummy());
+}
+
+#define MAKE_ELEMENT(T, P) \
+    template<> \
+    std::shared_ptr<T> makeElement<T>(Ms::Score* score) { return std::make_shared<T>(P); } \
+
+MAKE_ELEMENT(Dynamic, score->dummy()->segment())
+MAKE_ELEMENT(KeySig, score->dummy()->segment())
+MAKE_ELEMENT(BarLine, score->dummy()->segment())
+MAKE_ELEMENT(MeasureRepeat, score->dummy()->segment())
+MAKE_ELEMENT(Breath, score->dummy()->segment())
+MAKE_ELEMENT(Clef, score->dummy()->segment())
+MAKE_ELEMENT(Hairpin, score->dummy()->segment())
+MAKE_ELEMENT(Ambitus, score->dummy()->segment())
+MAKE_ELEMENT(SystemText, score->dummy()->segment())
+MAKE_ELEMENT(TempoText, score->dummy()->segment())
+MAKE_ELEMENT(StaffText, score->dummy()->segment())
+MAKE_ELEMENT(RehearsalMark, score->dummy()->segment())
+
+MAKE_ELEMENT(Jump, score->dummy()->measure())
+MAKE_ELEMENT(LayoutBreak, score->dummy()->measure())
+MAKE_ELEMENT(Spacer, score->dummy()->measure())
+MAKE_ELEMENT(StaffTypeChange, score->dummy()->measure())
+MAKE_ELEMENT(MeasureNumber, score->dummy()->measure())
+
+MAKE_ELEMENT(Articulation, score->dummy()->chord())
+MAKE_ELEMENT(Tremolo, score->dummy()->chord())
+MAKE_ELEMENT(Arpeggio, score->dummy()->chord())
+MAKE_ELEMENT(ChordLine, score->dummy()->chord())
+
+MAKE_ELEMENT(Fingering, score->dummy()->note())
+MAKE_ELEMENT(NoteHead, score->dummy()->note())
+MAKE_ELEMENT(Bend, score->dummy()->note())
+
 PaletteTreePtr PaletteCreator::newMasterPaletteTree()
 {
     PaletteTreePtr tree = std::make_shared<PaletteTree>();
@@ -1373,7 +1410,7 @@ PalettePtr PaletteCreator::newTimePalette()
     sp->setGridSize(42, 38);
 
     for (unsigned i = 0; i < sizeof(tsList) / sizeof(*tsList); ++i) {
-        auto ts = makeElement<TimeSig>(gpaletteScore);
+        auto ts = std::make_shared<TimeSig>(gpaletteScore->dummy()->segment());
         ts->setSig(Fraction(tsList[i].numerator, tsList[i].denominator), tsList[i].type);
         sp->appendElement(ts, tsList[i].name);
     }

--- a/src/palette/view/palettemodel.cpp
+++ b/src/palette/view/palettemodel.cpp
@@ -875,7 +875,7 @@ void PaletteTreeModel::updateCellsState(const Selection& sel)
 
     for (Element* e : sel.elements()) {
         if (e->isNote()) {
-            e = e->parent();
+            e = e->parentElement();
         }
         if (e->isChordRest()) {
             if (toChordRest(e)->beamMode() != bm) {

--- a/src/palette/view/widgets/drumsetpalette.cpp
+++ b/src/palette/view/widgets/drumsetpalette.cpp
@@ -111,15 +111,15 @@ void DrumsetPalette::updateDrumset()
             up = line > 4;
         }
 
-        auto chord = std::make_shared<Chord>(gpaletteScore);
+        auto chord = std::make_shared<Chord>(gpaletteScore->dummy()->segment());
         chord->setDurationType(TDuration::DurationType::V_QUARTER);
         chord->setStemDirection(dir);
         chord->setUp(up);
         chord->setTrack(voice);
-        Stem* stem = new Stem(gpaletteScore);
+        Stem* stem = new Stem(chord.get());
         stem->setLen((up ? -3.0 : 3.0) * _spatium);
         chord->add(stem);
-        Note* note = new Note(gpaletteScore);
+        Note* note = new Note(chord.get());
         note->setMark(true);
         note->setParent(chord.get());
         note->setTrack(voice);

--- a/src/palette/view/widgets/editdrumsetdialog.cpp
+++ b/src/palette/view/widgets/editdrumsetdialog.cpp
@@ -583,12 +583,12 @@ void EditDrumsetDialog::updateExample()
     int v         = m_editedDrumset.voice(pitch);
     Direction dir = m_editedDrumset.stemDirection(pitch);
     bool up = (Direction::UP == dir) || (Direction::AUTO == dir && line > 4);
-    std::shared_ptr<Chord> chord = std::make_shared<Chord>(gpaletteScore);
+    std::shared_ptr<Chord> chord = std::make_shared<Chord>(gpaletteScore->dummy()->segment());
     chord->setDurationType(TDuration::DurationType::V_QUARTER);
     chord->setStemDirection(dir);
     chord->setTrack(v);
     chord->setUp(up);
-    Note* note = new Note(gpaletteScore);
+    Note* note = new Note(chord.get());
     note->setParent(chord.get());
     note->setTrack(v);
     note->setPitch(pitch);
@@ -599,7 +599,7 @@ void EditDrumsetDialog::updateExample()
     note->setHeadGroup(nh);
     note->setCachedNoteheadSym(Sym::name2id(quarterCmb->currentData().toString()));
     chord->add(note);
-    Stem* stem = new Stem(gpaletteScore);
+    Stem* stem = new Stem(chord.get());
     stem->setLen((up ? -3.0 : 3.0) * gpaletteScore->spatium());
     chord->add(stem);
     drumNote->appendElement(chord, mu::qtrc("drumset", m_editedDrumset.name(pitch).toUtf8().constData()));

--- a/src/palette/view/widgets/keyedit.cpp
+++ b/src/palette/view/widgets/keyedit.cpp
@@ -38,6 +38,7 @@
 #include "engraving/libmscore/masterscore.h"
 #include "engraving/libmscore/mscore.h"
 #include "engraving/style/defaultstyle.h"
+#include "engraving/compat/dummyelement.h"
 
 #include "keycanvas.h"
 #include "palettewidget.h"
@@ -63,7 +64,7 @@ KeyCanvas::KeyCanvas(QWidget* parent)
     QAction* a = new QAction("delete", this);
     a->setShortcut(Qt::Key_Delete);
     addAction(a);
-    clef = new Clef(gpaletteScore);
+    clef = new Clef(gpaletteScore->dummy()->segment());
     clef->setClefType(ClefType::G);
     connect(a, &QAction::triggered, this, &KeyCanvas::deleteElement);
 }
@@ -218,8 +219,8 @@ void KeyCanvas::dragEnterEvent(QDragEnterEvent* event)
         }
 
         event->acceptProposedAction();
-        dragElement = static_cast<Accidental*>(Element::create(type, gpaletteScore));
-        dragElement->setParent(0);
+        dragElement = static_cast<Accidental*>(Element::create(type, gpaletteScore->dummy()));
+        dragElement->moveToDummy();
         dragElement->read(e);
         dragElement->layout();
     } else {
@@ -361,7 +362,7 @@ void KeyEditor::addClicked()
         s.spos      = pos / spatium;
         e.keySymbols().append(s);
     }
-    auto ks = makeElement<KeySig>(gpaletteScore);
+    auto ks = std::make_shared<KeySig>(gpaletteScore->dummy()->segment());
     ks->setKeySigEvent(e);
     sp->appendElement(ks, "custom");
     _dirty = true;

--- a/src/palette/view/widgets/palettewidget.cpp
+++ b/src/palette/view/widgets/palettewidget.cpp
@@ -53,6 +53,7 @@
 #include "engraving/libmscore/symbol.h"
 #include "engraving/style/defaultstyle.h"
 #include "engraving/style/style.h"
+#include "engraving/compat/dummyelement.h"
 
 #include "internal/palettecelliconengine.h"
 
@@ -819,7 +820,7 @@ void PaletteWidget::dropEvent(QDropEvent* event)
         QList<QUrl> ul = event->mimeData()->urls();
         QUrl u = ul.front();
         if (u.scheme() == "file") {
-            auto image = makeElement<Image>(gpaletteScore);
+            auto image = makeElement<Image>(gpaletteScore->dummy());
             QString filePath(u.toLocalFile());
             image->load(filePath);
             element = image;
@@ -834,11 +835,11 @@ void PaletteWidget::dropEvent(QDropEvent* event)
         ElementType type = Element::readType(xml, &dragOffset, &duration);
 
         if (type == ElementType::SYMBOL) {
-            auto symbol = makeElement<Symbol>(gpaletteScore);
+            auto symbol = makeElement<Symbol>(gpaletteScore->dummy());
             symbol->read(xml);
             element = symbol;
         } else {
-            element = std::shared_ptr<Element>(Element::create(type, gpaletteScore));
+            element = std::shared_ptr<Element>(Element::create(type, gpaletteScore->dummy()));
             if (element) {
                 element->read(xml);
                 element->setTrack(0);

--- a/src/palette/view/widgets/specialcharactersdialog.cpp
+++ b/src/palette/view/widgets/specialcharactersdialog.cpp
@@ -796,20 +796,20 @@ void SpecialCharactersDialog::populateCommon()
     m_pCommon->clear();
 
     for (auto id : unicodeAccidentals) {
-        std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(gpaletteScore);
+        std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(gpaletteScore->dummy());
         fs->setCode(id);
         fs->setFont(m_font);
         m_pCommon->appendElement(fs, QString(id));
     }
 
     for (auto id : Sym::commonScoreSymbols) {
-        std::shared_ptr<Symbol> s = std::make_shared<Symbol>(gpaletteScore);
+        std::shared_ptr<Symbol> s = std::make_shared<Symbol>(gpaletteScore->dummy());
         s->setSym(id, gpaletteScore->scoreFont());
         m_pCommon->appendElement(s, Sym::id2userName(id));
     }
 
     for (auto id : commonTextSymbols) {
-        std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(gpaletteScore);
+        std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(gpaletteScore->dummy());
         fs->setCode(id);
         fs->setFont(m_font);
         m_pCommon->appendElement(fs, QString(id));
@@ -828,7 +828,7 @@ void SpecialCharactersDialog::populateSmufl()
 
     m_pSmufl->clear();
     for (QString name : smuflNames) {
-        std::shared_ptr<Symbol> s = std::make_shared<Symbol>(gpaletteScore);
+        std::shared_ptr<Symbol> s = std::make_shared<Symbol>(gpaletteScore->dummy());
         s->setSym(Sym::name2id(name), gpaletteScore->scoreFont());
         m_pSmufl->appendElement(s, Sym::id2userName(Sym::name2id(name)));
     }
@@ -844,7 +844,7 @@ void SpecialCharactersDialog::populateUnicode()
     QPoint p = rangeInfo[row];
     m_pUnicode->clear();
     for (int code = p.x(); code <= p.y(); ++code) {
-        std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(gpaletteScore);
+        std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(gpaletteScore->dummy());
         fs->setCode(code);
         fs->setFont(m_font);
         m_pUnicode->appendElement(fs, QString("0x%1").arg(code, 5, 16, QLatin1Char('0')));

--- a/src/palette/view/widgets/symboldialog.cpp
+++ b/src/palette/view/widgets/symboldialog.cpp
@@ -64,7 +64,7 @@ void SymbolDialog::createSymbols()
         SymId id     = Sym::name2id(name);
         if (search->text().isEmpty()
             || Sym::id2userName(id).contains(search->text(), Qt::CaseInsensitive)) {
-            auto s = makeElement<Symbol>(gpaletteScore);
+            auto s = makeElement<Symbol>(gpaletteScore->dummy());
             s->setSym(SymId(id), f);
             sp->appendElement(s, Sym::id2userName(SymId(id)));
         }

--- a/src/palette/view/widgets/timedialog.cpp
+++ b/src/palette/view/widgets/timedialog.cpp
@@ -32,6 +32,7 @@
 #include "engraving/libmscore/mcursor.h"
 #include "engraving/libmscore/part.h"
 #include "engraving/libmscore/timesig.h"
+#include "engraving/compat/dummyelement.h"
 
 #include "translation.h"
 
@@ -88,7 +89,7 @@ TimeDialog::TimeDialog(QWidget* parent)
 
 void TimeDialog::addClicked()
 {
-    auto ts = makeElement<TimeSig>(gpaletteScore);
+    auto ts = std::make_shared<TimeSig>(gpaletteScore->dummy()->segment());
     ts->setSig(Fraction(zNominal->value(), denominator()));
     ts->setGroups(groups->groups());
 

--- a/src/plugins/api/cursor.cpp
+++ b/src/plugins/api/cursor.cpp
@@ -508,7 +508,7 @@ void Cursor::addTuplet(FractionWrapper* ratio, FractionWrapper* duration)
 
     _score->changeCRlen(cr, fDuration);
 
-    Ms::Tuplet* tuplet = new Ms::Tuplet(_score);
+    Ms::Tuplet* tuplet = new Ms::Tuplet(tupletMeasure);
     tuplet->setParent(tupletMeasure);
     tuplet->setTrack(track());
     tuplet->setTick(tupletTick);

--- a/src/plugins/api/elements.h
+++ b/src/plugins/api/elements.h
@@ -406,7 +406,7 @@ class Element : public Ms::PluginAPI::ScoreElement
 
     QPointF pagePos() const { return mu::PointF(element()->pagePos() / element()->spatium()).toQPointF(); }
 
-    Ms::PluginAPI::Element* parent() const { return wrap(element()->parent()); }
+    Ms::PluginAPI::Element* parent() const { return wrap(element()->parentElement()); }
     Staff* staff() { return wrap<Staff>(element()->staff()); }
 
     QRectF bbox() const;

--- a/src/plugins/api/qmlpluginapi.cpp
+++ b/src/plugins/api/qmlpluginapi.cpp
@@ -34,6 +34,7 @@
 #include "libmscore/masterscore.h"
 #include "libmscore/musescoreCore.h"
 #include "engraving/compat/scoreaccess.h"
+#include "engraving/compat/dummyelement.h"
 
 #include <QQmlEngine>
 
@@ -164,7 +165,7 @@ Element* PluginAPI::newElement(int elementType)
         return nullptr;
     }
     const ElementType type = ElementType(elementType);
-    Ms::Element* e = Ms::Element::create(type, score);
+    Ms::Element* e = Ms::Element::create(type, score->dummy());
     return wrap(e, Ownership::PLUGIN);
 }
 


### PR DESCRIPTION
    //! NOTE Before, element tree is made to be done like this
    //! class ScoreElement
    //! {
    //!     Score* _score;
    //!     ScoreElement(Score* score)...
    //! }
    //!
    //! class Element : public ScoreElement
    //! {
    //!    Element* _parent;
    //!    Element(Score* s) : ScoreElement(s)...
    //!
    //!    Element* parent() const { return _parent; }
    //!    void setElement(Element* e) { _parent = e; }
    //! }
    //! accordingly:
    //! * All elements have a ref to score which they are located.
    //! * The base element (ScoreElement) itself has no parent property
    //! * The parent of an element could be set or could not be set, so in general, it is impossible to build a tree of elements
    //! (to solve this problem, a `treeParent` method was added that tries to determine the parent)
    //! * There was also logic for some elements that if a parent is set, then an element in the tree,
    //! if not set, then no, but for other elements, it does not matter.
    //!
    //! Now the element tree is:
    //! class ScoreElement
    //! {
    //!     ScoreElement* m_parent;
    //!     ScoreElement(ScoreElement* parent)...
    //! }
    //! accordingly:
    //! * No more score property (score is searched for in the parent tree)
    //! * All objects must belong to someone
    //!
    //! For compatibility purposes, it has been done so that the new structure has the old behavior.