### PR TITLE
colornotes plugin - when only single note is selected, acts as nothing was selected

### DIFF
--- a/share/plugins/colornotes.qml
+++ b/share/plugins/colornotes.qml
@@ -45,7 +45,7 @@ MuseScore {
       property string black : "#000000"
 
       // Apply the given function to all notes (elements with pitch) in selection
-      // or, if nothing is selected, in the entire score
+      // or, if nothing, or just signle note is selected, in the entire score
 
       function applyToNotesInSelection(func) {
             var fullScore = !(curScore.selection.elements.length > 1)

--- a/share/plugins/colornotes.qml
+++ b/share/plugins/colornotes.qml
@@ -48,7 +48,7 @@ MuseScore {
       // or, if nothing is selected, in the entire score
 
       function applyToNotesInSelection(func) {
-            var fullScore = !curScore.selection.elements.length
+            var fullScore = !(curScore.selection.elements.length > 1)
             if (fullScore) {
                   cmd("select-all")
                   curScore.startCmd()


### PR DESCRIPTION
Resolves: *(direct link to the issue)*
If only single note is selected, act as nothing was selected.
*(short description of the changes and the motivation to make the changes)*
When one edit score, ussually last entered, or edited note remains selected. 
In such cases plugin colors only that single note, but user wants to colors entire score.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
