### PR TITLE
Fix #326107: [MusicXML export] Off-by-one error in <midi-unpitched>

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -6383,7 +6383,7 @@ static void partList(XmlWriter& xml, Score* score, MxmlInstrumentMap& instrMap)
 
             for (int i = 0; i < 128; ++i) {
                 DrumInstrument di = drumset->drum(i);
-                if (di.notehead != NoteHead::Group::HEAD_INVALID || pitches.contains(i)) {
+                if (di.notehead != NoteHead::Group::HEAD_INVALID || pitches.contains(i + 1)) {
                     midiInstrument(xml, idx + 1, i + 1, part->instrument(), score, i + 1);
                 }
             }


### PR DESCRIPTION
Resolves: [*(direct link to the issue)*](https://musescore.org/en/node/326107)

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://musescore.org/en/cla) -- not right now, I think this is a trivial fix
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
