### PR TITLE
Straight flags - follow up 

### DIFF
--- a/src/engraving/libmscore/hook.cpp
+++ b/src/engraving/libmscore/hook.cpp
@@ -26,6 +26,8 @@
 #include "score.h"
 #include "symid.h"
 
+#include "log.h"
+
 using namespace mu;
 using namespace Ms;
 
@@ -44,63 +46,7 @@ void Hook::setHookType(int i)
 {
     bool straight = score()->styleB(Sid::useStraightNoteFlags);
     _hookType = i;
-
-    switch (i) {
-    case 0:
-        break;
-    case 1:
-        setSym(straight ? SymId::flag8thUpStraight : SymId::flag8thUp);
-        break;
-    case 2:
-        setSym(straight ? SymId::flag16thUpStraight : SymId::flag16thUp);
-        break;
-    case 3:
-        setSym(straight ? SymId::flag32ndUpStraight : SymId::flag32ndUp);
-        break;
-    case 4:
-        setSym(straight ? SymId::flag64thUpStraight : SymId::flag64thUp);
-        break;
-    case 5:
-        setSym(straight ? SymId::flag128thUpStraight : SymId::flag128thUp);
-        break;
-    case 6:
-        setSym(straight ? SymId::flag256thUpStraight : SymId::flag256thUp);
-        break;
-    case 7:
-        setSym(straight ? SymId::flag512thUpStraight : SymId::flag512thUp);
-        break;
-    case 8:
-        setSym(straight ? SymId::flag1024thUpStraight : SymId::flag1024thUp);
-        break;
-
-    case -1:
-        setSym(straight ? SymId::flag8thDownStraight : SymId::flag8thDown);
-        break;
-    case -2:
-        setSym(straight ? SymId::flag16thDownStraight : SymId::flag16thDown);
-        break;
-    case -3:
-        setSym(straight ? SymId::flag32ndDownStraight : SymId::flag32ndDown);
-        break;
-    case -4:
-        setSym(straight ? SymId::flag64thDownStraight : SymId::flag64thDown);
-        break;
-    case -5:
-        setSym(straight ? SymId::flag128thDownStraight : SymId::flag128thDown);
-        break;
-    case -6:
-        setSym(straight ? SymId::flag256thDownStraight : SymId::flag256thDown);
-        break;
-    case -7:
-        setSym(straight ? SymId::flag512thDownStraight : SymId::flag512thDown);
-        break;
-    case -8:
-        setSym(straight ? SymId::flag1024thDownStraight : SymId::flag1024thDown);
-        break;
-    default:
-        qDebug("no hook/flag for subtype %d", i);
-        break;
-    }
+    setSym(symIdForHookIndex(i, straight));
 }
 
 void Hook::layout()
@@ -123,4 +69,50 @@ void Hook::draw(mu::draw::Painter* painter) const
 mu::PointF Hook::smuflAnchor() const
 {
     return symSmuflAnchor(_sym, chord()->up() ? SmuflAnchorId::stemUpNW : SmuflAnchorId::stemDownSW);
+}
+
+SymId Hook::symIdForHookIndex(int index, bool straight)
+{
+    switch (index) {
+    case 0:
+        return SymId::noSym;
+    case 1:
+        return straight ? SymId::flag8thUpStraight : SymId::flag8thUp;
+    case 2:
+        return straight ? SymId::flag16thUpStraight : SymId::flag16thUp;
+    case 3:
+        return straight ? SymId::flag32ndUpStraight : SymId::flag32ndUp;
+    case 4:
+        return straight ? SymId::flag64thUpStraight : SymId::flag64thUp;
+    case 5:
+        return straight ? SymId::flag128thUpStraight : SymId::flag128thUp;
+    case 6:
+        return straight ? SymId::flag256thUpStraight : SymId::flag256thUp;
+    case 7:
+        return straight ? SymId::flag512thUpStraight : SymId::flag512thUp;
+    case 8:
+        return straight ? SymId::flag1024thUpStraight : SymId::flag1024thUp;
+
+    case -1:
+        return straight ? SymId::flag8thDownStraight : SymId::flag8thDown;
+    case -2:
+        return straight ? SymId::flag16thDownStraight : SymId::flag16thDown;
+    case -3:
+        return straight ? SymId::flag32ndDownStraight : SymId::flag32ndDown;
+    case -4:
+        return straight ? SymId::flag64thDownStraight : SymId::flag64thDown;
+    case -5:
+        return straight ? SymId::flag128thDownStraight : SymId::flag128thDown;
+    case -6:
+        return straight ? SymId::flag256thDownStraight : SymId::flag256thDown;
+    case -7:
+        return straight ? SymId::flag512thDownStraight : SymId::flag512thDown;
+    case -8:
+        return straight ? SymId::flag1024thDownStraight : SymId::flag1024thDown;
+    default:
+        LOGE() << "No hook/flag for hook index: " << index;
+        break;
+    }
+
+    return SymId::noSym;
 }

--- a/src/engraving/libmscore/hook.h
+++ b/src/engraving/libmscore/hook.h
@@ -25,6 +25,8 @@
 
 #include "symbol.h"
 
+#include "symid.h"
+
 namespace Ms {
 class Chord;
 
@@ -45,6 +47,10 @@ public:
     void draw(mu::draw::Painter*) const override;
     Chord* chord() const { return toChord(parent()); }
     mu::PointF smuflAnchor() const;
+
+    //! @p index: the number of flags (positive: upwards, negative: downwards)
+    //! @p straight: whether to use straight flags
+    static SymId symIdForHookIndex(int index, bool straight);
 };
 }     // namespace Ms
 #endif

--- a/src/engraving/libmscore/shadownote.h
+++ b/src/engraving/libmscore/shadownote.h
@@ -76,7 +76,9 @@ public:
 
     bool computeUp() const;
     SymId noteheadSymbol() const { return m_noteheadSymbol; }
-    SymId getNoteFlag() const;
+    bool hasStem() const;
+    bool hasFlag() const;
+    SymId flagSym() const;
 };
 } // namespace Ms
 #endif

--- a/src/inspector/models/notation/notes/stems/stemsettingsmodel.cpp
+++ b/src/inspector/models/notation/notes/stems/stemsettingsmodel.cpp
@@ -54,6 +54,10 @@ void StemSettingsModel::createProperties()
     m_verticalOffset = buildPropertyItem(Ms::Pid::OFFSET, [this](const Ms::Pid pid, const QVariant& newValue) {
         onPropertyValueChanged(pid, PointF(m_horizontalOffset->value().toDouble(), newValue.toDouble()));
     });
+
+    context()->currentNotation()->style()->styleChanged().onNotify(this, [this]() {
+        emit useStraightNoteFlagsChanged();
+    });
 }
 
 void StemSettingsModel::requestElements()
@@ -124,4 +128,20 @@ PropertyItem* StemSettingsModel::verticalOffset() const
 PropertyItem* StemSettingsModel::stemDirection() const
 {
     return m_stemDirection;
+}
+
+bool StemSettingsModel::useStraightNoteFlags() const
+{
+    return context()->currentNotation()->style()->styleValue(Ms::Sid::useStraightNoteFlags).toBool();
+}
+
+void StemSettingsModel::setUseStraightNoteFlags(bool use)
+{
+    if (use == useStraightNoteFlags()) {
+        return;
+    }
+
+    context()->currentNotation()->undoStack()->prepareChanges();
+    context()->currentNotation()->style()->setStyleValue(Ms::Sid::useStraightNoteFlags, use);
+    context()->currentNotation()->undoStack()->commitChanges();
 }

--- a/src/inspector/models/notation/notes/stems/stemsettingsmodel.h
+++ b/src/inspector/models/notation/notes/stems/stemsettingsmodel.h
@@ -24,8 +24,12 @@
 
 #include "models/abstractinspectormodel.h"
 
+#include "async/asyncable.h"
+#include "modularity/ioc.h"
+#include "context/iglobalcontext.h"
+
 namespace mu::inspector {
-class StemSettingsModel : public AbstractInspectorModel
+class StemSettingsModel : public AbstractInspectorModel, public async::Asyncable
 {
     Q_OBJECT
 
@@ -35,6 +39,11 @@ class StemSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(PropertyItem * horizontalOffset READ horizontalOffset CONSTANT)
     Q_PROPERTY(PropertyItem * verticalOffset READ verticalOffset CONSTANT)
     Q_PROPERTY(PropertyItem * stemDirection READ stemDirection CONSTANT)
+
+    Q_PROPERTY(bool useStraightNoteFlags READ useStraightNoteFlags WRITE setUseStraightNoteFlags NOTIFY useStraightNoteFlagsChanged)
+
+    INJECT(inspector, context::IGlobalContext, context)
+
 public:
     explicit StemSettingsModel(QObject* parent, IElementRepositoryService* repository);
 
@@ -45,6 +54,12 @@ public:
     PropertyItem* horizontalOffset() const;
     PropertyItem* verticalOffset() const;
     PropertyItem* stemDirection() const;
+
+    bool useStraightNoteFlags() const;
+    void setUseStraightNoteFlags(bool use);
+
+signals:
+    void useStraightNoteFlagsChanged();
 
 protected:
     void createProperties() override;

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/notes/StemSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/notes/StemSettings.qml
@@ -71,6 +71,56 @@ FocusableItem {
             ]
         }
 
+        Column {
+            width: parent.width
+            height: childrenRect.height
+            spacing: 8
+
+            StyledTextLabel {
+                width: parent.width
+                text: qsTrc("inspector", "Flag style")
+                horizontalAlignment: Text.AlignLeft
+            }
+
+            RadioButtonGroup {
+                width: parent.width
+                height: 70
+
+                model: [
+                    { iconCode: IconCode.NOTEFLAGS_TRADITIONAL, text: qsTrc("inspector", "Traditional", "Note flags"), value: false },
+                    { iconCode: IconCode.NOTEFLAGS_STRAIGHT, text: qsTrc("inspector", "Straight", "Note flags"), value: true }
+                ]
+
+                delegate: FlatRadioButton {
+                    height: 70
+
+                    Column {
+                        anchors.centerIn: parent
+                        height: childrenRect.height
+                        spacing: 8
+
+                        StyledIconLabel {
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            iconCode: modelData.iconCode
+                            font.pixelSize: 32
+                        }
+
+                        StyledTextLabel {
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            text: modelData.text
+                        }
+                    }
+
+                    checked: root.stemModel && root.stemModel.useStraightNoteFlags === modelData.value
+                    onToggled: {
+                        if (root.stemModel) {
+                            root.stemModel.useStraightNoteFlags = modelData.value
+                        }
+                    }
+                }
+            }
+        }
+
         ExpandableBlank {
             isExpanded: false
 


### PR DESCRIPTION
- Adds the flag style selector to the Stem section in the Inspector
  <img width="300" alt="Schermafbeelding 2021-09-28 om 23 54 19" src="https://user-images.githubusercontent.com/48658420/135171013-9a074e0e-f371-4c45-9dee-f729987e1fb3.png">

- Makes the Shadow Note follow the flag style of the score
  <img width="465" alt="Schermafbeelding 2021-09-28 om 23 53 38" src="https://user-images.githubusercontent.com/48658420/135170936-d9f053c4-6734-4a9d-95f0-f6312be9c4eb.png">
  