### PR TITLE
Adapt code style for Uncrustify 0.74.0

### DIFF
--- a/src/cloud/internal/cloudservice.h
+++ b/src/cloud/internal/cloudservice.h
@@ -92,7 +92,7 @@ private:
     RequestStatus downloadUserInfo();
     RequestStatus doUploadScore(io::Device& scoreSourceDevice, const QString& title, const QUrl& sourceUrl = QUrl());
 
-    using RequestCallback = std::function<RequestStatus()>;
+    using RequestCallback = std::function<RequestStatus ()>;
     void executeRequest(const RequestCallback& requestCallback);
 
     QOAuth2AuthorizationCodeFlow* m_oauth2 = nullptr;

--- a/src/engraving/infrastructure/draw/geometry.h
+++ b/src/engraving/infrastructure/draw/geometry.h
@@ -367,10 +367,10 @@ public:
 
     inline PolygonX<T>() = default;
     inline PolygonX<T>(const PolygonX<T>& p) = default;
-    inline PolygonX<T>(const std::vector<PointX<T> >& v) : std::vector<PointX<T> >(v) {
-    }
-    inline PolygonX<T>(size_t size) : std::vector<PointX<T> >(size) {
-    }
+    inline PolygonX<T>(const std::vector<PointX<T> >& v)
+        : std::vector<PointX<T> >(v) {}
+    inline PolygonX<T>(size_t size)
+        : std::vector<PointX<T> >(size) {}
 
     inline PolygonX<T>& operator<<(const PointX<T>& p)
     {

--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -2081,21 +2081,21 @@ void Score::cmdFlip()
             flipOnce(artic, [artic]() {
                 ArticulationAnchor articAnchor = artic->anchor();
                 switch (articAnchor) {
-                case ArticulationAnchor::TOP_CHORD:
-                    articAnchor = ArticulationAnchor::BOTTOM_CHORD;
-                    break;
-                case ArticulationAnchor::BOTTOM_CHORD:
-                    articAnchor = ArticulationAnchor::TOP_CHORD;
-                    break;
-                case ArticulationAnchor::CHORD:
-                    articAnchor = artic->up() ? ArticulationAnchor::BOTTOM_CHORD : ArticulationAnchor::TOP_CHORD;
-                    break;
-                case ArticulationAnchor::TOP_STAFF:
-                    articAnchor = ArticulationAnchor::BOTTOM_STAFF;
-                    break;
-                case ArticulationAnchor::BOTTOM_STAFF:
-                    articAnchor = ArticulationAnchor::TOP_STAFF;
-                    break;
+                    case ArticulationAnchor::TOP_CHORD:
+                        articAnchor = ArticulationAnchor::BOTTOM_CHORD;
+                        break;
+                    case ArticulationAnchor::BOTTOM_CHORD:
+                        articAnchor = ArticulationAnchor::TOP_CHORD;
+                        break;
+                    case ArticulationAnchor::CHORD:
+                        articAnchor = artic->up() ? ArticulationAnchor::BOTTOM_CHORD : ArticulationAnchor::TOP_CHORD;
+                        break;
+                    case ArticulationAnchor::TOP_STAFF:
+                        articAnchor = ArticulationAnchor::BOTTOM_STAFF;
+                        break;
+                    case ArticulationAnchor::BOTTOM_STAFF:
+                        articAnchor = ArticulationAnchor::TOP_STAFF;
+                        break;
                 }
                 PropertyFlags pf = artic->propertyFlags(Pid::ARTICULATION_ANCHOR);
                 if (pf == PropertyFlags::STYLED) {

--- a/src/engraving/libmscore/engravingobject.h
+++ b/src/engraving/libmscore/engravingobject.h
@@ -188,7 +188,7 @@ class EngravingObject
     void moveToDummy();
 
 protected:
-    const ElementStyle* _elementStyle {& emptyStyle };
+    const ElementStyle* _elementStyle { &emptyStyle };
     PropertyFlags* _propertyFlagsList { 0 };
     LinkedObjects* _links            { 0 };
     virtual int getPropertyFlagsIdx(Pid id) const;

--- a/src/framework/midi/internal/midideviceslistener.h
+++ b/src/framework/midi/internal/midideviceslistener.h
@@ -33,7 +33,7 @@ class MidiDevicesListener
 public:
     ~MidiDevicesListener();
 
-    using ActualDevicesCallback = std::function<MidiDeviceList()>;
+    using ActualDevicesCallback = std::function<MidiDeviceList ()>;
 
     void startWithCallback(const ActualDevicesCallback& callback);
 

--- a/src/framework/ui/view/interactiveprovider.cpp
+++ b/src/framework/ui/view/interactiveprovider.cpp
@@ -406,14 +406,14 @@ RetVal<InteractiveProvider::OpenData> InteractiveProvider::openWidgetDialog(cons
 
         QDialog::DialogCode dialogCode = static_cast<QDialog::DialogCode>(code);
         switch (dialogCode) {
-        case QDialog::Rejected: {
-            status["errcode"] = static_cast<int>(Ret::Code::Cancel);
-            break;
-        }
-        case QDialog::Accepted: {
-            status["errcode"] = static_cast<int>(Ret::Code::Ok);
-            break;
-        }
+            case QDialog::Rejected: {
+                status["errcode"] = static_cast<int>(Ret::Code::Cancel);
+                break;
+            }
+            case QDialog::Accepted: {
+                status["errcode"] = static_cast<int>(Ret::Code::Ok);
+                break;
+            }
         }
 
         onClose(objectId, status);

--- a/src/importexport/guitarpro_old/internal/importgtp-gp6.cpp
+++ b/src/importexport/guitarpro_old/internal/importgtp-gp6.cpp
@@ -1813,7 +1813,7 @@ void GuitarPro6::readBars(QDomNode* barList, Measure* measure, ClefType oldClefI
     int staffIdx           = 0;
 
     // used to keep track of tuplets
-    std::vector<Tuplet*> tuplets(staves* VOICES);
+    std::vector<Tuplet*> tuplets(staves * VOICES);
     for (int track = 0; track < staves * VOICES; ++track) {
         tuplets[track] = 0;
     }

--- a/src/inspector/models/notation/notes/beams/internal/beammodesmodel.cpp
+++ b/src/inspector/models/notation/notes/beams/internal/beammodesmodel.cpp
@@ -48,19 +48,19 @@ void BeamModesModel::loadProperties()
         Ms::TDuration durationType = elementPropertyValue.value<Ms::TDuration>();
 
         switch (durationType.type()) {
-        case Ms::TDuration::DurationType::V_INVALID:
-        case Ms::TDuration::DurationType::V_MEASURE:
-        case Ms::TDuration::DurationType::V_ZERO:
-        case Ms::TDuration::DurationType::V_LONG:
-        case Ms::TDuration::DurationType::V_BREVE:
-        case Ms::TDuration::DurationType::V_WHOLE:
-        case Ms::TDuration::DurationType::V_HALF:
-        case Ms::TDuration::DurationType::V_QUARTER:
-        case Ms::TDuration::DurationType::V_EIGHTH:
-            return false;
+            case Ms::TDuration::DurationType::V_INVALID:
+            case Ms::TDuration::DurationType::V_MEASURE:
+            case Ms::TDuration::DurationType::V_ZERO:
+            case Ms::TDuration::DurationType::V_LONG:
+            case Ms::TDuration::DurationType::V_BREVE:
+            case Ms::TDuration::DurationType::V_WHOLE:
+            case Ms::TDuration::DurationType::V_HALF:
+            case Ms::TDuration::DurationType::V_QUARTER:
+            case Ms::TDuration::DurationType::V_EIGHTH:
+                return false;
 
-        default:
-            return true;
+            default:
+                return true;
         }
     });
 }

--- a/tools/codestyle/uncrustify_musescore.cfg
+++ b/tools/codestyle/uncrustify_musescore.cfg
@@ -162,7 +162,7 @@ indent_func_throw                        = 0        # number
 indent_member                            = 0        # number
 
 # Spaces to indent single line ('//') comments on lines before code
-indent_sing_line_comments                = 0        # number
+indent_single_line_comments_before       = 0        # number
 
 # If set, will indent trailing single line ('//') comments relative
 # to the code instead of trying to keep the same absolute column
@@ -677,7 +677,7 @@ sp_before_oc_block_caret                 = ignore   # ignore/add/remove/force
 
 # Add or remove space after a block pointer caret
 # '^int (int arg){...}' vs. '^ int (int arg){...}'
-sp_after_oc_block_caret                  = ignore   # ignore/add/remove/force
+sp_after_oc_block_caret                  = remove   # ignore/add/remove/force
 
 # Add or remove space between the receiver and selector in a message.
 # '[receiver selector ...]'
@@ -717,10 +717,10 @@ sp_endif_cmt                             = ignore   # ignore/add/remove/force
 sp_after_new                             = ignore   # ignore/add/remove/force
 
 # Controls the spaces before a trailing or embedded comment
-sp_before_tr_emb_cmt                     = ignore   # ignore/add/remove/force
+sp_before_tr_cmt                         = ignore   # ignore/add/remove/force
 
 # Number of spaces before a trailing or embedded comment
-sp_num_before_tr_emb_cmt                 = 0        # number
+sp_num_before_tr_cmt                     = 0        # number
 
 # Control space between a Java annotation and the open paren.
 sp_annotation_paren                      = ignore   # ignore/add/remove/force


### PR DESCRIPTION
Uncrustify 0.74.0 is out, and it has somewhat changed behaviour, so this PR adapts our code to the new behaviour. 

As with 0.73.0, not all changes are desired. For five of the 10 changed files it becomes worse than what it was, for two other files the changes are questionable. Anyway, we have little choice... 

Like with 0.73.0, it will probably take some time before the new version also gets used on GitHub CI. Therefore, I'm just creating this PR now, so that we can merge it right at the moment when it's needed.