### PR TITLE
[Experiment] Implemented sending and receiving MIDI 2.0 events for CoreMIDI (macOS)

### DIFF
--- a/src/framework/midi/internal/platform/osx/coremidiinport.h
+++ b/src/framework/midi/internal/platform/osx/coremidiinport.h
@@ -45,9 +45,6 @@ public:
 
     async::Channel<tick_t, Event> eventReceived() const override;
 
-    //internal
-    void doProcess(uint32_t message, tick_t timing);
-
 private:
     Ret run();
     void stop();

--- a/src/framework/midi/midievent.h
+++ b/src/framework/midi/midievent.h
@@ -133,6 +133,13 @@ struct Event {
         return 0;
     }
 
+    static Event fromRawData(const uint32_t* data, size_t count)
+    {
+        Event e;
+        memcpy(e.m_data.data(), data, std::min(count, e.m_data.size()));
+        return e;
+    }
+
     bool operator ==(const Event& other) const { return m_data == other.m_data; }
     bool operator !=(const Event& other) const { return !operator==(other); }
     operator bool() const {
@@ -442,6 +449,11 @@ struct Event {
             break;
         default: assert(false);
         }
+    }
+
+    const uint32_t* rawData() const
+    {
+        return m_data.data();
     }
 
     /*! return signed value:

--- a/src/framework/midi/view/devtools/midiportdevmodel.cpp
+++ b/src/framework/midi/view/devtools/midiportdevmodel.cpp
@@ -186,6 +186,8 @@ void MidiPortDevModel::generateMIDI20()
             e.setData(++data);
         }
 
+        midiOutPort()->sendEvent(e);
+
         QString str = QString::fromStdString(e.to_string());
         QString str2 = "";
 


### PR DESCRIPTION
In macOS 11.0 (autumn 2020), many CoreMIDI APIs were deprecated, in favor of new ones that support MIDI 2.0. Because MuseScore also works with MIDI 2.0, I thought this would be a perfect combination. So I updated the implementation of our CoreMidiInPort and CoreMidiOutPort, to let them send and receive MIDI 2.0 events. Because those new APIs are only available on macOS 11.0 and later, I added a version check, so that order macOS versions still use the MIDI 1.0 APIs.

@vpereverzev You might be interested in this PR.

The documentation about CoreMIDI is scarce, so I'm not completely sure whether this implementation is correct, but it seems to be in line with everything I could find.

I could only test it with MIDI 1.0 devices. That worked correctly (even better than the old implementation). So CoreMIDI automatically converts MIDI 2.0 events to 1.0 when sending to a 1.0 device.

It would be great if someone who has a MIDI 2.0 device could test whether this works.

(Also, I discovered some playback issues:
- When entering notes with mouse or keyboard, those notes are played on the connected MIDI keyboard, but not through MuseScore's playback / the computer's speakers. 
- When playing the score (using the play button in the playback toolbar) the score only plays through MuseScore's playback / the computer's speakers, but not through the connected MIDI keyboard.
- Entering notes with a MIDI keyboard has never worked for me and still doesn't, even though there is some log output indicating that MuseScore does receive the MIDI events.)