### PR TITLE
fix #8944 - Add right margin to system trailers

### DIFF
--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -2273,6 +2273,9 @@ qreal Segment::minRight() const
     if (isClefType()) {
         distance += score()->styleP(Sid::clefBarlineDistance);
     }
+    if (trailer()) {
+        distance += score()->styleP(Sid::systemTrailerRightMargin);
+    }
     return distance;
 }
 

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -170,6 +170,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::keyBarlineDistance,      "keyBarlineDistance",      Spatium(1.0) },
     { Sid::systemHeaderDistance,    "systemHeaderDistance",    Spatium(2.5) },     // gould: 2.5
     { Sid::systemHeaderTimeSigDistance, "systemHeaderTimeSigDistance", Spatium(2.0) },  // gould: 2.0
+    { Sid::systemTrailerRightMargin, "systemTrailerRightMargin", Spatium(0.5) },
 
     { Sid::clefBarlineDistance,     "clefBarlineDistance",     Spatium(0.5) },
     { Sid::timesigBarlineDistance,  "timesigBarlineDistance",  Spatium(0.5) },

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -182,6 +182,7 @@ enum class Sid {
     keyBarlineDistance,
     systemHeaderDistance,
     systemHeaderTimeSigDistance,
+    systemTrailerRightMargin,
 
     clefBarlineDistance,
     timesigBarlineDistance,


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8944

![image](https://user-images.githubusercontent.com/89263931/133656527-58787803-ba23-43d9-8c77-63858632d32d.png)

Added a new style setting (not currently exposed in the UI) and documented it in https://github.com/musescore/MuseScore/wiki/Style-Parameter-changes-between-3.6-and-4.0