### PR TITLE
Fix #8952: Simplify/unify stem layout code and let it take SMuFL anchors of flag into account

### DIFF
--- a/src/engraving/layout/layoutchords.cpp
+++ b/src/engraving/layout/layoutchords.cpp
@@ -879,7 +879,7 @@ void LayoutChords::layoutChords3(const MStyle& style, std::vector<Note*>& notes,
             if (chord->stem()) {
                 chord->stem()->layout();
                 if (chord->hook()) {
-                    chord->hook()->rypos() = chord->stem()->hookPos().y();
+                    chord->hook()->rypos() = chord->stem()->flagPosition().y();
                 }
             }
         }

--- a/src/engraving/layout/layoutmeasure.cpp
+++ b/src/engraving/layout/layoutmeasure.cpp
@@ -705,14 +705,14 @@ void LayoutMeasure::getNextMeasure(const LayoutOptions& options, LayoutContext& 
                             if (drumset) {
                                 layoutDrumsetChord(c, drumset, st, score->spatium());
                             }
-                            c->layoutStem1();
+                            c->layoutStem();
                         }
                         if (drumset) {
                             layoutDrumsetChord(chord, drumset, st, score->spatium());
                         }
                         chord->computeUp();
-                        chord->layoutStem1();               // create stems needed to calculate spacing
-                                                            // stem direction can change later during beam processing
+                        chord->layoutStem();               // create stems needed to calculate spacing
+                                                           // stem direction can change later during beam processing
 
                         // if there is a two-note tremolo attached, and it is too steep,
                         // extend stem of one of the chords (if not cross-staff)
@@ -726,8 +726,8 @@ void LayoutMeasure::getNextMeasure(const LayoutOptions& options, LayoutContext& 
                                     chord->tremolo(),
                                     stem1->p2().y(),
                                     stem2->p2().y());
-                                stem1->setLen(extendedLen.first);
-                                stem2->setLen(extendedLen.second);
+                                stem1->setBaseLength(extendedLen.first);
+                                stem2->setBaseLength(extendedLen.second);
                             }
                         }
                     }

--- a/src/engraving/libmscore/chord.h
+++ b/src/engraving/libmscore/chord.h
@@ -70,14 +70,14 @@ enum class TremoloChordType : char {
 class Chord final : public ChordRest
 {
     std::vector<Note*> _notes;           // sorted to decreasing line step
-    LedgerLine* _ledgerLines;            // single linked list
+    LedgerLine* _ledgerLines = nullptr;  // single linked list
 
-    Stem* _stem;
-    Hook* _hook;
-    StemSlash* _stemSlash;               // for acciacatura
+    Stem* _stem = nullptr;
+    Hook* _hook = nullptr;
+    StemSlash* _stemSlash = nullptr;     // for acciacatura
 
-    Arpeggio* _arpeggio;
-    Tremolo* _tremolo;
+    Arpeggio* _arpeggio = nullptr;
+    Tremolo* _tremolo = nullptr;
     bool _endsGlissando;                 ///< true if this chord is the ending point of a glissando (needed for layout)
     QVector<Chord*> _graceNotes;
     int _graceIndex;                     ///< if this is a grace note, index in parent list
@@ -105,6 +105,9 @@ class Chord final : public ChordRest
     void layoutPitched();
     void layoutTablature();
     qreal noteHeadWidth() const;
+
+    bool shouldHaveStem() const;
+    bool shouldHaveHook() const;
 
 public:
 
@@ -138,7 +141,6 @@ public:
     qreal defaultStemLength() const;
     qreal minAbsStemLength() const;
 
-    void layoutStem1() override;
     void layoutStem();
     void layoutArpeggio2();
     void layoutSpanners();

--- a/src/engraving/libmscore/chordrest.h
+++ b/src/engraving/libmscore/chordrest.h
@@ -201,7 +201,6 @@ public:
     virtual EngravingItem* prevSegmentElement() override;
     virtual QString accessibleExtraInfo() const override;
     virtual Shape shape() const override;
-    virtual void layoutStem1() {}
     virtual void computeUp() { _up = true; }
 
     bool isFullMeasureRest() const { return _durationType == TDuration::DurationType::V_MEASURE; }

--- a/src/engraving/libmscore/hook.cpp
+++ b/src/engraving/libmscore/hook.cpp
@@ -24,13 +24,10 @@
 #include "chord.h"
 #include "stem.h"
 #include "score.h"
+#include "sym.h"
 
 using namespace mu;
-
-namespace Ms {
-//---------------------------------------------------------
-//   Hook
-//---------------------------------------------------------
+using namespace Ms;
 
 Hook::Hook(Chord* parent)
     : Symbol(ElementType::HOOK, parent, ElementFlag::NOTHING)
@@ -38,75 +35,61 @@ Hook::Hook(Chord* parent)
     setZ(int(type()) * 100);
 }
 
-//---------------------------------------------------------
-//   elementBase
-//---------------------------------------------------------
-
 EngravingItem* Hook::elementBase() const
 {
     return parentItem();
 }
 
-//---------------------------------------------------------
-//   setHookType
-//---------------------------------------------------------
-
 void Hook::setHookType(int i)
 {
     _hookType = i;
+
     switch (i) {
-    case 0:    break;
-    case 1:    setSym(SymId::flag8thUp);
+    case 0: break;
+    case 1: setSym(SymId::flag8thUp);
         break;
-    case 2:    setSym(SymId::flag16thUp);
+    case 2: setSym(SymId::flag16thUp);
         break;
-    case 3:    setSym(SymId::flag32ndUp);
+    case 3: setSym(SymId::flag32ndUp);
         break;
-    case 4:    setSym(SymId::flag64thUp);
+    case 4: setSym(SymId::flag64thUp);
         break;
-    case 5:    setSym(SymId::flag128thUp);
+    case 5: setSym(SymId::flag128thUp);
         break;
-    case 6:    setSym(SymId::flag256thUp);
+    case 6: setSym(SymId::flag256thUp);
         break;
-    case 7:    setSym(SymId::flag512thUp);
+    case 7: setSym(SymId::flag512thUp);
         break;
-    case 8:    setSym(SymId::flag1024thUp);
+    case 8: setSym(SymId::flag1024thUp);
         break;
 
-    case -1:   setSym(SymId::flag8thDown);
+    case -1: setSym(SymId::flag8thDown);
         break;
-    case -2:   setSym(SymId::flag16thDown);
+    case -2: setSym(SymId::flag16thDown);
         break;
-    case -3:   setSym(SymId::flag32ndDown);
+    case -3: setSym(SymId::flag32ndDown);
         break;
-    case -4:   setSym(SymId::flag64thDown);
+    case -4: setSym(SymId::flag64thDown);
         break;
-    case -5:   setSym(SymId::flag128thDown);
+    case -5: setSym(SymId::flag128thDown);
         break;
-    case -6:   setSym(SymId::flag256thDown);
+    case -6: setSym(SymId::flag256thDown);
         break;
-    case -7:   setSym(SymId::flag512thDown);
+    case -7: setSym(SymId::flag512thDown);
         break;
-    case -8:   setSym(SymId::flag1024thDown);
+    case -8: setSym(SymId::flag1024thDown);
         break;
+
     default:
         qDebug("no hook/flag for subtype %d", i);
         break;
     }
 }
 
-//---------------------------------------------------------
-//   layout
-//---------------------------------------------------------
-
 void Hook::layout()
 {
     setbbox(symBbox(_sym));
 }
-
-//---------------------------------------------------------
-//   draw
-//---------------------------------------------------------
 
 void Hook::draw(mu::draw::Painter* painter) const
 {
@@ -119,4 +102,8 @@ void Hook::draw(mu::draw::Painter* painter) const
     painter->setPen(curColor());
     drawSymbol(_sym, painter);
 }
+
+mu::PointF Hook::smuflAnchor() const
+{
+    return symSmuflAnchor(_sym, chord()->up() ? SmuflAnchorId::stemUpNW : SmuflAnchorId::stemDownSW);
 }

--- a/src/engraving/libmscore/hook.h
+++ b/src/engraving/libmscore/hook.h
@@ -28,10 +28,6 @@
 namespace Ms {
 class Chord;
 
-//---------------------------------------------------------
-//   @@ Hook
-//---------------------------------------------------------
-
 class Hook final : public Symbol
 {
     int _hookType { 0 };
@@ -47,7 +43,8 @@ public:
     int hookType() const { return _hookType; }
     void layout() override;
     void draw(mu::draw::Painter*) const override;
-    Chord* chord() const { return (Chord*)parent(); }
+    Chord* chord() const { return toChord(parent()); }
+    mu::PointF smuflAnchor() const;
 };
 }     // namespace Ms
 #endif

--- a/src/engraving/libmscore/stem.cpp
+++ b/src/engraving/libmscore/stem.cpp
@@ -34,22 +34,17 @@
 #include "tremolo.h"
 #include "note.h"
 
-// TEMPORARY HACK!!
+// Part of the dot-drawing hack in Stem::draw()
 #include "symid.h"
-// END OF HACK
+//--
 
 using namespace mu;
 using namespace mu::draw;
+using namespace Ms;
 
-namespace Ms {
 static const ElementStyle stemStyle {
-    { Sid::stemWidth,                          Pid::LINE_WIDTH },
+    { Sid::stemWidth, Pid::LINE_WIDTH }
 };
-
-//---------------------------------------------------------
-//   Stem
-//    Notenhals
-//---------------------------------------------------------
 
 Stem::Stem(Chord* parent)
     : EngravingItem(ElementType::STEM, parent)
@@ -58,120 +53,100 @@ Stem::Stem(Chord* parent)
     resetProperty(Pid::USER_LEN);
 }
 
-//---------------------------------------------------------
-//   elementBase
-//---------------------------------------------------------
 EngravingItem* Stem::elementBase() const
 {
     return parentItem();
 }
-
-//---------------------------------------------------------
-//   vStaffIdx
-//---------------------------------------------------------
 
 int Stem::vStaffIdx() const
 {
     return staffIdx() + chord()->staffMove();
 }
 
-//---------------------------------------------------------
-//   up
-//---------------------------------------------------------
-
 bool Stem::up() const
 {
     return chord() ? chord()->up() : true;
 }
 
-//---------------------------------------------------------
-//   stemLen
-//---------------------------------------------------------
-
-qreal Stem::stemLen() const
-{
-    return up() ? -_len : _len;
-}
-
-//-------------------------------------------------------------------
-//   layout
-//    For beamed notes this is called twice. The final stem
-//    length can only be calculated after stretching of the measure.
-//    We need a guessed stem shape to calculate the minimal distance
-//    between segments. The guessed stem must have at least the
-//    right direction.
-//-------------------------------------------------------------------
-
+//! For beamed notes this is called twice. The final stem length
+//! can only be calculated after stretching of the measure. We
+//! need a guessed stem shape to calculate the minimal distance
+//! between segments. The guessed stem must have at least the
+//! right direction.
 void Stem::layout()
 {
-    qreal l    = _len + _userLen;
-    qreal _up  = up() ? -1.0 : 1.0;
-    l         *= _up;
+    const bool up = this->up();
+    const double _up = up ? -1.0 : 1.0;
 
-    qreal y1 = 0.0;                             // vertical displacement to match note attach point
-    const Staff* stf = staff();
+    double y1 = 0.0; // vertical displacement to match note attach point
+    double y2 = _up * (m_baseLength + m_userLength);
+
+    bool isTabStaff = false;
     if (chord()) {
         setMag(chord()->mag());
-        Fraction tick = chord()->tick();
-        const StaffType* st = stf ? stf->staffType(tick) : 0;
-        if (st && st->isTabStaff()) {                 // TAB staves
-            if (st->stemThrough()) {
+
+        const Staff* staff = this->staff();
+        const StaffType* staffType = staff ? staff->staffTypeForElement(chord()) : nullptr;
+        isTabStaff = staffType && staffType->isTabStaff();
+
+        if (isTabStaff) {
+            if (staffType->stemThrough()) {
                 // if stems through staves, gets Y pos. of stem-side note relative to chord other side
-                qreal lineDist = st->lineDistance().val() * spatium();
-                y1             = (chord()->downString() - chord()->upString()) * _up * lineDist;
+                const double staffLinesDistance = staffType->lineDistance().val() * spatium();
+                y1 = (chord()->downString() - chord()->upString()) * _up * staffLinesDistance;
+
                 // if fret marks above lines, raise stem beginning by 1/2 line distance
-                if (!st->onLines()) {
-                    y1 -= lineDist * 0.5;
+                if (!staffType->onLines()) {
+                    y1 -= staffLinesDistance * 0.5;
                 }
+
                 // shorten stem by 1/2 lineDist to clear the note and a little more to keep 'air' between stem and note
-                lineDist *= 0.7 * mag();
-                y1       += _up * lineDist;
+                y1 += _up * staffLinesDistance * 0.7;
             }
             // in other TAB types, no correction
-        } else {                                // non-TAB
+        } else { // non-TAB
             // move stem start to note attach point
-            Note* n = up() ? chord()->downNote() : chord()->upNote();
-            if ((up() && !n->mirror()) || (!up() && n->mirror())) {
-                y1 += n->stemUpSE().y();
+            Note* note = up ? chord()->downNote() : chord()->upNote();
+            if ((up && !note->mirror()) || (!up && note->mirror())) {
+                y1 = note->stemUpSE().y();
             } else {
-                y1 += n->stemDownNW().y();
+                y1 = note->stemDownNW().y();
             }
-            rypos() = n->rypos();
+
+            rypos() = note->rypos();
+        }
+
+        if (chord()->hook() && !chord()->beam()) {
+            y2 += chord()->hook()->smuflAnchor().y();
         }
     }
 
-    qreal lw5 = 0.5 * lineWidthMag();
+    double lineWidthCorrection = lineWidthMag() * 0.5;
+    double lineX = isTabStaff ? 0.0 : _up * lineWidthCorrection;
+    m_line.setLine(lineX, y1, lineX, y2);
 
-    line.setLine(0.0, y1, 0.0, l);
-
-    // compute bounding rectangle
-    RectF r(line.p1(), line.p2());
-    setbbox(r.normalized().adjusted(-lw5, -lw5, lw5, lw5));
+    // compute line and bounding rectangle
+    RectF rect(m_line.p1(), m_line.p2());
+    setbbox(rect.normalized().adjusted(-lineWidthCorrection, 0, lineWidthCorrection, 0));
 }
 
-//---------------------------------------------------------
-//   setLen
-//---------------------------------------------------------
-
-void Stem::setLen(qreal v)
+void Stem::setBaseLength(double baseLength)
 {
-    _len = (v < 0.0) ? -v : v;
+    m_baseLength = std::abs(baseLength);
     layout();
 }
 
-//---------------------------------------------------------
-//   spatiumChanged
-//---------------------------------------------------------
-
-void Stem::spatiumChanged(qreal oldValue, qreal newValue)
+void Stem::spatiumChanged(double oldValue, double newValue)
 {
-    _userLen = (_userLen / oldValue) * newValue;
+    m_userLength = (m_userLength / oldValue) * newValue;
     layout();
 }
 
-//---------------------------------------------------------
-//   draw
-//---------------------------------------------------------
+//! In chord coordinates
+PointF Stem::flagPosition() const
+{
+    return pos() + PointF(_bbox.left(), up() ? -length() : length());
+}
 
 void Stem::draw(mu::draw::Painter* painter) const
 {
@@ -185,14 +160,14 @@ void Stem::draw(mu::draw::Painter* painter) const
         return;
     }
 
-    const Staff* st      = staff();
-    const StaffType* stt = st ? st->staffType(chord()->tick()) : 0;
-    bool useTab          = stt && stt->isTabStaff();
+    const Staff* staff = this->staff();
+    const StaffType* staffType = staff ? staff->staffTypeForElement(chord()) : nullptr;
+    const bool isTablature = staffType && staffType->isTabStaff();
 
     painter->setPen(Pen(curColor(), lineWidthMag(), PenStyle::SolidLine, PenCapStyle::FlatCap));
-    painter->drawLine(line);
+    painter->drawLine(m_line);
 
-    if (!useTab) {
+    if (!isTablature) {
         return;
     }
 
@@ -201,12 +176,14 @@ void Stem::draw(mu::draw::Painter* painter) const
     bool isUp = up();
 
     // slashed half note stem
-    if (chord()->durationType().type() == TDuration::DurationType::V_HALF && stt->minimStyle() == TablatureMinimStyle::SLASHED) {
+    if (chord()->durationType().type() == TDuration::DurationType::V_HALF
+        && staffType->minimStyle() == TablatureMinimStyle::SLASHED) {
         // position slashes onto stem
-        qreal y = isUp ? -(_len + _userLen) + STAFFTYPE_TAB_SLASH_2STARTY_UP * sp : (_len + _userLen) - STAFFTYPE_TAB_SLASH_2STARTY_DN * sp;
+        qreal y = isUp ? -length() + STAFFTYPE_TAB_SLASH_2STARTY_UP * sp
+                  : length() - STAFFTYPE_TAB_SLASH_2STARTY_DN * sp;
         // if stems through, try to align slashes within or across lines
-        if (stt->stemThrough()) {
-            qreal halfLineDist = stt->lineDistance().val() * sp * 0.5;
+        if (staffType->stemThrough()) {
+            qreal halfLineDist = staffType->lineDistance().val() * sp * 0.5;
             qreal halfSlashHgt = STAFFTYPE_TAB_SLASH_2TOTHEIGHT * sp * 0.5;
             y = lrint((y + halfSlashHgt) / halfLineDist) * halfLineDist - halfSlashHgt;
         }
@@ -233,7 +210,7 @@ void Stem::draw(mu::draw::Painter* painter) const
     // NOT THE BEST PLACE FOR THIS?
     // with tablatures and stems beside staves, dots are not drawn near 'notes', but near stems
     int nDots = chord()->dots();
-    if (nDots > 0 && !stt->stemThrough()) {
+    if (nDots > 0 && !staffType->stemThrough()) {
         qreal x     = chord()->dotPosX();
         qreal y     = ((STAFFTYPE_TAB_DEFAULTSTEMLEN_DN * 0.2) * sp) * (isUp ? -1.0 : 1.0);
         qreal step  = score()->styleS(Sid::dotDotDistance).val() * sp;
@@ -242,10 +219,6 @@ void Stem::draw(mu::draw::Painter* painter) const
         }
     }
 }
-
-//---------------------------------------------------------
-//   write
-//---------------------------------------------------------
 
 void Stem::write(XmlWriter& xml) const
 {
@@ -256,10 +229,6 @@ void Stem::write(XmlWriter& xml) const
     xml.endObject();
 }
 
-//---------------------------------------------------------
-//   read
-//---------------------------------------------------------
-
 void Stem::read(XmlReader& e)
 {
     while (e.readNextStartElement()) {
@@ -268,10 +237,6 @@ void Stem::read(XmlReader& e)
         }
     }
 }
-
-//---------------------------------------------------------
-//   readProperties
-//---------------------------------------------------------
 
 bool Stem::readProperties(XmlReader& e)
 {
@@ -286,18 +251,10 @@ bool Stem::readProperties(XmlReader& e)
     return true;
 }
 
-//---------------------------------------------------------
-//   gripsPositions
-//---------------------------------------------------------
-
 std::vector<mu::PointF> Stem::gripsPositions(const EditData&) const
 {
-    return { pagePos() + line.p2() };
+    return { pagePos() + m_line.p2() };
 }
-
-//---------------------------------------------------------
-//   startEdit
-//---------------------------------------------------------
 
 void Stem::startEdit(EditData& ed)
 {
@@ -306,34 +263,22 @@ void Stem::startEdit(EditData& ed)
     eed->pushProperty(Pid::USER_LEN);
 }
 
-//---------------------------------------------------------
-//   editDrag
-//---------------------------------------------------------
-
 void Stem::editDrag(EditData& ed)
 {
-    qreal yDelta = ed.delta.y();
-    _userLen += up() ? -yDelta : yDelta;
+    double yDelta = ed.delta.y();
+    m_userLength += up() ? -yDelta : yDelta;
     layout();
     Chord* c = chord();
     if (c->hook()) {
-        c->hook()->move(PointF(0.0, ed.delta.y()));
+        c->hook()->move(PointF(0.0, yDelta));
     }
 }
-
-//---------------------------------------------------------
-//   reset
-//---------------------------------------------------------
 
 void Stem::reset()
 {
     undoChangeProperty(Pid::USER_LEN, 0.0);
     EngravingItem::reset();
 }
-
-//---------------------------------------------------------
-//   acceptDrop
-//---------------------------------------------------------
 
 bool Stem::acceptDrop(EditData& data) const
 {
@@ -343,10 +288,6 @@ bool Stem::acceptDrop(EditData& data) const
     }
     return false;
 }
-
-//---------------------------------------------------------
-//   drop
-//---------------------------------------------------------
 
 EngravingItem* Stem::drop(EditData& data)
 {
@@ -365,27 +306,19 @@ EngravingItem* Stem::drop(EditData& data)
     return 0;
 }
 
-//---------------------------------------------------------
-//   getProperty
-//---------------------------------------------------------
-
 QVariant Stem::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
     case Pid::LINE_WIDTH:
         return lineWidth();
     case Pid::USER_LEN:
-        return userLen();
+        return userLength();
     case Pid::STEM_DIRECTION:
         return QVariant::fromValue<Direction>(chord()->stemDirection());
     default:
         return EngravingItem::getProperty(propertyId);
     }
 }
-
-//---------------------------------------------------------
-//   setProperty
-//---------------------------------------------------------
 
 bool Stem::setProperty(Pid propertyId, const QVariant& v)
 {
@@ -394,7 +327,7 @@ bool Stem::setProperty(Pid propertyId, const QVariant& v)
         setLineWidth(v.toReal());
         break;
     case Pid::USER_LEN:
-        setUserLen(v.toDouble());
+        setUserLength(v.toDouble());
         break;
     case Pid::STEM_DIRECTION:
         chord()->setStemDirection(v.value<Direction>());
@@ -406,35 +339,14 @@ bool Stem::setProperty(Pid propertyId, const QVariant& v)
     return true;
 }
 
-//---------------------------------------------------------
-//   propertyDefault
-//---------------------------------------------------------
-
 QVariant Stem::propertyDefault(Pid id) const
 {
     switch (id) {
     case Pid::USER_LEN:
         return 0.0;
-//            case Pid::LINE_WIDTH:
-//                  return score()->styleP(Sid::stemWidth);
     case Pid::STEM_DIRECTION:
         return QVariant::fromValue<Direction>(Direction::AUTO);
     default:
         return EngravingItem::propertyDefault(id);
     }
-}
-
-//---------------------------------------------------------
-//   hookPos
-//    in chord coordinates
-//---------------------------------------------------------
-
-PointF Stem::hookPos() const
-{
-    PointF p(pos() + line.p2());
-
-    qreal xoff = 0.5 * lineWidthMag();
-    p.rx() += xoff;
-    return p;
-}
 }

--- a/src/engraving/libmscore/stem.h
+++ b/src/engraving/libmscore/stem.h
@@ -28,41 +28,31 @@
 namespace Ms {
 class Chord;
 
-//---------------------------------------------------------
-//   @@ Stem
-///    Graphic representation of a note stem.
-//---------------------------------------------------------
-
 class Stem final : public EngravingItem
 {
-    mu::LineF line;   // p1 is attached to notehead
-    qreal _lineWidth;
-    qreal _userLen;
-    qreal _len       { 0.0 };       // always positive
-
-    friend class mu::engraving::Factory;
-    Stem(Chord* parent = 0);
-
 public:
 
     Stem& operator=(const Stem&) = delete;
 
     Stem* clone() const override { return new Stem(*this); }
-    void draw(mu::draw::Painter*) const override;
-    bool isEditable() const override { return true; }
+
     void layout() override;
-    void spatiumChanged(qreal /*oldValue*/, qreal /*newValue*/) override;
+    void draw(mu::draw::Painter*) const override;
+    void spatiumChanged(double oldValue, double newValue) override;
     EngravingItem* elementBase() const override;
 
+    bool isEditable() const override { return true; }
     void startEdit(EditData&) override;
     void editDrag(EditData&) override;
-    void write(XmlWriter& xml) const override;
-    void read(XmlReader& e) override;
-    bool readProperties(XmlReader&) override;
-    void reset() override;
+
     bool acceptDrop(EditData&) const override;
     EngravingItem* drop(EditData&) override;
 
+    void write(XmlWriter& xml) const override;
+    void read(XmlReader& e) override;
+    bool readProperties(XmlReader&) override;
+
+    void reset() override;
     QVariant getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const QVariant&) override;
     QVariant propertyDefault(Pid id) const override;
@@ -72,25 +62,36 @@ public:
     Chord* chord() const { return toChord(parent()); }
     bool up() const;
 
-    qreal userLen() const { return _userLen; }
-    void setUserLen(qreal l) { _userLen = l; }
+    double baseLength() const { return m_baseLength; }
+    void setBaseLength(double baseLength);
 
-    qreal lineWidth() const { return _lineWidth; }
-    qreal lineWidthMag() const { return _lineWidth * mag(); }
-    void setLineWidth(qreal w) { _lineWidth = w; }
+    double userLength() const { return m_userLength; }
+    void setUserLength(double userLength) { m_userLength = userLength; }
 
-    void setLen(qreal l);
-    qreal len() const { return _len; }
+    double lineWidth() const { return m_lineWidth; }
+    double lineWidthMag() const { return m_lineWidth * mag(); }
+    void setLineWidth(double lineWidth) { m_lineWidth = lineWidth; }
 
-    mu::PointF hookPos() const;
-    qreal stemLen() const;
-    mu::PointF p2() const { return line.p2(); }
+    mu::PointF p2() const { return m_line.p2(); }
+    mu::PointF flagPosition() const;
+    double length() const { return m_baseLength + m_userLength; }
 
     EditBehavior normalModeEditBehavior() const override { return EditBehavior::Edit; }
     int gripsCount() const override { return 1; }
     Grip initialEditModeGrip() const override { return Grip::START; }
     Grip defaultGrip() const override { return Grip::START; }
     std::vector<mu::PointF> gripsPositions(const EditData&) const override;
+
+private:
+    friend class mu::engraving::Factory;
+    Stem(Chord* parent = 0);
+
+    mu::LineF m_line;
+
+    double m_baseLength = 0.0;
+    double m_userLength = 0.0;
+
+    double m_lineWidth = 0.0;
 };
-}     // namespace Ms
+}
 #endif

--- a/src/engraving/libmscore/stemslash.cpp
+++ b/src/engraving/libmscore/stemslash.cpp
@@ -67,7 +67,7 @@ void StemSlash::layout()
     qreal h2;
     qreal _spatium = spatium();
     qreal l = chord()->up() ? _spatium : -_spatium;
-    PointF p(stem->hookPos());
+    PointF p(stem->flagPosition());
     qreal x = p.x() + _spatium * .1;
     qreal y = p.y();
 

--- a/src/engraving/libmscore/tremolo.cpp
+++ b/src/engraving/libmscore/tremolo.cpp
@@ -514,9 +514,9 @@ void Tremolo::layout()
     Stem* stem    = _chord1->stem();
     qreal x, y, h;
     if (stem) {
-        x  = stem->pos().x();
-        y  = stem->pos().y();
-        h  = stem->stemLen();
+        x = stem->pos().x();
+        y = stem->pos().y();
+        h = stem->length();
     } else {
         // center tremolo above note
         x = anchor1->x() + anchor1->headWidth() * .5;

--- a/src/engraving/rw/measurerw.cpp
+++ b/src/engraving/rw/measurerw.cpp
@@ -45,6 +45,7 @@
 #include "../libmscore/keysig.h"
 #include "../libmscore/stafftext.h"
 #include "../libmscore/ambitus.h"
+#include "../libmscore/dynamic.h"
 
 #include "../libmscore/score.h"
 

--- a/src/palette/view/widgets/drumsetpalette.cpp
+++ b/src/palette/view/widgets/drumsetpalette.cpp
@@ -120,7 +120,7 @@ void DrumsetPalette::updateDrumset()
         chord->setUp(up);
         chord->setTrack(voice);
         Stem* stem = Factory::createStem(chord.get());
-        stem->setLen((up ? -3.0 : 3.0) * _spatium);
+        stem->setBaseLength((up ? -3.0 : 3.0) * _spatium);
         chord->add(stem);
         Note* note = Factory::createNote(chord.get());
         note->setMark(true);

--- a/src/palette/view/widgets/editdrumsetdialog.cpp
+++ b/src/palette/view/widgets/editdrumsetdialog.cpp
@@ -603,7 +603,7 @@ void EditDrumsetDialog::updateExample()
     note->setCachedNoteheadSym(Sym::name2id(quarterCmb->currentData().toString()));
     chord->add(note);
     Stem* stem = Factory::createStem(chord.get());
-    stem->setLen((up ? -3.0 : 3.0) * gpaletteScore->spatium());
+    stem->setBaseLength((up ? -3.0 : 3.0) * gpaletteScore->spatium());
     chord->add(stem);
     drumNote->appendElement(chord, mu::qtrc("drumset", m_editedDrumset.name(pitch).toUtf8().constData()));
 }


### PR DESCRIPTION
Resolves: #8952

Also fixes an issue that has existed for a longer time, where on a TAB staff, the width of the stem of the start chord of a beam influences the end position of the beam:
<img width="159" alt="Schermafbeelding 2021-09-22 om 23 47 39" src="https://user-images.githubusercontent.com/48658420/134426567-77fee29c-aad7-44f3-95fd-08a87b274035.png">

It would be nice if the vtests could be repaired... that would give a lot more confidence. But I tested it with all cases I could think of (normal staves, different kinds of TAB staffs; with and without beams; tremolos...)