### PR TITLE
bugfix: indexing an empty categoriesTitles

### DIFF
--- a/src/project/view/templatesmodel.cpp
+++ b/src/project/view/templatesmodel.cpp
@@ -91,6 +91,10 @@ void TemplatesModel::setCurrentCategory(int index)
 
 void TemplatesModel::updateTemplatesByCategory()
 {
+    if (categoriesTitles().isEmpty()) {
+        return;
+    }
+
     m_visibleTemplates.clear();
     m_currentTemplateIndex = 0;
 


### PR DESCRIPTION
Not sure why it's needed. Am running from build directory, so no proper install.

- [x] I signed [CLA](https://musescore.org/en/cla)
