### PR TITLE
Now using playback note length to determine scale of adjustments.

### DIFF
--- a/mscore/pianoroll/pianolevelsfilter.cpp
+++ b/mscore/pianoroll/pianolevelsfilter.cpp
@@ -161,8 +161,7 @@ int PianoLevelFilterLenWholenote::value(Staff* /*staff*/, Note* note, NoteEvent*
 
 void PianoLevelFilterLenWholenote::setValue(Staff* staff, Note* note, NoteEvent* evt, int value)
       {
-      Chord* chord = note->chord();
-      Fraction noteLen = chord->ticks();
+      Fraction noteLen = note->playTicksFraction();
       Fraction cutLen(-value, 1000);
       Fraction playLen = noteLen - cutLen;
       Fraction evtLenFrac = playLen / noteLen;

--- a/mscore/pianoroll/pianolevelsfilter.cpp
+++ b/mscore/pianoroll/pianolevelsfilter.cpp
@@ -161,7 +161,8 @@ int PianoLevelFilterLenWholenote::value(Staff* /*staff*/, Note* note, NoteEvent*
 
 void PianoLevelFilterLenWholenote::setValue(Staff* staff, Note* note, NoteEvent* evt, int value)
       {
-      Fraction noteLen = note->playTicksFraction();
+      Chord* chord = note->chord();
+      Fraction noteLen = chord->ticks();
       Fraction cutLen(-value, 1000);
       Fraction playLen = noteLen - cutLen;
       Fraction evtLenFrac = playLen / noteLen;

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -86,13 +86,12 @@ PianoItem::PianoItem(Note* n, PianoView* pianoView)
 QRect PianoItem::boundingRectTicks(NoteEvent* evt)
       {
       Chord* chord = _note->chord();
-      int ticks = chord->ticks().ticks();
-      int tieLen = _note->playTicks() - ticks;
+      int chordTicks = chord->ticks().ticks();
+      int ticks = _note->playTicks();
+      int len = evt ? ticks * evt->len() / 1000 : ticks;
       int pitch = _note->pitch() + (evt ? evt->pitch() : 0);
-      int len = (evt ? ticks * evt->len() / 1000 : ticks) + tieLen;
 
-      int x1 = _note->chord()->tick().ticks()
-            + (evt ? evt->ontime() * ticks / 1000 : 0);
+      int x1 = ticks + (evt ? evt->ontime() * chordTicks / 1000 : 0);
       qreal y1 = pitch;
 
       QRect rect;

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -86,12 +86,22 @@ PianoItem::PianoItem(Note* n, PianoView* pianoView)
 QRect PianoItem::boundingRectTicks(NoteEvent* evt)
       {
       Chord* chord = _note->chord();
-      int chordTicks = chord->ticks().ticks();
-      int ticks = _note->playTicks();
-      int len = evt ? ticks * evt->len() / 1000 : ticks;
       int pitch = _note->pitch() + (evt ? evt->pitch() : 0);
 
-      int x1 = ticks + (evt ? evt->ontime() * chordTicks / 1000 : 0);
+      int ticks = chord->ticks().ticks();
+      int tieLen = _note->playTicks() - ticks;
+
+      Tuplet* tup = chord->tuplet();
+      if (tup)
+      {
+          Fraction frac = tup->ratio();
+          ticks = ticks * frac.denominator() / frac.numerator();
+      }
+
+      int len = (evt ? ticks * evt->len() / 1000 : ticks) + tieLen;
+      
+      int x1 = _note->chord()->tick().ticks()
+          + (evt ? evt->ontime() * ticks / 1000 : 0);
       qreal y1 = pitch;
 
       QRect rect;

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -94,7 +94,7 @@ QRect PianoItem::boundingRectTicks(NoteEvent* evt)
       if (tup) {
             Fraction frac = tup->ratio();
             ticks = ticks * frac.denominator() / frac.numerator();
-      }
+            }
       int tieLen = _note->playTicks() - ticks;
 
       int len = (evt ? ticks * evt->len() / 1000 : ticks) + tieLen;

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -92,8 +92,7 @@ QRect PianoItem::boundingRectTicks(NoteEvent* evt)
       int tieLen = _note->playTicks() - ticks;
 
       Tuplet* tup = chord->tuplet();
-      if (tup)
-      {
+      if (tup) {
             Fraction frac = tup->ratio();
             ticks = ticks * frac.denominator() / frac.numerator();
       }

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -89,13 +89,13 @@ QRect PianoItem::boundingRectTicks(NoteEvent* evt)
       int pitch = _note->pitch() + (evt ? evt->pitch() : 0);
 
       int ticks = chord->ticks().ticks();
-      int tieLen = _note->playTicks() - ticks;
 
       Tuplet* tup = chord->tuplet();
       if (tup) {
             Fraction frac = tup->ratio();
             ticks = ticks * frac.denominator() / frac.numerator();
       }
+      int tieLen = _note->playTicks() - ticks;
 
       int len = (evt ? ticks * evt->len() / 1000 : ticks) + tieLen;
       

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -94,14 +94,14 @@ QRect PianoItem::boundingRectTicks(NoteEvent* evt)
       Tuplet* tup = chord->tuplet();
       if (tup)
       {
-          Fraction frac = tup->ratio();
-          ticks = ticks * frac.denominator() / frac.numerator();
+            Fraction frac = tup->ratio();
+            ticks = ticks * frac.denominator() / frac.numerator();
       }
 
       int len = (evt ? ticks * evt->len() / 1000 : ticks) + tieLen;
       
       int x1 = _note->chord()->tick().ticks()
-          + (evt ? evt->ontime() * ticks / 1000 : 0);
+            + (evt ? evt->ontime() * ticks / 1000 : 0);
       qreal y1 = pitch;
 
       QRect rect;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/306180

Incorrect note lengths were being displayed in piano roll editor when adjusting playback events for tuplets.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://musescore.org/en/cla)
- [ ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ ] I made sure the code compiles on my machine
- [ ] I made sure there are no unnecessary changes in the code
- [ ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
