### PR TITLE
[MU3] Fix #274126 Crash when entering music on top of an unterminated slur by MIDI

### DIFF
--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -256,17 +256,19 @@ Note* Score::addPitch(NoteVal& nval, bool addFlag, InputState* externalInputStat
             if (e) {
                   Fraction stick = Fraction(0, 1);
                   Element* ee = is.slur()->startElement();
-                  if (ee->isChordRest())
-                        stick = toChordRest(ee)->tick();
-                  else if (ee->isNote())
-                        stick = toNote(ee)->chord()->tick();
-                  if (stick == e->tick()) {
-                        is.slur()->setTick(stick);
-                        is.slur()->setStartElement(e);
-                        }
-                  else {
-                        is.slur()->setTick2(e->tick());
-                        is.slur()->setEndElement(e);
+                  if (ee) {
+                        if (ee->isChordRest())
+                              stick = toChordRest(ee)->tick();
+                        else if (ee->isNote())
+                              stick = toNote(ee)->chord()->tick();
+                        if (stick == e->tick()) {
+                              is.slur()->setTick(stick);
+                              is.slur()->setStartElement(e);
+                              }
+                        else {
+                              is.slur()->setTick2(e->tick());
+                              is.slur()->setEndElement(e);
+                              }
                         }
                   }
             else


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/274126

Tiny fix, that enables different note-value entered from midi, on top of an slur.


- [x ] I signed [CLA](https://musescore.org/en/cla)

Perhaps too late for 3.6.3, on the other hand, a very conservative change.