### PR TITLE
fix #9013 Adjust dot placement for upward hooks

### DIFF
--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -1365,6 +1365,7 @@ qreal Chord::defaultStemLength() const
     }
 
     qreal normalStemLen = isSmall() ? 2.5 : 3.5;
+    /* We no longer need to adjust stem hight for dot-hook collisions (Issue #9095)
     if (hookIdx && tab == 0) {
         if (up() && durationType().dots()) {
             //
@@ -1375,7 +1376,7 @@ qreal Chord::defaultStemLength() const
             }
             shortenStem = false;
         }
-    }
+    } */
 
     if (isGrace()) {
         // grace notes stems are not subject to normal

--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -2269,7 +2269,7 @@ void Note::layout2()
             // the top dot in the chord, not the dot for this particular note:
             qreal dotY = chord()->notes().back()->y() + chord()->notes().back()->dots().first()->pos().y();
             if (chord()->dotPosX() < hookRight && dotY < hookBottom) {
-                d = chord()->hook()->width();
+                d = chord()->hook()->width() + (0.25 * spatium());
             }
         }
         // if TAB and stems through staff

--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -2265,7 +2265,10 @@ void Note::layout2()
         // adjust dot distance for hooks
         if (chord()->hook() && chord()->up()) {
             qreal hookRight = chord()->hook()->width() + chord()->hook()->x() + chord()->pos().x();
-            if (chord()->dotPosX() < hookRight) {
+            qreal hookBottom = chord()->hook()->height() + chord()->hook()->y() + chord()->pos().y() + (0.25 * spatium());
+            // the top dot in the chord, not the dot for this particular note:
+            qreal dotY = chord()->notes().back()->y() + chord()->notes().back()->dots().first()->pos().y();
+            if (chord()->dotPosX() < hookRight && dotY < hookBottom) {
                 d = chord()->hook()->width();
             }
         }

--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -73,6 +73,7 @@
 #include "tuplet.h"
 #include "undo.h"
 #include "utils.h"
+#include "hook.h"
 
 #include "config.h"
 #include "log.h"
@@ -2261,6 +2262,13 @@ void Note::layout2()
         qreal d  = score()->point(score()->styleS(Sid::dotNoteDistance)) * mag();
         qreal dd = score()->point(score()->styleS(Sid::dotDotDistance)) * mag();
         qreal x  = chord()->dotPosX() - pos().x() - chord()->pos().x();
+        // adjust dot distance for hooks
+        if (chord()->hook() && chord()->up()) {
+            qreal hookRight = chord()->hook()->width() + chord()->hook()->x() + chord()->pos().x();
+            if (chord()->dotPosX() < hookRight) {
+                d = chord()->hook()->width();
+            }
+        }
         // if TAB and stems through staff
         if (staff()->isTabStaff(chord()->tick())) {
             const Staff* st = staff();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9013

Quick fix to move dots over if the stem is up and there is a hook on the chord and the chord's dot placement is left of the right bound of the hook:
![image](https://user-images.githubusercontent.com/89263931/132762407-a6635204-5429-4019-8b4f-c5a743469c51.png)
