### PR TITLE
Consistent system left alignment

### DIFF
--- a/src/engraving/libmscore/system.h
+++ b/src/engraving/libmscore/system.h
@@ -126,6 +126,10 @@ class System final : public EngravingItem
     void setBracketsXPosition(const qreal xOffset);
     Bracket* createBracket(const mu::engraving::LayoutContext& ctx, Ms::BracketItem* bi, int column, int staffIdx, QList<Ms::Bracket*>& bl,
                            Measure* measure);
+    
+    qreal systemNamesWidth(bool getTotalWidth);
+    qreal layoutBrackets(const mu::engraving::LayoutContext& ctx);
+    qreal totalBracketOffset(const mu::engraving::LayoutContext& ctx);
 
 public:
 
@@ -154,7 +158,7 @@ public:
 
     Page* page() const { return (Page*)parent(); }
 
-    void layoutSystem(const mu::engraving::LayoutContext& ctx, qreal, const bool isFirstSystem = false, bool firstSystemIndent = false);
+    void layoutSystem(const mu::engraving::LayoutContext& ctx, qreal xo1, const bool isFirstSystem = false, bool firstSystemIndent = false);
 
     void setMeasureHeight(qreal height);
     void layoutBracketsVertical();

--- a/src/engraving/libmscore/system.h
+++ b/src/engraving/libmscore/system.h
@@ -126,8 +126,8 @@ class System final : public EngravingItem
     void setBracketsXPosition(const qreal xOffset);
     Bracket* createBracket(const mu::engraving::LayoutContext& ctx, Ms::BracketItem* bi, int column, int staffIdx, QList<Ms::Bracket*>& bl,
                            Measure* measure);
-    
-    qreal systemNamesWidth(bool getTotalWidth);
+
+    qreal systemNamesWidth();
     qreal layoutBrackets(const mu::engraving::LayoutContext& ctx);
     qreal totalBracketOffset(const mu::engraving::LayoutContext& ctx);
 

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -58,10 +58,11 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::staffUpperBorder,        "staffUpperBorder",        Spatium(7.0) },
     { Sid::staffLowerBorder,        "staffLowerBorder",        Spatium(7.0) },
     { Sid::staffDistance,           "staffDistance",           Spatium(6.5) },
-    { Sid::instrumentNameOffset,    "instrumentNameOffset",    Spatium(1.0)   },
+    { Sid::instrumentNameOffset,    "instrumentNameOffset",    Spatium(1.0) },
     { Sid::akkoladeDistance,        "akkoladeDistance",        Spatium(6.5) },
     { Sid::minSystemDistance,       "minSystemDistance",       Spatium(8.5) },
     { Sid::maxSystemDistance,       "maxSystemDistance",       Spatium(15.0) },
+    { Sid::alignSystemToMargin,     "alignSystemToMargin",     true },
 
     { Sid::enableVerticalSpread,    "enableVerticalSpread",    false },
     { Sid::spreadSystem,            "spreadSystem",            2.5 },

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -58,6 +58,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::staffUpperBorder,        "staffUpperBorder",        Spatium(7.0) },
     { Sid::staffLowerBorder,        "staffLowerBorder",        Spatium(7.0) },
     { Sid::staffDistance,           "staffDistance",           Spatium(6.5) },
+    { Sid::instrumentNameOffset,    "instrumentNameOffset",    Spatium(1.0)   },
     { Sid::akkoladeDistance,        "akkoladeDistance",        Spatium(6.5) },
     { Sid::minSystemDistance,       "minSystemDistance",       Spatium(8.5) },
     { Sid::maxSystemDistance,       "maxSystemDistance",       Spatium(15.0) },

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -73,6 +73,7 @@ enum class Sid {
     staffUpperBorder,
     staffLowerBorder,
     staffDistance,
+    instrumentNameOffset,
     akkoladeDistance,
     minSystemDistance,
     maxSystemDistance,

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -77,6 +77,7 @@ enum class Sid {
     akkoladeDistance,
     minSystemDistance,
     maxSystemDistance,
+    alignSystemToMargin,
 
     enableVerticalSpread,
     spreadSystem,


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8968

Here's a brief overview:

1. Aligns the left origins of systems
2. When no staff names are present, it aligns the system to the left margin (putting brackets outside the margin)
3. Adds new style settings `instrumentNameOffset`, which removes a few `TODO` items from the code
4. Makes the behavior in number 2 configurable with a new style setting `alignSystemToMargin`

More details can be found in the issue itself.