### PR TITLE
[MU4] Fixed accessibility on macOS

### DIFF
--- a/src/framework/accessibility/accessibilitymodule.cpp
+++ b/src/framework/accessibility/accessibilitymodule.cpp
@@ -32,8 +32,6 @@
 using namespace mu::accessibility;
 using namespace mu::modularity;
 
-static std::shared_ptr<AccessibilityController> s_accessibilityController = std::make_shared<AccessibilityController>();
-
 std::string AccessibilityModule::moduleName() const
 {
     return "accessibility";
@@ -42,14 +40,5 @@ std::string AccessibilityModule::moduleName() const
 void AccessibilityModule::registerExports()
 {
     ioc()->registerExport<IAccessibilityConfiguration>(moduleName(), new AccessibilityConfiguration());
-    ioc()->registerExport<IAccessibilityController>(moduleName(), s_accessibilityController);
-}
-
-void AccessibilityModule::onInit(const framework::IApplication::RunMode& mode)
-{
-    if (mode != framework::IApplication::RunMode::Editor) {
-        return;
-    }
-
-    s_accessibilityController->init();
+    ioc()->registerExport<IAccessibilityController>(moduleName(), std::make_shared<AccessibilityController>());
 }

--- a/src/framework/accessibility/accessibilitymodule.h
+++ b/src/framework/accessibility/accessibilitymodule.h
@@ -32,7 +32,6 @@ public:
     std::string moduleName() const override;
 
     void registerExports() override;
-    void onInit(const framework::IApplication::RunMode& mode) override;
 };
 }
 

--- a/src/framework/accessibility/internal/accessibilitycontroller.h
+++ b/src/framework/accessibility/internal/accessibilitycontroller.h
@@ -53,8 +53,6 @@ public:
     AccessibilityController() = default;
     ~AccessibilityController();
 
-    void init();
-
     // IAccessibilityController
     const IAccessible* accessibleRoot() const override;
 
@@ -82,6 +80,7 @@ public:
     int childCount(const IAccessible* item) const;
     QAccessibleInterface* child(const IAccessible* item, int i) const;
     int indexOfChild(const IAccessible* item, const QAccessibleInterface* iface) const;
+    QAccessibleInterface* focusedChild(const IAccessible* item) const;
 
     async::Channel<QAccessibleEvent*> eventSent() const;
 
@@ -98,6 +97,8 @@ private:
         bool isValid() const { return item != nullptr; }
     };
 
+    void init();
+
     const Item& findItem(const IAccessible* aitem) const;
 
     void propertyChanged(IAccessible* item, IAccessible::Property p);
@@ -109,6 +110,8 @@ private:
 
     QList<IAccessible*> m_children;
     async::Channel<QAccessibleEvent*> m_eventSent;
+
+    bool m_inited = false;
 };
 }
 

--- a/src/framework/accessibility/internal/accessibleiteminterface.cpp
+++ b/src/framework/accessibility/internal/accessibleiteminterface.cpp
@@ -104,8 +104,9 @@ QAccessibleInterface* AccessibleItemInterface::childAt(int, int) const
 
 QAccessibleInterface* AccessibleItemInterface::focusChild() const
 {
-    NOT_IMPLEMENTED;
-    return nullptr;
+    QAccessibleInterface* child = m_object->controller()->focusedChild(m_object->item());
+    MYLOG() << "item: " << m_object->item()->accessibleName() << ", focused child: " << (child ? child->text(QAccessible::Name) : "null");
+    return child;
 }
 
 QAccessible::State AccessibleItemInterface::state() const

--- a/src/framework/global/globalmodule.cpp
+++ b/src/framework/global/globalmodule.cpp
@@ -31,6 +31,7 @@
 #include "logremover.h"
 #include "thirdparty/haw_logger/logger/logdefdest.h"
 #include "version.h"
+#include "config.h"
 
 #include "internal/application.h"
 #include "internal/interactive.h"

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/GradientTabButton.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/GradientTabButton.qml
@@ -47,7 +47,7 @@ RadioDelegate {
     rightPadding: 0
 
     //! NONE Disabled default Qt Accessible
-    Accessible.role: Accessible.NoRole
+    Accessible.ignored: true
 
     NavigationControl {
         id: navCtrl

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/RoundedRadioButton.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/RoundedRadioButton.qml
@@ -49,7 +49,7 @@ RadioDelegate {
     hoverEnabled: true
 
     //! NONE Disabled default Qt Accessible
-    Accessible.role: Accessible.NoRole
+    Accessible.ignored: true
 
     NavigationControl {
         id: keynavCtrl


### PR DESCRIPTION
Resolves: #9153

For macOS, installing a root object(QAccessible::setRootObject) doesn't make any sense(not implemented). Instead, the root object of the main window (QQuickWindow) is taken. Let's return our root object for QQuickWindow so that accessibility works with our custom tree, not the qt tree

Also, installFactory adds a factory to the queue. And whichever factory is installed last, it will be called first. To replace the qt tree with work, we need to set our factory after the gui is initialized(on the first request to register the gui element)