### PR TITLE
Fixed resolving ui context

### DIFF
--- a/src/context/internal/uicontextresolver.h
+++ b/src/context/internal/uicontextresolver.h
@@ -36,7 +36,6 @@ class UiContextResolver : public IUiContextResolver, public async::Asyncable
     INJECT(context, framework::IInteractive, interactive)
     INJECT(context, playback::IPlaybackController, playbackController)
     INJECT(context, IGlobalContext, globalContext)
-    INJECT(context, ui::INavigationController, navigationController)
 
 public:
     UiContextResolver() = default;
@@ -49,13 +48,13 @@ public:
     bool match(const ui::UiContext& currentCtx, const ui::UiContext& actCtx) const override;
     bool matchWithCurrent(const ui::UiContext& ctx) const override;
 
+    void onNotationViewFocuseChanged(bool focused) override;
+
 private:
+    void notifyAboutContextChanged();
 
-    ui::UiContext resolveCurrentUiContext() const;
-    void notifyAboutContextIfChanged();
-
-    ui::UiContext m_lastUiContext = context::UiCtxUnknown;
     async::Notification m_currentUiContextChanged;
+    int m_notationViewFocusedCounter = 0;
 };
 }
 

--- a/src/framework/ui/iuicontextresolver.h
+++ b/src/framework/ui/iuicontextresolver.h
@@ -40,6 +40,8 @@ public:
 
     virtual bool match(const ui::UiContext& currentCtx, const ui::UiContext& actCtx) const = 0;
     virtual bool matchWithCurrent(const ui::UiContext& ctx) const = 0;
+
+    virtual void onNotationViewFocuseChanged(bool focused) = 0;
 };
 
 using IUiContextResolverPtr = std::shared_ptr<IUiContextResolver>;

--- a/src/notation/qml/MuseScore/NotationScene/NotationView.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NotationView.qml
@@ -112,7 +112,11 @@ FocusScope {
 
                         onActiveChanged: {
                             if (fakeNavCtrl.active) {
+                                notationView.focus = true
+                                notationView.forceActiveFocus()
                                 notationView.selectOnNavigationActive()
+                            } else {
+                                notationView.focus = false
                             }
                         }
                     }

--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -790,6 +790,13 @@ bool NotationPaintView::event(QEvent* ev)
     if (ev->type() == QEvent::Type::ShortcutOverride) {
         shortcutOverride(dynamic_cast<QKeyEvent*>(ev));
     }
+
+    if (ev->type() == QEvent::Type::FocusIn || ev->type() == QEvent::Type::FocusOut) {
+        bool ok = QQuickPaintedItem::event(ev);
+        uiContextResolver()->onNotationViewFocuseChanged(hasFocus());
+        return ok;
+    }
+
     return QQuickPaintedItem::event(ev);
 }
 

--- a/src/notation/view/notationpaintview.h
+++ b/src/notation/view/notationpaintview.h
@@ -34,8 +34,7 @@
 #include "context/iglobalcontext.h"
 #include "async/asyncable.h"
 #include "playback/iplaybackcontroller.h"
-#include "shortcuts/ishortcutsregister.h"
-#include "ui/iuiactionsregister.h"
+#include "ui/iuicontextresolver.h"
 #include "ui/view/abstractmenumodel.h"
 
 #include "notationviewinputcontroller.h"
@@ -54,8 +53,7 @@ class NotationPaintView : public QQuickPaintedItem, public IControlledView, publ
     INJECT(notation, actions::IActionsDispatcher, dispatcher)
     INJECT(notation, context::IGlobalContext, globalContext)
     INJECT(notation, playback::IPlaybackController, playbackController)
-    INJECT(notation, mu::shortcuts::IShortcutsRegister, shortcutsRegister)
-    INJECT(notation, ui::IUiActionsRegister, actionsRegister)
+    INJECT(notation, ui::IUiContextResolver, uiContextResolver)
 
     Q_PROPERTY(qreal startHorizontalScrollPosition READ startHorizontalScrollPosition NOTIFY horizontalScrollChanged)
     Q_PROPERTY(qreal horizontalScrollbarSize READ horizontalScrollbarSize NOTIFY horizontalScrollChanged)


### PR DESCRIPTION
Fixed detecting that notation is in focus

I roll back of determining what ui context really changed, there is architecture trouble with actions enabled update, which should be fixed separately