### PR TITLE
fix #8980 - improve horizontal placement of tie endpoints

### DIFF
--- a/src/engraving/libmscore/tie.cpp
+++ b/src/engraving/libmscore/tie.cpp
@@ -509,9 +509,9 @@ void Tie::slurPos(SlurPos* sp)
         for (auto note : sc->notes()) {
             // adjust for dots
             if (startNote()->dots().size() > 0) {
-                qreal dotY = note->pos().y() + note->dots().last()->pos().y();
+                qreal dotY = note->pos().y() + note->dots().last()->y();
                 if (qAbs(y1 - dotY) < _spatium * 0.5) {
-                    xo = qMax(xo, startNote()->dots().last()->x() + startNote()->dots().last()->width());
+                    xo = qMax(xo, note->x() + note->dots().last()->x() + note->dots().last()->width());
                 }
             }
 

--- a/src/engraving/libmscore/tie.cpp
+++ b/src/engraving/libmscore/tie.cpp
@@ -534,16 +534,13 @@ void Tie::slurPos(SlurPos* sp)
         }
 
         // adjust for ledger lines
-        if (startNote()->line() >= 8 || startNote()->line() <= 0) {
-            // note is above or below the staff
-            auto currLedger = sc->ledgerLines();  // search through ledger lines and see if any are within .5sp of tie start
-            while (currLedger) {
-                if (qAbs(y1 - currLedger->y()) < _spatium * 0.5) {
-                    xo = qMax(xo, currLedger->x() + currLedger->len());
-                    break;
-                }
-                currLedger = currLedger->next();
+        auto currLedger = sc->ledgerLines();  // search through ledger lines and see if any are within .5sp of tie start
+        while (currLedger) {
+            if (qAbs(y1 - currLedger->y()) < _spatium * 0.5) {
+                xo = qMax(xo, currLedger->x() + currLedger->len());
+                break;
             }
+            currLedger = currLedger->next();
         }
 
         x1 += xo + offsetMargin;
@@ -579,15 +576,12 @@ void Tie::slurPos(SlurPos* sp)
         // ADJUST FOR COLLISIONS ----------------
 
         // adjust for ledger lines
-        if (endNote()->line() >= 8 || endNote()->line() <= 0) {
-            // note is above or below the staff
-            auto currLedger = ec->ledgerLines();  // search through ledger lines and see if any are within .5sp of tie end
-            while (currLedger) {
-                if (qAbs(y1 - currLedger->y()) < _spatium * 0.5) {
-                    xo = qMax(xo, x2 - currLedger->x());
-                }
-                currLedger = currLedger->next();
+        auto currLedger = ec->ledgerLines();  // search through ledger lines and see if any are within .5sp of tie end
+        while (currLedger) {
+            if (qAbs(y1 - currLedger->y()) < _spatium * 0.5) {
+                xo = qMax(xo, x2 - currLedger->x());
             }
+            currLedger = currLedger->next();
         }
 
         // adjust for shifted notes (such as intervals of unison or second)


### PR DESCRIPTION
addresses #8980 Improve horizontal position of chord tie endpoints

Tie endpoints now adjust for offset noteheads, ledger lines, flags, and dots. This PR does not deal with the vertical placement of these ties; that will be a different issue popping up in the near future.