### PR TITLE
Take staff scaling into account when calculating length of fractional beams

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -1627,7 +1627,6 @@ void Beam::layout2(std::vector<ChordRest*> crl, SpannerSegmentType, int frag)
 
     qreal _spatium   = spatium();
     PointF _pagePos(pagePos());
-    qreal beamMinLen = score()->styleP(Sid::beamMinLen) * mag();
 
     if (beamLevels == 4) {
         _beamDist = score()->styleP(Sid::beamWidth) * (1 + score()->styleD(Sid::beamDistance) * 4 / 3);
@@ -1900,13 +1899,13 @@ void Beam::layout2(std::vector<ChordRest*> crl, SpannerSegmentType, int frag)
                     }
                 }
             } else {
-                // create broken segment
+                // create broken segment / fractional beams
                 if (cr1->isRest()) {
                     continue;
                 }
 
                 size_t sizeChordRests = crl.size();
-                qreal len = beamMinLen;
+                qreal len = score()->styleP(Sid::beamMinLen) * mag() * c1->staff()->staffMag(c1);
                 //
                 // find direction (by default, segment points to right)
                 //


### PR DESCRIPTION
Resolves: #9025 
Resolves: https://musescore.org/en/node/319243

<img width="776" alt="Fractional beam length fixed" src="https://user-images.githubusercontent.com/48658420/137872509-385be2d8-f782-4384-8990-2a0e91fc7284.png">