### PR TITLE
re-add overshoot to arpeggios

### DIFF
--- a/src/engraving/libmscore/arpeggio.cpp
+++ b/src/engraving/libmscore/arpeggio.cpp
@@ -35,6 +35,7 @@
 #include "score.h"
 #include "symid.h"
 #include "staff.h"
+#include "stafflines.h"
 #include "part.h"
 #include "page.h"
 #include "segment.h"
@@ -141,9 +142,9 @@ void Arpeggio::read(XmlReader& e)
 
 void Arpeggio::symbolLine(SymId end, SymId fill)
 {
-    qreal y1 = -_userLen1;
-    qreal y2 = _height + _userLen2;
-    qreal w   = y2 - y1;
+    qreal top = calcTop();
+    qreal bottom = calcBottom();
+    qreal w   = bottom - top;
     qreal mag = magS();
     ScoreFont* f = score()->scoreFont();
 
@@ -158,13 +159,79 @@ void Arpeggio::symbolLine(SymId end, SymId fill)
 }
 
 //---------------------------------------------------------
+//   calcTop
+//---------------------------------------------------------
+
+qreal Arpeggio::calcTop() const
+{
+    qreal top = -_userLen1;
+    if (!parent()) {
+        return top;
+    }
+    switch (arpeggioType()) {
+    case ArpeggioType::BRACKET: {
+        qreal lineWidth = score()->styleP(Sid::ArpeggioLineWidth);
+        return top - lineWidth / 2.0;
+    }
+    case ArpeggioType::NORMAL:
+    case ArpeggioType::UP:
+    case ArpeggioType::DOWN: {
+        // if the top is in the staff on a space, move it up
+        // if the bottom note is on a line, the distance is 0.25 spaces
+        // if the bottom note is on a space, the distance is 0.5 spaces
+        int topNoteLine = chord()->upNote()->line();
+        int lines = staff()->lines(tick());
+        int bottomLine = (lines - 1) * 2;
+        if (topNoteLine <= 0 || topNoteLine % 2 == 0 || topNoteLine >= bottomLine) {
+            return top;
+        }
+        int downNoteLine = chord()->downNote()->line();
+        if (downNoteLine % 2 == 1 && downNoteLine < bottomLine) {
+            return top - 0.4 * spatium();
+        }
+        return top - 0.25 * spatium();
+    }
+    default: {
+        return top - spatium() / 4;
+    }
+    }
+}
+
+//---------------------------------------------------------
+//   calcBottom
+//---------------------------------------------------------
+
+qreal Arpeggio::calcBottom() const
+{
+    qreal top = -_userLen1;
+    qreal bottom = _height + _userLen2;
+    if (!parent()) {
+        return bottom;
+    }
+    switch (arpeggioType()) {
+    case ArpeggioType::BRACKET: {
+        qreal lineWidth = score()->styleP(Sid::ArpeggioLineWidth);
+        return bottom - top + lineWidth;
+    }
+    case ArpeggioType::NORMAL:
+    case ArpeggioType::UP:
+    case ArpeggioType::DOWN: {
+        return bottom;
+    }
+    default: {
+        return bottom + spatium() / 2;
+    }
+    }
+}
+
+//---------------------------------------------------------
 //   layout
 //---------------------------------------------------------
 
 void Arpeggio::layout()
 {
-    qreal y1 = -_userLen1;
-    qreal y2 = _height + _userLen2;
+    qreal top = calcTop();
+    qreal bottom = calcBottom();
     _hidden = false;
     if (score()->styleB(Sid::ArpeggioHiddenInStdIfTab)) {
         if (staff() && staff()->isPitchedStaff(tick())) {
@@ -185,7 +252,7 @@ void Arpeggio::layout()
         symbolLine(SymId::wiggleArpeggiatoUp, SymId::wiggleArpeggiatoUp);
         // string is rotated -90 degrees
         RectF r(symBbox(symbols));
-        setbbox(RectF(0.0, -r.x() + y1, r.height(), r.width()));
+        setbbox(RectF(0.0, -r.x() + top, r.height(), r.width()));
     }
     break;
 
@@ -193,7 +260,7 @@ void Arpeggio::layout()
         symbolLine(SymId::wiggleArpeggiatoUpArrow, SymId::wiggleArpeggiatoUp);
         // string is rotated -90 degrees
         RectF r(symBbox(symbols));
-        setbbox(RectF(0.0, -r.x() + y1, r.height(), r.width()));
+        setbbox(RectF(0.0, -r.x() + top, r.height(), r.width()));
     }
     break;
 
@@ -201,7 +268,7 @@ void Arpeggio::layout()
         symbolLine(SymId::wiggleArpeggiatoUpArrow, SymId::wiggleArpeggiatoUp);
         // string is rotated +90 degrees (so that UpArrow turns into a DownArrow)
         RectF r(symBbox(symbols));
-        setbbox(RectF(0.0, r.x() + y1, r.height(), r.width()));
+        setbbox(RectF(0.0, r.x() + top, r.height(), r.width()));
     }
     break;
 
@@ -209,11 +276,7 @@ void Arpeggio::layout()
         qreal _spatium = spatium();
         qreal x1 = _spatium * .5;
         qreal w  = symBbox(SymId::arrowheadBlackUp).width();
-        qreal terminalDistance = 0;
-        if (parent()) {
-            terminalDistance = _spatium / 4 - score()->styleP(Sid::ArpeggioLineWidth) / 2;
-        }
-        setbbox(RectF(x1 - w * .5, y1, w, y2 - y1 + terminalDistance));
+        setbbox(RectF(x1 - w * .5, top, w, bottom));
     }
     break;
 
@@ -221,18 +284,14 @@ void Arpeggio::layout()
         qreal _spatium = spatium();
         qreal x1 = _spatium * .5;
         qreal w  = symBbox(SymId::arrowheadBlackDown).width();
-        qreal terminalDistance = 0;
-        if (parent()) {
-            terminalDistance = _spatium / 4 - score()->styleP(Sid::ArpeggioLineWidth) / 2;
-        }
-        setbbox(RectF(x1 - w * .5, y1 - terminalDistance, w, y2 - y1 + terminalDistance));
+        setbbox(RectF(x1 - w * .5, top, w, bottom));
     }
     break;
 
     case ArpeggioType::BRACKET: {
         qreal _spatium = spatium();
         qreal w  = score()->styleS(Sid::ArpeggioHookLen).val() * _spatium;
-        setbbox(RectF(0.0, y1, w, y2 - y1));
+        setbbox(RectF(0.0, top, w, bottom));
         break;
     }
     }

--- a/src/engraving/libmscore/arpeggio.h
+++ b/src/engraving/libmscore/arpeggio.h
@@ -58,12 +58,14 @@ class Arpeggio final : public EngravingItem
     Arpeggio(Chord* parent);
 
     void symbolLine(SymId start, SymId fill);
-    void symbolLine2(SymId end, SymId fill);
 
     void spatiumChanged(qreal /*oldValue*/, qreal /*newValue*/) override;
     QVector<mu::LineF> dragAnchorLines() const override;
     QVector<mu::LineF> gripAnchorLines(Grip) const override;
     void startEdit(EditData&) override;
+
+    qreal calcTop() const;
+    qreal calcBottom() const;
 
     static const std::array<const char*, 6> arpeggioTypeNames;
 


### PR DESCRIPTION
Fixes regression from earlier this week and re-adds the overshoot in arpeggios. Ultimately, this regression/fix is better than the previous solution as the code. The code is cleaner and we have more precise control over the overshoot amount. Before, a scaling factor was used to add the overshoot (e.g the arpeggios were X% larger). Now, the overshoot is precisely 0.25 spaces.

Current

![image](https://user-images.githubusercontent.com/5659171/134746866-c12780aa-14c3-4424-a3ae-793ae185e4f0.png)

Fixed

<img width="589" alt="Screen Shot 2021-09-24 at 3 46 30 PM" src="https://user-images.githubusercontent.com/5659171/134746896-00ee6eca-f961-420c-8454-b22840ac8973.png">