### PR TITLE
use opticalCenter to align dynamics

### DIFF
--- a/src/engraving/libmscore/scorefont.cpp
+++ b/src/engraving/libmscore/scorefont.cpp
@@ -284,7 +284,8 @@ void ScoreFont::loadGlyphsWithAnchors(const QJsonObject& glyphsWithAnchors)
             { "cutOutNE", SmuflAnchorId::cutOutNE },
             { "cutOutNW", SmuflAnchorId::cutOutNW },
             { "cutOutSE", SmuflAnchorId::cutOutSE },
-            { "cutOutSW", SmuflAnchorId::cutOutSW }
+            { "cutOutSW", SmuflAnchorId::cutOutSW },
+            { "opticalCenter", SmuflAnchorId::opticalCenter },
         };
 
         for (const QString& anchorId : anchors.keys()) {

--- a/src/engraving/libmscore/symid.h
+++ b/src/engraving/libmscore/symid.h
@@ -50,6 +50,7 @@ enum class SmuflAnchorId {
     cutOutNW,
     cutOutSE,
     cutOutSW,
+    opticalCenter,
 };
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9027

Previously, dynamics were horizontally aligned in respect to their bounding box. Now, they are aligned to the SMuFL `opticalCenter` property. If a dynamic does not have that property, it falls back to using its bounding box.

Note that the `sff` is not aligned correctly because the font needs to be updated.

@oktophonie, some of the dynamics in other fonts do not feel properly aligned when using `opticalCenter` (mainly Petaluma and Bravura). I double-checked the code is correctly using the values present in their `metadata.json`. Could you check the original font files to ensure the correct value for `opticalCenter` is present to begin with?

![dynamics-fonts](https://user-images.githubusercontent.com/5659171/137035532-ea0f559c-d7ba-436e-b111-0a674095c75e.png)

Test file: [optical-center.mscz.zip](https://github.com/musescore/MuseScore/files/7333386/optical-center.mscz.zip)
 