### PR TITLE
[MU4] Fix #324413: Allow importing files with uppercase extensions

### DIFF
--- a/src/engraving/compat/mscxcompat.cpp
+++ b/src/engraving/compat/mscxcompat.cpp
@@ -54,14 +54,14 @@ Ms::Score::FileError mu::engraving::compat::loadMsczOrMscx(Ms::MasterScore* scor
 {
     QByteArray msczData;
     QString filePath = path;
-    if (path.endsWith(".mscx")) {
+    if (path.endsWith(".mscx", Qt::CaseInsensitive)) {
         //! NOTE Convert mscx -> mscz
 
         Ms::Score::FileError err = mscxToMscz(path, &msczData);
         if (err != Ms::Score::FileError::FILE_NO_ERROR) {
             return err;
         }
-    } else if (path.endsWith(".mscz")) {
+    } else if (path.endsWith(".mscz", Qt::CaseInsensitive)) {
         QFile msczFile(path);
         if (!msczFile.open(QIODevice::ReadOnly)) {
             LOGE() << "failed open file: " << path;
@@ -91,14 +91,14 @@ mu::engraving::Err mu::engraving::compat::loadMsczOrMscx(EngravingProjectPtr pro
 {
     QByteArray msczData;
     QString filePath = path;
-    if (path.endsWith(".mscx")) {
+    if (path.endsWith(".mscx", Qt::CaseInsensitive)) {
         //! NOTE Convert mscx -> mscz
 
         Ms::Score::FileError err = mscxToMscz(path, &msczData);
         if (err != Ms::Score::FileError::FILE_NO_ERROR) {
             return scoreFileErrorToErr(err);
         }
-    } else if (path.endsWith(".mscz")) {
+    } else if (path.endsWith(".mscz", Qt::CaseInsensitive)) {
         QFile msczFile(path);
         if (!msczFile.open(QIODevice::ReadOnly)) {
             LOGE() << "failed open file: " << path;

--- a/src/engraving/infrastructure/io/mscreader.cpp
+++ b/src/engraving/infrastructure/io/mscreader.cpp
@@ -125,7 +125,7 @@ QByteArray MscReader::readScoreFile() const
         QStringList files = reader()->fileList();
         for (const QString& name : files) {
             // mscx file in the root dir
-            if (!name.contains("/") && name.endsWith(".mscx")) {
+            if (!name.contains("/") && name.endsWith(".mscx", Qt::CaseInsensitive)) {
                 mscxFileName = name;
                 break;
             }
@@ -145,7 +145,7 @@ std::vector<QString> MscReader::excerptNames() const
     std::vector<QString> names;
     QStringList files = reader()->fileList();
     for (const QString& filePath : files) {
-        if (filePath.startsWith("Excerpts/") && filePath.endsWith(".mscx")) {
+        if (filePath.startsWith("Excerpts/") && filePath.endsWith(".mscx", Qt::CaseInsensitive)) {
             names.push_back(QFileInfo(filePath).completeBaseName());
         }
     }

--- a/src/engraving/libmscore/image.cpp
+++ b/src/engraving/libmscore/image.cpp
@@ -397,7 +397,7 @@ void Image::read(XmlReader& e)
         path = _linkPath;
     }
 
-    if (path.endsWith(".svg")) {
+    if (path.endsWith(".svg", Qt::CaseInsensitive)) {
         setImageType(ImageType::SVG);
     } else {
         setImageType(ImageType::RASTER);
@@ -434,7 +434,7 @@ bool Image::load(const QString& ss)
     _linkPath = fi.canonicalFilePath();
     _storeItem = imageStore.add(_linkPath, ba);
     _storeItem->reference(this);
-    if (path.endsWith(".svg")) {
+    if (path.endsWith(".svg", Qt::CaseInsensitive)) {
         setImageType(ImageType::SVG);
     } else {
         setImageType(ImageType::RASTER);
@@ -456,7 +456,7 @@ bool Image::loadFromData(const QString& ss, const QByteArray& ba)
     _linkPath = "";
     _storeItem = imageStore.add(ss, ba);
     _storeItem->reference(this);
-    if (ss.endsWith(".svg")) {
+    if (ss.endsWith(".svg", Qt::CaseInsensitive)) {
         setImageType(ImageType::SVG);
     } else {
         setImageType(ImageType::RASTER);

--- a/src/engraving/libmscore/masterscore.cpp
+++ b/src/engraving/libmscore/masterscore.cpp
@@ -144,7 +144,7 @@ void MasterScore::setName(const QString& ss)
 {
     QString s(ss);
     s.replace('/', '_');      // for sanity
-    if (!(s.endsWith(".mscz") || s.endsWith(".mscx"))) {
+    if (!(s.endsWith(".mscz", Qt::CaseInsensitive) || s.endsWith(".mscx", Qt::CaseInsensitive))) {
         s += ".mscz";
     }
     info.setFile(s);

--- a/src/framework/global/io/path.cpp
+++ b/src/framework/global/io/path.cpp
@@ -85,7 +85,7 @@ paths path::pathsFromString(const std::string& str, const std::string& delim)
 std::string mu::io::suffix(const mu::io::path& path)
 {
     QFileInfo fi(path.toQString());
-    return fi.suffix().toStdString();
+    return fi.suffix().toLower().toStdString();
 }
 
 mu::io::path mu::io::filename(const mu::io::path& path)

--- a/src/palette/internal/palette.cpp
+++ b/src/palette/internal/palette.cpp
@@ -332,7 +332,7 @@ PalettePtr Palette::fromMimeData(const QByteArray& data)
 bool Palette::readFromFile(const QString& p)
 {
     QString path(p);
-    if (!path.endsWith(".mpal")) {
+    if (!path.endsWith(".mpal", Qt::CaseInsensitive)) {
         path += ".mpal";
     }
 
@@ -423,7 +423,7 @@ bool Palette::writeToFile(const QString& p) const
     }
 
     QString path(p);
-    if (!path.endsWith(".mpal")) {
+    if (!path.endsWith(".mpal", Qt::CaseInsensitive)) {
         path += ".mpal";
     }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/324413

Same method is used for GuitarPro .gtp, .pg and .gpx too, but broke at the "front door"