### PR TITLE
fix #8975 - Change how barline distance is used in order to avoid collisions in double bar lines

### DIFF
--- a/src/engraving/libmscore/barline.cpp
+++ b/src/engraving/libmscore/barline.cpp
@@ -662,17 +662,17 @@ void BarLine::draw(mu::draw::Painter* painter) const
 
         qreal lw2 = score()->styleP(Sid::endBarWidth) * mag();
         painter->setPen(Pen(curColor(), lw2, PenStyle::SolidLine, PenCapStyle::FlatCap));
-        x  += score()->styleP(Sid::endBarDistance) * mag();
+        x += ((lw * .5) + score()->styleP(Sid::endBarDistance) + (lw2 * .5)) * mag();
         painter->drawLine(LineF(x, y1, x, y2));
     }
     break;
 
     case BarLineType::DOUBLE: {
-        qreal lw2 = score()->styleP(Sid::doubleBarWidth) * mag();
-        painter->setPen(Pen(curColor(), lw2, PenStyle::SolidLine, PenCapStyle::FlatCap));
-        qreal x = lw2 * .5;
+        qreal lw = score()->styleP(Sid::doubleBarWidth) * mag();
+        painter->setPen(Pen(curColor(), lw, PenStyle::SolidLine, PenCapStyle::FlatCap));
+        qreal x = lw * .5;
         painter->drawLine(LineF(x, y1, x, y2));
-        x += score()->styleP(Sid::doubleBarDistance) * mag();
+        x += ((lw * .5) + score()->styleP(Sid::doubleBarDistance) + (lw * .5)) * mag();
         painter->drawLine(LineF(x, y1, x, y2));
     }
     break;
@@ -685,7 +685,7 @@ void BarLine::draw(mu::draw::Painter* painter) const
 
         qreal lw2 = score()->styleP(Sid::barWidth) * mag();
         painter->setPen(Pen(curColor(), lw2, PenStyle::SolidLine, PenCapStyle::FlatCap));
-        x += score()->styleP(Sid::endBarDistance) * mag();
+        x += ((lw * .5) + score()->styleP(Sid::endBarDistance) + (lw2 * .5)) * mag();
         painter->drawLine(LineF(x, y1, x, y2));
     }
     break;
@@ -702,7 +702,7 @@ void BarLine::draw(mu::draw::Painter* painter) const
         painter->setPen(Pen(curColor(), lw2, PenStyle::SolidLine, PenCapStyle::FlatCap));
         qreal x = lw2 * .5;
         painter->drawLine(LineF(x, y1, x, y2));
-        x += score()->styleP(Sid::endBarDistance) * mag();
+        x += ((lw2 * .5) + score()->styleP(Sid::endBarDistance) + (lw2 * .5)) * mag();
         painter->drawLine(LineF(x, y1, x, y2));
     }
     break;
@@ -715,11 +715,10 @@ void BarLine::draw(mu::draw::Painter* painter) const
 
         qreal lw = score()->styleP(Sid::barWidth) * mag();
         painter->setPen(Pen(curColor(), lw, PenStyle::SolidLine, PenCapStyle::FlatCap));
-        x  += score()->styleP(Sid::endBarDistance) * mag();
+        x += ((lw2 * .5) + score()->styleP(Sid::endBarDistance) + (lw * .5)) * mag();
         painter->drawLine(LineF(x, y1, x, y2));
 
-        x += score()->styleP(Sid::repeatBarlineDotSeparation) * mag();
-        x -= symBbox(SymId::repeatDot).width() * .5;
+        x += ((lw * .5) + score()->styleP(Sid::repeatBarlineDotSeparation)) * mag();
         drawDots(painter, x);
 
         if (score()->styleB(Sid::repeatBarTips)) {
@@ -732,16 +731,15 @@ void BarLine::draw(mu::draw::Painter* painter) const
         qreal lw = score()->styleP(Sid::barWidth) * mag();
         painter->setPen(Pen(curColor(), lw, PenStyle::SolidLine, PenCapStyle::FlatCap));
 
-        qreal x = 0.0;           // symBbox(SymId::repeatDot).width() * .5;
+        qreal x = 0.0;
         drawDots(painter, x);
 
-        x += score()->styleP(Sid::repeatBarlineDotSeparation) * mag();
-        x += symBbox(SymId::repeatDot).width() * .5;
+        x += symBbox(SymId::repeatDot).width();
+        x += (score()->styleP(Sid::repeatBarlineDotSeparation) + (lw * .5)) * mag();
         painter->drawLine(LineF(x, y1, x, y2));
 
-        x  += score()->styleP(Sid::endBarDistance) * mag();
-
         qreal lw2 = score()->styleP(Sid::endBarWidth) * mag();
+        x += ((lw * .5) + score()->styleP(Sid::endBarDistance) + (lw2 * .5)) * mag();
         painter->setPen(Pen(curColor(), lw2, PenStyle::SolidLine, PenCapStyle::FlatCap));
         painter->drawLine(LineF(x, y1, x, y2));
 
@@ -754,16 +752,15 @@ void BarLine::draw(mu::draw::Painter* painter) const
         qreal lw = score()->styleP(Sid::barWidth) * mag();
         painter->setPen(Pen(curColor(), lw, PenStyle::SolidLine, PenCapStyle::FlatCap));
 
-        qreal x = 0.0;           // symBbox(SymId::repeatDot).width() * .5;
+        qreal x = 0.0;
         drawDots(painter, x);
 
-        x += score()->styleP(Sid::repeatBarlineDotSeparation) * mag();
-        x += symBbox(SymId::repeatDot).width() * .5;
+        x += symBbox(SymId::repeatDot).width();
+        x += (score()->styleP(Sid::repeatBarlineDotSeparation) + (lw * .5)) * mag();
         painter->drawLine(LineF(x, y1, x, y2));
 
-        x  += score()->styleP(Sid::endBarDistance) * mag();
-
         qreal lw2 = score()->styleP(Sid::endBarWidth) * mag();
+        x += ((lw * .5) + score()->styleP(Sid::endBarDistance) + (lw2 * .5)) * mag();
         painter->setPen(Pen(curColor(), lw2, PenStyle::SolidLine, PenCapStyle::FlatCap));
         painter->drawLine(LineF(x, y1, x, y2));
 
@@ -772,11 +769,10 @@ void BarLine::draw(mu::draw::Painter* painter) const
         }
 
         painter->setPen(Pen(curColor(), lw, PenStyle::SolidLine, PenCapStyle::FlatCap));
-        x  += score()->styleP(Sid::endBarDistance) * mag();
+        x  += ((lw2 * .5) + score()->styleP(Sid::endBarDistance) + (lw * .5)) * mag();
         painter->drawLine(LineF(x, y1, x, y2));
 
-        x += score()->styleP(Sid::repeatBarlineDotSeparation) * mag();
-        x -= symBbox(SymId::repeatDot).width() * .5;
+        x += ((lw * .5) + score()->styleP(Sid::repeatBarlineDotSeparation)) * mag();
         drawDots(painter, x);
 
         if (score()->styleB(Sid::repeatBarTips)) {
@@ -1181,26 +1177,32 @@ qreal BarLine::layoutWidth(Score* score, BarLineType type)
     qreal w { 0.0 };
     switch (type) {
     case BarLineType::DOUBLE:
-        w = score->styleP(Sid::doubleBarWidth) + score->styleP(Sid::doubleBarDistance);
+        w = (score->styleP(Sid::doubleBarWidth) * 2)
+            + score->styleP(Sid::doubleBarDistance);
         break;
     case BarLineType::DOUBLE_HEAVY:
-        w = score->styleP(Sid::endBarWidth) + score->styleP(Sid::endBarDistance);
+        w = (score->styleP(Sid::endBarWidth) * 2)
+            + score->styleP(Sid::endBarDistance);
         break;
     case BarLineType::END_START_REPEAT:
-        w = score->styleP(Sid::endBarDistance) * 2
-            + score->styleP(Sid::repeatBarlineDotSeparation) * 2
-            + dotwidth;
+        w = score->styleP(Sid::endBarWidth)
+            + (score->styleP(Sid::barWidth) * 2)
+            + (score->styleP(Sid::endBarDistance) * 2)
+            + (score->styleP(Sid::repeatBarlineDotSeparation) * 2)
+            + (dotwidth * 2);
         break;
     case BarLineType::START_REPEAT:
     case BarLineType::END_REPEAT:
-        w = score->styleP(Sid::endBarWidth) * .5
+        w = score->styleP(Sid::endBarWidth)
+            + score->styleP(Sid::barWidth)
             + score->styleP(Sid::endBarDistance)
             + score->styleP(Sid::repeatBarlineDotSeparation)
-            + dotwidth * .5;
+            + dotwidth;
         break;
     case BarLineType::END:
     case BarLineType::REVERSE_END:
-        w = (score->styleP(Sid::endBarWidth) + score->styleP(Sid::barWidth)) * .5
+        w = score->styleP(Sid::endBarWidth)
+            + score->styleP(Sid::barWidth)
             + score->styleP(Sid::endBarDistance);
         break;
     case BarLineType::BROKEN:

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -137,9 +137,9 @@ const StyleDef::StyleValue StyleDef::styleValues[int(Sid::STYLES)] = {
     { Sid::doubleBarWidth,          "doubleBarWidth",          Spatium(0.18) },
 
     { Sid::endBarWidth,             "endBarWidth",             Spatium(0.55) },
-    { Sid::doubleBarDistance,       "doubleBarDistance",       Spatium(0.55) },
-    { Sid::endBarDistance,          "endBarDistance",          Spatium(0.7) },
-    { Sid::repeatBarlineDotSeparation, "repeatBarlineDotSeparation", Spatium(0.7) },
+    { Sid::doubleBarDistance,       "doubleBarDistance",       Spatium(0.37) },
+    { Sid::endBarDistance,          "endBarDistance",          Spatium(0.37) },
+    { Sid::repeatBarlineDotSeparation, "repeatBarlineDotSeparation", Spatium(0.52) },
     { Sid::repeatBarTips,           "repeatBarTips",           QVariant(false) },
     { Sid::startBarlineSingle,      "startBarlineSingle",      QVariant(false) },
     { Sid::startBarlineMultiple,    "startBarlineMultiple",    QVariant(true) },


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8975

Before, style options such as endBarDistance or doubleBarDistance described the distance between the mid points of the bar lines. This created an inconsistent distance when the line thicknesses were changed. Now, those distance style settings describe the distance between the right side of one bar and the left side of another.

![image](https://user-images.githubusercontent.com/89263931/133500182-eef582bd-eae8-4f51-9e5e-4dfcca51acb6.png)
