### PR TITLE
Added Profiler View and Removed update parts name on drop elements

### DIFF
--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -318,6 +318,7 @@ MenuItem AppMenuModel::diagnosticItem() const
 {
     MenuItemList systemItems {
         makeMenuItem("diagnostic-show-paths"),
+        makeMenuItem("diagnostic-show-profiler"),
     };
 
     MenuItemList accessibilityItems {

--- a/src/diagnostics/CMakeLists.txt
+++ b/src/diagnostics/CMakeLists.txt
@@ -45,6 +45,9 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/diagnosticaccessiblemodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/diagnosticaccessiblemodel.h
 
+    ${CMAKE_CURRENT_LIST_DIR}/view/system/profilerviewmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/system/profilerviewmodel.h
+
     ${CMAKE_CURRENT_LIST_DIR}/view/keynav/diagnosticnavigationmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/keynav/diagnosticnavigationmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/keynav/abstractkeynavdevitem.cpp

--- a/src/diagnostics/diagnostics.qrc
+++ b/src/diagnostics/diagnostics.qrc
@@ -9,5 +9,7 @@
         <file>qml/MuseScore/Diagnostics/DiagnosticAccessiblePanel.qml</file>
         <file>qml/MuseScore/Diagnostics/EngravingElementsDialog.qml</file>
         <file>qml/MuseScore/Diagnostics/EngravingElementsPanel.qml</file>
+        <file>qml/MuseScore/Diagnostics/DiagnosticProfilerDialog.qml</file>
+        <file>qml/MuseScore/Diagnostics/DiagnosticProfilerPanel.qml</file>
     </qresource>
 </RCC>

--- a/src/diagnostics/diagnosticsmodule.cpp
+++ b/src/diagnostics/diagnosticsmodule.cpp
@@ -33,6 +33,7 @@
 #include "internal/engravingelementsprovider.h"
 
 #include "view/diagnosticspathsmodel.h"
+#include "view/system/profilerviewmodel.h"
 
 #include "view/keynav/diagnosticnavigationmodel.h"
 #include "view/keynav/abstractkeynavdevitem.h"
@@ -65,6 +66,7 @@ void DiagnosticsModule::resolveImports()
     auto ir = ioc()->resolve<ui::IInteractiveUriRegister>(moduleName());
     if (ir) {
         ir->registerQmlUri(Uri("musescore://diagnostics/system/paths"), "MuseScore/Diagnostics/DiagnosticPathsDialog.qml");
+        ir->registerQmlUri(Uri("musescore://diagnostics/system/profiler"), "MuseScore/Diagnostics/DiagnosticProfilerDialog.qml");
         ir->registerQmlUri(Uri("musescore://diagnostics/navigation/tree"), "MuseScore/Diagnostics/DiagnosticNavigationDialog.qml");
         ir->registerQmlUri(Uri("musescore://diagnostics/accessible/tree"), "MuseScore/Diagnostics/DiagnosticAccessibleDialog.qml");
         ir->registerQmlUri(Uri("musescore://diagnostics/engraving/elements"), "MuseScore/Diagnostics/EngravingElementsDialog.qml");
@@ -79,6 +81,7 @@ void DiagnosticsModule::resolveImports()
 void DiagnosticsModule::registerUiTypes()
 {
     qmlRegisterType<DiagnosticsPathsModel>("MuseScore.Diagnostics", 1, 0, "DiagnosticsPathsModel");
+    qmlRegisterType<ProfilerViewModel>("MuseScore.Diagnostics", 1, 0, "ProfilerViewModel");
 
     qmlRegisterType<DiagnosticNavigationModel>("MuseScore.Diagnostics", 1, 0, "DiagnosticNavigationModel");
     qmlRegisterUncreatableType<AbstractKeyNavDevItem>("MuseScore.Diagnostics", 1, 0, "AbstractKeyNavDevItem", "Cannot create a Abstract");

--- a/src/diagnostics/internal/diagnosticsactions.cpp
+++ b/src/diagnostics/internal/diagnosticsactions.cpp
@@ -32,6 +32,10 @@ const UiActionList DiagnosticsActions::m_actions = {
              mu::context::UiCtxAny,
              QT_TRANSLATE_NOOP("action", "Show paths…")
              ),
+    UiAction("diagnostic-show-profiler",
+             mu::context::UiCtxAny,
+             QT_TRANSLATE_NOOP("action", "Show profiler…")
+             ),
     UiAction("diagnostic-show-navigation-tree",
              mu::context::UiCtxAny,
              QT_TRANSLATE_NOOP("action", "Show navigation tree…")

--- a/src/diagnostics/internal/diagnosticsactionscontroller.cpp
+++ b/src/diagnostics/internal/diagnosticsactionscontroller.cpp
@@ -29,6 +29,7 @@ using namespace mu::diagnostics;
 using namespace mu::accessibility;
 
 static const mu::UriQuery SYSTEN_PATHS_URI("musescore://diagnostics/system/paths?sync=false&modal=false&floating=true");
+static const mu::UriQuery PROFILER_URI("musescore://diagnostics/system/profiler?sync=false&modal=false&floating=true");
 static const mu::UriQuery NAVIGATION_TREE_URI("musescore://diagnostics/navigation/tree?sync=false&modal=false&floating=true");
 static const mu::UriQuery ACCESSIBLE_TREE_URI("musescore://diagnostics/accessible/tree?sync=false&modal=false&floating=true");
 static const mu::UriQuery ENGRAVING_ELEMENTS_URI("musescore://diagnostics/engraving/elements?sync=false&modal=false&floating=true");
@@ -36,6 +37,7 @@ static const mu::UriQuery ENGRAVING_ELEMENTS_URI("musescore://diagnostics/engrav
 void DiagnosticsActionsController::init()
 {
     dispatcher()->reg(this, "diagnostic-show-paths", [this]() { openUri(SYSTEN_PATHS_URI); });
+    dispatcher()->reg(this, "diagnostic-show-profiler", [this]() { openUri(PROFILER_URI); });
     dispatcher()->reg(this, "diagnostic-show-navigation-tree", [this]() { openUri(NAVIGATION_TREE_URI); });
     dispatcher()->reg(this, "diagnostic-show-accessible-tree", [this]() { openUri(ACCESSIBLE_TREE_URI); });
     dispatcher()->reg(this, "diagnostic-accessible-tree-dump", []() { DiagnosticAccessibleModel::dumpTree(); });

--- a/src/diagnostics/qml/MuseScore/Diagnostics/DiagnosticProfilerDialog.qml
+++ b/src/diagnostics/qml/MuseScore/Diagnostics/DiagnosticProfilerDialog.qml
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.15
+import MuseScore.Ui 1.0
+import MuseScore.UiComponents 1.0
+
+StyledDialogView {
+    id: root
+
+    title: "Diagnostic: Profile"
+
+    contentHeight: 800
+    contentWidth: 900
+    resizable: true
+
+    //! NOTE It is necessary that it can be determined that this is an object for diagnostics
+    contentItem.objectName: panel.objectName
+
+    DiagnosticProfilerPanel {
+        id: panel
+        anchors.fill: parent
+    }
+}

--- a/src/diagnostics/qml/MuseScore/Diagnostics/DiagnosticProfilerPanel.qml
+++ b/src/diagnostics/qml/MuseScore/Diagnostics/DiagnosticProfilerPanel.qml
@@ -1,0 +1,129 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.15
+import QtQuick.Controls 1.4
+import QtQuick.Controls.Styles 1.4
+
+import MuseScore.Ui 1.0
+import MuseScore.UiComponents 1.0
+import MuseScore.Diagnostics 1.0
+
+Rectangle {
+
+    id: root
+
+    objectName: "DiagnosticProfilePanel"
+    color: ui.theme.backgroundPrimaryColor
+
+    Component.onCompleted: {
+        updateContent()
+    }
+
+    function updateContent() {
+        profModel.reload()
+    }
+
+    Item {
+        id: toolPanel
+        anchors.left: parent.left
+        anchors.right: parent.right
+        height: 48
+
+        TextInputField {
+            id: inputItem
+            anchors.left: parent.left
+            anchors.right: btnRow.left
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.margins: 16
+            onCurrentTextEdited: {
+                profModel.find(newTextValue)
+            }
+        }
+
+        Row {
+            id: btnRow
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            anchors.right: parent.right
+            width: childrenRect.width
+            spacing: 8
+
+            FlatButton {
+                anchors.verticalCenter: parent.verticalCenter
+                text: "Update"
+                onClicked: root.updateContent()
+            }
+
+            FlatButton {
+                anchors.verticalCenter: parent.verticalCenter
+                text: "Print"
+                onClicked: profModel.print()
+            }
+
+            FlatButton {
+                anchors.verticalCenter: parent.verticalCenter
+                text: "Clear"
+                onClicked: profModel.clear()
+            }
+        }
+    }
+
+    ProfilerViewModel {
+        id: profModel
+    }
+
+    ListView {
+        anchors.top: toolPanel.bottom
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        clip: true
+        model: profModel
+        section.property: "groupRole"
+        section.delegate: Rectangle {
+            width: parent.width
+            height: 24
+            color: ui.theme.backgroundSecondaryColor
+            StyledTextLabel {
+                anchors.fill: parent
+                anchors.margins: 2
+                horizontalAlignment: Qt.AlignLeft
+                text: section
+            }
+        }
+        delegate: ListItemBlank {
+
+            anchors.left: parent ? parent.left : undefined
+            anchors.right: parent ? parent.right : undefined
+            height: 24
+
+            StyledTextLabel {
+                anchors.fill: parent
+                anchors.leftMargin: 16
+                verticalAlignment: Text.AlignVCenter
+                horizontalAlignment: Text.AlignLeft
+                font.family: "Consolas"
+                text: dataRole
+            }
+        }
+    }
+}

--- a/src/diagnostics/qml/MuseScore/Diagnostics/DiagnosticProfilerPanel.qml
+++ b/src/diagnostics/qml/MuseScore/Diagnostics/DiagnosticProfilerPanel.qml
@@ -75,14 +75,14 @@ Rectangle {
 
             FlatButton {
                 anchors.verticalCenter: parent.verticalCenter
-                text: "Print"
-                onClicked: profModel.print()
+                text: "Clear"
+                onClicked: profModel.clear()
             }
 
             FlatButton {
                 anchors.verticalCenter: parent.verticalCenter
-                text: "Clear"
-                onClicked: profModel.clear()
+                text: "Print"
+                onClicked: profModel.print()
             }
         }
     }

--- a/src/diagnostics/qml/MuseScore/Diagnostics/qmldir
+++ b/src/diagnostics/qml/MuseScore/Diagnostics/qmldir
@@ -5,3 +5,5 @@ DiagnosticNavigationDialog 1.0 DiagnosticNavigationDialog.qml
 DiagnosticNavigationPanel 1.0 DiagnosticNavigationPanel.qml
 EngravingElementsDialog 1.0 EngravingElementsDialog.qml
 EngravingElementsPanel 1.0 EngravingElementsPanel.qml
+DiagnosticProfilerDialog 1.0 DiagnosticProfilerDialog.qml
+DiagnosticProfilerPanel 1.0 DiagnosticProfilerPanel.qml

--- a/src/diagnostics/view/system/profilerviewmodel.cpp
+++ b/src/diagnostics/view/system/profilerviewmodel.cpp
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "profilerviewmodel.h"
+
+#include "log.h"
+
+using namespace mu::diagnostics;
+using namespace haw::profiler;
+
+ProfilerViewModel::ProfilerViewModel(QObject* parent)
+    : QAbstractListModel(parent)
+{
+}
+
+QVariant ProfilerViewModel::data(const QModelIndex& index, int role) const
+{
+    if (!index.isValid()) {
+        return QVariant();
+    }
+
+    const Item& item = m_list.at(index.row());
+    switch (role) {
+    case rData: return QVariant::fromValue(item.data);
+    case rGroup: return QVariant::fromValue(item.group);
+    default: break;
+    }
+
+    return QVariant();
+}
+
+int ProfilerViewModel::rowCount(const QModelIndex& parent) const
+{
+    Q_UNUSED(parent);
+    return m_list.count();
+}
+
+QHash<int, QByteArray> ProfilerViewModel::roleNames() const
+{
+    static const QHash<int, QByteArray> roles = {
+        { rData, "dataRole" },
+        { rGroup, "groupRole" },
+    };
+    return roles;
+}
+
+void ProfilerViewModel::reload()
+{
+    m_allList.clear();
+
+    QString group = "Main thread";
+    QString str = QString::fromStdString(Profiler::instance()->threadsDataString(Profiler::Data::OnlyMain));
+    QStringList list = str.split("\n");
+    foreach (const QString& data, list) {
+        Item item;
+        item.group = group;
+        item.data = data;
+
+        m_allList.append(item);
+    }
+
+    group = "Other thread";
+    str = QString::fromStdString(Profiler::instance()->threadsDataString(Profiler::Data::OnlyOther));
+    list = str.split("\n");
+    foreach (const QString& data, list) {
+        Item item;
+        item.group = group;
+        item.data = data;
+
+        m_allList.append(item);
+    }
+
+    find(m_searchText);
+}
+
+void ProfilerViewModel::find(const QString& str)
+{
+    beginResetModel();
+
+    m_searchText = str;
+
+    if (m_searchText.isEmpty()) {
+        m_list = m_allList;
+    } else {
+        m_list.clear();
+        for (const Item& item : m_allList) {
+            if (item.data.contains(m_searchText, Qt::CaseInsensitive)) {
+                m_list.append(item);
+            }
+        }
+    }
+
+    endResetModel();
+}
+
+void ProfilerViewModel::clear()
+{
+    PROFILER_CLEAR;
+    reload();
+}
+
+void ProfilerViewModel::print()
+{
+    PROFILER_PRINT;
+}

--- a/src/diagnostics/view/system/profilerviewmodel.h
+++ b/src/diagnostics/view/system/profilerviewmodel.h
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_DIAGNOSTICS_PROFILERVIEWMODEL_H
+#define MU_DIAGNOSTICS_PROFILERVIEWMODEL_H
+
+#include <QAbstractListModel>
+
+namespace mu::diagnostics {
+class ProfilerViewModel : public QAbstractListModel
+{
+    Q_OBJECT
+public:
+    explicit ProfilerViewModel(QObject* parent = 0);
+
+    QVariant data(const QModelIndex& index, int role) const override;
+    int rowCount(const QModelIndex& parent) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+    Q_INVOKABLE void reload();
+    Q_INVOKABLE void find(const QString& str);
+    Q_INVOKABLE void clear();
+    Q_INVOKABLE void print();
+
+private:
+
+    enum Roles {
+        rData = Qt::UserRole + 1,
+        rGroup
+    };
+
+    struct Item {
+        QString group;
+        QString data;
+    };
+
+    QHash<int, QByteArray> m_roles;
+    QList<Item> m_list;
+    QList<Item> m_allList;
+    QString m_searchText;
+};
+}
+
+#endif // MU_DIAGNOSTICS_PROFILERVIEWMODEL_H

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -63,6 +63,8 @@
 #include "slur.h"
 #include "fingering.h"
 
+#include "log.h"
+
 using namespace mu;
 using namespace mu::engraving;
 
@@ -1643,6 +1645,7 @@ void Chord::layout2()
 
 static void updatePercussionNotes(Chord* c, const Drumset* drumset)
 {
+    TRACEFUNC;
     for (Chord* ch : c->graceNotes()) {
         updatePercussionNotes(ch, drumset);
     }
@@ -1654,7 +1657,8 @@ static void updatePercussionNotes(Chord* c, const Drumset* drumset)
             int pitch = note->pitch();
             if (!drumset->isValid(pitch)) {
                 note->setLine(0);
-                qWarning("unmapped drum note %d", pitch);
+                //! NOTE May be called too often
+                //qWarning("unmapped drum note %d", pitch);
             } else if (!note->fixed()) {
                 note->undoChangeProperty(Pid::HEAD_GROUP, int(drumset->noteHead(pitch)));
                 note->setLine(drumset->line(pitch));

--- a/src/engraving/libmscore/engravingitem.cpp
+++ b/src/engraving/libmscore/engravingitem.cpp
@@ -183,7 +183,8 @@ EngravingItem::~EngravingItem()
 void EngravingItem::setup()
 {
     static std::list<ElementType> accessibleDisabled = {
-        ElementType::LEDGER_LINE
+        ElementType::LEDGER_LINE,
+        ElementType::SYSTEM
     };
 
     if (score() && !score()->isPaletteScore()) {

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -60,10 +60,6 @@ static QString formatPartTitle(const Part* part)
 NotationParts::NotationParts(IGetScore* getScore, INotationInteractionPtr interaction, INotationUndoStackPtr undoStack)
     : m_getScore(getScore), m_undoStack(undoStack), m_interaction(interaction)
 {
-    m_interaction->dropChanged().onNotify(this, [this]() {
-        updatePartTitles();
-    });
-
     m_undoStack->undoNotification().onNotify(this, [this]() {
         m_partChangedNotifier.changed();
     });
@@ -321,6 +317,7 @@ void NotationParts::setPartTransposition(const ID& partId, const Interval& trans
 
 void NotationParts::updatePartTitles()
 {
+    TRACEFUNC;
     for (const Part* part: score()->parts()) {
         setPartName(part->id(), formatPartTitle(part));
     }

--- a/thirdparty/haw_profiler/src/profiler.h
+++ b/thirdparty/haw_profiler/src/profiler.h
@@ -116,7 +116,8 @@ public:
         virtual void printTraceEnd(const std::string& func, double calltimeMs, long callcount, double sumtimeMs, size_t stackCounter);
         virtual void printData(const Data& data, Data::Mode mode, int maxcount);
         virtual std::string formatData(const Data& data, Data::Mode mode, int maxcount) const;
-        virtual void funcsToStream(std::stringstream& stream, const std::string& title, const std::list<Data::Func>& funcs,int count) const;
+        virtual void funcsToStream(std::stringstream& stream, const std::string& title, const std::list<Data::Func>& funcs,
+                                   int count) const;
     };
 
     struct ElapsedTimer {
@@ -203,7 +204,7 @@ private:
     Printer* m_printer{ nullptr };
 
     StepsData m_steps;
-    FuncsData m_funcs;
+    mutable FuncsData m_funcs;
 
     size_t m_stackCounter{ 0 };
 };


### PR DESCRIPTION
For view Profile data - go to Diagnostic->System->Show profiler...

![image](https://user-images.githubusercontent.com/3818029/143221507-9e579d83-4643-4bab-8cc8-a0613995b35e.png)


About removing update parts name on drop elements
There are several problems:
* The parts names were updated every time any element was dropped from the Palette to Score
* Each time the names of all parts are updated ( only need for which we added an instrument change)
* Updating the names of parts, if the new name differs from the current one, is carried out slowly, respectively, when updating the names of all parts, this can take more than 30 seconds
* It is not correct to update the name of the part for a drop element from the Palette, because we can also edit an already added "instrument change". Accordingly, in this case, we should also update the name of the part. Accordingly, part name updates when adding a "instrument change" and editing a "instrument change" should be consistent.

In general, the зart name update needs to be re-implemented properly. @DmitryArefiev FYI