### PR TITLE
reformat code to match code style

### DIFF
--- a/src/appshell/view/dockwindow/dockpage.h
+++ b/src/appshell/view/dockwindow/dockpage.h
@@ -47,8 +47,8 @@ class DockPage : public QQuickItem
     Q_PROPERTY(QQmlListProperty<mu::dock::DockToolBarHolder> toolBarsDockingHolders READ toolBarsDockingHoldersProperty)
     Q_PROPERTY(QQmlListProperty<mu::dock::DockPanel> panels READ panelsProperty)
     Q_PROPERTY(QQmlListProperty<mu::dock::DockPanelHolder> panelsDockingHolders READ panelsDockingHoldersProperty)
-    Q_PROPERTY(mu::dock::DockCentral* centralDock READ centralDock WRITE setCentralDock NOTIFY centralDockChanged)
-    Q_PROPERTY(mu::dock::DockStatusBar* statusBar READ statusBar WRITE setStatusBar NOTIFY statusBarChanged)
+    Q_PROPERTY(mu::dock::DockCentral * centralDock READ centralDock WRITE setCentralDock NOTIFY centralDockChanged)
+    Q_PROPERTY(mu::dock::DockStatusBar * statusBar READ statusBar WRITE setStatusBar NOTIFY statusBarChanged)
 
 public:
     explicit DockPage(QQuickItem* parent = nullptr);

--- a/src/appshell/view/dockwindow/dockpanel.h
+++ b/src/appshell/view/dockwindow/dockpanel.h
@@ -40,7 +40,7 @@ class DockPanel : public DockBase
 
     Q_PROPERTY(DockPanel * tabifyPanel READ tabifyPanel WRITE setTabifyPanel NOTIFY tabifyPanelChanged)
     Q_PROPERTY(QObject * navigationSection READ navigationSection WRITE setNavigationSection NOTIFY navigationSectionChanged)
-    Q_PROPERTY(mu::ui::AbstractMenuModel* contextMenuModel READ contextMenuModel WRITE setContextMenuModel NOTIFY contextMenuModelChanged)
+    Q_PROPERTY(mu::ui::AbstractMenuModel * contextMenuModel READ contextMenuModel WRITE setContextMenuModel NOTIFY contextMenuModelChanged)
 
 public:
     explicit DockPanel(QQuickItem* parent = nullptr);

--- a/src/engraving/infrastructure/draw/geometry.h
+++ b/src/engraving/infrastructure/draw/geometry.h
@@ -388,10 +388,10 @@ public:
 
     inline PolygonX<T>() = default;
     inline PolygonX<T>(const PolygonX<T>& p) = default;
-    inline PolygonX<T>(const std::vector<PointX<T> >& v)
-        : std::vector<PointX<T> >(v) {}
-    inline PolygonX<T>(size_t size)
-        : std::vector<PointX<T> >(size) {}
+    inline PolygonX<T>(const std::vector<PointX<T> >& v) : std::vector<PointX<T> >(v) {
+    }
+    inline PolygonX<T>(size_t size) : std::vector<PointX<T> >(size) {
+    }
 
     inline PolygonX<T>& operator<<(const PointX<T>& p)
     {

--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -3753,7 +3753,7 @@ void Score::cmdPitchUp()
     if (el && el->isLyrics()) {
         cmdMoveLyrics(toLyrics(el), Direction::UP);
     } else if (el && (el->isArticulation() || el->isTextBase())) {
-        el->undoChangeProperty(Pid::OFFSET, el->offset() + PointF(0.0, -MScore::nudgeStep* el->spatium()), PropertyFlags::UNSTYLED);
+        el->undoChangeProperty(Pid::OFFSET, el->offset() + PointF(0.0, -MScore::nudgeStep * el->spatium()), PropertyFlags::UNSTYLED);
     } else if (el && el->isRest()) {
         cmdMoveRest(toRest(el), Direction::UP);
     } else {
@@ -3771,7 +3771,7 @@ void Score::cmdPitchDown()
     if (el && el->isLyrics()) {
         cmdMoveLyrics(toLyrics(el), Direction::DOWN);
     } else if (el && (el->isArticulation() || el->isTextBase())) {
-        el->undoChangeProperty(Pid::OFFSET, QVariant::fromValue(el->offset() + PointF(0.0, MScore::nudgeStep* el->spatium())),
+        el->undoChangeProperty(Pid::OFFSET, QVariant::fromValue(el->offset() + PointF(0.0, MScore::nudgeStep * el->spatium())),
                                PropertyFlags::UNSTYLED);
     } else if (el && el->isRest()) {
         cmdMoveRest(toRest(el), Direction::DOWN);
@@ -3808,7 +3808,7 @@ void Score::cmdPitchUpOctave()
     EngravingItem* el = selection().element();
     if (el && (el->isArticulation() || el->isTextBase())) {
         el->undoChangeProperty(Pid::OFFSET,
-                               QVariant::fromValue(el->offset() + PointF(0.0, -MScore::nudgeStep10* el->spatium())),
+                               QVariant::fromValue(el->offset() + PointF(0.0, -MScore::nudgeStep10 * el->spatium())),
                                PropertyFlags::UNSTYLED);
     } else {
         upDown(true, UpDownMode::OCTAVE);
@@ -3823,7 +3823,7 @@ void Score::cmdPitchDownOctave()
 {
     EngravingItem* el = selection().element();
     if (el && (el->isArticulation() || el->isTextBase())) {
-        el->undoChangeProperty(Pid::OFFSET, el->offset() + PointF(0.0, MScore::nudgeStep10* el->spatium()), PropertyFlags::UNSTYLED);
+        el->undoChangeProperty(Pid::OFFSET, el->offset() + PointF(0.0, MScore::nudgeStep10 * el->spatium()), PropertyFlags::UNSTYLED);
     } else {
         upDown(false, UpDownMode::OCTAVE);
     }

--- a/src/engraving/libmscore/factory.cpp
+++ b/src/engraving/libmscore/factory.cpp
@@ -572,7 +572,7 @@ MAKE_ITEM_IMPL(StaffTypeChange, MeasureBase)
 CREATE_ITEM_IMPL(Stem, ElementType::STEM, Chord)
 COPY_ITEM_IMPL(Stem)
 
-Ms::StemSlash* Factory::createStemSlash(Ms::Chord* parent)
+Ms::StemSlash* Factory::createStemSlash(Ms::Chord * parent)
 {
     StemSlash* s = new StemSlash(parent);
     s->setup();
@@ -581,7 +581,7 @@ Ms::StemSlash* Factory::createStemSlash(Ms::Chord* parent)
 
 COPY_ITEM_IMPL(StemSlash)
 
-Ms::System* Factory::createSystem(Ms::Page* parent)
+Ms::System* Factory::createSystem(Ms::Page * parent)
 {
     System* s = new System(parent);
     s->setup();

--- a/src/engraving/libmscore/fraction.h
+++ b/src/engraving/libmscore/fraction.h
@@ -249,7 +249,7 @@ public:
         if (ticks == -1) {
             return Fraction(-1, 1);        // HACK
         }
-        return Fraction(ticks, MScore::division* 4).reduced();
+        return Fraction(ticks, MScore::division * 4).reduced();
     }
 
     //---------------------------------------------------------
@@ -257,7 +257,7 @@ public:
     ///   A very small fraction, corresponds to 1 MIDI tick
     //---------------------------------------------------------
 
-    static Fraction eps() { return Fraction(1, MScore::division* 4); }
+    static Fraction eps() { return Fraction(1, MScore::division * 4); }
 
     //---------------------------------------------------------
     //   ticks

--- a/src/engraving/libmscore/fret.cpp
+++ b/src/engraving/libmscore/fret.cpp
@@ -417,7 +417,7 @@ void FretDiagram::draw(mu::draw::Painter* painter) const
     if (_fretOffset > 0) {
         qreal fretNumMag = score()->styleD(Sid::fretNumMag);
         mu::draw::Font scaledFont(font);
-        scaledFont.setPointSizeF(font.pointSizeF() * _userMag * (spatium() / SPATIUM20) * MScore::pixelRatio* fretNumMag);
+        scaledFont.setPointSizeF(font.pointSizeF() * _userMag * (spatium() / SPATIUM20) * MScore::pixelRatio * fretNumMag);
         painter->setFont(scaledFont);
         QString text = QString("%1").arg(_fretOffset + 1);
 

--- a/src/engraving/libmscore/glissando.cpp
+++ b/src/engraving/libmscore/glissando.cpp
@@ -136,7 +136,7 @@ void GlissandoSegment::draw(mu::draw::Painter* painter) const
 
     if (glissando()->showText()) {
         mu::draw::Font f(glissando()->fontFace());
-        f.setPointSizeF(glissando()->fontSize() * MScore::pixelRatio* _spatium / SPATIUM20);
+        f.setPointSizeF(glissando()->fontSize() * MScore::pixelRatio * _spatium / SPATIUM20);
         f.setBold(glissando()->fontStyle() & FontStyle::Bold);
         f.setItalic(glissando()->fontStyle() & FontStyle::Italic);
         f.setUnderline(glissando()->fontStyle() & FontStyle::Underline);

--- a/src/engraving/libmscore/sig.cpp
+++ b/src/engraving/libmscore/sig.cpp
@@ -45,7 +45,7 @@ int ticks_beat(int n)
 
 static int ticks_measure(const Fraction& f)
 {
-    return (MScore::division* 4 * f.numerator()) / f.denominator();
+    return (MScore::division * 4 * f.numerator()) / f.denominator();
 }
 
 //---------------------------------------------------------

--- a/src/framework/ui/view/navigationcontrol.h
+++ b/src/framework/ui/view/navigationcontrol.h
@@ -33,7 +33,7 @@ class NavigationPanel;
 class NavigationControl : public AbstractNavigation, public INavigationControl, public async::Asyncable
 {
     Q_OBJECT
-    Q_PROPERTY(mu::ui::NavigationPanel* panel READ panel_property WRITE setPanel NOTIFY panelChanged)
+    Q_PROPERTY(mu::ui::NavigationPanel * panel READ panel_property WRITE setPanel NOTIFY panelChanged)
 
 public:
     explicit NavigationControl(QObject* parent = nullptr);

--- a/src/framework/ui/view/navigationpanel.h
+++ b/src/framework/ui/view/navigationpanel.h
@@ -34,7 +34,7 @@ class NavigationSection;
 class NavigationPanel : public AbstractNavigation, public INavigationPanel, public async::Asyncable
 {
     Q_OBJECT
-    Q_PROPERTY(mu::ui::NavigationSection* section READ section_property WRITE setSection_property NOTIFY sectionChanged)
+    Q_PROPERTY(mu::ui::NavigationSection * section READ section_property WRITE setSection_property NOTIFY sectionChanged)
     Q_PROPERTY(QmlDirection direction READ direction_property WRITE setDirection NOTIFY directionChanged)
     Q_PROPERTY(QString directionInfo READ directionInfo NOTIFY directionChanged)
 

--- a/src/importexport/midi/internal/midiimport/importmidi_fraction.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_fraction.cpp
@@ -134,7 +134,7 @@ ReducedFraction::ReducedFraction(const Fraction& fraction)
 
 ReducedFraction ReducedFraction::fromTicks(int ticks)
 {
-    return ReducedFraction(ticks, MScore::division* 4).reduced();
+    return ReducedFraction(ticks, MScore::division * 4).reduced();
 }
 
 ReducedFraction ReducedFraction::reduced() const

--- a/src/inspector/models/inspectorpopupcontroller.h
+++ b/src/inspector/models/inspectorpopupcontroller.h
@@ -37,7 +37,7 @@ class InspectorPopupController : public QObject
     Q_OBJECT
 
     Q_PROPERTY(QQuickItem * visualControl READ visualControl WRITE setVisualControl NOTIFY visualControlChanged)
-    Q_PROPERTY(mu::uicomponents::PopupView* popup READ popup WRITE setPopup NOTIFY popupChanged)
+    Q_PROPERTY(mu::uicomponents::PopupView * popup READ popup WRITE setPopup NOTIFY popupChanged)
 
 public:
     explicit InspectorPopupController(QObject* parent = nullptr);

--- a/src/inspector/models/text/textsettingsmodel.cpp
+++ b/src/inspector/models/text/textsettingsmodel.cpp
@@ -84,17 +84,17 @@ void TextSettingsModel::loadProperties()
 {
     loadPropertyItem(m_fontFamily, [](const QVariant& elementPropertyValue) -> QVariant {
         return elementPropertyValue.toString() == Ms::TextBase::UNDEFINED_FONT_FAMILY
-        ? QVariant() : elementPropertyValue.toString();
+               ? QVariant() : elementPropertyValue.toString();
     });
 
     loadPropertyItem(m_fontStyle, [](const QVariant& elementPropertyValue) -> QVariant {
         return elementPropertyValue.toInt() == static_cast<int>(Ms::FontStyle::Undefined)
-        ? QVariant() : elementPropertyValue.toInt();
+               ? QVariant() : elementPropertyValue.toInt();
     });
 
     loadPropertyItem(m_fontSize, [](const QVariant& elementPropertyValue) -> QVariant {
         return elementPropertyValue.toInt() == Ms::TextBase::UNDEFINED_FONT_SIZE
-        ? QVariant() : elementPropertyValue.toInt();
+               ? QVariant() : elementPropertyValue.toInt();
     });
 
     loadPropertyItem(m_horizontalAlignment, [](const QVariant& elementPropertyValue) -> QVariant {
@@ -141,7 +141,7 @@ void TextSettingsModel::loadProperties()
     loadPropertyItem(m_textPlacement);
     loadPropertyItem(m_textScriptAlignment, [](const QVariant& elementPropertyValue) -> QVariant {
         return elementPropertyValue.toInt() == static_cast<int>(Ms::VerticalAlignment::AlignUndefined)
-        ? QVariant() : elementPropertyValue.toInt();
+               ? QVariant() : elementPropertyValue.toInt();
     });
 
     updateFramePropertiesAvailability();

--- a/src/notation/inotationplayback.h
+++ b/src/notation/inotationplayback.h
@@ -45,7 +45,7 @@ public:
 
     virtual RetVal<midi::tick_t> playPositionTickByElement(const EngravingItem* element) const = 0;
 
-    enum BoundaryTick : midi::tick_t {
+    enum BoundaryTick : midi :: tick_t {
         FirstScoreTick = 0,
         SelectedNoteTick,
         LastScoreTick

--- a/src/notation/internal/masternotationmididata.cpp
+++ b/src/notation/internal/masternotationmididata.cpp
@@ -308,7 +308,7 @@ Ret MasterNotationMidiData::playNoteMidiData(const Ms::Note* note) const
     MidiData midiData = trackMidiData(masterNote->part()->id());
 
     Events events = retrieveEventsForElement(masterNote, midiChannel);
-    midiData.stream.backgroundStream.send(std::move(events), Ms::MScore::defaultPlayDuration* 2);
+    midiData.stream.backgroundStream.send(std::move(events), Ms::MScore::defaultPlayDuration * 2);
 
     return make_ret(Ret::Code::Ok);
 }
@@ -327,7 +327,7 @@ Ret MasterNotationMidiData::playChordMidiData(const Ms::Chord* chord) const
     MidiData midiData = trackMidiData(part->id());
 
     Events events = retrieveEventsForElement(chord, midiChannel);
-    midiData.stream.backgroundStream.send(std::move(events), Ms::MScore::defaultPlayDuration* 2);
+    midiData.stream.backgroundStream.send(std::move(events), Ms::MScore::defaultPlayDuration * 2);
 
     return make_ret(Ret::Code::Ok);
 }
@@ -352,7 +352,7 @@ Ret MasterNotationMidiData::playHarmonyMidiData(const Ms::Harmony* harmony) cons
     MidiData midiData = trackMidiData(harmony->part()->id());
 
     Events events = retrieveEventsForElement(harmony, midiChannel);
-    midiData.stream.backgroundStream.send(std::move(events), Ms::MScore::defaultPlayDuration* 2);
+    midiData.stream.backgroundStream.send(std::move(events), Ms::MScore::defaultPlayDuration * 2);
 
     return make_ret(Ret::Code::Ok);
 }

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -93,7 +93,7 @@ template<typename T> std::shared_ptr<T> makeElement(Ms::Score* score)
 
 #define MAKE_ELEMENT(T, P) \
     template<> \
-    std::shared_ptr<T> makeElement<T>(Ms::Score* score) { return std::make_shared<T>(P); } \
+    std::shared_ptr<T> makeElement<T>(Ms::Score * score) { return std::make_shared<T>(P); } \
 
 MAKE_ELEMENT(Dynamic, score->dummy()->segment())
 MAKE_ELEMENT(MeasureRepeat, score->dummy()->segment())

--- a/src/palette/internal/paletteprovider.h
+++ b/src/palette/internal/paletteprovider.h
@@ -205,11 +205,11 @@ class PaletteProvider : public QObject, public mu::palette::IPaletteProvider
     INJECT(palette, mu::framework::IInteractive, interactive)
 
     Q_PROPERTY(QAbstractItemModel * mainPaletteModel READ mainPaletteModel NOTIFY mainPaletteChanged)
-    Q_PROPERTY(Ms::AbstractPaletteController* mainPaletteController READ mainPaletteController NOTIFY mainPaletteChanged)
+    Q_PROPERTY(Ms::AbstractPaletteController * mainPaletteController READ mainPaletteController NOTIFY mainPaletteChanged)
 
-    Q_PROPERTY(Ms::FilterPaletteTreeModel* customElementsPaletteModel READ customElementsPaletteModel CONSTANT)
+    Q_PROPERTY(Ms::FilterPaletteTreeModel * customElementsPaletteModel READ customElementsPaletteModel CONSTANT)
     Q_PROPERTY(
-        Ms::AbstractPaletteController* customElementsPaletteController READ customElementsPaletteController CONSTANT)
+        Ms::AbstractPaletteController * customElementsPaletteController READ customElementsPaletteController CONSTANT)
 
 public:
     void init() override;

--- a/src/palette/view/palettemodel.h
+++ b/src/palette/view/palettemodel.h
@@ -44,7 +44,7 @@ class PaletteCellFilter : public QObject
 {
     Q_OBJECT
 
-    PaletteCellFilter* chainedFilter = nullptr;
+    PaletteCellFilter * chainedFilter = nullptr;
 
 signals:
     void filterChanged();

--- a/src/palette/view/paletterootmodel.h
+++ b/src/palette/view/paletterootmodel.h
@@ -39,7 +39,7 @@ class PaletteRootModel : public QObject, public actions::Actionable, public asyn
     INJECT(palette, IPaletteProvider, paletteProvider)
     INJECT(palette, actions::IActionsDispatcher, dispatcher)
 
-    Q_PROPERTY(Ms::PaletteProvider* paletteProvider READ paletteProvider_property CONSTANT)
+    Q_PROPERTY(Ms::PaletteProvider * paletteProvider READ paletteProvider_property CONSTANT)
 
     Q_PROPERTY(bool paletteEnabled READ paletteEnabled NOTIFY paletteEnabledChanged)
     Q_PROPERTY(bool needShowShadowOverlay READ needShowShadowOverlay NOTIFY needShowShadowOverlayChanged)

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -606,7 +606,7 @@ void PlaybackController::setupSequencePlayer()
     PlaybackCursorType cursorType = configuration()->cursorType();
 
     playback()->player()->playbackPositionMsecs().onReceive(this, [this, cursor = std::move(cursorType)]
-                                                                (const TrackSequenceId id, const audio::msecs_t& msecs) {
+                                                            (const TrackSequenceId id, const audio::msecs_t& msecs) {
         if (m_currentSequenceId != id) {
             return;
         }

--- a/src/plugins/api/cursor.h
+++ b/src/plugins/api/cursor.h
@@ -88,14 +88,14 @@ class Cursor : public QObject
     /** Key signature of current staff at tick pos. (read only) */
     Q_PROPERTY(int keySignature READ qmlKeySignature)
     /** Associated score */
-    Q_PROPERTY(Ms::PluginAPI::Score* score READ score WRITE setScore)
+    Q_PROPERTY(Ms::PluginAPI::Score * score READ score WRITE setScore)
 
     /** Current element at track, read only */
-    Q_PROPERTY(Ms::PluginAPI::EngravingItem* element READ element)
+    Q_PROPERTY(Ms::PluginAPI::EngravingItem * element READ element)
     /** Current segment, read only */
-    Q_PROPERTY(Ms::PluginAPI::Segment* segment READ qmlSegment)
+    Q_PROPERTY(Ms::PluginAPI::Segment * segment READ qmlSegment)
     /** Current measure, read only */
-    Q_PROPERTY(Ms::PluginAPI::Measure* measure READ measure)
+    Q_PROPERTY(Ms::PluginAPI::Measure * measure READ measure)
     /**
      * A physical string number where this cursor currently at. This is useful
      * in conjunction with \ref InputStateMode.INPUT_STATE_SYNC_WITH_SCORE

--- a/src/plugins/api/elements.h
+++ b/src/plugins/api/elements.h
@@ -103,12 +103,12 @@ class EngravingItem : public Ms::PluginAPI::ScoreElement
      * Parent element for this element.
      * \since 3.3
      */
-    Q_PROPERTY(Ms::PluginAPI::EngravingItem* parent READ parent)
+    Q_PROPERTY(Ms::PluginAPI::EngravingItem * parent READ parent)
     /**
      * Staff which this element belongs to.
      * \since MuseScore 3.5
      */
-    Q_PROPERTY(Ms::PluginAPI::Staff* staff READ staff)
+    Q_PROPERTY(Ms::PluginAPI::Staff * staff READ staff)
     /**
      * X-axis offset from a reference position in spatium units.
      * \see EngravingItem::offset
@@ -439,7 +439,7 @@ public:
 class Note : public EngravingItem
 {
     Q_OBJECT
-    Q_PROPERTY(Ms::PluginAPI::EngravingItem* accidental READ accidental)
+    Q_PROPERTY(Ms::PluginAPI::EngravingItem * accidental READ accidental)
     Q_PROPERTY(Ms::AccidentalType accidentalType READ accidentalType WRITE setAccidentalType)
     /** List of dots attached to this note */
     Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::EngravingItem> dots READ dots)
@@ -466,18 +466,18 @@ class Note : public EngravingItem
 //       Q_PROPERTY(int                            subchannel        READ subchannel)
     /// Backward tie for this Note.
     /// \since MuseScore 3.3
-    Q_PROPERTY(Ms::PluginAPI::Tie* tieBack READ tieBack)
+    Q_PROPERTY(Ms::PluginAPI::Tie * tieBack READ tieBack)
     /// Forward tie for this Note.
     /// \since MuseScore 3.3
-    Q_PROPERTY(Ms::PluginAPI::Tie* tieForward READ tieForward)
+    Q_PROPERTY(Ms::PluginAPI::Tie * tieForward READ tieForward)
     /// The first note of a series of ties to this note.
     /// This will return the calling note if there is not tieBack.
     /// \since MuseScore 3.3
-    Q_PROPERTY(Ms::PluginAPI::Note* firstTiedNote READ firstTiedNote)
+    Q_PROPERTY(Ms::PluginAPI::Note * firstTiedNote READ firstTiedNote)
     /// The last note of a series of ties to this note.
     /// This will return the calling note if there is not tieForward.
     /// \since MuseScore 3.3
-    Q_PROPERTY(Ms::PluginAPI::Note* lastTiedNote READ lastTiedNote)
+    Q_PROPERTY(Ms::PluginAPI::Note * lastTiedNote READ lastTiedNote)
     /// The NoteType of the note.
     /// \since MuseScore 3.2.1
     Q_PROPERTY(Ms::NoteType noteType READ noteType)
@@ -576,20 +576,20 @@ class DurationElement : public EngravingItem
     * parent tuplets if there are any.
     * \since MuseScore 3.5
     */
-    Q_PROPERTY(Ms::PluginAPI::FractionWrapper* globalDuration READ globalDuration)
+    Q_PROPERTY(Ms::PluginAPI::FractionWrapper * globalDuration READ globalDuration)
 
     /**
     * Actual duration of this element, taking into account ratio of
     * parent tuplets and local time signatures if there are any.
     * \since MuseScore 3.5
     */
-    Q_PROPERTY(Ms::PluginAPI::FractionWrapper* actualDuration READ actualDuration)
+    Q_PROPERTY(Ms::PluginAPI::FractionWrapper * actualDuration READ actualDuration)
 
     /**
     * Tuplet which this element belongs to. If there is no parent tuplet, returns null.
     * \since MuseScore 3.5
     */
-    Q_PROPERTY(Ms::PluginAPI::Tuplet* tuplet READ parentTuplet)
+    Q_PROPERTY(Ms::PluginAPI::Tuplet * tuplet READ parentTuplet)
 
 public:
     /// \cond MS_INTERNAL
@@ -664,7 +664,7 @@ class ChordRest : public DurationElement
      * Beam which covers this chord/rest, if such exists.
      * \since MuseScore 3.6
      */
-    Q_PROPERTY(Ms::PluginAPI::EngravingItem* beam READ beam)
+    Q_PROPERTY(Ms::PluginAPI::EngravingItem * beam READ beam)
 
 public:
     /// \cond MS_INTERNAL
@@ -691,12 +691,12 @@ class Chord : public ChordRest
     /// List of notes belonging to this chord.
     Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::Note> notes READ notes)
     /// Stem of this chord, if exists. \since MuseScore 3.6
-    Q_PROPERTY(Ms::PluginAPI::EngravingItem* stem READ stem)
+    Q_PROPERTY(Ms::PluginAPI::EngravingItem * stem READ stem)
     /// Stem slash of this chord, if exists. Stem slashes are present in grace notes of type acciaccatura.
     /// \since MuseScore 3.6
-    Q_PROPERTY(Ms::PluginAPI::EngravingItem* stemSlash READ stemSlash)
+    Q_PROPERTY(Ms::PluginAPI::EngravingItem * stemSlash READ stemSlash)
     /// Hook on a stem of this chord, if exists. \since MuseScore 3.6
-    Q_PROPERTY(Ms::PluginAPI::EngravingItem* hook READ hook)
+    Q_PROPERTY(Ms::PluginAPI::EngravingItem * hook READ hook)
     /// The NoteType of the chord.
     /// \since MuseScore 3.2.1
     Q_PROPERTY(Ms::NoteType noteType READ noteType)
@@ -748,19 +748,19 @@ class Segment : public EngravingItem
     /// \brief Next segment in this measure
     /// \returns The next segment in this segment's measure.
     /// Null if there is no such segment.
-    Q_PROPERTY(Ms::PluginAPI::Segment* nextInMeasure READ nextInMeasure)
+    Q_PROPERTY(Ms::PluginAPI::Segment * nextInMeasure READ nextInMeasure)
     /// \brief Next segment in this score.\ Doesn't stop at measure border.
     /// \returns The next segment in this score. Null if there is
     /// no such segment (i.e. this is the last segment in the score).
-    Q_PROPERTY(Ms::PluginAPI::Segment* next READ nextInScore)
+    Q_PROPERTY(Ms::PluginAPI::Segment * next READ nextInScore)
     /// \brief Previous segment in this measure
     /// \returns The previous segment in this segment's measure.
     /// Null if there is no such segment.
-    Q_PROPERTY(Ms::PluginAPI::Segment* prevInMeasure READ prevInMeasure)
+    Q_PROPERTY(Ms::PluginAPI::Segment * prevInMeasure READ prevInMeasure)
     /// \brief Previous segment in this score.\ Doesn't stop at measure border.
     /// \returns The previous segment in this score. Null if there is
     /// no such segment (i.e. this is the first segment in the score).
-    Q_PROPERTY(Ms::PluginAPI::Segment* prev READ prevInScore)
+    Q_PROPERTY(Ms::PluginAPI::Segment * prev READ prevInScore)
     // segmentType was read&write in MuseScore 2.X plugin API.
     // Allowing plugins to change random segments types doesn't seem to be a
     // good idea though.
@@ -808,14 +808,14 @@ class Measure : public EngravingItem
 {
     Q_OBJECT
     /// The first segment of this measure
-    Q_PROPERTY(Ms::PluginAPI::Segment* firstSegment READ firstSegment)
+    Q_PROPERTY(Ms::PluginAPI::Segment * firstSegment READ firstSegment)
     /// The last segment of this measure
-    Q_PROPERTY(Ms::PluginAPI::Segment* lastSegment READ lastSegment)
+    Q_PROPERTY(Ms::PluginAPI::Segment * lastSegment READ lastSegment)
 
     // TODO: to MeasureBase?
 //       Q_PROPERTY(bool         lineBreak         READ lineBreak   WRITE undoSetLineBreak)
     /// Next measure.
-    Q_PROPERTY(Ms::PluginAPI::Measure* nextMeasure READ nextMeasure)
+    Q_PROPERTY(Ms::PluginAPI::Measure * nextMeasure READ nextMeasure)
     /// Next measure, accounting for multimeasure rests.
     /// This property may differ from \ref nextMeasure if multimeasure rests
     /// are enabled. If next measure is a multimeasure rest, this property
@@ -825,15 +825,15 @@ class Measure : public EngravingItem
     /// score structure) this property should be preferred.
     /// \see \ref Score.firstMeasureMM
     /// \since MuseScore 3.6
-    Q_PROPERTY(Ms::PluginAPI::Measure* nextMeasureMM READ nextMeasureMM)
+    Q_PROPERTY(Ms::PluginAPI::Measure * nextMeasureMM READ nextMeasureMM)
 //       Q_PROPERTY(bool         pageBreak         READ pageBreak   WRITE undoSetPageBreak)
     /// Previous measure.
-    Q_PROPERTY(Ms::PluginAPI::Measure* prevMeasure READ prevMeasure)
+    Q_PROPERTY(Ms::PluginAPI::Measure * prevMeasure READ prevMeasure)
     /// Previous measure, accounting for multimeasure rests.
     /// See \ref nextMeasureMM for a reference on multimeasure rests.
     /// \see \ref Score.lastMeasureMM
     /// \since MuseScore 3.6
-    Q_PROPERTY(Ms::PluginAPI::Measure* prevMeasureMM READ prevMeasureMM)
+    Q_PROPERTY(Ms::PluginAPI::Measure * prevMeasureMM READ prevMeasureMM)
 
     /// List of measure-related elements: layout breaks, jump/repeat markings etc.
     /// \since MuseScore 3.3
@@ -933,7 +933,7 @@ class Staff : public ScoreElement
     API_PROPERTY_T(qreal, staffUserdist,  STAFF_USERDIST)
 
     /** Part which this staff belongs to. */
-    Q_PROPERTY(Ms::PluginAPI::Part* part READ part);
+    Q_PROPERTY(Ms::PluginAPI::Part * part READ part);
 
 public:
     /// \cond MS_INTERNAL

--- a/src/plugins/api/excerpt.h
+++ b/src/plugins/api/excerpt.h
@@ -46,7 +46,7 @@ class Excerpt : public QObject
 {
     Q_OBJECT
     /** The score object for this part */
-    Q_PROPERTY(Ms::PluginAPI::Score* partScore READ partScore)
+    Q_PROPERTY(Ms::PluginAPI::Score * partScore READ partScore)
     /** The title of this part */
     Q_PROPERTY(QString title READ title)
 

--- a/src/plugins/api/instrument.h
+++ b/src/plugins/api/instrument.h
@@ -231,7 +231,7 @@ class Instrument : public QObject
      * For fretted instruments, an information about this
      * instrument's strings.
      */
-    Q_PROPERTY(Ms::PluginAPI::StringData* stringData READ stringData)
+    Q_PROPERTY(Ms::PluginAPI::StringData * stringData READ stringData)
 
     // TODO: a property for drumset?
 

--- a/src/plugins/api/qmlpluginapi.h
+++ b/src/plugins/api/qmlpluginapi.h
@@ -53,7 +53,7 @@ class MsProcess;
 class Score;
 
 #define DECLARE_API_ENUM(qmlName, cppName, enumName) \
-    Q_PROPERTY(Ms::PluginAPI::Enum* qmlName READ get_##cppName CONSTANT) \
+    Q_PROPERTY(Ms::PluginAPI::Enum * qmlName READ get_##cppName CONSTANT) \
     static Enum* cppName; \
     static Enum* get_##cppName() { \
         if (!cppName) \
@@ -108,7 +108,7 @@ class PluginAPI : public Ms::QmlPlugin
     /** (read-only) */
     Q_PROPERTY(qreal mscoreDPI READ mscoreDPI)
     /** Current score, if any (read only) */
-    Q_PROPERTY(Ms::PluginAPI::Score* curScore READ curScore)
+    Q_PROPERTY(Ms::PluginAPI::Score * curScore READ curScore)
     /** List of currently open scores (read only).\n \since MuseScore 3.2 */
     Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::Score> scores READ scores)
 

--- a/src/plugins/api/score.h
+++ b/src/plugins/api/score.h
@@ -56,13 +56,13 @@ class Score : public Ms::PluginAPI::ScoreElement
     /** List of the excerpts (linked parts) (read only) */
     Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::Excerpt> excerpts READ excerpts)
     /** First measure of the score (read only) */
-    Q_PROPERTY(Ms::PluginAPI::Measure* firstMeasure READ firstMeasure)
+    Q_PROPERTY(Ms::PluginAPI::Measure * firstMeasure READ firstMeasure)
     /**
      * First multimeasure rest measure of the score (read only).
      * \see \ref Measure.nextMeasureMM
      * \since MuseScore 3.2
      */
-    Q_PROPERTY(Ms::PluginAPI::Measure* firstMeasureMM READ firstMeasureMM)
+    Q_PROPERTY(Ms::PluginAPI::Measure * firstMeasureMM READ firstMeasureMM)
     /** Number of harmony items (chord symbols) in the score (read only).\n \since MuseScore 3.2 */
     Q_PROPERTY(int harmonyCount READ harmonyCount)
     /** Whether score has harmonies (chord symbols) (read only).\n \since MuseScore 3.2 */
@@ -73,15 +73,15 @@ class Score : public Ms::PluginAPI::ScoreElement
     /// negative for flats, postitive for sharps (read only).\n \since MuseScore 3.2
     Q_PROPERTY(int keysig READ keysig)
     /** Last measure of the score (read only) */
-    Q_PROPERTY(Ms::PluginAPI::Measure* lastMeasure READ lastMeasure)
+    Q_PROPERTY(Ms::PluginAPI::Measure * lastMeasure READ lastMeasure)
     /**
      * Last multimeasure rest measure of the score (read only).
      * \see \ref Measure.prevMeasureMM
      * \since MuseScore 3.2
      */
-    Q_PROPERTY(Ms::PluginAPI::Measure* lastMeasureMM READ lastMeasureMM)
+    Q_PROPERTY(Ms::PluginAPI::Measure * lastMeasureMM READ lastMeasureMM)
     /** Last score segment (read only) */
-    Q_PROPERTY(Ms::PluginAPI::Segment* lastSegment READ lastSegment)                // TODO: make it function? Was property in 2.X, but firstSegment is a function...
+    Q_PROPERTY(Ms::PluginAPI::Segment * lastSegment READ lastSegment)                // TODO: make it function? Was property in 2.X, but firstSegment is a function...
     /** Number of lyrics items (syllables) in the score (read only).\n \since MuseScore 3.2 */
     Q_PROPERTY(int lyricCount READ lyricCount)
     /** Name of the score, without path leading to it and extension.\n \since MuseScore 3.2 */
@@ -107,9 +107,9 @@ class Score : public Ms::PluginAPI::ScoreElement
     /** MuseScore revision the score has been last saved with (includes autosave) (read only) */
     Q_PROPERTY(QString mscoreRevision READ mscoreRevision)
     /** Current selections for the score. \since MuseScore 3.3 */
-    Q_PROPERTY(Ms::PluginAPI::Selection* selection READ selection)
+    Q_PROPERTY(Ms::PluginAPI::Selection * selection READ selection)
     /** Style settings for this score. \since MuseScore 3.5 */
-    Q_PROPERTY(Ms::PluginAPI::MStyle* style READ style)
+    Q_PROPERTY(Ms::PluginAPI::MStyle * style READ style)
     /**
      * Page numbering offset. The user-visible number of the given \p page is defined as
      * \code

--- a/src/plugins/api/selection.h
+++ b/src/plugins/api/selection.h
@@ -53,14 +53,14 @@ class Selection : public QObject
      * \since MuseScore 3.5
      * \see \ref isRange
      */
-    Q_PROPERTY(Ms::PluginAPI::Segment* startSegment READ startSegment)
+    Q_PROPERTY(Ms::PluginAPI::Segment * startSegment READ startSegment)
     /**
      * End segment of selection, excluded. This property is valid
      * only for range selection.
      * \since MuseScore 3.5
      * \see \ref isRange
      */
-    Q_PROPERTY(Ms::PluginAPI::Segment* endSegment READ endSegment)
+    Q_PROPERTY(Ms::PluginAPI::Segment * endSegment READ endSegment)
     /**
      * First staff of selection, included. This property is valid
      * only for range selection.

--- a/src/plugins/api/tie.h
+++ b/src/plugins/api/tie.h
@@ -39,10 +39,10 @@ class Tie : public EngravingItem
     Q_OBJECT
     /// The starting note of the tie.
     /// \since MuseScore 3.3
-    Q_PROPERTY(Ms::PluginAPI::Note* startNote READ startNote)
+    Q_PROPERTY(Ms::PluginAPI::Note * startNote READ startNote)
     /// The ending note of the tie.
     /// \since MuseScore 3.3
-    Q_PROPERTY(Ms::PluginAPI::Note* endNote READ endNote)
+    Q_PROPERTY(Ms::PluginAPI::Note * endNote READ endNote)
 
     /// \cond MS_INTERNAL
 


### PR DESCRIPTION
29 files were not properly formatted according to the code style bash script. This PR simply fixes the style problems found by that bash script.

Without this change, it can be a pain to check code style locally since running the bash script results in dozens of unwanted changes. With this PR merged, developers can use the bash script again to check code style before submitting a PR.

All changes were made by simply running.

```bash
bash ./build/ci/macos/checkcodestyle.sh
```

_P.S. We need to figure out how these style errors were allowed on the main branch to begin with. Simple things like this should not be allowed past our CI tests and code review._