### PR TITLE
[MU4] Fix dynamic and ottava symbols when Musical Text font does not match the Musical Symbols font

### DIFF
--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -796,7 +796,8 @@ mu::draw::Font TextFragment::font(const TextBase* t) const
     if (format.fontFamily() == "ScoreText") {
         if (t->isDynamic() || t->textStyleType() == TextStyleType::OTTAVA) {
             family
-                = String::fromStdString(engravingFonts()->fontByName(t->score()->styleSt(Sid::MusicalSymbolFont).toStdString())->family());
+                = String::fromStdString(engravingFonts()->fontByName(t->score()->styleSt(Sid::MusicalTextFont).replace(u" Text",
+                                                                                                                       u"").toStdString())->family());
             fontType = draw::Font::Type::MusicSymbol;
             // to keep desired size ratio (based on 20pt symbol size to 10pt text size)
             m *= 2;


### PR DESCRIPTION
after #9359 and #9395 and as discussed there.
Also after #12354

Sample scores attached (from the 3.x vtests):
[vtest.zip](https://github.com/musescore/MuseScore/files/7327172/vtest.zip)
 
