### PR TITLE
Fix computation of smallness for tuplets

### DIFF
--- a/src/engraving/libmscore/tuplet.cpp
+++ b/src/engraving/libmscore/tuplet.cpp
@@ -206,14 +206,14 @@ void Tuplet::layout()
             _number->setXmlText(QString("%1:%2").arg(_ratio.numerator()).arg(_ratio.denominator()));
         }
 
-        bool isSmall = true;
+        _isSmall = true;
         for (const DurationElement* e : _elements) {
-            if (e->isChordRest() && !toChordRest(e)->isSmall()) {
-                isSmall = false;
+            if ((e->isChordRest() && !toChordRest(e)->isSmall()) || (e->isTuplet() && !toTuplet(e)->isSmall())) {
+                _isSmall = false;
                 break;
             }
         }
-        _number->setMag(isSmall ? score()->styleD(Sid::smallNoteMag) : 1.0);
+        _number->setMag(_isSmall ? score()->styleD(Sid::smallNoteMag) : 1.0);
     } else {
         if (_number) {
             if (_number->selected()) {

--- a/src/engraving/libmscore/tuplet.h
+++ b/src/engraving/libmscore/tuplet.h
@@ -55,6 +55,7 @@ class Tuplet final : public DurationElement
     TDuration _baseLen;        // 1/8 for a triplet of 1/8
 
     bool _isUp;
+    bool _isSmall;
 
     Fraction _tick;
 
@@ -138,6 +139,7 @@ public:
     void setDirection(Direction d) { _direction = d; }
     Direction direction() const { return _direction; }
     bool isUp() const { return _isUp; }
+    bool isSmall() const { return _isSmall; }
     Fraction tick() const override { return _tick; }
     Fraction rtick() const override;
     void setTick(const Fraction& v) { _tick = v; }


### PR DESCRIPTION
The problem:
![image](https://user-images.githubusercontent.com/89263931/143093434-a2cf9cba-5d6d-48c1-ae40-ddfbbb4b3528.png)

The issue was that a tuplet is set to small if all of its elements are small chordrests. More accurately, it is set to regular size if any of its elements are normal-sized chordrests. This fails for tuplets whose elements are only other tuplets, and the containing tuplet remains small.

Since tuplets are laid out from contained to containing, the fix adds an `isSmall` value which is set in the layout function, which layout checks in a way similar to how it checks the smallness of chordrests:
![image](https://user-images.githubusercontent.com/89263931/143093869-bb29921c-6786-4fe8-844f-b4d47fb60d8a.png)
![image](https://user-images.githubusercontent.com/89263931/143093887-8e273bbb-1d53-421d-a8ca-1ca580ae824c.png)
