### PR TITLE
Minor fixes for StyleDialog > Beams > Beam distance section

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/BeamsPage.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/BeamsPage.qml
@@ -33,7 +33,7 @@ StyleDialogPage {
     }
 
     ItemWithTitle {
-        title: qsTrc("notation", "Beam thickness")
+        title: qsTrc("notation", "Beam distance")
 
         RadioButtonGroup {
             width: 224
@@ -59,7 +59,7 @@ StyleDialogPage {
                     StyledIconLabel {
                         anchors.horizontalCenter: parent.horizontalCenter
                         iconCode: modelData.iconCode
-                        font.pixelSize: 32
+                        font.pixelSize: 28
                     }
 
                     StyledTextLabel {


### PR DESCRIPTION
Fixed title and slightly reduced icons size

Resolves: https://github.com/musescore/MuseScore/pull/9683#issuecomment-964853276