### PR TITLE
Fix #9175 Cannot open multiple score parts at once

### DIFF
--- a/src/notation/view/partlistmodel.cpp
+++ b/src/notation/view/partlistmodel.cpp
@@ -279,6 +279,8 @@ void PartListModel::openSelectedParts()
         return;
     }
 
+    std::sort(rows.begin(), rows.end());
+
     ExcerptNotationList newExcerpts;
     for (int index : rows) {
         newExcerpts.push_back(m_excerpts[index]);
@@ -286,6 +288,9 @@ void PartListModel::openSelectedParts()
 
     masterNotation()->addExcerpts(newExcerpts);
 
+    for (int index : rows) {
+        m_excerpts[index]->notation()->setOpened(true);
+    }
     context()->setCurrentNotation(m_excerpts[rows.last()]->notation());
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9175

After selecting multiple parts in "parts" dialog, you can now open all of them. Previously, you could open only one. Therefore, you would have to open all of them one-by-one, causing an inconvenience. So, I created a loop which iterates through the selected rows and opens them. I have also sorted the selected rows in the order in which they appear, so that when you open them, it opens in the correct order.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
