### PR TITLE
Show instrument descriptions in New Score Wizard

### DIFF
--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/ChooseInstrumentsPage.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/ChooseInstrumentsPage.qml
@@ -33,6 +33,7 @@ Rectangle {
 
     property bool canSelectMultipleInstruments: true
     property string currentInstrumentId: ""
+    property string description: instrumentsModel.selectedInstrumentDescription
 
     property bool hasSelectedInstruments: instrumentsOnScoreView.hasInstruments
 

--- a/src/instrumentsscene/view/instrumentlistmodel.cpp
+++ b/src/instrumentsscene/view/instrumentlistmodel.cpp
@@ -222,6 +222,7 @@ void InstrumentListModel::loadInstruments()
     sortInstruments(m_instruments);
 
     endResetModel();
+    emit selectionChanged();
 }
 
 void InstrumentListModel::sortInstruments(Instruments& instruments) const
@@ -281,6 +282,7 @@ void InstrumentListModel::selectInstrument(int instrumentIndex)
         }
     }
 
+    emit selectionChanged();
     emit dataChanged(index(0), index(rowCount() - 1), { RoleIsSelected });
 }
 
@@ -393,6 +395,16 @@ int InstrumentListModel::currentGroupIndex() const
 bool InstrumentListModel::hasSelection() const
 {
     return m_selection->hasSelection();
+}
+
+QString InstrumentListModel::selectedInstrumentDescription() const
+{
+    QList<int> selectedRows = m_selection->selectedRows();
+    if (selectedRows.length() != 1) {
+        return QString();
+    }
+    CombinedInstrument instrument = m_instruments.at(selectedRows.at(0));
+    return instrument.templates.at(instrument.currentTemplateIndex)->description;
 }
 
 bool InstrumentListModel::isSearching() const

--- a/src/instrumentsscene/view/instrumentlistmodel.h
+++ b/src/instrumentsscene/view/instrumentlistmodel.h
@@ -45,6 +45,7 @@ class InstrumentListModel : public QAbstractListModel, public async::Asyncable
     Q_PROPERTY(int currentGroupIndex READ currentGroupIndex WRITE setCurrentGroupIndex NOTIFY currentGroupChanged)
 
     Q_PROPERTY(bool hasSelection READ hasSelection NOTIFY selectionChanged)
+    Q_PROPERTY(QString selectedInstrumentDescription READ selectedInstrumentDescription NOTIFY selectionChanged)
 
 public:
     InstrumentListModel(QObject* parent = nullptr);
@@ -61,6 +62,7 @@ public:
     int currentGroupIndex() const;
 
     bool hasSelection() const;
+    QString selectedInstrumentDescription() const;
 
     Q_INVOKABLE void load(bool canSelectMultipleInstruments, const QString& currentInstrumentId);
 

--- a/src/project/qml/MuseScore/Project/NewScoreDialog.qml
+++ b/src/project/qml/MuseScore/Project/NewScoreDialog.qml
@@ -87,10 +87,8 @@ StyledDialogView {
             }
         }
 
-        Row {
-            id: buttons
-
-            Layout.alignment: Qt.AlignRight
+        RowLayout {
+            id: footer
 
             spacing: 12
 
@@ -106,9 +104,25 @@ StyledDialogView {
                 direction: NavigationPanel.Horizontal
             }
 
+            StyledTextLabel {
+                id: descriptionLabel
+                text: pagesStack.currentIndex === 0
+                      ? chooseInstrumentsAndTemplatePage.description
+                      : ""
+
+                height: footer.buttonHeight
+                Layout.fillWidth: true
+                Layout.leftMargin: 12
+
+                font: ui.theme.bodyFont
+                opacity: 0.7
+                horizontalAlignment: Text.AlignLeft
+                wrapMode: Text.Wrap
+            }
+
             FlatButton {
-                height: buttons.buttonHeight
-                width: buttons.buttonWidth
+                height: footer.buttonHeight
+                width: footer.buttonWidth
 
                 navigation.name: "Cancel"
                 navigation.panel: navBottomPanel
@@ -122,8 +136,8 @@ StyledDialogView {
             }
 
             FlatButton {
-                height: buttons.buttonHeight
-                width: buttons.buttonWidth
+                height: footer.buttonHeight
+                width: footer.buttonWidth
 
                 navigation.name: "Back"
                 navigation.panel: navBottomPanel
@@ -139,8 +153,8 @@ StyledDialogView {
             }
 
             FlatButton {
-                height: buttons.buttonHeight
-                width: buttons.buttonWidth
+                height: footer.buttonHeight
+                width: footer.buttonWidth
 
                 navigation.name: "Next"
                 navigation.panel: navBottomPanel
@@ -157,8 +171,8 @@ StyledDialogView {
             }
 
             FlatButton {
-                height: buttons.buttonHeight
-                width: buttons.buttonWidth
+                height: footer.buttonHeight
+                width: footer.buttonWidth
 
                 navigation.name: "Done"
                 navigation.panel: navBottomPanel

--- a/src/project/qml/MuseScore/Project/internal/ChooseInstrumentsAndTemplatesPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/ChooseInstrumentsAndTemplatesPage.qml
@@ -33,6 +33,10 @@ Item {
 
     property string preferredScoreCreationMode: ""
 
+    property string description: pagesStack.currentIndex === 0
+                                 ? instrumentsPage.description
+                                 : ""
+
     property NavigationSection navigationSection: null
 
     readonly property bool hasSelection: {


### PR DESCRIPTION
Instrument descriptions are displayed in the bottom left corner of the New Score Wizard dialog. The description text is taken from instruments.xml (i.e. the online instruments spreadsheet).

## Example descriptions

### Timpani

![image](https://user-images.githubusercontent.com/11011881/134895405-ee2b7fe3-ae94-4d65-aa88-f884eabf1b3e.png)

### G Dizi

![image](https://user-images.githubusercontent.com/11011881/134895489-3d9170c8-e7ff-4359-8796-bd1d07cd8e55.png)