### PR TITLE
[DAISY] Fix #312626: Add speech for symbols from Symbols palette

### DIFF
--- a/src/engraving/libmscore/symbol.cpp
+++ b/src/engraving/libmscore/symbol.cpp
@@ -69,6 +69,15 @@ QString Symbol::symName() const
 }
 
 //---------------------------------------------------------
+//   accessibleInfo
+//---------------------------------------------------------
+
+QString Symbol::accessibleInfo() const
+{
+    return QString("%1: %2").arg(EngravingItem::accessibleInfo(), SymNames::userNameForSymId(_sym));
+}
+
+//---------------------------------------------------------
 //   layout
 //    height() and width() should return sensible
 //    values when calling this method

--- a/src/engraving/libmscore/symbol.h
+++ b/src/engraving/libmscore/symbol.h
@@ -58,6 +58,8 @@ public:
     SymId sym() const { return _sym; }
     QString symName() const;
 
+    QString accessibleInfo() const override;
+
     void draw(mu::draw::Painter*) const override;
     void write(XmlWriter& xml) const override;
     void read(XmlReader&) override;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/312626

Improve accessibility by adding status bar text and screen reader output for arbitrary SMuFL symbols added to the score from the Symbols palette at the bottom of the Master Palette (shortcut: Shift+F9).