### PR TITLE
[MU3] Fix 324388 negative midi time

### DIFF
--- a/importexport/midiimport/importmidi.cpp
+++ b/importexport/midiimport/importmidi.cpp
@@ -662,6 +662,7 @@ std::multimap<int, MTrack> createMTrackList(TimeSigMap *sigmap, const MidiFile *
 
       std::multimap<int, MTrack> tracks;   // <track index, track>
       int trackIndex = -1;
+      int tickOffset = 0;
       for (const auto &t: mf->tracks()) {
             MTrack track;
             track.mtrack = &t;
@@ -673,7 +674,10 @@ std::multimap<int, MTrack> createMTrackList(TimeSigMap *sigmap, const MidiFile *
                         //  - extract some information from track: program, min/max pitch
             for (const auto &i: t.events()) {
                   const MidiEvent& e = i.second;
-                  const auto tick = toMuseScoreTicks(i.first, track.division,
+                  if (tickOffset == 0 && i.first < 0) {
+                        tickOffset = 0 - i.first;
+                        }
+                  const auto tick = toMuseScoreTicks(i.first + tickOffset, track.division,
                                                      track.isDivisionInTps);
                               // remove time signature events
                   if ((e.type() == ME_META) && (e.metaType() == META_TIME_SIGNATURE)) {
@@ -1090,8 +1094,8 @@ QList<MTrack> convertMidi(Score *score, const MidiFile *mf)
                   }
             MidiLyrics::extractLyricsToMidiData(mf);
             }
-                  // for newly opened MIDI file - detect if it is a human performance
-                  // if so - detect beats and set initial time signature
+      // for newly opened MIDI file - detect if it is a human performance
+      // if so - detect beats and set initial time signature
       if (opers.data()->processingsOfOpenedFile == 0)
             Quantize::setIfHumanPerformance(tracks, sigmap);
       else        // user value


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/324388

Opening a midi file with negative time, crashes musescore.

- [x ] I signed [CLA](https://musescore.org/en/cla)
- [ ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ ] I made sure the code compiles on my machine
- [ ] I made sure there are no unnecessary changes in the code
- [ ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
