### PR TITLE
Fix #9352: Add ability to guess tie attachment point for different noteheads

### DIFF
--- a/src/engraving/libmscore/note.h
+++ b/src/engraving/libmscore/note.h
@@ -376,6 +376,7 @@ public:
     qreal noteheadCenterX() const;
     qreal bboxRightPos() const;
     qreal headBodyWidth() const;
+    qreal outsideTieAttachX(bool up) const;
 
     NoteHead::Scheme headScheme() const { return _headScheme; }
     void updateHeadGroup(const NoteHead::Group headGroup);

--- a/src/engraving/libmscore/tie.h
+++ b/src/engraving/libmscore/tie.h
@@ -53,7 +53,7 @@ public:
     int subtype() const override { return static_cast<int>(spanner()->type()); }
     void draw(mu::draw::Painter*) const override;
 
-    void layoutSegment(const mu::PointF& p1, const mu::PointF& p2);
+    void adjustY(const mu::PointF& p1, const mu::PointF& p2);
     void adjustX();
     void finalizeSegment();
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9352

Noteheads are now taken into account when determining where to attach ties. For noteheads with cutout information, this is the average of the cutouts. Also, now that noteheads have a single attachment point, ties adjust for each other when they share that point:
![image](https://user-images.githubusercontent.com/89263931/140239807-62f45c5c-dd4d-4739-a134-a29086aa22a2.png)

For slash noteheads, which are special, the tie attachment point takes the stem anchor into account:
![image](https://user-images.githubusercontent.com/89263931/140239843-28fe6942-6418-4f48-9068-c437a2f08232.png)

For all other noteheads, the exact center is used.
![image](https://user-images.githubusercontent.com/89263931/140239884-28a13aa9-ef31-4013-be9d-4404552f29a7.png)
