### PR TITLE
Fixed navigation - window determination

### DIFF
--- a/share/autobotscripts/TC4_UsingPalettes.js
+++ b/share/autobotscripts/TC4_UsingPalettes.js
@@ -131,7 +131,7 @@ var testCase = {
             Palette.togglePalette("Ornaments") // close
         }},
         {name: "Save", func: function() {
-            api.autobot.saveProject("TC3 Using note input toolbar.mscz")
+            api.autobot.saveProject("TC4_UsingPalettes.mscz")
         }},
         {name: "Close", func: function() {
             api.dispatcher.dispatch("file-close")

--- a/src/diagnostics/internal/diagnosticsactionscontroller.cpp
+++ b/src/diagnostics/internal/diagnosticsactionscontroller.cpp
@@ -28,10 +28,10 @@
 using namespace mu::diagnostics;
 using namespace mu::accessibility;
 
-static const mu::UriQuery SYSTEN_PATHS_URI("musescore://diagnostics/system/paths?sync=false&modal=false");
-static const mu::UriQuery NAVIGATION_TREE_URI("musescore://diagnostics/navigation/tree?sync=false&modal=false");
-static const mu::UriQuery ACCESSIBLE_TREE_URI("musescore://diagnostics/accessible/tree?sync=false&modal=false");
-static const mu::UriQuery ENGRAVING_ELEMENTS_URI("musescore://diagnostics/engraving/elements?sync=false&modal=false");
+static const mu::UriQuery SYSTEN_PATHS_URI("musescore://diagnostics/system/paths?sync=false&modal=false&floating=true");
+static const mu::UriQuery NAVIGATION_TREE_URI("musescore://diagnostics/navigation/tree?sync=false&modal=false&floating=true");
+static const mu::UriQuery ACCESSIBLE_TREE_URI("musescore://diagnostics/accessible/tree?sync=false&modal=false&floating=true");
+static const mu::UriQuery ENGRAVING_ELEMENTS_URI("musescore://diagnostics/engraving/elements?sync=false&modal=false&floating=true");
 
 void DiagnosticsActionsController::init()
 {

--- a/src/framework/accessibility/internal/accessibilitycontroller.cpp
+++ b/src/framework/accessibility/internal/accessibilitycontroller.cpp
@@ -280,7 +280,7 @@ QAccessibleInterface* AccessibilityController::parentIface(const IAccessible* it
 
     if (it.item->accessibleRole() == IAccessible::Role::Application) {
         if (!qApp->isQuitLockEnabled()) {
-            return QAccessible::queryAccessibleInterface(mainWindow()->topWindow());
+            return QAccessible::queryAccessibleInterface(interactiveProvider()->topWindow());
         } else {
             return QAccessible::queryAccessibleInterface(qApp->focusWindow());
         }

--- a/src/framework/accessibility/internal/accessibilitycontroller.h
+++ b/src/framework/accessibility/internal/accessibilitycontroller.h
@@ -33,6 +33,7 @@
 
 #include "modularity/ioc.h"
 #include "ui/imainwindow.h"
+#include "ui/iinteractiveprovider.h"
 #include "accessibility/iaccessibilityconfiguration.h"
 
 class QAccessibleInterface;
@@ -48,6 +49,7 @@ class AccessibilityController : public IAccessibilityController, public IAccessi
 {
     INJECT(accessibility, IAccessibilityConfiguration, configuration)
     INJECT(accessibility, ui::IMainWindow, mainWindow)
+    INJECT(accessibility, ui::IInteractiveProvider, interactiveProvider)
 
 public:
     AccessibilityController() = default;

--- a/src/framework/accessibility/internal/accessibleiteminterface.cpp
+++ b/src/framework/accessibility/internal/accessibleiteminterface.cpp
@@ -60,7 +60,7 @@ QWindow* AccessibleItemInterface::window() const
 //    if (w) {
 //        return w;
 //    }
-    return mainWindow()->topWindow();
+    return interactiveProvider()->topWindow();
 }
 
 QRect AccessibleItemInterface::rect() const

--- a/src/framework/accessibility/internal/accessibleiteminterface.h
+++ b/src/framework/accessibility/internal/accessibleiteminterface.h
@@ -27,12 +27,12 @@
 #include "accessibleobject.h"
 
 #include "modularity/ioc.h"
-#include "ui/imainwindow.h"
+#include "ui/iinteractiveprovider.h"
 
 namespace mu::accessibility {
 class AccessibleItemInterface : public QAccessibleInterface, public QAccessibleValueInterface
 {
-    INJECT(accessibility, ui::IMainWindow, mainWindow)
+    INJECT(accessibility, ui::IInteractiveProvider, interactiveProvider)
 
 public:
     AccessibleItemInterface(AccessibleObject* object);

--- a/src/framework/ui/imainwindow.h
+++ b/src/framework/ui/imainwindow.h
@@ -36,7 +36,6 @@ public:
     virtual ~IMainWindow() = default;
 
     virtual QWindow* qWindow() const = 0;
-    virtual QWindow* topWindow() const = 0;
 
     virtual void requestShowOnBack() = 0;
     virtual void requestShowOnFront() = 0;

--- a/src/framework/ui/internal/navigationcontroller.cpp
+++ b/src/framework/ui/internal/navigationcontroller.cpp
@@ -249,7 +249,7 @@ template<class T>
 static T* findByName(const std::set<T*>& set, const QString& name)
 {
     auto it = std::find_if(set.cbegin(), set.cend(), [name](const T* s) {
-        return s->enabled() && s->name() == name;
+        return s->name() == name && s->enabled();
     });
 
     if (it != set.cend()) {

--- a/src/framework/ui/tests/mocks/mainwindowprovidermock.h
+++ b/src/framework/ui/tests/mocks/mainwindowprovidermock.h
@@ -32,7 +32,6 @@ class MainWindowProviderMock : public IMainWindow
 public:
 
     MOCK_METHOD(QWindow*, qWindow, (), (const, override));
-    MOCK_METHOD(QWindow*, topWindow, (), (const, override));
 
     MOCK_METHOD(void, requestShowOnBack, (), (override));
     MOCK_METHOD(void, requestShowOnFront, (), (override));

--- a/src/framework/ui/view/interactiveprovider.cpp
+++ b/src/framework/ui/view/interactiveprovider.cpp
@@ -298,7 +298,17 @@ std::vector<Uri> InteractiveProvider::stack() const
 
 QWindow* InteractiveProvider::topWindow() const
 {
-    return qobject_cast<QWindow*>(m_stack.last().window);
+    if (m_stack.empty()) {
+        LOGE() << "stack is empty";
+        return mainWindow()->qWindow();
+    }
+
+    const ObjectInfo& last = m_stack.last();
+    if (!last.window) {
+        return mainWindow()->qWindow();
+    }
+
+    return qobject_cast<QWindow*>(last.window);
 }
 
 QString InteractiveProvider::objectId(const QVariant& val) const
@@ -486,7 +496,10 @@ void InteractiveProvider::onOpen(const QVariant& type, const QVariant& objectId,
     ObjectInfo objectInfo;
     objectInfo.uriQuery = m_openingUriQuery;
     objectInfo.objectId = objectId;
-    objectInfo.window = window ? window : qApp->focusWindow();
+    objectInfo.window = window;
+    if (!objectInfo.window) {
+        objectInfo.window = (containerType == ContainerType::PrimaryPage) ? mainWindow()->qWindow() : qApp->focusWindow();
+    }
 
     if (ContainerType::PrimaryPage == containerType) {
         m_stack.clear();

--- a/src/framework/ui/view/interactiveprovider.h
+++ b/src/framework/ui/view/interactiveprovider.h
@@ -30,6 +30,7 @@
 #include "modularity/ioc.h"
 #include "../iinteractiveprovider.h"
 #include "../iinteractiveuriregister.h"
+#include "../imainwindow.h"
 #include "retval.h"
 
 namespace mu::ui {
@@ -52,6 +53,7 @@ class InteractiveProvider : public QObject, public IInteractiveProvider
     Q_OBJECT
 
     INJECT(ui, IInteractiveUriRegister, uriRegister)
+    INJECT(ui, IMainWindow, mainWindow)
 
 public:
     explicit InteractiveProvider();

--- a/src/framework/ui/view/mainwindowprovider.cpp
+++ b/src/framework/ui/view/mainwindowprovider.cpp
@@ -41,16 +41,6 @@ QWindow* MainWindowProvider::qWindow() const
     return m_window;
 }
 
-QWindow* MainWindowProvider::topWindow() const
-{
-    QWindow* window = interactiveProvider()->topWindow();
-    if (!window) {
-        window = qWindow();
-    }
-
-    return window;
-}
-
 void MainWindowProvider::setWindow(QWindow* window)
 {
     if (m_window != nullptr) {

--- a/src/framework/ui/view/mainwindowprovider.h
+++ b/src/framework/ui/view/mainwindowprovider.h
@@ -46,7 +46,6 @@ public:
     explicit MainWindowProvider(QObject* parent = nullptr);
 
     QWindow* qWindow() const override;
-    QWindow* topWindow() const override;
 
     QString filePath() const;
     virtual bool fileModified() const;

--- a/src/framework/ui/view/navigationsection.cpp
+++ b/src/framework/ui/view/navigationsection.cpp
@@ -75,7 +75,9 @@ bool NavigationSection::enabled() const
     }
 
     QWindow* sectionWindow = window();
-    if (sectionWindow && (mainWindow()->topWindow() != sectionWindow)) {
+    QWindow* topWindow = interactiveProvider()->topWindow();
+
+    if (sectionWindow && (topWindow != sectionWindow)) {
         return false;
     }
 

--- a/src/framework/ui/view/navigationsection.h
+++ b/src/framework/ui/view/navigationsection.h
@@ -31,7 +31,7 @@
 #include "async/asyncable.h"
 #include "modularity/ioc.h"
 #include "../inavigationcontroller.h"
-#include "../imainwindow.h"
+#include "../iinteractiveprovider.h"
 
 namespace mu::ui {
 class NavigationSection : public AbstractNavigation, public INavigationSection, public async::Asyncable
@@ -40,7 +40,7 @@ class NavigationSection : public AbstractNavigation, public INavigationSection, 
     Q_PROPERTY(QmlType type READ type_property WRITE setType NOTIFY typeChanged)
 
     INJECT(ui, INavigationController, navigationController)
-    INJECT(ui, IMainWindow, mainWindow)
+    INJECT(ui, IInteractiveProvider, interactiveProvider)
 
 public:
     explicit NavigationSection(QObject* parent = nullptr);

--- a/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
+++ b/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
@@ -106,7 +106,7 @@ void PopupWindow_QQuickView::forceActiveFocus()
 
 void PopupWindow_QQuickView::show(QPoint p)
 {
-    QWindow* top = mainWindow()->topWindow();
+    QWindow* top = interactiveProvider()->topWindow();
 
     m_view->setPosition(p);
     m_view->setTransientParent(top);

--- a/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.h
+++ b/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.h
@@ -27,14 +27,14 @@
 #include "ipopupwindow.h"
 
 #include "modularity/ioc.h"
-#include "ui/imainwindow.h"
+#include "ui/iinteractiveprovider.h"
 
 namespace mu::uicomponents {
 class PopupWindow_QQuickView : public QObject, public IPopupWindow
 {
     Q_OBJECT
 
-    INJECT(uicomponents, ui::IMainWindow, mainWindow)
+    INJECT(uicomponents, ui::IInteractiveProvider, interactiveProvider)
 
 public:
     explicit PopupWindow_QQuickView(QObject* parent = nullptr);

--- a/src/project/internal/projectfilescontroller.cpp
+++ b/src/project/internal/projectfilescontroller.cpp
@@ -252,6 +252,11 @@ IInteractive::Button ProjectFilesController::askAboutSavingScore(const io::path&
 
 void ProjectFilesController::saveProject(const io::path& path)
 {
+    if (!currentNotationProject()) {
+        LOGW() << "no current project";
+        return;
+    }
+
     if (!currentNotationProject()->created().val) {
         doSaveScore();
         return;


### PR DESCRIPTION
Main problem - for primary pages not pass window to `InteractiveProvider::onOpen`, in this case trying get focus window, but it's wrong for some cases, for example if opened "floating" dialog. For primary pages need use explicitly main window.  