### PR TITLE
fix edge case from #9086, inner hidden staves affect bracket span

### DIFF
--- a/src/engraving/libmscore/bracket.cpp
+++ b/src/engraving/libmscore/bracket.cpp
@@ -133,6 +133,14 @@ void Bracket::setStaffSpan(int a, int b)
     if (bracketType() == BracketType::BRACE
         && score()->styleSt(Sid::MusicalSymbolFont) != "Emmentaler" && score()->styleSt(Sid::MusicalSymbolFont) != "Gonville") {
         int v = _lastStaff - _firstStaff + 1;
+
+        // if staves inner staves are hidden, decrease span
+        for (int staffIndex = _firstStaff; staffIndex <= _lastStaff; ++staffIndex) {
+            if (system() && !system()->staff(staffIndex)->show()) {
+                --v;
+            }
+        }
+
         if (score()->styleSt(Sid::MusicalSymbolFont) == "Leland") {
             v = qMin(4, v);
         }


### PR DESCRIPTION
After [#9086](https://github.com/musescore/MuseScore/pull/9086) was merged, @DmitryArefiev pointed out a bug in the implimentation:

https://github.com/musescore/MuseScore/pull/9086#issuecomment-919983727

The original PR was to select correct brace symbol for each system independently. This mean that hidden staves should not affect bracket size. The original PR worked when outer staves were hidden, but not inner staves.

This PR resolves that bug such that hidden inner staves don't affect bracket size.

Tested this PR with the following file: [bracket-staves.mscz.zip](https://github.com/musescore/MuseScore/files/7173614/bracket-staves.mscz.zip)
