### PR TITLE
added option to always layout the title on the same page as beginning of the score

### DIFF
--- a/src/engraving/layout/layoutpage.cpp
+++ b/src/engraving/layout/layoutpage.cpp
@@ -206,7 +206,11 @@ void LayoutPage::collectPage(const LayoutOptions& options, LayoutContext& lc)
                 qreal margin = qMax(lc.curSystem->minBottom(), lc.curSystem->spacerDistance(false));
                 dist += qMax(margin, slb);
             }
-            breakPage = (y + dist) >= ey && breakPages;
+            if (MScore::layoutTitleAlwaysOnSamePage && lc.prevSystem->vbox() && *lc.score->systems().begin() == lc.prevSystem) {
+                breakPage = false;
+            } else {
+                breakPage = (y + dist) >= ey && breakPages;
+            }
         }
         if (breakPage) {
             qreal dist = qMax(lc.prevSystem->minBottom(), lc.prevSystem->spacerDistance(false));

--- a/src/engraving/libmscore/mscore.cpp
+++ b/src/engraving/libmscore/mscore.cpp
@@ -100,6 +100,7 @@ bool MScore::_verticalOrientation = false;
 qreal MScore::verticalPageGap = 5.0;
 qreal MScore::horizontalPageGapEven = 1.0;
 qreal MScore::horizontalPageGapOdd = 50.0;
+bool MScore::layoutTitleAlwaysOnSamePage = false;
 
 bool MScore::warnPitchRange;
 int MScore::pedalEventsMinTicks;

--- a/src/engraving/libmscore/mscore.h
+++ b/src/engraving/libmscore/mscore.h
@@ -378,6 +378,7 @@ public:
     static qreal verticalPageGap;
     static qreal horizontalPageGapEven;
     static qreal horizontalPageGapOdd;
+    static bool layoutTitleAlwaysOnSamePage;
 
     static void setError(MsError e) { _error = e; }
     static const char* errorMessage();


### PR DESCRIPTION
when there's a lot of instruments, the first page may not fit, so title is layouted on the separate page

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
