### PR TITLE
Fix #9719 add/remove system breaks behavior

### DIFF
--- a/src/notation/view/widgets/breaksdialog.cpp
+++ b/src/notation/view/widgets/breaksdialog.cpp
@@ -56,14 +56,6 @@ void BreaksDialog::accept()
     }
 
     INotationInteractionPtr interaction = notation->interaction();
-    INotationSelectionPtr selection = interaction->selection();
-
-    bool allSelected = false;
-
-    if (selection->isNone()) {
-        interaction->selectAll();
-        allSelected = true;
-    }
 
     int interval = intervalButton->isChecked() ? intervalBox->value() : 0;
     BreaksSpawnIntervalType intervalType = BreaksSpawnIntervalType::MeasuresInterval;
@@ -76,9 +68,33 @@ void BreaksDialog::accept()
 
     interaction->setBreaksSpawnInterval(intervalType, interval);
 
-    if (allSelected) {
+    if (_allSelected) {
         interaction->clearSelection();
     }
 
     QDialog::accept();
+}
+
+//---------------------------------------------------------
+//   showEvent
+//---------------------------------------------------------
+
+void BreaksDialog::showEvent(QShowEvent* ev)
+{
+    INotationPtr notation = context()->currentNotation();
+    if (!notation) {
+        return;
+    }
+
+    INotationInteractionPtr interaction = notation->interaction();
+    INotationSelectionPtr selection = interaction->selection();
+
+    if (!selection->isRange()) {
+        interaction->selectAll();
+        _allSelected = true;
+    } else {
+        _allSelected = false;
+    }
+
+    QWidget::showEvent(ev);
 }

--- a/src/notation/view/widgets/breaksdialog.h
+++ b/src/notation/view/widgets/breaksdialog.h
@@ -45,6 +45,11 @@ public:
 
 private slots:
     void accept() override;
+
+private:
+    void showEvent(QShowEvent*);
+
+    bool _allSelected = false;
 };
 }
 


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/9719*

Implement BreaksDialog::showEvent method to show the user on which
range the breaks will be applied before the dialog is displayed.

Call Selection::isRange method to know if a range is already selected.

All of the code for the breaks dialog is in its accept method which is
called only when the dialog is closed. So, the problem is that there
is no way for the user to see the range on which the system breaks
will be applied.

Also, the code which sets the range on which the breaks will be applied
needs to first check if a range is selected. The problem is that in
the current implementation, it calls the Selection::isNone method.
The right method to call is Selection::isRange because we need to
know if a range is selected. Selection::isNone returns false even if
something other than a range is selected.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
