### PR TITLE
Make VST windows stay on top when the application is active

### DIFF
--- a/build/package_mac
+++ b/build/package_mac
@@ -2,7 +2,7 @@
 
 APPNAME=mscore
 LONG_NAME="MuseScore"
-LONGER_NAME="MuseScore 3"
+LONGER_NAME="MuseScore 4"
 VERSION=0
 
 while [[ "$#" -gt 0 ]]; do
@@ -15,7 +15,7 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-if [ $VERSION -eq 0 ]; then 
+if [ "$VERSION" = 0 ]; then
     SCRIPT_DIR=$(cd "$(dirname ${BASH_SOURCE[0]})" && pwd)
     VERSION=$(cmake -P "$SCRIPT_DIR/../config.cmake" | sed -n -e "s/^.*VERSION  *//p")
 fi    

--- a/src/framework/vst/CMakeLists.txt
+++ b/src/framework/vst/CMakeLists.txt
@@ -63,6 +63,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/devtools/vstpluginlistmodelexample.cpp
     ${CMAKE_CURRENT_LIST_DIR}/devtools/vstpluginlistmodelexample.h
 
+    ${CMAKE_CURRENT_LIST_DIR}/view/abstractvsteditorview.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/abstractvsteditorview.h
     ${CMAKE_CURRENT_LIST_DIR}/view/vstieditorview.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/vstieditorview.h
     ${CMAKE_CURRENT_LIST_DIR}/view/vstfxeditorview.cpp

--- a/src/framework/vst/devtools/vstpluginlistmodelexample.cpp
+++ b/src/framework/vst/devtools/vstpluginlistmodelexample.cpp
@@ -88,7 +88,7 @@ void VstPluginListModelExample::load()
 
 void VstPluginListModelExample::showSynthPluginEditor()
 {
-    QString uri = QString("musescore://vsti/editor?sync=false&trackId=%1&resourceId=%2")
+    QString uri = QString("musescore://vsti/editor?sync=false&floating=true&trackId=%1&resourceId=%2")
                   .arg(m_currentTrackId)
                   .arg(m_currentSynthResource);
 
@@ -97,7 +97,7 @@ void VstPluginListModelExample::showSynthPluginEditor()
 
 void VstPluginListModelExample::showFxPluginEditor()
 {
-    QString uri = QString("musescore://vstfx/editor?sync=false&trackId=%1&resourceId=%2")
+    QString uri = QString("musescore://vstfx/editor?sync=false&floating=true&trackId=%1&resourceId=%2")
                   .arg(m_currentTrackId)
                   .arg(m_currentFxResource);
 

--- a/src/framework/vst/view/abstractvsteditorview.cpp
+++ b/src/framework/vst/view/abstractvsteditorview.cpp
@@ -1,0 +1,182 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "abstractvsteditorview.h"
+
+#include <QWindow>
+#include <QResizeEvent>
+
+#include "log.h"
+#include "async/async.h"
+
+#include "vsttypes.h"
+#include "internal/vstplugin.h"
+
+using namespace mu::vst;
+using namespace Steinberg;
+
+AbstractVstEditorView::AbstractVstEditorView(QWidget* parent)
+    : QDialog(parent)
+{
+    setAttribute(Qt::WA_NativeWindow, true);
+    updateStayOnTopness();
+    connect(qApp, &QApplication::applicationStateChanged, this, &AbstractVstEditorView::updateStayOnTopness);
+}
+
+AbstractVstEditorView::~AbstractVstEditorView()
+{
+    if (m_view) {
+        m_view->removed();
+    }
+
+    if (m_pluginPtr) {
+        m_pluginPtr->loadingCompleted().resetOnNotify(this);
+    }
+}
+
+tresult AbstractVstEditorView::resizeView(IPlugView* view, ViewRect* newSize)
+{
+    setGeometry(QRect(geometry().x(), geometry().y(), newSize->getWidth(), newSize->getHeight()));
+    view->onSize(newSize);
+
+    update();
+
+    return kResultTrue;
+}
+
+void AbstractVstEditorView::wrapPluginView()
+{
+    m_pluginPtr = getPluginPtr();
+
+    if (!m_pluginPtr) {
+        return;
+    }
+
+    if (m_pluginPtr->isLoaded()) {
+        attachView(m_pluginPtr);
+    } else {
+        m_pluginPtr->loadingCompleted().onNotify(this, [this]() {
+            attachView(m_pluginPtr);
+        });
+    }
+}
+
+void AbstractVstEditorView::attachView(VstPluginPtr pluginPtr)
+{
+    if (!pluginPtr || !pluginPtr->view()) {
+        return;
+    }
+
+    m_view = pluginPtr->view();
+
+    if (m_view->isPlatformTypeSupported(currentPlatformUiType()) != Steinberg::kResultTrue) {
+        return;
+    }
+
+    m_view->setFrame(this);
+
+    Steinberg::tresult attached;
+    attached = m_view->attached(reinterpret_cast<void*>(windowHandle()->winId()), currentPlatformUiType());
+    if (attached != kResultOk) {
+        LOGE() << "Unable to attach vst plugin view to window"
+               << ", resourceId: " << m_resourceId;
+        return;
+    }
+}
+
+FIDString AbstractVstEditorView::currentPlatformUiType() const
+{
+#ifdef Q_OS_MAC
+    return Steinberg::kPlatformTypeNSView;
+#elif defined(Q_OS_IOS)
+    return Steinberg::kPlatformTypeUIView;
+#elif defined(Q_OS_WIN)
+    return Steinberg::kPlatformTypeHWND;
+#else
+    return Steinberg::kPlatformTypeX11EmbedWindowID;
+#endif
+}
+
+int AbstractVstEditorView::trackId() const
+{
+    return m_trackId;
+}
+
+void AbstractVstEditorView::setTrackId(int newTrackId)
+{
+    if (m_trackId == newTrackId) {
+        return;
+    }
+    m_trackId = newTrackId;
+    emit trackIdChanged();
+
+    if (isAbleToWrapPlugin()) {
+        wrapPluginView();
+    }
+}
+
+const QString& AbstractVstEditorView::resourceId() const
+{
+    return m_resourceId;
+}
+
+void AbstractVstEditorView::setResourceId(const QString& newResourceId)
+{
+    if (m_resourceId == newResourceId) {
+        return;
+    }
+    m_resourceId = newResourceId;
+    emit resourceIdChanged();
+
+    setWindowTitle(newResourceId);
+
+    if (isAbleToWrapPlugin()) {
+        wrapPluginView();
+    }
+}
+
+// We want the VST windows to be on top of the main window.
+// But not on top of all other applications when MuseScore isn't active.
+// So when the application becomes active, the VST windows will get the StayOnTop hint.
+// and when the application becomes inactive, the hint will be removed.
+// Some ceremony is required to make this work.
+void AbstractVstEditorView::updateStayOnTopness()
+{
+    bool stay = qApp->applicationState() == Qt::ApplicationActive;
+
+    bool wasShown = isVisible();
+    bool wasActive = isActiveWindow();
+
+    setWindowFlag(Qt::WindowStaysOnTopHint, stay);
+    if (wasShown) {
+        if (!wasActive) {
+            setAttribute(Qt::WA_ShowWithoutActivating, true);
+        }
+        show();
+#ifdef Q_OS_WIN
+        if (!wasActive && !stay) {
+            lower();
+        }
+#endif
+        setAttribute(Qt::WA_ShowWithoutActivating, false);
+    }
+}

--- a/src/framework/vst/view/abstractvsteditorview.h
+++ b/src/framework/vst/view/abstractvsteditorview.h
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_VST_ABSTRACTVSTEDITORVIEW_H
+#define MU_VST_ABSTRACTVSTEDITORVIEW_H
+
+#include <QDialog>
+#include <QWidget>
+
+#include "async/asyncable.h"
+#include "modularity/ioc.h"
+
+#include "ivstpluginsregister.h"
+
+namespace mu::vst {
+class AbstractVstEditorView : public QDialog, public Steinberg::IPlugFrame, public async::Asyncable
+{
+    Q_OBJECT
+
+    Q_PROPERTY(int trackId READ trackId WRITE setTrackId NOTIFY trackIdChanged)
+    Q_PROPERTY(QString resourceId READ resourceId WRITE setResourceId NOTIFY resourceIdChanged)
+
+    INJECT(vst, IVstPluginsRegister, pluginsRegister)
+
+public:
+    AbstractVstEditorView(QWidget* parent = nullptr);
+    ~AbstractVstEditorView();
+
+    Steinberg::tresult resizeView(Steinberg::IPlugView* view, Steinberg::ViewRect* newSize) override;
+
+    int trackId() const;
+    void setTrackId(int newTrackId);
+
+    const QString& resourceId() const;
+    void setResourceId(const QString& newResourceId);
+
+signals:
+    void trackIdChanged();
+    void resourceIdChanged();
+
+protected:
+    virtual bool isAbleToWrapPlugin() const = 0;
+    virtual VstPluginPtr getPluginPtr() const = 0;
+    void wrapPluginView();
+
+private:
+    void attachView(VstPluginPtr pluginPtr);
+
+    void updateStayOnTopness();
+
+    FIDString currentPlatformUiType() const;
+
+    VstPluginPtr m_pluginPtr = nullptr;
+    PluginViewPtr m_view = nullptr;
+
+    audio::TrackId m_trackId = -1;
+    QString m_resourceId;
+    audio::AudioFxChainOrder m_chainOrder = -1;
+};
+}
+
+#endif // MU_VST_ABSTRACTVSTEDITORVIEW_H

--- a/src/framework/vst/view/vstfxeditorview.cpp
+++ b/src/framework/vst/view/vstfxeditorview.cpp
@@ -22,12 +22,6 @@
 
 #include "vstfxeditorview.h"
 
-#include <QWindow>
-#include <QResizeEvent>
-
-#include "log.h"
-#include "async/async.h"
-
 #include "vsttypes.h"
 #include "internal/vstplugin.h"
 
@@ -37,11 +31,8 @@ using namespace Steinberg;
 IMPLEMENT_FUNKNOWN_METHODS(VstFxEditorView, IPlugFrame, IPlugFrame::iid)
 
 VstFxEditorView::VstFxEditorView(QWidget* parent)
-    : QDialog(parent)
+    : AbstractVstEditorView(parent)
 {
-    setAttribute(Qt::WA_NativeWindow, true);
-    updateStayOnTopness();
-    connect(qApp, &QApplication::applicationStateChanged, this, &VstFxEditorView::updateStayOnTopness);
 }
 
 VstFxEditorView::VstFxEditorView(const VstFxEditorView& copy)
@@ -49,123 +40,18 @@ VstFxEditorView::VstFxEditorView(const VstFxEditorView& copy)
 {
 }
 
-VstFxEditorView::~VstFxEditorView()
-{
-    if (m_view) {
-        m_view->removed();
-    }
-
-    if (m_pluginPtr) {
-        m_pluginPtr->loadingCompleted().resetOnNotify(this);
-    }
-}
-
-tresult VstFxEditorView::resizeView(IPlugView* view, ViewRect* newSize)
-{
-    setGeometry(QRect(geometry().x(), geometry().y(), newSize->getWidth(), newSize->getHeight()));
-    view->onSize(newSize);
-
-    return kResultTrue;
-}
-
 bool VstFxEditorView::isAbleToWrapPlugin() const
 {
-    return !m_resourceId.isEmpty() && m_chainOrder != -1;
+    return !resourceId().isEmpty() && m_chainOrder != -1;
 }
 
-void VstFxEditorView::wrapPluginView()
+VstPluginPtr VstFxEditorView::getPluginPtr() const
 {
-    if (m_trackId == -1) {
-        m_pluginPtr = pluginsRegister()->masterFxPlugin(m_resourceId.toStdString(), m_chainOrder);
-    } else {
-        m_pluginPtr = pluginsRegister()->fxPlugin(m_trackId, m_resourceId.toStdString(), m_chainOrder);
+    if (trackId() == -1) {
+        return pluginsRegister()->masterFxPlugin(resourceId().toStdString(), m_chainOrder);
     }
 
-    if (!m_pluginPtr) {
-        return;
-    }
-
-    if (m_pluginPtr->isLoaded()) {
-        attachView(m_pluginPtr);
-    } else {
-        m_pluginPtr->loadingCompleted().onNotify(this, [this]() {
-            attachView(m_pluginPtr);
-        });
-    }
-}
-
-void VstFxEditorView::attachView(VstPluginPtr pluginPtr)
-{
-    if (!pluginPtr || !pluginPtr->view()) {
-        return;
-    }
-
-    m_view = pluginPtr->view();
-
-    if (m_view->isPlatformTypeSupported(currentPlatformUiType()) != Steinberg::kResultTrue) {
-        return;
-    }
-
-    m_view->setFrame(this);
-
-    Steinberg::tresult attached;
-    attached = m_view->attached(reinterpret_cast<void*>(windowHandle()->winId()), currentPlatformUiType());
-    if (attached != kResultOk) {
-        LOGE() << "Unable to attach vsti plugin view to window"
-               << ", resourceId: " << m_resourceId;
-        return;
-    }
-}
-
-FIDString VstFxEditorView::currentPlatformUiType() const
-{
-#ifdef Q_OS_MAC
-    return Steinberg::kPlatformTypeNSView;
-#elif defined(Q_OS_IOS)
-    return Steinberg::kPlatformTypeUIView;
-#elif defined(Q_OS_WIN)
-    return Steinberg::kPlatformTypeHWND;
-#else
-    return Steinberg::kPlatformTypeX11EmbedWindowID;
-#endif
-}
-
-int VstFxEditorView::trackId() const
-{
-    return m_trackId;
-}
-
-void VstFxEditorView::setTrackId(int newTrackId)
-{
-    if (m_trackId == newTrackId) {
-        return;
-    }
-    m_trackId = newTrackId;
-    emit trackIdChanged();
-
-    if (isAbleToWrapPlugin()) {
-        wrapPluginView();
-    }
-}
-
-const QString& VstFxEditorView::resourceId() const
-{
-    return m_resourceId;
-}
-
-void VstFxEditorView::setResourceId(const QString& newResourceId)
-{
-    if (m_resourceId == newResourceId) {
-        return;
-    }
-    m_resourceId = newResourceId;
-    emit resourceIdChanged();
-
-    setWindowTitle(newResourceId);
-
-    if (isAbleToWrapPlugin()) {
-        wrapPluginView();
-    }
+    return pluginsRegister()->fxPlugin(trackId(), resourceId().toStdString(), m_chainOrder);
 }
 
 int VstFxEditorView::chainOrder() const
@@ -184,29 +70,4 @@ void VstFxEditorView::setChainOrder(int newChainOrder)
     if (isAbleToWrapPlugin()) {
         wrapPluginView();
     }
-}
-
-// We want the VST windows to be on top of the main window.
-// But not on top of all other applications when MuseScore isn't active.
-// Qt has no API for this, so we use a hack.
-// When the application becomes active, the VST windows will get the StayOnTop hint.
-// When the application becomes inactive, the hint will be dropped.
-// The nice thing is that it works... (with some ceremony)
-void VstFxEditorView::updateStayOnTopness()
-{
-    auto setStayOnTop = [this](bool stay) {
-        bool wasShown = isVisible();
-        bool wasActive = isActiveWindow();
-
-        setWindowFlag(Qt::WindowStaysOnTopHint, stay);
-        if (wasShown) {
-            if (!wasActive) {
-                setAttribute(Qt::WA_ShowWithoutActivating, true);
-            }
-            show();
-            setAttribute(Qt::WA_ShowWithoutActivating, false);
-        }
-    };
-
-    setStayOnTop(qApp->applicationState() == Qt::ApplicationActive);
 }

--- a/src/framework/vst/view/vstfxeditorview.h
+++ b/src/framework/vst/view/vstfxeditorview.h
@@ -23,61 +23,31 @@
 #ifndef MU_VST_VSTFXEDITORVIEW_H
 #define MU_VST_VSTFXEDITORVIEW_H
 
-#include <QDialog>
-#include <QWidget>
-
-#include "async/asyncable.h"
-#include "modularity/ioc.h"
-
-#include "ivstpluginsregister.h"
+#include "vstieditorview.h"
 
 namespace mu::vst {
-class VstFxEditorView : public QDialog, public Steinberg::IPlugFrame, public async::Asyncable
+class VstFxEditorView : public AbstractVstEditorView
 {
     Q_OBJECT
 
-    Q_PROPERTY(int trackId READ trackId WRITE setTrackId NOTIFY trackIdChanged)
-    Q_PROPERTY(QString resourceId READ resourceId WRITE setResourceId NOTIFY resourceIdChanged)
     Q_PROPERTY(int chainOrder READ chainOrder WRITE setChainOrder NOTIFY chainOrderChanged)
 
-    INJECT(vst, IVstPluginsRegister, pluginsRegister)
-
     DECLARE_FUNKNOWN_METHODS
+
 public:
-    VstFxEditorView(QWidget* parent = nullptr);
+    explicit VstFxEditorView(QWidget* parent = nullptr);
     VstFxEditorView(const VstFxEditorView& copy);
-    ~VstFxEditorView();
-
-    Steinberg::tresult resizeView(Steinberg::IPlugView* view, Steinberg::ViewRect* newSize) override;
-
-    int trackId() const;
-    void setTrackId(int newTrackId);
-
-    const QString& resourceId() const;
-    void setResourceId(const QString& newResourceId);
 
     int chainOrder() const;
     void setChainOrder(int newChainOrder);
 
 signals:
-    void trackIdChanged();
-    void resourceIdChanged();
     void chainOrderChanged();
 
 private:
-    bool isAbleToWrapPlugin() const;
-    void wrapPluginView();
-    void attachView(VstPluginPtr pluginPtr);
+    bool isAbleToWrapPlugin() const override;
+    VstPluginPtr getPluginPtr() const override;
 
-    void updateStayOnTopness();
-
-    FIDString currentPlatformUiType() const;
-
-    VstPluginPtr m_pluginPtr = nullptr;
-    PluginViewPtr m_view = nullptr;
-
-    audio::TrackId m_trackId = -1;
-    QString m_resourceId;
     audio::AudioFxChainOrder m_chainOrder = -1;
 };
 }

--- a/src/framework/vst/view/vstfxeditorview.h
+++ b/src/framework/vst/view/vstfxeditorview.h
@@ -69,6 +69,8 @@ private:
     void wrapPluginView();
     void attachView(VstPluginPtr pluginPtr);
 
+    void updateStayOnTopness();
+
     FIDString currentPlatformUiType() const;
 
     VstPluginPtr m_pluginPtr = nullptr;

--- a/src/framework/vst/view/vstieditorview.cpp
+++ b/src/framework/vst/view/vstieditorview.cpp
@@ -39,6 +39,8 @@ VstiEditorView::VstiEditorView(QWidget* parent)
     : QDialog(parent)
 {
     setAttribute(Qt::WA_NativeWindow, true);
+    updateStayOnTopness();
+    connect(qApp, &QApplication::applicationStateChanged, this, &VstiEditorView::updateStayOnTopness);
 }
 
 VstiEditorView::VstiEditorView(const VstiEditorView& copy)
@@ -152,4 +154,29 @@ void VstiEditorView::setResourceId(const QString& newResourceId)
     if (m_trackId != -1 && !m_resourceId.isEmpty()) {
         wrapPluginView();
     }
+}
+
+// We want the VST windows to be on top of the main window.
+// But not on top of all other applications when MuseScore isn't active.
+// Qt has no API for this, so we use a hack.
+// When the application becomes active, the VST windows will get the StayOnTop hint.
+// When the application becomes inactive, the hint will be dropped.
+// The nice thing is that it works... (with some ceremony)
+void VstiEditorView::updateStayOnTopness()
+{
+    auto setStayOnTop = [this](bool stay) {
+        bool wasShown = isVisible();
+        bool wasActive = isActiveWindow();
+
+        setWindowFlag(Qt::WindowStaysOnTopHint, stay);
+        if (wasShown) {
+            if (!wasActive) {
+                setAttribute(Qt::WA_ShowWithoutActivating, true);
+            }
+            show();
+            setAttribute(Qt::WA_ShowWithoutActivating, false);
+        }
+    };
+
+    setStayOnTop(qApp->applicationState() == Qt::ApplicationActive);
 }

--- a/src/framework/vst/view/vstieditorview.h
+++ b/src/framework/vst/view/vstieditorview.h
@@ -23,56 +23,22 @@
 #ifndef MU_VST_VSTIEDITORVIEW_H
 #define MU_VST_VSTIEDITORVIEW_H
 
-#include <QDialog>
-#include <QWidget>
-
-#include "async/asyncable.h"
-#include "modularity/ioc.h"
-
-#include "ivstpluginsregister.h"
+#include "abstractvsteditorview.h"
 
 namespace mu::vst {
-class VstiEditorView : public QDialog, public Steinberg::IPlugFrame, public async::Asyncable
+class VstiEditorView : public AbstractVstEditorView
 {
     Q_OBJECT
 
-    Q_PROPERTY(int trackId READ trackId WRITE setTrackId NOTIFY trackIdChanged)
-    Q_PROPERTY(QString resourceId READ resourceId WRITE setResourceId NOTIFY resourceIdChanged)
-
-    INJECT(vst, IVstPluginsRegister, pluginsRegister)
-
     DECLARE_FUNKNOWN_METHODS
+
 public:
-    VstiEditorView(QWidget* parent = nullptr);
+    explicit VstiEditorView(QWidget* parent = nullptr);
     VstiEditorView(const VstiEditorView& copy);
-    ~VstiEditorView();
-
-    Steinberg::tresult resizeView(Steinberg::IPlugView* view, Steinberg::ViewRect* newSize) override;
-
-    int trackId() const;
-    void setTrackId(int newTrackId);
-
-    const QString& resourceId() const;
-    void setResourceId(const QString& newResourceId);
-
-signals:
-    void trackIdChanged();
-
-    void resourceIdChanged();
 
 private:
-    void wrapPluginView();
-    void attachView(VstPluginPtr pluginPtr);
-
-    void updateStayOnTopness();
-
-    FIDString currentPlatformUiType() const;
-
-    VstPluginPtr m_pluginPtr = nullptr;
-    PluginViewPtr m_view = nullptr;
-
-    audio::TrackId m_trackId = -1;
-    QString m_resourceId;
+    bool isAbleToWrapPlugin() const override;
+    VstPluginPtr getPluginPtr() const override;
 };
 }
 

--- a/src/framework/vst/view/vstieditorview.h
+++ b/src/framework/vst/view/vstieditorview.h
@@ -64,6 +64,8 @@ private:
     void wrapPluginView();
     void attachView(VstPluginPtr pluginPtr);
 
+    void updateStayOnTopness();
+
     FIDString currentPlatformUiType() const;
 
     VstPluginPtr m_pluginPtr = nullptr;

--- a/src/playback/view/internal/mixerchannelitem.cpp
+++ b/src/playback/view/internal/mixerchannelitem.cpp
@@ -34,8 +34,8 @@ static constexpr float BALANCE_SCALING_FACTOR = 100.f;
 
 static constexpr int OUTPUT_RESOURCE_COUNT_LIMIT = 4;
 
-static const std::string VSTFX_EDITOR_URI("musescore://vstfx/editor?sync=false&modal=false");
-static const std::string VSTI_EDITOR_URI("musescore://vsti/editor?sync=false&modal=false");
+static const std::string VSTFX_EDITOR_URI("musescore://vstfx/editor?sync=false&floating=true&modal=false");
+static const std::string VSTI_EDITOR_URI("musescore://vsti/editor?sync=false&floating=true&modal=false");
 
 static const std::string TRACK_ID_KEY("trackId");
 static const std::string RESOURCE_ID_KEY("resourceId");


### PR DESCRIPTION
Resolves: #9157

Also introduces a common base class for VstFxEditorView and VstiEditorView to reduce code duplication.