### PR TITLE
Remove unused `physicalLine` method

### DIFF
--- a/src/engraving/libmscore/note.h
+++ b/src/engraving/libmscore/note.h
@@ -425,7 +425,6 @@ public:
 
     int line() const;
     void setLine(int n) { _line = n; }
-    int physicalLine() const;
 
     int fret() const { return _fret; }
     void setFret(int val) { _fret = val; }


### PR DESCRIPTION
Removes the `physicalLine` method declaration as it is unused.

`physicalLine` is not referenced anywhere in the codebase, and it's not even defined. So it's safe to remove, and will improve the code health.