### PR TITLE
Fix #9416 reset grip edit after deleting selected bar lines

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2430,6 +2430,8 @@ void NotationInteraction::deleteSelection()
     }
     apply();
 
+    resetGripEdit();
+
     notifyAboutSelectionChanged();
     notifyAboutNotationChanged();
 }


### PR DESCRIPTION
Resolves: #9416, #9303

Hello,

I appears that while the selection was successfully cleared from the notation after deleting a repeat, the bar line was still being drawn by the `NotationInteraction` because it was still present in `m_gripEditData.element`.

Now, after deleting a repeat (or any bar line), the grip edit will be cleared as well:

![Screenshot 2021-10-16 200049](https://user-images.githubusercontent.com/36641081/137597591-7bb04a8c-89e4-46fd-9317-ed1871665020.png)

![Screenshot 2021-10-16 200040](https://user-images.githubusercontent.com/36641081/137597596-cee2f9a3-0f22-4603-97ca-a1962487c656.png)

Is a test is necessary for this kind of issue ?

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
