### PR TITLE
[MU4] Fix Theme Switching

### DIFF
--- a/src/appshell/qml/Preferences/AppearancePreferencesPage.qml
+++ b/src/appshell/qml/Preferences/AppearancePreferencesPage.qml
@@ -49,7 +49,7 @@ PreferencesPage {
         ThemesSection {
             width: content.width
 
-            themes: appearanceModel.generalThemes
+            themes: appearanceModel.highContrastEnabled ? appearanceModel.highContrastThemes : appearanceModel.generalThemes
             currentThemeCode: appearanceModel.currentThemeCode
             highContrastEnabled: appearanceModel.highContrastEnabled
             accentColors: appearanceModel.accentColors


### PR DESCRIPTION
Theme Switching now works correctly.

Previous Behaviour:
Clicking on "Enable high-contrast" checkbox switched themes, but did not display the correct High-Contrast themes in the 'Themes' section.

Updated Behviour:
Clicking on "Enable high-contrast" checkbox switches themes, and also updates the 'Themes' section view.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
