### PR TITLE
Fix realtime noteentry 8th crash (fixes #321716)

### DIFF
--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -171,7 +171,7 @@ Note* Score::addPitch(NoteVal& nval, bool addFlag, InputState* externalInputStat
             //   We could split the duration at the barline and continue into the next bar, but this would create extra
             //   notes, extra ties, and extra pain. Instead, we simply truncate the duration at the barline.
             Fraction ticks2measureEnd = is.segment()->measure()->ticks() - is.segment()->rtick();
-            duration = is.duration() > ticks2measureEnd ? ticks2measureEnd : is.duration().fraction();
+            duration = is.duration().fraction() > ticks2measureEnd ? ticks2measureEnd : is.duration().fraction();
             }
       else {
             duration = is.duration().fraction();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/321716

To reproduce (on MuseScore 3.6.2):

* Connect MIDI keyboard (via JACK/Pipewire in my case)
* Enter Realtime (Manual) note input mode
* Select "8th notes"
* Enter 1 note and hit the manual input button 4 times on the MIDI keyboard, the 4th makes MuseScore crash

----

<!-- Use "x" to fill the checkboxes below like [x] -->

- [?] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [?] I created the test (mtest, vtest, script test) to verify the changes I made
