### PR TITLE
Fixed scaling for 100% zoom

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -214,12 +214,7 @@ int NotationViewInputController::currentZoomIndex() const
 
 int NotationViewInputController::currentZoomPercentage() const
 {
-    return qRound(m_view->currentScaling() * 100.0 / notationScaling());
-}
-
-qreal NotationViewInputController::notationScaling() const
-{
-    return configuration()->notationScaling();
+    return qRound(m_view->currentScaling() * 100.0 / configuration()->notationScaling() / configuration()->guiScaling());
 }
 
 void NotationViewInputController::setZoom(int zoomPercentage, const QPoint& pos)
@@ -232,7 +227,7 @@ void NotationViewInputController::setZoom(int zoomPercentage, const QPoint& pos)
         configuration()->setCurrentZoom(correctedZoom);
     }
 
-    qreal scaling = static_cast<qreal>(correctedZoom) / 100.0 * notationScaling();
+    qreal scaling = static_cast<qreal>(correctedZoom) / 100.0 * configuration()->notationScaling() * configuration()->guiScaling();
     m_view->setScaling(scaling, pos);
 }
 

--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -111,7 +111,6 @@ private:
 
     int currentZoomIndex() const;
     int currentZoomPercentage() const;
-    qreal notationScaling() const;
     void setZoom(int zoomPercentage, const QPoint& pos = QPoint());
 
     void setViewMode(const ViewMode& viewMode);


### PR DESCRIPTION
When zooming to 100% in an A4 score, the page size on screen is exactly as big as a physical sheet of A4 paper. Same as in MU3.

Tested on macOS on the builtin display, both when running in normal mode and in low resolution mode (which can be enabled by showing the app in Finder -> right click -> show info -> open in low resolution)
<img width="912" alt="Schermafbeelding 2021-09-13 om 19 35 03" src="https://user-images.githubusercontent.com/48658420/133130884-7f771f97-b965-4aef-8e41-754c61c5b2f0.png">
