### PR TITLE
[MU4] wincore_audio_driver_log_output

### DIFF
--- a/src/framework/audio/internal/platform/win/wincoreaudiodriver.cpp
+++ b/src/framework/audio/internal/platform/win/wincoreaudiodriver.cpp
@@ -193,6 +193,14 @@ bool CoreAudioDriver::isOpened() const
 
 void logError(HRESULT hr)
 {
+    static HRESULT lastError = S_OK;
+
+    if (hr == lastError) {
+        return;
+    }
+
+    lastError = hr;
+
     switch (hr) {
     case S_OK: return;
     case AUDCLNT_E_NOT_INITIALIZED: LOGE() << "AUDCLNT_E_NOT_INITIALIZED";


### PR DESCRIPTION
Temporary workaround to prevent overfilled log file, which literally eats free space on Windows

A proper fix will come with this task from [TECH_DEBTS] project - https://github.com/musescore/MuseScore/issues/9842