### PR TITLE
Update instruments.xml to add Shakuhachi

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -43,6 +43,9 @@
       <Family id="dizis">
             <name>Dizis</name>
       </Family>
+      <Family id="shakuhachis">
+            <name>Shakuhachis</name>
+      </Family>
       <Family id="fifes">
             <name>Fifes</name>
       </Family>
@@ -845,6 +848,23 @@
                   <Channel>
                         <!--MIDI: Bank 0, Prog 72; MS General: Piccolo-->
                         <program value="72"/> <!--Piccolo-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="shakuhachi">
+                  <family>shakuhachis</family>
+                  <trackName>Shakuhachi</trackName>
+                  <longName>Shakuhachi</longName>
+                  <shortName>Shak.</shortName>
+                  <description>Japanese bamboo flute</description>
+                  <musicXMLid>wind.flutes.shakuhachi</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>60-88</aPitchRange>
+                  <pPitchRange>60-100</pPitchRange>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 77; MS General: Shakuhachi-->
+                        <program value="77"/> <!--Shakuhachi-->
                   </Channel>
                   <genre>world</genre>
             </Instrument>


### PR DESCRIPTION
Run share/instruments/update_instruments_xml.py to fetch the latest version of the online spreadsheet, which now includes the Shakuhachi instrument.

Resolves: https://musescore.org/en/node/325402#comment-1099569