### PR TITLE
[MU4] Fix #325825: Crash on playback with an open volta before a section break on a frame

### DIFF
--- a/src/engraving/libmscore/repeatlist.cpp
+++ b/src/engraving/libmscore/repeatlist.cpp
@@ -563,7 +563,8 @@ void RepeatList::collectRepeatListElements()
                 if (volta != nullptr) {
                     //if (volta->endMeasure()->tick() < mb->tick()) {
                     // The previous volta was supposed to end before us (open volta case) -> insert the end
-                    sectionRLElements->push_back(new RepeatListElement(RepeatListElementType::VOLTA_END, volta, toMeasure(mb)));
+                    sectionRLElements->push_back(new RepeatListElement(RepeatListElementType::VOLTA_END, volta,
+                                                                       toMeasure(sectionEndMeasureBase)));
                     volta = nullptr;
                     //} else {
                     //    // Volta is spanning over this section break, consider splitting the volta


### PR DESCRIPTION
Resolves: *https://musescore.org/en/node/325825*

Same issue with 3.x, so will add it to #9000 too