### PR TITLE
Fixed crash on page destroy

### DIFF
--- a/src/engraving/libmscore/page.cpp
+++ b/src/engraving/libmscore/page.cpp
@@ -65,11 +65,6 @@ Page::Page(EngravingObject* parent)
 
 Page::~Page()
 {
-    for (System* s : _systems) {
-        if (s->page() == this) {
-            s->moveToDummy();
-        }
-    }
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
I am confused that the systems in the list have already been destroyed, despite the fact that they are present in the list.
At the moment, there is no need to change the parent of the systems (there is a temporary hack in the base class for this)