### PR TITLE
Fixed crash on score close

### DIFF
--- a/thirdparty/deto_async/async/asyncable.h
+++ b/thirdparty/deto_async/async/asyncable.h
@@ -25,6 +25,8 @@ public:
         virtual void disconnectAsync(Asyncable* a) = 0;
     };
 
+    bool isConnectedAsync() const { return !m_connects.empty(); }
+
     void connectAsync(IConnectable* c)
     {
         if (c && m_connects.count(c) == 0) {

--- a/thirdparty/deto_async/async/internal/abstractinvoker.cpp
+++ b/thirdparty/deto_async/async/internal/abstractinvoker.cpp
@@ -49,6 +49,9 @@ void AbstractInvoker::invoke(int type, const NotifyData& data)
 void AbstractInvoker::invokeCallback(int type, const CallBack& c, const NotifyData& data)
 {
     assert(c.threadID == std::this_thread::get_id());
+    if (c.receiver && !c.receiver->isConnectedAsync()) {
+        return;
+    }
     doInvoke(type, c.call, data);
 }
 


### PR DESCRIPTION
There is an implementation problem in the asynchronous communication system (channels, promises, etc.).
AbstractInvoker uses the CallBack structure by value. It may be that we put CallBack in the queue, but while CallBack is in the queue and has not yet been executed, we can delete it and, accordingly, we do not need to call it. Now, this moment has not been worked out properly.
I will work through this case later. The current solution solves the problem but is rather temporary.