### PR TITLE
fix #8970: remove space between accidentals and arpeggios

### DIFF
--- a/src/engraving/libmscore/arpeggio.cpp
+++ b/src/engraving/libmscore/arpeggio.cpp
@@ -607,13 +607,16 @@ qreal Arpeggio::insetDistance(QVector<Accidental*>& accidentals, qreal mag_) con
     qreal top = furthestAccidental->note()->pos().y() * mag_ + bbox.top() * mag_;
     qreal bottom = furthestAccidental->note()->pos().y() * mag_ + bbox.bottom() * mag_;
 
-    // if it collides with the top arrow/hoo
-    if (hasTopArrow && top <= arpeggioTop) {
-        return accidentalCutOutX;
-    }
-
-    // if it collides with the bottom arrow/hook
-    if (hasBottomArrow && bottom >= arpeggioBottom) {
+    // if it collides with the top arrow/hook
+    if ((hasTopArrow && top <= arpeggioTop)
+        // if it collides with the bottom arrow/hook
+        || (hasBottomArrow && bottom >= arpeggioBottom)) {
+        // optical adjustment for one edge case
+        if (type == ArpeggioType::BRACKET
+            && (furthestAccidental->symbol() == SymId::accidentalNatural
+                || furthestAccidental->symbol() == SymId::accidentalFlat)) {
+            return accidentalCutOutX + score()->styleP(Sid::ArpeggioAccidentalDistance) * mag_ / 2;
+        }
         return accidentalCutOutX;
     }
 

--- a/src/engraving/libmscore/arpeggio.cpp
+++ b/src/engraving/libmscore/arpeggio.cpp
@@ -23,6 +23,7 @@
 #include "arpeggio.h"
 
 #include <cmath>
+#include <QVector>
 
 #include "translation.h"
 #include "io/xml.h"
@@ -32,6 +33,7 @@
 #include "chord.h"
 #include "note.h"
 #include "score.h"
+#include "sym.h"
 #include "staff.h"
 #include "part.h"
 #include "page.h"
@@ -601,21 +603,25 @@ qreal Arpeggio::insetDistance(QVector<Accidental*>& accidentals, qreal mag_) con
 
     // this cutout means the vertical lines for a ♯, ♭, and ♮ are in the same position
     // if an accidental does not have a cutout (e.g., ♭), this value is 0
-    qreal accidentalCutOutX = symSmuflAnchor(furthestAccidental->symbol(), SmuflAnchorId::cutOutNW).x();
+    qreal accidentalCutOutX = symSmuflAnchor(furthestAccidental->symbol(), SmuflAnchorId::cutOutNW).x() * mag_;
+    qreal accidentalCutOutYTop = symSmuflAnchor(furthestAccidental->symbol(), SmuflAnchorId::cutOutNW).y() * mag_;
+    qreal accidentalCutOutYBottom = symSmuflAnchor(furthestAccidental->symbol(), SmuflAnchorId::cutOutSW).y() * mag_;
 
     auto bbox = symBbox(furthestAccidental->symbol());
-    qreal top = furthestAccidental->note()->pos().y() * mag_ + bbox.top() * mag_;
-    qreal bottom = furthestAccidental->note()->pos().y() * mag_ + bbox.bottom() * mag_;
+    qreal center = furthestAccidental->note()->pos().y() * mag_;
+    qreal top = center + bbox.top() * mag_;
+    qreal bottom = center + bbox.bottom() * mag_;
+    bool collidesWithTop = hasTopArrow && top <= arpeggioTop;
+    bool collidesWithBottom = hasBottomArrow && bottom >= arpeggioBottom;
+    bool cutoutCollidesWithTop = collidesWithTop && top - accidentalCutOutYTop >= arpeggioTop;
+    bool cutoutCollidesWithBottom = collidesWithBottom && bottom - accidentalCutOutYBottom <= arpeggioBottom;
 
-    // if it collides with the top arrow/hook
-    if ((hasTopArrow && top <= arpeggioTop)
-        // if it collides with the bottom arrow/hook
-        || (hasBottomArrow && bottom >= arpeggioBottom)) {
+    if (collidesWithTop || collidesWithBottom) {
         // optical adjustment for one edge case
-        if (type == ArpeggioType::BRACKET
-            && (furthestAccidental->symbol() == SymId::accidentalNatural
-                || furthestAccidental->symbol() == SymId::accidentalFlat)) {
-            return accidentalCutOutX + score()->styleP(Sid::ArpeggioAccidentalDistance) * mag_ / 2;
+        if (accidentalCutOutX == 0.0 || cutoutCollidesWithTop || cutoutCollidesWithBottom) {
+            qreal offset = score()->styleP(Sid::ArpeggioAccidentalDistance)
+                           - score()->styleP(Sid::ArpeggioAccidentalDistanceShort);
+            return accidentalCutOutX + offset * mag_;
         }
         return accidentalCutOutX;
     }

--- a/src/engraving/libmscore/arpeggio.cpp
+++ b/src/engraving/libmscore/arpeggio.cpp
@@ -607,7 +607,14 @@ qreal Arpeggio::insetDistance(QVector<Accidental*>& accidentals, qreal mag_) con
     qreal accidentalCutOutYTop = symSmuflAnchor(furthestAccidental->symbol(), SmuflAnchorId::cutOutNW).y() * mag_;
     qreal accidentalCutOutYBottom = symSmuflAnchor(furthestAccidental->symbol(), SmuflAnchorId::cutOutSW).y() * mag_;
 
-    auto bbox = symBbox(furthestAccidental->symbol());
+    qreal maximumInset = (score()->styleP(Sid::ArpeggioAccidentalDistance)
+                          - score()->styleP(Sid::ArpeggioAccidentalDistanceMin)) * mag_;
+
+    if (accidentalCutOutX > maximumInset) {
+        accidentalCutOutX = maximumInset;
+    }
+
+    RectF bbox = symBbox(furthestAccidental->symbol());
     qreal center = furthestAccidental->note()->pos().y() * mag_;
     qreal top = center + bbox.top() * mag_;
     qreal bottom = center + bbox.bottom() * mag_;
@@ -619,9 +626,7 @@ qreal Arpeggio::insetDistance(QVector<Accidental*>& accidentals, qreal mag_) con
     if (collidesWithTop || collidesWithBottom) {
         // optical adjustment for one edge case
         if (accidentalCutOutX == 0.0 || cutoutCollidesWithTop || cutoutCollidesWithBottom) {
-            qreal offset = score()->styleP(Sid::ArpeggioAccidentalDistance)
-                           - score()->styleP(Sid::ArpeggioAccidentalDistanceShort);
-            return accidentalCutOutX + offset * mag_;
+            return accidentalCutOutX + maximumInset;
         }
         return accidentalCutOutX;
     }

--- a/src/engraving/libmscore/arpeggio.h
+++ b/src/engraving/libmscore/arpeggio.h
@@ -67,6 +67,12 @@ class Arpeggio final : public EngravingItem
 
     static const std::array<const char*, 6> arpeggioTypeNames;
 
+private:
+
+    qreal insetTop() const;
+    qreal insetBottom() const;
+    qreal insetWidth() const;
+
 public:
 
     Arpeggio* clone() const override { return new Arpeggio(*this); }
@@ -97,6 +103,8 @@ public:
     qreal userLen2() const { return _userLen2; }
     void setUserLen1(qreal v) { _userLen1 = v; }
     void setUserLen2(qreal v) { _userLen2 = v; }
+
+    qreal insetDistance(QVector<Accidental*>& accidentals, qreal mag_) const;
 
     bool playArpeggio() { return _playArpeggio; }
     void setPlayArpeggio(bool p) { _playArpeggio = p; }

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -1914,6 +1914,12 @@ void Chord::layoutPitched()
     //  process notes
     //-----------------------------------------
 
+    // Keeps track if there are any accidentals in this cord.
+    // Used to remove excess space in front of arpeggios.
+    // See GitHub issue #8970 for more details.
+    // https://github.com/musescore/MuseScore/issues/8970
+    bool chordHasAccidental = false;
+
     for (Note* note : _notes) {
         note->layout();
 
@@ -1925,6 +1931,9 @@ void Chord::layoutPitched()
         lhead    = qMax(lhead, -x1);
 
         Accidental* accidental = note->accidental();
+        if (accidental) {
+            chordHasAccidental = true;
+        }
         if (accidental && accidental->addToSkyline() && !note->fixed()) {
             // convert x position of accidental to segment coordinate system
             qreal x = accidental->pos().x() + note->pos().x() + chordX;
@@ -2009,8 +2018,9 @@ void Chord::layoutPitched()
         _arpeggio->layout();        // only for width() !
         _arpeggio->setHeight(0.0);
         qreal extraX = _arpeggio->width() + arpeggioDistance + chordX;
+        qreal accidentalCorrection = chordHasAccidental ? 0.25 * spatium() : 0;
         qreal y1   = upnote->pos().y() - upnote->headHeight() * .5;
-        _arpeggio->setPos(-(lll + extraX), y1);
+        _arpeggio->setPos(-(lll + extraX - accidentalCorrection), y1);
         if (_arpeggio->visible()) {
             lll += extraX;
         }

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -2018,7 +2018,7 @@ void Chord::layoutPitched()
         _arpeggio->layout();        // only for width() !
         _arpeggio->setHeight(0.0);
         qreal extraX = _arpeggio->width() + arpeggioDistance + chordX;
-        qreal accidentalCorrection = chordHasAccidental ? 0.25 * spatium() : 0;
+        qreal accidentalCorrection = chordHasAccidental ? 0.5 * spatium() : 0;
         qreal y1   = upnote->pos().y() - upnote->headHeight() * .5;
         _arpeggio->setPos(-(lll + extraX - accidentalCorrection), y1);
         if (_arpeggio->visible()) {

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -2014,13 +2014,19 @@ void Chord::layoutPitched()
     addLedgerLines();
 
     if (_arpeggio) {
-        qreal arpeggioDistance = score()->styleP(Sid::ArpeggioNoteDistance) * mag_;
+        qreal arpeggioAccidentalDistance = score()->styleP(Sid::ArpeggioAccidentalDistance) * mag_;
+        qreal arpeggioNoteDistance = score()->styleP(Sid::ArpeggioNoteDistance) * mag_;
+        qreal accidentalDistance = score()->styleP(Sid::accidentalDistance) * mag_;
+
+        qreal gapSize = chordHasAccidental ? (arpeggioAccidentalDistance - accidentalDistance) : arpeggioNoteDistance;
+
         _arpeggio->layout();        // only for width() !
         _arpeggio->setHeight(0.0);
-        qreal extraX = _arpeggio->width() + arpeggioDistance + chordX;
-        qreal accidentalCorrection = chordHasAccidental ? 0.5 * spatium() : 0;
+
+        qreal extraX = _arpeggio->width() + gapSize + chordX;
+
         qreal y1   = upnote->pos().y() - upnote->headHeight() * .5;
-        _arpeggio->setPos(-(lll + extraX - accidentalCorrection), y1);
+        _arpeggio->setPos(-(lll + extraX), y1);
         if (_arpeggio->visible()) {
             lll += extraX;
         }

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -451,7 +451,7 @@ const StyleDef::StyleValue StyleDef::styleValues[int(Sid::STYLES)] = {
     { Sid::slurGateTime,            "slurGateTime",            QVariant(100) },
 
     { Sid::ArpeggioNoteDistance,    "ArpeggioNoteDistance",    Spatium(.5) },
-    { Sid::ArpeggioAccidentalDistance,    "ArpeggioAccidentalDistance",    Spatium(.25) },
+    { Sid::ArpeggioAccidentalDistance,    "ArpeggioAccidentalDistance",    Spatium(.5) },
     { Sid::ArpeggioLineWidth,       "ArpeggioLineWidth",       Spatium(.18) },
     { Sid::ArpeggioHookLen,         "ArpeggioHookLen",         Spatium(.8) },
     { Sid::ArpeggioHiddenInStdIfTab, "ArpeggioHiddenInStdIfTab", QVariant(false) },

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -451,6 +451,7 @@ const StyleDef::StyleValue StyleDef::styleValues[int(Sid::STYLES)] = {
     { Sid::slurGateTime,            "slurGateTime",            QVariant(100) },
 
     { Sid::ArpeggioNoteDistance,    "ArpeggioNoteDistance",    Spatium(.5) },
+    { Sid::ArpeggioAccidentalDistance,    "ArpeggioAccidentalDistance",    Spatium(.25) },
     { Sid::ArpeggioLineWidth,       "ArpeggioLineWidth",       Spatium(.18) },
     { Sid::ArpeggioHookLen,         "ArpeggioHookLen",         Spatium(.8) },
     { Sid::ArpeggioHiddenInStdIfTab, "ArpeggioHiddenInStdIfTab", QVariant(false) },

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -452,6 +452,7 @@ const StyleDef::StyleValue StyleDef::styleValues[int(Sid::STYLES)] = {
 
     { Sid::ArpeggioNoteDistance,    "ArpeggioNoteDistance",    Spatium(.5) },
     { Sid::ArpeggioAccidentalDistance,    "ArpeggioAccidentalDistance",    Spatium(.5) },
+    { Sid::ArpeggioAccidentalDistanceShort,    "ArpeggioAccidentalDistanceShort",    Spatium(0.25) },
     { Sid::ArpeggioLineWidth,       "ArpeggioLineWidth",       Spatium(.18) },
     { Sid::ArpeggioHookLen,         "ArpeggioHookLen",         Spatium(.8) },
     { Sid::ArpeggioHiddenInStdIfTab, "ArpeggioHiddenInStdIfTab", QVariant(false) },

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -452,7 +452,7 @@ const StyleDef::StyleValue StyleDef::styleValues[int(Sid::STYLES)] = {
 
     { Sid::ArpeggioNoteDistance,    "ArpeggioNoteDistance",    Spatium(.5) },
     { Sid::ArpeggioAccidentalDistance,    "ArpeggioAccidentalDistance",    Spatium(.5) },
-    { Sid::ArpeggioAccidentalDistanceShort,    "ArpeggioAccidentalDistanceShort",    Spatium(0.25) },
+    { Sid::ArpeggioAccidentalDistanceMin,    "ArpeggioAccidentalDistanceMin",    Spatium(0.33) },
     { Sid::ArpeggioLineWidth,       "ArpeggioLineWidth",       Spatium(.18) },
     { Sid::ArpeggioHookLen,         "ArpeggioHookLen",         Spatium(.8) },
     { Sid::ArpeggioHiddenInStdIfTab, "ArpeggioHiddenInStdIfTab", QVariant(false) },

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -450,7 +450,7 @@ enum class Sid {
 
     ArpeggioNoteDistance,
     ArpeggioAccidentalDistance,
-    ArpeggioAccidentalDistanceShort,
+    ArpeggioAccidentalDistanceMin,
     ArpeggioLineWidth,
     ArpeggioHookLen,
     ArpeggioHiddenInStdIfTab,

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -449,6 +449,7 @@ enum class Sid {
     slurGateTime,
 
     ArpeggioNoteDistance,
+    ArpeggioAccidentalDistance,
     ArpeggioLineWidth,
     ArpeggioHookLen,
     ArpeggioHiddenInStdIfTab,

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -450,6 +450,7 @@ enum class Sid {
 
     ArpeggioNoteDistance,
     ArpeggioAccidentalDistance,
+    ArpeggioAccidentalDistanceShort,
     ArpeggioLineWidth,
     ArpeggioHookLen,
     ArpeggioHiddenInStdIfTab,


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8970

Accidentals have a quarter space padding around them. This creates an unnecessarily large gap between accidentals and arpeggios. This PR decreases that gap by a quarter space, making the gap the same size as if the accidentals weren't there.

Before:

<img width="709" alt="Screen Shot 2021-09-09 at 4 00 08 PM" src="https://user-images.githubusercontent.com/5659171/132773440-a8d06a86-9749-450c-b35d-1b76f9f54312.png">

After:

<img width="707" alt="Screen Shot 2021-09-09 at 3 55 52 PM" src="https://user-images.githubusercontent.com/5659171/132773100-fa727505-6824-4877-bdd0-ebaef0270498.png">

Currently, the decrease of a quarter space is hardcoded in. Alternatively, we can use the same value that defines the spaces between accidentals. I have not yet found where this is defined, though.