### PR TITLE
use accidental width to space key signatures

### DIFF
--- a/src/engraving/libmscore/keysig.cpp
+++ b/src/engraving/libmscore/keysig.cpp
@@ -100,13 +100,18 @@ void KeySig::addLayout(SymId sym, int line)
     if (_sig.keySymbols().size() > 0) {
         KeySym& previous = _sig.keySymbols().back();
         qreal accidentalGap = score()->styleS(Sid::keysigAccidentalDistance).val();
+        if (previous.sym != sym) {
+            accidentalGap *= 2;
+        } else if (previous.sym == SymId::accidentalNatural && sym == SymId::accidentalNatural) {
+            accidentalGap = score()->styleS(Sid::keysigNaturalDistance).val();
+        }
         // width is divided by mag() to get the staff-scaling-independent width of the symbols
         qreal previousWidth = symWidth(previous.sym) / score()->spatium() / mag();
         x = previous.spos.x() + previousWidth + accidentalGap;
         bool isAscending = y < previous.spos.y();
         SmuflAnchorId currentCutout = isAscending ? SmuflAnchorId::cutOutSW : SmuflAnchorId::cutOutNW;
         SmuflAnchorId previousCutout = isAscending ? SmuflAnchorId::cutOutNE : SmuflAnchorId::cutOutSE;
-        PointF cutout = symSmuflAnchor(sym, isAscending ? SmuflAnchorId::cutOutSW : SmuflAnchorId::cutOutNW);
+        PointF cutout = symSmuflAnchor(sym, currentCutout);
         qreal currentCutoutY = y * spatium() + cutout.y();
         qreal previousCoutoutY = previous.spos.y() * spatium() + symSmuflAnchor(previous.sym, previousCutout).y();
         if ((isAscending && currentCutoutY < previousCoutoutY) || (!isAscending && currentCutoutY > previousCoutoutY)) {

--- a/src/engraving/libmscore/keysig.cpp
+++ b/src/engraving/libmscore/keysig.cpp
@@ -244,46 +244,49 @@ void KeySig::layout()
     const signed char* lines = ClefInfo::lines(clef);
 
     // add prefixed naturals, if any
+    qreal accidentalGap = score()->styleS(Sid::accidentalDistance).val();
+    // width is divided by mag() to get the staff-scaling-independent width of the symbols
+    qreal sharpWidth = symWidth(SymId::accidentalSharp) / score()->spatium() / mag() + accidentalGap;
+    qreal flatWidth = symWidth(SymId::accidentalFlat) / score()->spatium() / mag() + accidentalGap;
+    qreal naturalWidth = symWidth(SymId::accidentalNatural) / score()->spatium() / mag() + accidentalGap;
 
     qreal xo = 0.0;
     if (prefixNaturals) {
         for (int i = 0; i < 7; ++i) {
             if (naturals & (1 << i)) {
                 addLayout(SymId::accidentalNatural, xo, lines[i + coffset]);
-                xo += 1.0;
+                xo += naturalWidth;
             }
         }
     }
     // add accidentals
-    static const qreal sspread = 1.0;
-    static const qreal fspread = 1.0;
 
     switch (t1) {
-    case 7:  addLayout(SymId::accidentalSharp, xo + 6.0 * sspread, lines[6]);
+    case 7:  addLayout(SymId::accidentalSharp, xo + 6.0 * sharpWidth, lines[6]);
     // fall through
-    case 6:  addLayout(SymId::accidentalSharp, xo + 5.0 * sspread, lines[5]);
+    case 6:  addLayout(SymId::accidentalSharp, xo + 5.0 * sharpWidth, lines[5]);
     // fall through
-    case 5:  addLayout(SymId::accidentalSharp, xo + 4.0 * sspread, lines[4]);
+    case 5:  addLayout(SymId::accidentalSharp, xo + 4.0 * sharpWidth, lines[4]);
     // fall through
-    case 4:  addLayout(SymId::accidentalSharp, xo + 3.0 * sspread, lines[3]);
+    case 4:  addLayout(SymId::accidentalSharp, xo + 3.0 * sharpWidth, lines[3]);
     // fall through
-    case 3:  addLayout(SymId::accidentalSharp, xo + 2.0 * sspread, lines[2]);
+    case 3:  addLayout(SymId::accidentalSharp, xo + 2.0 * sharpWidth, lines[2]);
     // fall through
-    case 2:  addLayout(SymId::accidentalSharp, xo + 1.0 * sspread, lines[1]);
+    case 2:  addLayout(SymId::accidentalSharp, xo + 1.0 * sharpWidth, lines[1]);
     // fall through
     case 1:  addLayout(SymId::accidentalSharp, xo,                 lines[0]);
         break;
-    case -7: addLayout(SymId::accidentalFlat, xo + 6.0 * fspread, lines[13]);
+    case -7: addLayout(SymId::accidentalFlat, xo + 6.0 * flatWidth, lines[13]);
     // fall through
-    case -6: addLayout(SymId::accidentalFlat, xo + 5.0 * fspread, lines[12]);
+    case -6: addLayout(SymId::accidentalFlat, xo + 5.0 * flatWidth, lines[12]);
     // fall through
-    case -5: addLayout(SymId::accidentalFlat, xo + 4.0 * fspread, lines[11]);
+    case -5: addLayout(SymId::accidentalFlat, xo + 4.0 * flatWidth, lines[11]);
     // fall through
-    case -4: addLayout(SymId::accidentalFlat, xo + 3.0 * fspread, lines[10]);
+    case -4: addLayout(SymId::accidentalFlat, xo + 3.0 * flatWidth, lines[10]);
     // fall through
-    case -3: addLayout(SymId::accidentalFlat, xo + 2.0 * fspread, lines[9]);
+    case -3: addLayout(SymId::accidentalFlat, xo + 2.0 * flatWidth, lines[9]);
     // fall through
-    case -2: addLayout(SymId::accidentalFlat, xo + 1.0 * fspread, lines[8]);
+    case -2: addLayout(SymId::accidentalFlat, xo + 1.0 * flatWidth, lines[8]);
     // fall through
     case -1: addLayout(SymId::accidentalFlat, xo,                 lines[7]);
     case 0:
@@ -294,18 +297,12 @@ void KeySig::layout()
     }
     // add suffixed naturals, if any
     if (suffixNaturals) {
-        xo += qAbs(t1);                   // skip accidentals
-        if (t1 > 0) {                     // after sharps, add a little more space
-            xo += 0.15;
-            // if last sharp (t1) is above next natural (t1+1)...
-            if (lines[t1] < lines[t1 + 1]) {
-                xo += 0.2;                // ... add more space
-            }
-        }
+        qreal accidentalWidth = (t1 > 0 ? sharpWidth : flatWidth);
+        xo += qAbs(t1) * accidentalWidth; // skip accidentals
         for (int i = 0; i < 7; ++i) {
             if (naturals & (1 << i)) {
                 addLayout(SymId::accidentalNatural, xo, lines[i + coffset]);
-                xo += 1.0;
+                xo += naturalWidth;
             }
         }
     }

--- a/src/engraving/libmscore/keysig.cpp
+++ b/src/engraving/libmscore/keysig.cpp
@@ -90,12 +90,30 @@ qreal KeySig::mag() const
 //   add
 //---------------------------------------------------------
 
-void KeySig::addLayout(SymId sym, qreal x, int line)
+void KeySig::addLayout(SymId sym, int line)
 {
     qreal stepDistance = staff() ? staff()->lineDistance(tick()) * 0.5 : 0.5;
     KeySym ks;
-    ks.sym    = sym;
-    ks.spos   = PointF(x, qreal(line) * stepDistance);
+    ks.sym = sym;
+    qreal x = 0.0;
+    qreal y = qreal(line) * stepDistance;
+    if (_sig.keySymbols().size() > 0) {
+        KeySym& previous = _sig.keySymbols().back();
+        qreal accidentalGap = score()->styleS(Sid::keysigAccidentalDistance).val();
+        // width is divided by mag() to get the staff-scaling-independent width of the symbols
+        qreal previousWidth = symWidth(previous.sym) / score()->spatium() / mag();
+        x = previous.spos.x() + previousWidth + accidentalGap;
+        bool isAscending = y < previous.spos.y();
+        SmuflAnchorId currentCutout = isAscending ? SmuflAnchorId::cutOutSW : SmuflAnchorId::cutOutNW;
+        SmuflAnchorId previousCutout = isAscending ? SmuflAnchorId::cutOutNE : SmuflAnchorId::cutOutSE;
+        PointF cutout = symSmuflAnchor(sym, isAscending ? SmuflAnchorId::cutOutSW : SmuflAnchorId::cutOutNW);
+        qreal currentCutoutY = y * spatium() + cutout.y();
+        qreal previousCoutoutY = previous.spos.y() * spatium() + symSmuflAnchor(previous.sym, previousCutout).y();
+        if ((isAscending && currentCutoutY < previousCoutoutY) || (!isAscending && currentCutoutY > previousCoutoutY)) {
+            x -= cutout.x() / spatium();
+        }
+    }
+    ks.spos = PointF(x, y);
     _sig.keySymbols().append(ks);
 }
 
@@ -243,66 +261,28 @@ void KeySig::layout()
 
     const signed char* lines = ClefInfo::lines(clef);
 
-    // add prefixed naturals, if any
-    qreal accidentalGap = score()->styleS(Sid::accidentalDistance).val();
-    // width is divided by mag() to get the staff-scaling-independent width of the symbols
-    qreal sharpWidth = symWidth(SymId::accidentalSharp) / score()->spatium() / mag() + accidentalGap;
-    qreal flatWidth = symWidth(SymId::accidentalFlat) / score()->spatium() / mag() + accidentalGap;
-    qreal naturalWidth = symWidth(SymId::accidentalNatural) / score()->spatium() / mag() + accidentalGap;
-
-    qreal xo = 0.0;
     if (prefixNaturals) {
         for (int i = 0; i < 7; ++i) {
             if (naturals & (1 << i)) {
-                addLayout(SymId::accidentalNatural, xo, lines[i + coffset]);
-                xo += naturalWidth;
+                addLayout(SymId::accidentalNatural, lines[i + coffset]);
             }
         }
     }
-    // add accidentals
-
-    switch (t1) {
-    case 7:  addLayout(SymId::accidentalSharp, xo + 6.0 * sharpWidth, lines[6]);
-    // fall through
-    case 6:  addLayout(SymId::accidentalSharp, xo + 5.0 * sharpWidth, lines[5]);
-    // fall through
-    case 5:  addLayout(SymId::accidentalSharp, xo + 4.0 * sharpWidth, lines[4]);
-    // fall through
-    case 4:  addLayout(SymId::accidentalSharp, xo + 3.0 * sharpWidth, lines[3]);
-    // fall through
-    case 3:  addLayout(SymId::accidentalSharp, xo + 2.0 * sharpWidth, lines[2]);
-    // fall through
-    case 2:  addLayout(SymId::accidentalSharp, xo + 1.0 * sharpWidth, lines[1]);
-    // fall through
-    case 1:  addLayout(SymId::accidentalSharp, xo,                 lines[0]);
-        break;
-    case -7: addLayout(SymId::accidentalFlat, xo + 6.0 * flatWidth, lines[13]);
-    // fall through
-    case -6: addLayout(SymId::accidentalFlat, xo + 5.0 * flatWidth, lines[12]);
-    // fall through
-    case -5: addLayout(SymId::accidentalFlat, xo + 4.0 * flatWidth, lines[11]);
-    // fall through
-    case -4: addLayout(SymId::accidentalFlat, xo + 3.0 * flatWidth, lines[10]);
-    // fall through
-    case -3: addLayout(SymId::accidentalFlat, xo + 2.0 * flatWidth, lines[9]);
-    // fall through
-    case -2: addLayout(SymId::accidentalFlat, xo + 1.0 * flatWidth, lines[8]);
-    // fall through
-    case -1: addLayout(SymId::accidentalFlat, xo,                 lines[7]);
-    case 0:
-        break;
-    default:
+    if (abs(t1) <= 7) {
+        SymId symbol = t1 > 0 ? SymId::accidentalSharp : SymId::accidentalFlat;
+        int lineIndexOffset = t1 > 0 ? 0 : 7;
+        for (int i = 0; i < abs(t1); ++i) {
+            addLayout(symbol, lines[lineIndexOffset + i]);
+        }
+    } else {
         qDebug("illegal t1 key %d", t1);
-        break;
     }
+
     // add suffixed naturals, if any
     if (suffixNaturals) {
-        qreal accidentalWidth = (t1 > 0 ? sharpWidth : flatWidth);
-        xo += qAbs(t1) * accidentalWidth; // skip accidentals
         for (int i = 0; i < 7; ++i) {
             if (naturals & (1 << i)) {
-                addLayout(SymId::accidentalNatural, xo, lines[i + coffset]);
-                xo += naturalWidth;
+                addLayout(SymId::accidentalNatural, lines[i + coffset]);
             }
         }
     }

--- a/src/engraving/libmscore/keysig.h
+++ b/src/engraving/libmscore/keysig.h
@@ -50,7 +50,7 @@ class KeySig final : public EngravingItem
     KeySig(Segment* = 0);
     KeySig(const KeySig&);
 
-    void addLayout(SymId sym, qreal x, int y);
+    void addLayout(SymId sym, int y);
 
 public:
 

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -208,6 +208,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::accidentalNoteDistance,  "accidentalNoteDistance",  Spatium(0.25) },
     { Sid::bracketedAccidentalPadding,  "bracketedAccidentalPadding",  Spatium(0.175) }, // Padding inside parentheses for bracketed accidentals
     { Sid::alignAccidentalsLeft,    "alignAccidentalsLeft",    false },   // When laid out in columns, whether accidentals align left or right. Musescore <= 3.5 uses left alignment.
+    { Sid::keysigAccidentalDistance, "keysigAccidentalDistance", Spatium(0.22) },
 
     { Sid::beamWidth,               "beamWidth",               Spatium(0.5) },      // was 0.48
     { Sid::beamDistance,            "beamDistance",            PropertyValue(0.5) },

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -208,7 +208,8 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::accidentalNoteDistance,  "accidentalNoteDistance",  Spatium(0.25) },
     { Sid::bracketedAccidentalPadding,  "bracketedAccidentalPadding",  Spatium(0.175) }, // Padding inside parentheses for bracketed accidentals
     { Sid::alignAccidentalsLeft,    "alignAccidentalsLeft",    false },   // When laid out in columns, whether accidentals align left or right. Musescore <= 3.5 uses left alignment.
-    { Sid::keysigAccidentalDistance, "keysigAccidentalDistance", Spatium(0.22) },
+    { Sid::keysigAccidentalDistance, "keysigAccidentalDistance", Spatium(0.3) },
+    { Sid::keysigNaturalDistance,   "keysigNaturalDistance",   Spatium(0.4) },
 
     { Sid::beamWidth,               "beamWidth",               Spatium(0.5) },      // was 0.48
     { Sid::beamDistance,            "beamDistance",            PropertyValue(0.5) },

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -222,6 +222,7 @@ enum class Sid {
     bracketedAccidentalPadding,
     alignAccidentalsLeft,
     keysigAccidentalDistance,
+    keysigNaturalDistance,
     beamWidth,
     beamDistance,
     beamMinLen,

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -221,6 +221,7 @@ enum class Sid {
     accidentalNoteDistance,
     bracketedAccidentalPadding,
     alignAccidentalsLeft,
+    keysigAccidentalDistance,
     beamWidth,
     beamDistance,
     beamMinLen,


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9379

This PR uses the accidental width to calculate the spacing of key signatures. Before, all accidentals were spaced 1 space apart, regardless of font or symbol. Now, the key signature calculates each symbol's width to space them out appropriately, and the gap between them is `accidentalDistance`, the same style value used for accidentals on chords.

This will provide greater consistency and clarity for accidentals.

Notes
- This PR may not work for custom key signatures. As of today, it looks like it's not possible to create custom key signatures in v4, so I was not able to test it.
- Unlike for chords, there does not seem to be much space remove extra space with symbol cutouts. This is because key signatures have well defined patterns (like they move in 4ths or 5ths), and there's just not the vertical clearance in any of the fonts. _The only_ places I could see making the case for adding this is sharps in Peteluma or naturals cancelling out the sharps. If this is desired, I can add that in (though it would increase the scope of the PR quite a bit).

<img width="450" alt="Screen Shot 2021-10-06 at 2 57 34 PM" src="https://user-images.githubusercontent.com/5659171/136289186-e3b64519-614f-4a2b-a6bd-ddc08dd04ef1.png">

<img width="369" alt="Screen Shot 2021-10-06 at 2 57 55 PM" src="https://user-images.githubusercontent.com/5659171/136289236-f54e0268-ae03-42df-b73f-a9ef4c5353f7.png">

<img width="564" alt="Screen Shot 2021-10-06 at 2 58 16 PM" src="https://user-images.githubusercontent.com/5659171/136289276-ba5f4a27-23d8-41b8-bcb1-39f884e06dc5.png">

<img width="379" alt="Screen Shot 2021-10-06 at 3 03 43 PM" src="https://user-images.githubusercontent.com/5659171/136289864-d6495bd2-923a-45f8-bdd5-9004686961f5.png">