### PR TITLE
Fix #9218: Fix transparent .png file export

### DIFF
--- a/src/importexport/imagesexport/internal/imagesexportconfiguration.cpp
+++ b/src/importexport/imagesexport/internal/imagesexportconfiguration.cpp
@@ -35,7 +35,7 @@ static const Settings::Key EXPORT_PNG_USE_TRANSPARENCY_KEY("iex_imagesexport", "
 void ImagesExportConfiguration::init()
 {
     settings()->setDefaultValue(EXPORT_PNG_DPI_RESOLUTION_KEY, Val(Ms::DPI));
-    settings()->setDefaultValue(EXPORT_PNG_USE_TRANSPARENCY_KEY, Val(true));
+    settings()->setDefaultValue(EXPORT_PNG_USE_TRANSPARENCY_KEY, Val(false));
     settings()->setDefaultValue(EXPORT_PDF_DPI_RESOLUTION_KEY, Val(Ms::DPI));
 }
 

--- a/src/importexport/imagesexport/internal/pngwriter.cpp
+++ b/src/importexport/imagesexport/internal/pngwriter.cpp
@@ -82,7 +82,7 @@ mu::Ret PngWriter::write(INotationPtr notation, Device& destinationDevice, const
     image.setDotsPerMeterY(std::lrint((CANVAS_DPI * 1000) / Ms::INCH));
 
     const bool TRANSPARENT_BACKGROUND = options.value(OptionKey::TRANSPARENT_BACKGROUND, Val(false)).toBool();
-    image.fill(TRANSPARENT_BACKGROUND ? 0 : Qt::white);
+    image.fill(TRANSPARENT_BACKGROUND ? Qt::transparent : Qt::white);
 
     double scaling = CANVAS_DPI / Ms::DPI;
     Ms::MScore::pixelRatio = 1.0 / scaling;


### PR DESCRIPTION
Before this commit, when exported in .png format, exported .png files always used to have
a transparent background whether transparent option was checked or not.
This commit has solved this bug. Also, the default value of transparent background has been changed from true to false

Resolves: https://github.com/musescore/MuseScore/issues/9218

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
