### PR TITLE
fix #9020: Select correct brace symbol for each system independently

### DIFF
--- a/src/engraving/libmscore/system.cpp
+++ b/src/engraving/libmscore/system.cpp
@@ -598,12 +598,12 @@ Bracket* System::createBracket(Ms::BracketItem* bi, int column, int staffIdx, QL
     }
 
     for (; firstStaff <= lastStaff; ++firstStaff) {
-        if (score()->staff(firstStaff)->show()) {
+        if (staff(firstStaff)->show()) {
             break;
         }
     }
     for (; lastStaff >= firstStaff; --lastStaff) {
-        if (score()->staff(lastStaff)->show()) {
+        if (staff(lastStaff)->show()) {
             break;
         }
     }
@@ -612,7 +612,7 @@ Bracket* System::createBracket(Ms::BracketItem* bi, int column, int staffIdx, QL
     // do not show bracket if it only spans one
     // system due to some invisible staves
     //
-    if ((span > 1) || (bi->bracketSpan() == span)) {
+    if ((span > 1) || (bi->bracketSpan() == span) || (span == 1 && score()->styleB(Sid::alwaysShowBracketsWhenEmptyStavesAreHidden))) {
         //
         // this bracket is visible
         //

--- a/src/engraving/libmscore/system.cpp
+++ b/src/engraving/libmscore/system.cpp
@@ -612,7 +612,9 @@ Bracket* System::createBracket(Ms::BracketItem* bi, int column, int staffIdx, QL
     // do not show bracket if it only spans one
     // system due to some invisible staves
     //
-    if ((span > 1) || (bi->bracketSpan() == span) || (span == 1 && score()->styleB(Sid::alwaysShowBracketsWhenEmptyStavesAreHidden))) {
+    if (span > 1
+        || (bi->bracketSpan() == span)
+        || (span == 1 && score()->styleB(Sid::alwaysShowBracketsWhenEmptyStavesAreHidden))) {
         //
         // this bracket is visible
         //


### PR DESCRIPTION
Resolves: #9020

MuseScore uses different brace symbols depending on the number of staves the brace covers. Currently, this is is calculated once for the entire piece. This PR allows the brace size to be calculated on a system-by-system basis, such that staves hidden in a particular system don't affect the size of the brace.