### PR TITLE
Implemented zooming the Notation View by Pinch Gestures

### DIFF
--- a/src/engraving/libmscore/mscore.cpp
+++ b/src/engraving/libmscore/mscore.cpp
@@ -107,7 +107,6 @@ int MScore::pedalEventsMinTicks;
 bool MScore::harmonyPlayDisableCompatibility;
 bool MScore::harmonyPlayDisableNew;
 bool MScore::playRepeats;
-bool MScore::panPlayback;
 int MScore::playbackSpeedIncrement;
 qreal MScore::nudgeStep;
 qreal MScore::nudgeStep10;
@@ -277,7 +276,6 @@ void MScore::init()
     warnPitchRange      = true;
     pedalEventsMinTicks = 1;
     playRepeats         = true;
-    panPlayback         = true;
     playbackSpeedIncrement = 5;
 
     lastError           = "";

--- a/src/engraving/libmscore/mscore.h
+++ b/src/engraving/libmscore/mscore.h
@@ -339,7 +339,6 @@ public:
     static bool harmonyPlayDisableCompatibility;
     static bool harmonyPlayDisableNew;
     static bool playRepeats;
-    static bool panPlayback;
     static int playbackSpeedIncrement;
     static qreal nudgeStep;
     static qreal nudgeStep10;

--- a/src/notation/inotation.h
+++ b/src/notation/inotation.h
@@ -49,7 +49,6 @@ public:
 
     virtual QString title() const = 0;
 
-    virtual void setViewSize(const QSizeF& vs) = 0;
     virtual void setViewMode(const ViewMode& vm) = 0;
     virtual ViewMode viewMode() const = 0;
     virtual void paint(mu::draw::Painter* painter, const RectF& frameRect) = 0;

--- a/src/notation/internal/notation.cpp
+++ b/src/notation/internal/notation.cpp
@@ -125,7 +125,6 @@ void Notation::init()
     bool isVertical = configuration()->canvasOrientation().val == framework::Orientation::Vertical;
     Ms::MScore::setVerticalOrientation(isVertical);
 
-    Ms::MScore::panPlayback = configuration()->isAutomaticallyPanEnabled();
     Ms::MScore::playRepeats = configuration()->isPlayRepeatsEnabled();
 }
 

--- a/src/notation/internal/notation.cpp
+++ b/src/notation/internal/notation.cpp
@@ -48,7 +48,6 @@ using namespace mu::notation;
 
 Notation::Notation(Ms::Score* score)
 {
-    m_scoreGlobal = new Ms::MScore(); //! TODO May be static?
     m_opened.val = false;
 
     m_undoStack = std::make_shared<NotationUndoStack>(this, m_notationChanged);
@@ -136,11 +135,6 @@ void Notation::setScore(Ms::Score* score)
         static_cast<NotationInteraction*>(m_interaction.get())->init();
         static_cast<NotationPlayback*>(m_playback.get())->init();
     }
-}
-
-Ms::MScore* Notation::scoreGlobal() const
-{
-    return m_scoreGlobal;
 }
 
 QString Notation::title() const

--- a/src/notation/internal/notation.cpp
+++ b/src/notation/internal/notation.cpp
@@ -142,11 +142,6 @@ QString Notation::title() const
     return m_score ? m_score->title() : QString();
 }
 
-void Notation::setViewSize(const QSizeF& vs)
-{
-    m_viewSize = vs;
-}
-
 void Notation::setViewMode(const ViewMode& viewMode)
 {
     if (!m_score) {
@@ -325,9 +320,4 @@ INotationPartsPtr Notation::parts() const
 Ms::Score* Notation::score() const
 {
     return m_score;
-}
-
-QSizeF Notation::viewSize() const
-{
-    return m_viewSize;
 }

--- a/src/notation/internal/notation.h
+++ b/src/notation/internal/notation.h
@@ -73,7 +73,6 @@ public:
 protected:
     Ms::Score* score() const override;
     void setScore(Ms::Score* score);
-    Ms::MScore* scoreGlobal() const;
     void notifyAboutNotationChanged();
 
     INotationPartsPtr m_parts = nullptr;
@@ -89,7 +88,6 @@ private:
     QSizeF viewSize() const;
 
     QSizeF m_viewSize;
-    Ms::MScore* m_scoreGlobal = nullptr;
     Ms::Score* m_score = nullptr;
     ValCh<bool> m_opened;
 

--- a/src/notation/internal/notation.h
+++ b/src/notation/internal/notation.h
@@ -51,7 +51,6 @@ public:
 
     QString title() const override;
 
-    void setViewSize(const QSizeF& vs) override;
     void setViewMode(const ViewMode& viewMode) override;
     ViewMode viewMode() const override;
     void paint(draw::Painter* painter, const RectF& frameRect) override;
@@ -85,9 +84,6 @@ private:
     void paintPageBorder(mu::draw::Painter* painter, const Ms::Page* page) const;
     void paintForeground(mu::draw::Painter* painter, const RectF& pageRect) const;
 
-    QSizeF viewSize() const;
-
-    QSizeF m_viewSize;
     Ms::Score* m_score = nullptr;
     ValCh<bool> m_opened;
 

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -483,7 +483,6 @@ bool NotationConfiguration::isAutomaticallyPanEnabled() const
 void NotationConfiguration::setIsAutomaticallyPanEnabled(bool enabled)
 {
     settings()->setSharedValue(IS_AUTOMATICALLY_PAN_ENABLED, Val(enabled));
-    Ms::MScore::panPlayback = enabled;
 }
 
 bool NotationConfiguration::isPlayRepeatsEnabled() const

--- a/src/notation/notationscene.qrc
+++ b/src/notation/notationscene.qrc
@@ -25,5 +25,6 @@
         <file>qml/MuseScore/NotationScene/Timeline.qml</file>
         <file>qml/MuseScore/NotationScene/SelectionFilterPanel.qml</file>
         <file>qml/MuseScore/NotationScene/EditGridSizeDialog.qml</file>
+        <file>qml/MuseScore/NotationScene/NotationZoomPinchArea.qml</file>
     </qresource>
 </RCC>

--- a/src/notation/qml/MuseScore/NotationScene/NotationView.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NotationView.qml
@@ -80,24 +80,9 @@ FocusScope {
                 color: notationView.backgroundColor
             }
 
-            Item {
+            NotationZoomPinchArea {
                 SplitView.fillWidth: true
                 SplitView.fillHeight: true
-
-                // Hack: the PinchArea must be outside the NotationPaintView, and must have a lower z-index,
-                // to prevent it from stealing hover events from the NotationPaintView.
-                PinchArea {
-                    anchors.fill: notationView
-
-                    onPinchUpdated: function(pinch) {
-                        notationView.scale(pinch.scale / pinch.previousScale, pinch.center)
-                    }
-
-                    // A macOS feature which allows double-tapping with two fingers to zoom in or out
-                    onSmartZoom: function(pinch) {
-                        notationView.scale(pinch.scale === 0 ? 0.5 : 2, pinch.center)
-                    }
-                }
 
                 NotationPaintView {
                     id: notationView

--- a/src/notation/qml/MuseScore/NotationScene/NotationView.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NotationView.qml
@@ -80,124 +80,142 @@ FocusScope {
                 color: notationView.backgroundColor
             }
 
-            NotationPaintView {
-                id: notationView
-
-                NavigationPanel {
-                    id: navPanel
-                    name: "ScoreView"
-                    section: navSec
-                    direction: NavigationPanel.Both
-                    order: 2
-                }
-
-                NavigationControl {
-                    id: fakeNavCtrl
-                    name: "Score"
-
-                    panel: navPanel
-                    order: 1
-
-                    accessible.role: MUAccessible.Panel
-                    accessible.name: "Score"
-
-                    onActiveChanged: {
-                        if (fakeNavCtrl.active) {
-                            notationView.selectOnNavigationActive()
-                        }
-                    }
-                }
-
+            Item {
                 SplitView.fillWidth: true
                 SplitView.fillHeight: true
 
-                onTextEdittingStarted: {
-                    root.textEdittingStarted()
-                }
+                // Hack: the PinchArea must be outside the NotationPaintView, and must have a lower z-index,
+                // to prevent it from stealing hover events from the NotationPaintView.
+                PinchArea {
+                    anchors.fill: notationView
 
-                onShowContextMenuRequested: function (elementType, pos) {
-                    contextMenuModel.loadItems(elementType)
+                    onPinchUpdated: function(pinch) {
+                        notationView.scale(pinch.scale / pinch.previousScale, pinch.center)
+                    }
 
-                    if (contextMenuLoader.isMenuOpened) {
-                        contextMenuLoader.update(contextMenuModel.items, pos.x, pos.y)
-                    } else {
-                        contextMenuLoader.open(contextMenuModel.items, pos.x, pos.y)
+                    // A macOS feature which allows double-tapping with two fingers to zoom in or out
+                    onSmartZoom: function(pinch) {
+                        notationView.scale(pinch.scale === 0 ? 0.5 : 2, pinch.center)
                     }
                 }
 
-                onHideContextMenuRequested: function() {
-                    contextMenuLoader.close()
-                }
+                NotationPaintView {
+                    id: notationView
+                    anchors.fill: parent
 
-                onViewportChanged: {
-                    notationNavigator.setCursorRect(viewport)
-                }
-
-                onHorizontalScrollChanged: {
-                    if (!horizontalScrollBar.pressed) {
-                        horizontalScrollBar.setPosition(notationView.startHorizontalScrollPosition)
+                    NavigationPanel {
+                        id: navPanel
+                        name: "ScoreView"
+                        section: navSec
+                        direction: NavigationPanel.Both
+                        order: 2
                     }
-                }
 
-                onVerticalScrollChanged: {
-                    if (!verticalScrollBar.pressed) {
-                        verticalScrollBar.setPosition(notationView.startVerticalScrollPosition)
-                    }
-                }
+                    NavigationControl {
+                        id: fakeNavCtrl
+                        name: "Score"
 
-                StyledScrollBar {
-                    id: verticalScrollBar
+                        panel: navPanel
+                        order: 1
 
-                    anchors.top: parent.top
-                    anchors.bottomMargin: prv.scrollbarMargin
-                    anchors.bottom: parent.bottom
-                    anchors.right: parent.right
+                        accessible.role: MUAccessible.Panel
+                        accessible.name: "Score"
 
-                    orientation: Qt.Vertical
-
-                    color: "black"
-                    border.width: 1
-                    border.color: "white"
-
-                    size: notationView.verticalScrollSize
-
-                    onPositionChanged: {
-                        if (pressed) {
-                            notationView.scrollVertical(position)
+                        onActiveChanged: {
+                            if (fakeNavCtrl.active) {
+                                notationView.selectOnNavigationActive()
+                            }
                         }
                     }
-                }
 
-                StyledScrollBar {
-                    id: horizontalScrollBar
+                    onTextEdittingStarted: {
+                        root.textEdittingStarted()
+                    }
 
-                    anchors.bottom: parent.bottom
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    anchors.rightMargin: prv.scrollbarMargin
+                    onShowContextMenuRequested: function (elementType, pos) {
+                        contextMenuModel.loadItems(elementType)
 
-                    orientation: Qt.Horizontal
-
-                    color: "black"
-                    border.width: 1
-                    border.color: "white"
-
-                    size: notationView.horizontalScrollSize
-
-                    onPositionChanged: {
-                        if (pressed) {
-                            notationView.scrollHorizontal(position)
+                        if (contextMenuLoader.isMenuOpened) {
+                            contextMenuLoader.update(contextMenuModel.items, pos.x, pos.y)
+                        } else {
+                            contextMenuLoader.open(contextMenuModel.items, pos.x, pos.y)
                         }
                     }
-                }
 
-                StyledMenuLoader {
-                    id: contextMenuLoader
+                    onHideContextMenuRequested: function() {
+                        contextMenuLoader.close()
+                    }
 
-                    navigation: fakeNavCtrl
+                    onViewportChanged: {
+                        notationNavigator.setCursorRect(viewport)
+                    }
 
-                    onHandleMenuItem: function (itemId) {
-                        contextMenuModel.handleMenuItem(itemId)
+                    onHorizontalScrollChanged: {
+                        if (!horizontalScrollBar.pressed) {
+                            horizontalScrollBar.setPosition(notationView.startHorizontalScrollPosition)
+                        }
+                    }
+
+                    onVerticalScrollChanged: {
+                        if (!verticalScrollBar.pressed) {
+                            verticalScrollBar.setPosition(notationView.startVerticalScrollPosition)
+                        }
+                    }
+
+                    StyledScrollBar {
+                        id: verticalScrollBar
+
+                        anchors.top: parent.top
+                        anchors.bottomMargin: prv.scrollbarMargin
+                        anchors.bottom: parent.bottom
+                        anchors.right: parent.right
+
+                        orientation: Qt.Vertical
+
+                        color: "black"
+                        border.width: 1
+                        border.color: "white"
+
+                        size: notationView.verticalScrollSize
+
+                        onPositionChanged: {
+                            if (pressed) {
+                                notationView.scrollVertical(position)
+                            }
+                        }
+                    }
+
+                    StyledScrollBar {
+                        id: horizontalScrollBar
+
+                        anchors.bottom: parent.bottom
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.rightMargin: prv.scrollbarMargin
+
+                        orientation: Qt.Horizontal
+
+                        color: "black"
+                        border.width: 1
+                        border.color: "white"
+
+                        size: notationView.horizontalScrollSize
+
+                        onPositionChanged: {
+                            if (pressed) {
+                                notationView.scrollHorizontal(position)
+                            }
+                        }
+                    }
+
+                    StyledMenuLoader {
+                        id: contextMenuLoader
+
+                        navigation: fakeNavCtrl
+
+                        onHandleMenuItem: function (itemId) {
+                            contextMenuModel.handleMenuItem(itemId)
+                        }
                     }
                 }
             }

--- a/src/notation/qml/MuseScore/NotationScene/NotationZoomPinchArea.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NotationZoomPinchArea.qml
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.15
+
+import MuseScore.NotationScene 1.0
+
+PinchArea {
+    default property NotationPaintView notationView: null
+    data: [ notationView ]
+
+    onPinchUpdated: function(pinch) {
+        notationView.scale(pinch.scale / pinch.previousScale, pinch.center)
+    }
+
+    // A macOS feature which allows double-tapping with two fingers to zoom in or out
+    onSmartZoom: function(pinch) {
+        notationView.scale(pinch.scale === 0 ? 0.5 : 2, pinch.center)
+    }
+}

--- a/src/notation/qml/MuseScore/NotationScene/qmldir
+++ b/src/notation/qml/MuseScore/NotationScene/qmldir
@@ -10,3 +10,4 @@ NoteInputBarCustomizationDialog 1.0 NoteInputBarCustomizationDialog.qml
 UndoRedoToolBar 1.0 UndoRedoToolBar.qml
 Timeline 1.0 Timeline.qml
 SelectionFilterPanel 1.0 SelectionFilterPanel.qml
+NotationZoomPinchArea 1.0 NotationZoomPinchArea.qml

--- a/src/notation/view/notationnavigator.cpp
+++ b/src/notation/view/notationnavigator.cpp
@@ -92,7 +92,7 @@ void NotationNavigator::rescale()
         _scale = height() * guiScaling() / scoreHeight;
     }
 
-    scale(_scale, QPoint());
+    setScaling(_scale, QPoint());
 }
 
 void NotationNavigator::wheelEvent(QWheelEvent*)

--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -222,7 +222,7 @@ void NotationPaintView::onCurrentNotationChanged()
     m_loopOutMarker->setStyle(m_notation->style());
 
     update();
-    
+
     emit horizontalScrollChanged();
     emit verticalScrollChanged();
     emit viewportChanged(viewport());
@@ -634,7 +634,7 @@ qreal NotationPaintView::currentScaling() const
     return m_matrix.m11();
 }
 
-void NotationPaintView::scale(qreal scaling, const QPoint& pos)
+void NotationPaintView::setScaling(qreal scaling, const QPoint& pos)
 {
     qreal currentScaling = this->currentScaling();
 
@@ -646,10 +646,19 @@ void NotationPaintView::scale(qreal scaling, const QPoint& pos)
         currentScaling = 1;
     }
 
+    qreal deltaScaling = scaling / currentScaling;
+    scale(deltaScaling, pos);
+}
+
+void NotationPaintView::scale(qreal factor, const QPoint& pos)
+{
+    if (qFuzzyCompare(factor, 1.0)) {
+        return;
+    }
+
     PointF pointBeforeScaling = toLogical(pos);
 
-    qreal deltaScaling = scaling / currentScaling;
-    m_matrix.scale(deltaScaling, deltaScaling);
+    m_matrix.scale(factor, factor);
 
     PointF pointAfterScaling = toLogical(pos);
 

--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -190,8 +190,6 @@ void NotationPaintView::onCurrentNotationChanged()
         return;
     }
 
-    onViewSizeChanged(); //! NOTE Set view size to notation
-
     m_notation->notationChanged().onNotify(this, [this]() {
         update();
     });
@@ -224,6 +222,10 @@ void NotationPaintView::onCurrentNotationChanged()
     m_loopOutMarker->setStyle(m_notation->style());
 
     update();
+    
+    emit horizontalScrollChanged();
+    emit verticalScrollChanged();
+    emit viewportChanged(viewport());
 }
 
 void NotationPaintView::onViewSizeChanged()
@@ -235,8 +237,6 @@ void NotationPaintView::onViewSizeChanged()
     if (viewport().isValid() && !m_inputController->isZoomInited()) {
         m_inputController->initZoom();
     }
-
-    notation()->setViewSize(viewport().size());
 
     emit horizontalScrollChanged();
     emit verticalScrollChanged();

--- a/src/notation/view/notationpaintview.h
+++ b/src/notation/view/notationpaintview.h
@@ -88,7 +88,8 @@ public:
     void moveCanvasHorizontal(int dx) override;
 
     qreal currentScaling() const override;
-    void scale(qreal scaling, const QPoint& pos) override;
+    void setScaling(qreal scaling, const QPoint& pos) override;
+    Q_INVOKABLE void scale(qreal factor, const QPoint& pos);
 
     bool isNoteEnterMode() const override;
     void showShadowNote(const PointF& pos) override;

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -628,8 +628,3 @@ mu::PointF NotationViewInputController::hitElementPos() const
     }
     return mu::PointF();
 }
-
-double NotationViewInputController::guiScalling() const
-{
-    return configuration()->guiScaling();
-}

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -233,7 +233,7 @@ void NotationViewInputController::setZoom(int zoomPercentage, const QPoint& pos)
     }
 
     qreal scaling = static_cast<qreal>(correctedZoom) / 100.0 * notationScaling();
-    m_view->scale(scaling, pos);
+    m_view->setScaling(scaling, pos);
 }
 
 void NotationViewInputController::setViewMode(const ViewMode& viewMode)

--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -123,8 +123,6 @@ private:
 
     bool needSelect(const QMouseEvent* event, const PointF& clickLogicPos) const;
 
-    double guiScalling() const;
-
     IControlledView* m_view = nullptr;
 
     QList<int> m_possibleZoomsPercentage;

--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -50,7 +50,7 @@ public:
     virtual void moveCanvasVertical(int dy) = 0;
 
     virtual qreal currentScaling() const = 0;
-    virtual void scale(qreal scaling, const QPoint& pos) = 0;
+    virtual void setScaling(qreal scaling, const QPoint& pos) = 0;
 
     virtual PointF toLogical(const QPoint& p) const = 0;
 

--- a/src/project/qml/MuseScore/Project/internal/TemplatePreview.qml
+++ b/src/project/qml/MuseScore/Project/internal/TemplatePreview.qml
@@ -25,6 +25,7 @@ import QtQuick.Layouts 1.15
 
 import MuseScore.UiComponents 1.0
 import MuseScore.Project 1.0
+import MuseScore.NotationScene 1.0
 
 Item {
     id: root
@@ -50,59 +51,62 @@ Item {
         font: ui.theme.bodyBoldFont
     }
 
-    TemplatePaintView {
-        id: templateView
-
+    NotationZoomPinchArea {
         anchors.top: title.bottom
         anchors.topMargin: 16
         anchors.bottom: parent.bottom
         anchors.left: parent.left
         anchors.right: parent.right
 
-        onHorizontalScrollChanged: {
-            if (!horizontalScrollBar.pressed) {
-                horizontalScrollBar.setPosition(templateView.startHorizontalScrollPosition)
-            }
-        }
+        TemplatePaintView {
+            id: templateView
+            anchors.fill: parent
 
-        onVerticalScrollChanged: {
-            if (!verticalScrollBar.pressed) {
-                verticalScrollBar.setPosition(templateView.startVerticalScrollPosition)
-            }
-        }
-
-        StyledScrollBar {
-            id: verticalScrollBar
-
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
-            anchors.right: parent.right
-            orientation: Qt.Vertical
-
-            position: templateView.startVerticalScrollPosition
-            size: templateView.verticalScrollSize
-
-            onPositionChanged: {
-                if (pressed) {
-                    templateView.scrollVertical(position)
+            onHorizontalScrollChanged: {
+                if (!horizontalScrollBar.pressed) {
+                    horizontalScrollBar.setPosition(templateView.startHorizontalScrollPosition)
                 }
             }
-        }
 
-        StyledScrollBar {
-            id: horizontalScrollBar
+            onVerticalScrollChanged: {
+                if (!verticalScrollBar.pressed) {
+                    verticalScrollBar.setPosition(templateView.startVerticalScrollPosition)
+                }
+            }
 
-            anchors.bottom: parent.bottom
-            anchors.left: parent.left
-            anchors.right: parent.right
-            orientation: Qt.Horizontal
+            StyledScrollBar {
+                id: verticalScrollBar
 
-            position: templateView.startHorizontalScrollPosition
-            size: templateView.horizontalScrollSize
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+                anchors.right: parent.right
+                orientation: Qt.Vertical
 
-            onPositionChanged: {
-                if (pressed) {
-                    templateView.scrollHorizontal(position)
+                position: templateView.startVerticalScrollPosition
+                size: templateView.verticalScrollSize
+
+                onPositionChanged: {
+                    if (pressed) {
+                        templateView.scrollVertical(position)
+                    }
+                }
+            }
+
+            StyledScrollBar {
+                id: horizontalScrollBar
+
+                anchors.bottom: parent.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                orientation: Qt.Horizontal
+
+                position: templateView.startHorizontalScrollPosition
+                size: templateView.horizontalScrollSize
+
+                onPositionChanged: {
+                    if (pressed) {
+                        templateView.scrollHorizontal(position)
+                    }
                 }
             }
         }

--- a/src/project/view/templatepaintview.cpp
+++ b/src/project/view/templatepaintview.cpp
@@ -68,7 +68,7 @@ void TemplatePaintView::adjustCanvas()
         return;
     }
 
-    scale(scaling, QPoint());
+    setScaling(scaling, QPoint());
     moveCanvasToCenter();
 }
 


### PR DESCRIPTION
Resolves: #7640 
(for both the regular NotationPaintView and the TemplatePaintView)

We need to check if this does not break zooming on operating systems other that macOS.

Todo: when zooming using the trackpad, this is not reflected by the zoom field in the Status Bar. I will fix this in a next PR, where I will also move the information about the view state to (a struct inside) the Notation class. This way, each Notation will have its own view state, which would be a fix for #7879. 