### PR TITLE
let dynamic/tempo symbols auto-resize to surrounding text

### DIFF
--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -962,10 +962,12 @@ mu::draw::Font TextFragment::font(const TextBase* t) const
     if (format.fontFamily() == "ScoreText") {
         if (t->parent() && t->isDynamic()) {
             family = t->score()->scoreFont()->fontByName(t->score()->styleSt(Sid::MusicalSymbolFont))->family();
-            m = t->score()->styleV(Sid::dynamicsSymbolFontSize).toReal() * t->mag();
+            // to keep desired size ratio (based on 20pt symbol size to 10pt text size)
+            m *= 2;
         } else if (t->parent() && t->isTempoText()) {
             family = t->score()->styleSt(Sid::MusicalTextFont);
-            m = t->score()->styleV(Sid::tempoSymbolFontSize).toReal();
+            // to keep desired size ratio (based on 20pt symbol size to 12pt text size)
+            m *= 5.0 / 3.0;
         } else {
             family = t->score()->styleSt(Sid::MusicalTextFont);
         }

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -823,8 +823,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::partInstrumentFrameBgColor,    "partInstrumentFrameBgColor",   QVariant::fromValue(draw::Color::transparent) },
 
     { Sid::dynamicsFontFace,              "dynamicsFontFace",             "Edwin" },
-    { Sid::dynamicsFontSize,              "dynamicsFontSize",             11.0 },
-    { Sid::dynamicsSymbolFontSize,        "dynamicsSymbolFontSize",       20.0 },
+    { Sid::dynamicsFontSize,              "dynamicsFontSize",             10.0 },
     { Sid::dynamicsLineSpacing,           "dynamicsLineSpacing",          1.0 },
     { Sid::dynamicsFontSpatiumDependent,  "dynamicsFontSpatiumDependent", true },
     { Sid::dynamicsFontStyle,             "dynamicsFontStyle",            int(FontStyle::Italic) },
@@ -855,7 +854,6 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
 
     { Sid::tempoFontFace,                 "tempoFontFace",                "Edwin" },
     { Sid::tempoFontSize,                 "tempoFontSize",                12.0 },
-    { Sid::tempoSymbolFontSize,           "tempoSymbolFontSize",          20.0 },
     { Sid::tempoLineSpacing,              "tempoLineSpacing",             1.0 },
     { Sid::tempoFontSpatiumDependent,     "tempoFontSpatiumDependent",    true },
     { Sid::tempoFontStyle,                "tempoFontStyle",               int(FontStyle::Bold) },

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -835,7 +835,6 @@ enum class Sid {
 
     dynamicsFontFace,
     dynamicsFontSize,
-    dynamicsSymbolFontSize,
     dynamicsLineSpacing,
     dynamicsFontSpatiumDependent,
     dynamicsFontStyle,
@@ -866,7 +865,6 @@ enum class Sid {
 
     tempoFontFace,
     tempoFontSize,
-    tempoSymbolFontSize,
     tempoLineSpacing,
     tempoFontSpatiumDependent,
     tempoFontStyle,


### PR DESCRIPTION
Follow up to resolve some of the comments brought up in https://github.com/musescore/MuseScore/pull/9359 after it was merged.

Instead of having separate font sizes for dynamic/tempo symbols, the symbols will automatically resize given the surrounding context text sizes.

One other change: default dynamics font size is now 10pt instead of 11pt.