### PR TITLE
fix #9417 Nested tuplet bracket collisions

### DIFF
--- a/src/engraving/layout/layouttuplets.cpp
+++ b/src/engraving/layout/layouttuplets.cpp
@@ -27,6 +27,31 @@
 using namespace mu::engraving;
 using namespace Ms;
 
+/// <summary>
+/// Recursively calls layout() on any nested tuplets and then the tuplet itself
+/// </summary>
+/// <param name="de">Start element of the tuplet</param>
+void LayoutTuplets::layout(DurationElement* de)
+{
+    Tuplet* t = reinterpret_cast<Tuplet*>(de);
+    if (!t) {
+        return;
+    }
+    // t is top level tuplet
+    // loop through elements of that tuplet
+    for (DurationElement* d : t->elements()) {
+        if (d == de) {
+            continue;
+        }
+        // if element is tuplet, layoutTuplet(that tuplet)
+        if (d->isTuplet()) {
+            layout(d);
+        }
+    }
+    // layout t
+    t->layout();
+}
+
 bool LayoutTuplets::isTopTuplet(ChordRest* cr)
 {
     Tuplet* t = cr->tuplet();

--- a/src/engraving/layout/layouttuplets.h
+++ b/src/engraving/layout/layouttuplets.h
@@ -24,13 +24,14 @@
 
 namespace Ms {
 class ChordRest;
+class DurationElement;
 }
 
 namespace mu::engraving {
 class LayoutTuplets
 {
 public:
-
+    static void layout(Ms::DurationElement* de);
     static bool isTopTuplet(Ms::ChordRest* cr);
     static bool notTopTuplet(Ms::ChordRest* cr);
 };

--- a/src/engraving/libmscore/tuplet.cpp
+++ b/src/engraving/libmscore/tuplet.cpp
@@ -249,14 +249,12 @@ void Tuplet::layout()
     // find first and last chord of tuplet
     // (tuplets can be nested)
     //
-    bool nested = false;
     const DurationElement* cr1 = _elements.front();
     while (cr1->isTuplet()) {
         const Tuplet* t = toTuplet(cr1);
         if (t->elements().empty()) {
             break;
         }
-        nested = true;
         cr1 = t->elements().front();
     }
     const DurationElement* cr2 = _elements.back();
@@ -265,7 +263,6 @@ void Tuplet::layout()
         if (t->elements().empty()) {
             break;
         }
-        nested = true;
         cr2 = t->elements().back();
     }
 
@@ -310,8 +307,7 @@ void Tuplet::layout()
     if (outOfStaff && cr1->isChordRest() && cr2->isChordRest()) {
         // account for staff move when adjusting bracket to avoid staff
         // but don't attempt adjustment unless both endpoints are in same staff
-        // and not a nested tuplet
-        if (toChordRest(cr1)->staffMove() == toChordRest(cr2)->staffMove() && !tuplet() && !nested) {
+        if (toChordRest(cr1)->staffMove() == toChordRest(cr2)->staffMove()) {
             move = toChordRest(cr1)->staffMove();
             if (move == 1) {
                 setStaffIdx(cr1->vStaffIdx());


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9417

Nested tuplets weren't being added to the skyline, presumably because the infrastructure wasn't in place to add them in the right order (nested -> parent). I added that infrastructure, which ended up being a recursive layout function that lays out all nested tuplets before the containing one.
![image](https://user-images.githubusercontent.com/89263931/137221059-65a4ec00-2e40-4025-a4e0-6e0ec2c28b96.png)
Now that they're properly added to the skyline, they respect collisions with accidentals and other lines.