### PR TITLE
[MU4] Fix #326083: Capella (.cap) import does not handle breve notes correctly

### DIFF
--- a/src/importexport/capella/internal/capella.cpp
+++ b/src/importexport/capella/internal/capella.cpp
@@ -2675,7 +2675,7 @@ Fraction BasicDurationalObj::ticks() const
         break;
     case TIMESTEP::D256:        len = Fraction(1, 256);
         break;
-    case TIMESTEP::D_BREVE:     len = Fraction(2, 2);
+    case TIMESTEP::D_BREVE:     len = Fraction(2, 1);
         break;
     default:
         qDebug("BasicDurationalObj::ticks: illegal duration value %d", int(t));


### PR DESCRIPTION
Resolves: *https://musescore.org/en/node/326083*

Same issue (and fix) with 3.x. Bug got introduced with ec3be9a, so ever since 3.1beta, but not in 2.x