### PR TITLE
First steps to enabling plugins

### DIFF
--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -48,6 +48,7 @@ void ApplicationActionController::init()
     dispatcher()->reg(this, "report-bug", this, &ApplicationActionController::openBugReportPage);
     dispatcher()->reg(this, "leave-feedback", this, &ApplicationActionController::openLeaveFeedbackPage);
     dispatcher()->reg(this, "preference-dialog", this, &ApplicationActionController::openPreferencesDialog);
+    dispatcher()->reg(this, "manage-plugins", this, &ApplicationActionController::openAddonsPlugins);
 
     dispatcher()->reg(this, "revert-factory", this, &ApplicationActionController::revertToFactorySettings);
 
@@ -140,6 +141,11 @@ void ApplicationActionController::openPreferencesDialog()
     }
 
     interactive()->open("musescore://preferences");
+}
+
+void ApplicationActionController::openAddonsPlugins()
+{
+    interactive()->open("musescore://home?section=add-ons&subSection=plugins");
 }
 
 void ApplicationActionController::revertToFactorySettings()

--- a/src/appshell/internal/applicationactioncontroller.h
+++ b/src/appshell/internal/applicationactioncontroller.h
@@ -69,6 +69,7 @@ private:
     void openBugReportPage();
     void openLeaveFeedbackPage();
     void openPreferencesDialog();
+    void openAddonsPlugins();
 
     void revertToFactorySettings();
 

--- a/src/appshell/internal/applicationuiactions.cpp
+++ b/src/appshell/internal/applicationuiactions.cpp
@@ -181,7 +181,12 @@ const UiActionList ApplicationUiActions::m_actions = {
              mu::context::UiCtxAny,
              QT_TRANSLATE_NOOP("action", "Check for updates"),
              QT_TRANSLATE_NOOP("action", "Check for updates")
-             )
+             ),
+    UiAction("manage-plugins",
+             mu::context::UiCtxAny,
+             QT_TRANSLATE_NOOP("action", "Manage Plugins"),
+             QT_TRANSLATE_NOOP("action", "Install or remove plugins and change plugin settings")
+             ),
 };
 
 ApplicationUiActions::ApplicationUiActions(std::shared_ptr<ApplicationActionController> controller)

--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -55,6 +55,7 @@ void AppMenuModel::load()
         addItem(),
         formatItem(),
         toolsItem(),
+        pluginsItem(),
         helpItem(),
 #ifdef BUILD_DIAGNOSTICS
         diagnosticItem()
@@ -288,6 +289,18 @@ MenuItem AppMenuModel::toolsItem() const
     };
 
     return makeMenu(qtrc("appshell", "&Tools"), toolsItems);
+}
+
+MenuItem AppMenuModel::pluginsItem() const
+{
+    MenuItemList pluginsItems {
+        makeMenuItem("manage-plugins"),
+//        makeSeparator(),
+//        makeMenuItem("run-plugin-color-notes"), // need implement
+//        makeMenuItem("run-plugin-hello-qml"), // need implement
+    };
+
+    return makeMenu(qtrc("appshell", "&Plugins"), pluginsItems);
 }
 
 MenuItem AppMenuModel::helpItem() const

--- a/src/appshell/view/appmenumodel.h
+++ b/src/appshell/view/appmenumodel.h
@@ -58,6 +58,7 @@ private:
     ui::MenuItem addItem() const;
     ui::MenuItem formatItem() const;
     ui::MenuItem toolsItem() const;
+    ui::MenuItem pluginsItem() const;
     ui::MenuItem helpItem() const;
     ui::MenuItem diagnosticItem() const;
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/PopupPanel.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/PopupPanel.qml
@@ -53,7 +53,9 @@ Rectangle {
     }
 
     function open(navigationCtrl) {
-        root.navigationParentControl = navigationCtrl
+        if (navigationCtrl) {
+            root.navigationParentControl = navigationCtrl
+        }
         root.visible = true
         root.opened()
     }


### PR DESCRIPTION
Reinstate the 'Plugins' menu from MuseScore 3. Currently the only item is "Manage Plugins", which takes the user to the Home tab. (It should take them directly to the Plugins page but this relies on URI functionality not yet implemented.)

![image](https://user-images.githubusercontent.com/11011881/137723956-ce6589c3-6cea-460f-aa70-6ad781049de9.png)

Also fixes a bug that prevents the plugin installation panel from showing when you click a plugin at the bottom of the Add-ons page.

![image](https://user-images.githubusercontent.com/11011881/137725484-9d05985d-a8c2-463d-ab60-586d111c82ac.png)

Once a plugin is installed, it can be run using the "Restart" button. QML UI elements for GUI plugins appear correctly (e.g. helloqml, random2).

![image](https://user-images.githubusercontent.com/11011881/137725843-2411f9b9-6580-4b80-89d5-14ae54fcbef2.png)

However, plugins that interact with the score do not work yet (e.g. colornotes, random2 after you click "create").