### PR TITLE
[MU4] fix #8694 properly - drag handles are not page relative

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2163,15 +2163,14 @@ bool NotationInteraction::isGripEditStarted() const
     return m_gripEditData.element && m_gripEditData.curGrip != Ms::Grip::NO_GRIP;
 }
 
-static int findGrip(const QVector<mu::RectF>& grips, Ms::Page* page, const mu::PointF& canvasPos)
+static int findGrip(const QVector<mu::RectF>& grips, const mu::PointF& canvasPos)
 {
-    if (grips.empty() || page == nullptr) {
+    if (grips.empty()) {
         return -1;
     }
-    mu::PointF pos = canvasPos - page->pos();
     qreal align = grips[0].width() / 2;
     for (int i = 0; i < grips.size(); ++i) {
-        if (grips[i].adjusted(-align, -align, align, align).contains(pos)) {
+        if (grips[i].adjusted(-align, -align, align, align).contains(canvasPos)) {
             return i;
         }
     }
@@ -2180,12 +2179,12 @@ static int findGrip(const QVector<mu::RectF>& grips, Ms::Page* page, const mu::P
 
 bool NotationInteraction::isHitGrip(const PointF& pos) const
 {
-    return selection()->element() && findGrip(m_gripEditData.grip, point2page(pos), pos) != -1;
+    return selection()->element() && findGrip(m_gripEditData.grip, pos) != -1;
 }
 
 void NotationInteraction::startEditGrip(const PointF& pos)
 {
-    int grip = findGrip(m_gripEditData.grip, point2page(pos), pos);
+    int grip = findGrip(m_gripEditData.grip, pos);
     if (grip == -1) {
         return;
     }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8694

My original fix for this was just wrong, grip handle coordinates are not page-relative, so it was only working for the first page.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
