### PR TITLE
fix GH#8938: inspector setting for tremolo doesn't appear

### DIFF
--- a/src/inspector/models/abstractinspectormodel.cpp
+++ b/src/inspector/models/abstractinspectormodel.cpp
@@ -68,7 +68,7 @@ static const QMap<Ms::ElementType, AbstractInspectorModel::InspectorModelType> N
     { Ms::ElementType::MMREST, AbstractInspectorModel::InspectorModelType::TYPE_MMREST },
     { Ms::ElementType::BEND, AbstractInspectorModel::InspectorModelType::TYPE_BEND },
     { Ms::ElementType::TREMOLOBAR, AbstractInspectorModel::InspectorModelType::TYPE_TREMOLOBAR },
-    { Ms::ElementType::TREMOLO, AbstractInspectorModel::InspectorModelType::TYPE_TREMOLOBAR },
+    { Ms::ElementType::TREMOLO, AbstractInspectorModel::InspectorModelType::TYPE_TREMOLO },
     { Ms::ElementType::MEASURE_REPEAT, AbstractInspectorModel::InspectorModelType::TYPE_MEASURE_REPEAT }
 };
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8938

The original fix is here:
https://github.com/musescore/MuseScore/issues/8938

