### PR TITLE
Added Create New Score script

### DIFF
--- a/src/autobot/CMakeLists.txt
+++ b/src/autobot/CMakeLists.txt
@@ -92,6 +92,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/api/autobotapi.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/api/dispatcherapi.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/api/dispatcherapi.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/api/navigationapi.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/api/navigationapi.h
     ${CMAKE_CURRENT_LIST_DIR}/view/autobotmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/autobotmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/abfilesmodel.cpp

--- a/src/autobot/autobotmodule.cpp
+++ b/src/autobot/autobotmodule.cpp
@@ -42,6 +42,7 @@
 #include "internal/api/logapi.h"
 #include "internal/api/autobotapi.h"
 #include "internal/api/dispatcherapi.h"
+#include "internal/api/navigationapi.h"
 
 using namespace mu::autobot;
 using namespace mu::api;
@@ -79,10 +80,11 @@ void AutobotModule::resolveImports()
     }
 
     auto api = modularity::ioc()->resolve<IApiRegister>(moduleName());
-    if (ar) {
+    if (api) {
         api->regApiCreator("global", "api.log", new ApiCreator<LogApi>());
         api->regApiCreator("autobot", "api.autobot", new ApiCreator<AutobotApi>());
         api->regApiCreator("autobot", "api.dispatcher", new ApiCreator<DispatcherApi>());
+        api->regApiCreator("autobot", "api.navigation", new ApiCreator<NavigationApi>());
     }
 }
 

--- a/src/autobot/examples/New Score.js
+++ b/src/autobot/examples/New Score.js
@@ -1,0 +1,41 @@
+function main()
+{
+    var testCase = {
+        name: "New Score",
+        steps: [
+            {name: "Open Dialog", wait: false, func: function() {
+                api.dispatcher.dispatch("file-new")
+            }},
+            {name: "Select Flute", func: function() {
+                api.navigation.goToControlByName("NewScoreDialog", "FamilyView", "Woodwinds")
+                api.navigation.goToControlByName("NewScoreDialog", "InstrumentsView", "Flute")
+
+            }},
+            {name: "Select Flute (apply)", func: function() {
+                api.navigation.goToControlByName("NewScoreDialog", "SelectPanel", "Select")
+                api.navigation.triggerCurrentControl()
+
+            }},
+            {name: "Select Piano", func: function() {
+                api.navigation.goToControlByName("NewScoreDialog", "FamilyView", "Keyboards")
+                api.navigation.goToControlByName("NewScoreDialog", "InstrumentsView", "Piano")
+
+
+            }},
+            {name: "Select Piano (apply)", func: function() {
+                api.navigation.goToControlByName("NewScoreDialog", "SelectPanel", "Select")
+                api.navigation.triggerCurrentControl()
+
+            }},
+            {name: "Done", func: function() {
+                api.navigation.goToControlByName("NewScoreDialog", "BottomPanel", "Done")
+                api.navigation.triggerCurrentControl()
+
+            }},
+        ]
+    };
+
+    api.autobot.setInterval(500)
+    api.autobot.runTestCase(testCase)
+    api.log.info("----------- end script ---------------")
+}

--- a/src/autobot/examples/New Score.js
+++ b/src/autobot/examples/New Score.js
@@ -7,30 +7,29 @@ function main()
                 api.dispatcher.dispatch("file-new")
             }},
             {name: "Select Flute", func: function() {
-                api.navigation.goToControlByName("NewScoreDialog", "FamilyView", "Woodwinds")
-                api.navigation.goToControlByName("NewScoreDialog", "InstrumentsView", "Flute")
+                api.navigation.goToControl("NewScoreDialog", "FamilyView", "Woodwinds")
+                api.navigation.goToControl("NewScoreDialog", "InstrumentsView", "Flute")
 
             }},
             {name: "Select Flute (apply)", func: function() {
-                api.navigation.goToControlByName("NewScoreDialog", "SelectPanel", "Select")
-                api.navigation.triggerCurrentControl()
+                api.navigation.goToControl("NewScoreDialog", "SelectPanel", "Select")
+                api.navigation.trigger()
 
             }},
             {name: "Select Piano", func: function() {
-                api.navigation.goToControlByName("NewScoreDialog", "FamilyView", "Keyboards")
-                api.navigation.goToControlByName("NewScoreDialog", "InstrumentsView", "Piano")
+                api.navigation.goToControl("NewScoreDialog", "FamilyView", "Keyboards")
+                api.navigation.goToControl("NewScoreDialog", "InstrumentsView", "Piano")
 
 
             }},
             {name: "Select Piano (apply)", func: function() {
-                api.navigation.goToControlByName("NewScoreDialog", "SelectPanel", "Select")
-                api.navigation.triggerCurrentControl()
+                api.navigation.goToControl("NewScoreDialog", "SelectPanel", "Select")
+                api.navigation.trigger()
 
             }},
             {name: "Done", func: function() {
-                api.navigation.goToControlByName("NewScoreDialog", "BottomPanel", "Done")
-                api.navigation.triggerCurrentControl()
-
+                api.navigation.goToControl("NewScoreDialog", "BottomPanel", "Done")
+                api.navigation.trigger()
             }},
         ]
     };

--- a/src/autobot/examples/simple1.js
+++ b/src/autobot/examples/simple1.js
@@ -1,0 +1,21 @@
+
+function main()
+{
+    api.log.info("----------- begin script simple 1 ---------------")
+
+    api.autobot.setInterval(1000)
+
+    api.autobot.openProject("simple1.mscz");
+    api.autobot.sleep()
+
+    api.dispatcher.dispatch("zoom-x-percent", [100]);
+    api.autobot.sleep()
+
+    api.dispatcher.dispatch("zoom-x-percent", [50]);
+    api.autobot.sleep()
+
+    api.dispatcher.dispatch("zoom-x-percent", [100]);
+    api.autobot.sleep()
+
+    api.log.info("----------- end script simple 1 ---------------")
+}

--- a/src/autobot/internal/api/autobotapi.cpp
+++ b/src/autobot/internal/api/autobotapi.cpp
@@ -42,6 +42,10 @@ bool AutobotApi::openProject(const QString& name)
 
 void AutobotApi::sleep(int msec)
 {
+    if (msec < 0) {
+        msec = m_intervalMsec;
+    }
+
     QEventLoop loop;
     QTimer timer;
     connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);

--- a/src/autobot/internal/api/autobotapi.h
+++ b/src/autobot/internal/api/autobotapi.h
@@ -47,7 +47,7 @@ public:
 
     Q_INVOKABLE bool openProject(const QString& name);
 
-    Q_INVOKABLE void sleep(int msec);
+    Q_INVOKABLE void sleep(int msec = -1);
 
 private:
 

--- a/src/autobot/internal/api/autobotapi.h
+++ b/src/autobot/internal/api/autobotapi.h
@@ -22,6 +22,9 @@
 #ifndef MU_API_AUTOBOTAPI_H
 #define MU_API_AUTOBOTAPI_H
 
+#include <QJSValue>
+#include <QEventLoop>
+
 #include "apiobject.h"
 
 #include "modularity/ioc.h"
@@ -39,15 +42,29 @@ class AutobotApi : public ApiObject
 public:
     explicit AutobotApi(IApiEngine* e);
 
+    Q_INVOKABLE void setInterval(int msec);
+    Q_INVOKABLE void runTestCase(QJSValue testCase);
+
     Q_INVOKABLE bool openProject(const QString& name);
+
     Q_INVOKABLE void sleep(int msec);
 
-    Q_INVOKABLE void setInterval(int msec);
-    Q_INVOKABLE void setTestCase(const QString& name);
-    Q_INVOKABLE void step(const QString& name);
-
 private:
+
+    struct TestCase
+    {
+        QJSValue testCase;
+        QJSValue steps;
+        int stepsCount = 0;
+        int currentStepIdx = -1;
+        int finishedCount = 0;
+        QEventLoop loop;
+    };
+
+    void nextStep();
+
     int m_intervalMsec = 1000;
+    TestCase m_testCase;
 };
 }
 

--- a/src/autobot/internal/api/navigationapi.cpp
+++ b/src/autobot/internal/api/navigationapi.cpp
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "navigationapi.h"
+
+#include "log.h"
+
+using namespace mu::api;
+
+NavigationApi::NavigationApi(IApiEngine* e)
+    : ApiObject(e)
+{
+}
+
+void NavigationApi::nextPanel()
+{
+    dispatcher()->dispatch("nav-next-panel");
+}
+
+void NavigationApi::prevPanel()
+{
+    dispatcher()->dispatch("nav-prev-panel");
+}
+
+void NavigationApi::right()
+{
+    dispatcher()->dispatch("nav-right");
+}
+
+void NavigationApi::left()
+{
+    dispatcher()->dispatch("nav-left");
+}
+
+void NavigationApi::up()
+{
+    dispatcher()->dispatch("nav-up");
+}
+
+void NavigationApi::down()
+{
+    dispatcher()->dispatch("nav-down");
+}
+
+bool NavigationApi::goToControlByName(const QString& section, const QString& panel, const QString& contol)
+{
+    bool ok = navigation()->requestActivateByName(section.toStdString(), panel.toStdString(), contol.toStdString());
+    return ok;
+}
+
+void NavigationApi::triggerCurrentControl()
+{
+    dispatcher()->dispatch("nav-trigger-control");
+}
+
+bool NavigationApi::triggerControlByName(const QString& section, const QString& panel, const QString& contol)
+{
+    bool ok = goToControlByName(section, panel, contol);
+    if (ok) {
+        triggerCurrentControl();
+    }
+    return ok;
+}

--- a/src/autobot/internal/api/navigationapi.cpp
+++ b/src/autobot/internal/api/navigationapi.cpp
@@ -60,22 +60,22 @@ void NavigationApi::down()
     dispatcher()->dispatch("nav-down");
 }
 
-bool NavigationApi::goToControlByName(const QString& section, const QString& panel, const QString& contol)
+bool NavigationApi::goToControl(const QString& section, const QString& panel, const QString& contol)
 {
     bool ok = navigation()->requestActivateByName(section.toStdString(), panel.toStdString(), contol.toStdString());
     return ok;
 }
 
-void NavigationApi::triggerCurrentControl()
+void NavigationApi::trigger()
 {
     dispatcher()->dispatch("nav-trigger-control");
 }
 
-bool NavigationApi::triggerControlByName(const QString& section, const QString& panel, const QString& contol)
+bool NavigationApi::triggerControl(const QString& section, const QString& panel, const QString& contol)
 {
-    bool ok = goToControlByName(section, panel, contol);
+    bool ok = goToControl(section, panel, contol);
     if (ok) {
-        triggerCurrentControl();
+        trigger();
     }
     return ok;
 }

--- a/src/autobot/internal/api/navigationapi.h
+++ b/src/autobot/internal/api/navigationapi.h
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_API_NAVIGATIONAPI_H
+#define MU_API_NAVIGATIONAPI_H
+
+#include <QString>
+
+#include "apiobject.h"
+#include "modularity/ioc.h"
+#include "actions/iactionsdispatcher.h"
+#include "ui/inavigationcontroller.h"
+
+namespace mu::api {
+class NavigationApi : public ApiObject
+{
+    Q_OBJECT
+
+    INJECT(api, actions::IActionsDispatcher, dispatcher)
+    INJECT(api, ui::INavigationController, navigation)
+
+public:
+    explicit NavigationApi(IApiEngine* e);
+
+    Q_INVOKABLE void nextPanel();
+    Q_INVOKABLE void prevPanel();
+    Q_INVOKABLE void right();
+    Q_INVOKABLE void left();
+    Q_INVOKABLE void up();
+    Q_INVOKABLE void down();
+    Q_INVOKABLE bool goToControlByName(const QString& section, const QString& panel, const QString& contol);
+    Q_INVOKABLE void triggerCurrentControl();
+    Q_INVOKABLE bool triggerControlByName(const QString& section, const QString& panel, const QString& contol);
+};
+}
+
+#endif // MU_API_NAVIGATIONAPI_H

--- a/src/autobot/internal/api/navigationapi.h
+++ b/src/autobot/internal/api/navigationapi.h
@@ -46,9 +46,9 @@ public:
     Q_INVOKABLE void left();
     Q_INVOKABLE void up();
     Q_INVOKABLE void down();
-    Q_INVOKABLE bool goToControlByName(const QString& section, const QString& panel, const QString& contol);
-    Q_INVOKABLE void triggerCurrentControl();
-    Q_INVOKABLE bool triggerControlByName(const QString& section, const QString& panel, const QString& contol);
+    Q_INVOKABLE bool goToControl(const QString& section, const QString& panel, const QString& contol);
+    Q_INVOKABLE void trigger();
+    Q_INVOKABLE bool triggerControl(const QString& section, const QString& panel, const QString& contol);
 };
 }
 

--- a/src/autobot/internal/api/scriptapi.h
+++ b/src/autobot/internal/api/scriptapi.h
@@ -36,6 +36,7 @@ class ScriptApi : public QObject
     Q_PROPERTY(QJSValue log READ log CONSTANT)
     Q_PROPERTY(QJSValue autobot READ autobot CONSTANT)
     Q_PROPERTY(QJSValue dispatcher READ dispatcher CONSTANT)
+    Q_PROPERTY(QJSValue navigation READ navigation CONSTANT)
 
     INJECT(api, IApiRegister, apiRegister)
 
@@ -45,6 +46,7 @@ public:
     QJSValue log() const { return api("api.log"); }
     QJSValue autobot() const { return api("api.autobot"); }
     QJSValue dispatcher() const { return api("api.dispatcher"); }
+    QJSValue navigation() const { return api("api.navigation"); }
 
 private:
 

--- a/src/framework/ui/internal/navigationcontroller.cpp
+++ b/src/framework/ui/internal/navigationcontroller.cpp
@@ -1038,7 +1038,7 @@ void NavigationController::doTriggerControl()
 bool NavigationController::requestActivateByName(const std::string& sectName, const std::string& panelName, const std::string& controlName)
 {
     INavigationSection* section = findByName(m_sections, QString::fromStdString(sectName));
-    if (section) {
+    if (!section) {
         LOGE() << "not found section with name: " << sectName;
         return false;
     }
@@ -1050,16 +1050,16 @@ bool NavigationController::requestActivateByName(const std::string& sectName, co
     }
 
     INavigationControl* control = findByName(panel->controls(), QString::fromStdString(controlName));
-    if (!panel) {
+    if (!control) {
         LOGE() << "not found control with name: " << controlName << ", panel: " << panelName << ", section: " << sectName;
         return false;
     }
 
-    onActiveRequested(section, panel, control);
+    onActiveRequested(section, panel, control, true);
     return true;
 }
 
-void NavigationController::onActiveRequested(INavigationSection* sect, INavigationPanel* panel, INavigationControl* ctrl)
+void NavigationController::onActiveRequested(INavigationSection* sect, INavigationPanel* panel, INavigationControl* ctrl, bool force)
 {
     TRACEFUNC;
 
@@ -1071,13 +1071,13 @@ void NavigationController::onActiveRequested(INavigationSection* sect, INavigati
 
     //! NOTE If there is no active section,
     //! we may not be using keyboard navigation, so ignore the request.
-    if (!activeSec) {
+    if (!force && !activeSec) {
         return;
     }
 
     bool isChanged = false;
 
-    if (activeSec != sect) {
+    if (activeSec && activeSec != sect) {
         doDeactivateSection(activeSec);
     }
 

--- a/src/framework/ui/internal/navigationcontroller.h
+++ b/src/framework/ui/internal/navigationcontroller.h
@@ -88,7 +88,7 @@ private:
     void onEscape();
 
     void doTriggerControl();
-    void onActiveRequested(INavigationSection* sect, INavigationPanel* panel, INavigationControl* ctrl);
+    void onActiveRequested(INavigationSection* sect, INavigationPanel* panel, INavigationControl* ctrl, bool force = false);
 
     void doActivateSection(INavigationSection* sect, bool isActivateLastPanel = false);
     void doDeactivateSection(INavigationSection* sect);

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/FamilyView.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/FamilyView.qml
@@ -122,7 +122,7 @@ Item {
 
             onNavigationActived: {
                 prv.currentItemNavigationIndex = [navigation.row, navigation.column]
-                item.clicked()
+                item.clicked(null)
             }
 
             StyledTextLabel {

--- a/src/project/qml/MuseScore/Project/NewScoreDialog.qml
+++ b/src/project/qml/MuseScore/Project/NewScoreDialog.qml
@@ -37,6 +37,8 @@ StyledDialogView {
     contentWidth: 1024
     resizable: true
 
+    objectName: "NewScoreDialog"
+
     NewScoreModel {
         id: newScoreModel
     }


### PR DESCRIPTION
Added the ability to declare the test case and run it.
Each step is performed on a timer at a specified interval
It is important!
Since some API calls can be synchronous, and accordingly we cannot execute anything in the script until the call ends.
For example, in this case, "file-new" is a synchronous call, that is, the dialog for creating a score is opened in a synchronous mode. Accordingly, until the dialog is closed, we cannot perform anything in the script, but we need to perform navigation actions.
The current solution works around this issue.

UPD: a little changed the script, see the code

Interval - 2000 msec

https://user-images.githubusercontent.com/3818029/136209431-ca90c17b-66fb-4730-aadf-7e312d4b9d97.mp4

Same, but interval - 500 msec

https://user-images.githubusercontent.com/3818029/136209512-8e5ff557-c20e-4bb3-a466-4dbe22a905f5.mp4



