### PR TITLE
Prevent CoreMidiPorts related crashes on macOS when running app in command line mode

### DIFF
--- a/src/framework/midi/internal/platform/osx/coremidiinport.cpp
+++ b/src/framework/midi/internal/platform/osx/coremidiinport.cpp
@@ -38,6 +38,11 @@ struct mu::midi::CoreMidiInPort::Core {
     int deviceID = -1;
 };
 
+CoreMidiInPort::CoreMidiInPort()
+    : m_core(std::make_unique<Core>())
+{
+}
+
 CoreMidiInPort::~CoreMidiInPort()
 {
     if (isConnected()) {
@@ -55,7 +60,6 @@ CoreMidiInPort::~CoreMidiInPort()
 
 void CoreMidiInPort::init()
 {
-    m_core = std::make_shared<Core>();
     initCore();
 }
 
@@ -150,7 +154,7 @@ void CoreMidiInPort::initCore()
 
     QString portName = "MuseScore MIDI input port";
     if (__builtin_available(macOS 11.0, *)) {
-        MIDIReceiveBlock receiveBlock = ^(const MIDIEventList* eventList, void* /*srcConnRefCon*/) {
+        MIDIReceiveBlock receiveBlock = ^ (const MIDIEventList* eventList, void* /*srcConnRefCon*/) {
             const MIDIEventPacket* packet = eventList->packet;
             for (UInt32 index = 0; index < eventList->numPackets; index++) {
                 // Handle packet
@@ -170,7 +174,7 @@ void CoreMidiInPort::initCore()
         result
             = MIDIInputPortCreateWithProtocol(m_core->client, portName.toCFString(), kMIDIProtocol_2_0, &m_core->inputPort, receiveBlock);
     } else {
-        MIDIReadBlock readBlock = ^(const MIDIPacketList* packetList, void* /*srcConnRefCon*/)
+        MIDIReadBlock readBlock = ^ (const MIDIPacketList* packetList, void* /*srcConnRefCon*/)
         {
             const MIDIPacket* packet = packetList->packet;
             for (UInt32 index = 0; index < packetList->numPackets; index++) {

--- a/src/framework/midi/internal/platform/osx/coremidiinport.h
+++ b/src/framework/midi/internal/platform/osx/coremidiinport.h
@@ -30,7 +30,7 @@ namespace mu::midi {
 class CoreMidiInPort : public IMidiInPort
 {
 public:
-    CoreMidiInPort() = default;
+    CoreMidiInPort();
     ~CoreMidiInPort() override;
 
     void init();
@@ -52,7 +52,7 @@ private:
     void initCore();
 
     struct Core;
-    std::shared_ptr<Core> m_core;
+    std::unique_ptr<Core> m_core;
     MidiDeviceID m_deviceID;
     async::Notification m_devicesChanged;
 

--- a/src/framework/midi/internal/platform/osx/coremidioutport.cpp
+++ b/src/framework/midi/internal/platform/osx/coremidioutport.cpp
@@ -39,6 +39,11 @@ struct mu::midi::CoreMidiOutPort::Core {
     int deviceID = -1;
 };
 
+CoreMidiOutPort::CoreMidiOutPort()
+    : m_core(std::make_unique<Core>())
+{
+}
+
 CoreMidiOutPort::~CoreMidiOutPort()
 {
     if (isConnected()) {
@@ -55,7 +60,6 @@ CoreMidiOutPort::~CoreMidiOutPort()
 
 void CoreMidiOutPort::init()
 {
-    m_core = std::make_shared<Core>();
     initCore();
 }
 

--- a/src/framework/midi/internal/platform/osx/coremidioutport.h
+++ b/src/framework/midi/internal/platform/osx/coremidioutport.h
@@ -30,7 +30,7 @@ namespace mu::midi {
 class CoreMidiOutPort : public IMidiOutPort
 {
 public:
-    CoreMidiOutPort() = default;
+    CoreMidiOutPort();
     ~CoreMidiOutPort() override;
 
     void init();
@@ -49,7 +49,7 @@ private:
     void initCore();
 
     struct Core;
-    std::shared_ptr<Core> m_core;
+    std::unique_ptr<Core> m_core;
     MidiDeviceID m_deviceID;
 
     async::Notification m_devicesChanged;

--- a/src/notation/notationmodule.cpp
+++ b/src/notation/notationmodule.cpp
@@ -198,13 +198,16 @@ void NotationModule::registerUiTypes()
     }
 }
 
-void NotationModule::onInit(const framework::IApplication::RunMode&)
+void NotationModule::onInit(const framework::IApplication::RunMode& mode)
 {
     s_configuration->init();
     s_instrumentsRepository->init();
     s_actionController->init();
     s_notationUiActions->init();
-    s_midiInputController->init();
+
+    if (mode == framework::IApplication::RunMode::Editor) {
+        s_midiInputController->init();
+    }
 
     Notation::init();
 


### PR DESCRIPTION
The MIDI ports are inited only in Editor mode, but the NotationMidiInputController depends on them and was inited also in command line mode, which caused a crash. Now, the NotationMidiInputController will also be inited only when running in Editor mode.

The app would also crash while stopping, because in their destructors, `CoreMidiInPort` and `CoreMidiOutPort` assume that their `m_core` has been created (not nullptr). That was only the case in Editor mode, but not in Converter mode. Now, the `m_core` is created, but still only fully inited in Editor mode.

This also solves a crash when for some reason the app quits before CoreMidiPorts are initialized, which happens sometimes when there is a QML load error. 

In practice, these crashes seem fixed now. However, theoretically it is not totally safe yet. In editor mode, the NotationMidiInputController (which is initialized in `NotationModule::onInit`) still assumes the midi ports are initialized already, but since the order in which the modules is undefined by design, there is no guarantee.