### PR TITLE
[MU4] vst_plugins_persistence

### DIFF
--- a/src/framework/audio/audiotypes.h
+++ b/src/framework/audio/audiotypes.h
@@ -53,6 +53,7 @@ using AudioSourceName = std::string;
 using AudioResourceId = std::string;
 using AudioResourceIdList = std::vector<AudioResourceId>;
 using AudioResourceVendor = std::string;
+using AudioUnitConfig = std::map<std::string, std::string>;
 
 enum class AudioResourceType {
     Undefined = -1,
@@ -116,7 +117,6 @@ enum class AudioFxCategory {
 };
 
 using AudioFxCategories = std::set<AudioFxCategory>;
-
 using AudioFxChainOrder = int8_t;
 
 struct AudioFxParams {
@@ -131,6 +131,7 @@ struct AudioFxParams {
     AudioFxCategories categories;
     AudioFxChainOrder chainOrder = -1;
     AudioResourceMeta resourceMeta;
+    AudioUnitConfig configuration;
     bool active = false;
 
     bool operator ==(const AudioFxParams& other) const
@@ -138,7 +139,8 @@ struct AudioFxParams {
         return resourceMeta == other.resourceMeta
                && active == other.active
                && chainOrder == other.chainOrder
-               && categories == other.categories;
+               && categories == other.categories
+               && configuration == other.configuration;
     }
 
     bool operator<(const AudioFxParams& other) const
@@ -189,6 +191,7 @@ struct AudioSourceParams {
     }
 
     AudioResourceMeta resourceMeta;
+    AudioUnitConfig configuration;
 
     bool isValid() const
     {
@@ -199,7 +202,8 @@ struct AudioSourceParams {
     bool operator ==(const AudioSourceParams& other) const
     {
         return type() == other.type()
-               && resourceMeta == other.resourceMeta;
+               && resourceMeta == other.resourceMeta
+               && configuration == other.configuration;
     }
 };
 

--- a/src/framework/audio/ifxprocessor.h
+++ b/src/framework/audio/ifxprocessor.h
@@ -34,6 +34,7 @@ public:
 
     virtual AudioFxType type() const = 0;
     virtual const AudioFxParams& params() const = 0;
+    virtual async::Channel<audio::AudioFxParams> paramsChanged() const = 0;
     virtual void setSampleRate(unsigned int sampleRate) = 0;
 
     virtual bool active() const = 0;

--- a/src/framework/audio/internal/audioconfiguration.cpp
+++ b/src/framework/audio/internal/audioconfiguration.cpp
@@ -126,7 +126,10 @@ void AudioConfiguration::setIsShowControlsInMixer(bool show)
 
 AudioInputParams AudioConfiguration::defaultAudioInputParams() const
 {
-    return { DEFAULT_AUDIO_RESOURCE_META };
+    AudioInputParams result;
+    result.resourceMeta = DEFAULT_AUDIO_RESOURCE_META;
+
+    return result;
 }
 
 const SynthesizerState& AudioConfiguration::defaultSynthesizerState() const

--- a/src/framework/audio/internal/fx/fxresolver.cpp
+++ b/src/framework/audio/internal/fx/fxresolver.cpp
@@ -46,7 +46,7 @@ std::vector<IFxProcessorPtr> FxResolver::resolveMasterFxList(const AudioFxChain&
         AudioFxChain fxChainByType;
 
         for (const auto& fx : fxChain) {
-            if (resolver.first == fx.second.type()) {
+            if (resolver.first == fx.second.type() || fx.second.type() == AudioFxType::Undefined) {
                 fxChainByType.insert(fx);
             }
         }
@@ -76,7 +76,7 @@ std::vector<IFxProcessorPtr> FxResolver::resolveFxList(const TrackId trackId, co
         AudioFxChain fxChainByType;
 
         for (const auto& fx : fxChain) {
-            if (resolver.first == fx.second.type()) {
+            if (resolver.first == fx.second.type() || fx.second.type() == AudioFxType::Undefined) {
                 fxChainByType.insert(fx);
             }
         }

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidresolver.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidresolver.cpp
@@ -50,17 +50,17 @@ FluidResolver::FluidResolver(const io::paths& soundFontDirs, async::Channel<io::
     });
 }
 
-ISynthesizerPtr FluidResolver::resolveSynth(const TrackId /*trackId*/, const AudioResourceId& resourceId) const
+ISynthesizerPtr FluidResolver::resolveSynth(const TrackId /*trackId*/, const AudioInputParams& params) const
 {
     ONLY_AUDIO_WORKER_THREAD;
 
-    ISynthesizerPtr synth = std::make_shared<FluidSynth>();
+    ISynthesizerPtr synth = std::make_shared<FluidSynth>(params);
     synth->init();
 
-    auto search = m_resourcesCache.find(resourceId);
+    auto search = m_resourcesCache.find(params.resourceMeta.id);
 
     if (search == m_resourcesCache.end()) {
-        LOGE() << "Not found: " << resourceId;
+        LOGE() << "Not found: " << params.resourceMeta.id;
         return synth;
     }
 

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidresolver.h
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidresolver.h
@@ -40,7 +40,7 @@ class FluidResolver : public ISynthResolver::IResolver, public async::Asyncable
 public:
     explicit FluidResolver(const io::paths& soundFontDirs, async::Channel<io::paths> sfDirsChanges);
 
-    ISynthesizerPtr resolveSynth(const audio::TrackId trackId, const audio::AudioResourceId& resourceId) const override;
+    ISynthesizerPtr resolveSynth(const audio::TrackId trackId, const audio::AudioInputParams& params) const override;
     audio::AudioResourceMetaList resolveResources() const override;
 
     void refresh() override;

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
@@ -56,8 +56,9 @@ struct mu::audio::synth::Fluid {
     }
 };
 
-FluidSynth::FluidSynth()
+FluidSynth::FluidSynth(const AudioSourceParams& params)
 {
+    m_params = params;
     m_fluid = std::make_shared<Fluid>();
 }
 
@@ -74,6 +75,16 @@ std::string FluidSynth::name() const
 AudioSourceType FluidSynth::type() const
 {
     return AudioSourceType::Fluid;
+}
+
+const AudioInputParams& FluidSynth::params() const
+{
+    return m_params;
+}
+
+async::Channel<AudioInputParams> FluidSynth::paramsChanged() const
+{
+    return m_paramsChanges;
 }
 
 SoundFontFormats FluidSynth::soundFontFormats() const

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.h
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.h
@@ -37,12 +37,14 @@ struct Fluid;
 class FluidSynth : public ISynthesizer
 {
 public:
-    FluidSynth();
+    FluidSynth(const audio::AudioSourceParams& params);
 
     bool isValid() const override;
 
     std::string name() const override;
     AudioSourceType type() const override;
+    const audio::AudioInputParams& params() const override;
+    async::Channel<audio::AudioInputParams> paramsChanged() const override;
     SoundFontFormats soundFontFormats() const override;
 
     Ret init() override;
@@ -92,6 +94,8 @@ private:
     bool m_isActive = false;
 
     unsigned int m_sampleRate = 0;
+    audio::AudioInputParams m_params;
+    async::Channel<audio::AudioInputParams> m_paramsChanges;
     async::Channel<unsigned int> m_streamsCountChanged;
 };
 

--- a/src/framework/audio/internal/synthesizers/synthresolver.cpp
+++ b/src/framework/audio/internal/synthesizers/synthresolver.cpp
@@ -50,7 +50,7 @@ ISynthesizerPtr SynthResolver::resolveSynth(const TrackId trackId, const AudioIn
 
     TRACEFUNC;
 
-    IF_ASSERT_FAILED(params.isValid()) {
+    if (!params.isValid()) {
         LOGE() << "invalid audio source params for trackId: " << trackId;
         return nullptr;
     }
@@ -64,7 +64,7 @@ ISynthesizerPtr SynthResolver::resolveSynth(const TrackId trackId, const AudioIn
     }
 
     const IResolverPtr& resolver = search->second;
-    return resolver->resolveSynth(trackId, params.resourceMeta.id);
+    return resolver->resolveSynth(trackId, params);
 }
 
 ISynthesizerPtr SynthResolver::resolveDefaultSynth(const TrackId trackId) const

--- a/src/framework/audio/internal/worker/igettracks.h
+++ b/src/framework/audio/internal/worker/igettracks.h
@@ -23,6 +23,8 @@
 #ifndef MU_AUDIO_IGETTRACKS_H
 #define MU_AUDIO_IGETTRACKS_H
 
+#include "async/channel.h"
+
 #include "track.h"
 #include "audiotypes.h"
 
@@ -34,6 +36,9 @@ public:
 
     virtual TrackPtr track(const TrackId id) const = 0;
     virtual TracksMap allTracks() const = 0;
+
+    virtual async::Channel<TrackPtr> trackAboutToBeAdded() const = 0;
+    virtual async::Channel<TrackPtr> trackAboutToBeRemoved() const = 0;
 };
 }
 

--- a/src/framework/audio/internal/worker/midiaudiosource.h
+++ b/src/framework/audio/internal/worker/midiaudiosource.h
@@ -56,7 +56,11 @@ public:
     samples_t process(float* buffer, samples_t samplesPerChannel) override;
 
     void seek(const msecs_t newPositionMsecs) override;
-    void applyInputParams(const AudioInputParams& originParams, AudioInputParams& resultParams) override;
+
+    const AudioInputParams& inputParams() const override;
+    void applyInputParams(const AudioInputParams& requiredParams) override;
+    async::Channel<AudioInputParams> inputParamsChanged() const override;
+
 
 private:
     struct EventsBuffer {
@@ -139,6 +143,7 @@ private:
     TrackId m_trackId = -1;
     synth::ISynthesizerPtr m_synth = nullptr;
     AudioInputParams m_params;
+    async::Channel<AudioInputParams> m_paramsChanges;
 
     midi::MidiStream m_stream;
     midi::MidiMapping m_mapping;

--- a/src/framework/audio/internal/worker/midiaudiosource.h
+++ b/src/framework/audio/internal/worker/midiaudiosource.h
@@ -61,7 +61,6 @@ public:
     void applyInputParams(const AudioInputParams& requiredParams) override;
     async::Channel<AudioInputParams> inputParamsChanged() const override;
 
-
 private:
     struct EventsBuffer {
         midi::tick_t size = 480 * 4 * 10;

--- a/src/framework/audio/internal/worker/mixerchannel.h
+++ b/src/framework/audio/internal/worker/mixerchannel.h
@@ -39,7 +39,9 @@ class MixerChannel : public ITrackAudioOutput, public async::Asyncable
 public:
     explicit MixerChannel(const TrackId trackId, IAudioSourcePtr source, const unsigned int sampleRate);
 
-    void applyOutputParams(const AudioOutputParams& originParams, AudioOutputParams& resultParams) override;
+    const AudioOutputParams& outputParams() const override;
+    void applyOutputParams(const AudioOutputParams& requiredParams) override;
+    async::Channel<AudioOutputParams> outputParamsChanged() const override;
 
     async::Channel<audioch_t, float> signalAmplitudeRmsChanged() const override;
     async::Channel<audioch_t, volume_dbfs_t> volumePressureDbfsChanged() const override;
@@ -66,6 +68,7 @@ private:
 
     dsp::CompressorPtr m_compressor = nullptr;
 
+    mutable async::Channel<AudioOutputParams> m_paramsChanges;
     mutable async::Channel<audioch_t, float> m_signalAmplitudeRmsChanged;
     mutable async::Channel<audioch_t, volume_dbfs_t> m_volumePressureDbfsChanged;
 };

--- a/src/framework/audio/internal/worker/sequenceio.cpp
+++ b/src/framework/audio/internal/worker/sequenceio.cpp
@@ -46,7 +46,7 @@ SequenceIO::SequenceIO(IGetTracks* getTracks)
         });
 
         trackPtr->outputParamsChanged().onReceive(this, [this, id](const AudioOutputParams& params) {
-           m_outputParamsChanged.send(id, params);
+            m_outputParamsChanged.send(id, params);
         });
     });
 

--- a/src/framework/audio/internal/worker/sequenceio.h
+++ b/src/framework/audio/internal/worker/sequenceio.h
@@ -23,12 +23,14 @@
 #ifndef MU_AUDIO_SEQUENCEIO_H
 #define MU_AUDIO_SEQUENCEIO_H
 
+#include "async/asyncable.h"
+
 #include "isequenceio.h"
 #include "igettracks.h"
 #include "audiotypes.h"
 
 namespace mu::audio {
-class SequenceIO : public ISequenceIO
+class SequenceIO : public ISequenceIO, public async::Asyncable
 {
 public:
     explicit SequenceIO(IGetTracks* getTracks);

--- a/src/framework/audio/internal/worker/track.h
+++ b/src/framework/audio/internal/worker/track.h
@@ -143,6 +143,7 @@ public:
 
         return inputHandler->inputParamsChanged();
     }
+
     async::Channel<AudioOutputParams> outputParamsChanged()
     {
         if (!outputHandler) {

--- a/src/framework/audio/internal/worker/tracksequence.h
+++ b/src/framework/audio/internal/worker/tracksequence.h
@@ -64,6 +64,9 @@ public:
     TrackPtr track(const TrackId id) const override;
     TracksMap allTracks() const override;
 
+    async::Channel<TrackPtr> trackAboutToBeAdded() const override;
+    async::Channel<TrackPtr> trackAboutToBeRemoved() const override;
+
 private:
     std::shared_ptr<Mixer> mixer() const;
 
@@ -78,6 +81,9 @@ private:
 
     async::Channel<TrackId> m_trackAdded;
     async::Channel<TrackId> m_trackRemoved;
+
+    async::Channel<TrackPtr> m_trackAboutToBeAdded;
+    async::Channel<TrackPtr> m_trackAboutToBeRemoved;
 };
 }
 

--- a/src/framework/audio/isynthesizer.h
+++ b/src/framework/audio/isynthesizer.h
@@ -23,10 +23,13 @@
 #ifndef MU_AUDIO_ISYNTHESIZER_H
 #define MU_AUDIO_ISYNTHESIZER_H
 
+#include "async/channel.h"
 #include "io/path.h"
 #include "ret.h"
-#include "synthtypes.h"
 #include "midi/miditypes.h"
+
+#include "synthtypes.h"
+#include "audiotypes.h"
 #include "iaudiosource.h"
 
 namespace mu::audio::synth {
@@ -39,6 +42,8 @@ public:
 
     virtual std::string name() const = 0;
     virtual AudioSourceType type() const = 0;
+    virtual const audio::AudioInputParams& params() const = 0;
+    virtual async::Channel<audio::AudioInputParams> paramsChanged() const = 0;
     virtual SoundFontFormats soundFontFormats() const = 0;
 
     virtual Ret init() = 0;

--- a/src/framework/audio/isynthresolver.h
+++ b/src/framework/audio/isynthresolver.h
@@ -43,7 +43,7 @@ public:
     public:
         virtual ~IResolver() = default;
 
-        virtual ISynthesizerPtr resolveSynth(const audio::TrackId trackId, const audio::AudioResourceId& resourceId) const = 0;
+        virtual ISynthesizerPtr resolveSynth(const audio::TrackId trackId, const audio::AudioInputParams& params) const = 0;
         virtual audio::AudioResourceMetaList resolveResources() const = 0;
         virtual void refresh() = 0;
     };

--- a/src/framework/vst/CMakeLists.txt
+++ b/src/framework/vst/CMakeLists.txt
@@ -45,6 +45,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/vstconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/vstplugin.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/vstplugin.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/vstcomponenthandler.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/vstcomponenthandler.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/vstaudioclient.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/vstaudioclient.h
 

--- a/src/framework/vst/internal/fx/vstfxprocessor.h
+++ b/src/framework/vst/internal/fx/vstfxprocessor.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 
+#include "async/asyncable.h"
 #include "audio/ifxprocessor.h"
 
 #include "internal/vstaudioclient.h"
@@ -10,7 +11,7 @@
 #include "vsttypes.h"
 
 namespace mu::vst {
-class VstFxProcessor : public audio::IFxProcessor
+class VstFxProcessor : public audio::IFxProcessor, public async::Asyncable
 {
 public:
     explicit VstFxProcessor(VstPluginPtr&& pluginPtr, const audio::AudioFxParams& params);
@@ -19,6 +20,7 @@ public:
 
     audio::AudioFxType type() const override;
     const audio::AudioFxParams& params() const override;
+    async::Channel<audio::AudioFxParams> paramsChanged() const override;
     void setSampleRate(unsigned int sampleRate) override;
     bool active() const override;
     void setActive(bool active) override;
@@ -29,6 +31,7 @@ private:
     std::unique_ptr<VstAudioClient> m_vstAudioClient = nullptr;
 
     audio::AudioFxParams m_params;
+    async::Channel<audio::AudioFxParams> m_paramsChanges;
 };
 
 using VstFxPtr = std::shared_ptr<VstFxProcessor>;

--- a/src/framework/vst/internal/fx/vstfxresolver.cpp
+++ b/src/framework/vst/internal/fx/vstfxresolver.cpp
@@ -32,7 +32,7 @@ bool filterFxParams(const std::pair<AudioFxChainOrder, AudioFxParams>& f,
                     const std::pair<AudioFxChainOrder, AudioFxParams>& s)
 {
     return (f.first == s.first) && !(f.second == s.second);
-};
+}
 
 std::vector<IFxProcessorPtr> VstFxResolver::resolveFxList(const audio::TrackId trackId, const AudioFxChain& fxChain)
 {

--- a/src/framework/vst/internal/synth/vstiresolver.h
+++ b/src/framework/vst/internal/synth/vstiresolver.h
@@ -38,12 +38,12 @@ class VstiResolver : public audio::synth::ISynthResolver::IResolver
     INJECT(vst, IVstModulesRepository, pluginModulesRepo)
     INJECT(vst, IVstPluginsRegister, pluginsRegister)
 public:
-    audio::synth::ISynthesizerPtr resolveSynth(const audio::TrackId trackId, const audio::AudioResourceId& resourceId) const override;
+    audio::synth::ISynthesizerPtr resolveSynth(const audio::TrackId trackId, const audio::AudioInputParams& params) const override;
     audio::AudioResourceMetaList resolveResources() const override;
     void refresh() override;
 
 private:
-    VstSynthPtr createSynth(const audio::TrackId trackId, const audio::AudioResourceId& resourceId) const;
+    VstSynthPtr createSynth(const audio::TrackId trackId, const audio::AudioInputParams &params) const;
 
     using SynthPair = std::pair<audio::AudioResourceId, VstSynthPtr>;
 

--- a/src/framework/vst/internal/synth/vstiresolver.h
+++ b/src/framework/vst/internal/synth/vstiresolver.h
@@ -43,7 +43,7 @@ public:
     void refresh() override;
 
 private:
-    VstSynthPtr createSynth(const audio::TrackId trackId, const audio::AudioInputParams &params) const;
+    VstSynthPtr createSynth(const audio::TrackId trackId, const audio::AudioInputParams& params) const;
 
     using SynthPair = std::pair<audio::AudioResourceId, VstSynthPtr>;
 

--- a/src/framework/vst/internal/synth/vstsynthesiser.h
+++ b/src/framework/vst/internal/synth/vstsynthesiser.h
@@ -25,6 +25,7 @@
 
 #include <memory>
 
+#include "async/asyncable.h"
 #include "audio/isynthesizer.h"
 #include "audio/iaudioconfiguration.h"
 #include "audio/audiotypes.h"
@@ -36,14 +37,14 @@
 #include "vsttypes.h"
 
 namespace mu::vst {
-class VstSynthesiser : public audio::synth::ISynthesizer
+class VstSynthesiser : public audio::synth::ISynthesizer, public async::Asyncable
 {
     INJECT(vst, IVstPluginsRegister, pluginsRegister)
     INJECT(vst, IVstModulesRepository, modulesRepo)
     INJECT(vst, audio::IAudioConfiguration, config)
 
 public:
-    explicit VstSynthesiser(VstPluginPtr&& pluginPtr);
+    explicit VstSynthesiser(VstPluginPtr&& pluginPtr, const audio::AudioInputParams& params);
 
     Ret init() override;
 
@@ -53,6 +54,9 @@ public:
 
     audio::AudioSourceType type() const override;
     std::string name() const override;
+
+    const audio::AudioInputParams& params() const override;
+    async::Channel<audio::AudioInputParams> paramsChanged() const override;
 
     audio::synth::SoundFontFormats soundFontFormats() const override;
     Ret addSoundFonts(const std::vector<io::path>& sfonts) override;
@@ -81,6 +85,9 @@ private:
 
     bool m_isActive = false;
 
+    audio::AudioInputParams m_params;
+
+    async::Channel<audio::AudioInputParams> m_paramsChanges;
     async::Channel<unsigned int> m_streamsCountChanged;
 };
 

--- a/src/framework/vst/internal/vstaudioclient.cpp
+++ b/src/framework/vst/internal/vstaudioclient.cpp
@@ -29,7 +29,7 @@ using namespace mu::vst;
 
 VstAudioClient::~VstAudioClient()
 {
-    if (!pluginComponent()) {
+    if (!m_pluginComponent) {
         return;
     }
 
@@ -134,8 +134,12 @@ IAudioProcessorPtr VstAudioClient::pluginProcessor() const
 
 PluginComponentPtr VstAudioClient::pluginComponent() const
 {
+    IF_ASSERT_FAILED(m_pluginPtr && m_pluginPtr->provider()) {
+        return nullptr;
+    }
+
     if (!m_pluginComponent) {
-        m_pluginComponent = m_pluginPtr->component();
+        m_pluginComponent = m_pluginPtr->provider()->getComponent();
     }
 
     return m_pluginComponent;

--- a/src/framework/vst/internal/vstcomponenthandler.cpp
+++ b/src/framework/vst/internal/vstcomponenthandler.cpp
@@ -1,0 +1,40 @@
+#include "vstcomponenthandler.h"
+
+using namespace mu::vst;
+using namespace mu::async;
+
+IMPLEMENT_FUNKNOWN_METHODS(VstComponentHandler, IComponentHandler, IComponentHandler::iid)
+
+Channel<PluginParamId, PluginParamValue> VstComponentHandler::pluginParamChanged() const
+{
+    return m_paramChanged;
+}
+
+Notification VstComponentHandler::pluginParamsChanged() const
+{
+    return m_paramsChangedNotify;
+}
+
+Steinberg::tresult VstComponentHandler::beginEdit(Steinberg::Vst::ParamID /*id*/)
+{
+    return Steinberg::kResultOk;
+}
+
+Steinberg::tresult VstComponentHandler::performEdit(Steinberg::Vst::ParamID id, Steinberg::Vst::ParamValue valueNormalized)
+{
+    m_paramChanged.send(std::move(id), std::move(valueNormalized));
+
+    return Steinberg::kResultOk;
+}
+
+Steinberg::tresult VstComponentHandler::endEdit(Steinberg::Vst::ParamID /*id*/)
+{
+    m_paramsChangedNotify.notify();
+
+    return Steinberg::kResultOk;
+}
+
+Steinberg::tresult VstComponentHandler::restartComponent(Steinberg::int32 /*flags*/)
+{
+    return Steinberg::kResultOk;
+}

--- a/src/framework/vst/internal/vstcomponenthandler.h
+++ b/src/framework/vst/internal/vstcomponenthandler.h
@@ -1,0 +1,30 @@
+#ifndef MU_VST_VSTCOMPONENTHANDLER_H
+#define MU_VST_VSTCOMPONENTHANDLER_H
+
+#include "async/notification.h"
+#include "async/channel.h"
+
+#include "vsttypes.h"
+
+namespace mu::vst {
+class VstComponentHandler : public IComponentHandler
+{
+    DECLARE_FUNKNOWN_METHODS
+public:
+    VstComponentHandler() = default;
+
+    async::Channel<PluginParamId, PluginParamValue> pluginParamChanged() const;
+    async::Notification pluginParamsChanged() const;
+
+private:
+    Steinberg::tresult beginEdit(Steinberg::Vst::ParamID id) override;
+    Steinberg::tresult performEdit(Steinberg::Vst::ParamID id, Steinberg::Vst::ParamValue valueNormalized) override;
+    Steinberg::tresult endEdit(Steinberg::Vst::ParamID id) override;
+    Steinberg::tresult restartComponent(Steinberg::int32 flags) override;
+
+    async::Channel<PluginParamId, PluginParamValue> m_paramChanged;
+    async::Notification m_paramsChangedNotify;
+};
+}
+
+#endif // MU_VST_VSTCOMPONENTHANDLER_H

--- a/src/framework/vst/internal/vstplugin.cpp
+++ b/src/framework/vst/internal/vstplugin.cpp
@@ -106,13 +106,11 @@ void VstPlugin::rescanParams()
 
     audio::AudioUnitConfig updatedConfig;
 
-    VstMemoryStream componentStateBuffer;
-    component->getState(&componentStateBuffer);
-    updatedConfig.emplace(COMPONENT_STATE_KEY, std::string(componentStateBuffer.getData(), componentStateBuffer.getSize()));
+    component->getState(&m_componentStateBuffer);
+    updatedConfig.emplace(COMPONENT_STATE_KEY, std::string(m_componentStateBuffer.getData(), m_componentStateBuffer.getSize()));
 
-    VstMemoryStream controllerStateBuffer;
-    controller->getState(&controllerStateBuffer);
-    updatedConfig.emplace(CONTROLLER_STATE_KEY, std::string(controllerStateBuffer.getData(), controllerStateBuffer.getSize()));
+    controller->getState(&m_controllerStateBuffer);
+    updatedConfig.emplace(CONTROLLER_STATE_KEY, std::string(m_controllerStateBuffer.getData(), m_controllerStateBuffer.getSize()));
 
     for (int32_t i = 0; i < controller->getParameterCount(); ++i) {
         PluginParamInfo info;
@@ -182,18 +180,15 @@ void VstPlugin::updatePluginConfig(const audio::AudioUnitConfig& config)
 
     for (auto& pair : config) {
         if (pair.first == COMPONENT_STATE_KEY) {
-            VstMemoryStream componentStateBuffer;
-            stateBufferFromString(componentStateBuffer, const_cast<char*>(pair.second.data()), pair.second.size());
-            component->setState(&componentStateBuffer);
-            controller->setComponentState(&componentStateBuffer);
-
+            stateBufferFromString(m_componentStateBuffer, const_cast<char*>(pair.second.data()), pair.second.size());
+            component->setState(&m_componentStateBuffer);
+            controller->setComponentState(&m_componentStateBuffer);
             continue;
         }
 
         if (pair.first == CONTROLLER_STATE_KEY) {
-            VstMemoryStream controllerStateBuffer;
-            stateBufferFromString(controllerStateBuffer, const_cast<char*>(pair.second.data()), pair.second.size());
-            controller->setState(&controllerStateBuffer);
+            stateBufferFromString(m_controllerStateBuffer, const_cast<char*>(pair.second.data()), pair.second.size());
+            controller->setState(&m_controllerStateBuffer);
 
             continue;
         }

--- a/src/framework/vst/internal/vstplugin.h
+++ b/src/framework/vst/internal/vstplugin.h
@@ -71,7 +71,8 @@ private:
 
     VstComponentHandler m_componentHandler;
 
-    VstMemoryStream m_pluginStateBuffer;
+    VstMemoryStream m_componentStateBuffer;
+    VstMemoryStream m_controllerStateBuffer;
     mutable async::Channel<audio::AudioUnitConfig> m_pluginSettingsChanges;
 
     std::atomic_bool m_isLoaded = false;

--- a/src/framework/vst/internal/vstplugin.h
+++ b/src/framework/vst/internal/vstplugin.h
@@ -63,7 +63,7 @@ public:
 
 private:
     void rescanParams();
-    void stateBufferFromString(VstMemoryStream &buffer, char *strData, const size_t strSize) const;
+    void stateBufferFromString(VstMemoryStream& buffer, char* strData, const size_t strSize) const;
 
     PluginModulePtr m_module = nullptr;
     PluginProviderPtr m_pluginProvider = nullptr;

--- a/src/framework/vst/sdk/CMakeLists.txt
+++ b/src/framework/vst/sdk/CMakeLists.txt
@@ -118,6 +118,8 @@ set(VST_SDK_COMMON_SRC
     ${VST3_SDK_PATH}/public.sdk/source/common/threadchecker.h
     ${VST3_SDK_PATH}/public.sdk/source/common/pluginview.cpp
     ${VST3_SDK_PATH}/public.sdk/source/common/pluginview.h
+    ${VST3_SDK_PATH}/public.sdk/source/common/memorystream.cpp
+    ${VST3_SDK_PATH}/public.sdk/source/common/memorystream.h
     ${VST3_SDK_PATH}/public.sdk/source/main/pluginfactory.cpp
     ${VST3_SDK_PATH}/public.sdk/source/main/pluginfactory.h
     )

--- a/src/framework/vst/view/vstfxeditorview.h
+++ b/src/framework/vst/view/vstfxeditorview.h
@@ -26,12 +26,13 @@
 #include <QDialog>
 #include <QWidget>
 
+#include "async/asyncable.h"
 #include "modularity/ioc.h"
 
 #include "ivstpluginsregister.h"
 
 namespace mu::vst {
-class VstFxEditorView : public QDialog, public Steinberg::IPlugFrame
+class VstFxEditorView : public QDialog, public Steinberg::IPlugFrame, public async::Asyncable
 {
     Q_OBJECT
 
@@ -66,9 +67,11 @@ signals:
 private:
     bool isAbleToWrapPlugin() const;
     void wrapPluginView();
+    void attachView(VstPluginPtr pluginPtr);
 
     FIDString currentPlatformUiType() const;
 
+    VstPluginPtr m_pluginPtr = nullptr;
     PluginViewPtr m_view = nullptr;
 
     audio::TrackId m_trackId = -1;

--- a/src/framework/vst/view/vstieditorview.h
+++ b/src/framework/vst/view/vstieditorview.h
@@ -26,12 +26,13 @@
 #include <QDialog>
 #include <QWidget>
 
+#include "async/asyncable.h"
 #include "modularity/ioc.h"
 
 #include "ivstpluginsregister.h"
 
 namespace mu::vst {
-class VstiEditorView : public QDialog, public Steinberg::IPlugFrame
+class VstiEditorView : public QDialog, public Steinberg::IPlugFrame, public async::Asyncable
 {
     Q_OBJECT
 
@@ -61,9 +62,11 @@ signals:
 
 private:
     void wrapPluginView();
+    void attachView(VstPluginPtr pluginPtr);
 
     FIDString currentPlatformUiType() const;
 
+    VstPluginPtr m_pluginPtr = nullptr;
     PluginViewPtr m_view = nullptr;
 
     audio::TrackId m_trackId = -1;

--- a/src/framework/vst/vsttypes.h
+++ b/src/framework/vst/vsttypes.h
@@ -30,6 +30,8 @@
 #include "public.sdk/source/vst/hosting/hostclasses.h"
 #include "public.sdk/source/vst/hosting/eventlist.h"
 #include "public.sdk/source/vst/hosting/processdata.h"
+#include "public.sdk/source/vst/hosting/parameterchanges.h"
+#include "public.sdk/source/common/memorystream.h"
 #include "pluginterfaces/gui/iplugview.h"
 #include "pluginterfaces/vst/ivstaudioprocessor.h"
 #include "pluginterfaces/vst/ivsteditcontroller.h"
@@ -54,7 +56,12 @@ using PluginProvider = Steinberg::Vst::PlugProvider;
 using PluginControllerPtr = Steinberg::IPtr<Steinberg::Vst::IEditController>;
 using PluginComponentPtr = Steinberg::IPtr<Steinberg::Vst::IComponent>;
 using PluginViewPtr = Steinberg::IPtr<Steinberg::IPlugView>;
+using PluginParamInfo = Steinberg::Vst::ParameterInfo;
+using PluginParamId = Steinberg::Vst::ParamID;
+using PluginParamValue = Steinberg::Vst::ParamValue;
 using IAudioProcessorPtr = Steinberg::FUnknownPtr<Steinberg::Vst::IAudioProcessor>;
+using IComponentHandler = Steinberg::Vst::IComponentHandler;
+using IAdvancedComponentHandler = Steinberg::Vst::IComponentHandler2;
 using FIDString = Steinberg::FIDString;
 
 enum class VstPluginType {
@@ -86,6 +93,7 @@ using VstEvent = Steinberg::Vst::Event;
 using VstProcessData = Steinberg::Vst::HostProcessData;
 using VstProcessContext = Steinberg::Vst::ProcessContext;
 using VstProcessSetup = Steinberg::Vst::ProcessSetup;
+using VstMemoryStream = Steinberg::MemoryStream;
 
 namespace PluginEditorViewType = Steinberg::Vst::ViewType;
 }

--- a/src/playback/view/internal/abstractaudioresourceitem.cpp
+++ b/src/playback/view/internal/abstractaudioresourceitem.cpp
@@ -7,7 +7,7 @@ using namespace mu::playback;
 
 //!Note Some resources like VST plugins are not able to work in a couple of msecs
 //!     So we've to add explicit delay before the launching their 'native' editor views
-static constexpr int EXPLICIT_DELAY_MSECS = 3000;
+static constexpr int EXPLICIT_DELAY_MSECS = 1000;
 
 AbstractAudioResourceItem::AbstractAudioResourceItem(QObject* parent)
     : QObject(parent)

--- a/src/playback/view/internal/mixerchannelitem.cpp
+++ b/src/playback/view/internal/mixerchannelitem.cpp
@@ -133,16 +133,13 @@ void MixerChannelItem::loadOutputParams(AudioOutputParams&& newParams)
         m_outputResourceItemList.clear();
 
         for (int i = 0; i < OUTPUT_RESOURCE_COUNT_LIMIT; ++i) {
-            AudioFxParams& params = newParams.fxChain[i];
-            params.chainOrder = i;
-
-            m_outputResourceItemList << buildOutputResourceItem(params);
+            m_outputResourceItemList << buildOutputResourceItem(newParams.fxChain[i]);
         }
+
+        emit outputResourceItemListChanged(m_outputResourceItemList);
     }
 
     ensureBlankOutputResourceSlot();
-
-    emit outputResourceItemListChanged(m_outputResourceItemList);
 }
 
 void MixerChannelItem::subscribeOnAudioSignalChanges(AudioSignalChanges&& audioSignalChanges)

--- a/src/playback/view/internal/outputresourceitem.cpp
+++ b/src/playback/view/internal/outputresourceitem.cpp
@@ -130,8 +130,8 @@ void OutputResourceItem::updateCurrentFxParams(const AudioResourceMeta& newMeta)
 
     emit isActiveChanged();
     emit titleChanged();
-    emit isBlankChanged();
     emit fxParamsChanged();
+    emit isBlankChanged();
 
     requestToLaunchNativeEditorView();
 }

--- a/src/playback/view/mixerpanelmodel.cpp
+++ b/src/playback/view/mixerpanelmodel.cpp
@@ -154,6 +154,13 @@ MixerChannelItem* MixerPanelModel::buildTrackChannelItem(const audio::TrackSeque
                << ", " << text;
     });
 
+    playback()->tracks()->inputParamsChanged().onReceive(this,
+                                                         [item](const TrackSequenceId /*sequenceId*/,
+                                                                const TrackId /*trackId*/,
+                                                                AudioInputParams params) {
+        item->loadInputParams(std::move(params));
+    });
+
     playback()->tracks()->trackName(sequenceId, trackId)
     .onResolve(this, [item](const TrackName& trackName) {
         item->setTitle(QString::fromStdString(trackName));
@@ -170,6 +177,13 @@ MixerChannelItem* MixerPanelModel::buildTrackChannelItem(const audio::TrackSeque
     .onReject(this, [](int errCode, std::string text) {
         LOGE() << "unable to get track output parameters, error code: " << errCode
                << ", " << text;
+    });
+
+    playback()->audioOutput()->outputParamsChanged().onReceive(this,
+                                                               [item](const TrackSequenceId /*sequenceId*/,
+                                                                      const TrackId /*trackId*/,
+                                                                      AudioOutputParams params) {
+        item->loadOutputParams(std::move(params));
     });
 
     playback()->audioOutput()->signalChanges(sequenceId, trackId)

--- a/src/project/internal/projectaudiosettings.cpp
+++ b/src/project/internal/projectaudiosettings.cpp
@@ -148,6 +148,7 @@ AudioInputParams ProjectAudioSettings::inputParamsFromJson(const QJsonObject& ob
 {
     AudioInputParams result;
     result.resourceMeta = resourceMetaFromJson(object.value("resourceMeta").toObject());
+    result.configuration = unitConfigFromJson(object.value("unitConfiguration").toObject());
 
     return result;
 }
@@ -182,6 +183,7 @@ AudioFxParams ProjectAudioSettings::fxParamsFromJson(const QJsonObject& object) 
     result.active = object.value("active").toBool();
     result.chainOrder = static_cast<AudioFxChainOrder>(object.value("chainOrder").toInt());
     result.resourceMeta = resourceMetaFromJson(object.value("resourceMeta").toObject());
+    result.configuration = unitConfigFromJson(object.value("unitConfiguration").toObject());
 
     return result;
 }
@@ -190,8 +192,20 @@ AudioResourceMeta ProjectAudioSettings::resourceMetaFromJson(const QJsonObject& 
 {
     AudioResourceMeta result;
     result.id = object.value("id").toString().toStdString();
+    result.hasNativeEditorSupport = object.value("hasNativeEditorSupport").toBool();
     result.vendor = object.value("vendor").toString().toStdString();
     result.type = resourceTypeFromString(object.value("type").toString());
+
+    return result;
+}
+
+AudioUnitConfig ProjectAudioSettings::unitConfigFromJson(const QJsonObject& object) const
+{
+    AudioUnitConfig result;
+
+    for (const QString& key : object.keys()) {
+        result.emplace(key.toStdString(), object.value(key).toString().toStdString());
+    }
 
     return result;
 }
@@ -200,6 +214,7 @@ QJsonObject ProjectAudioSettings::inputParamsToJson(const audio::AudioInputParam
 {
     QJsonObject result;
     result.insert("resourceMeta", resourceMetaToJson(params.resourceMeta));
+    result.insert("unitConfiguration", unitConfigToJson(params.configuration));
 
     return result;
 }
@@ -233,6 +248,7 @@ QJsonObject ProjectAudioSettings::fxParamsToJson(const audio::AudioFxParams& fxP
     result.insert("active", fxParams.active);
     result.insert("chainOrder", static_cast<int>(fxParams.chainOrder));
     result.insert("resourceMeta", resourceMetaToJson(fxParams.resourceMeta));
+    result.insert("unitConfiguration", unitConfigToJson(fxParams.configuration));
 
     return result;
 }
@@ -241,8 +257,20 @@ QJsonObject ProjectAudioSettings::resourceMetaToJson(const audio::AudioResourceM
 {
     QJsonObject result;
     result.insert("id", QString::fromStdString(meta.id));
+    result.insert("hasNativeEditorSupport", meta.hasNativeEditorSupport);
     result.insert("vendor", QString::fromStdString(meta.vendor));
     result.insert("type", resourceTypeToString(meta.type));
+
+    return result;
+}
+
+QJsonObject ProjectAudioSettings::unitConfigToJson(const audio::AudioUnitConfig& config) const
+{
+    QJsonObject result;
+
+    for (const auto& pair : config) {
+        result.insert(QString::fromStdString(pair.first), QString::fromStdString(pair.second));
+    }
 
     return result;
 }

--- a/src/project/internal/projectaudiosettings.h
+++ b/src/project/internal/projectaudiosettings.h
@@ -62,12 +62,14 @@ private:
     audio::AudioFxChain fxChainFromJson(const QJsonObject& fxChainObject) const;
     audio::AudioFxParams fxParamsFromJson(const QJsonObject& object) const;
     audio::AudioResourceMeta resourceMetaFromJson(const QJsonObject& object) const;
+    audio::AudioUnitConfig unitConfigFromJson(const QJsonObject& object) const;
 
     QJsonObject inputParamsToJson(const audio::AudioInputParams& params) const;
     QJsonObject outputParamsToJson(const audio::AudioOutputParams& params) const;
     QJsonObject fxChainToJson(const audio::AudioFxChain& fxChain) const;
     QJsonObject fxParamsToJson(const audio::AudioFxParams& fxParams) const;
     QJsonObject resourceMetaToJson(const audio::AudioResourceMeta& meta) const;
+    QJsonObject unitConfigToJson(const audio::AudioUnitConfig& config) const;
 
     audio::AudioSourceType sourceTypeFromString(const QString& string) const;
     audio::AudioResourceType resourceTypeFromString(const QString& string) const;

--- a/src/stubs/multiinstances/multiinstancesstubprovider.cpp
+++ b/src/stubs/multiinstances/multiinstancesstubprovider.cpp
@@ -93,3 +93,7 @@ mu::async::Notification MultiInstancesStubProvider::instancesChanged() const
     static mu::async::Notification n;
     return n;
 }
+
+void MultiInstancesStubProvider::quitForAll()
+{
+}

--- a/src/stubs/multiinstances/multiinstancesstubprovider.h
+++ b/src/stubs/multiinstances/multiinstancesstubprovider.h
@@ -51,6 +51,9 @@ public:
     const std::string& selfID() const override;
     std::vector<InstanceMeta> instances() const override;
     async::Notification instancesChanged() const override;
+
+    // Quit for all
+    void quitForAll() override;
 };
 }
 


### PR DESCRIPTION
Implemented an ability to save/restore VST plugins states and parameters in the project audio settings

see simple demo:

https://user-images.githubusercontent.com/57620349/135281823-67925d89-26f4-4b45-9958-981f38c49a09.mp4


https://user-images.githubusercontent.com/57620349/135281779-afd00692-71ca-40e6-b05e-1903859025f8.mp4



Also fixed a couple of minor issues with applying output parameters and launching of VST views



