### PR TITLE
Fix #9514: only apply text to the first element in range selections

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1418,7 +1418,7 @@ bool NotationInteraction::applyPaletteElement(Ms::EngravingItem* element, Qt::Ke
             int lastStaffIndex = sel.staffEnd();
 
             // A text should only be added at the start of the selection
-            // There shouldn't be a text at each note
+            // There shouldn't be a text at each element
             for (int staff = firstStaffIndex; staff < lastStaffIndex; staff++) {
                 applyDropPaletteElement(score, firstSegment->firstElement(staff), element, modifiers);
             }


### PR DESCRIPTION
Resolves: #9514

When a text is added to a range selection, the text will be added to the first element instead of each one.
This works for any subtype of ``TextBase`` so it includes staff text, system text, expression, dynamics...

Before:

https://user-images.githubusercontent.com/36641081/138561777-b46dfc1f-f0c7-4a62-9842-44dd30045b63.mp4

After:

https://user-images.githubusercontent.com/36641081/138561782-f522d610-0418-463f-ba51-2abca2785341.mp4


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
