### PR TITLE
Added tree mode switcher for diagnostic

### DIFF
--- a/src/diagnostics/qml/MuseScore/Diagnostics/EngravingElementsPanel.qml
+++ b/src/diagnostics/qml/MuseScore/Diagnostics/EngravingElementsPanel.qml
@@ -58,10 +58,20 @@ Rectangle {
             onClicked: elementsModel.reload()
         }
 
+        CheckBox {
+            id: modeCheckBox
+            anchors.top: parent.top
+            anchors.left: reloadBtn.right
+            anchors.leftMargin: 8
+            text: elementsModel.isUseTreeParent ? "Use treeParent" : "Use parent"
+            checked: elementsModel.isUseTreeParent
+            onClicked: elementsModel.isUseTreeParent = !elementsModel.isUseTreeParent
+        }
+
         StyledTextLabel {
             id: summaryLabel
             anchors.top: parent.top
-            anchors.left: reloadBtn.right
+            anchors.left: modeCheckBox.right
             anchors.right: parent.right
             anchors.leftMargin: 8
             height: 32

--- a/src/diagnostics/view/engraving/engravingelementsmodel.h
+++ b/src/diagnostics/view/engraving/engravingelementsmodel.h
@@ -36,6 +36,8 @@ class EngravingElementsModel : public QAbstractItemModel
     Q_PROPERTY(QString info READ info NOTIFY infoChanged)
     Q_PROPERTY(QString summary READ summary NOTIFY summaryChanged)
 
+    Q_PROPERTY(bool isUseTreeParent READ isUseTreeParent WRITE setIsUseTreeParent NOTIFY isUseTreeParentChanged)
+
     INJECT(diagnostics, IEngravingElementsProvider, elementsProvider)
     INJECT(diagnostics, actions::IActionsDispatcher, dispatcher)
 
@@ -51,6 +53,7 @@ public:
 
     QString info() const;
     QString summary() const;
+    bool isUseTreeParent() const;
 
     Q_INVOKABLE void init();
     Q_INVOKABLE void reload();
@@ -60,6 +63,10 @@ public:
 signals:
     void infoChanged();
     void summaryChanged();
+    void isUseTreeParentChanged();
+
+public slots:
+    void setIsUseTreeParent(bool arg);
 
 private:
 
@@ -98,7 +105,7 @@ private:
     QVariant makeData(const Ms::EngravingObject* el) const;
 
     void load(const std::list<const Ms::EngravingObject*>& elements, Item* root);
-    void findAndAddLoss(const std::list<const Ms::EngravingObject*>& elements, Item* lossRoot, const Item* root);
+    void findAndAddLost(const std::list<const Ms::EngravingObject*>& elements, Item* lossRoot, const Item* root);
     const Item* findItem(const Ms::EngravingObject* el, const Item* root) const;
 
     void updateInfo();
@@ -108,6 +115,7 @@ private:
 
     QString m_info;
     QString m_summary;
+    bool m_isUseTreeParent = true;
 };
 }
 

--- a/src/engraving/libmscore/engravingobject.h
+++ b/src/engraving/libmscore/engravingobject.h
@@ -208,6 +208,7 @@ public:
     virtual ~EngravingObject();
 
     inline ElementType type() const { return m_type; }
+    inline bool isType(ElementType t) const { return t == m_type; }
 
     //! NOTE Before, element tree is made to be done like this
     //! class ScoreElement


### PR DESCRIPTION
At the moment we have element tree two implementations: 
1. virtual  treeParent method - trying parent determinate differently by element type 
2. Use explicitly element parent