### PR TITLE
[MU4] fix #8885 selection range rectangle not shown if last measure selected

### DIFF
--- a/src/notation/internal/notationselectionrange.cpp
+++ b/src/notation/internal/notationselectionrange.cpp
@@ -82,6 +82,9 @@ std::vector<mu::RectF> NotationSelectionRange::boundingArea() const
 
     Ms::Segment* startSegment = rangeStartSegment();
     Ms::Segment* endSegment = rangeEndSegment();
+    if (!endSegment) {
+        endSegment = score()->lastSegment();
+    }
 
     if (!startSegment || !endSegment || startSegment->tick() > endSegment->tick()) {
         return {};


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8885

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
