### PR TITLE
fix #318085: [MusicXML export] figuredBass xml export (multiple figur…

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -1126,7 +1126,7 @@ static void divideBy(int d)
 
 static void addInteger(int len)
 {
-    if (!integers.contains(len)) {
+    if (len > 0 && !integers.contains(len)) {
         integers.append(len);
     }
 }
@@ -1205,13 +1205,23 @@ void ExportMusicXml::calcDivisions()
 
             for (track_idx_t st = strack; st < etrack; ++st) {
                 for (Segment* seg = m->first(); seg; seg = seg->next()) {
+                    for (const EngravingItem* e : seg->annotations()) {
+                        if (e->track() == st && e->type() == ElementType::FIGURED_BASS) {
+                            const FiguredBass* fb = toFiguredBass(e);
+#ifdef DEBUG_TICK
+                            LOGD("figuredbass tick %d duration %d", fb->tick().ticks(), fb->ticks().ticks());
+#endif
+                            addInteger(fb->ticks().ticks());
+                        }
+                    }
+
                     EngravingItem* el = seg->element(st);
                     if (!el) {
                         continue;
                     }
 
                     // must ignore start repeat to prevent spurious backup/forward
-                    if (el->type() == ElementType::BAR_LINE && static_cast<BarLine*>(el)->barLineType() == BarLineType::START_REPEAT) {
+                    if (el->type() == ElementType::BAR_LINE && toBarLine(el)->barLineType() == BarLineType::START_REPEAT) {
                         continue;
                     }
 
@@ -1227,7 +1237,7 @@ void ExportMusicXml::calcDivisions()
                             }
                         }
 #ifdef DEBUG_TICK
-                        LOGD("chordrest %d", l);
+                        LOGD("chordrest tick %d duration %d", _tick.ticks(), l.ticks());
 #endif
                         addInteger(l.ticks());
                         _tick += l;

--- a/src/importexport/musicxml/tests/data/testFiguredBassDivisions.xml
+++ b/src/importexport/musicxml/tests/data/testFiguredBassDivisions.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-number>MuseScore testfile</work-number>
+    <work-title>Figured Bass Divisions</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Leon Vinken</creator>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Voice</part-name>
+      <part-abbreviation>Vo.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Voice</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>53</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>2</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>1</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <figured-bass>
+        <figure>
+          <figure-number>1</figure-number>
+          </figure>
+        <duration>1</duration>
+        </figured-bass>
+      <figured-bass>
+        <figure>
+          <figure-number>2</figure-number>
+          </figure>
+        <duration>1</duration>
+        </figured-bass>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/tst_mxml_io.cpp
+++ b/src/importexport/musicxml/tests/tst_mxml_io.cpp
@@ -135,6 +135,7 @@ private slots:
     void figuredBass1() { mxmlIoTest("testFiguredBass1"); }
     void figuredBass2() { mxmlIoTest("testFiguredBass2"); }
     void figuredBass3() { mxmlIoTest("testFiguredBass3"); }
+    void figuredBassDivisions() { mxmlIoTest("testFiguredBassDivisions"); }
     void formattedThings() { mxmlIoTest("testFormattedThings"); }
     void fractionMinus() { mxmlIoTestRef("testFractionMinus"); }
     void fractionPlus() { mxmlIoTestRef("testFractionPlus"); }


### PR DESCRIPTION
…es per note)

Resolves: https://musescore.org/en/node/318085

When figured bass elements have a duration shorter than the shortest note, they are exported to MusicXML with duration zero. Caused by function ExportMusicXml::calcDivisions(), which does not seem to take figured bass duration into account when calculating the divisions value. Added figured bass handling to calcDivisions().

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
