### PR TITLE
[MU3] fix #310921 - remove unnecessary limit for plugin playevent.len

### DIFF
--- a/mscore/pianoroll/pianolevelschooser.ui
+++ b/mscore/pianoroll/pianolevelschooser.ui
@@ -11,7 +11,13 @@
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
+    <property name="leftMargin">
+      <number>5</number>
+    </property>
+    <property name="rightMargin">
+      <number>5</number>
+    </property>
+    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QComboBox" name="levelsCombo">
@@ -31,7 +37,13 @@
    <item>
     <widget class="QGroupBox" name="groupBox">
      <layout class="QGridLayout" name="gridLayout">
-      <item row="2" column="1">
+       <property name="leftMargin">
+         <number>5</number>
+       </property>
+       <property name="rightMargin">
+         <number>5</number>
+       </property>
+       <item row="2" column="1">
        <widget class="QPushButton" name="setEventsBn">
         <property name="toolTip">
          <string>Set selected note event data</string>

--- a/mscore/pianoroll/pianoroll.cpp
+++ b/mscore/pianoroll/pianoroll.cpp
@@ -318,7 +318,7 @@ PianorollEditor::PianorollEditor(QWidget* parent)
 
       tbTweak->addWidget(new QLabel(tr("Len:")));
       tbTweak->addWidget((tickLen = new QSpinBox));
-      tickLen->setRange(-2000, 2000);
+      tickLen->setRange(-2000, 60000);
 
 
       // --------------------------------------------------

--- a/mscore/plugin/api/playevent.cpp
+++ b/mscore/plugin/api/playevent.cpp
@@ -103,7 +103,7 @@ void PlayEvent::setLen(int v)
       {
       if (!ne || ne->len() == v)
             return;                                   // Value hasn't changed so no need to do more.
-      if (v <= 0 || v > 2 * Ms::NoteEvent::NOTE_LENGTH) {
+      if (v <= 0 || v > 60 * Ms::NoteEvent::NOTE_LENGTH) {
             qWarning("PluginAPI::PlayEvent::setLen: Invalid value.");
             return;
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/310921

Increase unnecessarily low limit when setting PlayEvent.len from plugins

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
