### PR TITLE
Changed pipe-organ pedals clef from F8vb to F

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -10110,8 +10110,12 @@
                   <bracketSpan>2</bracketSpan>
                   <barlineSpan>2</barlineSpan>
                   <clef staff="2">F</clef>
-                  <clef staff="3">F8vb</clef>
+                  <clef staff="3">F</clef>
                   <barlineSpan staff="3">1</barlineSpan>
+                  <!--
+                  <transposeDiatonic>-7</transposeDiatonic>
+                  <transposeChromatic>-12</transposeChromatic>
+                  -->
                   <Channel>
                         <!--MIDI: Bank 0, Prog 19; MS General: Church Organ-->
                         <program value="19"/> <!--Church Organ-->


### PR DESCRIPTION
Resolves: "Pipe Organ" instrument has a F8vb clef in the pedals by default, which is not appropriate for organ music.

This pull (which is nothing more than an xml file adjustment, akin to a spelling fix) changes the default clef of the third stave of the pipe-organ instrument from a transposed bass clef to a non-transposed bass clef. The reason for this change is simply that no organ music in the world uses a bass clef that is transposed by one octave for pedals. Terminology of the pipe organ requires that the compass of the pedalboard reach from `C` to `f'` or `g'` (depending on the particular pedalboard), and not from `C,` to `f`, for example (these are the pitches which are played by an 8-foot stop).

I understand, however, that one reason to define the pipe organ clef in the way it is now is to be of help for those who are relying on the midi playback to hear 16-foot tone in the pedals. Although I would argue that having a transposed bass clef for the pedals is still inappropriate for printed organ music, using 16-foot tone in the pedals and 8-foot tone in the manuals is a common registration. Hopefully, someone with more experience with the Musescore source code than me can consider implementing stave-specific transposition similar to the already-existing transposeChromatic tag.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://musescore.org/en/cla)
- [x ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x ] I made sure the code compiles on my machine
- [x ] I made sure there are no unnecessary changes in the code
- [x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x ] I created the test (mtest, vtest, script test) to verify the changes I made
