### PR TITLE
Update instruments.xml to add Sousaphone (treble clef) in B♭

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -5924,6 +5924,28 @@
                   <genre>jazz</genre>
                   <genre>marching</genre>
             </Instrument>
+            <Instrument id="bb-sousaphone-treble">
+                  <family>sousaphones</family>
+                  <trackName>Sousaphone (treble clef)</trackName>
+                  <longName>Sousaphone</longName>
+                  <shortName>Sphn.</shortName>
+                  <dropdownName meaning="transposition">(B♭)</dropdownName>
+                  <description>Sousaphone (B♭, treble clef)</description>
+                  <musicXMLid>brass.sousaphone</musicXMLid>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>F</concertClef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>30-60</aPitchRange>
+                  <pPitchRange>24-74</pPitchRange>
+                  <transposeDiatonic>-15</transposeDiatonic>
+                  <transposeChromatic>-26</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 58; MS General: Tuba-->
+                        <program value="58"/> <!--Tuba-->
+                  </Channel>
+                  <genre>jazz</genre>
+                  <genre>marching</genre>
+            </Instrument>
             <Instrument id="sousaphone">
                   <family>sousaphones</family>
                   <trackName>Sousaphone (concert pitch)</trackName>


### PR DESCRIPTION
Replaces #9405 by @simonstuder

> Added the treble clef version of the b sousaphone to help beginners play multiple instruments with the same clef.
In our town so far multiple bands use a custom instrument.xml as second instrument list.