### PR TITLE
Fix #325735: [MusicXML import] Final barlines wrongly and only partia…

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -1616,10 +1616,11 @@ void MusicXMLParserPass2::scorePartwise()
         }
     }
     // set last measure barline to normal or MuseScore will generate light-heavy EndBarline
-    // TODO, handle other tracks?
     auto lm = _score->lastMeasure();
     if (lm && lm->endBarLineType() == BarLineType::NORMAL) {
-        lm->setEndBarLineType(BarLineType::NORMAL, 0);
+        for (int staff = 0; staff < _score->nstaves(); staff++) {
+            lm->setEndBarLineType(BarLineType::NORMAL, staff * VOICES);
+        }
     }
 
     addError(checkAtEndElement(_e, "score-partwise"));


### PR DESCRIPTION
…lly assumed from musicxml import lacking barlines

Resolves: https://musescore.org/en/node/325735

Ensures all staves end with a normal barline, if no barline is present in the MusicXML file. The current implementation handles the first staff only, incorrectly resulting in a normal barline in the first staff and a final barline in every other staff. 
This was not caught by the autotester, as the assumption in Measure::endBarLineType() that all barlines have the same type results in the expected MusicXML output anyway. Requested by the music21 project.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
