### PR TITLE
Added migration option for convert mode

### DIFF
--- a/src/appshell/commandlinecontroller.h
+++ b/src/appshell/commandlinecontroller.h
@@ -34,6 +34,7 @@
 #include "iappshellconfiguration.h"
 #include "internal/istartupscenario.h"
 #include "notation/inotationconfiguration.h"
+#include "project/iprojectconfiguration.h"
 
 namespace mu::appshell {
 class CommandLineController
@@ -46,6 +47,7 @@ class CommandLineController
     INJECT(appshell, IAppShellConfiguration, configuration)
     INJECT(appshell, IStartupScenario, startupScenario)
     INJECT(appshell, notation::INotationConfiguration, notationConfiguration)
+    INJECT(appshell, project::IProjectConfiguration, projectConfiguration)
 
 public:
     CommandLineController() = default;

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -220,32 +220,39 @@ void ProjectConfiguration::setPreferredScoreCreationMode(PreferredScoreCreationM
 
 MigrationOptions ProjectConfiguration::migrationOptions() const
 {
+    if (m_migrationOptions.isValid()) {
+        return m_migrationOptions;
+    }
+
     QString json = settings()->value(MIGRATION_OPTIONS).toQString();
     QJsonObject obj = QJsonDocument::fromJson(json.toUtf8()).object();
 
-    MigrationOptions opt;
-    opt.appVersion = obj.value("appVersion").toInt(0);
-    opt.isApplyMigration = obj.value("isApplyMigration").toBool(false);
-    opt.isAskAgain = obj.value("isAskAgain").toBool(true);
+    m_migrationOptions.appVersion = obj.value("appVersion").toInt(0);
+    m_migrationOptions.isApplyMigration = obj.value("isApplyMigration").toBool(false);
+    m_migrationOptions.isAskAgain = obj.value("isAskAgain").toBool(true);
 
-    opt.isApplyLeland = obj.value("isApplyLeland").toBool(false);
-    opt.isApplyEdwin = obj.value("isApplyEdwin").toBool(false);
+    m_migrationOptions.isApplyLeland = obj.value("isApplyLeland").toBool(false);
+    m_migrationOptions.isApplyEdwin = obj.value("isApplyEdwin").toBool(false);
 
-    return opt;
+    return m_migrationOptions;
 }
 
-void ProjectConfiguration::setMigrationOptions(const MigrationOptions& opt)
+void ProjectConfiguration::setMigrationOptions(const MigrationOptions& opt, bool persistent)
 {
-    QJsonObject obj;
-    obj["appVersion"] = opt.appVersion;
-    obj["isApplyMigration"] = opt.isApplyMigration;
-    obj["isAskAgain"] = opt.isAskAgain;
+    m_migrationOptions = opt;
 
-    obj["isApplyLeland"] = opt.isApplyLeland;
-    obj["isApplyEdwin"] = opt.isApplyEdwin;
+    if (persistent) {
+        QJsonObject obj;
+        obj["appVersion"] = opt.appVersion;
+        obj["isApplyMigration"] = opt.isApplyMigration;
+        obj["isAskAgain"] = opt.isAskAgain;
 
-    QString json = QJsonDocument(obj).toJson(QJsonDocument::Compact);
-    settings()->setSharedValue(MIGRATION_OPTIONS, Val(json));
+        obj["isApplyLeland"] = opt.isApplyLeland;
+        obj["isApplyEdwin"] = opt.isApplyEdwin;
+
+        QString json = QJsonDocument(obj).toJson(QJsonDocument::Compact);
+        settings()->setSharedValue(MIGRATION_OPTIONS, Val(json));
+    }
 }
 
 bool ProjectConfiguration::isAutoSaveEnabled() const

--- a/src/project/internal/projectconfiguration.h
+++ b/src/project/internal/projectconfiguration.h
@@ -69,7 +69,7 @@ public:
     void setPreferredScoreCreationMode(PreferredScoreCreationMode mode) override;
 
     MigrationOptions migrationOptions() const override;
-    void setMigrationOptions(const MigrationOptions& opt) override;
+    void setMigrationOptions(const MigrationOptions& opt, bool persistent = true) override;
 
     bool isAutoSaveEnabled() const override;
     void setAutoSaveEnabled(bool enabled) override;
@@ -90,6 +90,8 @@ private:
 
     async::Channel<bool> m_autoSaveEnabledChanged;
     async::Channel<int> m_autoSaveIntervalChanged;
+
+    mutable MigrationOptions m_migrationOptions;
 };
 }
 

--- a/src/project/internal/projectmigrator.cpp
+++ b/src/project/internal/projectmigrator.cpp
@@ -54,7 +54,6 @@ Ret ProjectMigrator::migrateEngravingProjectIfNeed(engraving::EngravingProjectPt
             return ret;
         }
 
-        migrationOptions.appVersion = Ms::MSCVERSION;
         configuration()->setMigrationOptions(migrationOptions);
     }
 
@@ -63,6 +62,12 @@ Ret ProjectMigrator::migrateEngravingProjectIfNeed(engraving::EngravingProjectPt
     }
 
     Ret ret = migrateProject(project, migrationOptions);
+    if (!ret) {
+        LOGE() << "failed migration";
+    } else {
+        LOGI() << "success migration";
+    }
+
     return ret;
 }
 
@@ -77,6 +82,7 @@ Ret ProjectMigrator::askAboutMigration(MigrationOptions& out, const engraving::E
     }
 
     QVariantMap vals = rv.val.toQVariant().toMap();
+    out.appVersion = Ms::MSCVERSION;
     out.isApplyMigration = vals.value("isApplyMigration").toBool();
     out.isAskAgain = vals.value("isAskAgain").toBool();
     out.isApplyLeland = vals.value("isApplyLeland").toBool();
@@ -113,7 +119,7 @@ Ret ProjectMigrator::migrateProject(engraving::EngravingProjectPtr project, cons
 
     score->endCmd();
 
-    return make_ret(Ret::Code::Ok);
+    return ok ? make_ret(Ret::Code::Ok) : make_ret(Ret::Code::InternalError);
 }
 
 bool ProjectMigrator::applyLelandStyle(Ms::MasterScore* score)

--- a/src/project/iprojectconfiguration.h
+++ b/src/project/iprojectconfiguration.h
@@ -69,7 +69,7 @@ public:
     virtual void setPreferredScoreCreationMode(PreferredScoreCreationMode mode) = 0;
 
     virtual MigrationOptions migrationOptions() const = 0;
-    virtual void setMigrationOptions(const MigrationOptions& opt) = 0;
+    virtual void setMigrationOptions(const MigrationOptions& opt, bool persistent = true) = 0;
 
     virtual bool isAutoSaveEnabled() const = 0;
     virtual void setAutoSaveEnabled(bool enabled) = 0;

--- a/src/project/projecttypes.h
+++ b/src/project/projecttypes.h
@@ -52,6 +52,8 @@ struct MigrationOptions
     // for MU 4.0 (from 3.6)
     bool isApplyLeland = false;
     bool isApplyEdwin = false;
+
+    bool isValid() const { return appVersion != 0; }
 };
 
 enum class SaveMode

--- a/src/project/tests/mocks/projectconfigurationmock.h
+++ b/src/project/tests/mocks/projectconfigurationmock.h
@@ -55,7 +55,7 @@ public:
     MOCK_METHOD(void, setPreferredScoreCreationMode, (PreferredScoreCreationMode), (override));
 
     MOCK_METHOD(MigrationOptions, migrationOptions, (), (const, override));
-    MOCK_METHOD(void, setMigrationOptions, (const MigrationOptions&), (override));
+    MOCK_METHOD(void, setMigrationOptions, (const MigrationOptions&, bool), (override));
 
     MOCK_METHOD(bool, isAutoSaveEnabled, (), (const, override));
     MOCK_METHOD(void, setAutoSaveEnabled, (bool), (override));


### PR DESCRIPTION
Did so:

In conversion mode, migration will not be done by default
We can add an option `--migration full`, then migration will do if need

Fixed https://github.com/musescore/MuseScore/issues/9579