### PR TITLE
[MU4] Fix some compiler warnings

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build_mu3:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.5.0
@@ -116,7 +116,7 @@ jobs:
         path: ./build.artifacts/
 
   run_mtests:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     env:
         # Enable AddressSanitizer in the mtest build
         CFLAGS: "-fsanitize=address -fno-omit-frame-pointer"

--- a/src/engraving/infrastructure/draw/painterpath.cpp
+++ b/src/engraving/infrastructure/draw/painterpath.cpp
@@ -41,7 +41,7 @@ void PainterPath::moveTo(const PointF& p)
 {
     if (!hasValidCoords(p)) {
 #ifdef TRACE_DRAW_OBJ_ENABLED
-        LOGW() << "PainterPath::moveTo: Adding point with invalid coordinates, ignoring call");
+        LOGW() << "PainterPath::moveTo: Adding point with invalid coordinates, ignoring call";
 #endif
         return;
     }

--- a/src/framework/audio/internal/worker/equaliser.h
+++ b/src/framework/audio/internal/worker/equaliser.h
@@ -47,7 +47,7 @@ private:
     unsigned int m_sampleRate = 0;
     bool m_active = true;
 
-    float m_gain = 0, m_frequency = 1'000.f, m_q = 1.f;
+    float m_gain = 0, m_frequency = 1000.f, m_q = 1.f;
     float m_a[3] = { 0, 0, 0 };
     float m_b[3] = { 0, 0, 0 };
     float m_x[3] = { 0, 0, 0 };

--- a/src/framework/audio/internal/worker/sinesource.h
+++ b/src/framework/audio/internal/worker/sinesource.h
@@ -36,7 +36,7 @@ public:
     void process(float* buffer, unsigned int sampleCount) override;
 
 private:
-    float m_frequency = 1'000.f;
+    float m_frequency = 1000.f;
     float m_phase = 0;
 };
 }

--- a/src/framework/ui/internal/uiarrangement.cpp
+++ b/src/framework/ui/internal/uiarrangement.cpp
@@ -126,7 +126,7 @@ ToolConfig UiArrangement::toolConfig(const QString& toolName) const
     ToolConfig config;
 
     config.items.reserve(itemsArr.size());
-    for (const QJsonValue& v : itemsArr) {
+    for (const QJsonValue v : itemsArr) {
         QJsonObject itemObj = v.toObject();
 
         ToolConfig::Item item;

--- a/src/importexport/guitarpro/internal/gtp/gp67dombuilder.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gp67dombuilder.cpp
@@ -266,13 +266,9 @@ std::vector<GPMasterTracks::Automation> GP67DomBuilder::readTempoMap(QDomNode* c
 {
     std::vector<GPMasterTracks::Automation> tempoMap;
     QDomNode currentAutomation = currentNode->firstChild();
-    bool linearTemp{ false };
     while (!currentAutomation.isNull()) {
         if (!currentAutomation.nodeName().compare("Automation")) {
             auto ln = currentAutomation.firstChildElement("Linear");
-            if (!ln.isNull()) {
-                linearTemp = ln.text() == "true";
-            }
             auto first_name = currentAutomation.firstChild().nodeName();
             if (first_name == "Type") {
                 first_name = currentAutomation.firstChild().toElement().text();

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -390,7 +390,7 @@ void GPConverter::addVolta(const GPMasterBar* mB, Measure* measure)
         return;
     }
 
-    if (_lastVolta && _lastVolta->endings().size() != mB->alternateEnding().size()) {
+    if (_lastVolta && _lastVolta->endings().size() != static_cast<int>(mB->alternateEnding().size())) {
         _lastVolta = nullptr;
     }
 
@@ -676,11 +676,11 @@ void GPConverter::setUpTrack(const std::unique_ptr<GPTrack>& tR)
                 tunning = standartTuning;
             }
 
-            StringData stringData = StringData(fretCount, tunning.size(), tunning.data());
+            StringData stringData = StringData(fretCount, static_cast<int>(tunning.size()), tunning.data());
 
             part->instrument()->setStringData(stringData);
         } else {
-            StringData stringData = StringData(24, standartTuning.size(), standartTuning.data());
+            StringData stringData = StringData(24, static_cast<int>(standartTuning.size()), standartTuning.data());
             part->instrument()->setStringData(stringData);
 //            part->staff(0)->insertIntoCapoList({0, 1}, 0);
 //            part->setCapoFret(0);
@@ -801,12 +801,11 @@ void GPConverter::addTempoMap()
 
 bool GPConverter::addSimileMark(const GPBar* bar, int /*curTrack*/)
 {
-    //!@NOTE add simile mark
-    return false;
-
     if (bar->simileMark() == GPBar::SimileMark::None) {
         return false;
     }
+    //!@NOTE add simile mark
+    return false;
 }
 
 void GPConverter::addClef(const GPBar* bar, int curTrack)
@@ -2022,7 +2021,7 @@ int GPConverter::getStringNumberFor(Ms::Note* pNote, int pitch) const
         return -1;
     }
 
-    const int32_t lastIdx = stringTableSize - 1;
+    const int32_t lastIdx = static_cast<int32_t>(stringTableSize) - 1;
 
     for (int32_t idx = lastIdx; idx >= 0; --idx) {
         auto string = stringTable[idx];

--- a/src/inspector/models/inspectormodelcreator.cpp
+++ b/src/inspector/models/inspectormodelcreator.cpp
@@ -142,6 +142,9 @@ AbstractInspectorModel* InspectorModelCreator::newInspectorModel(AbstractInspect
         return new TremoloSettingsModel(parent, repository);
     case AbstractInspectorModel::InspectorModelType::TYPE_MEASURE_REPEAT:
         return new MeasureRepeatSettingsModel(parent, repository);
+    case AbstractInspectorModel::InspectorModelType::TYPE_BREATH:
+    case AbstractInspectorModel::InspectorModelType::TYPE_ARPEGGIO:
+    case AbstractInspectorModel::InspectorModelType::TYPE_DYNAMIC:
     case AbstractInspectorModel::InspectorModelType::TYPE_UNDEFINED:
         break;
     }


### PR DESCRIPTION
1. Actually seen while (accidentially) doing an `lupdate` (which works surprisingly fast now, in 3.x (and on Windows) it takes more than an hour, here it took just about a minute). Not really compiler warnings though...
2. Code style issues seen after fixing the 1st
3. May not affect master, but will 3.x. And won't harm here
4. Fixing one of quite many warnings seen on GitHub CI for Mac
5. Fixing compiler warnings seen after rebasing to include #8976, revisited after rebasing to include #9069, which resolved some of those warnings in a slightly different way
6. Fixing unhandled cases.