### PR TITLE
fix #8971 Tie directions on multivoice chords

### DIFF
--- a/src/engraving/libmscore/tie.cpp
+++ b/src/engraving/libmscore/tie.cpp
@@ -593,9 +593,11 @@ void Tie::calculateDirection()
     if (_slurDirection == Direction::AUTO) {
         std::vector<Note*> notes = c1->notes();
         size_t n = notes.size();
-        if (m1->hasVoices(c1->staffIdx(), c1->tick(), c1->actualTicks()) || m2->hasVoices(c2->staffIdx(), c2->tick(), c2->actualTicks())) {
-            // in polyphonic passage, ties go on the stem side
+        // if there are multiple voices, the tie direction goes on stem side
+        if (m1->hasVoices(c1->staffIdx(), c1->tick(), c1->actualTicks())) {
             _up = c1->up();
+        } else if (m2->hasVoices(c2->staffIdx(), c2->tick(), c2->actualTicks())) {
+            _up = c2->up();
         } else if (n == 1) {
             //
             // single note


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8971

Originally, if one or both chords on either side of the tie were affected by other voices, the stem direction for the first chord was used. This has been changed to use the stem direction of the chord affected by other voices.
![image](https://user-images.githubusercontent.com/89263931/132909690-c2bb8778-0ce2-4077-91d6-472dfe994eb9.png)
