### PR TITLE
Added TC1 Create simple score

### DIFF
--- a/share/autobotscripts/CMakeLists.txt
+++ b/share/autobotscripts/CMakeLists.txt
@@ -21,12 +21,14 @@
 # Scripts
 install(FILES
       NewScore10InstrPutNotesSaveClose.js
+      TC1_CreateSimpleScore.js
       DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME}autobotscripts
       )
 
 # Steps
 install(FILES
       steps/NewScore.js
+      steps/NoteInput.js
       DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME}autobotscripts/steps
       )
 

--- a/share/autobotscripts/TC1_CreateSimpleScore.js
+++ b/share/autobotscripts/TC1_CreateSimpleScore.js
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+var NewScore = require("steps/NewScore.js")
+var NoteInput = require("steps/NoteInput.js")
+
+function main()
+{
+    var testCase = {
+        name: "Create Simple Score",
+        description: "Just create a simple two-instrument score, a few notes, play it and save the project",
+        steps: [
+            {name: "Open New Score Dialog", func: function() {
+                NewScore.openNewScoreDialog()
+            }},
+            {name: "Select Instruments", func: function() {
+                NewScore.сhooseFluteAndPiano()
+            }},
+            {name: "Turn on note input", func: function() {
+                NoteInput.chooseDefaultMode()
+                NoteInput.chooseNoteDuration("pad-note-8")
+            }},
+            {name: "Put notes", func: function() {
+                NoteInput.putNote("note-c")
+                NoteInput.putNote("note-d")
+                NoteInput.putNote("note-e")
+                NoteInput.putNote("note-f")
+                NoteInput.putNote("note-g")
+                NoteInput.putNote("note-a")
+                NoteInput.putNote("note-b")
+            }},
+            {name: "Play", func: function() {
+                api.navigation.triggerControl("TopTool", "PlaybackToolBar", "Play")
+            }},
+            {name: "Stop", func: function() {
+                // wait interval + 5 sec
+                api.autobot.sleep(5000)
+                api.navigation.triggerControl("TopTool", "PlaybackToolBar", "Play")
+            }},
+            {name: "Save", func: function() {
+                api.autobot.saveProject("TC1_CreateSimpleScore.mscz")
+            }},
+            {name: "Close", func: function() {
+                api.dispatcher.dispatch("file-close")
+            }},
+            {name: "Home", func: function() {
+                // Go Home
+                api.navigation.triggerControl("TopTool", "MainToolBar", "Home")
+            }},
+            {name: "Open last", func: function() {
+                api.navigation.goToControl("RecentScores", "RecentScores", "New score")
+                api.navigation.right()
+                api.navigation.trigger()
+            }}
+        ]
+    };
+
+    api.autobot.setInterval(1000)
+    api.autobot.runTestCase(testCase)
+}

--- a/share/autobotscripts/steps/NoteInput.js
+++ b/share/autobotscripts/steps/NoteInput.js
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+module.exports = {
+
+chooseDefaultMode: function()
+{
+    api.navigation.triggerControl("NoteInputSection", "NoteInputBar", "note-input-steptime")
+    api.autobot.waitPopup()
+    // First item become automatically current, so just trigger
+    api.navigation.trigger()
+},
+
+// "note-longa", "note-breve",
+// "pad-note-1", "pad-note-2", "pad-note-4", "pad-note-8", "pad-note-16", "pad-note-32", "pad-note-64", "pad-note-128", "pad-note-256", "pad-note-512", "pad-note-1024"
+// "pad-dot", "pad-dotdot", "pad-dot3", "pad-dot4", "pad-rest"
+chooseNoteDuration: function(mode)
+{
+    api.navigation.triggerControl("NoteInputSection", "NoteInputBar", mode)
+},
+
+// "note-c", "note-d", "note-e", "note-f", "note-g", "note-a", "note-b"
+putNote: function(note)
+{
+    api.dispatcher.dispatch(note)
+}
+
+}

--- a/src/autobot/autobottypes.h
+++ b/src/autobot/autobottypes.h
@@ -53,6 +53,7 @@ struct Step
         : val(jsval) {}
 
     QString name() const { return val.property("name").toString(); }
+    bool skip() const { return val.property("skip").toBool(); }
     Ret exec()
     {
         val.property("func").call();
@@ -93,6 +94,13 @@ struct TestCase
 
 private:
     QJSValue val;
+};
+
+enum class StepStatus {
+    Undefined = 0,
+    Started,
+    Finished,
+    Skipped
 };
 }
 

--- a/src/autobot/internal/autobot.cpp
+++ b/src/autobot/internal/autobot.cpp
@@ -29,13 +29,12 @@ using namespace mu::autobot;
 
 void Autobot::init()
 {
-    m_runner.stepStarted().onReceive(this, [this](const QString& name) {
-        m_context->addStep(name);
-        m_report.beginStep(name);
-    });
+    m_runner.stepStatusChanged().onReceive(this, [this](const QString& name, StepStatus status) {
+        if (status == StepStatus::Started) {
+            m_context->addStep(name);
+        }
 
-    m_runner.stepFinished().onReceive(this, [this](const QString& name) {
-        m_report.endStep(name, m_context);
+        m_report.onStepStatusChanged(name, status, m_context);
     });
 
     m_runner.allFinished().onReceive(this, [this](bool aborted) {

--- a/src/autobot/internal/testcasereport.cpp
+++ b/src/autobot/internal/testcasereport.cpp
@@ -98,25 +98,29 @@ void TestCaseReport::endReport(bool aborted)
     m_file.close();
 }
 
-void TestCaseReport::beginStep(const QString& name)
+void TestCaseReport::onStepStatusChanged(const QString& name, StepStatus status, const ITestCaseContextPtr& ctx)
 {
     if (!m_opened) {
         return;
     }
-    m_stream << "  begin step: " << name << Qt::endl;
+
+    switch (status) {
+    case StepStatus::Undefined: break;
+    case StepStatus::Started: {
+        m_stream << "  started step: " << name << Qt::endl;
+    } break;
+    case StepStatus::Finished: {
+        const ITestCaseContext::StepContext& step = ctx->currentStep();
+        for (auto it = step.vals.cbegin(); it != step.vals.cend(); ++it) {
+            m_stream << "    " << it->first << ": " << formatVal(it->second) << Qt::endl;
+        }
+
+        m_stream << "  finished step: " << name << Qt::endl;
+    } break;
+    case StepStatus::Skipped: {
+        m_stream << "  skipped step: " << name << Qt::endl;
+    } break;
+    }
+
     m_stream.flush();
-}
-
-void TestCaseReport::endStep(const QString& name, const ITestCaseContextPtr& ctx)
-{
-    if (!m_opened) {
-        return;
-    }
-
-    const ITestCaseContext::StepContext& step = ctx->currentStep();
-    for (auto it = step.vals.cbegin(); it != step.vals.cend(); ++it) {
-        m_stream << "    " << it->first << ": " << formatVal(it->second) << Qt::endl;
-    }
-
-    m_stream << "  end step: " << name << Qt::endl;
 }

--- a/src/autobot/internal/testcasereport.h
+++ b/src/autobot/internal/testcasereport.h
@@ -44,8 +44,7 @@ public:
     Ret beginReport(const TestCase& testCase);
     void endReport(bool aborted);
 
-    void beginStep(const QString& name);
-    void endStep(const QString& name, const ITestCaseContextPtr& ctx);
+    void onStepStatusChanged(const QString& name, StepStatus status, const ITestCaseContextPtr& ctx);
 
 private:
 

--- a/src/autobot/internal/testcaserunner.h
+++ b/src/autobot/internal/testcaserunner.h
@@ -44,8 +44,8 @@ public:
     void runTestCase(const TestCase& testCase);
     void abortTestCase();
 
-    async::Channel<QString /*name*/> stepStarted() const;
-    async::Channel<QString /*name*/> stepFinished() const;
+    async::Channel<QString /*name*/, StepStatus> stepStatusChanged() const;
+
     async::Channel<bool /*aborted*/> allFinished() const;
 
 private:
@@ -66,8 +66,7 @@ private:
     TestCaseData m_testCase;
     bool m_abort = false;
 
-    async::Channel<QString /*name*/> m_stepStarted;
-    async::Channel<QString /*name*/> m_stepFinished;
+    async::Channel<QString /*name*/, StepStatus> m_stepStatusChanged;
     async::Channel<bool /*aborted*/> m_allFinished;
 };
 }

--- a/src/autobot/qml/MuseScore/Autobot/ScriptsDialog.qml
+++ b/src/autobot/qml/MuseScore/Autobot/ScriptsDialog.qml
@@ -32,6 +32,8 @@ StyledDialogView {
     contentWidth: 400
     resizable: true
 
+    x: 800
+
     ScriptsPanel {
         anchors.fill: parent
     }

--- a/src/framework/ui/internal/navigationcontroller.cpp
+++ b/src/framework/ui/internal/navigationcontroller.cpp
@@ -249,7 +249,7 @@ template<class T>
 static T* findByName(const std::set<T*>& set, const QString& name)
 {
     auto it = std::find_if(set.cbegin(), set.cend(), [name](const T* s) {
-        return s->name() == name;
+        return s->enabled() && s->name() == name;
     });
 
     if (it != set.cend()) {

--- a/src/framework/uicomponents/view/dialogview.cpp
+++ b/src/framework/uicomponents/view/dialogview.cpp
@@ -44,10 +44,6 @@ bool DialogView::isDialog() const
 
 void DialogView::beforeShow()
 {
-    if (!m_localPos.isNull()) {
-        return;
-    }
-
     QWindow* qMainWindow = mainWindow()->qWindow();
     IF_ASSERT_FAILED(qMainWindow) {
         return;
@@ -58,6 +54,9 @@ void DialogView::beforeShow()
 
     m_globalPos.setX(appRect.x() + (appRect.width() / 2 - dlgRect.width() / 2));
     m_globalPos.setY(appRect.y() + (appRect.height() / 2 - dlgRect.height() / 2) - DIALOG_WINDOW_FRAME_HEIGHT);
+
+    m_globalPos.setX(m_globalPos.x() + m_localPos.x());
+    m_globalPos.setY(m_globalPos.y() + m_localPos.y());
 
     //! NOTE ok will be if they call accept
     setErrCode(Ret::Code::Cancel);


### PR DESCRIPTION
We are getting closer to release, so we need to invest more and more effort in testing and stabilizing the application.

In order to make manual testing more effective, I started writing a structure of the testing documentation in our wiki 
https://github.com/musescore/MuseScore/wiki/Manual-testing-overview
https://github.com/musescore/MuseScore/wiki/TestCases-1-10

And also I'm starting to write scripts to automate the passage of tests scenarios
(about the automation system https://github.com/musescore/MuseScore/wiki/Autobot-overview) 
As we gain experience, we will improve and simplify the automation system, so now it may still be unstable or something may change.
This is the first simple scenario, just create a simple score.
https://github.com/musescore/MuseScore/wiki/TestCases-1-10#TC1-Create-Simple-Score

You can try it yourself: Diagnostic -> Autobot -> Show scripts...

https://user-images.githubusercontent.com/3818029/138554148-375547de-7919-47a8-b0c1-24945badf0f4.mp4



