### PR TITLE
Fix https://musescore.org/en/node/324626 - linked dynamics not saving

### DIFF
--- a/src/engraving/libmscore/dynamic.cpp
+++ b/src/engraving/libmscore/dynamic.cpp
@@ -447,8 +447,11 @@ void Dynamic::startEdit(EditData& ed)
 void Dynamic::endEdit(EditData& ed)
 {
     TextBase::endEdit(ed);
-    if (xmlText() != QString::fromUtf8(dynList[int(_dynamicType)].text)) {
-        _dynamicType = DynamicType::OTHER;
+    auto text = xmlText();
+    auto it = std::find_if(std::begin(dynList), std::end(dynList), [text](const Ms::Dyn& d) { return text == QString::fromUtf8(d.text); });
+    _dynamicType = it == std::end(dynList) ? DynamicType::OTHER : static_cast<DynamicType>(it - std::begin(dynList));
+    for (auto* e : this->linkList()) {
+        toDynamic(e)->_dynamicType = _dynamicType;
     }
 }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/324626 

Dynamics not correctly updated when they had linked elements in other parts (in fact even for unlinked dynamics, the dynamicType wasn't getting set as expected if the new text was a valid dynamic)

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
