### PR TITLE
Update instruments.xml with new instrument descriptions

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -411,7 +411,7 @@
                   <trackName>Winds</trackName>
                   <longName>Winds</longName>
                   <shortName>Wi.</shortName>
-                  <description>Wind section on grand staff.</description>
+                  <description>Wind section notated on a grand staff.</description>
                   <musicXMLid>wind.group</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -432,7 +432,7 @@
                   <longName>Piccolo</longName>
                   <shortName>Picc.</shortName>
                   <dropdownName meaning="transposition">E♭</dropdownName>
-                  <description>Piccolo</description>
+                  <description>Piccolo in E♭, sounding a minor third above the standard piccolo.</description>
                   <musicXMLid>wind.flutes.flute.piccolo</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8va</concertClef>
@@ -452,7 +452,7 @@
                   <longName>Piccolo</longName>
                   <shortName>Picc.</shortName>
                   <dropdownName meaning="transposition">D♭</dropdownName>
-                  <description>Piccolo</description>
+                  <description>Piccolo in D♭, sounding a semitone above the standard piccolo.</description>
                   <musicXMLid>wind.flutes.flute.piccolo</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8va</concertClef>
@@ -472,7 +472,7 @@
                   <longName>Piccolo</longName>
                   <shortName>Picc.</shortName>
                   <dropdownName meaning="transposition">*(C)</dropdownName>
-                  <description>Piccolo</description>
+                  <description>Standard concert piccolo in C.</description>
                   <musicXMLid>wind.flutes.flute.piccolo</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8va</concertClef>
@@ -496,7 +496,7 @@
                   <trackName>Treble Flute</trackName>
                   <longName>Treble Flute</longName>
                   <shortName>Tr. Fl.</shortName>
-                  <description>Treble Flute pitched a fifth above concert flute</description>
+                  <description>Flute in G, sounding a fifth higher than the standard flute.</description>
                   <musicXMLid>wind.flutes.flute</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -514,7 +514,7 @@
                   <trackName>Danso</trackName>
                   <longName>Danso</longName>
                   <shortName>Da.</shortName>
-                  <description>Danso</description>
+                  <description>Notched, end-blown vertical bamboo flute used in Korean folk music.</description>
                   <musicXMLid>wind.flutes.danso</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -531,7 +531,7 @@
                   <trackName>Soprano Flute</trackName>
                   <longName>Soprano Flute</longName>
                   <shortName>Sop. Fl.</shortName>
-                  <description>Flute in E♭, a minor third above concert flute.</description>
+                  <description>Flute in E♭, sound a minor third above the standard flute.</description>
                   <musicXMLid>wind.flutes.flute</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -549,7 +549,7 @@
                   <trackName>Irish Flute</trackName>
                   <longName>Irish Flute</longName>
                   <shortName>Ir. Fl.</shortName>
-                  <description>6 hole tranverse flute</description>
+                  <description>6-hole simple-system wooden transverse flute.</description>
                   <musicXMLid>wind.flutes.flute.irish</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -566,7 +566,7 @@
                   <trackName>Traverso</trackName>
                   <longName>Traverso</longName>
                   <shortName>Trv.</shortName>
-                  <description>Traverso</description>
+                  <description>Baroque wooden transverse flute.</description>
                   <musicXMLid>wind.flutes.flute</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -587,7 +587,7 @@
                   <trackName>Flute</trackName>
                   <longName>Flute</longName>
                   <shortName>Fl.</shortName>
-                  <description>Standard concert flute.</description>
+                  <description>Standard concert flute in C.</description>
                   <musicXMLid>wind.flutes.flute</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -613,7 +613,7 @@
                   <trackName>Alto Flute</trackName>
                   <longName>Alto Flute</longName>
                   <shortName>A. Fl.</shortName>
-                  <description>Alto Flute</description>
+                  <description>Flute in G, sounding a fourth lower than the standard flute.</description>
                   <musicXMLid>wind.flutes.flute.alto</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -634,7 +634,7 @@
                   <trackName>Bass Flute</trackName>
                   <longName>Bass Flute</longName>
                   <shortName>B. Fl.</shortName>
-                  <description>Bass Flute</description>
+                  <description>Flute in C, sounding an octave lower than the standard flute.</description>
                   <musicXMLid>wind.flutes.flute.bass</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
@@ -653,7 +653,7 @@
                   <trackName>Contra-alto Flute</trackName>
                   <longName>Contra-alto Flute</longName>
                   <shortName>C-a. Fl.</shortName>
-                  <description>Contra-alto Flute</description>
+                  <description>Flute in G, sounding an octave below the alto flute.</description>
                   <musicXMLid>wind.flutes.flute.contra-alto</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
@@ -672,7 +672,7 @@
                   <trackName>Contrabass Flute</trackName>
                   <longName>Contrabass Flute</longName>
                   <shortName>Cb. Fl.</shortName>
-                  <description>Contrabass Flute</description>
+                  <description>Flute in C, sounding two octaves lower than the standard flute.</description>
                   <musicXMLid>wind.flutes.flute.contrabass</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -691,7 +691,7 @@
                   <trackName>Sub Contra-alto Flute</trackName>
                   <longName>Sub Contra-alto Flute</longName>
                   <shortName>Sc-a. Fl.</shortName>
-                  <description>Subcontra-alto Flute</description>
+                  <description>Flute in G, sounding two octaves below the alto flute.</description>
                   <musicXMLid>wind.flutes.flute.subcontrabass</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -710,7 +710,7 @@
                   <trackName>Double Contrabass Flute</trackName>
                   <longName>Double Contrabass Flute</longName>
                   <shortName>D. Cb. Fl.</shortName>
-                  <description>Double Contrabass Flute</description>
+                  <description>Flute in C, sounding three octaves below the standard flute.</description>
                   <musicXMLid>wind.flutes.flute.double-contrabass</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -729,7 +729,7 @@
                   <trackName>Hyperbass Flute</trackName>
                   <longName>Hyperbass Flute</longName>
                   <shortName>Hb. Fl.</shortName>
-                  <description>Hyperbass Flute</description>
+                  <description>Flute in C, sounding four octaves below the standard flute.</description>
                   <musicXMLid>wind.flutes.flute.double-contrabass</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F15mb</concertClef>
@@ -749,7 +749,7 @@
                   <longName>A Dizi</longName>
                   <shortName>A Di.</shortName>
                   <dropdownName meaning="tuning">A</dropdownName>
-                  <description>Chinese flute tuned to A (written in C, non-transposing).</description>
+                  <description>Chinese bamboo transverse flute, pitched in A.</description>
                   <musicXMLid>wind.flutes.di-zi</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -767,7 +767,7 @@
                   <longName>G Dizi</longName>
                   <shortName>G Di.</shortName>
                   <dropdownName meaning="tuning">*G</dropdownName>
-                  <description>Chinese flute tuned to G (written in C, non-transposing). The most common Dizi.</description>
+                  <description>Chinese bamboo transverse flute, pitched in G. The most common variant.</description>
                   <musicXMLid>wind.flutes.di-zi</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -785,7 +785,7 @@
                   <longName>F Dizi</longName>
                   <shortName>F Di.</shortName>
                   <dropdownName meaning="tuning">F</dropdownName>
-                  <description>Chinese flute tuned to F (written in C, non-transposing).</description>
+                  <description>Chinese bamboo transverse flute, pitched in F.</description>
                   <musicXMLid>wind.flutes.di-zi</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -803,7 +803,7 @@
                   <longName>E Dizi</longName>
                   <shortName>E Di.</shortName>
                   <dropdownName meaning="tuning">E</dropdownName>
-                  <description>Chinese flute tuned to E (written in C, non-transposing).</description>
+                  <description>Chinese bamboo transverse flute, pitched in E.</description>
                   <musicXMLid>wind.flutes.di-zi</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -821,7 +821,7 @@
                   <longName>D Dizi</longName>
                   <shortName>D Di.</shortName>
                   <dropdownName meaning="tuning">D</dropdownName>
-                  <description>Chinese flute tuned to D (written in C, non-transposing).</description>
+                  <description>Chinese bamboo transverse flute, pitched in D.</description>
                   <musicXMLid>wind.flutes.di-zi</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -839,7 +839,7 @@
                   <longName>C Dizi</longName>
                   <shortName>C Di.</shortName>
                   <dropdownName meaning="tuning">C</dropdownName>
-                  <description>Chinese flute tuned to C (non-transposing).</description>
+                  <description>Chinese bamboo transverse flute, pitched in C.</description>
                   <musicXMLid>wind.flutes.di-zi</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -856,7 +856,7 @@
                   <trackName>Shakuhachi</trackName>
                   <longName>Shakuhachi</longName>
                   <shortName>Shak.</shortName>
-                  <description>Japanese bamboo flute</description>
+                  <description>Japanese bamboo end-blown flute.</description>
                   <musicXMLid>wind.flutes.shakuhachi</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -874,7 +874,7 @@
                   <longName>B♭ Fife</longName>
                   <shortName>B♭ Fife</shortName>
                   <dropdownName meaning="tuning">B♭</dropdownName>
-                  <description>Fife tuned to B♭ when all 6 holes are covered (written in A♭, transposing). The standard fife.</description>
+                  <description>Fife pitched in B♭ (when all 6 holes are covered), notated in A♭, sounding a minor sixth higher than written.</description>
                   <musicXMLid>wind.flutes.fife</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -893,7 +893,7 @@
                   <longName>D Tin Whistle</longName>
                   <shortName>D Tin Wh.</shortName>
                   <dropdownName meaning="tuning">D</dropdownName>
-                  <description>Whistle tuned to B♭ (written in C, non-transposing)</description>
+                  <description>Whistle pitched in D (notated at concert pitch).</description>
                   <musicXMLid>wind.flutes.whistle.tin.d</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -910,7 +910,7 @@
                   <longName>C Tin Whistle</longName>
                   <shortName>C Tin Wh.</shortName>
                   <dropdownName meaning="tuning">C</dropdownName>
-                  <description>Whistle tuned to B♭ (written in C, non-transposing)</description>
+                  <description>Whistle pitched in C.</description>
                   <musicXMLid>wind.flutes.whistle.tin</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -928,7 +928,7 @@
                   <longName>B♭ Tin Whistle</longName>
                   <shortName>B♭ Tin Wh.</shortName>
                   <dropdownName meaning="tuning">B♭</dropdownName>
-                  <description>Whistle tuned to B♭ (written in C, non-transposing)</description>
+                  <description>Whistle pitched in B♭ (notated at concert pitch).</description>
                   <musicXMLid>wind.flutes.whistle.tin.bflat</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -944,7 +944,7 @@
                   <trackName>Slide Whistle</trackName>
                   <longName>Slide Whistle</longName>
                   <shortName>Sl. Wh.</shortName>
-                  <description>Slide or Swanee Whistle</description>
+                  <description>Slide or swanee whistle.</description>
                   <musicXMLid>wind.flutes.slide</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -960,7 +960,7 @@
                   <trackName>French Flageolet</trackName>
                   <longName>French Flageolet</longName>
                   <shortName>Fr. Fla.</shortName>
-                  <description>4 hole Flageolet</description>
+                  <description>Flageolet with four holes.</description>
                   <musicXMLid>wind.flutes.flageolet</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -976,7 +976,7 @@
                   <trackName>English Flageolet</trackName>
                   <longName>English Flageolet</longName>
                   <shortName>Eng. Fla.</shortName>
-                  <description>6 hole Flageolet</description>
+                  <description>Flageolet with six holes.</description>
                   <musicXMLid>wind.flutes.flageolet</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -989,7 +989,7 @@
             </Instrument>
             <Instrument id="flageolet">
                   <family>flageolets</family>
-                  <description>6 hole Flageolet</description>
+                  <description>Flageolet with six holes.</description>
                   <musicXMLid>wind.flutes.flageolet</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1005,7 +1005,7 @@
                   <trackName>Garklein Recorder</trackName>
                   <longName>Garklein Recorder</longName>
                   <shortName>Gk. Rec.</shortName>
-                  <description>Garklein Recorder</description>
+                  <description>The smallest modern recorder, pitched in C (an octave above the soprano).</description>
                   <musicXMLid>wind.flutes.recorder.garklein</musicXMLid>
                   <clef>G15ma</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1022,7 +1022,7 @@
                   <trackName>Sopranino Recorder</trackName>
                   <longName>Sopranino Recorder</longName>
                   <shortName>Si. Rec.</shortName>
-                  <description>Sopranino Recorder</description>
+                  <description>The second smallest recorder, pitched in F (an octave above the alto).</description>
                   <musicXMLid>wind.flutes.recorder.sopranino</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1039,7 +1039,7 @@
                   <trackName>Soprano Recorder</trackName>
                   <longName>Soprano Recorder</longName>
                   <shortName>S. Rec.</shortName>
-                  <description>Soprano Recorder</description>
+                  <description>Also known as the descant recorder. Pitched in C.</description>
                   <musicXMLid>wind.flutes.recorder.soprano</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1056,7 +1056,7 @@
                   <trackName>Recorder</trackName>
                   <longName>Recorder</longName>
                   <shortName>Rec.</shortName>
-                  <description>Recorder</description>
+                  <description>Soprano or descant recorder, pitched in C.</description>
                   <musicXMLid>wind.flutes.recorder</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1074,7 +1074,7 @@
                   <trackName>Alto Recorder</trackName>
                   <longName>Alto Recorder</longName>
                   <shortName>A. Rec.</shortName>
-                  <description>Alto Recorder</description>
+                  <description>Also known as the treble recorder. Pitched in F.</description>
                   <musicXMLid>wind.flutes.recorder.alto</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1091,7 +1091,7 @@
                   <trackName>Tenor Recorder</trackName>
                   <longName>Tenor Recorder</longName>
                   <shortName>T. Rec.</shortName>
-                  <description>Tenor Recorder</description>
+                  <description>Recorder pitched in C (an octave below the soprano).</description>
                   <musicXMLid>wind.flutes.recorder.tenor</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1108,7 +1108,7 @@
                   <trackName>Bass Recorder</trackName>
                   <longName>Bass Recorder</longName>
                   <shortName>B. Rec.</shortName>
-                  <description>Bass Recorder</description>
+                  <description>Recorder pitched in F (an octave below the alto).</description>
                   <musicXMLid>wind.flutes.recorder.bass</musicXMLid>
                   <clef>F8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1125,7 +1125,7 @@
                   <trackName>Greatbass Recorder</trackName>
                   <longName>Greatbass Recorder</longName>
                   <shortName>Gb. Rec.</shortName>
-                  <description>Greatbass Recorder</description>
+                  <description>Recorder pitched in C (an octave below the tenor).</description>
                   <musicXMLid>wind.flutes.recorder.great-bass</musicXMLid>
                   <clef>F8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1142,7 +1142,7 @@
                   <trackName>Contrabass Recorder</trackName>
                   <longName>Contrabass Recorder</longName>
                   <shortName>Cb. Rec.</shortName>
-                  <description>Contrabass Recorder</description>
+                  <description>Recorder pitched in F (an octave below the bass).</description>
                   <musicXMLid>wind.flutes.recorder.contrabass</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1160,7 +1160,7 @@
                   <longName>G Soprano Ocarina</longName>
                   <shortName>G S. Oc.</shortName>
                   <dropdownName meaning="tuning">G</dropdownName>
-                  <description>G Soprano Ocarina</description>
+                  <description>Soprano ocarina pitched in G.</description>
                   <musicXMLid>wind.flutes.ocarina</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1178,7 +1178,7 @@
                   <longName>F Soprano Ocarina</longName>
                   <shortName>F S. Oc.</shortName>
                   <dropdownName meaning="tuning">F</dropdownName>
-                  <description>F Soprano Ocarina</description>
+                  <description>Soprano ocarina pitched in F.</description>
                   <musicXMLid>wind.flutes.ocarina</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1192,7 +1192,7 @@
             </Instrument>
             <Instrument id="ocarina">
                   <family>ocarinas</family>
-                  <description>Ocarina</description>
+                  <description>Soprano ocarina pitched in C.</description>
                   <musicXMLid>wind.flutes.ocarina</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1210,7 +1210,7 @@
                   <longName>C Soprano Ocarina</longName>
                   <shortName>C S. Oc.</shortName>
                   <dropdownName meaning="tuning">*C</dropdownName>
-                  <description>C Soprano Ocarina</description>
+                  <description>Soprano ocarina pitched in C.</description>
                   <musicXMLid>wind.flutes.ocarina</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1228,7 +1228,7 @@
                   <longName>B♭ Soprano Ocarina</longName>
                   <shortName>B♭ S. Oc.</shortName>
                   <dropdownName meaning="tuning">B♭</dropdownName>
-                  <description>B♭ Soprano Ocarina</description>
+                  <description>Soprano ocarina pitched in B♭.</description>
                   <musicXMLid>wind.flutes.ocarina</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1246,7 +1246,7 @@
                   <longName>G Alto Ocarina</longName>
                   <shortName>G A. Oc.</shortName>
                   <dropdownName meaning="tuning">G</dropdownName>
-                  <description>G Alto Ocarina</description>
+                  <description>Alto ocarina pitched in G.</description>
                   <musicXMLid>wind.flutes.ocarina</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1264,7 +1264,7 @@
                   <longName>F Alto Ocarina</longName>
                   <shortName>F A. Oc.</shortName>
                   <dropdownName meaning="tuning">F</dropdownName>
-                  <description>F Alto Ocarina</description>
+                  <description>Alto ocarina pitched in F.</description>
                   <musicXMLid>wind.flutes.ocarina</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1282,7 +1282,7 @@
                   <longName>C Alto Ocarina</longName>
                   <shortName>C A. Oc.</shortName>
                   <dropdownName meaning="tuning">*C</dropdownName>
-                  <description>C Alto Ocarina</description>
+                  <description>Alto ocarina pitched in C.</description>
                   <musicXMLid>wind.flutes.ocarina</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1300,7 +1300,7 @@
                   <longName>B♭ Alto Ocarina</longName>
                   <shortName>B♭ A. Oc.</shortName>
                   <dropdownName meaning="tuning">B♭</dropdownName>
-                  <description>B♭ Alto Ocarina</description>
+                  <description>Alto ocarina pitched in B♭.</description>
                   <musicXMLid>wind.flutes.ocarina</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1318,7 +1318,7 @@
                   <longName>C Bass Ocarina</longName>
                   <shortName>C B. Oc.</shortName>
                   <dropdownName meaning="tuning">*C</dropdownName>
-                  <description>C Bass Ocarina</description>
+                  <description>Bass ocarina pitched in C.</description>
                   <musicXMLid>wind.flutes.ocarina</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1332,7 +1332,7 @@
             </Instrument>
             <Instrument id="gemshorn">
                   <family>gemshorns</family>
-                  <description>Gemshorn</description>
+                  <description>Soprano ocarina made from an animal horn. Pitched in C.</description>
                   <musicXMLid>wind.flutes.gemshorn</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1349,7 +1349,7 @@
                   <trackName>Soprano Gemshorn</trackName>
                   <longName>Soprano Gemshorn</longName>
                   <shortName>S. Gh.</shortName>
-                  <description>Soprano Gemshorn</description>
+                  <description>Soprano ocarina made from an animal horn. Pitched in C.</description>
                   <musicXMLid>wind.flutes.gemshorn</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1366,7 +1366,7 @@
                   <trackName>Alto Gemshorn</trackName>
                   <longName>Alto Gemshorn</longName>
                   <shortName>A. Gh.</shortName>
-                  <description>Alto Gemshorn</description>
+                  <description>Alto ocarina made from an animal horn. Pitched in F.</description>
                   <musicXMLid>wind.flutes.gemshorn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1383,7 +1383,7 @@
                   <trackName>Tenor Gemshorn</trackName>
                   <longName>Tenor Gemshorn</longName>
                   <shortName>T. Gh.</shortName>
-                  <description>Tenor Gemshorn</description>
+                  <description>Tenor ocarina made from an animal horn. Pitched in C (an octave below the soprano).</description>
                   <musicXMLid>wind.flutes.gemshorn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1400,7 +1400,7 @@
                   <trackName>Bass Gemshorn</trackName>
                   <longName>Bass Gemshorn</longName>
                   <shortName>B. Gh.</shortName>
-                  <description>Bass Gemshorn</description>
+                  <description>Bass ocarina made from an animal horn. Pitched in F (an octave below the alto).</description>
                   <musicXMLid>wind.flutes.gemshorn</musicXMLid>
                   <clef>F8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1417,7 +1417,7 @@
                   <trackName>Pan Flute</trackName>
                   <longName>Pan Flute</longName>
                   <shortName>Pn. Fl.</shortName>
-                  <description>Pan Flute</description>
+                  <description>End-blown flute made of a row of closed tubes.</description>
                   <musicXMLid>wind.flutes.panpipes</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1431,7 +1431,7 @@
             </Instrument>
             <Instrument id="quena">
                   <family>quenas</family>
-                  <description>South American traditional flute tuned to C (non-transposing).</description>
+                  <description>South American traditional flute pitched in C.</description>
                   <musicXMLid>wind.flutes.quena</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1449,7 +1449,7 @@
                   <longName>C Quena</longName>
                   <shortName>C Qn.</shortName>
                   <dropdownName meaning="tuning">C</dropdownName>
-                  <description>South American traditional flute tuned to C (non-transposing).</description>
+                  <description>South American traditional flute pitched in C.</description>
                   <musicXMLid>wind.flutes.quena</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1467,7 +1467,7 @@
                   <longName>G Quena</longName>
                   <shortName>G Qn.</shortName>
                   <dropdownName meaning="tuning">*G</dropdownName>
-                  <description>South American traditional flute tuned to G (written in C, non-transposing).</description>
+                  <description>South American traditional flute pitched in G. The most common variant.</description>
                   <musicXMLid>wind.flutes.quena</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1485,7 +1485,7 @@
                   <longName>F Quena</longName>
                   <shortName>F Qn.</shortName>
                   <dropdownName meaning="tuning">F</dropdownName>
-                  <description>South American traditional flute tuned to F (written in C, non-transposing).</description>
+                  <description>South American traditional flute pitched in F.</description>
                   <musicXMLid>wind.flutes.quena</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1503,7 +1503,7 @@
                   <longName>D Quena</longName>
                   <shortName>D Qn.</shortName>
                   <dropdownName meaning="tuning">D</dropdownName>
-                  <description>South American traditional flute tuned to D (written in C, non-transposing).</description>
+                  <description>South American traditional flute pitched in D.</description>
                   <musicXMLid>wind.flutes.quena</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1520,7 +1520,7 @@
                   <trackName>Piccolo Heckelphone</trackName>
                   <longName>Piccolo Heckelphone</longName>
                   <shortName>P. Hph.</shortName>
-                  <description>Piccolo Heckelphone</description>
+                  <description>Very rare variant of the heckelphone in F, sounding a fourth higher than the oboe.</description>
                   <musicXMLid>wind.reed.heckelphone.piccolo</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1536,7 +1536,7 @@
                   <trackName>Piccolo Oboe</trackName>
                   <longName>Piccolo Oboe</longName>
                   <shortName>P. Ob.</shortName>
-                  <description>Piccolo Oboe</description>
+                  <description>Oboe in E♭, sounding a minor third above the standard oboe. Historically called the oboe musette.</description>
                   <musicXMLid>wind.reed.oboe.piccolo</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1554,7 +1554,7 @@
                   <trackName>Baroque Oboe</trackName>
                   <longName>Baroque Oboe</longName>
                   <shortName>Bq. Ob.</shortName>
-                  <description>Baroque Oboe</description>
+                  <description>Baroque oboe with three keys, generally made of boxwood.</description>
                   <musicXMLid>wind.reed.oboe</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1571,7 +1571,7 @@
                   <trackName>Oboe</trackName>
                   <longName>Oboe</longName>
                   <shortName>Ob.</shortName>
-                  <description>Oboe</description>
+                  <description>Standard concert oboe.</description>
                   <musicXMLid>wind.reed.oboe</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1590,7 +1590,7 @@
                   <trackName>Oboe d’amore</trackName>
                   <longName>Oboe d’amore</longName>
                   <shortName>Ob. d’a.</shortName>
-                  <description>Oboe d’amore</description>
+                  <description>Oboe in A, sounding a minor third below the standard oboe.</description>
                   <musicXMLid>wind.reed.oboe-damore</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1608,7 +1608,7 @@
                   <trackName>Oboe da caccia</trackName>
                   <longName>Oboe da caccia</longName>
                   <shortName>Ob. d. ca.</shortName>
-                  <description>Oboe da caccia</description>
+                  <description>Oboe in F, sounding a perfect fifth below the standard oboe.</description>
                   <musicXMLid>wind.reed.oboe-da-caccia</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1627,7 +1627,7 @@
                   <trackName>English Horn</trackName>
                   <longName>English Horn</longName>
                   <shortName>E. Hn.</shortName>
-                  <description>Cor anglais</description>
+                  <description>Oboe in F, sounding a perfect fifth below the standard oboe.</description>
                   <musicXMLid>wind.reed.english-horn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1647,7 +1647,7 @@
                   <trackName>Bass Oboe</trackName>
                   <longName>Bass Oboe</longName>
                   <shortName>B. Ob.</shortName>
-                  <description>Bass Oboe</description>
+                  <description>Oboe in C, sounding an octave lower than the standard oboe. Similar, but not identical to, the heckelphone.</description>
                   <musicXMLid>wind.reed.oboe.bass</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1663,7 +1663,7 @@
                   <trackName>Heckelphone</trackName>
                   <longName>Heckelphone</longName>
                   <shortName>Hph.</shortName>
-                  <description>Heckelphone</description>
+                  <description>Oboe in C, sounding an octave lower than the standard oboe. Similar, but not identical to, the bass oboe.</description>
                   <musicXMLid>wind.reed.heckelphone</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
@@ -1682,7 +1682,7 @@
                   <trackName>Lupophone</trackName>
                   <longName>Lupophone</longName>
                   <shortName>Lph.</shortName>
-                  <description>Lupophone</description>
+                  <description>Very rare instrument similar to the heckelphone, with slightly smaller bore and lower range.</description>
                   <musicXMLid>wind.reed.heckelphone</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1700,7 +1700,7 @@
                   <trackName>Sopranino Shawm</trackName>
                   <longName>Sopranino Shawm</longName>
                   <shortName>Si. Sh.</shortName>
-                  <description>Sopranino Shawm</description>
+                  <description>12th-century conical bore, double-reed instrument, pitched in F (an octave above the alto shawm).</description>
                   <musicXMLid>wind.reed.shawm</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1717,7 +1717,7 @@
                   <trackName>Soprano Shawm</trackName>
                   <longName>Soprano Shawm</longName>
                   <shortName>S. Sh.</shortName>
-                  <description>Shawm</description>
+                  <description>12th-century conical bore, double-reed instrument, pitched in C.</description>
                   <musicXMLid>wind.reed.shawm</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1734,7 +1734,7 @@
                   <trackName>Alto Shawm</trackName>
                   <longName>Alto Shawm</longName>
                   <shortName>A. Sh.</shortName>
-                  <description>Alto Shawm</description>
+                  <description>12th-century conical bore, double-reed instrument, pitched in F (a fifth below the soprano shawm).</description>
                   <musicXMLid>wind.reed.shawm</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1751,7 +1751,7 @@
                   <trackName>Tenor Shawm</trackName>
                   <longName>Tenor Shawm</longName>
                   <shortName>T. Sh.</shortName>
-                  <description>Tenor Shawm</description>
+                  <description>12th-century conical bore, double-reed instrument, pitched in C (an octave below the soprano shawm).</description>
                   <musicXMLid>wind.reed.shawm</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1768,7 +1768,7 @@
                   <trackName>Bass Shawm</trackName>
                   <longName>Bass Shawm</longName>
                   <shortName>B. Sh.</shortName>
-                  <description>Bass Shawm</description>
+                  <description>12th-century conical bore, double-reed instrument, pitched in F (an octave below the alto shawm).</description>
                   <musicXMLid>wind.reed.shawm</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1785,7 +1785,7 @@
                   <trackName>Great Bass Shawm</trackName>
                   <longName>Great Bass Shawm</longName>
                   <shortName>G.B. Sh.</shortName>
-                  <description>Great Bass Shawm</description>
+                  <description>12th-century conical bore, double-reed instrument, pitched in C (an octave below the tenor shawm).</description>
                   <musicXMLid>wind.reed.shawm</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1802,7 +1802,7 @@
                   <trackName>Cromorne</trackName>
                   <longName>Cromorne</longName>
                   <shortName>Cr.</shortName>
-                  <description>French reed instrument from early Baroque period.</description>
+                  <description>French baroque reed instrument of uncertain identity. Not to be confused with the crumhorn.</description>
                   <musicXMLid>wind.reed.cromorne</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1816,7 +1816,7 @@
             </Instrument>
             <Instrument id="crumhorn">
                   <family>crumhorns</family>
-                  <description>Renaissance double-reed instrument with curved end.</description>
+                  <description>Renaissance double-reed instrument with curved end, pitched in C.</description>
                   <musicXMLid>wind.reed.crumhorn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1833,7 +1833,7 @@
                   <trackName>Soprano Crumhorn</trackName>
                   <longName>Soprano Crumhorn</longName>
                   <shortName>S. Crh.</shortName>
-                  <description>Renaissance double-reed instrument with curved end.</description>
+                  <description>Renaissance double-reed instrument with curved end, pitched in C.</description>
                   <musicXMLid>wind.reed.crumhorn.soprano</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1850,7 +1850,7 @@
                   <trackName>Alto Crumhorn</trackName>
                   <longName>Alto Crumhorn</longName>
                   <shortName>A. Crh.</shortName>
-                  <description>Renaissance double-reed instrument with curved end.</description>
+                  <description>Renaissance double-reed instrument with curved end, pitched in F (a fifth below the soprano crumhorn).</description>
                   <musicXMLid>wind.reed.crumhorn.alto</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1867,7 +1867,7 @@
                   <trackName>Tenor Crumhorn</trackName>
                   <longName>Tenor Crumhorn</longName>
                   <shortName>T. Crh.</shortName>
-                  <description>Renaissance double-reed instrument with curved end.</description>
+                  <description>Renaissance double-reed instrument with curved end, pitched in C (an octave below the soprano crumhorn).</description>
                   <musicXMLid>wind.reed.crumhorn.tenor</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1884,7 +1884,7 @@
                   <trackName>Bass Crumhorn</trackName>
                   <longName>Bass Crumhorn</longName>
                   <shortName>B. Crh.</shortName>
-                  <description>Renaissance double-reed instrument with curved end.</description>
+                  <description>Renaissance double-reed instrument with curved end, pitched in F (an octave below the alto crumhorn).</description>
                   <musicXMLid>wind.reed.crumhorn.bass</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1901,7 +1901,7 @@
                   <trackName>Greatbass Crumhorn</trackName>
                   <longName>Greatbass Crumhorn</longName>
                   <shortName>Gb. Crh.</shortName>
-                  <description>Renaissance double-reed instrument with curved end.</description>
+                  <description>Renaissance double-reed instrument with curved end, pitched in C (an octave below the tenor crumhorn).</description>
                   <musicXMLid>wind.reed.crumhorn.great-bass</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1915,7 +1915,7 @@
             </Instrument>
             <Instrument id="cornamuse">
                   <family>cornamuses</family>
-                  <description>Renaissance double-reed instrument with straight end and single bore.</description>
+                  <description>Renaissance double-reed instrument with straight end and single bore, pitched in C.</description>
                   <musicXMLid>wind.reed.cornamuse</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1931,7 +1931,7 @@
                   <trackName>Soprano Cornamuse</trackName>
                   <longName>Soprano Cornamuse</longName>
                   <shortName>S. Cm.</shortName>
-                  <description>Renaissance double-reed instrument with straight end and single bore.</description>
+                  <description>Renaissance double-reed instrument with straight end and single bore, pitched in C.</description>
                   <musicXMLid>wind.reed.cornamuse</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1947,7 +1947,7 @@
                   <trackName>Alto Cornamuse</trackName>
                   <longName>Alto Cornamuse</longName>
                   <shortName>A. Cm.</shortName>
-                  <description>Renaissance double-reed instrument with straight end and single bore.</description>
+                  <description>Renaissance double-reed instrument with straight end and single bore, pitched in G (a fourth below the soprano cornamuse).</description>
                   <musicXMLid>wind.reed.cornamuse</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1963,7 +1963,7 @@
                   <trackName>Tenor Cornamuse</trackName>
                   <longName>Tenor Cornamuse</longName>
                   <shortName>T. Cm.</shortName>
-                  <description>Renaissance double-reed instrument with straight end and single bore.</description>
+                  <description>Renaissance double-reed instrument with straight end and single bore, pitched in C (an octave below the soprano cornamuse).</description>
                   <musicXMLid>wind.reed.cornamuse</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1979,7 +1979,7 @@
                   <trackName>Bass Cornamuse</trackName>
                   <longName>Bass Cornamuse</longName>
                   <shortName>B. Cm.</shortName>
-                  <description>Renaissance double-reed instrument with straight end and single bore.</description>
+                  <description>Renaissance double-reed instrument with straight end and single bore, pitched in F (a ninth below the alto cornamuse).</description>
                   <musicXMLid>wind.reed.cornamuse</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -1995,7 +1995,7 @@
                   <trackName>Soprano Kelhorn</trackName>
                   <longName>Soprano Kelhorn</longName>
                   <shortName>S. Kh.</shortName>
-                  <description>Soprano Kelhorn</description>
+                  <description>20th-century instrument similar to the crumhorn and cornamuse, pitched in C.</description>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>60-74</aPitchRange>
@@ -2011,7 +2011,7 @@
                   <trackName>Alto Kelhorn</trackName>
                   <longName>Alto Kelhorn</longName>
                   <shortName>A. Kh.</shortName>
-                  <description>Alto Kelhorn</description>
+                  <description>20th-century instrument similar to the crumhorn and cornamuse, pitched in F (a fifth below the soprano kelhorn).</description>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>53-67</aPitchRange>
@@ -2027,7 +2027,7 @@
                   <trackName>Tenor Kelhorn</trackName>
                   <longName>Tenor Kelhorn</longName>
                   <shortName>T. Kh.</shortName>
-                  <description>Tenor Kelhorn</description>
+                  <description>20th-century instrument similar to the crumhorn and cornamuse, pitched in C (an octave below the soprano kelhorn).</description>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>48-62</aPitchRange>
@@ -2043,7 +2043,7 @@
                   <trackName>Bass Kelhorn</trackName>
                   <longName>Bass Kelhorn</longName>
                   <shortName>B. Kh.</shortName>
-                  <description>Bass Kelhorn</description>
+                  <description>20th-century instrument similar to the crumhorn and cornamuse, pitched in F (an octave below the alto kelhorn).</description>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>41-55</aPitchRange>
@@ -2059,7 +2059,7 @@
                   <trackName>Greatbass Kelhorn</trackName>
                   <longName>Greatbass Kelhorn</longName>
                   <shortName>Gb. Kh.</shortName>
-                  <description>Greatbass Kelhorn</description>
+                  <description>20th-century instrument similar to the crumhorn and cornamuse, pitched in C (an octave below the tenor kelhorn).</description>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>36-50</aPitchRange>
@@ -2075,7 +2075,7 @@
                   <trackName>Sopranino Rauschpfeife</trackName>
                   <longName>Sopranino Rauschpfeife</longName>
                   <shortName>Si. Rpf.</shortName>
-                  <description>Sopranino Rauschpfeife</description>
+                  <description>16th-century double-reed instrument with a conical bore, pitched in F (a fourth higher than the soprano rauschpfeife).</description>
                   <musicXMLid>wind.reed.rauschpfeife</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2089,7 +2089,7 @@
             </Instrument>
             <Instrument id="rauschpfeife">
                   <family>rauschpfeifes</family>
-                  <description>Rauschpfeife</description>
+                  <description>16th-century double-reed instrument with a conical bore, pitched in C.</description>
                   <musicXMLid>wind.reed.rauschpfeife</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2106,7 +2106,7 @@
                   <trackName>Soprano Rauschpfeife</trackName>
                   <longName>Soprano Rauschpfeife</longName>
                   <shortName>S. Rpf.</shortName>
-                  <description>Soprano Rauschpfeife</description>
+                  <description>16th-century double-reed instrument with a conical bore, pitched in C.</description>
                   <musicXMLid>wind.reed.rauschpfeife</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2124,7 +2124,7 @@
                   <longName>F Duduk</longName>
                   <shortName>F Du.</shortName>
                   <dropdownName meaning="tuning">F</dropdownName>
-                  <description>Armenian double reed woodwind instrument tuned to F (written in C, non-transposing)</description>
+                  <description>Armenian double-reed instrument made of apricot wood, pitched in F.</description>
                   <musicXMLid>wind.reed.duduk</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2142,7 +2142,7 @@
                   <longName>E Duduk</longName>
                   <shortName>E Du.</shortName>
                   <dropdownName meaning="tuning">E</dropdownName>
-                  <description>Armenian double reed woodwind instrument tuned to E (written in C, non-transposing)</description>
+                  <description>Armenian double-reed instrument made of apricot wood, pitched in E.</description>
                   <musicXMLid>wind.reed.duduk</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2160,7 +2160,7 @@
                   <longName>D Duduk</longName>
                   <shortName>D Du.</shortName>
                   <dropdownName meaning="tuning">D</dropdownName>
-                  <description>Armenian double reed woodwind instrument tuned to D (written in C, non-transposing)</description>
+                  <description>Armenian double-reed instrument made of apricot wood, pitched in D.</description>
                   <musicXMLid>wind.reed.duduk</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2178,7 +2178,7 @@
                   <longName>C Duduk</longName>
                   <shortName>C Du.</shortName>
                   <dropdownName meaning="tuning">C</dropdownName>
-                  <description>Armenian double reed woodwind instrument tuned to C (written in C, non-transposing)</description>
+                  <description>Armenian double-reed instrument made of apricot wood, pitched in C.</description>
                   <musicXMLid>wind.reed.duduk</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2196,7 +2196,7 @@
                   <longName>B Duduk</longName>
                   <shortName>B Du.</shortName>
                   <dropdownName meaning="tuning">B</dropdownName>
-                  <description>Armenian double reed woodwind instrument tuned to B (written in C, non-transposing)</description>
+                  <description>Armenian double-reed instrument made of apricot wood, pitched in B.</description>
                   <musicXMLid>wind.reed.duduk</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2214,7 +2214,7 @@
                   <longName>B♭ Duduk</longName>
                   <shortName>B♭ Du.</shortName>
                   <dropdownName meaning="tuning">B♭</dropdownName>
-                  <description>Armenian double reed woodwind instrument tuned to B♭ (written in C, non-transposing)</description>
+                  <description>Armenian double-reed instrument made of apricot wood, pitched in B♭.</description>
                   <musicXMLid>wind.reed.duduk</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2228,7 +2228,7 @@
             </Instrument>
             <Instrument id="duduk">
                   <family>duduks</family>
-                  <description>Armenian double reed woodwind instrument tuned to A (written in C, non-transposing)</description>
+                  <description>Armenian double-reed instrument made of apricot wood, pitched in A.</description>
                   <musicXMLid>wind.reed.duduk</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2246,7 +2246,7 @@
                   <longName>A Duduk</longName>
                   <shortName>A Du.</shortName>
                   <dropdownName meaning="tuning">*A</dropdownName>
-                  <description>Armenian double reed woodwind instrument tuned to A (written in C, non-transposing)</description>
+                  <description>Armenian double-reed instrument made of apricot wood, pitched in A.</description>
                   <musicXMLid>wind.reed.duduk</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2264,7 +2264,7 @@
                   <longName>G Duduk</longName>
                   <shortName>G Du.</shortName>
                   <dropdownName meaning="tuning">G</dropdownName>
-                  <description>Armenian double reed woodwind instrument tuned to G (written in C, non-transposing)</description>
+                  <description>Armenian double-reed instrument made of apricot wood, pitched in G.</description>
                   <musicXMLid>wind.reed.duduk</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2282,7 +2282,7 @@
                   <longName>A Bass Duduk</longName>
                   <shortName>A B. Du.</shortName>
                   <dropdownName meaning="tuning">*A</dropdownName>
-                  <description>Armenian double reed woodwind instrument tuned to A (written in C, non-transposing)</description>
+                  <description>Armenian double-reed instrument made of apricot wood, pitched in A (an octave below the normal duduk in A).</description>
                   <musicXMLid>wind.reed.duduk</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2299,7 +2299,7 @@
                   <trackName>Shenai</trackName>
                   <longName>Shenai</longName>
                   <shortName>She.</shortName>
-                  <description>Shenai</description>
+                  <description>Indian double-reed instrument with a flared bell.</description>
                   <musicXMLid>wind.reed.shenai</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2316,7 +2316,7 @@
                   <trackName>Piccolo Clarinet</trackName>
                   <longName>Piccolo Clarinet</longName>
                   <shortName>P. Cl.</shortName>
-                  <description>Piccolo Clarinet</description>
+                  <description>Sopranino clarinet in A♭.</description>
                   <musicXMLid>wind.reed.clarinet.piccolo.aflat</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2334,7 +2334,7 @@
                   <trackName>Soprano Clarinet</trackName>
                   <longName>Soprano Clarinet</longName>
                   <shortName>S. Cl.</shortName>
-                  <description>Soprano Clarinet</description>
+                  <description>Sopranino clarinet (despite the name) in G.</description>
                   <musicXMLid>wind.reed.clarinet</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2354,7 +2354,7 @@
                   <longName>Clarinet</longName>
                   <shortName>Cl.</shortName>
                   <dropdownName meaning="transposition">E♭</dropdownName>
-                  <description>A soprano clarinet (single-reed woodwind instrument). Sometimes classified as a sopranino clarinet.</description>
+                  <description>Sopranino clarinet in E♭.</description>
                   <musicXMLid>wind.reed.clarinet.eflat</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2376,7 +2376,7 @@
                   <longName>Clarinet</longName>
                   <shortName>Cl.</shortName>
                   <dropdownName meaning="transposition">D</dropdownName>
-                  <description>A soprano clarinet (single-reed woodwind instrument). Sometimes classified as a sopranino clarinet.</description>
+                  <description>Sopranino clarinet in D.</description>
                   <musicXMLid>wind.reed.clarinet</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2395,7 +2395,7 @@
                   <longName>Clarinet</longName>
                   <shortName>Cl.</shortName>
                   <dropdownName meaning="transposition">C</dropdownName>
-                  <description>A soprano clarinet (single-reed woodwind instrument).</description>
+                  <description>Soprano clarinet in C.</description>
                   <musicXMLid>wind.reed.clarinet</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2412,7 +2412,7 @@
                   <longName>Clarinet</longName>
                   <shortName>Cl.</shortName>
                   <dropdownName meaning="transposition">*B♭</dropdownName>
-                  <description>A soprano clarinet (single-reed woodwind instrument). The standard clarinet.</description>
+                  <description>Soprano clarinet in B♭. One of the standard orchestral clarinets.</description>
                   <musicXMLid>wind.reed.clarinet.bflat</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2432,7 +2432,7 @@
             </Instrument>
             <Instrument id="clarinet">
                   <family>clarinets</family>
-                  <description>A soprano clarinet (single-reed woodwind instrument).</description>
+                  <description>Soprano clarinet in B♭. One of the standard orchestral clarinets.</description>
                   <musicXMLid>wind.reed.clarinet</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2451,7 +2451,7 @@
                   <longName>Clarinet</longName>
                   <shortName>Cl.</shortName>
                   <dropdownName meaning="transposition">A</dropdownName>
-                  <description>A soprano clarinet (single-reed woodwind instrument).</description>
+                  <description>Soprano clarinet in A. One of the standard orchestral clarinets.</description>
                   <musicXMLid>wind.reed.clarinet.a</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2471,7 +2471,7 @@
                   <longName>Clarinet</longName>
                   <shortName>Cl.</shortName>
                   <dropdownName meaning="transposition">G</dropdownName>
-                  <description>A soprano clarinet (single-reed woodwind instrument).</description>
+                  <description>Soprano clarinet in G.</description>
                   <musicXMLid>wind.reed.clarinet</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2489,7 +2489,7 @@
                   <trackName>Basset Clarinet</trackName>
                   <longName>Basset Clarinet</longName>
                   <shortName>Ba. Cl.</shortName>
-                  <description>Basset Clarinet</description>
+                  <description>Similar to the standard soprano clarinet, but with an extension to the lower range.</description>
                   <musicXMLid>wind.reed.clarinet.basset</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2507,7 +2507,7 @@
                   <trackName>Alto Clarinet</trackName>
                   <longName>Alto Clarinet</longName>
                   <shortName>A. Cl.</shortName>
-                  <description>Alto Clarinet</description>
+                  <description>Alto clarinet in E♭.</description>
                   <musicXMLid>wind.reed.clarinet.alto</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2526,7 +2526,7 @@
                   <trackName>Basset Horn</trackName>
                   <longName>Basset Horn</longName>
                   <shortName>Ba. Hn.</shortName>
-                  <description>Basset Horn</description>
+                  <description>Member of the clarinet family with a larger bore and extended lower range.</description>
                   <musicXMLid>wind.reed.basset-horn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2542,7 +2542,7 @@
             </Instrument>
             <Instrument id="bass-clarinet">
                   <family>clarinets</family>
-                  <description>Bass Clarinet</description>
+                  <description>Bass clarinet in B♭. An octave lower than the B♭ soprano clarinet.</description>
                   <musicXMLid>wind.reed.clarinet.bass</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
@@ -2562,7 +2562,7 @@
                   <longName>Bass Clarinet</longName>
                   <shortName>B. Cl.</shortName>
                   <dropdownName meaning="transposition">*(B♭)</dropdownName>
-                  <description>B♭ Bass Clarinet</description>
+                  <description>Bass clarinet in B♭. An octave lower than the B♭ soprano clarinet. Notated in the treble clef (‘French notation’).</description>
                   <musicXMLid>wind.reed.clarinet.bass</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
@@ -2587,7 +2587,7 @@
                   <longName>Bass Clarinet</longName>
                   <shortName>B. Cl.</shortName>
                   <dropdownName meaning="transposition">*(B♭)</dropdownName>
-                  <description>B♭ Bass Clarinet (Bass Clef)</description>
+                  <description>Bass clarinet in B♭. An octave lower than the B♭ soprano clarinet. Notated in the bass clef (‘German notation’).</description>
                   <musicXMLid>wind.reed.clarinet.bass</musicXMLid>
                   <transposingClef>F</transposingClef>
                   <concertClef>F</concertClef>
@@ -2607,7 +2607,7 @@
                   <longName>Bass Clarinet</longName>
                   <shortName>B. Cl.</shortName>
                   <dropdownName meaning="transposition">A</dropdownName>
-                  <description>A Bass Clarinet</description>
+                  <description>Bass clarinet in A. Extremely rare and almost never used today. Notated in the treble clef (‘French notation’).</description>
                   <musicXMLid>wind.reed.clarinet.bass</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
@@ -2628,7 +2628,7 @@
                   <longName>Bass Clarinet</longName>
                   <shortName>B. Cl.</shortName>
                   <dropdownName meaning="transposition">A</dropdownName>
-                  <description>A Bass Clarinet (Bass Clef)</description>
+                  <description>Bass clarinet in A. Extremely rare and almost never used today. Notated in the bass clef (‘German notation’).</description>
                   <musicXMLid>wind.reed.clarinet.bass</musicXMLid>
                   <transposingClef>F</transposingClef>
                   <concertClef>F</concertClef>
@@ -2647,7 +2647,7 @@
                   <trackName>Contra-alto Clarinet</trackName>
                   <longName>Contra-alto Clarinet</longName>
                   <shortName>C-a. Cl.</shortName>
-                  <description>Contra-alto Clarinet</description>
+                  <description>Contra-alto clarinet in E♭. An octave lower than the E♭ alto clarinet.</description>
                   <musicXMLid>wind.reed.clarinet.contra-alto</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -2667,7 +2667,7 @@
                   <trackName>Contrabass Clarinet</trackName>
                   <longName>Contrabass Clarinet</longName>
                   <shortName>Cb. Cl.</shortName>
-                  <description>Contrabass Clarinet</description>
+                  <description>Contrabass clarinet in B♭. An octave lower than the B♭ bass clarinet.</description>
                   <musicXMLid>wind.reed.clarinet.contrabass</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -2689,7 +2689,7 @@
                   <trackName>Sopranino Chalumeau</trackName>
                   <longName>Sopranino Chalumeau</longName>
                   <shortName>Si. Cha.</shortName>
-                  <description>Sopranino Chalumeau</description>
+                  <description>Predecessor of the modern-day clarinet, pitched in F (an octave above the alto chalumeau).</description>
                   <musicXMLid>wind.reed.chalumeau</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2706,7 +2706,7 @@
                   <trackName>Soprano Chalumeau</trackName>
                   <longName>Soprano Chalumeau</longName>
                   <shortName>S. Cha.</shortName>
-                  <description>Soprano Chalumeau</description>
+                  <description>Predecessor of the modern-day clarinet, pitched in C (an octave above the tenor chalumeau).</description>
                   <musicXMLid>wind.reed.chalumeau</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2723,7 +2723,7 @@
                   <trackName>Alto Chalumeau</trackName>
                   <longName>Alto Chalumeau</longName>
                   <shortName>A. Cha.</shortName>
-                  <description>Alto Chalumeau</description>
+                  <description>Predecessor of the modern-day clarinet, pitched in F (a fourth above the tenor chalumeau).</description>
                   <musicXMLid>wind.reed.chalumeau</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2737,7 +2737,7 @@
             </Instrument>
             <Instrument id="chalumeau">
                   <family>chalumeaus</family>
-                  <description>Chalumeau</description>
+                  <description>Predecessor of the modern-day clarinet, pitched in C.</description>
                   <musicXMLid>wind.reed.chalumeau</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2754,7 +2754,7 @@
                   <trackName>Tenor Chalumeau</trackName>
                   <longName>Tenor Chalumeau</longName>
                   <shortName>T. Cha.</shortName>
-                  <description>Tenor Chalumeau</description>
+                  <description>Predecessor of the modern-day clarinet, pitched in C (an octave below the soprano chalumeau).</description>
                   <musicXMLid>wind.reed.chalumeau</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2771,7 +2771,7 @@
                   <trackName>Bass Chalumeau</trackName>
                   <longName>Bass Chalumeau</longName>
                   <shortName>B. Cha.</shortName>
-                  <description>Bass Chalumeau</description>
+                  <description>Predecessor of the modern-day clarinet, pitched in F (an fifth below the tenor chalumeau).</description>
                   <musicXMLid>wind.reed.chalumeau</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2789,7 +2789,7 @@
                   <longName>Pocket Sax</longName>
                   <shortName>Pkt. Sax</shortName>
                   <dropdownName meaning="transposition">D</dropdownName>
-                  <description>Xaphoon/Pocket Sax in D</description>
+                  <description>Keyless single-reed instrument with a cylindrical bore and slightly flared bell, in D.</description>
                   <musicXMLid>wind.reed.xaphoon</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
@@ -2811,7 +2811,7 @@
                   <longName>Pocket Sax</longName>
                   <shortName>Pkt. Sax</shortName>
                   <dropdownName meaning="transposition">*C</dropdownName>
-                  <description>Xaphoon/Pocket Sax in C</description>
+                  <description>Keyless single-reed instrument with a cylindrical bore and slightly flared bell, in C.</description>
                   <musicXMLid>wind.reed.xaphoon</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
@@ -2831,7 +2831,7 @@
                   <longName>Pocket Sax</longName>
                   <shortName>Pkt. Sax</shortName>
                   <dropdownName meaning="transposition">B♭</dropdownName>
-                  <description>Xaphoon/Pocket Sax in B♭</description>
+                  <description>Keyless single-reed instrument with a cylindrical bore and slightly flared bell, in B♭.</description>
                   <musicXMLid>wind.reed.xaphoon</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
@@ -2853,7 +2853,7 @@
                   <longName>Pocket Sax</longName>
                   <shortName>Pkt. Sax</shortName>
                   <dropdownName meaning="transposition">G</dropdownName>
-                  <description>Xaphoon/Pocket Sax in G</description>
+                  <description>Keyless single-reed instrument with a cylindrical bore and slightly flared bell, in G.</description>
                   <musicXMLid>wind.reed.xaphoon</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
@@ -2874,7 +2874,7 @@
                   <trackName>Tarogato</trackName>
                   <longName>Tarogato</longName>
                   <shortName>Tar.</shortName>
-                  <description>Tarogato</description>
+                  <description>Single-reed, conical bore instrument used in Hungarian and Romanian folk music.</description>
                   <musicXMLid>wind.reed.taroagato</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2891,7 +2891,7 @@
                   <trackName>Octavin</trackName>
                   <longName>Octavin</longName>
                   <shortName>Oct.</shortName>
-                  <description>Octavin</description>
+                  <description>Very rare single-reed, conical bore woodwind instrument.</description>
                   <musicXMLid>wind.reed.octavin</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2907,7 +2907,7 @@
                   <trackName>Sopranissimo Saxophone</trackName>
                   <longName>Sopranissimo Saxophone</longName>
                   <shortName>Sio. Sax.</shortName>
-                  <description>Sopranissimo Saxophone</description>
+                  <description>Saxophone in B♭ (an octave above the soprano).</description>
                   <musicXMLid>wind.reed.saxophone.sopraninissimo</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2925,7 +2925,7 @@
                   <trackName>Sopranino Saxophone</trackName>
                   <longName>Sopranino Saxophone</longName>
                   <shortName>Si. Sax.</shortName>
-                  <description>Sopranino Saxophone</description>
+                  <description>Saxophone in E♭ (an octave above the alto).</description>
                   <musicXMLid>wind.reed.saxophone.sopranino</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2944,7 +2944,7 @@
                   <trackName>Aulochrome</trackName>
                   <longName>Aulochrome</longName>
                   <shortName>Aul.</shortName>
-                  <description>2 soprano saxes joined together</description>
+                  <description>Consists of two soprano saxophones joined together, played either separately or simultaneously.</description>
                   <musicXMLid>wind.reed.saxophone.aulochrome</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2962,7 +2962,7 @@
                   <trackName>Soprano Saxophone</trackName>
                   <longName>Soprano Saxophone</longName>
                   <shortName>S. Sax.</shortName>
-                  <description>Soprano Saxophone</description>
+                  <description>Saxophone in B♭ (an octave above the tenor).</description>
                   <musicXMLid>wind.reed.saxophone.soprano</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -2985,7 +2985,7 @@
                   <trackName>Mezzo-Soprano Saxophone</trackName>
                   <longName>Mezzo-Soprano Saxophone</longName>
                   <shortName>M.S. Sax.</shortName>
-                  <description>Mezzo-Soprano Saxophone</description>
+                  <description>Saxophone in F (a tone above the alto).</description>
                   <musicXMLid>wind.reed.saxophone.mezzo-soprano</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3003,7 +3003,7 @@
                   <trackName>Heckelphone-clarinet</trackName>
                   <longName>Heckelphone-clarinet</longName>
                   <shortName>Hph.-cl.</shortName>
-                  <description>Heckelphone</description>
+                  <description>Rare wooden instrument with a wide conical bore, akin to a saxophone.</description>
                   <musicXMLid>wind.reed.heckelphone-clarinet</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3019,7 +3019,7 @@
                   <trackName>Alto Saxophone</trackName>
                   <longName>Alto Saxophone</longName>
                   <shortName>A. Sax.</shortName>
-                  <description>Alto Saxophone</description>
+                  <description>Saxophone in E♭ (an octave above the baritone).</description>
                   <musicXMLid>wind.reed.saxophone.alto</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3043,7 +3043,7 @@
                   <trackName>Melody Saxophone</trackName>
                   <longName>Melody Saxophone</longName>
                   <shortName>Mel. Sax.</shortName>
-                  <description>Tenor Saxophone in C</description>
+                  <description>Saxophone in C (a tone above the tenor).</description>
                   <musicXMLid>wind.reed.saxophone.melody</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
@@ -3059,7 +3059,7 @@
             </Instrument>
             <Instrument id="saxophone">
                   <family>saxophones</family>
-                  <description>Saxophone</description>
+                  <description>Saxophone in B♭ (an octave below the soprano).</description>
                   <musicXMLid>wind.reed.saxophone</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
@@ -3078,7 +3078,7 @@
                   <trackName>Tenor Saxophone</trackName>
                   <longName>Tenor Saxophone</longName>
                   <shortName>T. Sax.</shortName>
-                  <description>Tenor Saxophone</description>
+                  <description>Saxophone in B♭ (an octave below the soprano).</description>
                   <musicXMLid>wind.reed.saxophone.tenor</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
@@ -3103,7 +3103,7 @@
                   <trackName>Baritone Saxophone</trackName>
                   <longName>Baritone Saxophone</longName>
                   <shortName>Bar. Sax.</shortName>
-                  <description>Baritone Saxophone</description>
+                  <description>Saxophone in E♭ (an octave below the alto).</description>
                   <musicXMLid>wind.reed.saxophone.baritone</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -3127,7 +3127,7 @@
                   <trackName>Bass Saxophone</trackName>
                   <longName>Bass Saxophone</longName>
                   <shortName>B. Sax.</shortName>
-                  <description>Bass Saxophone</description>
+                  <description>Saxophone in B♭ (an octave below the tenor).</description>
                   <musicXMLid>wind.reed.saxophone.bass</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -3147,7 +3147,7 @@
                   <trackName>Contrabass Saxophone</trackName>
                   <longName>Contrabass Saxophone</longName>
                   <shortName>Cb. Sax.</shortName>
-                  <description>Contrabass Saxophone</description>
+                  <description>Saxophone in E♭ (an octave below the baritone).</description>
                   <musicXMLid>wind.reed.saxophone.contrabass</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F8vb</concertClef>
@@ -3166,7 +3166,7 @@
                   <trackName>Subcontrabass Saxophone</trackName>
                   <longName>Subcontrabass Saxophone</longName>
                   <shortName>Scb. Sax.</shortName>
-                  <description>Subcontrabass Saxophone</description>
+                  <description>Saxophone in B♭ (an octave below the bass).</description>
                   <musicXMLid>wind.reed.saxophone.subcontrabass</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F8vb</concertClef>
@@ -3185,7 +3185,7 @@
                   <trackName>Bassoon</trackName>
                   <longName>Bassoon</longName>
                   <shortName>Bsn.</shortName>
-                  <description>Bassoon</description>
+                  <description>Standard concert bassoon.</description>
                   <musicXMLid>wind.reed.bassoon</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3204,7 +3204,7 @@
                   <trackName>Contrabassoon</trackName>
                   <longName>Contrabassoon</longName>
                   <shortName>Cbsn.</shortName>
-                  <description>Contrabassoon</description>
+                  <description>Larger version of the bassoon, sounding an octave lower.</description>
                   <musicXMLid>wind.reed.contrabassoon</musicXMLid>
                   <transposingClef>F</transposingClef>
                   <concertClef>F8vb</concertClef>
@@ -3225,7 +3225,7 @@
                   <trackName>Reed Contrabass</trackName>
                   <longName>Reed Contrabass</longName>
                   <shortName>Rd. Cbs.</shortName>
-                  <description>Reed Contrabass</description>
+                  <description>Double-reed instrument with an unusually wide conical bore, normally made of metal.</description>
                   <musicXMLid>wind.reed.contrabass</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3243,7 +3243,7 @@
                   <trackName>Dulcian</trackName>
                   <longName>Dulcian</longName>
                   <shortName>Du.</shortName>
-                  <description>Dulcian</description>
+                  <description>Renaissance double-reed instrument with a folded conical bore.</description>
                   <musicXMLid>wind.reed.dulcian</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3260,7 +3260,7 @@
                   <trackName>Rackett</trackName>
                   <longName>Rackett</longName>
                   <shortName>Ra.</shortName>
-                  <description>Rackett</description>
+                  <description>Renaissance double-reed instrument; a predecessor of the bassoon.</description>
                   <musicXMLid>wind.reed.rackett</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3277,7 +3277,7 @@
                   <trackName>Sopranino Sarrusophone</trackName>
                   <longName>Sopranino Sarrusophone</longName>
                   <shortName>Si. Sar.</shortName>
-                  <description>Sopranino Sarrusophone</description>
+                  <description>Single- or double-reed metal instrument with a conical bore, in B♭ (an octave above the soprano).</description>
                   <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3292,7 +3292,7 @@
             </Instrument>
             <Instrument id="sarrusophone">
                   <family>sarrusophones</family>
-                  <description>Sarrusophone</description>
+                  <description>Single- or double-reed metal instrument with a conical bore, in B♭.</description>
                   <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3310,7 +3310,7 @@
                   <trackName>Soprano Sarrusophone</trackName>
                   <longName>Soprano Sarrusophone</longName>
                   <shortName>S. Sar.</shortName>
-                  <description>Soprano Sarrusophone</description>
+                  <description>Single- or double-reed metal instrument with a conical bore, in B♭.</description>
                   <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3328,7 +3328,7 @@
                   <trackName>Alto Sarrusophone</trackName>
                   <longName>Alto Sarrusophone</longName>
                   <shortName>A. Sar.</shortName>
-                  <description>Alto Sarrusophone</description>
+                  <description>Single- or double-reed metal instrument with a conical bore, in E♭.</description>
                   <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3346,7 +3346,7 @@
                   <trackName>Tenor Sarrusophone</trackName>
                   <longName>Tenor Sarrusophone</longName>
                   <shortName>T. Sar.</shortName>
-                  <description>Tenor Sarrusophone</description>
+                  <description>Single- or double-reed metal instrument with a conical bore, in B♭ (an octave below the soprano).</description>
                   <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
@@ -3365,7 +3365,7 @@
                   <trackName>Baritone Sarrusophone</trackName>
                   <longName>Baritone Sarrusophone</longName>
                   <shortName>Bar. Sar.</shortName>
-                  <description>Baritone Sarrusophone</description>
+                  <description>Single- or double-reed metal instrument with a conical bore, in E♭ (an octave below the alto).</description>
                   <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -3384,7 +3384,7 @@
                   <trackName>Bass Sarrusophone</trackName>
                   <longName>Bass Sarrusophone</longName>
                   <shortName>B. Sar.</shortName>
-                  <description>Bass Sarrusophone</description>
+                  <description>Single- or double-reed metal instrument with a conical bore, in B♭ (an octave below the tenor).</description>
                   <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -3403,7 +3403,7 @@
                   <trackName>Contrabass Sarrusophone</trackName>
                   <longName>Contrabass Sarrusophone</longName>
                   <shortName>Cb. Sar.</shortName>
-                  <description>Contrabass Sarrusophone</description>
+                  <description>Single- or double-reed metal instrument with a conical bore, in E♭ (an octave below the baritone).</description>
                   <musicXMLid>wind.reed.sarrusaphone</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F8vb</concertClef>
@@ -3422,7 +3422,7 @@
                   <trackName>Bagpipe</trackName>
                   <longName>Bagpipe</longName>
                   <shortName>Bagp.</shortName>
-                  <description>Bagpipe</description>
+                  <description>Bagpipe.</description>
                   <musicXMLid>wind.pipes.bagpipes</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3444,7 +3444,7 @@
                   <trackName>Accordion</trackName>
                   <longName>Accordion</longName>
                   <shortName>Acc.</shortName>
-                  <description>Accordion</description>
+                  <description>Bellows-driven free-reed instrument with a keyboard or buttons on one end, and buttons on the other.</description>
                   <musicXMLid>keyboard.accordion</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -3466,7 +3466,7 @@
                   <trackName>Bandoneon</trackName>
                   <longName>Bandoneon</longName>
                   <shortName>Ban.</shortName>
-                  <description>Bandoneon</description>
+                  <description>Type of concertina particularly popular in Argentina and Uruguay.</description>
                   <musicXMLid>keyboard.bandoneon</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -3487,7 +3487,7 @@
                   <trackName>Concertina</trackName>
                   <longName>Concertina</longName>
                   <shortName>Conc.</shortName>
-                  <description>Concertina</description>
+                  <description>Bellows-driven free-reed instrument with buttons usually on both ends.</description>
                   <musicXMLid>keyboard.concertina</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -3504,7 +3504,7 @@
             </Instrument>
             <Instrument id="harmonica">
                   <family>harmonicas</family>
-                  <description>Harmonica</description>
+                  <description>10-hole diatonic harmonica pitched in C.</description>
                   <musicXMLid>wind.reed.harmonica</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3524,7 +3524,7 @@
                   <longName>10 Hole High G Diatonic Harmonica</longName>
                   <shortName>Harm.</shortName>
                   <dropdownName meaning="tuning">High G</dropdownName>
-                  <description>Harmonica tuned to G (written in C, non-transposing).</description>
+                  <description>10-hole diatonic harmonica pitched in high G.</description>
                   <musicXMLid>wind.reed.harmonica</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3541,7 +3541,7 @@
                   <longName>10 Hole F Diatonic Harmonica</longName>
                   <shortName>Harm.</shortName>
                   <dropdownName meaning="tuning">F</dropdownName>
-                  <description>Harmonica tuned to F (written in C, non-transposing).</description>
+                  <description>10-hole diatonic harmonic pitched in F.</description>
                   <musicXMLid>wind.reed.harmonica</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3558,7 +3558,7 @@
                   <longName>10 Hole D Diatonic Harmonica</longName>
                   <shortName>Harm.</shortName>
                   <dropdownName meaning="tuning">D</dropdownName>
-                  <description>Harmonica tuned to D (written in C, non-transposing).</description>
+                  <description>10-hole diatonic harmonica pitched in D.</description>
                   <musicXMLid>wind.reed.harmonica</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3575,7 +3575,7 @@
                   <longName>10 Hole C Diatonic Harmonica</longName>
                   <shortName>Harm.</shortName>
                   <dropdownName meaning="tuning">*C</dropdownName>
-                  <description>Harmonica tuned to C (non-transposing).</description>
+                  <description>10-hole diatonic harmonica pitched in C.</description>
                   <musicXMLid>wind.reed.harmonica</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3592,7 +3592,7 @@
                   <longName>10 Hole A Diatonic Harmonica</longName>
                   <shortName>Harm.</shortName>
                   <dropdownName meaning="tuning">A</dropdownName>
-                  <description>Harmonica tuned to A (written in C, non-transposing).</description>
+                  <description>10-hole diatonic harmonica pitched in A.</description>
                   <musicXMLid>wind.reed.harmonica</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3609,7 +3609,7 @@
                   <longName>10 Hole G Diatonic Harmonica</longName>
                   <shortName>Harm.</shortName>
                   <dropdownName meaning="tuning">G</dropdownName>
-                  <description>Harmonica tuned to G (written in C, non-transposing).</description>
+                  <description>10-hole diatonic harmonica pitched in high G.</description>
                   <musicXMLid>wind.reed.harmonica</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3626,7 +3626,7 @@
                   <longName>10 Hole Low D Diatonic Harmonica</longName>
                   <shortName>Harm.</shortName>
                   <dropdownName meaning="tuning">Low D</dropdownName>
-                  <description>Harmonica tuned to D (written in C, non-transposing).</description>
+                  <description>10-hole diatonic harmonica pitched in low D.</description>
                   <musicXMLid>wind.reed.harmonica</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3643,7 +3643,7 @@
                   <longName>12 Hole C Chromatic Harmonica</longName>
                   <shortName>Harm.</shortName>
                   <dropdownName meaning="tuning">*C</dropdownName>
-                  <description>Harmonica tuned to C (non-transposing).</description>
+                  <description>12-hole chromatic harmonica pitched in C.</description>
                   <musicXMLid>wind.reed.harmonica</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3660,7 +3660,7 @@
                   <longName>12 Hole G Chromatic Harmonica</longName>
                   <shortName>Harm.</shortName>
                   <dropdownName meaning="tuning">G</dropdownName>
-                  <description>Harmonica tuned to G (written in C, non-transposing).</description>
+                  <description>12-hole chromatic harmonica pitched in G.</description>
                   <musicXMLid>wind.reed.harmonica</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3677,7 +3677,7 @@
                   <longName>12 Hole Tenor C Chromatic Harmonica</longName>
                   <shortName>Harm.</shortName>
                   <dropdownName meaning="tuning">Tenor C</dropdownName>
-                  <description>Harmonica tuned to C (non-transposing).</description>
+                  <description>12-hole chromatic tenor harmonica pitched in C.</description>
                   <musicXMLid>wind.reed.harmonica</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3694,7 +3694,7 @@
                   <longName>14 Hole C Chromatic Harmonica</longName>
                   <shortName>Harm.</shortName>
                   <dropdownName meaning="tuning">*C</dropdownName>
-                  <description>Harmonica tuned to C (non-transposing).</description>
+                  <description>14-hole chromatic harmonica pitched in C.</description>
                   <musicXMLid>wind.reed.harmonica</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3711,7 +3711,7 @@
                   <longName>16 Hole C Chromatic Harmonica</longName>
                   <shortName>Harm.</shortName>
                   <dropdownName meaning="tuning">*C</dropdownName>
-                  <description>Harmonica tuned to C (non-transposing).</description>
+                  <description>16-hole chromatic harmonica pitched in C.</description>
                   <musicXMLid>wind.reed.harmonica</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3727,7 +3727,7 @@
                   <trackName>20 Hole Chordet Harmonica</trackName>
                   <longName>20 Hole Chordet Harmonica</longName>
                   <shortName>Harm.</shortName>
-                  <description>20 Hole Huang Chordet Harmonica</description>
+                  <description>Huang Chordet 20-hole double harmonica.</description>
                   <musicXMLid>wind.reed.harmonica</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3743,7 +3743,7 @@
                   <trackName>Bass Hohner Harmonica</trackName>
                   <longName>Bass Hohner Harmonica</longName>
                   <shortName>Bs. Harm.</shortName>
-                  <description>Bass 31 hole Hohner Harmonica</description>
+                  <description>Hohner 31-hole bas harmonica.</description>
                   <musicXMLid>wind.reed.harmonica.bass</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3759,7 +3759,7 @@
                   <trackName>Bass Huang Harmonica</trackName>
                   <longName>Bass Huang Harmonica</longName>
                   <shortName>Bs. Harm.</shortName>
-                  <description>Bass 30 hole Huang Harmonica</description>
+                  <description>Huang 30-hole bass harmonica.</description>
                   <musicXMLid>wind.reed.harmonica.bass</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3775,7 +3775,7 @@
                   <trackName>Bass Harmonica</trackName>
                   <longName>Bass Harmonica</longName>
                   <shortName>Bs. Harm.</shortName>
-                  <description>Bass Harmonica</description>
+                  <description>Bass harmonica (non-specific model).</description>
                   <musicXMLid>wind.reed.harmonica.bass</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3791,7 +3791,7 @@
                   <trackName>Melodica</trackName>
                   <longName>Melodica</longName>
                   <shortName>Mel.</shortName>
-                  <description>Melodica</description>
+                  <description>Mouth-blown free reed instrument with a keyboard.</description>
                   <musicXMLid>wind.reed.melodica</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3804,7 +3804,7 @@
             </Instrument>
             <Instrument id="sheng">
                   <family>shengs</family>
-                  <description>Sheng (generic)</description>
+                  <description>Chinese mouth-blown free reed instrument.</description>
                   <musicXMLid>wind.reed.sheng</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3821,7 +3821,7 @@
                   <trackName>Soprano Sheng</trackName>
                   <longName>Soprano Sheng</longName>
                   <shortName>S. She.</shortName>
-                  <description>Soprano Sheng</description>
+                  <description>Chinese mouth-blown free reed instrument.</description>
                   <musicXMLid>wind.reed.sheng</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3838,7 +3838,7 @@
                   <trackName>Alto Sheng</trackName>
                   <longName>Alto Sheng</longName>
                   <shortName>A. She.</shortName>
-                  <description>Alto Sheng</description>
+                  <description>Chinese mouth-blown free reed instrument.</description>
                   <musicXMLid>wind.reed.sheng</musicXMLid>
                   <clef>C3</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3855,7 +3855,7 @@
                   <trackName>Tenor Sheng</trackName>
                   <longName>Tenor Sheng</longName>
                   <shortName>T. She.</shortName>
-                  <description>Tenor Sheng</description>
+                  <description>Chinese mouth-blown free reed instrument.</description>
                   <musicXMLid>wind.reed.sheng</musicXMLid>
                   <clef>C4</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3872,7 +3872,7 @@
                   <trackName>Bass Sheng</trackName>
                   <longName>Bass Sheng</longName>
                   <shortName>B. She.</shortName>
-                  <description>Bass Sheng</description>
+                  <description>Chinese mouth-blown free reed instrument.</description>
                   <musicXMLid>wind.reed.sheng</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3892,7 +3892,7 @@
                   <trackName>Brass</trackName>
                   <longName>Brass</longName>
                   <shortName>Br.</shortName>
-                  <description>Brass section on grand staff as used in Tchaikovsky’s 1812 Overture.</description>
+                  <description>Brass section notated on a grand staff.</description>
                   <musicXMLid>brass.group</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -3913,7 +3913,7 @@
                   <longName>Horn</longName>
                   <shortName>Hn.</shortName>
                   <dropdownName meaning="transposition">C alto</dropdownName>
-                  <description>Horn in C alto</description>
+                  <description>Horn in high C.</description>
                   <musicXMLid>brass.natural-horn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3934,7 +3934,7 @@
                   <longName>Horn</longName>
                   <shortName>Hn.</shortName>
                   <dropdownName meaning="transposition">B♭ alto</dropdownName>
-                  <description>Horn in B♭ alto</description>
+                  <description>Horn in high B♭.</description>
                   <musicXMLid>brass.french-horn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3957,7 +3957,7 @@
                   <longName>Horn</longName>
                   <shortName>Hn.</shortName>
                   <dropdownName meaning="transposition">A</dropdownName>
-                  <description>A Horn</description>
+                  <description>Horn in A.</description>
                   <musicXMLid>brass.natural-horn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -3980,7 +3980,7 @@
                   <longName>Horn</longName>
                   <shortName>Hn.</shortName>
                   <dropdownName meaning="transposition">A♭</dropdownName>
-                  <description>A♭ Horn</description>
+                  <description>Horn in A♭.</description>
                   <musicXMLid>brass.natural-horn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4003,7 +4003,7 @@
                   <longName>Horn</longName>
                   <shortName>Hn.</shortName>
                   <dropdownName meaning="transposition">G</dropdownName>
-                  <description>G Horn</description>
+                  <description>Horn in G.</description>
                   <musicXMLid>brass.natural-horn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4026,7 +4026,7 @@
                   <longName>Horn</longName>
                   <shortName>Hn.</shortName>
                   <dropdownName meaning="transposition">E</dropdownName>
-                  <description>E Horn</description>
+                  <description>Horn in E.</description>
                   <musicXMLid>brass.natural-horn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4049,7 +4049,7 @@
                   <longName>Horn</longName>
                   <shortName>Hn.</shortName>
                   <dropdownName meaning="transposition">E♭</dropdownName>
-                  <description>E♭ Horn</description>
+                  <description>Horn in E♭.</description>
                   <musicXMLid>brass.natural-horn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4072,7 +4072,7 @@
                   <longName>Horn</longName>
                   <shortName>Hn.</shortName>
                   <dropdownName meaning="transposition">D</dropdownName>
-                  <description>D Horn</description>
+                  <description>Horn in D.</description>
                   <musicXMLid>brass.natural-horn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4095,7 +4095,7 @@
                   <longName>Horn</longName>
                   <shortName>Hn.</shortName>
                   <dropdownName meaning="transposition">*F</dropdownName>
-                  <description>Horn</description>
+                  <description>Horn in F. The most common modern orchestral horn.</description>
                   <musicXMLid>brass.french-horn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4122,7 +4122,7 @@
                   <longName>Horn</longName>
                   <shortName>Hn.</shortName>
                   <dropdownName meaning="transposition">C</dropdownName>
-                  <description>Horn in C</description>
+                  <description>Horn in low C.</description>
                   <musicXMLid>brass.natural-horn</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -4146,7 +4146,7 @@
                   <longName>Horn</longName>
                   <shortName>Hn.</shortName>
                   <dropdownName meaning="transposition">C</dropdownName>
-                  <description>Horn in C (bass clef)</description>
+                  <description>Horn in low C (notated in bass clef).</description>
                   <musicXMLid>brass.natural-horn</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4167,7 +4167,7 @@
                   <longName>Horn</longName>
                   <shortName>Hn.</shortName>
                   <dropdownName meaning="transposition">B♭ basso</dropdownName>
-                  <description>Horn in B♭ basso</description>
+                  <description>Horn in low B♭.</description>
                   <musicXMLid>brass.natural-horn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4189,7 +4189,7 @@
                   <trackName>Vienna Horn</trackName>
                   <longName>Vienna Horn</longName>
                   <shortName>V. Hn.</shortName>
-                  <description>Vienna Horn</description>
+                  <description>Horn used primarily in Vienna for classical orchestral music.</description>
                   <musicXMLid>brass.vienna-horn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4212,7 +4212,7 @@
                   <longName>Wagner Tuba</longName>
                   <shortName>Wag. Tb.</shortName>
                   <dropdownName meaning="transposition">B♭</dropdownName>
-                  <description>B♭ Wagner Tuba</description>
+                  <description>Wagner tuba in B♭.</description>
                   <musicXMLid>brass.wagner-tuba</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4231,7 +4231,7 @@
                   <longName>Wagner Tuba</longName>
                   <shortName>Wag. Tb.</shortName>
                   <dropdownName meaning="transposition">*F</dropdownName>
-                  <description>F Wagner Tuba</description>
+                  <description>Wagner tuba in F.</description>
                   <musicXMLid>brass.wagner-tuba</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4246,7 +4246,7 @@
             </Instrument>
             <Instrument id="wagner-tuba">
                   <family>wagner-tubas</family>
-                  <description>F Wagner Tuba (generic)</description>
+                  <description>Wagner tuba in F.</description>
                   <musicXMLid>brass.wagner-tuba</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4265,7 +4265,7 @@
                   <longName>Cornet</longName>
                   <shortName>Cnt.</shortName>
                   <dropdownName meaning="transposition">E♭</dropdownName>
-                  <description>E♭ Cornet</description>
+                  <description>Soprano cornet in E♭.</description>
                   <musicXMLid>brass.cornet.soprano</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4289,7 +4289,7 @@
                   <longName>Cornet</longName>
                   <shortName>Cnt.</shortName>
                   <dropdownName meaning="transposition">C</dropdownName>
-                  <description>C Cornet</description>
+                  <description>Cornet in C.</description>
                   <musicXMLid>brass.cornet</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4310,7 +4310,7 @@
                   <longName>Cornet</longName>
                   <shortName>Cnt.</shortName>
                   <dropdownName meaning="transposition">*B♭</dropdownName>
-                  <description>B♭ Cornet</description>
+                  <description>Cornet in B♭. The most common cornet.</description>
                   <musicXMLid>brass.cornet</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4336,7 +4336,7 @@
                   <longName>Cornet</longName>
                   <shortName>Cnt.</shortName>
                   <dropdownName meaning="transposition">A</dropdownName>
-                  <description>A Cornet</description>
+                  <description>Cornet in A.</description>
                   <musicXMLid>brass.cornet</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4358,7 +4358,7 @@
                   <trackName>Saxhorn</trackName>
                   <longName>Saxhorn</longName>
                   <shortName>Saxhorn</shortName>
-                  <description>Saxhorn</description>
+                  <description>Soprano saxhorn.</description>
                   <musicXMLid>brass.saxhorn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4381,7 +4381,7 @@
                   <longName>Alto Horn</longName>
                   <shortName>A. Hn.</shortName>
                   <dropdownName meaning="transposition">F</dropdownName>
-                  <description>F Alto Horn</description>
+                  <description>Alto horn in F. (Known as ‘tenor horn’ in British English.)</description>
                   <musicXMLid>brass.alto-horn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4404,7 +4404,7 @@
                   <longName>Alto Horn</longName>
                   <shortName>A. Hn.</shortName>
                   <dropdownName meaning="transposition">*E♭</dropdownName>
-                  <description>E♭ Alto Horn</description>
+                  <description>Alto horn in E♭. (Known as ‘tenor horn’ in British English.)</description>
                   <musicXMLid>brass.alto-horn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4426,7 +4426,7 @@
                   <trackName>Baritone Horn</trackName>
                   <longName>Baritone Horn</longName>
                   <shortName>Bar. Hn.</shortName>
-                  <description>Baritone Horn</description>
+                  <description>Baritone horn (sometimes just called ‘baritone’). Notated in bass clef, at concert pitch.</description>
                   <musicXMLid>brass.baritone-horn</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4448,7 +4448,7 @@
                   <trackName>Baritone Horn (treble clef)</trackName>
                   <longName>Baritone Horn</longName>
                   <shortName>Bar. Hn.</shortName>
-                  <description>Baritone Horn (treble clef)</description>
+                  <description>Baritone horn (sometimes just called ‘baritone’). Notated in treble clef, often as a transposing instrument.</description>
                   <musicXMLid>brass.baritone-horn</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -4472,7 +4472,7 @@
                   <trackName>Baritone Horn (Central European, treble clef)</trackName>
                   <longName>Baritone Horn</longName>
                   <shortName>Bar. Hn.</shortName>
-                  <description>Baritone Horn (Central Europe, Treble Clef)</description>
+                  <description>Central European variant of the baritone horn. Notated in treble clef, often as a transposing instrument.</description>
                   <musicXMLid>brass.baritone-horn</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -4497,7 +4497,7 @@
                   <trackName>Baritone Horn (Central European)</trackName>
                   <longName>Baritone Horn</longName>
                   <shortName>Bar. Hn.</shortName>
-                  <description>Baritone Horn (Central Europe)</description>
+                  <description>Central European variant of the baritone horn. Notated in bass clef, at concert pitch.</description>
                   <musicXMLid>brass.baritone-horn</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4519,7 +4519,7 @@
                   <trackName>Posthorn</trackName>
                   <longName>Posthorn</longName>
                   <shortName>Psthn.</shortName>
-                  <description>Posthorn</description>
+                  <description>Valveless cylindrical horn with cupped mouthpiece.</description>
                   <musicXMLid>brass.posthorn</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4540,7 +4540,7 @@
                   <longName>Piccolo Trumpet</longName>
                   <shortName>P. Tpt.</shortName>
                   <dropdownName meaning="transposition">*B♭</dropdownName>
-                  <description>Piccolo Trumpet in B♭</description>
+                  <description>Piccolo trumpet in B♭.</description>
                   <musicXMLid>brass.trumpet.piccolo</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4559,7 +4559,7 @@
             </Instrument>
             <Instrument id="piccolo-trumpet">
                   <family>trumpets</family>
-                  <description>Piccolo Trumpet in B♭ (generic)</description>
+                  <description>Piccolo trumpet in B♭.</description>
                   <musicXMLid>brass.trumpet.piccolo</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4582,7 +4582,7 @@
                   <longName>Piccolo Trumpet</longName>
                   <shortName>P. Tpt.</shortName>
                   <dropdownName meaning="transposition">A</dropdownName>
-                  <description>Piccolo Trumpet in A</description>
+                  <description>Piccolo trumpet in A.</description>
                   <musicXMLid>brass.trumpet.piccolo</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4605,7 +4605,7 @@
                   <longName>Trumpet</longName>
                   <shortName>Tpt.</shortName>
                   <dropdownName meaning="transposition">F</dropdownName>
-                  <description>F Trumpet</description>
+                  <description>Trumpet in F.</description>
                   <musicXMLid>brass.trumpet</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4628,7 +4628,7 @@
                   <longName>Trumpet</longName>
                   <shortName>Tpt.</shortName>
                   <dropdownName meaning="transposition">E</dropdownName>
-                  <description>E Trumpet</description>
+                  <description>Trumpet in E.</description>
                   <musicXMLid>brass.trumpet</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4651,7 +4651,7 @@
                   <longName>Trumpet</longName>
                   <shortName>Tpt.</shortName>
                   <dropdownName meaning="transposition">E♭</dropdownName>
-                  <description>E♭ Trumpet</description>
+                  <description>Trumpet in E♭.</description>
                   <musicXMLid>brass.trumpet</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4674,7 +4674,7 @@
                   <longName>Trumpet</longName>
                   <shortName>Tpt.</shortName>
                   <dropdownName meaning="transposition">D</dropdownName>
-                  <description>D Trumpet</description>
+                  <description>Trumpet in D.</description>
                   <musicXMLid>brass.trumpet.d</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4697,7 +4697,7 @@
                   <longName>Trumpet</longName>
                   <shortName>Tpt.</shortName>
                   <dropdownName meaning="transposition">*C</dropdownName>
-                  <description>Most commonly used transposition in contemporary works.</description>
+                  <description>Trumpet in C. Nowadays the most common orchestral trumpet.</description>
                   <musicXMLid>brass.trumpet.c</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4715,7 +4715,7 @@
             </Instrument>
             <Instrument id="trumpet">
                   <family>trumpets</family>
-                  <description>B♭ Trumpet (generic)</description>
+                  <description>Trumpet in B♭.</description>
                   <musicXMLid>brass.trumpet</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4738,7 +4738,7 @@
                   <longName>Trumpet</longName>
                   <shortName>Tpt.</shortName>
                   <dropdownName meaning="transposition">B♭</dropdownName>
-                  <description>B♭ Trumpet</description>
+                  <description>Trumpet in B♭.</description>
                   <musicXMLid>brass.trumpet.bflat</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4767,7 +4767,7 @@
                   <longName>Trumpet</longName>
                   <shortName>Tpt.</shortName>
                   <dropdownName meaning="transposition">A</dropdownName>
-                  <description>A Trumpet</description>
+                  <description>Trumpet in A.</description>
                   <musicXMLid>brass.trumpet</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4789,7 +4789,7 @@
                   <trackName>Pocket Trumpet</trackName>
                   <longName>Pocket Trumpet</longName>
                   <shortName>Pkt. Tpt.</shortName>
-                  <description>Pocket Trumpet</description>
+                  <description>Trumpet in B♭, with the tubing wound into a smaller coil than the standard trumpet.</description>
                   <musicXMLid>brass.trumpet.pocket</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4811,7 +4811,7 @@
                   <trackName>Slide Trumpet</trackName>
                   <longName>Slide Trumpet</longName>
                   <shortName>Sl.Tpt.</shortName>
-                  <description>SlideTrumpet in B♭</description>
+                  <description>Trumpet in D, fitted with a slide much like a trombone. A predecessor of the sackbut.</description>
                   <musicXMLid>brass.trumpet.slide</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4833,7 +4833,7 @@
                   <trackName>Tenor Trumpet</trackName>
                   <longName>Tenor Trumpet</longName>
                   <shortName>T. Tpt.</shortName>
-                  <description>Tenor Trumpet (included for MusicXML 3 compatibility no range information available)</description>
+                  <description>Tenor trumpet in B♭.</description>
                   <musicXMLid>brass.trumpet.tenor</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4856,7 +4856,7 @@
                   <longName>Bass Trumpet</longName>
                   <shortName>B. Tpt.</shortName>
                   <dropdownName meaning="transposition">E♭</dropdownName>
-                  <description>E♭ Bass Trumpet</description>
+                  <description>Bass trumpet in E♭.</description>
                   <musicXMLid>brass.trumpet.bass</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4880,7 +4880,7 @@
                   <longName>Bass Trumpet</longName>
                   <shortName>B. Tpt.</shortName>
                   <dropdownName meaning="transposition">*C</dropdownName>
-                  <description>Bass Trumpet in C</description>
+                  <description>Bass trumpet in C. The most common bass trumpet in use today.</description>
                   <musicXMLid>brass.trumpet.bass</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
@@ -4900,7 +4900,7 @@
             </Instrument>
             <Instrument id="bass-trumpet">
                   <family>trumpets</family>
-                  <description>Bass Trumpet in B♭ (generic)</description>
+                  <description>Bass trumpet in B♭.</description>
                   <musicXMLid>brass.trumpet.bass</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
@@ -4924,7 +4924,7 @@
                   <longName>Bass Trumpet</longName>
                   <shortName>B. Tpt.</shortName>
                   <dropdownName meaning="transposition">B♭</dropdownName>
-                  <description>B♭ Bass Trumpet</description>
+                  <description>Bass trumpet in B♭.</description>
                   <musicXMLid>brass.trumpet.bass</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
@@ -4949,7 +4949,7 @@
                   <longName>Baroque Trumpet</longName>
                   <shortName>Bq. Tpt.</shortName>
                   <dropdownName meaning="transposition">F</dropdownName>
-                  <description>Baroque Trumpet in F</description>
+                  <description>Baroque trumpet in F.</description>
                   <musicXMLid>brass.trumpet.baroque</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4973,7 +4973,7 @@
                   <longName>Baroque Trumpet</longName>
                   <shortName>Bq. Tpt.</shortName>
                   <dropdownName meaning="transposition">E♭</dropdownName>
-                  <description>Baroque Trumpet in E♭</description>
+                  <description>Baroque trumpet in E♭.</description>
                   <musicXMLid>brass.trumpet.baroque</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -4997,7 +4997,7 @@
                   <longName>Baroque Trumpet</longName>
                   <shortName>Bq. Tpt.</shortName>
                   <dropdownName meaning="transposition">*D</dropdownName>
-                  <description>Baroque Trumpet in D</description>
+                  <description>Baroque trumpet in D.</description>
                   <musicXMLid>brass.trumpet.baroque</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5021,7 +5021,7 @@
                   <longName>Baroque Trumpet</longName>
                   <shortName>Bq. Tpt.</shortName>
                   <dropdownName meaning="transposition">C</dropdownName>
-                  <description>Baroque Trumpet in C</description>
+                  <description>Baroque trumpet in C.</description>
                   <musicXMLid>brass.trumpet.baroque</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5043,7 +5043,7 @@
                   <longName>Baroque Trumpet</longName>
                   <shortName>Bq. Tpt.</shortName>
                   <dropdownName meaning="transposition">B♭</dropdownName>
-                  <description>Baroque Trumpet in B♭</description>
+                  <description>Baroque trumpet in B♭.</description>
                   <musicXMLid>brass.trumpet.baroque</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5063,7 +5063,7 @@
             </Instrument>
             <Instrument id="baroque-trumpet">
                   <family>baroque-trumpets</family>
-                  <description>Baroque Trumpet in B♭ (generic)</description>
+                  <description>Baroque trumpet in B♭.</description>
                   <musicXMLid>brass.trumpet.baroque</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5086,7 +5086,7 @@
                   <trackName>Bugle</trackName>
                   <longName>Bugle</longName>
                   <shortName>Bu.</shortName>
-                  <description>Bugle</description>
+                  <description>Soprano bugle.</description>
                   <musicXMLid>brass.bugle</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5102,7 +5102,7 @@
                   <trackName>Soprano Bugle</trackName>
                   <longName>Soprano Bugle</longName>
                   <shortName>S. Bu.</shortName>
-                  <description>Soprano Bugle</description>
+                  <description>Soprano bugle.</description>
                   <musicXMLid>brass.bugle.soprano</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5119,7 +5119,7 @@
                   <trackName>Alto Bugle</trackName>
                   <longName>Alto Bugle</longName>
                   <shortName>A. Bu.</shortName>
-                  <description>Alto Bugle</description>
+                  <description>Alto bugle.</description>
                   <musicXMLid>brass.bugle.alto</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5136,7 +5136,7 @@
                   <trackName>Mellophone</trackName>
                   <longName>Mellophone</longName>
                   <shortName>Mello.</shortName>
-                  <description>Mellophone</description>
+                  <description>Mellophone bugle in F.</description>
                   <musicXMLid>brass.mellophone</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5156,7 +5156,7 @@
                   <trackName>Baritone Bugle</trackName>
                   <longName>Baritone Bugle</longName>
                   <shortName>Bar. Bu.</shortName>
-                  <description>Bugle</description>
+                  <description>Baritone bugle.</description>
                   <musicXMLid>brass.bugle.baritone</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5175,7 +5175,7 @@
                   <trackName>Euphonium Bugle</trackName>
                   <longName>Euphonium Bugle</longName>
                   <shortName>Euph. Bu.</shortName>
-                  <description>Euphonium Bugle</description>
+                  <description>Euphonium bugle.</description>
                   <musicXMLid>brass.bugle.euphonium-bugle</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5194,7 +5194,7 @@
                   <trackName>Mellophone Bugle</trackName>
                   <longName>Mellophone Bugle</longName>
                   <shortName>Mello. Bu.</shortName>
-                  <description>Bugle</description>
+                  <description>Mellophone bugle in C.</description>
                   <musicXMLid>brass.bugle.mellophone-bugle</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5211,7 +5211,7 @@
                   <trackName>Contrabass Bugle</trackName>
                   <longName>Contrabass Bugle</longName>
                   <shortName>Cb. Bu.</shortName>
-                  <description>Contrabass Bugle</description>
+                  <description>Contrabass bugle.</description>
                   <musicXMLid>brass.bugle.contrabass</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5230,7 +5230,7 @@
                   <trackName>Fiscorn</trackName>
                   <longName>Fiscorn</longName>
                   <shortName>Fsc.</shortName>
-                  <description>Fiscorn</description>
+                  <description>Bass flugelhorn, originally played in polka bands in central Europe.</description>
                   <musicXMLid>brass.fiscorn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5252,7 +5252,7 @@
                   <trackName>Flugelhorn</trackName>
                   <longName>Flugelhorn</longName>
                   <shortName>Flghn.</shortName>
-                  <description>Flugelhorn</description>
+                  <description>Flugelhorn in B♭.</description>
                   <musicXMLid>brass.flugelhorn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5277,7 +5277,7 @@
                   <trackName>Kuhlohorn</trackName>
                   <longName>Kuhlohorn</longName>
                   <shortName>Klhn.</shortName>
-                  <description>Kuhllohorn</description>
+                  <description>Small flugelhorn in B♭, played using a deel bowled mouthpiece.</description>
                   <musicXMLid>brass.kuhlohorn</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5300,7 +5300,7 @@
                   <longName>Alto Ophicleide</longName>
                   <shortName>A. Oph.</shortName>
                   <dropdownName meaning="transposition">F</dropdownName>
-                  <description>F Alto Ophicleide</description>
+                  <description>Alto ophicleide in F.</description>
                   <musicXMLid>brass.ophicleide</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5317,7 +5317,7 @@
                   <longName>Alto Ophicleide</longName>
                   <shortName>A. Oph.</shortName>
                   <dropdownName meaning="transposition">*E♭</dropdownName>
-                  <description>E♭ Alto Ophicleide</description>
+                  <description>Alto ophicleide in E♭.</description>
                   <musicXMLid>brass.ophicleide</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5330,7 +5330,7 @@
             </Instrument>
             <Instrument id="ophicleide">
                   <family>ophicleides</family>
-                  <description>Bass Ophicleide (generic)</description>
+                  <description>Bass ophicleide in C.</description>
                   <musicXMLid>brass.ophicleide</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5347,7 +5347,7 @@
                   <longName>Bass Ophicleide</longName>
                   <shortName>B. Oph.</shortName>
                   <dropdownName meaning="transposition">*C</dropdownName>
-                  <description>C Bass Ophicleide</description>
+                  <description>Bass ophicleide in C.</description>
                   <musicXMLid>brass.ophicleide</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5364,7 +5364,7 @@
                   <longName>Bass Ophicleide</longName>
                   <shortName>B. Oph.</shortName>
                   <dropdownName meaning="transposition">B♭</dropdownName>
-                  <description>B♭ Bass Ophicleide</description>
+                  <description>Bass ophicleide in B♭.</description>
                   <musicXMLid>brass.ophicleide</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5381,7 +5381,7 @@
                   <longName>Contrabass Ophicleide</longName>
                   <shortName>Cb. Oph.</shortName>
                   <dropdownName meaning="transposition">*E♭</dropdownName>
-                  <description>E♭ Contrabass Ophicleide</description>
+                  <description>Contrabass ophicleide in E♭.</description>
                   <musicXMLid>brass.ophicleide</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5397,7 +5397,7 @@
                   <trackName>Cornettino</trackName>
                   <longName>Cornettino</longName>
                   <shortName>Co.</shortName>
-                  <description>Cornettino</description>
+                  <description>Medieval wind instrument, consisting of a conical wooden pipe covered in leather. The cornettino is the descant of the family.</description>
                   <musicXMLid>brass.cornettino</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5411,7 +5411,7 @@
             </Instrument>
             <Instrument id="cornett">
                   <family>cornetts</family>
-                  <description>Soprano Cornett (generic)</description>
+                  <description>Medieval wind instrument, consisting of a conical wooden pipe covered in leather. The soprano is the most common cornett.</description>
                   <musicXMLid>brass.cornett</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5428,7 +5428,7 @@
                   <trackName>Soprano Cornett</trackName>
                   <longName>Soprano Cornett</longName>
                   <shortName>S. Co.</shortName>
-                  <description>The most common cornett.</description>
+                  <description>Medieval wind instrument, consisting of a conical wooden pipe covered in leather. The soprano is the most common cornett.</description>
                   <musicXMLid>brass.cornett</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5445,7 +5445,7 @@
                   <trackName>Alto Cornett</trackName>
                   <longName>Alto Cornett</longName>
                   <shortName>A. Co.</shortName>
-                  <description>Alto Cornett</description>
+                  <description>Medieval wind instrument, consisting of a conical wooden pipe covered in leather.</description>
                   <musicXMLid>brass.cornett</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5462,7 +5462,7 @@
                   <trackName>Tenor Cornett</trackName>
                   <longName>Tenor Cornett</longName>
                   <shortName>T. Co.</shortName>
-                  <description>Tenor Cornett</description>
+                  <description>Medieval wind instrument, consisting of a conical wooden pipe covered in leather.</description>
                   <musicXMLid>brass.cornett.tenor</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5479,7 +5479,7 @@
                   <trackName>Serpent</trackName>
                   <longName>Serpent</longName>
                   <shortName>Spt.</shortName>
-                  <description>Serpent</description>
+                  <description>Descendant of the cornett, and distant ancestor of the tuba.</description>
                   <musicXMLid>brass.serpent</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5496,7 +5496,7 @@
                   <trackName>Soprano Trombone</trackName>
                   <longName>Soprano Trombone</longName>
                   <shortName>S. Tbn.</shortName>
-                  <description>Soprano Trombone</description>
+                  <description>Soprano trombone (usually pitched in B♭, an octave above the tenor).</description>
                   <musicXMLid>brass.trombone</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5516,7 +5516,7 @@
                   <trackName>Alto Trombone</trackName>
                   <longName>Alto Trombone</longName>
                   <shortName>A. Tbn.</shortName>
-                  <description>Alto Trombone</description>
+                  <description>Alto trombone (pitched in E♭ or F).</description>
                   <musicXMLid>brass.trombone.alto</musicXMLid>
                   <clef>C3</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5537,7 +5537,7 @@
                   <trackName>Tenor Trombone</trackName>
                   <longName>Tenor Trombone</longName>
                   <shortName>T. Tbn.</shortName>
-                  <description>Tenor Trombone</description>
+                  <description>Tenor trombone (pitched in B♭).</description>
                   <musicXMLid>brass.trombone.tenor</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5557,7 +5557,7 @@
                   <trackName>Trombone</trackName>
                   <longName>Trombone</longName>
                   <shortName>Tbn.</shortName>
-                  <description>Trombone</description>
+                  <description>Orchestral trombone (either tenor or bass; this is often not explicitly specified in scores).</description>
                   <musicXMLid>brass.trombone</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5583,7 +5583,7 @@
                   <trackName>Trombone (treble clef)</trackName>
                   <longName>Trombone</longName>
                   <shortName>Tbn.</shortName>
-                  <description>Trombone (treble clef, B♭)</description>
+                  <description>Trombone (notated in treble clef as a transposing instrument in B♭).</description>
                   <musicXMLid>brass.trombone</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -5606,7 +5606,7 @@
                   <trackName>Contrabass Trombone</trackName>
                   <longName>Contrabass Trombone</longName>
                   <shortName>Cb. Tbn.</shortName>
-                  <description>Contrabass Trombone</description>
+                  <description>Contrabass Trombone (usually pitched in F).</description>
                   <musicXMLid>brass.trombone.contrabass</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5627,7 +5627,7 @@
                   <trackName>Bass Trombone</trackName>
                   <longName>Bass Trombone</longName>
                   <shortName>B. Tbn.</shortName>
-                  <description>Bass Trombone</description>
+                  <description>Bass trombone (pitched in B♭).</description>
                   <musicXMLid>brass.trombone.bass</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5651,7 +5651,7 @@
                   <trackName>Cimbasso</trackName>
                   <longName>Cimbasso</longName>
                   <shortName>Cim.</shortName>
-                  <description>Cimbasso</description>
+                  <description>Instrument with a similar range to the contrabass trombone, most commonly encountered in 19th-century Italian opera scores.</description>
                   <musicXMLid>brass.cimbasso</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5667,7 +5667,7 @@
                   <trackName>Alto Sackbut</trackName>
                   <longName>Alto Sackbut</longName>
                   <shortName>A. Sack.</shortName>
-                  <description>Alto Sackbut</description>
+                  <description>Renaissance and Baroque trombone. A descendant of the slide trumpet.</description>
                   <musicXMLid>brass.sackbutt.alto</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5684,7 +5684,7 @@
                   <trackName>Tenor Sackbut</trackName>
                   <longName>Tenor Sackbut</longName>
                   <shortName>T. Sack.</shortName>
-                  <description>Tenor Sackbut</description>
+                  <description>Renaissance and Baroque trombone. A descendant of the slide trumpet.</description>
                   <musicXMLid>brass.sackbutt.tenor</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5701,7 +5701,7 @@
                   <trackName>Bass Sackbut</trackName>
                   <longName>Bass Sackbut</longName>
                   <shortName>B. Sack.</shortName>
-                  <description>Bass Sackbut</description>
+                  <description>Renaissance and Baroque trombone. A descendant of the slide trumpet.</description>
                   <musicXMLid>brass.sackbutt.bass</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5718,7 +5718,7 @@
                   <trackName>Euphonium</trackName>
                   <longName>Euphonium</longName>
                   <shortName>Euph.</shortName>
-                  <description>Euphonium</description>
+                  <description>Euphonium (notated in bass clef at concert pitch).</description>
                   <musicXMLid>brass.euphonium</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5736,7 +5736,7 @@
                   <trackName>Euphonium (treble clef)</trackName>
                   <longName>Euphonium</longName>
                   <shortName>Euph.</shortName>
-                  <description>Euphonium (treble clef, B♭)</description>
+                  <description>Euphonium (notated in treble clef as a transposing instrument in B♭).</description>
                   <musicXMLid>brass.euphonium</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -5757,7 +5757,7 @@
                   <trackName>Tuba (unspecified)</trackName>
                   <longName>Tuba</longName>
                   <shortName>Tba.</shortName>
-                  <description>Composers write for the "Tuba" and they don't care which one plays it</description>
+                  <description>Orchestral tuba (where the exact type is not specified).</description>
                   <musicXMLid>brass.tuba</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5775,6 +5775,7 @@
             </Instrument>
             <Instrument id="f-tuba">
                   <family>tubas</family>
+                  <description>Bass tuba in F (notated in bass clef at concert pitch).</description>
                   <musicXMLid>brass.tuba</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5788,6 +5789,7 @@
             </Instrument>
             <Instrument id="eb-tuba">
                   <family>tubas</family>
+                  <description>Bass tuba in E♭ (notated in bass clef at concert pitch).</description>
                   <musicXMLid>brass.tuba</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5804,7 +5806,7 @@
                   <longName>E♭ Bass Tuba</longName>
                   <shortName>E♭ Ba. Tb.</shortName>
                   <dropdownName meaning="tuning">E♭</dropdownName>
-                  <description>Bass Tuba</description>
+                  <description>Bass tuba in E♭ (notated in bass clef at concert pitch).</description>
                   <musicXMLid>brass.tuba.bass</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5821,7 +5823,7 @@
                   <longName>F Bass Tuba</longName>
                   <shortName>F Ba. Tb.</shortName>
                   <dropdownName meaning="tuning">*F</dropdownName>
-                  <description>Bass Tuba</description>
+                  <description>Bass tuba in F (notated in bass clef at concert pitch).</description>
                   <musicXMLid>brass.tuba.bass</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5838,7 +5840,7 @@
                   <longName>Bass Tuba</longName>
                   <shortName>Ba. Tb.</shortName>
                   <dropdownName meaning="transposition">E♭</dropdownName>
-                  <description>Bass Tuba (treble clef)</description>
+                  <description>Bass tuba in E♭ (notated in treble clef as a transposing instrument).</description>
                   <musicXMLid>brass.tuba</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -5858,7 +5860,7 @@
                   <longName>C Contrabass Tuba</longName>
                   <shortName>C Cb. Tb.</shortName>
                   <dropdownName meaning="tuning">C</dropdownName>
-                  <description>Contrabass Tuba</description>
+                  <description>Contrabass tuba in C (notated in bass clef).</description>
                   <musicXMLid>brass.tuba</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5875,7 +5877,7 @@
                   <longName>B♭ Contrabass Tuba</longName>
                   <shortName>B♭ Cb. Tb.</shortName>
                   <dropdownName meaning="tuning">*B♭</dropdownName>
-                  <description>Contrabass Tuba</description>
+                  <description>Contrabass tuba in B♭ (notated in bass clef at concert pitch).</description>
                   <musicXMLid>brass.tuba</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5893,7 +5895,7 @@
                   <longName>Contrabass Tuba</longName>
                   <shortName>Cb. Tb.</shortName>
                   <dropdownName meaning="transposition">B♭</dropdownName>
-                  <description>Contrabass Tuba (treble clef)</description>
+                  <description>Contrabass tuba in B♭ (notated in treble clef as a transposing instrument).</description>
                   <musicXMLid>brass.tuba</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -5912,7 +5914,7 @@
                   <trackName>Sub-Contrabass Tuba</trackName>
                   <longName>Sub-Contrabass Tuba</longName>
                   <shortName>SCb. Tb.</shortName>
-                  <description>Sub-Contrabass Tuba</description>
+                  <description>Sub-contrabass tuba in C.</description>
                   <musicXMLid>brass.tuba.subcontrabass</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5929,7 +5931,7 @@
                   <longName>Sousaphone</longName>
                   <shortName>Sphn.</shortName>
                   <dropdownName meaning="transposition">(B♭)</dropdownName>
-                  <description>Sousaphone (B♭)</description>
+                  <description>Sousaphone in B♭ (notated in bass clef).</description>
                   <musicXMLid>brass.sousaphone</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5950,7 +5952,7 @@
                   <longName>Sousaphone</longName>
                   <shortName>Sphn.</shortName>
                   <dropdownName meaning="transposition">(B♭)</dropdownName>
-                  <description>Sousaphone (B♭, treble clef)</description>
+                  <description>Sousaphone in B♭ (notated in treble clef).</description>
                   <musicXMLid>brass.sousaphone</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
@@ -5971,7 +5973,7 @@
                   <trackName>Sousaphone (concert pitch)</trackName>
                   <longName>Sousaphone</longName>
                   <shortName>Sphn.</shortName>
-                  <description>Sousaphone (concert pitch)</description>
+                  <description>Sousaphone in B♭ (notated in treble clef at concert pitch).</description>
                   <musicXMLid>brass.sousaphone</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -5989,7 +5991,7 @@
                   <trackName>Helicon</trackName>
                   <longName>Helicon</longName>
                   <shortName>Helicon</shortName>
-                  <description>Helicon</description>
+                  <description>Instrument of the tuba family.</description>
                   <musicXMLid>brass.helicon</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6005,7 +6007,7 @@
                   <trackName>Conch</trackName>
                   <longName>Conch</longName>
                   <shortName>Cnch.</shortName>
-                  <description>Conch Shell</description>
+                  <description>Conch shell, sometimes fitted with a mouthpiece.</description>
                   <musicXMLid>brass.conch-shell</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6022,7 +6024,7 @@
                   <trackName>Horagai</trackName>
                   <longName>Horagai</longName>
                   <shortName>Hor.</shortName>
-                  <description>Horagai Conch</description>
+                  <description>Type of conch shell used as a trumpet in Japan, fitted with a bronze or wooden mouthpiece.</description>
                   <musicXMLid>brass.horagai</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6039,7 +6041,7 @@
                   <trackName>Alphorn</trackName>
                   <longName>Alphorn</longName>
                   <shortName>AlpHn.</shortName>
-                  <description>Alphorn</description>
+                  <description>Long wooden natural horn with conical bore and wooden cup-shaped mouthpiece, originating in the Alpine regions.</description>
                   <musicXMLid>brass.alphorn</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6055,7 +6057,7 @@
                   <trackName>Rag Dung</trackName>
                   <longName>Rag Dung</longName>
                   <shortName>Rg. Dng.</shortName>
-                  <description>Rag Dung (Tibetan Trumpet)</description>
+                  <description>Long Tibetan trumpet used for Buddhist religious purposes.</description>
                   <musicXMLid>brass.rag-dung</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6076,7 +6078,7 @@
                   <trackName>Didgeridoo</trackName>
                   <longName>Didgeridoo</longName>
                   <shortName>Doo.</shortName>
-                  <description>Didgeridoo</description>
+                  <description>Aboriginal Australian drone instrument.</description>
                   <musicXMLid>brass.didgeridoo</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6093,7 +6095,7 @@
                   <trackName>Shofar</trackName>
                   <longName>Shofar</longName>
                   <shortName>Sho.</shortName>
-                  <description>Shofar Ramshorn</description>
+                  <description>Typically made from a ram’s horn and used for Jewish religious purposes.</description>
                   <musicXMLid>brass.shofar</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6110,7 +6112,7 @@
                   <trackName>Vuvuzela</trackName>
                   <longName>Vuvuzela</longName>
                   <shortName>Vuv.</shortName>
-                  <description>Vuvuzela</description>
+                  <description>Plastic horn that produces a loud single pitch.</description>
                   <musicXMLid>brass.vuvuzela</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6130,7 +6132,7 @@
                   <trackName>Timpani</trackName>
                   <longName>Timpani</longName>
                   <shortName>Timp.</shortName>
-                  <description>Large orchestral drums (kettledrums) often with a pedal to change tuning. A single staff may be used for multiple timpani (i.e. multiple tunings). Modern music is always written in C (non-transposing).</description>
+                  <description>Large pitched orchestral drums, also known as kettle drums. Sometimes fitted with a pedal to allow quick changes of tuning.</description>
                   <musicXMLid>drum.timpani</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6151,7 +6153,7 @@
                   <trackName>Roto-Toms</trackName>
                   <longName>Roto-Toms</longName>
                   <shortName>Roto</shortName>
-                  <description>Roto-Toms</description>
+                  <description>Pitched drums that can be tuned quickly by rotating the drumhead.</description>
                   <musicXMLid>drum.rototom</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6168,7 +6170,7 @@
                   <trackName>Tubaphone</trackName>
                   <longName>Tubaphone</longName>
                   <shortName>Tph.</shortName>
-                  <description>Tubaphone</description>
+                  <description>Constructed from a series of metal tubes arranged in a keyboard configuration.</description>
                   <clef>G15ma</clef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>84-108</aPitchRange>
@@ -6184,7 +6186,7 @@
                   <trackName>Soprano Steel Drums</trackName>
                   <longName>Soprano Steel Drums</longName>
                   <shortName>S. St. Dr.</shortName>
-                  <description>Soprano Steel Drums</description>
+                  <description>Soprano steel drums.</description>
                   <musicXMLid>metal.steel-drums</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6201,7 +6203,7 @@
                   <trackName>Alto Steel Drums</trackName>
                   <longName>Alto Steel Drums</longName>
                   <shortName>A. St. Dr.</shortName>
-                  <description>Alto Steel Drums</description>
+                  <description>Alto steel drums.</description>
                   <musicXMLid>metal.steel-drums</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6218,7 +6220,7 @@
                   <trackName>Guitar Steel Drums</trackName>
                   <longName>Guitar Steel Drums</longName>
                   <shortName>Gtr. St. Dr.</shortName>
-                  <description>Guitar Steel Drums</description>
+                  <description>Guitar steel drums.</description>
                   <musicXMLid>metal.steel-drums</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6235,7 +6237,7 @@
                   <trackName>Tenor Steel Drums</trackName>
                   <longName>Tenor Steel Drums</longName>
                   <shortName>T. St. Dr.</shortName>
-                  <description>Tenor Steel Drums</description>
+                  <description>Tenor steel drums.</description>
                   <musicXMLid>metal.steel-drums</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6252,7 +6254,7 @@
                   <trackName>Cello Steel Drums</trackName>
                   <longName>Cello Steel Drums</longName>
                   <shortName>Ce. St. Dr.</shortName>
-                  <description>Cello Steel Drums</description>
+                  <description>Cello steel drums.</description>
                   <musicXMLid>metal.steel-drums</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6269,7 +6271,7 @@
                   <trackName>Steel Drums</trackName>
                   <longName>Steel Drums</longName>
                   <shortName>St. Dr.</shortName>
-                  <description>Steel Drums (generic)</description>
+                  <description>Steel drums on a grand staff.</description>
                   <musicXMLid>metal.steel-drums</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -6291,7 +6293,7 @@
                   <trackName>Bass Steel Drums</trackName>
                   <longName>Bass Steel Drums</longName>
                   <shortName>B. St. Dr.</shortName>
-                  <description>Bass Steel Drums</description>
+                  <description>Bass steel drums.</description>
                   <musicXMLid>metal.steel-drums</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6308,7 +6310,7 @@
                   <trackName>Glockenspiel</trackName>
                   <longName>Glockenspiel</longName>
                   <shortName>Glock.</shortName>
-                  <description>Glockenspiel</description>
+                  <description>Glockenspiel.</description>
                   <musicXMLid>pitched-percussion.glockenspiel</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G15ma</concertClef>
@@ -6334,7 +6336,7 @@
                   <trackName>Xylophone</trackName>
                   <longName>Xylophone</longName>
                   <shortName>Xyl.</shortName>
-                  <description>Xylophone</description>
+                  <description>Xylophone.</description>
                   <musicXMLid>pitched-percussion.xylophone</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8va</concertClef>
@@ -6360,7 +6362,7 @@
                   <trackName>Xylomarimba</trackName>
                   <longName>Xylomarimba</longName>
                   <shortName>XMrm.</shortName>
-                  <description>Xylomarimba</description>
+                  <description>Xylophone with an extended range, matching a 5-octave marimba but sounding an octave higher.</description>
                   <musicXMLid>pitched-percussion.xylomarimba</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -6383,7 +6385,7 @@
                   <trackName>Vibraphone</trackName>
                   <longName>Vibraphone</longName>
                   <shortName>Vib.</shortName>
-                  <description>Vibraphone</description>
+                  <description>Vibraphone.</description>
                   <musicXMLid>pitched-percussion.vibraphone</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6405,7 +6407,7 @@
                   <trackName>Dulcimer</trackName>
                   <longName>Dulcimer</longName>
                   <shortName>Dlc.</shortName>
-                  <description>Dulcimer</description>
+                  <description>Hammered dulcimer.</description>
                   <musicXMLid>pitched-percussion.hammer-dulcimer</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -6426,7 +6428,7 @@
                   <trackName>Cimbalom</trackName>
                   <longName>Cimbalom</longName>
                   <shortName>Cimb.</shortName>
-                  <description>Concert Cimbalom</description>
+                  <description>Concert cimbalom.</description>
                   <musicXMLid>pitched-percussion.cimbalom</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -6447,7 +6449,7 @@
                   <trackName>Marimba (grand staff)</trackName>
                   <longName>Marimba</longName>
                   <shortName>Mrm.</shortName>
-                  <description>Marimba (grand staff)</description>
+                  <description>Marimba notated on a grand staff.</description>
                   <musicXMLid>pitched-percussion.marimba</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -6473,7 +6475,7 @@
                   <trackName>Marimba (single staff)</trackName>
                   <longName>Marimba</longName>
                   <shortName>Mrm.</shortName>
-                  <description>Single-staff marimba</description>
+                  <description>Marimba notated on a single staff.</description>
                   <musicXMLid>pitched-percussion.marimba</musicXMLid>
                   <staves>1</staves>
                   <clef>G</clef>
@@ -6496,7 +6498,7 @@
                   <trackName>Bass Marimba</trackName>
                   <longName>Bass Marimba</longName>
                   <shortName>B. Mrm.</shortName>
-                  <description>Bass Marimba</description>
+                  <description>Bass marimba.</description>
                   <musicXMLid>pitched-percussion.marimba.bass</musicXMLid>
                   <staves>1</staves>
                   <clef>F</clef>
@@ -6515,7 +6517,7 @@
                   <trackName>Contrabass Marimba</trackName>
                   <longName>Contrabass Marimba</longName>
                   <shortName>Cb. Mrm.</shortName>
-                  <description>Contrabass Marimba</description>
+                  <description>Contrabass marimba.</description>
                   <musicXMLid>pitched-percussion.marimba.bass</musicXMLid>
                   <staves>1</staves>
                   <clef>F8vb</clef>
@@ -6534,7 +6536,7 @@
                   <trackName>Crotales</trackName>
                   <longName>Crotales</longName>
                   <shortName>Crot.</shortName>
-                  <description>Crotales</description>
+                  <description>Crotales, sometimes called antique cymbals.</description>
                   <musicXMLid>metal.crotales</musicXMLid>
                   <transposingClef>G</transposingClef>
                   <concertClef>G15ma</concertClef>
@@ -6557,7 +6559,7 @@
                   <trackName>Almglocken</trackName>
                   <longName>Almglocken</longName>
                   <shortName>Almg.</shortName>
-                  <description>Almglocken</description>
+                  <description>Almglocken, or cow bells.</description>
                   <musicXMLid>metal.bells.almglocken</musicXMLid>
                   <staves>2</staves>
                   <clef>G15ma</clef>
@@ -6578,7 +6580,7 @@
                   <trackName>Chimes</trackName>
                   <longName>Chimes</longName>
                   <shortName>Cme.</shortName>
-                  <description>Chimes or Tubular Bells</description>
+                  <description>Tubular bells (British English), or chimes (American English).</description>
                   <musicXMLid>pitched-percussion.tubular-bells</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6598,7 +6600,7 @@
                   <trackName>Carillon</trackName>
                   <longName>Carillon</longName>
                   <shortName>Car.</shortName>
-                  <description>Carillon</description>
+                  <description>Tuned bells installed in a bell tower and played with a keyboard.</description>
                   <musicXMLid>metal.bells.carillon</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -6620,7 +6622,7 @@
                   <trackName>Tuned Gongs</trackName>
                   <longName>Tuned Gongs</longName>
                   <shortName>Td. Gon.</shortName>
-                  <description>Tuned Gongs</description>
+                  <description>Tuned gongs.</description>
                   <musicXMLid>metal.gong</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6637,7 +6639,7 @@
                   <trackName>Hand Bells</trackName>
                   <longName>Hand Bells</longName>
                   <shortName>Ha. Be.</shortName>
-                  <description>Hand Bells</description>
+                  <description>Tuned hand bells.</description>
                   <musicXMLid>pitched-percussion.handbells</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -6660,7 +6662,7 @@
                   <trackName>Orff Soprano Glockenspiel</trackName>
                   <longName>Orff Soprano Glockenspiel</longName>
                   <shortName>O. S. Glk.</shortName>
-                  <description>Orff Soprano Glockenspiel</description>
+                  <description>Soprano glockenspiel for the Orff Schulwerk.</description>
                   <musicXMLid>pitched-percussion.glockenspiel.soprano</musicXMLid>
                   <clef>G15ma</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6678,7 +6680,7 @@
                   <trackName>Orff Alto Glockenspiel</trackName>
                   <longName>Orff Alto Glockenspiel</longName>
                   <shortName>O. A. Glk.</shortName>
-                  <description>Orff Alto Glockenspiel</description>
+                  <description>Alto glockenspiel for the Orff Schulwerk.</description>
                   <musicXMLid>pitched-percussion.glockenspiel.alto</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6696,7 +6698,7 @@
                   <trackName>Orff Soprano Metallophone</trackName>
                   <longName>Orff Soprano Metallophone</longName>
                   <shortName>O. S. Met.</shortName>
-                  <description>Orff Soprano Metallophone</description>
+                  <description>Soprano metallophone for the Orff Schulwerk.</description>
                   <musicXMLid>pitched-percussion.metallophone.soprano</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6714,7 +6716,7 @@
                   <trackName>Orff Soprano Xylophone</trackName>
                   <longName>Orff Soprano Xylophone</longName>
                   <shortName>O. S. Xyl.</shortName>
-                  <description>Orff Soprano Xylophone</description>
+                  <description>Soprano xylophone for the Orff Schulwerk.</description>
                   <musicXMLid>pitched-percussion.xylophone.soprano</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6729,7 +6731,7 @@
             </Instrument>
             <Instrument id="metallophone">
                   <family>orff-percussion</family>
-                  <description>Orff Metallophone (generic)</description>
+                  <description>Generic metallophone for the Orff Schulwerk.</description>
                   <musicXMLid>pitched-percussion.metallophone</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6747,7 +6749,7 @@
                   <trackName>Orff Alto Metallophone</trackName>
                   <longName>Orff Alto Metallophone</longName>
                   <shortName>O. A. Met.</shortName>
-                  <description>Orff Alto Metallophone</description>
+                  <description>Alto metallophone for the Orff Schulwerk.</description>
                   <musicXMLid>pitched-percussion.metallophone.alto</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6765,7 +6767,7 @@
                   <trackName>Orff Alto Xylophone</trackName>
                   <longName>Orff Alto Xylophone</longName>
                   <shortName>O. A. Xyl.</shortName>
-                  <description>Orff Alto Xylophone</description>
+                  <description>Alto xylophone for the Orff Schulwerk.</description>
                   <musicXMLid>pitched-percussion.xylophone.alto</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6783,7 +6785,7 @@
                   <trackName>Orff Bass Metallophone</trackName>
                   <longName>Orff Bass Metallophone</longName>
                   <shortName>O. B. Met.</shortName>
-                  <description>Orff Bass Metallophone</description>
+                  <description>Bass metallophone for the Orff Schulwerk.</description>
                   <musicXMLid>pitched-percussion.metallophone.bass</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6801,7 +6803,7 @@
                   <trackName>Orff Bass Xylophone</trackName>
                   <longName>Orff Bass Xylophone</longName>
                   <shortName>O. B. Xyl.</shortName>
-                  <description>Orff Bass Xylophone</description>
+                  <description>Bass xylophone for the Orff Schulwerk.</description>
                   <musicXMLid>pitched-percussion.xylophone.soprano</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6819,7 +6821,7 @@
                   <trackName>Flexatone</trackName>
                   <longName>Flexatone</longName>
                   <shortName>Flt.</shortName>
-                  <description>Flexatone</description>
+                  <description>Flexatone.</description>
                   <musicXMLid>metal.flexatone</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6836,7 +6838,7 @@
                   <trackName>Musical Saw</trackName>
                   <longName>Musical Saw</longName>
                   <shortName>Mu. Sw.</shortName>
-                  <description>Musical Saw</description>
+                  <description>Musical saw, played with a violin or cello bow.</description>
                   <musicXMLid>metal.musical-saw</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6852,7 +6854,7 @@
                   <trackName>Musical Glasses</trackName>
                   <longName>Musical Glasses</longName>
                   <shortName>Mu. Gla.</shortName>
-                  <description>Musical Glasses</description>
+                  <description>Wine glasses played by running moistened fingers around the rim. Sometimes called a glass harp.</description>
                   <musicXMLid>pitched-percussion.crystal-glasses</musicXMLid>
                   <clef>G8va</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6868,7 +6870,7 @@
                   <trackName>Glass Harmonica</trackName>
                   <longName>Glass Harmonica</longName>
                   <shortName>Gla. Har.</shortName>
-                  <description>Glass Harmonica</description>
+                  <description>Instrument made of spinning glass disks or bowls played by touching with the fingers.</description>
                   <musicXMLid>pitched-percussion.glass-harmonica</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6884,7 +6886,7 @@
                   <trackName>Tuned Klaxon Horns</trackName>
                   <longName>Tuned Klaxon Horns</longName>
                   <shortName>Tn. Klx. Hns.</shortName>
-                  <description>Tuned Klaxon Horns</description>
+                  <description>Tuned klaxon horns or car horns.</description>
                   <staves>2</staves>
                   <clef>G</clef>
                   <bracket>1</bracket>
@@ -6903,7 +6905,7 @@
                   <trackName>Alto Kalimba</trackName>
                   <longName>Alto Kalimba</longName>
                   <shortName>A. Kal.</shortName>
-                  <description>Alto Kalimba</description>
+                  <description>Alto kalimba. A modern interpretation of the traditional Shona mbira.</description>
                   <musicXMLid>pitched-percussion.kalimba</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6919,7 +6921,7 @@
                   <trackName>Kalimba</trackName>
                   <longName>Kalimba</longName>
                   <shortName>Kal.</shortName>
-                  <description>Kalimba (generic)</description>
+                  <description>Kalimba (generic). A modern interpretation of the traditional Shona mbira.</description>
                   <musicXMLid>pitched-percussion.kalimba</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6935,7 +6937,7 @@
                   <trackName>Treble Kalimba</trackName>
                   <longName>Treble Kalimba</longName>
                   <shortName>Tr. Kal.</shortName>
-                  <description>Treble Kalimba</description>
+                  <description>Treble kalimba. A modern interpretation of the traditional Shona mbira.</description>
                   <musicXMLid>pitched-percussion.kalimba</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -6954,7 +6956,7 @@
                   <trackName>Automobile Brake Drums</trackName>
                   <longName>Automobile Brake Drums</longName>
                   <shortName>Aut. Brk. Dr.</shortName>
-                  <description>Automobile Brake Drums</description>
+                  <description>Automobile brake drums.</description>
                   <musicXMLid>metal.brake-drums</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -6982,7 +6984,7 @@
                   <trackName>Bongos</trackName>
                   <longName>Bongos</longName>
                   <shortName>Bon.</shortName>
-                  <description>Bongos</description>
+                  <description>Bongos.</description>
                   <musicXMLid>drum.bongo</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7022,7 +7024,7 @@
                   <trackName>Chinese Tom-Toms</trackName>
                   <longName>Chinese Tom-Toms</longName>
                   <shortName>Ch. Toms</shortName>
-                  <description>Chinese Tom-toms</description>
+                  <description>Chinese tom-toms.</description>
                   <musicXMLid>drum.group.chinese</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7049,7 +7051,7 @@
                   <trackName>Concert Bass Drum</trackName>
                   <longName>Concert Bass Drum</longName>
                   <shortName>Con. BD</shortName>
-                  <description>Bass Drum</description>
+                  <description>Bass drum.</description>
                   <musicXMLid>drum.bass-drum</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7079,7 +7081,7 @@
                   <trackName>Concert Snare Drum</trackName>
                   <longName>Concert Snare Drum</longName>
                   <shortName>Con. Sn.</shortName>
-                  <description>Snare Drum</description>
+                  <description>Snare drum, also known as side drum.</description>
                   <musicXMLid>drum.snare-drum</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7118,7 +7120,7 @@
                   <trackName>Concert Toms</trackName>
                   <longName>Concert Toms</longName>
                   <shortName>C. Toms</shortName>
-                  <description>Concert Toms</description>
+                  <description>Concert tom-toms.</description>
                   <musicXMLid>drum.tom-tom</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc5Line">percussion</stafftype>
@@ -7181,7 +7183,7 @@
                   <trackName>Congas</trackName>
                   <longName>Congas</longName>
                   <shortName>Con.</shortName>
-                  <description>Congas</description>
+                  <description>Congas.</description>
                   <musicXMLid>drum.conga</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7228,7 +7230,7 @@
                   <trackName>Cuica</trackName>
                   <longName>Cuica</longName>
                   <shortName>Cu.</shortName>
-                  <description>Cuica</description>
+                  <description>Cuica.</description>
                   <musicXMLid>drum.cuica</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7264,7 +7266,7 @@
                   <trackName>Drumset</trackName>
                   <longName>Drumset</longName>
                   <shortName>D. Set</shortName>
-                  <description>Drumset</description>
+                  <description>Drumset.</description>
                   <musicXMLid>drum.group.set</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc5Line">percussion</stafftype>
@@ -7288,7 +7290,7 @@
                   <trackName>Field Drum</trackName>
                   <longName>Field Drum</longName>
                   <shortName>Field Dr.</shortName>
-                  <description>Military Field Drum</description>
+                  <description>Military field drum.</description>
                   <musicXMLid>drum.snare-drum</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7322,7 +7324,7 @@
                   <trackName>Frame Drum</trackName>
                   <longName>Frame Drum</longName>
                   <shortName>Fr. Dr.</shortName>
-                  <description>Frame Drum</description>
+                  <description>Frame drum.</description>
                   <musicXMLid>drum.frame-drum</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7349,7 +7351,7 @@
                   <trackName>Piccolo Snare</trackName>
                   <longName>Piccolo Snare</longName>
                   <shortName>Picc. Sn.</shortName>
-                  <description>Piccolo Snare Drum</description>
+                  <description>Piccolo snare drum.</description>
                   <musicXMLid>drum.snare-drum</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7383,7 +7385,7 @@
                   <trackName>Slit Drum</trackName>
                   <longName>Slit Drum</longName>
                   <shortName>Slt. Dr.</shortName>
-                  <description>Slit Drum</description>
+                  <description>Slit drum.</description>
                   <musicXMLid>drum.slit-drum</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7409,7 +7411,7 @@
                   <trackName>Tablas</trackName>
                   <longName>Tablas</longName>
                   <shortName>Tbs.</shortName>
-                  <description>Tablas</description>
+                  <description>Pair of twin hand drums used in Indian classical music.</description>
                   <musicXMLid>drum.tabla</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7444,7 +7446,7 @@
                   <trackName>Timbales</trackName>
                   <longName>Timbales</longName>
                   <shortName>Timb.</shortName>
-                  <description>Timbales</description>
+                  <description>Timbales.</description>
                   <musicXMLid>drum.timbale</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7481,7 +7483,7 @@
                   <trackName>Anvil</trackName>
                   <longName>Anvil</longName>
                   <shortName>Anv.</shortName>
-                  <description>Anvil</description>
+                  <description>Anvil.</description>
                   <musicXMLid>metal.anvil</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7508,7 +7510,7 @@
                   <trackName>Bell Plate</trackName>
                   <longName>Bell Plate</longName>
                   <shortName>Be. Pla.</shortName>
-                  <description>Bell Plate</description>
+                  <description>Bell plate.</description>
                   <musicXMLid>metal.bells.bell-plate</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7534,7 +7536,7 @@
                   <trackName>Ride Bell</trackName>
                   <longName>Ride Bell</longName>
                   <shortName>Ri. Be.</shortName>
-                  <description>Bells</description>
+                  <description>Bells.</description>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
@@ -7559,7 +7561,7 @@
                   <trackName>Bowl Gongs</trackName>
                   <longName>Bowl Gongs</longName>
                   <shortName>Bw. Gon.</shortName>
-                  <description>Bowl Gongs</description>
+                  <description>Bowl gongs.</description>
                   <musicXMLid>metal.gong</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7586,7 +7588,7 @@
                   <trackName>Chains</trackName>
                   <longName>Chains</longName>
                   <shortName>Chn.</shortName>
-                  <description>Chains</description>
+                  <description>Chains.</description>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
@@ -7611,7 +7613,7 @@
                   <trackName>Chinese Cymbal</trackName>
                   <longName>Chinese Cymbal</longName>
                   <shortName>Ch. Cym.</shortName>
-                  <description>Chinese Cymbal</description>
+                  <description>Chinese cymbal.</description>
                   <musicXMLid>metal.cymbal.chinese</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7639,7 +7641,7 @@
                   <trackName>Cowbell</trackName>
                   <longName>Cowbell</longName>
                   <shortName>Cwb.</shortName>
-                  <description>Cowbell</description>
+                  <description>Cowbell.</description>
                   <musicXMLid>metal.bells.cowbell</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7666,7 +7668,7 @@
                   <trackName>Crash Cymbal</trackName>
                   <longName>Crash Cymbal</longName>
                   <shortName>Cr. Cym.</shortName>
-                  <description>Crash Cymbal</description>
+                  <description>Crash cymbal.</description>
                   <musicXMLid>metal.cymbal.crash</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7694,7 +7696,7 @@
                   <trackName>Cymbal</trackName>
                   <longName>Cymbal</longName>
                   <shortName>Cym.</shortName>
-                  <description>Cymbal</description>
+                  <description>Cymbal.</description>
                   <musicXMLid>metal.cymbal.crash</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7725,7 +7727,7 @@
                   <trackName>Finger Cymbals</trackName>
                   <longName>Finger Cymbals</longName>
                   <shortName>Fi. Cym.</shortName>
-                  <description>Finger Cymbals</description>
+                  <description>Finger cymbals of unspecified pitch.</description>
                   <musicXMLid>metal.cymbal.finger</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7752,7 +7754,7 @@
                   <trackName>Hi-hat</trackName>
                   <longName>Hi-hat</longName>
                   <shortName>Hi-hat</shortName>
-                  <description>Hi-hat</description>
+                  <description>Hi-hat. Combination of two cymbals and a pedal.</description>
                   <musicXMLid>metal.hi-hat</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7794,7 +7796,7 @@
                   <trackName>Iron Pipes</trackName>
                   <longName>Iron Pipes</longName>
                   <shortName>Ir. Pi.</shortName>
-                  <description>Iron Pipes</description>
+                  <description>Iron pipes.</description>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
@@ -7819,7 +7821,7 @@
                   <trackName>Metal Castanets</trackName>
                   <longName>Metal Castanets</longName>
                   <shortName>Met. Cst.</shortName>
-                  <description>Metal Castanets</description>
+                  <description>Metal castanets.</description>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
@@ -7846,7 +7848,7 @@
                   <trackName>Metal Wind Chimes</trackName>
                   <longName>Metal Wind Chimes</longName>
                   <shortName>Met. Wn Ch.</shortName>
-                  <description>Metal Wind Chimes</description>
+                  <description>Metal wind chimes.</description>
                   <musicXMLid>metal.bells.wind-chimes</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7875,7 +7877,7 @@
                   <trackName>Ride Cymbal</trackName>
                   <longName>Ride Cymbal</longName>
                   <shortName>R. Cym.</shortName>
-                  <description>Ride Cymbal</description>
+                  <description>Ride cymbal.</description>
                   <musicXMLid>metal.cymbal.ride</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7909,7 +7911,7 @@
                   <trackName>Sleigh Bells</trackName>
                   <longName>Sleigh Bells</longName>
                   <shortName>Sle. Be.</shortName>
-                  <description>Sleigh Bells</description>
+                  <description>Sleigh bells.</description>
                   <musicXMLid>metal.bells.sleigh-bells</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7936,7 +7938,7 @@
                   <trackName>Splash Cymbal</trackName>
                   <longName>Splash Cymbal</longName>
                   <shortName>Sp. Cym.</shortName>
-                  <description>Splash Cymbal</description>
+                  <description>Splash cymbal.</description>
                   <musicXMLid>metal.cymbal.splash</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7964,7 +7966,7 @@
                   <trackName>Tam-Tam</trackName>
                   <longName>Tam-Tam</longName>
                   <shortName>Tam</shortName>
-                  <description>Tam-Tam</description>
+                  <description>Large unpitched gong.</description>
                   <musicXMLid>metal.tamtam</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -7993,7 +7995,7 @@
                   <trackName>Thundersheet</trackName>
                   <longName>Thundersheet</longName>
                   <shortName>Thu.</shortName>
-                  <description>Thundersheet</description>
+                  <description>Thundersheet.</description>
                   <musicXMLid>metal.thundersheet</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -8019,7 +8021,7 @@
                   <trackName>Triangle</trackName>
                   <longName>Triangle</longName>
                   <shortName>Trgl.</shortName>
-                  <description>Triangle</description>
+                  <description>Triangle.</description>
                   <musicXMLid>metal.triangle</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -8058,7 +8060,7 @@
                   <trackName>Bamboo Wind Chimes</trackName>
                   <longName>Bamboo Wind Chimes</longName>
                   <shortName>Bam. Wn. Ch.</shortName>
-                  <description>Bamboo Wind Chimes</description>
+                  <description>Bamboo wind chimes.</description>
                   <musicXMLid>metal.bells.wind-chimes</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -8084,7 +8086,7 @@
                   <trackName>Castanets</trackName>
                   <longName>Castanets</longName>
                   <shortName>Cst.</shortName>
-                  <description>Castanets</description>
+                  <description>Castanets.</description>
                   <musicXMLid>wood.castanets</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -8111,7 +8113,7 @@
                   <trackName>Claves</trackName>
                   <longName>Claves</longName>
                   <shortName>Clv.</shortName>
-                  <description>Claves</description>
+                  <description>Claves.</description>
                   <musicXMLid>wood.claves</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -8142,7 +8144,7 @@
                   <trackName>Güiro</trackName>
                   <longName>Güiro</longName>
                   <shortName>Gro.</shortName>
-                  <description>Güiro</description>
+                  <description>Güiro.</description>
                   <musicXMLid>wood.guiro</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -8171,7 +8173,7 @@
                   <trackName>Temple Blocks</trackName>
                   <longName>Temple Blocks</longName>
                   <shortName>Tmp. Bl.</shortName>
-                  <description>Temple Blocks</description>
+                  <description>Temple blocks, sometimes known as Chinese temple blocks or wooden bells.</description>
                   <musicXMLid>wood.temple-block</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -8208,7 +8210,7 @@
                   <trackName>Wood Blocks</trackName>
                   <longName>Wood Blocks</longName>
                   <shortName>Wd. Bl.</shortName>
-                  <description>Wood Blocks</description>
+                  <description>Wood blocks.</description>
                   <musicXMLid>wood.wood-block</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -8247,7 +8249,7 @@
                   <trackName>Wooden Wind Chimes</trackName>
                   <longName>Wooden Wind Chimes</longName>
                   <shortName>Wd. Wn. Ch.</shortName>
-                  <description>Wooden Wind Chimes</description>
+                  <description>Wooden wind chimes.</description>
                   <musicXMLid>metal.bells.wind-chimes</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -8273,7 +8275,7 @@
                   <trackName>Cabasa</trackName>
                   <longName>Cabasa</longName>
                   <shortName>Cabs.</shortName>
-                  <description>Cabasa</description>
+                  <description>Cabasa.</description>
                   <musicXMLid>rattle.cabasa</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -8300,7 +8302,7 @@
                   <trackName>Glass Wind Chimes</trackName>
                   <longName>Glass Wind Chimes</longName>
                   <shortName>Gl. Wn Ch.</shortName>
-                  <description>Glass Wind Chimes</description>
+                  <description>Glass wind chimes.</description>
                   <musicXMLid>metal.bells.wind-chimes</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -8326,7 +8328,7 @@
                   <trackName>Maracas</trackName>
                   <longName>Maracas</longName>
                   <shortName>Mrcs.</shortName>
-                  <description>Maracas</description>
+                  <description>Maracas.</description>
                   <musicXMLid>rattle.maraca</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -8355,7 +8357,7 @@
                   <trackName>Percussion</trackName>
                   <longName>Percussion</longName>
                   <shortName>Perc.</shortName>
-                  <description>Orchestral Percussion</description>
+                  <description>Orchestral percussion drumset.</description>
                   <musicXMLid>drum.group.set</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc5Line">percussion</stafftype>
@@ -8539,7 +8541,7 @@
                   <trackName>Quijada</trackName>
                   <longName>Quijada</longName>
                   <shortName>Qui.</shortName>
-                  <description>Dried donkey or horse jawbone traditionally used as a rattle in some Latin American countries.</description>
+                  <description>Dried donkey or horse jawbone, traditionally used as a rattle in some Latin American countries.</description>
                   <musicXMLid>rattle.jawbone</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -8566,7 +8568,7 @@
                   <trackName>Ratchet</trackName>
                   <longName>Ratchet</longName>
                   <shortName>Rat.</shortName>
-                  <description>Ratchet</description>
+                  <description>Ratchet, also known as a rattle.</description>
                   <musicXMLid>rattle.ratchet</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -8592,7 +8594,7 @@
                   <trackName>Sandpaper Blocks</trackName>
                   <longName>Sandpaper Blocks</longName>
                   <shortName>Sa. Bl.</shortName>
-                  <description>Sandpaper Blocks</description>
+                  <description>Pair of blocks wrapped in sandpaper, played by rubbing together.</description>
                   <musicXMLid>wood.sand-block</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -8619,7 +8621,7 @@
                   <trackName>Shaker</trackName>
                   <longName>Shaker</longName>
                   <shortName>Sh.</shortName>
-                  <description>Shaker</description>
+                  <description>Shaker.</description>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
@@ -8643,7 +8645,7 @@
                   <trackName>Shell Wind Chimes</trackName>
                   <longName>Shell Wind Chimes</longName>
                   <shortName>Sh. Wn Ch.</shortName>
-                  <description>Shell Wind Chimes</description>
+                  <description>Shell wind chimes.</description>
                   <musicXMLid>metal.bells.wind-chimes</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -8669,7 +8671,7 @@
                   <trackName>Stones</trackName>
                   <longName>Stones</longName>
                   <shortName>Sto.</shortName>
-                  <description>Stones</description>
+                  <description>Stones.</description>
                   <musicXMLid>rattle.lava-stones</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -8695,7 +8697,7 @@
                   <trackName>Tambourine</trackName>
                   <longName>Tambourine</longName>
                   <shortName>Tamb.</shortName>
-                  <description>Tambourine</description>
+                  <description>Tambourine.</description>
                   <musicXMLid>drum.tambourine</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -8727,7 +8729,7 @@
                   <trackName>Tubo</trackName>
                   <longName>Tubo</longName>
                   <shortName>Tu.</shortName>
-                  <description>Tubo</description>
+                  <description>Large shaker in the form of a tube.</description>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
@@ -8753,7 +8755,7 @@
                   <trackName>Vibraslap</trackName>
                   <longName>Vibraslap</longName>
                   <shortName>Vibslp.</shortName>
-                  <description>Vibraslap</description>
+                  <description>Vibraslap.</description>
                   <musicXMLid>rattle.vibraslap</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -8781,7 +8783,7 @@
                   <trackName>Whip</trackName>
                   <longName>Whip</longName>
                   <shortName>Wh.</shortName>
-                  <description>Whip</description>
+                  <description>Two wooden boards joined by a hinge, played by being brought together rapidly. Also known as a slap stick.</description>
                   <musicXMLid>effect.whip</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -8813,7 +8815,7 @@
                   <trackName>Snare Drum</trackName>
                   <longName>Snare Drum</longName>
                   <shortName>S.D.</shortName>
-                  <description>Marching Snare Drum</description>
+                  <description>Marching snare drum.</description>
                   <musicXMLid>drum.snare-drum</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc5Line">percussion</stafftype>
@@ -8914,7 +8916,7 @@
                   <trackName>Tenor Drums</trackName>
                   <longName>Tenor Drums</longName>
                   <shortName>T.D.</shortName>
-                  <description>Marching Tenor Drums</description>
+                  <description>Marching tenor drums.</description>
                   <musicXMLid>drum.tenor-drum</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc5Line">percussion</stafftype>
@@ -9124,7 +9126,7 @@
                   <trackName>Bass Drums</trackName>
                   <longName>Bass Drums</longName>
                   <shortName>B.D.</shortName>
-                  <description>Marching Bass Drums</description>
+                  <description>Marching bass drums.</description>
                   <musicXMLid>drum.bass-drum</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc5Line">percussion</stafftype>
@@ -9236,7 +9238,7 @@
                   <trackName>Cymbals</trackName>
                   <longName>Cymbals</longName>
                   <shortName>Cym.</shortName>
-                  <description>Marching Cymbals</description>
+                  <description>Marching cymbals.</description>
                   <musicXMLid>metal.cymbal.crash</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc5Line">percussion</stafftype>
@@ -9352,7 +9354,7 @@
                   <trackName>Finger Snap</trackName>
                   <longName>Finger Snap</longName>
                   <shortName>Fi. Sna.</shortName>
-                  <description>Finger Snap</description>
+                  <description>Finger snap.</description>
                   <musicXMLid>effect.snap</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -9382,7 +9384,7 @@
                   <trackName>Hand Clap</trackName>
                   <longName>Hand Clap</longName>
                   <shortName>Hd. Clp.</shortName>
-                  <description>Hand Clap</description>
+                  <description>Hand clap.</description>
                   <musicXMLid>effect.hand-clap</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -9412,7 +9414,7 @@
                   <trackName>Slap</trackName>
                   <longName>Slap</longName>
                   <shortName>Sla.</shortName>
-                  <description>Slap</description>
+                  <description>Hand slap.</description>
                   <musicXMLid>effect.slap</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -9442,7 +9444,7 @@
                   <trackName>Stamp</trackName>
                   <longName>Stamp</longName>
                   <shortName>Sta.</shortName>
-                  <description>Stamp</description>
+                  <description>Foot stamp.</description>
                   <musicXMLid>effect.stamp</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -9475,7 +9477,7 @@
                   <trackName>Boy Soprano</trackName>
                   <longName>Boy Soprano</longName>
                   <shortName>B. S.</shortName>
-                  <description>Boy Soprano</description>
+                  <description>Boy soprano voice.</description>
                   <musicXMLid>voice.child</musicXMLid>
                   <clef>G</clef>
                   <aPitchRange>60-81</aPitchRange>
@@ -9492,7 +9494,7 @@
                   <trackName>Soprano</trackName>
                   <longName>Soprano</longName>
                   <shortName>S.</shortName>
-                  <description>Soprano</description>
+                  <description>Soprano voice.</description>
                   <musicXMLid>voice.soprano</musicXMLid>
                   <clef>G</clef>
                   <aPitchRange>60-79</aPitchRange>
@@ -9511,7 +9513,7 @@
                   <trackName>Soprano (C clef)</trackName>
                   <longName>Soprano</longName>
                   <shortName>S.</shortName>
-                  <description>Soprano (C Clef)</description>
+                  <description>Soprano voice (notated in C clef).</description>
                   <musicXMLid>voice.soprano</musicXMLid>
                   <clef>C1</clef>
                   <aPitchRange>60-79</aPitchRange>
@@ -9527,7 +9529,7 @@
                   <trackName>Mezzo-soprano</trackName>
                   <longName>Mezzo-soprano</longName>
                   <shortName>Mzs.</shortName>
-                  <description>Mezzo-soprano</description>
+                  <description>Mezzo-soprano voice.</description>
                   <musicXMLid>voice.mezzo-soprano</musicXMLid>
                   <clef>G</clef>
                   <aPitchRange>57-77</aPitchRange>
@@ -9545,7 +9547,7 @@
                   <trackName>Mezzo-soprano (C clef)</trackName>
                   <longName>Mezzo-soprano</longName>
                   <shortName>Mzs.</shortName>
-                  <description>Mezzo-soprano (C Clef)</description>
+                  <description>Mezzo-soprano voice (notated in C clef).</description>
                   <musicXMLid>voice.mezzo-soprano</musicXMLid>
                   <clef>C2</clef>
                   <aPitchRange>57-77</aPitchRange>
@@ -9561,7 +9563,7 @@
                   <trackName>Countertenor</trackName>
                   <longName>Countertenor</longName>
                   <shortName>Ct.</shortName>
-                  <description>Countertenor or Male Alto</description>
+                  <description>Counter tenor or male alto voice.</description>
                   <musicXMLid>voice.countertenor</musicXMLid>
                   <clef>G</clef>
                   <aPitchRange>55-76</aPitchRange>
@@ -9577,7 +9579,7 @@
                   <trackName>Alto</trackName>
                   <longName>Alto</longName>
                   <shortName>A.</shortName>
-                  <description>Alto</description>
+                  <description>Alto voice.</description>
                   <musicXMLid>voice.alto</musicXMLid>
                   <clef>G</clef>
                   <aPitchRange>55-74</aPitchRange>
@@ -9596,7 +9598,7 @@
                   <trackName>Alto (C clef)</trackName>
                   <longName>Alto</longName>
                   <shortName>A.</shortName>
-                  <description>Alto (C Clef)</description>
+                  <description>Alto voice (notated in C clef).</description>
                   <musicXMLid>voice.alto</musicXMLid>
                   <clef>C3</clef>
                   <aPitchRange>55-74</aPitchRange>
@@ -9612,7 +9614,7 @@
                   <trackName>Contralto</trackName>
                   <longName>Contralto</longName>
                   <shortName>Contr.</shortName>
-                  <description>Female Alto</description>
+                  <description>Female alto voice.</description>
                   <musicXMLid>voice.alto</musicXMLid>
                   <clef>G</clef>
                   <aPitchRange>55-74</aPitchRange>
@@ -9629,7 +9631,7 @@
                   <trackName>Tenor</trackName>
                   <longName>Tenor</longName>
                   <shortName>T.</shortName>
-                  <description>Tenor</description>
+                  <description>Tenor voice.</description>
                   <musicXMLid>voice.tenor</musicXMLid>
                   <clef>G8vb</clef>
                   <aPitchRange>48-69</aPitchRange>
@@ -9648,7 +9650,7 @@
                   <trackName>Tenor (C clef)</trackName>
                   <longName>Tenor</longName>
                   <shortName>T.</shortName>
-                  <description>Tenor (C Clef)</description>
+                  <description>Tenor voice (notated in C clef).</description>
                   <musicXMLid>voice.tenor</musicXMLid>
                   <clef>C4</clef>
                   <aPitchRange>48-69</aPitchRange>
@@ -9664,7 +9666,7 @@
                   <trackName>Baritone</trackName>
                   <longName>Baritone</longName>
                   <shortName>Bar.</shortName>
-                  <description>Baritone</description>
+                  <description>Baritone voice.</description>
                   <musicXMLid>voice.baritone</musicXMLid>
                   <clef>F</clef>
                   <aPitchRange>43-64</aPitchRange>
@@ -9683,7 +9685,7 @@
                   <trackName>Baritone (C clef)</trackName>
                   <longName>Baritone</longName>
                   <shortName>Bar.</shortName>
-                  <description>Baritone (C Clef)</description>
+                  <description>Baritone voice (notated in C clef).</description>
                   <musicXMLid>voice.baritone</musicXMLid>
                   <clef>C5</clef>
                   <aPitchRange>43-64</aPitchRange>
@@ -9700,7 +9702,7 @@
                   <trackName>Voice</trackName>
                   <longName>Voice</longName>
                   <shortName>Vo.</shortName>
-                  <description>Voice</description>
+                  <description>Voice (unspecified type).</description>
                   <musicXMLid>voice.vocals</musicXMLid>
                   <clef>G</clef>
                   <aPitchRange>41-79</aPitchRange>
@@ -9718,7 +9720,7 @@
                   <trackName>Bass</trackName>
                   <longName>Bass</longName>
                   <shortName>B.</shortName>
-                  <description>Bass</description>
+                  <description>Bass voice.</description>
                   <musicXMLid>voice.bass</musicXMLid>
                   <clef>F</clef>
                   <aPitchRange>41-60</aPitchRange>
@@ -9737,7 +9739,7 @@
                   <trackName>Women</trackName>
                   <longName>Women</longName>
                   <shortName>W.</shortName>
-                  <description>Women</description>
+                  <description>Women’s voices.</description>
                   <musicXMLid>voice.female</musicXMLid>
                   <clef>G</clef>
                   <aPitchRange>55-81</aPitchRange>
@@ -9760,7 +9762,7 @@
                   <trackName>Men</trackName>
                   <longName>Men</longName>
                   <shortName>M.</shortName>
-                  <description>Men</description>
+                  <description>Men’s voices.</description>
                   <musicXMLid>voice.male</musicXMLid>
                   <clef>F</clef>
                   <aPitchRange>41-67</aPitchRange>
@@ -9783,7 +9785,7 @@
                   <trackName>Kazoo</trackName>
                   <longName>Kazoo</longName>
                   <shortName>Kaz.</shortName>
-                  <description>Kazoo</description>
+                  <description>Kazoo.</description>
                   <musicXMLid>voice.kazoo</musicXMLid>
                   <clef>G</clef>
                   <aPitchRange>41-81</aPitchRange>
@@ -9803,7 +9805,7 @@
                   <trackName>Celesta</trackName>
                   <longName>Celesta</longName>
                   <shortName>Cel.</shortName>
-                  <description>Celesta</description>
+                  <description>Celesta.</description>
                   <musicXMLid>keyboard.celesta</musicXMLid>
                   <staves>2</staves>
                   <transposingClef>G</transposingClef>
@@ -9829,7 +9831,7 @@
                   <trackName>Clavichord</trackName>
                   <longName>Clavichord</longName>
                   <shortName>Cch.</shortName>
-                  <description>Clavichord</description>
+                  <description>Clavichord.</description>
                   <musicXMLid>keyboard.clavichord</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -9851,7 +9853,7 @@
                   <trackName>Clavinet</trackName>
                   <longName>Clavinet</longName>
                   <shortName>Clav.</shortName>
-                  <description>Clavinet</description>
+                  <description>Electrically amplified clavichord.</description>
                   <musicXMLid>keyboard.clavichord.synth</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -9873,7 +9875,7 @@
                   <trackName>Harpsichord</trackName>
                   <longName>Harpsichord</longName>
                   <shortName>Hch.</shortName>
-                  <description>Harpsichord</description>
+                  <description>Harpsichord.</description>
                   <musicXMLid>keyboard.harpsichord</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -9897,7 +9899,7 @@
                   <trackName>Virginal</trackName>
                   <longName>Virginal</longName>
                   <shortName>Vir.</shortName>
-                  <description>Virginal</description>
+                  <description>Virginal.</description>
                   <musicXMLid>keyboard.virginal</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -9919,7 +9921,7 @@
                   <trackName>Electric Piano</trackName>
                   <longName>Electric Piano</longName>
                   <shortName>El. Pno.</shortName>
-                  <description>Electric Piano</description>
+                  <description>Electric piano.</description>
                   <musicXMLid>keyboard.piano.electric</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -9942,7 +9944,7 @@
                   <trackName>Grand Piano</trackName>
                   <longName>Grand Piano</longName>
                   <shortName>Pno.</shortName>
-                  <description>Grand Piano</description>
+                  <description>Specifically a grand piano.</description>
                   <musicXMLid>keyboard.piano.grand</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -9969,7 +9971,7 @@
                   <trackName>Honky Tonk Piano</trackName>
                   <longName>Honky Tonk Piano</longName>
                   <shortName>Hnk. Pno.</shortName>
-                  <description>Honky Tonk Piano</description>
+                  <description>Honky-tonk (very out of tune) piano.</description>
                   <musicXMLid>keyboard.piano.honky-tonk</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -9996,7 +9998,7 @@
                   <trackName>Piano</trackName>
                   <longName>Piano</longName>
                   <shortName>Pno.</shortName>
-                  <description>Piano</description>
+                  <description>Piano.</description>
                   <musicXMLid>keyboard.piano</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10027,7 +10029,7 @@
                   <trackName>Toy Piano</trackName>
                   <longName>Toy Piano</longName>
                   <shortName>Toy Pno.</shortName>
-                  <description>Toy Piano</description>
+                  <description>Toy piano.</description>
                   <musicXMLid>keyboard.piano.toy</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10053,7 +10055,7 @@
                   <trackName>Upright Piano</trackName>
                   <longName>Upright Piano</longName>
                   <shortName>Pno.</shortName>
-                  <description>Piano</description>
+                  <description>Specifically an upright piano.</description>
                   <musicXMLid>keyboard.piano.upright</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10078,7 +10080,7 @@
                   <trackName>Hammond Organ</trackName>
                   <longName>Hammond Organ</longName>
                   <shortName>Hm. Org.</shortName>
-                  <description>Hammond Electronic Organ</description>
+                  <description>Hammond electronic organ.</description>
                   <musicXMLid>keyboard.organ.drawbar</musicXMLid>
                   <staves>3</staves>
                   <clef>G</clef>
@@ -10100,7 +10102,7 @@
                   <trackName>Organ</trackName>
                   <longName>Organ</longName>
                   <shortName>Org.</shortName>
-                  <description>Electronic Organ (generic)</description>
+                  <description>Organ (generic).</description>
                   <musicXMLid>keyboard.organ</musicXMLid>
                   <staves>3</staves>
                   <clef>G</clef>
@@ -10124,7 +10126,7 @@
                   <trackName>Percussive Organ</trackName>
                   <longName>Percussive Organ</longName>
                   <shortName>Perc. Org.</shortName>
-                  <description>Electronic Percussive Organ</description>
+                  <description>Electronic organ with percussion feature.</description>
                   <musicXMLid>keyboard.organ.percussive</musicXMLid>
                   <staves>3</staves>
                   <clef>G</clef>
@@ -10144,7 +10146,7 @@
                   <trackName>Pipe Organ</trackName>
                   <longName>Pipe Organ</longName>
                   <shortName>Org.</shortName>
-                  <description>GM Pipe Organ</description>
+                  <description>Pipe organ.</description>
                   <musicXMLid>keyboard.organ.pipe</musicXMLid>
                   <staves>3</staves>
                   <clef>G</clef>
@@ -10166,7 +10168,7 @@
                   <trackName>Rotary Organ</trackName>
                   <longName>Rotary Organ</longName>
                   <shortName>Rot. Org.</shortName>
-                  <description>Electronic Rotary Organ (usually means Hammond with Leslie Speaker)</description>
+                  <description>Hammond organ with Leslie rotary speaker.</description>
                   <musicXMLid>keyboard.organ.rotary</musicXMLid>
                   <staves>3</staves>
                   <clef>G</clef>
@@ -10186,7 +10188,7 @@
                   <trackName>Harmonium</trackName>
                   <longName>Harmonium</longName>
                   <shortName>Harm.</shortName>
-                  <description>Harmonium</description>
+                  <description>Harmonium.</description>
                   <musicXMLid>keyboard.harmonium</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10206,7 +10208,7 @@
                   <trackName>Reed Organ</trackName>
                   <longName>Reed Organ</longName>
                   <shortName>Rd. Org.</shortName>
-                  <description>Reed Organ</description>
+                  <description>Reed organ.</description>
                   <musicXMLid>keyboard.organ.reed</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10229,7 +10231,7 @@
                   <trackName>Mallet Synthesizer</trackName>
                   <longName>Mallet Synthesizer</longName>
                   <shortName>Mal. Syn.</shortName>
-                  <description>Mallet Synthesizer</description>
+                  <description>Mallet synthesizer.</description>
                   <musicXMLid>synth.group</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10250,7 +10252,7 @@
                   <trackName>Ondes Martenot</trackName>
                   <longName>Ondes Martenot</longName>
                   <shortName>O.M.</shortName>
-                  <description>Ondes Martenot</description>
+                  <description>Ondes Martenot.</description>
                   <musicXMLid>keyboard.ondes-martenot</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10271,7 +10273,7 @@
                   <trackName>Percussion Synthesizer</trackName>
                   <longName>Percussion Synthesizer</longName>
                   <shortName>Perc. Syn.</shortName>
-                  <description>Percussion Synthesizer</description>
+                  <description>Percussion synthesizer.</description>
                   <musicXMLid>drum.snare-drum.electric</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>
@@ -10299,7 +10301,7 @@
                   <trackName>Atmosphere Synthesizer</trackName>
                   <longName>Atmosphere Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Atmosphere Effect Synthesizer</description>
+                  <description>Atmosphere synth effect (General MIDI program 100).</description>
                   <musicXMLid>synth.effects.atmosphere</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10322,7 +10324,7 @@
                   <trackName>Bass Synthesizer</trackName>
                   <longName>Bass Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Bass Synthesizer</description>
+                  <description>Bass synthesizer.</description>
                   <musicXMLid>pluck.bass.synth</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10349,7 +10351,7 @@
                   <trackName>Bowed Synthesizer</trackName>
                   <longName>Bowed Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Bowed Pad Synthesizer</description>
+                  <description>Bowed synth pad (General MIDI program 93).</description>
                   <musicXMLid>synth.pad.bowed</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10372,7 +10374,7 @@
                   <trackName>Brass Synthesizer</trackName>
                   <longName>Brass Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Brass Synthesizer</description>
+                  <description>Brass synthesizer.</description>
                   <musicXMLid>brass.group.synth</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10399,7 +10401,7 @@
                   <trackName>Brightness Synthesizer</trackName>
                   <longName>Brightness Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Brightness Effect Synthesizer</description>
+                  <description>Brightness synth effect (General MIDI program 101).</description>
                   <musicXMLid>synth.effects.brightness</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10422,7 +10424,7 @@
                   <trackName>Choir Synthesizer</trackName>
                   <longName>Choir Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Choir Pad Synthesizer</description>
+                  <description>Choir synth pad (General MIDI program 92).</description>
                   <musicXMLid>synth.pad.choir</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10445,7 +10447,7 @@
                   <trackName>Crystal Synthesizer</trackName>
                   <longName>Crystal Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Crystal Effect Synthesizer</description>
+                  <description>Crystal synth effect (General MIDI program 99).</description>
                   <musicXMLid>synth.effects.crystal</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10468,7 +10470,7 @@
                   <trackName>Echoes Synthesizer</trackName>
                   <longName>Echoes Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Echoes Effect Synthesizer</description>
+                  <description>Echoes synth effect (General MIDI program 103).</description>
                   <musicXMLid>synth.effects.echoes</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10491,7 +10493,7 @@
                   <trackName>Effect Synthesizer</trackName>
                   <longName>Effect Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>GM Effect Synthesizer (generic)</description>
+                  <description>General MIDI effect synthesizer (generic).</description>
                   <musicXMLid>synth.effects</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10542,7 +10544,7 @@
                   <trackName>Goblins Synthesizer</trackName>
                   <longName>Goblins Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Goblins Effect Synthesizer</description>
+                  <description>Goblins synth effect (General MIDI program 102).</description>
                   <musicXMLid>synth.effects.goblins</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10565,7 +10567,7 @@
                   <trackName>Halo Synthesizer</trackName>
                   <longName>Halo Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Halo Pad Synthesizer</description>
+                  <description>Halo synth pad (General MIDI program 95).</description>
                   <musicXMLid>synth.pad.halo</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10588,7 +10590,7 @@
                   <trackName>Metallic Synthesizer</trackName>
                   <longName>Metallic Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Metallic Pad Synthesizer</description>
+                  <description>Metallic synth pad (General MIDI program 94).</description>
                   <musicXMLid>synth.pad.metallic</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10611,7 +10613,7 @@
                   <trackName>New Age Synthesizer</trackName>
                   <longName>New Age Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>New Age Pad Synthesizer</description>
+                  <description>New age synth pad (General MIDI program 89).</description>
                   <musicXMLid>synth.pad</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10634,7 +10636,7 @@
                   <trackName>Pad Synthesizer</trackName>
                   <longName>Pad Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>GM Pad Synthesizer (generic)</description>
+                  <description>General MIDI synth pad (generic).</description>
                   <musicXMLid>synth.pad</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10685,7 +10687,7 @@
                   <trackName>Poly Synthesizer</trackName>
                   <longName>Poly Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Polysynth Pad Synthesizer</description>
+                  <description>Polysynth synth pad (General MIDI program 91).</description>
                   <musicXMLid>synth.pad.polysynth</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10708,7 +10710,7 @@
                   <trackName>Rain Synthesizer</trackName>
                   <longName>Rain Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Rain Effect Synthesizer</description>
+                  <description>Rain synth effect (General MIDI program 97).</description>
                   <musicXMLid>synth.effects.rain</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10731,7 +10733,7 @@
                   <trackName>Saw Synthesizer</trackName>
                   <longName>Saw Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Sawtooth Wave Synthesizer</description>
+                  <description>Sawtooth wave synthesizer.</description>
                   <musicXMLid>synth.tone.sawtooth</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10754,7 +10756,7 @@
                   <trackName>Sci-fi Synthesizer</trackName>
                   <longName>Sci-fi Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Sci-fi Effect Synthesizer</description>
+                  <description>Sci-fi synth effect (General MIDI program 104).</description>
                   <musicXMLid>synth.effects.sci-fi</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10777,7 +10779,7 @@
                   <trackName>Sine Synthesizer</trackName>
                   <longName>Sine Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Sine Wave Synthesizer</description>
+                  <description>Sine wave synthesizer.</description>
                   <musicXMLid>synth.tone.sine</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10800,7 +10802,7 @@
                   <trackName>Soundtrack Synthesizer</trackName>
                   <longName>Soundtrack Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Soundtrack Effect Synthesizer</description>
+                  <description>Soundtrack synth effect (General MIDI program 98).</description>
                   <musicXMLid>synth.effects.soundtrack</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10823,7 +10825,7 @@
                   <trackName>Square Synthesizer</trackName>
                   <longName>Square Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Square Wave Synthesizer</description>
+                  <description>Square wave synthesizer.</description>
                   <musicXMLid>synth.tone.sine</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10846,7 +10848,7 @@
                   <trackName>String Synthesizer</trackName>
                   <longName>String Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>String Synthesizer</description>
+                  <description>String synthesizer.</description>
                   <musicXMLid>strings.group.synth</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10873,7 +10875,7 @@
                   <trackName>Sweep Synthesizer</trackName>
                   <longName>Sweep Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Sweep Pad Synthesizer</description>
+                  <description>Sweep synth pad (General MIDI program 96).</description>
                   <musicXMLid>synth.pad.warm</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10896,7 +10898,7 @@
                   <trackName>Theremin</trackName>
                   <longName>Theremin</longName>
                   <shortName>Thmn.</shortName>
-                  <description>Theremin</description>
+                  <description>Theremin.</description>
                   <musicXMLid>synth.theremin</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10919,7 +10921,7 @@
                   <trackName>Warm Synthesizer</trackName>
                   <longName>Warm Synthesizer</longName>
                   <shortName>Synth.</shortName>
-                  <description>Warm Pad Synthesizer</description>
+                  <description>Warm synth pad (General MIDI program 90).</description>
                   <musicXMLid>synth.pad.warm</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10945,7 +10947,7 @@
                   <trackName>Harp</trackName>
                   <longName>Harp</longName>
                   <shortName>Hrp.</shortName>
-                  <description>Harp</description>
+                  <description>Harp.</description>
                   <musicXMLid>pluck.harp</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -10976,7 +10978,7 @@
                   <trackName>Cavaquinho</trackName>
                   <longName>Cavaquinho</longName>
                   <shortName>Cava.</shortName>
-                  <description>Cavaquinho (4-string Guitar)</description>
+                  <description>Small Portuguese 4-string guitar (staff notation).</description>
                   <musicXMLid>pluck.guitar</musicXMLid>
                   <StringData>
                         <frets>19</frets>
@@ -11001,7 +11003,7 @@
                   <family>guitars</family>
                   <trackName>Cavaquinho (tablature)</trackName>
                   <longName>Cavaquinho</longName>
-                  <description>Cavaquinho (4-string Guitar) (Tablature)</description>
+                  <description>Small Portuguese 4-string guitar (tablature).</description>
                   <musicXMLid>pluck.guitar</musicXMLid>
                   <stafftype staffTypePreset="tab4StrSimple">tablature</stafftype>
                   <genre>world</genre>
@@ -11011,7 +11013,7 @@
                   <trackName>Soprano Guitar</trackName>
                   <longName>Soprano Guitar</longName>
                   <shortName>S. Guit.</shortName>
-                  <description>Soprano Guitar</description>
+                  <description>Soprano guitar.</description>
                   <musicXMLid>pluck.guitar</musicXMLid>
                   <StringData>
                         <frets>19</frets>
@@ -11041,7 +11043,7 @@
                   <trackName>Alto Guitar</trackName>
                   <longName>Alto Guitar</longName>
                   <shortName>A. Guit.</shortName>
-                  <description>Alto Guitar</description>
+                  <description>Alto guitar.</description>
                   <musicXMLid>pluck.guitar</musicXMLid>
                   <StringData>
                         <frets>19</frets>
@@ -11072,7 +11074,7 @@
                   <trackName>Electric Guitar</trackName>
                   <longName>Electric Guitar</longName>
                   <shortName>El. Guit.</shortName>
-                  <description>Electric Guitar</description>
+                  <description>Electric guitar (notated with 8va bassa treble clef).</description>
                   <musicXMLid>pluck.guitar.electric</musicXMLid>
                   <StringData>
                         <frets>24</frets>
@@ -11122,7 +11124,7 @@
                   <trackName>Electric Guitar (treble clef)</trackName>
                   <longName>Electric Guitar</longName>
                   <shortName>El. Guit.</shortName>
-                  <description>Electric Guitar</description>
+                  <description>Electric guitar (notated with normal treble clef).</description>
                   <musicXMLid>pluck.guitar.electric</musicXMLid>
                   <StringData>
                         <frets>24</frets>
@@ -11151,7 +11153,7 @@
                   <trackName>Acoustic Guitar</trackName>
                   <longName>Acoustic Guitar</longName>
                   <shortName>Guit.</shortName>
-                  <description>Acoustic Steel-strung Guitar</description>
+                  <description>Acoustic steel-strung guitar (staff notation, with 8va bassa treble clef).</description>
                   <musicXMLid>pluck.guitar.acoustic</musicXMLid>
                   <StringData>
                         <frets>20</frets>
@@ -11189,7 +11191,7 @@
                   <trackName>Acoustic Guitar (treble clef)</trackName>
                   <longName>Guitar</longName>
                   <shortName>Guit.</shortName>
-                  <description>Acoustic Steel-strung Guitar (Treble Clef)</description>
+                  <description>Acoustic steel-strung guitar (staff notation, with normal treble clef).</description>
                   <musicXMLid>pluck.guitar.acoustic</musicXMLid>
                   <StringData>
                         <frets>20</frets>
@@ -11218,7 +11220,7 @@
                   <trackName>Classical Guitar</trackName>
                   <longName>Classical Guitar</longName>
                   <shortName>Guit.</shortName>
-                  <description>Acoustic Nylon-strung Guitar</description>
+                  <description>Acoustic nylon-strung guitar (staff notation, with 8va bassa treble clef).</description>
                   <musicXMLid>pluck.guitar.nylon-string</musicXMLid>
                   <StringData>
                         <frets>19</frets>
@@ -11250,7 +11252,7 @@
                   <trackName>Guitar (treble clef)</trackName>
                   <longName>Guitar</longName>
                   <shortName>Guit.</shortName>
-                  <description>Acoustic Nylon-strung Guitar (Treble Clef)</description>
+                  <description>Acoustic nylon-strung guitar (staff notation, with normal treble clef).</description>
                   <musicXMLid>pluck.guitar.nylon-string</musicXMLid>
                   <StringData>
                         <frets>19</frets>
@@ -11283,7 +11285,7 @@
                   <family>guitars</family>
                   <trackName>Electric Guitar (tablature)</trackName>
                   <longName>Electric Guitar</longName>
-                  <description>Electric Guitar (Tablature)</description>
+                  <description>Electric guitar (tablature).</description>
                   <stafftype staffTypePreset="tab6StrCommon">tablature</stafftype>
                   <genre>common</genre>
                   <genre>popular</genre>
@@ -11293,7 +11295,7 @@
                   <family>guitars</family>
                   <trackName>Classical Guitar (tablature)</trackName>
                   <longName>Classical Guitar</longName>
-                  <description>Acoustic Nylon Strung Guitar (Tablature)</description>
+                  <description>Acoustic nylon-string guitar (tablature).</description>
                   <musicXMLid>pluck.guitar.nylon-string</musicXMLid>
                   <stafftype staffTypePreset="tab6StrCommon">tablature</stafftype>
                   <genre>common</genre>
@@ -11303,7 +11305,7 @@
                   <family>guitars</family>
                   <trackName>Acoustic Guitar (tablature)</trackName>
                   <longName>Guitar</longName>
-                  <description>Acoustic Steel Strung Guitar (Tablature)</description>
+                  <description>Acoustic steel-string guitar (tablature).</description>
                   <musicXMLid>pluck.guitar.acoustic</musicXMLid>
                   <stafftype staffTypePreset="tab6StrCommon">tablature</stafftype>
                   <genre>common</genre>
@@ -11314,7 +11316,7 @@
                   <trackName>Pedal Steel Guitar</trackName>
                   <longName>Pedal Steel Guitar</longName>
                   <shortName>Ped. St. Guit.</shortName>
-                  <description>Pedal Steel Guitar</description>
+                  <description>Pedal steel guitar.</description>
                   <musicXMLid>pluck.guitar.pedal-steel</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -11340,7 +11342,7 @@
                   <trackName>Baritone Guitar</trackName>
                   <longName>Baritone Guitar</longName>
                   <shortName>Bar. Guit.</shortName>
-                  <description>Baritone Guitar</description>
+                  <description>Baritone guitar.</description>
                   <musicXMLid>pluck.guitar</musicXMLid>
                   <StringData>
                         <frets>19</frets>
@@ -11366,7 +11368,7 @@
                   <trackName>Contra Guitar</trackName>
                   <longName>Contra Guitar</longName>
                   <shortName>C. Guit.</shortName>
-                  <description>Acoustic Contra Guitar</description>
+                  <description>Guitar with a second, fretless neck with up to nine bass strings. Developed in Vienna in the mid-19th century.</description>
                   <musicXMLid>pluck.guitar</musicXMLid>
                   <StringData>
                         <frets>19</frets>
@@ -11406,7 +11408,7 @@
                   <trackName>7-string Guitar</trackName>
                   <longName>7-string Guitar</longName>
                   <shortName>Guit.</shortName>
-                  <description>7-string Guitar</description>
+                  <description>7-string guitar (staff notation).</description>
                   <musicXMLid>pluck.guitar.nylon-string</musicXMLid>
                   <StringData>
                         <frets>19</frets>
@@ -11434,7 +11436,7 @@
                   <family>guitars</family>
                   <trackName>7-string Guitar (tablature)</trackName>
                   <longName>7-string Guitar</longName>
-                  <description>7-string Guitar (Tablature)</description>
+                  <description>7-string guitar (tablature).</description>
                   <musicXMLid>pluck.guitar.nylon-string</musicXMLid>
                   <stafftype staffTypePreset="tab7StrCommon">tablature</stafftype>
                   <genre>world</genre>
@@ -11444,7 +11446,7 @@
                   <trackName>11-string Alto Guitar</trackName>
                   <longName>11-string Alto Guitar</longName>
                   <shortName>11-str. A. Guit.</shortName>
-                  <description>11-string Alto Guitar</description>
+                  <description>11-string alto guitar.</description>
                   <musicXMLid>pluck.guitar</musicXMLid>
                   <StringData>
                         <frets>19</frets>
@@ -11483,7 +11485,7 @@
                   <trackName>12-string Guitar</trackName>
                   <longName>12-string Guitar</longName>
                   <shortName>12-str. Guit.</shortName>
-                  <description>12-string Guitar</description>
+                  <description>12-string guitar.</description>
                   <musicXMLid>pluck.guitar</musicXMLid>
                   <StringData>
                         <frets>21</frets>
@@ -11518,7 +11520,7 @@
                   <trackName>5-str. Electric Bass</trackName>
                   <longName>5-str. Electric Bass</longName>
                   <shortName>El. B.</shortName>
-                  <description>5-string Electric Bass</description>
+                  <description>5-string electric bass guitar (staff notation).</description>
                   <musicXMLid>pluck.bass.electric</musicXMLid>
                   <StringData>
                         <frets>24</frets>
@@ -11557,7 +11559,7 @@
                   <trackName>5-str. Electric Bass (high C/tenor)</trackName>
                   <longName>5-str. Electric Bass</longName>
                   <shortName>El. B.</shortName>
-                  <description>5-string Electric Bass (High C/Tenor)</description>
+                  <description>5-string electric bass guitar, high C tuning (staff notation).</description>
                   <musicXMLid>pluck.bass.electric</musicXMLid>
                   <StringData>
                         <frets>24</frets>
@@ -11594,7 +11596,7 @@
                   <family>bass-guitars</family>
                   <trackName>5-str. Electric Bass (tablature)</trackName>
                   <longName>5-str. Electric Bass</longName>
-                  <description>5-string Electric Bass (Tablature)</description>
+                  <description>5-string electric bass guitar (tablature).</description>
                   <stafftype staffTypePreset="tab5StrCommon">tablature</stafftype>
                   <genre>common</genre>
                   <genre>popular</genre>
@@ -11604,7 +11606,7 @@
                   <family>bass-guitars</family>
                   <trackName>5-str. Electric Bass (high C/tenor) (tablature)</trackName>
                   <longName>5-str. Electric Bass</longName>
-                  <description>5-string Electric Bass (High C/Tenor) (Tablature)</description>
+                  <description>5-string electric bass guitar, high C tuning (tablature).</description>
                   <stafftype staffTypePreset="tab5StrCommon">tablature</stafftype>
                   <genre>jazz</genre>
             </Instrument>
@@ -11613,7 +11615,7 @@
                   <trackName>6-str. Electric Bass</trackName>
                   <longName>6-str. Electric Bass</longName>
                   <shortName>El. B.</shortName>
-                  <description>6-string Electric Bass</description>
+                  <description>6-string electric bass guitar (staff notation).</description>
                   <musicXMLid>pluck.bass.electric</musicXMLid>
                   <StringData>
                         <frets>24</frets>
@@ -11651,7 +11653,7 @@
                   <family>bass-guitars</family>
                   <trackName>6-str. Electric Bass (tablature)</trackName>
                   <longName>6-str. Electric Bass</longName>
-                  <description>6-string Electric Bass (Tablature)</description>
+                  <description>6-string electric bass guitar (tablature).</description>
                   <stafftype staffTypePreset="tab6StrCommon">tablature</stafftype>
                   <genre>jazz</genre>
             </Instrument>
@@ -11660,7 +11662,7 @@
                   <trackName>Bass Guitar</trackName>
                   <longName>Bass Guitar</longName>
                   <shortName>B. Guit.</shortName>
-                  <description>Bass Guitar</description>
+                  <description>Bass guitar (staff notation).</description>
                   <musicXMLid>pluck.bass</musicXMLid>
                   <StringData>
                         <frets>24</frets>
@@ -11699,7 +11701,7 @@
                   <trackName>Electric Bass</trackName>
                   <longName>Electric Bass</longName>
                   <shortName>El. B.</shortName>
-                  <description>Electric Bass</description>
+                  <description>Electric bass guitar (staff notation).</description>
                   <musicXMLid>pluck.bass.electric</musicXMLid>
                   <StringData>
                         <frets>24</frets>
@@ -11737,7 +11739,7 @@
                   <trackName>Fretless Electric Bass</trackName>
                   <longName>Fretless Electric Bass</longName>
                   <shortName>Frtl. El. B.</shortName>
-                  <description>Fretless Electric Bass</description>
+                  <description>Fretless electric bass guitar.</description>
                   <musicXMLid>pluck.bass.fretless</musicXMLid>
                   <StringData>
                         <frets>24</frets>
@@ -11775,7 +11777,7 @@
                   <trackName>Acoustic Bass</trackName>
                   <longName>Acoustic Bass</longName>
                   <shortName>Bass</shortName>
-                  <description>Acoustic Bass</description>
+                  <description>Acoustic bass guitar.</description>
                   <musicXMLid>pluck.bass.acoustic</musicXMLid>
                   <StringData>
                         <frets>24</frets>
@@ -11820,7 +11822,7 @@
                   <family>bass-guitars</family>
                   <trackName>Bass Guitar (tablature)</trackName>
                   <longName>Bass Guitar</longName>
-                  <description>Bass Guitar (Tablature)</description>
+                  <description>Bass guitar (tablature).</description>
                   <musicXMLid>pluck.bass</musicXMLid>
                   <stafftype staffTypePreset="tab4StrCommon">tablature</stafftype>
                   <genre>common</genre>
@@ -11831,7 +11833,7 @@
                   <family>bass-guitars</family>
                   <trackName>Electric Bass (tablature)</trackName>
                   <longName>Electric Bass</longName>
-                  <description>Electric Bass (Tablature)</description>
+                  <description>Electric bass guitar (tablature).</description>
                   <musicXMLid>pluck.bass.electric</musicXMLid>
                   <stafftype staffTypePreset="tab4StrCommon">tablature</stafftype>
                   <genre>common</genre>
@@ -11842,7 +11844,7 @@
                   <trackName>Banjo</trackName>
                   <longName>Banjo</longName>
                   <shortName>Bj.</shortName>
-                  <description>5 string Banjo</description>
+                  <description>5-string banjo (staff notation).</description>
                   <musicXMLid>pluck.banjo</musicXMLid>
                   <StringData>
                         <frets>19</frets>
@@ -11870,7 +11872,7 @@
                   <trackName>Tenor Banjo</trackName>
                   <longName>Tenor Banjo</longName>
                   <shortName>T. Bj.</shortName>
-                  <description>4 string Tenor Banjo</description>
+                  <description>4-string tenor banjo.</description>
                   <musicXMLid>pluck.banjo.tenor</musicXMLid>
                   <StringData>
                         <frets>19</frets>
@@ -11894,7 +11896,7 @@
                   <family>banjos</family>
                   <trackName>Banjo (tablature)</trackName>
                   <longName>Banjo</longName>
-                  <description>Banjo (Tablature)</description>
+                  <description>5-string banjo (tablature).</description>
                   <musicXMLid>pluck.banjo</musicXMLid>
                   <stafftype staffTypePreset="tab5StrCommon">tablature</stafftype>
                   <genre>common</genre>
@@ -11905,7 +11907,7 @@
                   <trackName>Irish Tenor Banjo</trackName>
                   <longName>Irish Tenor Banjo</longName>
                   <shortName>ITB</shortName>
-                  <description>4 string Irish Tenor Banjo</description>
+                  <description>4-string Irish tenor banjo (staff notation).</description>
                   <musicXMLid>pluck.banjo.tenor</musicXMLid>
                   <StringData>
                         <frets>19</frets>
@@ -11930,7 +11932,7 @@
                   <family>banjos</family>
                   <trackName>Irish Tenor Banjo (tablature)</trackName>
                   <longName>Irish Tenor Banjo</longName>
-                  <description>Irish Tenor Banjo (Tablature)</description>
+                  <description>4-string Irish tenor banjo (tablature).</description>
                   <musicXMLid>pluck.banjo.tenor</musicXMLid>
                   <stafftype staffTypePreset="tab4StrCommon">tablature</stafftype>
                   <genre>world</genre>
@@ -11940,7 +11942,7 @@
                   <trackName>Tenor Ukulele</trackName>
                   <longName>Tenor Ukulele</longName>
                   <shortName>Ten. Uk.</shortName>
-                  <description>Tenor Ukulele</description>
+                  <description>Tenor ukulele with bottom string tuned to G4.</description>
                   <musicXMLid>pluck.ukulele.tenor</musicXMLid>
                   <StringData>
                         <frets>18</frets>
@@ -11965,7 +11967,7 @@
                   <trackName>Ukulele</trackName>
                   <longName>Ukulele</longName>
                   <shortName>Uk.</shortName>
-                  <description>Ukulele</description>
+                  <description>Standard ukulele (staff notation).</description>
                   <musicXMLid>pluck.ukulele</musicXMLid>
                   <StringData>
                         <frets>18</frets>
@@ -11993,7 +11995,7 @@
                   <trackName>Ukulele (low G)</trackName>
                   <longName>Ukulele</longName>
                   <shortName>Uk.</shortName>
-                  <description>A plucked sting instrument with lowest string tuned to G3 (written in C, non-transposing), an octave below the tenor ukulele.</description>
+                  <description>Tenor ukulele with bottom string tuned to G3.</description>
                   <musicXMLid>pluck.ukulele</musicXMLid>
                   <StringData>
                         <frets>18</frets>
@@ -12018,7 +12020,7 @@
                   <family>ukuleles</family>
                   <trackName>Ukulele (tablature)</trackName>
                   <longName>Ukulele</longName>
-                  <description>Ukulele (4-str. TAB)</description>
+                  <description>Standard ukulele (tablature).</description>
                   <musicXMLid>pluck.ukulele</musicXMLid>
                   <stafftype staffTypePreset="tabUkulele">tablature</stafftype>
                   <genre>common</genre>
@@ -12030,7 +12032,7 @@
                   <trackName>Baritone Ukulele</trackName>
                   <longName>Baritone Ukulele</longName>
                   <shortName>Bar. Uk.</shortName>
-                  <description>Baritone Ukulele</description>
+                  <description>Baritone ukulele.</description>
                   <musicXMLid>pluck.ukulele.tenor</musicXMLid>
                   <StringData>
                         <frets>18</frets>
@@ -12055,7 +12057,7 @@
                   <trackName>Mandolin</trackName>
                   <longName>Mandolin</longName>
                   <shortName>Mdn.</shortName>
-                  <description>Mandolin</description>
+                  <description>Mandolin (staff notation).</description>
                   <musicXMLid>pluck.mandolin</musicXMLid>
                   <StringData>
                         <frets>24</frets>
@@ -12081,7 +12083,7 @@
                   <family>mandolins</family>
                   <trackName>Mandolin (tablature)</trackName>
                   <longName>Mandolin</longName>
-                  <description>Mandolin (Tablature)</description>
+                  <description>Mandolin (tablature).</description>
                   <musicXMLid>pluck.mandolin</musicXMLid>
                   <stafftype staffTypePreset="tab4StrCommon">tablature</stafftype>
                   <genre>popular</genre>
@@ -12091,7 +12093,7 @@
                   <trackName>Alto Mandola</trackName>
                   <longName>Alto Mandola</longName>
                   <shortName>A. Mda.</shortName>
-                  <description>Mandola Viola tuning</description>
+                  <description>Larger ancestor of the mandolin.</description>
                   <musicXMLid>pluck.mandola</musicXMLid>
                   <StringData>
                         <frets>24</frets>
@@ -12116,7 +12118,7 @@
                   <trackName>Mandola</trackName>
                   <longName>Mandola</longName>
                   <shortName>Mda.</shortName>
-                  <description>Mandola</description>
+                  <description>Larger ancestor of the mandolin.</description>
                   <musicXMLid>pluck.mandola</musicXMLid>
                   <StringData>
                         <frets>24</frets>
@@ -12141,7 +12143,7 @@
                   <trackName>Tenor Mandola</trackName>
                   <longName>Tenor Mandola</longName>
                   <shortName>T. Mda.</shortName>
-                  <description>Mandola 8va mandolin tuning</description>
+                  <description>Larger ancestor of the mandolin.</description>
                   <musicXMLid>pluck.mandola</musicXMLid>
                   <StringData>
                         <frets>24</frets>
@@ -12166,7 +12168,7 @@
                   <trackName>Octave Mandolin</trackName>
                   <longName>Octave Mandolin</longName>
                   <shortName>OM.</shortName>
-                  <description>Octave Mandolin</description>
+                  <description>Larger ancestor of the mandolin. Tuned an octave lower than the mandolin.</description>
                   <musicXMLid>pluck.mandolin.octave</musicXMLid>
                   <StringData>
                         <frets>24</frets>
@@ -12191,7 +12193,7 @@
                   <trackName>Mandocello</trackName>
                   <longName>Mandocello</longName>
                   <shortName>Mncl.</shortName>
-                  <description>Mandocello</description>
+                  <description>Larger ancestor of the mandolin. Tuned an octave lower than the standard mandola.</description>
                   <musicXMLid>pluck.mandocello</musicXMLid>
                   <StringData>
                         <frets>24</frets>
@@ -12216,7 +12218,7 @@
                   <trackName>Mtn. Dulcimer</trackName>
                   <longName>Mtn. Dulcimer</longName>
                   <shortName>Mtn. Dc.</shortName>
-                  <description>Standard Mountain Dulcimer</description>
+                  <description>Also known as the Appalachian dulcimer, among other names. A fretted string instrument of the zither family. (Staff notation).</description>
                   <musicXMLid>pluck.dulcimer</musicXMLid>
                   <StringData>
                         <frets>28</frets>
@@ -12240,7 +12242,7 @@
                   <family>mtn-dulcimers</family>
                   <trackName>Mtn. Dulcimer (tablature)</trackName>
                   <longName>Mtn. Dulcimer</longName>
-                  <description>Standard Mountain Dulcimer (3-str. chromatic TAB)</description>
+                  <description>Also known as the Appalachian dulcimer, among other names. A fretted string instrument of the zither family. (Tablature).</description>
                   <stafftype staffTypePreset="tabDulcimer">tablature</stafftype>
                   <genre>world</genre>
             </Instrument>
@@ -12249,7 +12251,7 @@
                   <trackName>Mtn. Dulcimer - Baritone</trackName>
                   <longName>Mtn. Dulcimer - Baritone</longName>
                   <shortName>Bar. M.D.</shortName>
-                  <description>Baritone Mountain Dulcimer</description>
+                  <description>Larger version of the mountain or Appalachian dulcimer. (Staff notation).</description>
                   <musicXMLid>pluck.dulcimer</musicXMLid>
                   <StringData>
                         <frets>23</frets>
@@ -12273,7 +12275,7 @@
                   <family>mtn-dulcimers</family>
                   <trackName>Mtn. Dulcimer - Baritone (tablature)</trackName>
                   <longName>Mtn. Dulcimer - Baritone</longName>
-                  <description>Baritone Mountain Dulcimer (3-str. chromatic TAB)</description>
+                  <description>Larger version of the mountain or Appalachian dulcimer. (Tablature).</description>
                   <stafftype staffTypePreset="tabDulcimer">tablature</stafftype>
                   <genre>world</genre>
             </Instrument>
@@ -12282,7 +12284,7 @@
                   <trackName>Mtn. Dulcimer - Bass</trackName>
                   <longName>Mtn. Dulcimer - Bass</longName>
                   <shortName>Bs. M.D.</shortName>
-                  <description>Bass Mountain Dulcimer</description>
+                  <description>Very large mountain or Appalachian dulcimer, an octave lower than the regular dulcimer. (Staff notation).</description>
                   <musicXMLid>pluck.dulcimer</musicXMLid>
                   <StringData>
                         <frets>28</frets>
@@ -12306,7 +12308,7 @@
                   <family>mtn-dulcimers</family>
                   <trackName>Mtn. Dulcimer - Bass (tablature)</trackName>
                   <longName>Mtn. Dulcimer - Bass</longName>
-                  <description>Bass Mountain Dulcimer (3-str. chromatic TAB)</description>
+                  <description>Larger version of the mountain or Appalachian dulcimer. (Tablature).</description>
                   <stafftype staffTypePreset="tabDulcimer">tablature</stafftype>
                   <genre>world</genre>
             </Instrument>
@@ -12315,7 +12317,7 @@
                   <trackName>Lute</trackName>
                   <longName>Lute</longName>
                   <shortName>Lt.</shortName>
-                  <description>Lute</description>
+                  <description>6-course lute (staff notation).</description>
                   <musicXMLid>pluck.lute</musicXMLid>
                   <StringData>
                         <frets>13</frets>
@@ -12343,7 +12345,7 @@
                   <family>lutes</family>
                   <trackName>Lute (tablature)</trackName>
                   <longName>Lute</longName>
-                  <description>Lute (Tablature)</description>
+                  <description>6-course lute (tablature).</description>
                   <musicXMLid>pluck.lute</musicXMLid>
                   <stafftype staffTypePreset="tab6StrFrench">tablature</stafftype>
                   <genre>earlymusic</genre>
@@ -12354,7 +12356,7 @@
                   <longName>Tenor Lute</longName>
                   <shortName>Lt.</shortName>
                   <dropdownName meaning="course">5-course</dropdownName>
-                  <description>Renaissance Tenor Lute (5-course).</description>
+                  <description>5-course Renaissance tenor lute.</description>
                   <musicXMLid>pluck.lute</musicXMLid>
                   <StringData>
                         <frets>13</frets>
@@ -12382,7 +12384,7 @@
                   <longName>Tenor Lute</longName>
                   <shortName>Lt.</shortName>
                   <dropdownName meaning="course">6-course</dropdownName>
-                  <description>Renaissance Tenor Lute (6-course).</description>
+                  <description>6-course Renaissance tenor lute.</description>
                   <musicXMLid>pluck.lute</musicXMLid>
                   <StringData>
                         <frets>13</frets>
@@ -12411,7 +12413,7 @@
                   <longName>Tenor Lute</longName>
                   <shortName>Lt.</shortName>
                   <dropdownName meaning="course">7-course</dropdownName>
-                  <description>Renaissance Tenor Lute (7-course).</description>
+                  <description>7-course Renaissance tenor lute.</description>
                   <musicXMLid>pluck.lute</musicXMLid>
                   <StringData>
                         <frets>13</frets>
@@ -12441,7 +12443,7 @@
                   <longName>Tenor Lute</longName>
                   <shortName>Lt.</shortName>
                   <dropdownName meaning="course">8-course</dropdownName>
-                  <description>Renaissance Tenor Lute (8-course).</description>
+                  <description>8-course Renaissance tenor lute.</description>
                   <musicXMLid>pluck.lute</musicXMLid>
                   <StringData>
                         <frets>13</frets>
@@ -12472,7 +12474,7 @@
                   <longName>Tenor Lute</longName>
                   <shortName>Lt.</shortName>
                   <dropdownName meaning="course">9-course</dropdownName>
-                  <description>Renaissance Tenor Lute (9-course).</description>
+                  <description>9-course Renaissance tenor lute.</description>
                   <musicXMLid>pluck.lute</musicXMLid>
                   <StringData>
                         <frets>13</frets>
@@ -12504,7 +12506,7 @@
                   <longName>Tenor Lute</longName>
                   <shortName>Lt.</shortName>
                   <dropdownName meaning="course">10-course</dropdownName>
-                  <description>Renaissance Tenor Lute (10-course).</description>
+                  <description>10-course Renaissance tenor lute.</description>
                   <musicXMLid>pluck.lute</musicXMLid>
                   <StringData>
                         <frets>13</frets>
@@ -12537,7 +12539,7 @@
                   <longName>Tenor Lute</longName>
                   <shortName>Lt.</shortName>
                   <dropdownName meaning="course">13-course</dropdownName>
-                  <description>Baroque Lute (13-course)</description>
+                  <description>13-course Baroque lute.</description>
                   <musicXMLid>pluck.lute</musicXMLid>
                   <StringData>
                         <frets>13</frets>
@@ -12572,7 +12574,7 @@
                   <trackName>Theorbo</trackName>
                   <longName>Theorbo</longName>
                   <shortName>Thb.</shortName>
-                  <description>Theorbo (14-course)</description>
+                  <description>14-course theorbo.</description>
                   <musicXMLid>pluck.theorbo</musicXMLid>
                   <StringData>
                         <frets>13</frets>
@@ -12608,7 +12610,7 @@
                   <trackName>Archlute</trackName>
                   <longName>Archlute</longName>
                   <shortName>A. Lt.</shortName>
-                  <description>Archlute (14-course)</description>
+                  <description>14-course archlute.</description>
                   <musicXMLid>pluck.archlute</musicXMLid>
                   <StringData>
                         <frets>13</frets>
@@ -12644,7 +12646,7 @@
                   <trackName>Piccolo Balalaika</trackName>
                   <longName>Piccolo Balalaika</longName>
                   <shortName>Pic. Bal.</shortName>
-                  <description>Piccolo Balalaika (the smallest and rarest of the family)</description>
+                  <description>Piccolo balalaika, tuned a fifth above the prima.</description>
                   <musicXMLid>pluck.balalaika.piccolo</musicXMLid>
                   <StringData>
                         <frets>17</frets>
@@ -12664,7 +12666,7 @@
             </Instrument>
             <Instrument id="balalaika">
                   <family>balalaikas</family>
-                  <description>Balalaika in fact the prima but a generic for simplicity</description>
+                  <description>Prima balalaika. The most common balalaika.</description>
                   <musicXMLid>pluck.balalaika</musicXMLid>
                   <StringData>
                         <frets>17</frets>
@@ -12688,7 +12690,7 @@
                   <trackName>Prima Balalaika</trackName>
                   <longName>Prima Balalaika</longName>
                   <shortName>Pr. Bal.</shortName>
-                  <description>Prima Balalaika (the most commonly played of the family)</description>
+                  <description>Prima balalaika. The most common balalaika.</description>
                   <musicXMLid>pluck.balalaika.prima</musicXMLid>
                   <StringData>
                         <frets>17</frets>
@@ -12711,7 +12713,7 @@
                   <trackName>Secunda Balalaika</trackName>
                   <longName>Secunda Balalaika</longName>
                   <shortName>Sec. Bal.</shortName>
-                  <description>Secunda Balalaika</description>
+                  <description>Secunda balalaika, tuned a fifth below the prima.</description>
                   <musicXMLid>pluck.balalaika.secunda</musicXMLid>
                   <StringData>
                         <frets>17</frets>
@@ -12734,7 +12736,7 @@
                   <trackName>Alto Balalaika</trackName>
                   <longName>Alto Balalaika</longName>
                   <shortName>Al. Bal.</shortName>
-                  <description>Alto Balalaika</description>
+                  <description>Alto balalaika, tuned an octave below the prima.</description>
                   <musicXMLid>pluck.balalaika.alto</musicXMLid>
                   <StringData>
                         <frets>17</frets>
@@ -12757,7 +12759,7 @@
                   <trackName>Bass Balalaika</trackName>
                   <longName>Bass Balalaika</longName>
                   <shortName>B. Bal.</shortName>
-                  <description>Bass Balalaika</description>
+                  <description>Bass balalaika, tuned an octave below the alto.</description>
                   <musicXMLid>pluck.balalaika.bass</musicXMLid>
                   <StringData>
                         <frets>17</frets>
@@ -12780,7 +12782,7 @@
                   <trackName>Contrabass Balalaika</trackName>
                   <longName>Contrabass Balalaika</longName>
                   <shortName>Cb. Bal.</shortName>
-                  <description>Contrabass Balalaika</description>
+                  <description>Contrabass balalaika, tuned an octave below the bass.</description>
                   <musicXMLid>pluck.balalaika.contrabass</musicXMLid>
                   <StringData>
                         <frets>17</frets>
@@ -12804,7 +12806,7 @@
                   <longName>Bouzouki</longName>
                   <shortName>Bou.</shortName>
                   <dropdownName meaning="course">3-course</dropdownName>
-                  <description>Bouzouki (3-course)</description>
+                  <description>Greek lute, with 3 courses.</description>
                   <musicXMLid>pluck.bouzouki</musicXMLid>
                   <StringData>
                         <frets>26</frets>
@@ -12830,7 +12832,7 @@
                   <longName>Bouzouki</longName>
                   <shortName>Bou.</shortName>
                   <dropdownName meaning="course">4-course</dropdownName>
-                  <description>Bouzouki (4-course)</description>
+                  <description>Greek lute, with 4 courses.</description>
                   <musicXMLid>pluck.bouzouki</musicXMLid>
                   <StringData>
                         <frets>26</frets>
@@ -12856,7 +12858,7 @@
                   <trackName>Koto</trackName>
                   <longName>Koto</longName>
                   <shortName>Ko.</shortName>
-                  <description>Koto</description>
+                  <description>Japanese plucked half-tube zither.</description>
                   <musicXMLid>pluck.koto</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -12874,7 +12876,7 @@
                   <trackName>Oud</trackName>
                   <longName>Oud</longName>
                   <shortName>O.</shortName>
-                  <description>Oud</description>
+                  <description>Short-neck lute-type fretless stringed instrument, common in the Middle East and North Africa.</description>
                   <musicXMLid>pluck.oud</musicXMLid>
                   <StringData>
                         <frets>15</frets>
@@ -12906,7 +12908,7 @@
                   <trackName>Shamisen</trackName>
                   <longName>Shamisen</longName>
                   <shortName>Sh.</shortName>
-                  <description>Shamisen</description>
+                  <description>Traditional Japanese three-stringed instrument played with a plectrum.</description>
                   <musicXMLid>pluck.shamisen</musicXMLid>
                   <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
@@ -12924,7 +12926,7 @@
                   <trackName>Sitar</trackName>
                   <longName>Sitar</longName>
                   <shortName>Si.</shortName>
-                  <description>Sitar</description>
+                  <description>Plucked string instrument used in Indian classical music.</description>
                   <musicXMLid>pluck.sitar</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -12942,7 +12944,7 @@
                   <trackName>Prim</trackName>
                   <longName>Prim</longName>
                   <shortName>Pr.</shortName>
-                  <description>Prim</description>
+                  <description>The smallest tamburica, mostly used as a lead instrument.</description>
                   <musicXMLid>pluck.tambura</musicXMLid>
                   <StringData>
                         <frets>15</frets>
@@ -12969,7 +12971,7 @@
                   <trackName>Brač</trackName>
                   <longName>Brač</longName>
                   <shortName>Br.</shortName>
-                  <description>Brač</description>
+                  <description>A larger tamburica than the prim, played in a similar way.</description>
                   <musicXMLid>pluck.tambura</musicXMLid>
                   <StringData>
                         <frets>15</frets>
@@ -12994,7 +12996,7 @@
                   <trackName>Bugarija</trackName>
                   <longName>Bugarija</longName>
                   <shortName>Bu.</shortName>
-                  <description>Bugarija</description>
+                  <description>A tamburica mostly used as a harmony/rhythm instrument.</description>
                   <musicXMLid>pluck.tambura</musicXMLid>
                   <StringData>
                         <frets>15</frets>
@@ -13021,7 +13023,7 @@
                   <trackName>Berda</trackName>
                   <longName>Berda</longName>
                   <shortName>Be.</shortName>
-                  <description>Berda</description>
+                  <description>The largest tamburica, used for playing bass lines.</description>
                   <musicXMLid>pluck.tambura</musicXMLid>
                   <StringData>
                         <frets>15</frets>
@@ -13048,7 +13050,7 @@
                   <trackName>Čelo</trackName>
                   <longName>Čelo</longName>
                   <shortName>Č.</shortName>
-                  <description>Čelo</description>
+                  <description>A tamburica similar in size to the bugarija, usually given counterpoint lines.</description>
                   <musicXMLid>pluck.tambura</musicXMLid>
                   <StringData>
                         <frets>15</frets>
@@ -13075,7 +13077,7 @@
                   <trackName>Bandurria</trackName>
                   <longName>Bandurria</longName>
                   <shortName>Band.</shortName>
-                  <description>Spanish Bandurria</description>
+                  <description>Spanish folk instrument similar to the mandolin. (Staff notation).</description>
                   <musicXMLid>pluck.bandurria</musicXMLid>
                   <StringData>
                         <frets>17</frets>
@@ -13102,7 +13104,7 @@
                   <family>bandurrias</family>
                   <trackName>Bandurria (tablature)</trackName>
                   <longName>Bandurria</longName>
-                  <description>Bandurria (Tablature)</description>
+                  <description>Spanish folk instrument similar to the mandolin. (Tablature).</description>
                   <musicXMLid>pluck.bandurria</musicXMLid>
                   <stafftype staffTypePreset="tab6StrCommon">tablature</stafftype>
                   <genre>popular</genre>
@@ -13112,7 +13114,7 @@
                   <trackName>Laúd</trackName>
                   <longName>Laúd</longName>
                   <shortName>Laúd</shortName>
-                  <description>Spanish Laúd</description>
+                  <description>Spanish lute similar to the bandurria. (Staff notation).</description>
                   <musicXMLid>pluck.laud</musicXMLid>
                   <StringData>
                         <frets>22</frets>
@@ -13139,7 +13141,7 @@
                   <family>lauds</family>
                   <trackName>Laúd (tablature)</trackName>
                   <longName>Laúd</longName>
-                  <description>Spanish Laúd (Tablature)</description>
+                  <description>Spanish lute similar to the bandurria. (Tablature).</description>
                   <musicXMLid>pluck.laud</musicXMLid>
                   <stafftype staffTypePreset="tab6StrCommon">tablature</stafftype>
                   <genre>popular</genre>
@@ -13152,7 +13154,7 @@
                   <trackName>Strings</trackName>
                   <longName>Strings</longName>
                   <shortName>St.</shortName>
-                  <description>String Section</description>
+                  <description>String section notated on a grand staff.</description>
                   <musicXMLid>strings.group</musicXMLid>
                   <staves>2</staves>
                   <clef>G</clef>
@@ -13175,13 +13177,14 @@
             <Instrument id="double-bass">
                   <init>contrabass</init>
                   <family>orchestral-strings</family>
+                  <description>Contrabass (double bass).</description>
             </Instrument>
             <Instrument id="violin">
                   <family>orchestral-strings</family>
                   <trackName>Violin</trackName>
                   <longName>Violin</longName>
                   <shortName>Vln.</shortName>
-                  <description>Violin</description>
+                  <description>Solo violin.</description>
                   <musicXMLid>strings.violin</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -13209,7 +13212,7 @@
                   <trackName>Violins</trackName>
                   <longName>Violins</longName>
                   <shortName>Vlns.</shortName>
-                  <description>Violins</description>
+                  <description>Violin section.</description>
                   <musicXMLid>strings.group</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -13237,7 +13240,7 @@
                   <trackName>Viola</trackName>
                   <longName>Viola</longName>
                   <shortName>Vla.</shortName>
-                  <description>Viola</description>
+                  <description>Solo viola.</description>
                   <musicXMLid>strings.viola</musicXMLid>
                   <clef>C3</clef>
                   <barlineSpan>1</barlineSpan>
@@ -13264,7 +13267,7 @@
                   <trackName>Violas</trackName>
                   <longName>Violas</longName>
                   <shortName>Vlas.</shortName>
-                  <description>Violas</description>
+                  <description>Viola section.</description>
                   <musicXMLid>strings.group</musicXMLid>
                   <clef>C3</clef>
                   <barlineSpan>1</barlineSpan>
@@ -13292,7 +13295,7 @@
                   <trackName>Violoncello</trackName>
                   <longName>Violoncello</longName>
                   <shortName>Vc.</shortName>
-                  <description>Violoncello</description>
+                  <description>Violoncello.</description>
                   <musicXMLid>strings.cello</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -13320,7 +13323,7 @@
                   <trackName>Violoncellos</trackName>
                   <longName>Violoncellos</longName>
                   <shortName>Vcs.</shortName>
-                  <description>Violoncellos</description>
+                  <description>Violoncello section.</description>
                   <musicXMLid>strings.group</musicXMLid>
                   <clef>F</clef>
                   <barlineSpan>1</barlineSpan>
@@ -13348,7 +13351,7 @@
                   <trackName>Contrabass</trackName>
                   <longName>Contrabass</longName>
                   <shortName>Cb.</shortName>
-                  <description>Contrabass</description>
+                  <description>Contrabass (double bass).</description>
                   <musicXMLid>strings.contrabass</musicXMLid>
                   <transposingClef>F</transposingClef>
                   <concertClef>F8vb</concertClef>
@@ -13379,7 +13382,7 @@
                   <trackName>Contrabasses</trackName>
                   <longName>Contrabasses</longName>
                   <shortName>Cbs.</shortName>
-                  <description>Contrabasses</description>
+                  <description>Contrabass (double bass) section.</description>
                   <musicXMLid>strings.group</musicXMLid>
                   <transposingClef>F</transposingClef>
                   <concertClef>F8vb</concertClef>
@@ -13410,7 +13413,7 @@
                   <trackName>Treble Viol</trackName>
                   <longName>Treble Viol</longName>
                   <shortName>Tr. Vl.</shortName>
-                  <description>Treble Viol</description>
+                  <description>Treble viol.</description>
                   <musicXMLid>strings.viol.treble</musicXMLid>
                   <StringData>
                         <frets>13</frets>
@@ -13444,7 +13447,7 @@
                   <trackName>Alto Viol</trackName>
                   <longName>Alto Viol</longName>
                   <shortName>A. Vl.</shortName>
-                  <description>Alto Viol (a smaller version of the tenor viol tuned higher)</description>
+                  <description>Alto viol.</description>
                   <musicXMLid>strings.viol.alto</musicXMLid>
                   <StringData>
                         <frets>13</frets>
@@ -13478,7 +13481,7 @@
                   <trackName>Pardessus de viole</trackName>
                   <longName>Pardessus de viole</longName>
                   <shortName>Pds. v.</shortName>
-                  <description>Pardessus de viole</description>
+                  <description>Highest-pitched member of the viol family.</description>
                   <musicXMLid>strings.viol</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
@@ -13503,7 +13506,7 @@
                   <trackName>Tenor Viol</trackName>
                   <longName>Tenor Viol</longName>
                   <shortName>T. Vl.</shortName>
-                  <description>Tenor Viol</description>
+                  <description>Tenor viol.</description>
                   <musicXMLid>strings.viol.tenor</musicXMLid>
                   <StringData>
                         <frets>13</frets>
@@ -13537,7 +13540,7 @@
                   <trackName>Baryton</trackName>
                   <longName>Baryton</longName>
                   <shortName>Bary.</shortName>
-                  <description>Baryton</description>
+                  <description>Similar to the viol, but with an extra set of plucked strings.</description>
                   <musicXMLid>strings.baryton</musicXMLid>
                   <StringData>
                         <frets>13</frets>
@@ -13571,7 +13574,7 @@
                   <trackName>Viola da gamba</trackName>
                   <longName>Viola da gamba</longName>
                   <shortName>Vla. d. g.</shortName>
-                  <description>Viola da gamba</description>
+                  <description>Viola da gamba (staff notation).</description>
                   <StringData>
                         <frets>13</frets>
                         <string>33</string>
@@ -13606,7 +13609,7 @@
                   <trackName>Viola da gamba (tablature)</trackName>
                   <longName>Viola da gamba</longName>
                   <shortName>Vla. d. g.</shortName>
-                  <description>Viola da gamba (Tablature)</description>
+                  <description>Viola da gamba (tablature).</description>
                   <stafftype staffTypePreset="tab6StrFrench">tablature</stafftype>
                   <genre>earlymusic</genre>
             </Instrument>
@@ -13615,7 +13618,7 @@
                   <trackName>G Violone</trackName>
                   <longName>G Violone</longName>
                   <shortName>G Vne.</shortName>
-                  <description>Large viol with lowest string tuned to G (written in C, non-transposing).</description>
+                  <description>Large viol with the lowest string tuned to G. Sometimes called the G violone or great bass viol.</description>
                   <musicXMLid>strings.viol.violone</musicXMLid>
                   <StringData>
                         <frets>13</frets>
@@ -13649,7 +13652,7 @@
                   <trackName>D Violone</trackName>
                   <longName>D Violone</longName>
                   <shortName>D Vne.</shortName>
-                  <description>Large viol with lowest string tuned to D (written in C, non-transposing).</description>
+                  <description>Large viol with the lowest string tuned to D. Sometimes called the D violone.</description>
                   <musicXMLid>strings.viol.violone</musicXMLid>
                   <StringData>
                         <frets>13</frets>
@@ -13683,7 +13686,7 @@
                   <trackName>Octobass</trackName>
                   <longName>Octobass</longName>
                   <shortName>Otb.</shortName>
-                  <description>Octobass</description>
+                  <description>Extremely large and rare bowed string instrument, essentially a larger version of the double bass.</description>
                   <musicXMLid>strings.octobass</musicXMLid>
                   <transposingClef>F</transposingClef>
                   <concertClef>F15mb</concertClef>
@@ -13710,7 +13713,7 @@
                   <trackName>Erhu</trackName>
                   <longName>Erhu</longName>
                   <shortName>Eh.</shortName>
-                  <description>Erhu</description>
+                  <description>Chinese two-stringed bowed instrument.</description>
                   <musicXMLid>strings.erhu</musicXMLid>
                   <StringData>
                         <frets>24</frets>
@@ -13740,7 +13743,7 @@
                   <trackName>Nyckelharpa</trackName>
                   <longName>Nyckelharpa</longName>
                   <shortName>Nyh.</shortName>
-                  <description>Nyckelharpa</description>
+                  <description>Swedish bowed instrument with keys to change the pitch of the strings.</description>
                   <musicXMLid>strings.nyckelharpa</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>


### PR DESCRIPTION
Run `share/instruments/update_instruments_xml.py` to fetch the latest version of the online spreadsheet. In this version, @oktophonie has improved the descriptions of all instruments. These descriptions are visible at the bottom of the New Score Wizard when a single instrument is selected.

![image](https://user-images.githubusercontent.com/11011881/138487879-25bc551a-a0e8-4fc5-9c6b-b056d3009495.png)
