### PR TITLE
[MU4] audio compressor + limiter

### DIFF
--- a/src/framework/audio/CMakeLists.txt
+++ b/src/framework/audio/CMakeLists.txt
@@ -137,6 +137,10 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/worker/sequenceio.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/worker/track.h
 
+    # DSP
+    ${CMAKE_CURRENT_LIST_DIR}/internal/dsp/compressor.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/dsp/compressor.h
+
     # fx
     ${CMAKE_CURRENT_LIST_DIR}/internal/fx/fxresolver.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/fx/fxresolver.h

--- a/src/framework/audio/CMakeLists.txt
+++ b/src/framework/audio/CMakeLists.txt
@@ -85,7 +85,6 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/audiothread.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/audiosanitizer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/audiosanitizer.h
-    ${CMAKE_CURRENT_LIST_DIR}/internal/audiomathutils.h
 
     # Driver
     ${DRIVER_SRC}
@@ -138,8 +137,12 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/worker/track.h
 
     # DSP
+    ${CMAKE_CURRENT_LIST_DIR}/internal/dsp/envelopefilterconfig.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/dsp/compressor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/dsp/compressor.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/dsp/limiter.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/dsp/limiter.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/dsp/audiomathutils.h
 
     # fx
     ${CMAKE_CURRENT_LIST_DIR}/internal/fx/fxresolver.cpp

--- a/src/framework/audio/internal/audiomathutils.h
+++ b/src/framework/audio/internal/audiomathutils.h
@@ -24,6 +24,7 @@
 #define MU_AUDIO_AUDIOMATHUTILS_H
 
 #include <cmath>
+#include <limits>
 
 #include "audiotypes.h"
 
@@ -41,6 +42,11 @@ inline float gainFromDecibels(const volume_dbfs_t volumeLevelDb)
 inline volume_dbfs_t dbFullScaleFromSample(const float signalValue)
 {
     return 20 * std::log10(std::abs(signalValue));
+}
+
+inline volume_db_t dbFromSample(const float signalValue)
+{
+    return 20 * std::log10(std::abs(signalValue) / std::numeric_limits<float>::max());
 }
 
 inline float samplesRootMeanSquare(float&& squaredSum, const samples_t sampleCount)

--- a/src/framework/audio/internal/dsp/audiomathutils.h
+++ b/src/framework/audio/internal/dsp/audiomathutils.h
@@ -23,35 +23,52 @@
 #ifndef MU_AUDIO_AUDIOMATHUTILS_H
 #define MU_AUDIO_AUDIOMATHUTILS_H
 
-#include <cmath>
+#include <cstdlib>
 #include <limits>
 
 #include "audiotypes.h"
 
-namespace mu::audio {
+namespace mu::audio::dsp {
 inline float balanceGain(const balance_t balance, const int audioChannelNumber)
 {
     return 0.5f * balance * ((audioChannelNumber * 2.f) - 1) + 0.5f;
 }
 
-inline float gainFromDecibels(const volume_dbfs_t volumeLevelDb)
+inline float linearFromDecibels(const volume_dbfs_t volumeLevelDb)
 {
     return std::pow(10.0f, volumeLevelDb * 0.05f);
 }
 
-inline volume_dbfs_t dbFullScaleFromSample(const float signalValue)
+inline volume_dbfs_t dbFromSample(const float signalValue)
 {
     return 20 * std::log10(std::abs(signalValue));
 }
 
-inline volume_db_t dbFromSample(const float signalValue)
-{
-    return 20 * std::log10(std::abs(signalValue) / std::numeric_limits<float>::max());
-}
-
-inline float samplesRootMeanSquare(float&& squaredSum, const samples_t sampleCount)
+inline float samplesRootMeanSquare(const float squaredSum, const samples_t sampleCount)
 {
     return std::sqrt(squaredSum / sampleCount);
+}
+
+inline float sampleAttackTimeCoefficient(const unsigned int sampleRate, const float attackTimeInSecs)
+{
+    return std::exp(-std::log(9) / (sampleRate * attackTimeInSecs));
+}
+
+inline float sampleReleaseTimeCoefficient(const unsigned int sampleRate, const float releaseTimeInSecs)
+{
+    return std::exp(-std::log(9) / (sampleRate * releaseTimeInSecs));
+}
+
+
+inline void multiplySamples(float* buffer, const audioch_t& audioChannelsCount,
+                            const audioch_t& audioChannelNumber, const samples_t& samplesPerChannel,
+                            const float& multiplier)
+{
+    for (samples_t i = 0; i < samplesPerChannel; ++i) {
+        int idx = i * audioChannelsCount + audioChannelNumber;
+
+        buffer[idx] *= multiplier;
+    }
 }
 }
 

--- a/src/framework/audio/internal/dsp/audiomathutils.h
+++ b/src/framework/audio/internal/dsp/audiomathutils.h
@@ -59,7 +59,6 @@ inline float sampleReleaseTimeCoefficient(const unsigned int sampleRate, const f
     return std::exp(-std::log(9) / (sampleRate * releaseTimeInSecs));
 }
 
-
 inline void multiplySamples(float* buffer, const audioch_t& audioChannelsCount,
                             const audioch_t& audioChannelNumber, const samples_t& samplesPerChannel,
                             const float& multiplier)

--- a/src/framework/audio/internal/dsp/compressor.cpp
+++ b/src/framework/audio/internal/dsp/compressor.cpp
@@ -1,43 +1,68 @@
 #include "compressor.h"
 
-#include "internal/audiomathutils.h"
+#include "log.h"
+
+#include "audiomathutils.h"
 
 using namespace mu::audio;
 using namespace mu::audio::dsp;
 
-static constexpr float HALF_KNEE = 3.f;
-static constexpr float RATIO = 1.f / 60.f;
-static constexpr volume_db_t THRESHOLD = -10.f;
-static constexpr float UPPER_KNEE_BOUNDARY = THRESHOLD + HALF_KNEE;
-static constexpr float LOWER_KNEE_BOUNDARY = THRESHOLD - HALF_KNEE;
-static constexpr float QUADRATIC_LOWER_KNEE_BOUNDARY = LOWER_KNEE_BOUNDARY * LOWER_KNEE_BOUNDARY;
-static constexpr float ATTACK_PHASE = 10.f;
-static constexpr float RELEASE_PHASE = 100.f;
-static constexpr float DIRECTION = -1.f;
+static constexpr float RATIO = 4.f;
 
-inline float calculateGainReduction(const volume_db_t& currentAmplitudeDb)
+
+Compressor::Compressor(const unsigned int sampleRate)
+    : m_filterConfig(sampleRate, RATIO),
+      m_feedbackFactor(1.f) // 0 = feed forward, 1 = feed back
 {
-    if (currentAmplitudeDb < UPPER_KNEE_BOUNDARY) {
-        return gainFromDecibels(currentAmplitudeDb + QUADRATIC_LOWER_KNEE_BOUNDARY * (RATIO - 1.f) / (4.f * HALF_KNEE));
-    } else {
-        return gainFromDecibels(THRESHOLD + (currentAmplitudeDb - THRESHOLD) * RATIO);
-    }
 }
 
-void Compressor::process(float* buffer, const samples_t& samplesPerChannel, const float& audioChannelRms,
-                         const audioch_t channelNumber, const audioch_t audioChannelsCount)
+volume_db_t Compressor::gainSmoothing(const float& newGainReduction) const
 {
-    volume_dbfs_t currentAmplitudeDb = dbFullScaleFromSample(audioChannelRms);
+    float coefficient = 0.f;
 
-    if (currentAmplitudeDb < LOWER_KNEE_BOUNDARY) {
-        return;
+    if (newGainReduction <= m_previousGainReduction) {
+        coefficient = m_filterConfig.attackTimeCoefficient();
+    } else {
+        coefficient = m_filterConfig.releaseTimeCoefficient();
     }
 
-    float gainReduction = calculateGainReduction(currentAmplitudeDb);
+    return (coefficient * m_previousGainReduction) + ((1 - coefficient) * newGainReduction);
+}
 
-    for (samples_t i = 0; i < samplesPerChannel; ++i) {
-        int idx = i * audioChannelsCount + channelNumber;
-
-        buffer[idx] = buffer[idx] * gainReduction;
+volume_db_t Compressor::computeGain(const volume_db_t& logarithmSample) const
+{
+    if (logarithmSample < m_softThresholdLower) {
+        return logarithmSample;
     }
+
+    if (logarithmSample >= m_softThresholdLower && logarithmSample <= m_softThresholdUpper) {
+        return logarithmSample
+               + ((((1 / m_filterConfig.ratio()) - 1) * std::pow(logarithmSample - m_softThresholdUpper, 2))
+                  / (2 * m_filterConfig.kneeWidth()));
+    }
+
+    return m_filterConfig.logarithmicThreshold()
+           + ((logarithmSample - m_filterConfig.logarithmicThreshold()) / m_filterConfig.ratio());
+}
+
+void Compressor::process(const float linearRms, float* buffer, const audioch_t& audioChannelsCount, const samples_t samplesPerChannel)
+{
+    float dbGain = dbFromSample(linearRms);
+
+    // trying to predict the next sample by the previous gain reduction
+    dbGain += m_feedbackFactor * m_feedbackGain;
+
+    float dbDiff = computeGain(dbGain) - dbGain;
+
+    m_feedbackGain = dbDiff;
+    float gainFact = linearFromDecibels(dbDiff * (1.f + m_feedbackFactor));
+
+    float currentGainReduction = std::min(gainFact, m_previousGainReduction);
+
+    // apply gain
+    for (audioch_t audioChNum = 0; audioChNum < audioChannelsCount; ++audioChNum) {
+        multiplySamples(buffer, audioChannelsCount, audioChNum, samplesPerChannel, currentGainReduction);
+    }
+
+    m_previousGainReduction = currentGainReduction;
 }

--- a/src/framework/audio/internal/dsp/compressor.cpp
+++ b/src/framework/audio/internal/dsp/compressor.cpp
@@ -1,0 +1,43 @@
+#include "compressor.h"
+
+#include "internal/audiomathutils.h"
+
+using namespace mu::audio;
+using namespace mu::audio::dsp;
+
+static constexpr float HALF_KNEE = 3.f;
+static constexpr float RATIO = 1.f / 60.f;
+static constexpr volume_db_t THRESHOLD = -10.f;
+static constexpr float UPPER_KNEE_BOUNDARY = THRESHOLD + HALF_KNEE;
+static constexpr float LOWER_KNEE_BOUNDARY = THRESHOLD - HALF_KNEE;
+static constexpr float QUADRATIC_LOWER_KNEE_BOUNDARY = LOWER_KNEE_BOUNDARY * LOWER_KNEE_BOUNDARY;
+static constexpr float ATTACK_PHASE = 10.f;
+static constexpr float RELEASE_PHASE = 100.f;
+static constexpr float DIRECTION = -1.f;
+
+inline float calculateGainReduction(const volume_db_t& currentAmplitudeDb)
+{
+    if (currentAmplitudeDb < UPPER_KNEE_BOUNDARY) {
+        return gainFromDecibels(currentAmplitudeDb + QUADRATIC_LOWER_KNEE_BOUNDARY * (RATIO - 1.f) / (4.f * HALF_KNEE));
+    } else {
+        return gainFromDecibels(THRESHOLD + (currentAmplitudeDb - THRESHOLD) * RATIO);
+    }
+}
+
+void Compressor::process(float* buffer, const samples_t& samplesPerChannel, const float& audioChannelRms,
+                         const audioch_t channelNumber, const audioch_t audioChannelsCount)
+{
+    volume_dbfs_t currentAmplitudeDb = dbFullScaleFromSample(audioChannelRms);
+
+    if (currentAmplitudeDb < LOWER_KNEE_BOUNDARY) {
+        return;
+    }
+
+    float gainReduction = calculateGainReduction(currentAmplitudeDb);
+
+    for (samples_t i = 0; i < samplesPerChannel; ++i) {
+        int idx = i * audioChannelsCount + channelNumber;
+
+        buffer[idx] = buffer[idx] * gainReduction;
+    }
+}

--- a/src/framework/audio/internal/dsp/compressor.cpp
+++ b/src/framework/audio/internal/dsp/compressor.cpp
@@ -9,10 +9,9 @@ using namespace mu::audio::dsp;
 
 static constexpr float RATIO = 4.f;
 
-
 Compressor::Compressor(const unsigned int sampleRate)
     : m_filterConfig(sampleRate, RATIO),
-      m_feedbackFactor(1.f) // 0 = feed forward, 1 = feed back
+    m_feedbackFactor(1.f)   // 0 = feed forward, 1 = feed back
 {
 }
 

--- a/src/framework/audio/internal/dsp/compressor.h
+++ b/src/framework/audio/internal/dsp/compressor.h
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_AUDIO_COMPRESSOR_H
+#define MU_AUDIO_COMPRESSOR_H
+
+#include <memory>
+
+#include "audiotypes.h"
+
+namespace mu::audio::dsp {
+class Compressor
+{
+public:
+    Compressor() = default;
+
+    void process(float* buffer, const samples_t& samplesPerChannel, const float& audioChannelRms,const audioch_t channelNumber,
+                 const audioch_t audioChannelsCount);
+};
+
+using CompressorPtr = std::unique_ptr<Compressor>;
+}
+
+#endif // MU_AUDIO_COMPRESSOR_H

--- a/src/framework/audio/internal/dsp/compressor.h
+++ b/src/framework/audio/internal/dsp/compressor.h
@@ -25,16 +25,30 @@
 
 #include <memory>
 
-#include "audiotypes.h"
+#include "envelopefilterconfig.h"
 
 namespace mu::audio::dsp {
 class Compressor
 {
 public:
-    Compressor() = default;
+    Compressor(const unsigned int sampleRate);
 
-    void process(float* buffer, const samples_t& samplesPerChannel, const float& audioChannelRms,const audioch_t channelNumber,
-                 const audioch_t audioChannelsCount);
+    void process(const float linearRms, float* buffer, const audioch_t& audioChannelsCount, const samples_t samplesPerChannel);
+private:
+    float attackTimeCoefficient() const;
+    float releaseTimeCoefficient() const;
+
+    volume_db_t gainSmoothing(const float& newGainReduction) const;
+    volume_db_t computeGain(const volume_db_t& logarithmSample) const;
+
+    EnvelopeFilterConfig m_filterConfig;
+
+    float m_softThresholdLower = 0.f;
+    float m_softThresholdUpper = 0.f;
+    float m_previousGainReduction = 1.f;
+
+    float m_feedbackGain = 0.f;
+    float m_feedbackFactor = 0.f;
 };
 
 using CompressorPtr = std::unique_ptr<Compressor>;

--- a/src/framework/audio/internal/dsp/envelopefilterconfig.h
+++ b/src/framework/audio/internal/dsp/envelopefilterconfig.h
@@ -1,0 +1,137 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_AUDIO_DSP_ENVELOPEFILTERCONFIG_H
+#define MU_AUDIO_DSP_ENVELOPEFILTERCONFIG_H
+
+#include "audiotypes.h"
+#include "audiomathutils.h"
+
+namespace mu::audio::dsp {
+struct EnvelopeFilterConfig
+{
+    explicit EnvelopeFilterConfig(const unsigned int sampleRate,
+                                  const float ratio = DEFAULT_RATIO,
+                                  const volume_db_t logarithmicThreshold = DEFAULT_THRESHOLD_DB,
+                                  const volume_db_t kneeWidth = DEFAULT_KNEE_WIDTH,
+                                  const float attackTime = DEFAULT_ATTACK_TIME,
+                                  const float releaseTime = DEFAULT_RELEASE_TIME,
+                                  const volume_db_t minimumOperableLevel = DEFAULT_MINIMUM_OPERABLE_LEVEL,
+                                  const volume_db_t makeUpGain = DEFAULT_MAKE_UP_GAIN)
+    {
+        m_sampleRate = sampleRate;
+        m_ratio = ratio;
+        m_kneeWidth = kneeWidth;
+        m_logarithmicThreshold = logarithmicThreshold;
+        m_attackTime = attackTime;
+        m_releaseTime = releaseTime;
+
+        m_attackTimeCoefficient = sampleAttackTimeCoefficient(sampleRate, attackTime);
+        m_releaseTimeCoefficient = sampleReleaseTimeCoefficient(sampleRate, releaseTime);
+
+        m_minimumOperableLevel = minimumOperableLevel;
+
+        m_softThresholdLower = m_logarithmicThreshold - (m_kneeWidth / 2);
+        m_softThresholdUpper = m_logarithmicThreshold + (m_kneeWidth / 2);
+
+        m_makeUpGain = makeUpGain;
+    }
+
+    static constexpr float DEFAULT_KNEE_WIDTH = 6.f; // [0, 20.f]
+    static constexpr float DEFAULT_RATIO = 4.f; // [1, 50.f]
+    static constexpr volume_db_t DEFAULT_THRESHOLD_DB = -10.f;
+    static constexpr float DEFAULT_ATTACK_TIME = 0.005; // [0, 4.f]
+    static constexpr float DEFAULT_RELEASE_TIME = 0.02; // [0, 4.f]
+    static constexpr volume_db_t DEFAULT_MINIMUM_OPERABLE_LEVEL = -60.f;
+    static constexpr volume_db_t DEFAULT_MAKE_UP_GAIN = -10.f; // [-10.f, 12.f]
+
+    unsigned int sampleRate() const
+    {
+        return m_sampleRate;
+    }
+
+    /// Compression ratio is the input/output ratio for signals that overshoot the operation threshold.
+    float ratio() const
+    {
+        return m_ratio;
+    }
+
+    volume_db_t kneeWidth() const
+    {
+        return m_kneeWidth;
+    }
+
+    /// Operation threshold is the level above which gain is applied to the input signal.
+    volume_db_t logarithmicThreshold() const
+    {
+        return m_logarithmicThreshold;
+    }
+
+    float attackTimeCoefficient() const
+    {
+        return m_attackTimeCoefficient;
+    }
+
+    float releaseTimeCoefficient() const
+    {
+        return m_releaseTimeCoefficient;
+    }
+
+    volume_db_t minimumOperableLevel() const
+    {
+        return m_minimumOperableLevel;
+    }
+
+    volume_db_t softThresholdUpper() const
+    {
+        return m_softThresholdUpper;
+    }
+
+    volume_db_t softThresholdLower() const
+    {
+        return m_softThresholdLower;
+    }
+
+    /// Make-up gain compensates for gain lost during limiting. It is applied at the output of the dynamic range limiter.
+    volume_db_t makeUpGain() const
+    {
+        return m_makeUpGain;
+    }
+
+private:
+    unsigned int m_sampleRate = 0;
+    float m_ratio = 0.f;
+    volume_db_t m_kneeWidth = 0.f;
+    volume_db_t m_logarithmicThreshold = 0.f;
+    float m_attackTime = 0.f;
+    float m_releaseTime = 0.f;
+    float m_attackTimeCoefficient = 0.f;
+    float m_releaseTimeCoefficient = 0.f;
+    float m_minimumOperableLevel = 0.f;
+
+    volume_db_t m_softThresholdUpper = 0.f;
+    volume_db_t m_softThresholdLower = 0.f;
+    volume_db_t m_makeUpGain = 0.f;
+};
+}
+
+#endif // MU_AUDIO_DSP_ABSTRACTENVELOPEFILTER_H

--- a/src/framework/audio/internal/dsp/limiter.cpp
+++ b/src/framework/audio/internal/dsp/limiter.cpp
@@ -1,0 +1,69 @@
+#include "limiter.h"
+
+#include "audiomathutils.h"
+
+using namespace mu::audio;
+using namespace mu::audio::dsp;
+
+static constexpr volume_db_t THRESHOLD = 0.f;
+
+Limiter::Limiter(const unsigned int sampleRate)
+    : m_filterConfig(sampleRate, 1.f, THRESHOLD)
+{
+}
+
+volume_db_t Limiter::gainSmoothing(const float newGainReduction) const
+{
+    float coefficient = 0.f;
+
+    if (newGainReduction <= m_previousGainReduction) {
+        coefficient = m_filterConfig.attackTimeCoefficient();
+    } else {
+        coefficient = m_filterConfig.releaseTimeCoefficient();
+    }
+
+    return (coefficient * m_previousGainReduction) + ((1 - coefficient) * newGainReduction);
+}
+
+volume_db_t Limiter::computeGain(const volume_db_t& logarithmSample) const
+{
+    if (logarithmSample < m_filterConfig.softThresholdLower()) {
+        return logarithmSample;
+    }
+
+    if (logarithmSample >= m_filterConfig.softThresholdLower() && logarithmSample <= m_filterConfig.softThresholdUpper()) {
+        return logarithmSample
+               - (std::pow((logarithmSample - m_filterConfig.softThresholdUpper()), 2)
+                  / (2 * m_filterConfig.kneeWidth()));
+    }
+
+    return m_filterConfig.logarithmicThreshold();
+}
+
+void Limiter::process(const float& linearRms, float* buffer, const audioch_t& audioChannelsCount,
+                      const samples_t samplesPerChannel)
+{
+    volume_db_t rmsDb = dbFromSample(linearRms);
+
+    if (rmsDb <= m_filterConfig.minimumOperableLevel()) {
+        return;
+    }
+
+    // gain computing
+    float computedGain = computeGain(rmsDb) - rmsDb;
+
+    // gain smoothing
+    float smoothedGain = gainSmoothing(computedGain);
+    m_previousGainReduction = smoothedGain;
+
+    // gain make-up
+    float makeUpGain = smoothedGain + m_filterConfig.makeUpGain();
+
+    // total linear gain
+    float totalLinearGain = linearFromDecibels(makeUpGain);
+
+    // apply linear gain
+    for (audioch_t audioChNum = 0; audioChNum < audioChannelsCount; ++audioChNum) {
+        multiplySamples(buffer, audioChannelsCount, audioChNum, samplesPerChannel, totalLinearGain);
+    }
+}

--- a/src/framework/audio/internal/dsp/limiter.h
+++ b/src/framework/audio/internal/dsp/limiter.h
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_AUDIO_LIMITER_H
+#define MU_AUDIO_LIMITER_H
+
+#include <memory>
+
+#include "envelopefilterconfig.h"
+
+namespace mu::audio::dsp {
+class Limiter
+{
+public:
+    Limiter(const unsigned int sampleRate);
+
+    void process(const float& linearRms, float* buffer, const audioch_t& audioChannelsCount, const samples_t samplesPerChannel);
+
+private:
+    volume_db_t gainSmoothing(const float newGainReduction) const;
+    volume_db_t computeGain(const volume_db_t& logarithmSample) const;
+
+    EnvelopeFilterConfig m_filterConfig;
+
+    float m_softThresholdLower = 0.f;
+    float m_softThresholdUpper = 0.f;
+    float m_previousGainReduction = 0.f;
+};
+
+using LimiterPtr = std::unique_ptr<Limiter>;
+}
+
+#endif // MU_AUDIO_LIMITER_H

--- a/src/framework/audio/internal/worker/mixer.h
+++ b/src/framework/audio/internal/worker/mixer.h
@@ -30,6 +30,7 @@
 
 #include "abstractaudiosource.h"
 #include "mixerchannel.h"
+#include "internal/dsp/limiter.h"
 #include "ifxresolver.h"
 #include "iclock.h"
 
@@ -74,6 +75,7 @@ private:
     std::vector<IFxProcessorPtr> m_masterFxProcessors = {};
 
     std::map<TrackId, MixerChannelPtr> m_mixerChannels = {};
+    dsp::LimiterPtr m_limiter = nullptr;
 
     std::set<IClockPtr> m_clocks;
     audioch_t m_audioChannelsCount = 0;

--- a/src/framework/audio/internal/worker/mixer.h
+++ b/src/framework/audio/internal/worker/mixer.h
@@ -66,7 +66,7 @@ public:
 
 private:
     void mixOutputFromChannel(float* outBuffer, float* inBuffer, unsigned int samplesCount);
-    void completeOutput(float* buffer, const samples_t &samplesPerChannel);
+    void completeOutput(float* buffer, const samples_t& samplesPerChannel);
 
     std::vector<float> m_writeCacheBuff;
 

--- a/src/framework/audio/internal/worker/mixer.h
+++ b/src/framework/audio/internal/worker/mixer.h
@@ -64,7 +64,8 @@ public:
     void process(float* outBuffer, unsigned int samplesPerChannel) override;
 
 private:
-    void mixOutput(float* outBuffer, float* inBuffer, unsigned int samplesCount);
+    void mixOutputFromChannel(float* outBuffer, float* inBuffer, unsigned int samplesCount);
+    void completeOutput(float* buffer, const samples_t &samplesPerChannel);
 
     std::vector<float> m_writeCacheBuff;
 

--- a/src/framework/audio/internal/worker/mixerchannel.h
+++ b/src/framework/audio/internal/worker/mixerchannel.h
@@ -29,6 +29,7 @@
 #include "ifxresolver.h"
 #include "ifxprocessor.h"
 #include "track.h"
+#include "internal/dsp/compressor.h"
 
 namespace mu::audio {
 class MixerChannel : public ITrackAudioOutput, public async::Asyncable
@@ -61,6 +62,8 @@ private:
 
     IAudioSourcePtr m_audioSource = nullptr;
     std::vector<IFxProcessorPtr> m_fxProcessors = {};
+
+    dsp::CompressorPtr m_compressor = nullptr;
 
     mutable async::Channel<audioch_t, float> m_signalAmplitudeRmsChanged;
     mutable async::Channel<audioch_t, volume_dbfs_t> m_volumePressureDbfsChanged;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/57620349/133133728-bf85901b-212e-4e1c-96c8-053b74cf64c4.png)


Implemented a built-in compressor and a limiter for our audio-engine. These guys will protect users from sound distortions due to over-sampling.

Both have been implemented using RMS (root mean square audio sugnal value) approach which is much less expensive and much more "smooth" comparing to "peak" approach where we've to analyze every single sample and apply appropriate calculated gain reduction.
