### PR TITLE
[MU4] audio_output_resurces_pipeline

### DIFF
--- a/src/framework/audio/audiotypes.h
+++ b/src/framework/audio/audiotypes.h
@@ -81,12 +81,16 @@ struct AudioResourceMeta {
                && type == other.type
                && hasNativeEditorSupport == other.hasNativeEditorSupport;
     }
+
+    bool operator<(const AudioResourceMeta& other) const
+    {
+        return id < other.id
+               && type < other.type
+               && vendor < other.vendor;
+    }
 };
 
 using AudioResourceMetaList = std::vector<AudioResourceMeta>;
-
-using FxProcessorId = std::string;
-using FxProcessorIdList =  std::vector<FxProcessorId>;
 
 enum class AudioFxType {
     Undefined = -1,
@@ -113,6 +117,8 @@ enum class AudioFxCategory {
 
 using AudioFxCategories = std::set<AudioFxCategory>;
 
+using AudioFxChainOrder = int8_t;
+
 struct AudioFxParams {
     AudioFxType type() const
     {
@@ -123,6 +129,7 @@ struct AudioFxParams {
     }
 
     AudioFxCategories categories;
+    AudioFxChainOrder chainOrder = -1;
     AudioResourceMeta resourceMeta;
     bool active = false;
 
@@ -130,7 +137,14 @@ struct AudioFxParams {
     {
         return resourceMeta == other.resourceMeta
                && active == other.active
+               && chainOrder == other.chainOrder
                && categories == other.categories;
+    }
+
+    bool operator<(const AudioFxParams& other) const
+    {
+        return resourceMeta < other.resourceMeta
+               && chainOrder < other.chainOrder;
     }
 
     bool isValid() const
@@ -139,17 +153,17 @@ struct AudioFxParams {
     }
 };
 
-using AudioFxParamsMap = std::map<AudioFxType, std::vector<AudioFxParams> >;
+using AudioFxChain = std::map<AudioFxChainOrder, AudioFxParams>;
 
 struct AudioOutputParams {
-    AudioFxParamsMap fxParams;
+    AudioFxChain fxChain;
     volume_db_t volume = 1.f;
     balance_t balance = 0.f;
     bool muted = false;
 
     bool operator ==(const AudioOutputParams& other) const
     {
-        return fxParams == other.fxParams
+        return fxChain == other.fxChain
                && volume == other.volume
                && balance == other.balance
                && muted == other.muted;

--- a/src/framework/audio/ifxprocessor.h
+++ b/src/framework/audio/ifxprocessor.h
@@ -33,6 +33,7 @@ public:
     virtual ~IFxProcessor() = default;
 
     virtual AudioFxType type() const = 0;
+    virtual const AudioFxParams& params() const = 0;
     virtual void setSampleRate(unsigned int sampleRate) = 0;
 
     virtual bool active() const = 0;

--- a/src/framework/audio/ifxresolver.h
+++ b/src/framework/audio/ifxresolver.h
@@ -44,15 +44,15 @@ public:
     public:
         virtual ~IResolver() = default;
 
-        virtual std::vector<IFxProcessorPtr> resolveFxList(const audio::TrackId trackId, const std::vector<AudioFxParams>& fxParams) = 0;
-        virtual std::vector<IFxProcessorPtr> resolveMasterFxList(const std::vector<AudioFxParams>& fxParams) = 0;
+        virtual std::vector<IFxProcessorPtr> resolveFxList(const audio::TrackId trackId, const AudioFxChain& fxChain) = 0;
+        virtual std::vector<IFxProcessorPtr> resolveMasterFxList(const AudioFxChain& fxChain) = 0;
         virtual AudioResourceMetaList resolveResources() const = 0;
         virtual void refresh() = 0;
     };
     using IResolverPtr = std::shared_ptr<IResolver>;
 
-    virtual std::vector<IFxProcessorPtr> resolveMasterFxList(const AudioFxParamsMap& params) = 0;
-    virtual std::vector<IFxProcessorPtr> resolveFxList(const TrackId trackId, const AudioFxParamsMap& params) = 0;
+    virtual std::vector<IFxProcessorPtr> resolveMasterFxList(const AudioFxChain& fxChain) = 0;
+    virtual std::vector<IFxProcessorPtr> resolveFxList(const TrackId trackId, const AudioFxChain& fxChain) = 0;
     virtual AudioResourceMetaList resolveAvailableResources() const = 0;
     virtual void registerResolver(const AudioFxType type, IResolverPtr resolver) = 0;
 };

--- a/src/framework/audio/internal/fx/fxresolver.cpp
+++ b/src/framework/audio/internal/fx/fxresolver.cpp
@@ -49,10 +49,14 @@ std::vector<IFxProcessorPtr> FxResolver::resolveMasterFxList(const AudioFxChain&
             if (resolver.first == fx.second.type()) {
                 fxChainByType.insert(fx);
             }
-
-            std::vector<IFxProcessorPtr> fxList = resolver.second->resolveMasterFxList(std::move(fxChainByType));
-            result.insert(result.end(), fxList.begin(), fxList.end());
         }
+
+        if (fxChainByType.empty()) {
+            continue;
+        }
+
+        std::vector<IFxProcessorPtr> fxList = resolver.second->resolveMasterFxList(std::move(fxChainByType));
+        result.insert(result.end(), fxList.begin(), fxList.end());
     }
 
     return result;

--- a/src/framework/audio/internal/fx/fxresolver.cpp
+++ b/src/framework/audio/internal/fx/fxresolver.cpp
@@ -75,10 +75,10 @@ std::vector<IFxProcessorPtr> FxResolver::resolveFxList(const TrackId trackId, co
             if (resolver.first == fx.second.type()) {
                 fxChainByType.insert(fx);
             }
-
-            std::vector<IFxProcessorPtr> fxList = resolver.second->resolveFxList(trackId, std::move(fxChainByType));
-            result.insert(result.end(), fxList.begin(), fxList.end());
         }
+
+        std::vector<IFxProcessorPtr> fxList = resolver.second->resolveFxList(trackId, std::move(fxChainByType));
+        result.insert(result.end(), fxList.begin(), fxList.end());
     }
 
     return result;

--- a/src/framework/audio/internal/fx/fxresolver.cpp
+++ b/src/framework/audio/internal/fx/fxresolver.cpp
@@ -77,6 +77,10 @@ std::vector<IFxProcessorPtr> FxResolver::resolveFxList(const TrackId trackId, co
             }
         }
 
+        if (fxChainByType.empty()) {
+            continue;
+        }
+
         std::vector<IFxProcessorPtr> fxList = resolver.second->resolveFxList(trackId, std::move(fxChainByType));
         result.insert(result.end(), fxList.begin(), fxList.end());
     }

--- a/src/framework/audio/internal/fx/fxresolver.h
+++ b/src/framework/audio/internal/fx/fxresolver.h
@@ -32,8 +32,8 @@ namespace mu::audio::fx {
 class FxResolver : public IFxResolver
 {
 public:
-    std::vector<IFxProcessorPtr> resolveMasterFxList(const AudioFxParamsMap& fxParams) override;
-    std::vector<IFxProcessorPtr> resolveFxList(const TrackId trackId, const AudioFxParamsMap& fxParams) override;
+    std::vector<IFxProcessorPtr> resolveMasterFxList(const AudioFxChain& fxChain) override;
+    std::vector<IFxProcessorPtr> resolveFxList(const TrackId trackId, const AudioFxChain& fxChain) override;
     AudioResourceMetaList resolveAvailableResources() const override;
     void registerResolver(const AudioFxType type, IResolverPtr resolver) override;
 

--- a/src/framework/audio/internal/worker/mixer.cpp
+++ b/src/framework/audio/internal/worker/mixer.cpp
@@ -170,7 +170,7 @@ void Mixer::setMasterOutputParams(const AudioOutputParams& params)
     m_masterParams = params;
 
     m_masterFxProcessors.clear();
-    m_masterFxProcessors = fxResolver()->resolveMasterFxList(params.fxParams);
+    m_masterFxProcessors = fxResolver()->resolveMasterFxList(params.fxChain);
     m_masterOutputParamsChanged.send(params);
 
     for (IFxProcessorPtr& fx : m_masterFxProcessors) {

--- a/src/framework/audio/internal/worker/mixerchannel.cpp
+++ b/src/framework/audio/internal/worker/mixerchannel.cpp
@@ -63,7 +63,7 @@ void MixerChannel::applyOutputParams(const AudioOutputParams& originParams, Audi
         return true;
     };
 
-    for (auto it = resultParams.fxChain.begin(); it != resultParams.fxChain.end(); ) {
+    for (auto it = resultParams.fxChain.begin(); it != resultParams.fxChain.end();) {
         if (filterOutInvalidFxParams(*it)) {
             it = resultParams.fxChain.erase(it);
         } else {

--- a/src/framework/audio/internal/worker/mixerchannel.cpp
+++ b/src/framework/audio/internal/worker/mixerchannel.cpp
@@ -70,6 +70,8 @@ void MixerChannel::applyOutputParams(const AudioOutputParams& originParams, Audi
             ++it;
         }
     }
+
+    m_params = resultParams;
 }
 
 Channel<audioch_t, float> MixerChannel::signalAmplitudeRmsChanged() const

--- a/src/framework/audio/internal/worker/mixerchannel.cpp
+++ b/src/framework/audio/internal/worker/mixerchannel.cpp
@@ -48,7 +48,6 @@ void MixerChannel::applyOutputParams(const AudioOutputParams& originParams, Audi
     m_fxProcessors = fxResolver()->resolveFxList(m_trackId, originParams.fxChain);
 
     for (IFxProcessorPtr& fx : m_fxProcessors) {
-        fx->setActive(true);
         fx->setSampleRate(m_sampleRate);
     }
 

--- a/src/framework/audio/internal/worker/mixerchannel.cpp
+++ b/src/framework/audio/internal/worker/mixerchannel.cpp
@@ -54,7 +54,7 @@ void MixerChannel::applyOutputParams(const AudioOutputParams& originParams, Audi
 
     resultParams = originParams;
 
-    auto filterInvalidFx = [this](const std::pair<AudioFxChainOrder, AudioFxParams>& params) {
+    auto filterOutInvalidFxParams = [this](const std::pair<AudioFxChainOrder, AudioFxParams>& params) {
         for (IFxProcessorPtr& fx : m_fxProcessors) {
             if (fx->params() == params.second) {
                 return false;
@@ -64,9 +64,13 @@ void MixerChannel::applyOutputParams(const AudioOutputParams& originParams, Audi
         return true;
     };
 
-    resultParams.fxChain.erase(std::find_if(resultParams.fxChain.begin(),
-                                            resultParams.fxChain.end(),
-                                            filterInvalidFx));
+    for (auto it = resultParams.fxChain.begin(); it != resultParams.fxChain.end(); ) {
+        if (filterOutInvalidFxParams(*it)) {
+            it = resultParams.fxChain.erase(it);
+        } else {
+            ++it;
+        }
+    }
 }
 
 Channel<audioch_t, float> MixerChannel::signalAmplitudeRmsChanged() const

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledMenuLoader.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledMenuLoader.qml
@@ -25,6 +25,8 @@ Loader {
     id: loader
 
     signal handleMenuItem(string itemId)
+    signal opened()
+    signal closed()
 
     property alias menu: loader.item
     property var menuAnchorItem: null
@@ -42,6 +44,7 @@ Loader {
 
         function unloadMenu() {
             loader.active = false
+            Qt.callLater(loader.closed)
         }
     }
 
@@ -52,7 +55,7 @@ Loader {
 
         onHandleMenuItem: {
             itemMenu.close()
-            Qt.callLater(loader.handleMenuItem, itemId)
+            loader.handleMenuItem(itemId)
         }
 
         onClosed: {
@@ -78,6 +81,8 @@ Loader {
 
         update(model, x, y)
         menu.open()
+
+        Qt.callLater(loader.opened)
     }
 
     function toggleOpened(model, x = 0, y = 0) {

--- a/src/framework/vst/devtools/vstpluginlistmodelexample.cpp
+++ b/src/framework/vst/devtools/vstpluginlistmodelexample.cpp
@@ -224,7 +224,7 @@ void VstPluginListModelExample::applyNewOutputParams()
     fxParams.resourceMeta.id = m_currentFxResource.toStdString();
 
     AudioOutputParams outputParams;
-    outputParams.fxParams.emplace(AudioFxType::VstFx, std::vector<AudioFxParams>({ fxParams }));
+    outputParams.fxChain.emplace(0, fxParams);
 
     playback()->audioOutput()->setOutputParams(m_currentSequenceId, m_currentTrackId, outputParams);
 }

--- a/src/framework/vst/internal/fx/vstfxprocessor.cpp
+++ b/src/framework/vst/internal/fx/vstfxprocessor.cpp
@@ -55,12 +55,12 @@ void VstFxProcessor::setSampleRate(unsigned int sampleRate)
 
 bool VstFxProcessor::active() const
 {
-    return m_isActive;
+    return m_params.active;
 }
 
 void VstFxProcessor::setActive(bool active)
 {
-    m_isActive = active;
+    m_params.active = active;
 }
 
 void VstFxProcessor::process(float* buffer, unsigned int sampleCount)

--- a/src/framework/vst/internal/fx/vstfxprocessor.cpp
+++ b/src/framework/vst/internal/fx/vstfxprocessor.cpp
@@ -26,8 +26,10 @@ using namespace mu;
 using namespace mu::vst;
 using namespace mu::audio;
 
-VstFxProcessor::VstFxProcessor(VstPluginPtr&& pluginPtr)
-    : m_pluginPtr(pluginPtr), m_vstAudioClient(std::make_unique<VstAudioClient>())
+VstFxProcessor::VstFxProcessor(VstPluginPtr&& pluginPtr, const AudioFxParams& params)
+    : m_pluginPtr(pluginPtr),
+    m_vstAudioClient(std::make_unique<VstAudioClient>()),
+    m_params(params)
 {
 }
 
@@ -39,6 +41,11 @@ void VstFxProcessor::init()
 AudioFxType VstFxProcessor::type() const
 {
     return audio::AudioFxType::VstFx;
+}
+
+const AudioFxParams& VstFxProcessor::params() const
+{
+    return m_params;
 }
 
 void VstFxProcessor::setSampleRate(unsigned int sampleRate)

--- a/src/framework/vst/internal/fx/vstfxprocessor.h
+++ b/src/framework/vst/internal/fx/vstfxprocessor.h
@@ -29,8 +29,6 @@ private:
     std::unique_ptr<VstAudioClient> m_vstAudioClient = nullptr;
 
     audio::AudioFxParams m_params;
-
-    bool m_isActive = false;
 };
 
 using VstFxPtr = std::shared_ptr<VstFxProcessor>;

--- a/src/framework/vst/internal/fx/vstfxprocessor.h
+++ b/src/framework/vst/internal/fx/vstfxprocessor.h
@@ -13,11 +13,12 @@ namespace mu::vst {
 class VstFxProcessor : public audio::IFxProcessor
 {
 public:
-    explicit VstFxProcessor(VstPluginPtr&& pluginPtr);
+    explicit VstFxProcessor(VstPluginPtr&& pluginPtr, const audio::AudioFxParams& params);
 
     void init();
 
     audio::AudioFxType type() const override;
+    const audio::AudioFxParams& params() const override;
     void setSampleRate(unsigned int sampleRate) override;
     bool active() const override;
     void setActive(bool active) override;
@@ -26,6 +27,8 @@ public:
 private:
     VstPluginPtr m_pluginPtr = nullptr;
     std::unique_ptr<VstAudioClient> m_vstAudioClient = nullptr;
+
+    audio::AudioFxParams m_params;
 
     bool m_isActive = false;
 };

--- a/src/framework/vst/internal/fx/vstfxresolver.cpp
+++ b/src/framework/vst/internal/fx/vstfxresolver.cpp
@@ -156,8 +156,8 @@ void VstFxResolver::updateMasterFxMap(const AudioFxChain& newFxChain)
 }
 
 void VstFxResolver::fxChainToRemove(const AudioFxChain& currentFxChain,
-                                   const audio::AudioFxChain& newFxChain,
-                                   audio::AudioFxChain& resultChain)
+                                    const audio::AudioFxChain& newFxChain,
+                                    audio::AudioFxChain& resultChain)
 {
     std::set_difference(newFxChain.begin(), newFxChain.end(),
                         currentFxChain.begin(), currentFxChain.end(),
@@ -165,8 +165,8 @@ void VstFxResolver::fxChainToRemove(const AudioFxChain& currentFxChain,
 }
 
 void VstFxResolver::fxChainToCreate(const AudioFxChain& currentFxChain,
-                                   const audio::AudioFxChain& newFxChain,
-                                   audio::AudioFxChain& resultChain)
+                                    const audio::AudioFxChain& newFxChain,
+                                    audio::AudioFxChain& resultChain)
 {
     std::set_difference(currentFxChain.begin(), currentFxChain.end(),
                         newFxChain.begin(), newFxChain.end(),

--- a/src/framework/vst/internal/fx/vstfxresolver.h
+++ b/src/framework/vst/internal/fx/vstfxresolver.h
@@ -44,29 +44,22 @@ class VstFxResolver : public audio::fx::IFxResolver::IResolver
     INJECT(vst, IVstPluginsRegister, pluginsRegister)
 public:
     // IFxResolver::IResolver interface
-    std::vector<audio::IFxProcessorPtr> resolveFxList(const audio::TrackId trackId,
-                                                      const std::vector<audio::AudioFxParams>& fxParams) override;
-    std::vector<audio::IFxProcessorPtr> resolveMasterFxList(const std::vector<audio::AudioFxParams>& fxParams) override;
+    std::vector<audio::IFxProcessorPtr> resolveFxList(const audio::TrackId trackId, const audio::AudioFxChain& fxChain) override;
+    std::vector<audio::IFxProcessorPtr> resolveMasterFxList(const audio::AudioFxChain& fxChain) override;
     audio::AudioResourceMetaList resolveResources() const override;
     void refresh() override;
 
 private:
-    using FxMap = std::unordered_map<audio::AudioResourceId, VstFxPtr>;
+    using FxMap = std::unordered_map<audio::AudioFxChainOrder, VstFxPtr>;
 
-    VstFxPtr createMasterFx(const audio::AudioResourceId& resourceId) const;
-    VstFxPtr createTrackFx(const audio::TrackId trackId, const audio::AudioResourceId& resourceId) const;
+    VstFxPtr createMasterFx(const audio::AudioFxParams& fxParams) const;
+    VstFxPtr createTrackFx(const audio::TrackId trackId, const audio::AudioFxParams& fxParams) const;
 
-    void updateMasterFxMap(const std::vector<audio::AudioFxParams>& fxParams);
-    void updateTrackFxMap(FxMap& fxMap, const audio::TrackId trackId, const std::vector<audio::AudioFxParams>& fxParams);
+    void updateMasterFxMap(const audio::AudioFxChain& newFxChain);
+    void updateTrackFxMap(FxMap& fxMap, const audio::TrackId trackId, const audio::AudioFxChain& newFxChain);
 
-    void fxListToRemove(const audio::AudioResourceIdList& currentResourceIdList, const audio::AudioResourceIdList& newResourceIdList,
-                        audio::AudioResourceIdList& resultList);
-    void removeUnusedMasterFx(const audio::AudioResourceIdList& currentResourceIdList, const audio::AudioResourceIdList& newResourceIdList);
-
-    void fxListToCreate(const audio::AudioResourceIdList& currentResourceIdList, const audio::AudioResourceIdList& newResourceIdList,
-                        audio::AudioResourceIdList& resultList);
-    void createMissingMasterFx(const audio::AudioResourceIdList& currentResourceIdList,
-                               const audio::AudioResourceIdList& newResourceIdList);
+    void fxChainToRemove(const audio::AudioFxChain& currentFxChain, const audio::AudioFxChain& newFxChain, audio::AudioFxChain& resultChain);
+    void fxChainToCreate(const audio::AudioFxChain& currentFxChain, const audio::AudioFxChain& newFxChain, audio::AudioFxChain& resultChain);
 
     std::map<audio::TrackId, FxMap> m_tracksFxMap;
     FxMap m_masterFxMap;

--- a/src/framework/vst/internal/fx/vstfxresolver.h
+++ b/src/framework/vst/internal/fx/vstfxresolver.h
@@ -58,8 +58,10 @@ private:
     void updateMasterFxMap(const audio::AudioFxChain& newFxChain);
     void updateTrackFxMap(FxMap& fxMap, const audio::TrackId trackId, const audio::AudioFxChain& newFxChain);
 
-    void fxChainToRemove(const audio::AudioFxChain& currentFxChain, const audio::AudioFxChain& newFxChain, audio::AudioFxChain& resultChain);
-    void fxChainToCreate(const audio::AudioFxChain& currentFxChain, const audio::AudioFxChain& newFxChain, audio::AudioFxChain& resultChain);
+    void fxChainToRemove(const audio::AudioFxChain& currentFxChain, const audio::AudioFxChain& newFxChain,
+                         audio::AudioFxChain& resultChain);
+    void fxChainToCreate(const audio::AudioFxChain& currentFxChain, const audio::AudioFxChain& newFxChain,
+                         audio::AudioFxChain& resultChain);
 
     std::map<audio::TrackId, FxMap> m_tracksFxMap;
     FxMap m_masterFxMap;

--- a/src/framework/vst/internal/vstaudioclient.cpp
+++ b/src/framework/vst/internal/vstaudioclient.cpp
@@ -165,8 +165,7 @@ void VstAudioClient::extractInputSamples(const audio::samples_t& sampleCount, co
 {
     for (unsigned int i = 0; i < sampleCount; ++i) {
         for (audio::audioch_t s = 0; s < m_audioChannelsCount; ++s) {
-            auto getFromChannel = std::min<unsigned int>(s, m_processData.outputs[0].numChannels - 1);
-            m_processData.inputs[0].channelBuffers32[getFromChannel][i] = sourceBuffer[i * m_audioChannelsCount + s];
+            m_processData.inputs[0].channelBuffers32[s][i] = sourceBuffer[i * m_audioChannelsCount + s];
         }
     }
 }

--- a/src/framework/vst/internal/vstpluginsregister.cpp
+++ b/src/framework/vst/internal/vstpluginsregister.cpp
@@ -45,8 +45,7 @@ void VstPluginsRegister::registerFxPlugin(const audio::TrackId trackId, const au
     std::lock_guard lock(m_mutex);
 
     VstFxInstancesMap& instancesMap = m_vstFxPluginsMap[trackId];
-    FxPluginKey key { resourceId, chainOrder };
-    instancesMap.emplace(std::move(key), pluginPtr);
+    instancesMap.emplace(std::make_pair(resourceId, chainOrder), pluginPtr);
 }
 
 void VstPluginsRegister::registerMasterFxPlugin(const audio::AudioResourceId& resourceId, const AudioFxChainOrder chainOrder,
@@ -56,8 +55,7 @@ void VstPluginsRegister::registerMasterFxPlugin(const audio::AudioResourceId& re
 
     std::lock_guard lock(m_mutex);
 
-    FxPluginKey key { resourceId, chainOrder };
-    m_masterPluginsMap.emplace(std::move(key), pluginPtr);
+    m_masterPluginsMap.emplace(std::make_pair(resourceId, chainOrder), pluginPtr);
 }
 
 VstPluginPtr VstPluginsRegister::instrumentPlugin(const audio::TrackId trackId, const audio::AudioResourceId& resourceId) const

--- a/src/framework/vst/internal/vstpluginsregister.h
+++ b/src/framework/vst/internal/vstpluginsregister.h
@@ -55,16 +55,7 @@ public:
 private:
     mutable std::mutex m_mutex;
 
-    struct FxPluginKey {
-        audio::AudioResourceId resourceId;
-        audio::AudioFxChainOrder chainOrder = 0;
-
-        bool operator<(const FxPluginKey& other) const
-        {
-            return chainOrder < other.chainOrder
-                   && resourceId < other.resourceId;
-        }
-    };
+    using FxPluginKey = std::pair<audio::AudioResourceId, audio::AudioFxChainOrder>;
 
     using VstiInstancesMap = std::map<audio::AudioResourceId, VstPluginPtr>;
     using VstFxInstancesMap = std::map<FxPluginKey, VstPluginPtr>;

--- a/src/framework/vst/ivstpluginsregister.h
+++ b/src/framework/vst/ivstpluginsregister.h
@@ -14,16 +14,20 @@ public:
     virtual ~IVstPluginsRegister() = default;
 
     virtual void registerInstrPlugin(const audio::TrackId trackId, const audio::AudioResourceId& resourceId, VstPluginPtr pluginPtr) = 0;
-    virtual void registerFxPlugin(const audio::TrackId trackId, const audio::AudioResourceId& resourceId, VstPluginPtr pluginPtr) = 0;
-    virtual void registerMasterFxPlugin(const audio::AudioResourceId& resourceId, VstPluginPtr pluginPtr) = 0;
+    virtual void registerFxPlugin(const audio::TrackId trackId, const audio::AudioResourceId& resourceId,
+                                  const audio::AudioFxChainOrder chainOrder, VstPluginPtr pluginPtr) = 0;
+    virtual void registerMasterFxPlugin(const audio::AudioResourceId& resourceId, const audio::AudioFxChainOrder chainOrder,
+                                        VstPluginPtr pluginPtr) = 0;
 
     virtual VstPluginPtr instrumentPlugin(const audio::TrackId trackId, const audio::AudioResourceId& resourceId) const = 0;
-    virtual VstPluginPtr fxPlugin(const audio::TrackId trackId, const audio::AudioResourceId& resourceId) const = 0;
-    virtual VstPluginPtr masterFxPlugin(const audio::AudioResourceId& resourceId) const = 0;
+    virtual VstPluginPtr fxPlugin(const audio::TrackId trackId, const audio::AudioResourceId& resourceId,
+                                  const audio::AudioFxChainOrder chainOrder) const = 0;
+    virtual VstPluginPtr masterFxPlugin(const audio::AudioResourceId& resourceId, const audio::AudioFxChainOrder chainOrder) const = 0;
 
     virtual void unregisterInstrPlugin(const audio::TrackId trackId, const audio::AudioResourceId& resourceId) = 0;
-    virtual void unregisterFxPlugin(const audio::TrackId trackId, const audio::AudioResourceId& resourceId) = 0;
-    virtual void unregisterMasterFxPlugin(const audio::AudioResourceId& resourceId) = 0;
+    virtual void unregisterFxPlugin(const audio::TrackId trackId, const audio::AudioResourceId& resourceId,
+                                    const audio::AudioFxChainOrder chainOrder) = 0;
+    virtual void unregisterMasterFxPlugin(const audio::AudioResourceId& resourceId, const audio::AudioFxChainOrder chainOrder) = 0;
 };
 }
 

--- a/src/framework/vst/view/vstfxeditorview.cpp
+++ b/src/framework/vst/view/vstfxeditorview.cpp
@@ -62,14 +62,19 @@ tresult VstFxEditorView::resizeView(IPlugView* view, ViewRect* newSize)
     return kResultTrue;
 }
 
+bool VstFxEditorView::isAbleToWrapPlugin() const
+{
+    return !m_resourceId.isEmpty() && m_chainOrder != -1;
+}
+
 void VstFxEditorView::wrapPluginView()
 {
     VstPluginPtr plugin;
 
     if (m_trackId == -1) {
-        plugin = pluginsRegister()->masterFxPlugin(m_resourceId.toStdString());
+        plugin = pluginsRegister()->masterFxPlugin(m_resourceId.toStdString(), m_chainOrder);
     } else {
-        plugin = pluginsRegister()->fxPlugin(m_trackId, m_resourceId.toStdString());
+        plugin = pluginsRegister()->fxPlugin(m_trackId, m_resourceId.toStdString(), m_chainOrder);
     }
 
     if (!plugin || !plugin->view()) {
@@ -119,7 +124,7 @@ void VstFxEditorView::setTrackId(int newTrackId)
     m_trackId = newTrackId;
     emit trackIdChanged();
 
-    if (!m_resourceId.isEmpty()) {
+    if (isAbleToWrapPlugin()) {
         wrapPluginView();
     }
 }
@@ -137,7 +142,25 @@ void VstFxEditorView::setResourceId(const QString& newResourceId)
     m_resourceId = newResourceId;
     emit resourceIdChanged();
 
-    if (!m_resourceId.isEmpty()) {
+    if (isAbleToWrapPlugin()) {
+        wrapPluginView();
+    }
+}
+
+int VstFxEditorView::chainOrder() const
+{
+    return m_chainOrder;
+}
+
+void VstFxEditorView::setChainOrder(int newChainOrder)
+{
+    if (m_chainOrder == newChainOrder) {
+        return;
+    }
+    m_chainOrder = newChainOrder;
+    emit chainOrderChanged();
+
+    if (isAbleToWrapPlugin()) {
         wrapPluginView();
     }
 }

--- a/src/framework/vst/view/vstfxeditorview.h
+++ b/src/framework/vst/view/vstfxeditorview.h
@@ -37,6 +37,7 @@ class VstFxEditorView : public QDialog, public Steinberg::IPlugFrame
 
     Q_PROPERTY(int trackId READ trackId WRITE setTrackId NOTIFY trackIdChanged)
     Q_PROPERTY(QString resourceId READ resourceId WRITE setResourceId NOTIFY resourceIdChanged)
+    Q_PROPERTY(int chainOrder READ chainOrder WRITE setChainOrder NOTIFY chainOrderChanged)
 
     INJECT(vst, IVstPluginsRegister, pluginsRegister)
 
@@ -54,11 +55,16 @@ public:
     const QString& resourceId() const;
     void setResourceId(const QString& newResourceId);
 
+    int chainOrder() const;
+    void setChainOrder(int newChainOrder);
+
 signals:
     void trackIdChanged();
     void resourceIdChanged();
+    void chainOrderChanged();
 
 private:
+    bool isAbleToWrapPlugin() const;
     void wrapPluginView();
 
     FIDString currentPlatformUiType() const;
@@ -67,6 +73,7 @@ private:
 
     audio::TrackId m_trackId = -1;
     QString m_resourceId;
+    audio::AudioFxChainOrder m_chainOrder = -1;
 };
 }
 

--- a/src/playback/qml/MuseScore/Playback/internal/AudioResourceControl.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/AudioResourceControl.qml
@@ -275,8 +275,12 @@ Item {
                         }
                     }
 
-                    onIsMenuOpenedChanged: {
-                        root.resourcePickingActive = menuLoader.isMenuOpened
+                    onOpened: {
+                        root.resourcePickingActive = true
+                    }
+
+                    onClosed: {
+                        root.resourcePickingActive = false
                     }
                 }
 

--- a/src/playback/view/internal/mixerchannelitem.h
+++ b/src/playback/view/internal/mixerchannelitem.h
@@ -75,8 +75,8 @@ public:
     bool muted() const;
     bool solo() const;
 
-    void loadInputParams(audio::AudioInputParams &&newParams);
-    void loadOutputParams(audio::AudioOutputParams &&newParams);
+    void loadInputParams(audio::AudioInputParams&& newParams);
+    void loadOutputParams(audio::AudioOutputParams&& newParams);
 
     void subscribeOnAudioSignalChanges(audio::AudioSignalChanges&& audioSignalChanges);
 

--- a/src/playback/view/internal/mixerchannelitem.h
+++ b/src/playback/view/internal/mixerchannelitem.h
@@ -75,8 +75,8 @@ public:
     bool muted() const;
     bool solo() const;
 
-    void loadInputParams(const audio::AudioInputParams& newParams);
-    void loadOutputParams(const audio::AudioOutputParams& newParams);
+    void loadInputParams(audio::AudioInputParams &&newParams);
+    void loadOutputParams(audio::AudioOutputParams &&newParams);
 
     void subscribeOnAudioSignalChanges(audio::AudioSignalChanges&& audioSignalChanges);
 

--- a/src/playback/view/internal/mixerchannelitem.h
+++ b/src/playback/view/internal/mixerchannelitem.h
@@ -128,6 +128,10 @@ private:
     OutputResourceItem* buildOutputResourceItem(const audio::AudioFxParams& fxParams);
     void ensureBlankOutputResourceSlot();
 
+    bool hasToCleanUpEmptySlots() const;
+    QList<OutputResourceItem*> emptySlotsToRemove() const;
+    void removeRedundantEmptySlots();
+
     audio::TrackId m_id = -1;
 
     audio::AudioInputParams m_inputParams;

--- a/src/playback/view/internal/outputresourceitem.cpp
+++ b/src/playback/view/internal/outputresourceitem.cpp
@@ -121,11 +121,12 @@ void OutputResourceItem::setIsActive(bool newIsActive)
 
 void OutputResourceItem::updateCurrentFxParams(const AudioResourceMeta& newMeta)
 {
-    m_currentFxParams.resourceMeta = newMeta;
-
-    if (m_currentFxParams.resourceMeta.isValid()) {
-        m_currentFxParams.active = true;
+    if (m_currentFxParams.resourceMeta == newMeta) {
+        return;
     }
+
+    m_currentFxParams.resourceMeta = newMeta;
+    m_currentFxParams.active = newMeta.isValid();
 
     emit isActiveChanged();
     emit titleChanged();

--- a/src/playback/view/mixerpanelmodel.cpp
+++ b/src/playback/view/mixerpanelmodel.cpp
@@ -147,7 +147,7 @@ MixerChannelItem* MixerPanelModel::buildTrackChannelItem(const audio::TrackSeque
 
     playback()->tracks()->inputParams(sequenceId, trackId)
     .onResolve(this, [item](AudioInputParams inParams) {
-        item->loadInputParams(inParams);
+        item->loadInputParams(std::move(inParams));
     })
     .onReject(this, [](int errCode, std::string text) {
         LOGE() << "unable to get track output parameters, error code: " << errCode
@@ -165,7 +165,7 @@ MixerChannelItem* MixerPanelModel::buildTrackChannelItem(const audio::TrackSeque
 
     playback()->audioOutput()->outputParams(sequenceId, trackId)
     .onResolve(this, [item](AudioOutputParams outParams) {
-        item->loadOutputParams(outParams);
+        item->loadOutputParams(std::move(outParams));
     })
     .onReject(this, [](int errCode, std::string text) {
         LOGE() << "unable to get track output parameters, error code: " << errCode
@@ -210,7 +210,7 @@ MixerChannelItem* MixerPanelModel::buildMasterChannelItem()
 
     playback()->audioOutput()->masterOutputParams()
     .onResolve(this, [item](AudioOutputParams outParams) {
-        item->loadOutputParams(outParams);
+        item->loadOutputParams(std::move(outParams));
     })
     .onReject(this, [](int errCode, std::string text) {
         LOGE() << "unable to get master output parameters, error code: " << errCode


### PR DESCRIPTION
- Implemented a fallback validation for Fx parameters
- Fixed an issue with menus in MixerPanel
- Introduced a concept of AudioFxChain and improved a VSTFX pipeline
- Simplified the management of empty FX slots in mixer, which now honors the fx chain ordering