### PR TITLE
Learn page: show error message when video playlist couldn't be loaded

### DIFF
--- a/src/autobot/internal/api/interactiveapi.cpp
+++ b/src/autobot/internal/api/interactiveapi.cpp
@@ -30,5 +30,5 @@ InteractiveApi::InteractiveApi(IApiEngine* e)
 
 void InteractiveApi::openUrl(const QString& url)
 {
-    interactive()->openUrl(url.toStdString());
+    interactive()->openUrl(QUrl(url));
 }

--- a/src/autobot/internal/autobotinteractive.cpp
+++ b/src/autobot/internal/autobotinteractive.cpp
@@ -159,6 +159,11 @@ Ret AutobotInteractive::openUrl(const std::string& url) const
     return m_real->openUrl(url);
 }
 
+Ret AutobotInteractive::openUrl(const QUrl& url) const
+{
+    return m_real->openUrl(url);
+}
+
 io::path AutobotInteractive::selectedFilePath() const
 {
     return m_selectedFilePath;

--- a/src/autobot/internal/autobotinteractive.h
+++ b/src/autobot/internal/autobotinteractive.h
@@ -84,6 +84,7 @@ public:
     std::vector<Uri> stack() const override;
 
     Ret openUrl(const std::string& url) const override;
+    Ret openUrl(const QUrl& url) const override;
 
     // AutobotInteractive
     io::path selectedFilePath() const; // last selected file path

--- a/src/cloud/internal/cloudservice.cpp
+++ b/src/cloud/internal/cloudservice.cpp
@@ -407,7 +407,7 @@ void CloudService::executeRequest(const RequestCallback& requestCallback)
 
 void CloudService::openUrl(const QUrl& url)
 {
-    Ret ret = interactive()->openUrl(url.toString().toStdString());
+    Ret ret = interactive()->openUrl(url);
     if (!ret) {
         LOGE() << ret.toString();
     }

--- a/src/diagnostics/view/diagnosticspathsmodel.cpp
+++ b/src/diagnostics/view/diagnosticspathsmodel.cpp
@@ -54,7 +54,7 @@ void DiagnosticsPathsModel::load()
 
 void DiagnosticsPathsModel::openPath(const QString& path)
 {
-    interactive()->openUrl(path.toStdString());
+    interactive()->openUrl(QUrl(path));
 }
 
 QVariant DiagnosticsPathsModel::data(const QModelIndex& index, int role) const

--- a/src/framework/global/iinteractive.h
+++ b/src/framework/global/iinteractive.h
@@ -171,6 +171,7 @@ public:
     virtual std::vector<Uri> stack() const = 0;
 
     virtual Ret openUrl(const std::string& url) const = 0;
+    virtual Ret openUrl(const QUrl& url) const = 0;
 };
 Q_DECLARE_OPERATORS_FOR_FLAGS(IInteractive::Options)
 }

--- a/src/framework/global/internal/interactive.cpp
+++ b/src/framework/global/internal/interactive.cpp
@@ -207,8 +207,12 @@ std::vector<Uri> Interactive::stack() const
 
 Ret Interactive::openUrl(const std::string& url) const
 {
-    QUrl _url(QString::fromStdString(url));
-    return QDesktopServices::openUrl(_url);
+    return openUrl(QUrl(QString::fromStdString(url)));
+}
+
+Ret Interactive::openUrl(const QUrl& url) const
+{
+    return QDesktopServices::openUrl(url);
 }
 
 IInteractive::ButtonDatas Interactive::buttonDataList(const Buttons& buttons) const

--- a/src/framework/global/internal/interactive.h
+++ b/src/framework/global/internal/interactive.h
@@ -84,6 +84,7 @@ public:
     std::vector<Uri> stack() const override;
 
     Ret openUrl(const std::string& url) const override;
+    Ret openUrl(const QUrl& url) const override;
 
 private:
     ButtonDatas buttonDataList(const Buttons& buttons) const;

--- a/src/framework/ui/view/qmllauncher.cpp
+++ b/src/framework/ui/view/qmllauncher.cpp
@@ -35,5 +35,5 @@ bool QmlLauncher::open(const QString& uri)
 
 bool QmlLauncher::openUrl(const QString& url)
 {
-    return interactive()->openUrl(url.toStdString());
+    return interactive()->openUrl(QUrl(url));
 }

--- a/src/learn/ilearnconfiguration.h
+++ b/src/learn/ilearnconfiguration.h
@@ -38,8 +38,8 @@ public:
     virtual QUrl startedPlaylistUrl() const = 0;
     virtual QUrl advancedPlaylistUrl() const = 0;
 
-    virtual QUrl videosInfoUrl(const std::vector<std::string>& videosIds) const = 0;
-    virtual QUrl videoOpenUrl(const std::string& videoId) const = 0;
+    virtual QUrl videosInfoUrl(const QStringList& videosIds) const = 0;
+    virtual QUrl videoOpenUrl(const QString& videoId) const = 0;
 };
 }
 

--- a/src/learn/ilearnservice.h
+++ b/src/learn/ilearnservice.h
@@ -40,7 +40,7 @@ public:
     virtual Playlist advancedPlaylist() const = 0;
     virtual async::Channel<Playlist> advancedPlaylistChanged() const = 0;
 
-    virtual void openVideo(const std::string& videoId) const = 0;
+    virtual void openVideo(const QString& videoId) const = 0;
 };
 }
 

--- a/src/learn/internal/learnconfiguration.cpp
+++ b/src/learn/internal/learnconfiguration.cpp
@@ -50,14 +50,14 @@ QUrl LearnConfiguration::advancedPlaylistUrl() const
     return QUrl(apiRootUrl() + "/playlistItems?" + playlistItemsParams(ADVANCED_PLAYLIST_ID));
 }
 
-QUrl LearnConfiguration::videosInfoUrl(const std::vector<std::string>& videosIds) const
+QUrl LearnConfiguration::videosInfoUrl(const QStringList& videosIds) const
 {
     return QUrl(apiRootUrl() + "/videos?" + videosParams(videosIds));
 }
 
-QUrl LearnConfiguration::videoOpenUrl(const std::string& videoId) const
+QUrl LearnConfiguration::videoOpenUrl(const QString& videoId) const
 {
-    return QUrl("https://www.youtube.com/watch?v=" + QString::fromStdString(videoId));
+    return QUrl("https://www.youtube.com/watch?v=" + videoId);
 }
 
 QString LearnConfiguration::apiRootUrl() const
@@ -77,7 +77,7 @@ QString LearnConfiguration::playlistItemsParams(const QString& playlistId) const
     return params.join('&');
 }
 
-QString LearnConfiguration::videosParams(const std::vector<std::string>& videosIds) const
+QString LearnConfiguration::videosParams(const QStringList& videosIds) const
 {
     QStringList params {
         "part=snippet,contentDetails",
@@ -85,8 +85,10 @@ QString LearnConfiguration::videosParams(const std::vector<std::string>& videosI
         "maxResults=" + QString::number(MAX_NUMBER_OF_RESULT_ITEMS)
     };
 
-    for (const std::string& videoId : videosIds) {
-        params << "id=" + QString::fromStdString(videoId);
+    params.reserve(params.size() + videosIds.size());
+
+    for (const QString& videoId : videosIds) {
+        params << "id=" + videoId;
     }
 
     return params.join('&');

--- a/src/learn/internal/learnconfiguration.h
+++ b/src/learn/internal/learnconfiguration.h
@@ -33,14 +33,14 @@ public:
     QUrl startedPlaylistUrl() const override;
     QUrl advancedPlaylistUrl() const override;
 
-    QUrl videosInfoUrl(const std::vector<std::string>& videosIds) const override;
-    QUrl videoOpenUrl(const std::string& videoId) const override;
+    QUrl videosInfoUrl(const QStringList& videosIds) const override;
+    QUrl videoOpenUrl(const QString& videoId) const override;
 
 private:
     QString apiRootUrl() const;
 
     QString playlistItemsParams(const QString& playlistId) const;
-    QString videosParams(const std::vector<std::string>& videosIds) const;
+    QString videosParams(const QStringList& videosIds) const;
 };
 }
 

--- a/src/learn/internal/learnservice.cpp
+++ b/src/learn/internal/learnservice.cpp
@@ -174,14 +174,14 @@ Playlist LearnService::parsePlaylist(const QJsonDocument& playlistDoc) const
         QJsonObject snippetObj = itemObj.value("snippet").toObject();
 
         PlaylistItem item;
-        item.videoId = itemObj.value("id").toString().toStdString();
+        item.videoId = itemObj.value("id").toString();
 
-        item.title = snippetObj.value("title").toString().toStdString();
-        item.author = snippetObj.value("channelTitle").toString().toStdString();
+        item.title = snippetObj.value("title").toString();
+        item.author = snippetObj.value("channelTitle").toString();
 
         QJsonObject thumbnailsObj = snippetObj.value("thumbnails").toObject();
         QJsonObject thumbnailsMediumObj = thumbnailsObj.value("medium").toObject();
-        item.thumbnailUrl = thumbnailsMediumObj.value("url").toString().toStdString();
+        item.thumbnailUrl = thumbnailsMediumObj.value("url").toString();
 
         QJsonObject contentDetails = itemObj.value("contentDetails").toObject();
         QString durationInIsoFormat = contentDetails["duration"].toString();

--- a/src/learn/internal/learnservice.cpp
+++ b/src/learn/internal/learnservice.cpp
@@ -90,10 +90,9 @@ mu::async::Channel<Playlist> LearnService::advancedPlaylistChanged() const
     return m_advancedPlaylistChannel;
 }
 
-void LearnService::openVideo(const std::string& videoId) const
+void LearnService::openVideo(const QString& videoId) const
 {
-    QUrl videoUrl = configuration()->videoOpenUrl(videoId);
-    interactive()->openUrl(videoUrl.toString().toStdString());
+    openUrl(configuration()->videoOpenUrl(videoId));
 }
 
 void LearnService::th_requestPlaylist(const QUrl& playlistUrl, async::Channel<RetVal<Playlist> >* finishChannel) const
@@ -112,8 +111,8 @@ void LearnService::th_requestPlaylist(const QUrl& playlistUrl, async::Channel<Re
 
     QJsonDocument playlistInfoDoc = QJsonDocument::fromJson(playlistItemsData.data());
 
-    std::vector<std::string> playlistItemsIds = parsePlaylistItemsIds(playlistInfoDoc);
-    if (playlistItemsIds.empty()) {
+    QStringList playlistItemsIds = parsePlaylistItemsIds(playlistInfoDoc);
+    if (playlistItemsIds.isEmpty()) {
         finishChannel->send(make_ret(Err::PlaylistIsEmpty));
         return;
     }
@@ -135,17 +134,17 @@ void LearnService::th_requestPlaylist(const QUrl& playlistUrl, async::Channel<Re
     finishChannel->send(result);
 }
 
-void LearnService::openUrl(const QUrl& url)
+void LearnService::openUrl(const QUrl& url) const
 {
-    Ret ret = interactive()->openUrl(url.toString().toStdString());
+    Ret ret = interactive()->openUrl(url);
     if (!ret) {
         LOGE() << ret.toString();
     }
 }
 
-std::vector<std::string> LearnService::parsePlaylistItemsIds(const QJsonDocument& playlistDoc) const
+QStringList LearnService::parsePlaylistItemsIds(const QJsonDocument& playlistDoc) const
 {
-    std::vector<std::string> result;
+    QStringList result;
 
     QJsonObject obj = playlistDoc.object();
     QJsonArray items = obj.value("items").toArray();
@@ -154,9 +153,9 @@ std::vector<std::string> LearnService::parsePlaylistItemsIds(const QJsonDocument
         QJsonObject itemObj = itemVal.toObject();
         QJsonObject snippetObj = itemObj.value("snippet").toObject();
         QJsonObject resourceIdObj = snippetObj.value("resourceId").toObject();
-        std::string videoId = resourceIdObj.value("videoId").toString().toStdString();
+        QString videoId = resourceIdObj.value("videoId").toString();
 
-        result.push_back(videoId);
+        result << videoId;
     }
 
     return result;
@@ -187,7 +186,7 @@ Playlist LearnService::parsePlaylist(const QJsonDocument& playlistDoc) const
         QString durationInIsoFormat = contentDetails["duration"].toString();
         item.durationSecs = DataFormatter::dateTimeFromIsoFormat(durationInIsoFormat).toSecsSinceEpoch();
 
-        result.push_back(item);
+        result << item;
     }
 
     return result;

--- a/src/learn/internal/learnservice.h
+++ b/src/learn/internal/learnservice.h
@@ -48,14 +48,14 @@ public:
     Playlist advancedPlaylist() const override;
     async::Channel<Playlist> advancedPlaylistChanged() const override;
 
-    void openVideo(const std::string& videoId) const override;
+    void openVideo(const QString& videoId) const override;
 
 private:
     void th_requestPlaylist(const QUrl& playlistUrl, async::Channel<RetVal<Playlist> >* finishChannel) const;
 
-    void openUrl(const QUrl& url);
+    void openUrl(const QUrl& url) const;
 
-    std::vector<std::string> parsePlaylistItemsIds(const QJsonDocument& playlistDoc) const;
+    QStringList parsePlaylistItemsIds(const QJsonDocument& playlistDoc) const;
     Playlist parsePlaylist(const QJsonDocument& playlistDoc) const;
 
     Playlist m_startedPlaylist;

--- a/src/learn/learntypes.h
+++ b/src/learn/learntypes.h
@@ -22,15 +22,15 @@
 #ifndef MU_LEARN_LEARNTYPES_H
 #define MU_LEARN_LEARNTYPES_H
 
-#include <string>
-#include <vector>
+#include <QString>
+#include <QList>
 
 namespace mu::learn {
 struct PlaylistItem {
-    std::string videoId;
-    std::string title;
-    std::string author;
-    std::string thumbnailUrl;
+    QString videoId;
+    QString title;
+    QString author;
+    QString thumbnailUrl;
     int durationSecs = 0;
 
     bool operator==(const PlaylistItem& other) const
@@ -39,7 +39,7 @@ struct PlaylistItem {
     }
 };
 
-using Playlist = std::vector<PlaylistItem>;
+using Playlist = QList<PlaylistItem>;
 }
 
 #endif // MU_LEARN_LEARNTYPES_H

--- a/src/learn/qml/MuseScore/Learn/internal/Playlist.qml
+++ b/src/learn/qml/MuseScore/Learn/internal/Playlist.qml
@@ -72,6 +72,7 @@ FocusScope {
 
         readonly property int columns: Math.max(0, Math.floor(width / cellWidth))
 
+        visible: count > 0
         anchors.fill: parent
         anchors.leftMargin: root.sideMargin - spacingBetweenColumns / 2
         anchors.rightMargin: root.sideMargin - spacingBetweenColumns / 2
@@ -130,6 +131,31 @@ FocusScope {
                     root.requestOpenVideo(modelData.videoId)
                 }
             }
+        }
+    }
+
+    Column {
+        id: errorMessageColumn
+        visible: !view.visible
+
+        anchors.top: parent.top
+        anchors.topMargin: topGradient.height + Math.max(parent.height / 4 - height / 2, 0)
+        anchors.left: parent.left
+        anchors.leftMargin: root.sideMargin
+        anchors.right: parent.right
+        anchors.rightMargin: root.sideMargin
+
+        spacing: 6
+
+        StyledTextLabel {
+            width: parent.width
+            font: ui.theme.tabBoldFont
+            text: qsTrc("learn", "Sorry, but we can’t load these videos right now")
+        }
+
+        StyledTextLabel {
+            width: parent.width
+            text: qsTrc("learn", "Please check your internet connection, or try again later.")
         }
     }
 }

--- a/src/learn/view/learnpagemodel.cpp
+++ b/src/learn/view/learnpagemodel.cpp
@@ -60,12 +60,12 @@ void LearnPageModel::load()
 
 void LearnPageModel::openVideo(const QString& videoId) const
 {
-    learnService()->openVideo(videoId.toStdString());
+    learnService()->openVideo(videoId);
 }
 
 void LearnPageModel::openUrl(const QString& url) const
 {
-    interactive()->openUrl(url.toStdString());
+    interactive()->openUrl(QUrl(url));
 }
 
 void LearnPageModel::setSearchText(const QString& text)

--- a/src/learn/view/learnpagemodel.cpp
+++ b/src/learn/view/learnpagemodel.cpp
@@ -137,10 +137,10 @@ QVariantList LearnPageModel::playlistToVariantList(const Playlist& playlist) con
 
     for (const PlaylistItem& item : playlist) {
         QVariantMap itemObj;
-        itemObj["videoId"] = QString::fromStdString(item.videoId);
-        itemObj["title"] = QString::fromStdString(item.title);
-        itemObj["author"] =QString::fromStdString(item.author);
-        itemObj["thumbnailUrl"] = QString::fromStdString(item.thumbnailUrl);
+        itemObj["videoId"] = item.videoId;
+        itemObj["title"] = item.title;
+        itemObj["author"] = item.author;
+        itemObj["thumbnailUrl"] = item.thumbnailUrl;
         itemObj["duration"] = formatDuration(item.durationSecs);
 
         result << itemObj;
@@ -154,10 +154,8 @@ Playlist LearnPageModel::filterPlaylistBySearch(const Playlist& playlist) const
     Playlist result;
 
     for (const PlaylistItem& playlistItem : playlist) {
-        QString title = QString::fromStdString(playlistItem.title);
-        QString author = QString::fromStdString(playlistItem.author);
-        if (title.contains(m_searchText, Qt::CaseInsensitive)
-            || author.contains(m_searchText, Qt::CaseInsensitive)) {
+        if (playlistItem.title.contains(m_searchText, Qt::CaseInsensitive)
+            || playlistItem.author.contains(m_searchText, Qt::CaseInsensitive)) {
             result.push_back(playlistItem);
         }
     }


### PR DESCRIPTION
The remaining part of the task #9468.
<img width="1262" alt="Schermafbeelding 2021-11-20 om 16 18 04" src="https://user-images.githubusercontent.com/48658420/142731710-9ea3b9be-b61e-499e-bb60-960dd73a17f4.png">

I also eliminated some back-and-forth conversions between QString and std::string, by just using Qt types. I don't see much benefit in trying to use only std types, where using Qt types is easier.