### PR TITLE
Fix #9553 "Open Recent" not disabled

### DIFF
--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -113,7 +113,7 @@ MenuItem AppMenuModel::makeMenuItem(const actions::ActionCode& actionCode, MenuI
 MenuItem AppMenuModel::fileItem() const
 {
     MenuItemList recentScoresList = recentScores();
-    bool openRecentEnabled = true;
+    bool openRecentEnabled = !recentScoresList.isEmpty();
 
     if (!recentScoresList.empty()) {
         recentScoresList = appendClearRecentSection(recentScoresList);

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -184,7 +184,8 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("copy",
              mu::context::UiCtxNotationFocused,
-             QT_TRANSLATE_NOOP("action", "Copy")
+             QT_TRANSLATE_NOOP("action", "Copy"),
+             IconCode::Code::COPY
              ),
     UiAction("paste",
              mu::context::UiCtxNotationFocused,
@@ -1085,12 +1086,14 @@ const UiActionList NotationUiActions::m_actions = {
     UiAction("zoomin",
              mu::context::UiCtxNotationOpened,
              QT_TRANSLATE_NOOP("action", "Zoom in"),
-             QT_TRANSLATE_NOOP("action", "Zoom in")
+             QT_TRANSLATE_NOOP("action", "Zoom in"),
+             IconCode::Code::ZOOM_IN
              ),
     UiAction("zoomout",
              mu::context::UiCtxNotationOpened,
              QT_TRANSLATE_NOOP("action", "Zoom out"),
-             QT_TRANSLATE_NOOP("action", "Zoom out")
+             QT_TRANSLATE_NOOP("action", "Zoom out"),
+             IconCode::Code::ZOOM_OUT
              )
 };
 

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -28,12 +28,14 @@ const UiActionList ProjectUiActions::m_actions = {
     UiAction("file-open",
              mu::context::UiCtxAny,
              QT_TRANSLATE_NOOP("action", "Open…"),
-             QT_TRANSLATE_NOOP("action", "Load score from file")
+             QT_TRANSLATE_NOOP("action", "Load score from file"),
+             IconCode::Code::OPEN_FILE
              ),
     UiAction("file-new",
              mu::context::UiCtxAny,
              QT_TRANSLATE_NOOP("action", "New…"),
-             QT_TRANSLATE_NOOP("action", "Create new score")
+             QT_TRANSLATE_NOOP("action", "Create new score"),
+             IconCode::Code::NEW_FILE
              ),
     UiAction("file-close",
              mu::context::UiCtxNotationOpened,
@@ -43,7 +45,8 @@ const UiActionList ProjectUiActions::m_actions = {
     UiAction("file-save",
              mu::context::UiCtxNotationOpened,
              QT_TRANSLATE_NOOP("action", "Save"),
-             QT_TRANSLATE_NOOP("action", "Save score to file")
+             QT_TRANSLATE_NOOP("action", "Save score to file"),
+             IconCode::Code::SAVE
              ),
     UiAction("file-save-online",
              mu::context::UiCtxNotationOpened,
@@ -75,7 +78,8 @@ const UiActionList ProjectUiActions::m_actions = {
     UiAction("file-import-pdf",
              mu::context::UiCtxAny,
              QT_TRANSLATE_NOOP("action", "Import PDF…"),
-             QT_TRANSLATE_NOOP("action", "Import a PDF file with an experimental service on musescore.com")
+             QT_TRANSLATE_NOOP("action", "Import a PDF file with an experimental service on musescore.com"),
+             IconCode::Code::IMPORT
              ),
     UiAction("print",
              mu::context::UiCtxAny,


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9553

This commit solved the bug that File->"Open Recent" is not disabled even if
there is no recent files. Now, it decides whether to enable "Open
Recent" on the basis of whether the recent scores list is empty.

Also, I have removed the comment: need implement of export since I think it has been implemented. Please tell me otherwise.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
