### PR TITLE
[MU4] Fix Compiler warnings

### DIFF
--- a/src/engraving/libmscore/tie.cpp
+++ b/src/engraving/libmscore/tie.cpp
@@ -448,7 +448,7 @@ void TieSegment::adjustX()
     qreal xo;
 
     // ADJUST LEFT GRIP -----------
-    if (sc && spannerSegmentType() == SpannerSegmentType::SINGLE || spannerSegmentType() == SpannerSegmentType::BEGIN) {
+    if (sc && (spannerSegmentType() == SpannerSegmentType::SINGLE || spannerSegmentType() == SpannerSegmentType::BEGIN)) {
         // grips are in system coordinates, normalize to note position
         PointF p1 = ups(Grip::START).p + PointF(system()->pos().x() - sn->canvasX() + sn->headWidth(), 0);
         xo = 0;
@@ -519,7 +519,7 @@ void TieSegment::adjustX()
     }
 
     // ADJUST RIGHT GRIP ----------
-    if (ec && spannerSegmentType() == SpannerSegmentType::SINGLE || spannerSegmentType() == SpannerSegmentType::END) {
+    if (ec && (spannerSegmentType() == SpannerSegmentType::SINGLE || spannerSegmentType() == SpannerSegmentType::END)) {
         // grips are in system coordinates, normalize to note position
         PointF p2 = ups(Grip::END).p + PointF(system()->pos().x() - en->canvasX(), 0);
         xo = 0;

--- a/src/framework/accessibility/internal/accessibilityconfiguration.cpp
+++ b/src/framework/accessibility/internal/accessibilityconfiguration.cpp
@@ -35,7 +35,7 @@ bool AccessibilityConfiguration::enabled() const
 
 #ifdef BUILD_DIAGNOSTICS
     return true;
-#endif
+#else
 
     if (!QAccessible::isActive()) {
         return false;
@@ -43,4 +43,5 @@ bool AccessibilityConfiguration::enabled() const
 
     //! NOTE Accessibility available if navigation is used
     return navigationController()->activeSection() != nullptr;
+#endif
 }


### PR DESCRIPTION
* In MSVC reg. unreachable code
* In MinGW reg. missing parenteses

Todo: there's another MSVC warning reg. unreachable code in https://github.com/musescore/MuseScore/blob/faff8166bf00091fa690547ef55c15f685c77bcb/src/notation/view/noteinputbarmodel.cpp#L380, but I don't have any clever idea how to solve it.