### PR TITLE
[MU4] Fix #325982: Allow for strike-through text

### DIFF
--- a/src/engraving/infrastructure/draw/font.cpp
+++ b/src/engraving/infrastructure/draw/font.cpp
@@ -99,6 +99,16 @@ void Font::setUnderline(bool arg)
     m_style.setFlag(Style::Underline, arg);
 }
 
+bool Font::strike() const
+{
+    return m_style.testFlag(Style::Strike);
+}
+
+void Font::setStrike(bool arg)
+{
+    m_style.setFlag(Style::Strike, arg);
+}
+
 void Font::setNoFontMerging(bool arg)
 {
     m_noFontMerging = arg;
@@ -131,6 +141,7 @@ QFont Font::toQFont() const
     qf.setBold(bold());
     qf.setItalic(italic());
     qf.setUnderline(underline());
+    qf.setStrikeOut(strike());
     if (noFontMerging()) {
         qf.setStyleStrategy(QFont::NoFontMerging);
     }
@@ -147,6 +158,7 @@ Font Font::fromQFont(const QFont& qf)
     f.setBold(qf.bold());
     f.setItalic(qf.italic());
     f.setUnderline(qf.underline());
+    f.setStrike(qf.strikeOut());
     if (qf.styleStrategy() == QFont::NoFontMerging) {
         f.setNoFontMerging(true);
     }

--- a/src/engraving/infrastructure/draw/font.h
+++ b/src/engraving/infrastructure/draw/font.h
@@ -35,10 +35,12 @@ public:
     Font(const QString& family = QString());
 
     enum class Style {
-        Undefined   = 0,
+        //Undefined   = -1,
+        Normal      = 0,
         Bold        = 1 << 0,
         Italic      = 1 << 1,
-        Underline   = 1 << 2
+        Underline   = 1 << 2,
+        Strike      = 1 << 3
     };
 
     enum class Hinting {
@@ -75,6 +77,8 @@ public:
     void setItalic(bool arg);
     bool underline() const;
     void setUnderline(bool arg);
+    bool strike() const;
+    void setStrike(bool arg);
 
     void setNoFontMerging(bool arg);
     bool noFontMerging() const;
@@ -95,7 +99,7 @@ private:
     QString m_family;
     qreal m_pointSizeF = -1.0;
     Weight m_weight = Weight::Normal;
-    QFlags<Style> m_style{ Style::Undefined };
+    QFlags<Style> m_style{ Style::Normal };
     bool m_noFontMerging = false;
     Hinting m_hinting = Hinting::PreferDefaultHinting;
 };

--- a/src/engraving/infrastructure/draw/painter.h
+++ b/src/engraving/infrastructure/draw/painter.h
@@ -150,7 +150,7 @@ public:
     //! in Qt 5.12.x this workaround should be no more necessary if
     //! env variable QT_MAX_CACHED_GLYPH_SIZE is set to 1.
     //! The workaround works badly if the text is at the same time
-    //! bold and underlined.
+    //! bold and underlined or struck out.
     //! (moved from TextBase::drawTextWorkaround)
     void drawTextWorkaround(Font& f, const PointF pos, const QString text);
 

--- a/src/engraving/libmscore/bend.cpp
+++ b/src/engraving/libmscore/bend.cpp
@@ -100,6 +100,7 @@ mu::draw::Font Bend::font(qreal sp) const
     f.setBold(_fontStyle & FontStyle::Bold);
     f.setItalic(_fontStyle & FontStyle::Italic);
     f.setUnderline(_fontStyle & FontStyle::Underline);
+    f.setStrike(_fontStyle & FontStyle::Strike);
     qreal m = _fontSize;
     m *= sp / SPATIUM20;
 

--- a/src/engraving/libmscore/engravingobject.cpp
+++ b/src/engraving/libmscore/engravingobject.cpp
@@ -436,6 +436,9 @@ void EngravingObject::writeProperty(XmlWriter& xml, Pid pid) const
         if ((fs& FontStyle::Underline) != (ds & FontStyle::Underline)) {
             xml.tag("underline", fs & FontStyle::Underline);
         }
+        if ((fs& FontStyle::Strike) != (ds & FontStyle::Strike)) {
+            xml.tag("strike", fs & FontStyle::Strike);
+        }
         return;
     }
 

--- a/src/engraving/libmscore/glissando.cpp
+++ b/src/engraving/libmscore/glissando.cpp
@@ -140,6 +140,7 @@ void GlissandoSegment::draw(mu::draw::Painter* painter) const
         f.setBold(glissando()->fontStyle() & FontStyle::Bold);
         f.setItalic(glissando()->fontStyle() & FontStyle::Italic);
         f.setUnderline(glissando()->fontStyle() & FontStyle::Underline);
+        f.setStrike(glissando()->fontStyle() & FontStyle::Strike);
         mu::draw::FontMetrics fm(f);
         RectF r = fm.boundingRect(glissando()->text());
 

--- a/src/engraving/libmscore/textbase.h
+++ b/src/engraving/libmscore/textbase.h
@@ -55,7 +55,7 @@ enum class VerticalAlignment : char {
 //---------------------------------------------------------
 
 enum class FormatId : char {
-    Bold, Italic, Underline, Valign, FontSize, FontFamily
+    Bold, Italic, Underline, Strike, Valign, FontSize, FontFamily
 };
 
 //---------------------------------------------------------
@@ -87,9 +87,11 @@ public:
     bool bold() const { return _style & FontStyle::Bold; }
     bool italic() const { return _style & FontStyle::Italic; }
     bool underline() const { return _style & FontStyle::Underline; }
+    bool strike() const { return _style & FontStyle::Strike; }
     void setBold(bool val) { _style = val ? _style + FontStyle::Bold : _style - FontStyle::Bold; }
     void setItalic(bool val) { _style = val ? _style + FontStyle::Italic : _style - FontStyle::Italic; }
     void setUnderline(bool val) { _style = val ? _style + FontStyle::Underline : _style - FontStyle::Underline; }
+    void setStrike(bool val) { _style = val ? _style + FontStyle::Strike : _style - FontStyle::Strike; }
 
     VerticalAlignment valign() const { return _valign; }
     qreal fontSize() const { return _fontSize; }
@@ -446,11 +448,17 @@ public:
     bool bold() const { return fontStyle() & FontStyle::Bold; }
     bool italic() const { return fontStyle() & FontStyle::Italic; }
     bool underline() const { return fontStyle() & FontStyle::Underline; }
+    bool strike() const { return fontStyle() & FontStyle::Strike; }
     void setBold(bool val) { setFontStyle(val ? fontStyle() + FontStyle::Bold : fontStyle() - FontStyle::Bold); }
     void setItalic(bool val) { setFontStyle(val ? fontStyle() + FontStyle::Italic : fontStyle() - FontStyle::Italic); }
     void setUnderline(bool val)
     {
         setFontStyle(val ? fontStyle() + FontStyle::Underline : fontStyle() - FontStyle::Underline);
+    }
+
+    void setStrike(bool val)
+    {
+        setFontStyle(val ? fontStyle() + FontStyle::Strike : fontStyle() - FontStyle::Strike);
     }
 
     bool hasCustomFormatting() const;

--- a/src/engraving/libmscore/textedit.cpp
+++ b/src/engraving/libmscore/textedit.cpp
@@ -869,7 +869,7 @@ void ChangeTextProperties::redo(EditData*)
     if (propertyId == Pid::FONT_STYLE) {
         FontStyle setStyle = static_cast<FontStyle>(propertyVal.toInt());
         TextCursor* tc = cursor().text()->cursor();
-        // user turned on bold/italic/underline for text where it's not set, or turned it off for text where it is set,
+        // user turned on bold/italic/underline/strike for text where it's not set, or turned it off for text where it is set,
         // note this logic only works because the user can only click one at a time
         if ((setStyle& FontStyle::Bold) != (existingStyle & FontStyle::Bold)) {
             tc->setFormat(FormatId::Bold, setStyle & FontStyle::Bold);
@@ -879,6 +879,9 @@ void ChangeTextProperties::redo(EditData*)
         }
         if ((setStyle& FontStyle::Underline) != (existingStyle & FontStyle::Underline)) {
             tc->setFormat(FormatId::Underline, setStyle & FontStyle::Underline);
+        }
+        if ((setStyle& FontStyle::Strike) != (existingStyle & FontStyle::Strike)) {
+            tc->setFormat(FormatId::Strike, setStyle & FontStyle::Strike);
         }
     } else {
         cursor().text()->setProperty(propertyId, propertyVal);

--- a/src/engraving/libmscore/textlinebase.cpp
+++ b/src/engraving/libmscore/textlinebase.cpp
@@ -286,6 +286,7 @@ void TextLineBaseSegment::layout()
         _text->setBold(tl->beginFontStyle() & FontStyle::Bold);
         _text->setItalic(tl->beginFontStyle() & FontStyle::Italic);
         _text->setUnderline(tl->beginFontStyle() & FontStyle::Underline);
+        _text->setStrike(tl->beginFontStyle() & FontStyle::Strike);
         break;
     case SpannerSegmentType::MIDDLE:
     case SpannerSegmentType::END:
@@ -297,7 +298,7 @@ void TextLineBaseSegment::layout()
         _text->setBold(tl->continueFontStyle() & FontStyle::Bold);
         _text->setItalic(tl->continueFontStyle() & FontStyle::Italic);
         _text->setUnderline(tl->continueFontStyle() & FontStyle::Underline);
-
+        _text->setStrike(tl->continueFontStyle() & FontStyle::Strike);
         break;
     }
     _text->setPlacement(Placement::ABOVE);
@@ -313,6 +314,7 @@ void TextLineBaseSegment::layout()
         _endText->setBold(tl->endFontStyle() & FontStyle::Bold);
         _endText->setItalic(tl->endFontStyle() & FontStyle::Italic);
         _endText->setUnderline(tl->endFontStyle() & FontStyle::Underline);
+        _endText->setStrike(tl->endFontStyle() & FontStyle::Strike);
         _endText->setPlacement(Placement::ABOVE);
         _endText->setTrack(track());
         _endText->layout();

--- a/src/engraving/libmscore/tuplet.cpp
+++ b/src/engraving/libmscore/tuplet.cpp
@@ -855,6 +855,14 @@ bool Tuplet::readProperties(XmlReader& e)
         if (isStyled(Pid::FONT_STYLE)) {
             setPropertyFlags(Pid::FONT_STYLE, PropertyFlags::UNSTYLED);
         }
+    } else if (tag == "strike") {
+        bool val = e.readInt();
+        if (_number) {
+            _number->setStrike(val);
+        }
+        if (isStyled(Pid::FONT_STYLE)) {
+            setPropertyFlags(Pid::FONT_STYLE, PropertyFlags::UNSTYLED);
+        }
     } else if (tag == "normalNotes") {
         _ratio.setDenominator(e.readInt());
     } else if (tag == "actualNotes") {

--- a/src/engraving/libmscore/types.h
+++ b/src/engraving/libmscore/types.h
@@ -616,7 +616,12 @@ constexpr Align operator~(Align a)
 //---------------------------------------------------------
 
 enum class FontStyle : char {
-    Undefined = -1, Normal = 0, Bold = 1, Italic = 2, Underline = 4
+    Undefined = -1,
+    Normal = 0,
+    Bold = 1 << 0,
+    Italic = 1 << 1,
+    Underline = 1 << 2,
+    Strike = 1 << 3
 };
 
 constexpr FontStyle operator+(FontStyle a1, FontStyle a2)

--- a/src/engraving/rw/compat/read206.cpp
+++ b/src/engraving/rw/compat/read206.cpp
@@ -154,6 +154,12 @@ void Read206::readTextStyle206(MStyle* style, XmlReader& e, std::map<QString, st
             if (e.readInt()) {
                 fontStyle = fontStyle + FontStyle::Underline;
             }
+#if 0 // should not happend, but won't harm either
+        } else if (tag == "strike") {
+            if (e.readInt()) {
+                fontStyle = fontStyle + FontStyle::Strike;
+            }
+#endif
         } else if (tag == "align") {
             align = Align(e.readInt());
         } else if (tag == "anchor") {     // obsolete

--- a/src/engraving/style/style.cpp
+++ b/src/engraving/style/style.cpp
@@ -209,17 +209,18 @@ bool MStyle::readStyleValCompat(XmlReader& e)
 
 //---------------------------------------------------------
 //   readTextStyleValCompat
-//    Handle transition from separate bold, underline and
-//    italic style properties to the single *FontStyle
+//    Handle transition from separate bold, underline, strike
+//    and italic style properties to the single *FontStyle
 //    property set.
 //---------------------------------------------------------
 
 bool MStyle::readTextStyleValCompat(XmlReader& e)
 {
-    static const std::array<std::pair<const char*, FontStyle>, 3> styleNamesEndings { {
+    static const std::array<std::pair<const char*, FontStyle>, 4> styleNamesEndings { {
         { "FontBold",      FontStyle::Bold },
         { "FontItalic",    FontStyle::Italic },
-        { "FontUnderline", FontStyle::Underline }
+        { "FontUnderline", FontStyle::Underline },
+        { "FontStrike",    FontStyle::Strike }
     } };
 
     const QStringRef tag(e.name());

--- a/src/framework/ui/view/iconcodes.h
+++ b/src/framework/ui/view/iconcodes.h
@@ -108,6 +108,7 @@ public:
         TEXT_ITALIC = 0xEF40,
         TEXT_UNDERLINE = 0xEF41,
         TEXT_BOLD = 0xEF42,
+        TEXT_STRIKE = 0xF424,
         APPLY_GLOBAL_STYLE = 0xEF43,
         HAIRPIN = 0xEF44,
         ACCIDENTAL_SHARP = 0xEF45,
@@ -333,7 +334,7 @@ public:
         BEAM_DISTANCE_REGULAR = 0xF425,
         BEAM_DISTANCE_WIDE = 0xF426,
 
-        NONE
+        NONE = 0xFFFF
     };
 
     Q_ENUM(Code)

--- a/src/importexport/capella/internal/capella.cpp
+++ b/src/importexport/capella/internal/capella.cpp
@@ -290,6 +290,7 @@ static void processBasicDrawObj(QList<BasicDrawObj*> objects, Segment* s, int tr
             text->setFamily(f.family());
             text->setItalic(f.italic());
             // text->setUnderline(f.underline());
+            // text->setStrike(f.strikeOut());
             text->setBold(f.bold());
             text->setSize(f.pointSizeF());
 
@@ -1288,6 +1289,7 @@ void convertCapella(Score* score, Capella* cap, bool capxMode)
             QFont f(to->font());
             s->setItalic(f.italic());
             // s->setUnderline(f.underline());
+            // s->setStrike(f.strikeOut());
             s->setBold(f.bold());
             s->setSize(f.pointSizeF());
 

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -674,6 +674,10 @@ static QString fontStyleToXML(const FontStyle style, bool allowUnderline = true)
     if (allowUnderline && style & FontStyle::Underline) {
         res += " underline=\"1\"";
     }
+    // at places where underline is not wanted (e.g. fingering, pluck), strike is not wanted too
+    if (allowUnderline && style & FontStyle::Strike) {
+        res += " line-through=\"1\"";
+    }
     return res;
 }
 

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -1268,6 +1268,7 @@ static QString nextPartOfFormattedString(QXmlStreamReader& e)
     QString fontSize   = e.attributes().value("font-size").toString();
     QString fontStyle  = e.attributes().value("font-style").toString();
     QString underline  = e.attributes().value("underline").toString();
+    QString strike     = e.attributes().value("line-through").toString();
     QString fontFamily = e.attributes().value("font-family").toString();
     // TODO: color, enclosure, yoffset in only part of the text, ...
 
@@ -1300,8 +1301,17 @@ static QString nextPartOfFormattedString(QXmlStreamReader& e)
     if (!underline.isEmpty()) {
         bool ok = true;
         int lines = underline.toInt(&ok);
-        if (ok && (lines > 0)) {    // 1,2, or 3 underlines are imported as single underline
+        if (ok && (lines > 0)) {    // 1, 2, or 3 underlines are imported as single underline
             importedtext += "<u>";
+        } else {
+            underline = "";
+        }
+    }
+    if (!strike.isEmpty()) {
+        bool ok = true;
+        int lines = strike.toInt(&ok);
+        if (ok && (lines > 0)) {    // 1, 2, or 3 strikes are imported as single strike
+            importedtext += "<s>";
         } else {
             underline = "";
         }
@@ -1312,6 +1322,9 @@ static QString nextPartOfFormattedString(QXmlStreamReader& e)
     } else {
         // <sym> replacement made, should be no need for line break or other conversions
         importedtext += syms;
+    }
+    if (strike != "") {
+        importedtext += "</s>";
     }
     if (underline != "") {
         importedtext += "</u>";

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -755,6 +755,7 @@ static QString nextPartOfFormattedString(QXmlStreamReader& e)
     QString fontSize   = e.attributes().value("font-size").toString();
     QString fontStyle  = e.attributes().value("font-style").toString();
     QString underline  = e.attributes().value("underline").toString();
+    QString strike     = e.attributes().value("line-through").toString();
     QString fontFamily = e.attributes().value("font-family").toString();
     // TODO: color, enclosure, yoffset in only part of the text, ...
 
@@ -787,10 +788,19 @@ static QString nextPartOfFormattedString(QXmlStreamReader& e)
     if (!underline.isEmpty()) {
         bool ok = true;
         int lines = underline.toInt(&ok);
-        if (ok && (lines > 0)) {    // 1,2, or 3 underlines are imported as single underline
+        if (ok && (lines > 0)) {    // 1, 2, or 3 underlines are imported as single underline
             importedtext += "<u>";
         } else {
             underline = "";
+        }
+    }
+    if (!strike.isEmpty()) {
+        bool ok = true;
+        int lines = strike.toInt(&ok);
+        if (ok && (lines > 0)) {    // 1, 2, or 3 strikes are imported as single strike
+            importedtext += "<s>";
+        } else {
+            strike = "";
         }
     }
     if (txt == syms) {
@@ -799,6 +809,9 @@ static QString nextPartOfFormattedString(QXmlStreamReader& e)
     } else {
         // <sym> replacement made, should be no need for line break or other conversions
         importedtext += syms;
+    }
+    if (strike != "") {
+        importedtext += "</s>";
     }
     if (underline != "") {
         importedtext += "</u>";

--- a/src/importexport/musicxml/internal/musicxml/musicxmlfonthandler.cpp
+++ b/src/importexport/musicxml/internal/musicxml/musicxmlfonthandler.cpp
@@ -237,6 +237,7 @@ QString MScoreTextToMXML::updateFormat()
     res += attribute(newFormat.bold() != oldFormat.bold(), newFormat.bold(), "font-weight=\"bold\"", "font-weight=\"normal\"");
     res += attribute(newFormat.italic() != oldFormat.italic(), newFormat.italic(), "font-style=\"italic\"", "font-style=\"normal\"");
     res += attribute(newFormat.underline() != oldFormat.underline(), newFormat.underline(), "underline=\"1\"", "underline=\"0\"");
+    res += attribute(newFormat.strike() != oldFormat.strike(), newFormat.strike(), "line-through=\"1\"", "line-though=\"0\"");
     res += attribute(newFormat.fontFamily() != oldFormat.fontFamily(), true, QString("font-family=\"%1\"").arg(newFormat.fontFamily()), "");
     bool needSize = newFormat.fontSize() < 0.99 * oldFormat.fontSize() || newFormat.fontSize() > 1.01 * oldFormat.fontSize();
     res += attribute(needSize, true, QString("font-size=\"%1\"").arg(newFormat.fontSize()), "");

--- a/src/inspector/types/texttypes.h
+++ b/src/inspector/types/texttypes.h
@@ -31,10 +31,12 @@ class TextTypes
 
 public:
     enum class FontStyle {
+        //FONT_STYLE_UNDEFINED = -1,
         FONT_STYLE_NORMAL = 0,
-        FONT_STYLE_BOLD = 1,
-        FONT_STYLE_ITALIC = 2,
-        FONT_STYLE_UNDERLINE = 4
+        FONT_STYLE_BOLD = 1 << 0,
+        FONT_STYLE_ITALIC = 1 << 1,
+        FONT_STYLE_UNDERLINE = 1 << 2,
+        FONT_STYLE_STRIKE = 1 << 3
     };
 
     enum class FontHorizontalAlignment {

--- a/src/inspector/view/qml/MuseScore/Inspector/text/TextInspectorView.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/TextInspectorView.qml
@@ -95,7 +95,8 @@ InspectorSectionView {
                     model: [
                         { iconCode: IconCode.TEXT_BOLD, value: TextTypes.FONT_STYLE_BOLD, title: qsTrc("inspector", "Bold") },
                         { iconCode: IconCode.TEXT_ITALIC, value: TextTypes.FONT_STYLE_ITALIC, title: qsTrc("inspector", "Italic") },
-                        { iconCode: IconCode.TEXT_UNDERLINE, value: TextTypes.FONT_STYLE_UNDERLINE, title: qsTrc("inspector", "Underline") }
+                        { iconCode: IconCode.TEXT_UNDERLINE, value: TextTypes.FONT_STYLE_UNDERLINE, title: qsTrc("inspector", "Underline") },
+                        { iconCode: IconCode.TEXT_STRIKE, value: TextTypes.FONT_STYLE_STRIKE, title: qsTrc("inspector", "Strike-through") }
                     ]
 
                     delegate: FlatToggleButton {

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -198,6 +198,7 @@ public:
     virtual void toggleBold() = 0;
     virtual void toggleItalic() = 0;
     virtual void toggleUnderline() = 0;
+    virtual void toggleStrike() = 0;
 };
 
 using INotationInteractionPtr = std::shared_ptr<INotationInteraction>;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -302,6 +302,7 @@ void NotationActionController::init()
     registerTextAction("text-b", &NotationActionController::toggleBold);
     registerTextAction("text-i", &NotationActionController::toggleItalic);
     registerTextAction("text-u", &NotationActionController::toggleUnderline);
+    registerTextAction("text-u", &NotationActionController::toggleStrike);
 
     for (int i = MIN_NOTES_INTERVAL; i <= MAX_NOTES_INTERVAL; ++i) {
         if (isNotesIntervalValid(i)) {
@@ -1899,6 +1900,11 @@ void NotationActionController::toggleUnderline()
 {
     TRACEFUNC;
     currentNotationInteraction()->toggleUnderline();
+}
+
+void NotationActionController::toggleStrike()
+{
+    currentNotationInteraction()->toggleStrike();
 }
 
 void NotationActionController::registerAction(const mu::actions::ActionCode& code,

--- a/src/notation/internal/notationactioncontroller.h
+++ b/src/notation/internal/notationactioncontroller.h
@@ -130,6 +130,7 @@ private:
     void toggleBold();
     void toggleItalic();
     void toggleUnderline();
+    void toggleStrike();
 
     void toggleLayoutBreak(LayoutBreakType breakType);
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3607,3 +3607,8 @@ void NotationInteraction::toggleUnderline()
 {
     toggleFontStyle(Ms::FontStyle::Underline);
 }
+
+void NotationInteraction::toggleStrike()
+{
+    toggleFontStyle(Ms::FontStyle::Strike);
+}

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -207,6 +207,7 @@ public:
     void toggleBold() override;
     void toggleItalic() override;
     void toggleUnderline() override;
+    void toggleStrike() override;
 
 private:
     Ms::Score* score() const;

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -1483,6 +1483,12 @@ const UiActionList NotationUiActions::m_scoreConfigActions = {
              QT_TRANSLATE_NOOP("action", "Underline"),
              QT_TRANSLATE_NOOP("action", "Underline"),
              Checkable::Yes
+             ),
+    UiAction("text-s",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Strike-throuch"),
+             QT_TRANSLATE_NOOP("action", "Strike-through"),
+             Checkable::Yes
              )
 };
 

--- a/src/notation/view/widgets/fontStyleSelect.cpp
+++ b/src/notation/view/widgets/fontStyleSelect.cpp
@@ -35,10 +35,12 @@ FontStyleSelect::FontStyleSelect(QWidget* parent)
     bold->setText(iconCodeToChar(IconCode::Code::TEXT_BOLD));
     italic->setText(iconCodeToChar(IconCode::Code::TEXT_ITALIC));
     underline->setText(iconCodeToChar(IconCode::Code::TEXT_UNDERLINE));
+    strike->setText(iconCodeToChar(IconCode::Code::TEXT_STRIKE));
 
     connect(bold, &QPushButton::toggled, this, &FontStyleSelect::_fontStyleChanged);
     connect(italic, &QPushButton::toggled, this, &FontStyleSelect::_fontStyleChanged);
     connect(underline, &QPushButton::toggled, this, &FontStyleSelect::_fontStyleChanged);
+    connect(strike, &QPushButton::toggled, this, &FontStyleSelect::_fontStyleChanged);
 }
 
 void FontStyleSelect::_fontStyleChanged()
@@ -59,6 +61,9 @@ Ms::FontStyle FontStyleSelect::fontStyle() const
     if (underline->isChecked()) {
         fs = fs + Ms::FontStyle::Underline;
     }
+    if (strike->isChecked()) {
+        fs = fs + Ms::FontStyle::Strike;
+    }
 
     return fs;
 }
@@ -68,4 +73,5 @@ void FontStyleSelect::setFontStyle(Ms::FontStyle fs)
     bold->setChecked(fs & Ms::FontStyle::Bold);
     italic->setChecked(fs & Ms::FontStyle::Italic);
     underline->setChecked(fs & Ms::FontStyle::Underline);
+    strike->setChecked(fs & Ms::FontStyle::Strike);
 }

--- a/src/notation/view/widgets/font_style_select.ui
+++ b/src/notation/view/widgets/font_style_select.ui
@@ -121,6 +121,31 @@
          </property>
         </widget>
        </item>
+       <item>
+        <widget class="QPushButton" name="strike">
+         <property name="minimumSize">
+          <size>
+           <width>28</width>
+           <height>28</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>28</width>
+           <height>28</height>
+          </size>
+         </property>
+         <property name="accessibleName">
+          <string>Strike</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="flat">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
     </layout>


### PR DESCRIPTION
Resolves: *https://musescore.org/en/node/325982*

Todo (@Tantacrul?): needs a Strike-through symbol in the icons font, maybe/probably "~~S~~", for now it re-uses the "<ins>U</ins>" (and while at it: an icon for 3.x would be appreciated too, SVG 24x24)

BTW: where is the text tool gone? How to have parts of a text set bold/italic/underscore(/strike-through)?