### PR TITLE
[MU4] Fix some compiler warnings

### DIFF
--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -989,7 +989,7 @@ void Chord::computeUp()
 int Chord::computeAutoStemDirection(const std::vector<int>* noteDistances)
 {
     int left = 0;
-    int right = noteDistances->size() - 1;
+    int right = static_cast<int>(noteDistances->size()) - 1;
 
     while (left <= right) {
         int leftNote = noteDistances->at(left);

--- a/src/engraving/libmscore/property.cpp
+++ b/src/engraving/libmscore/property.cpp
@@ -770,19 +770,20 @@ QString propertyToString(Pid id, const PropertyValue& value, bool mscx)
         return QString::number(value.value<double>());
     case P_TYPE::SPATIUM:
         return QString::number(value.value<Spatium>().val());
-    case P_TYPE::DIRECTION_V: {
+    case P_TYPE::DIRECTION_V:
         switch (value.value<DirectionV>()) {
         case DirectionV::AUTO:  return "auto";
         case DirectionV::UP:    return "up";
         case DirectionV::DOWN:  return "down";
         }
-    }
+        break;
     case P_TYPE::DIRECTION_H:
         switch (value.value<DirectionH>()) {
         case DirectionH::LEFT:  return "left";
         case DirectionH::RIGHT: return "right";
         case DirectionH::AUTO:  return "auto";
         }
+        break;
     case P_TYPE::STRING:
     case P_TYPE::FRACTION:
         return value.toString();

--- a/src/engraving/libmscore/property.cpp
+++ b/src/engraving/libmscore/property.cpp
@@ -486,7 +486,7 @@ PropertyValue propertyFromString(mu::engraving::P_TYPE type, QString value)
     case P_TYPE::SCALE: {
         const int i = value.indexOf('x');
         return PropertyValue::fromValue(ScaleF(value.leftRef(i).toDouble(), value.midRef(i + 1).toDouble()));
-    } break;
+    }
     case P_TYPE::SIZE: {
         // not used by MSCX
         const int i = value.indexOf('x');
@@ -494,7 +494,7 @@ PropertyValue propertyFromString(mu::engraving::P_TYPE type, QString value)
     }
     case P_TYPE::STRING:
         return value;
-    case P_TYPE::GLISS_STYLE: {
+    case P_TYPE::GLISS_STYLE:
         if (value == "whitekeys") {
             return PropertyValue(int(GlissandoStyle::WHITE_KEYS));
         } else if (value == "blackkeys") {
@@ -506,16 +506,14 @@ PropertyValue propertyFromString(mu::engraving::P_TYPE type, QString value)
         } else {       // e.g., normally "Chromatic"
             return PropertyValue(int(GlissandoStyle::CHROMATIC));
         }
-    }
-    break;
+        break;
     case P_TYPE::ORNAMENT_STYLE: {
         if (value == "baroque") {
             return PropertyValue(int(MScore::OrnamentStyle::BAROQUE));
         }
         return PropertyValue(int(MScore::OrnamentStyle::DEFAULT));
     }
-
-    case P_TYPE::DIRECTION_V: {
+    case P_TYPE::DIRECTION_V:
         if (value == "up") {
             return PropertyValue(DirectionV::UP);
         } else if (value == "down") {
@@ -525,10 +523,8 @@ PropertyValue propertyFromString(mu::engraving::P_TYPE type, QString value)
         } else {
             return PropertyValue(DirectionV(value.toInt()));
         }
-    }
-    break;
+        break;
     case P_TYPE::DIRECTION_H:
-    {
         if (value == "left" || value == "1") {
             return PropertyValue(DirectionH::LEFT);
         } else if (value == "right" || value == "2") {
@@ -536,9 +532,8 @@ PropertyValue propertyFromString(mu::engraving::P_TYPE type, QString value)
         } else if (value == "auto") {
             return PropertyValue(DirectionH::AUTO);
         }
-    }
-    break;
-    case P_TYPE::LAYOUT_BREAK: {
+        break;
+    case P_TYPE::LAYOUT_BREAK:
         if (value == "line") {
             return PropertyValue(int(LayoutBreak::Type::LINE));
         }
@@ -552,25 +547,22 @@ PropertyValue propertyFromString(mu::engraving::P_TYPE type, QString value)
             return PropertyValue(int(LayoutBreak::Type::NOBREAK));
         }
         qDebug("getProperty: invalid P_TYPE::LAYOUT_BREAK: <%s>", qPrintable(value));
-    }
-    break;
-    case P_TYPE::VALUE_TYPE: {
+        break;
+    case P_TYPE::VALUE_TYPE:
         if (value == "offset") {
             return PropertyValue(int(Note::ValueType::OFFSET_VAL));
         } else if (value == "user") {
             return PropertyValue(int(Note::ValueType::USER_VAL));
         }
-    }
-    break;
-    case P_TYPE::PLACEMENT_V: {
+        break;
+    case P_TYPE::PLACEMENT_V:
         if (value == "above") {
             return PropertyValue(int(PlacementV::ABOVE));
         } else if (value == "below") {
             return PropertyValue(int(PlacementV::BELOW));
         }
-    }
-    break;
-    case P_TYPE::PLACEMENT_H: {
+        break;
+    case P_TYPE::PLACEMENT_H:
         if (value == "left") {
             return PropertyValue(int(PlacementH::LEFT));
         } else if (value == "center") {
@@ -578,9 +570,8 @@ PropertyValue propertyFromString(mu::engraving::P_TYPE type, QString value)
         } else if (value == "right") {
             return PropertyValue(int(PlacementH::RIGHT));
         }
-    }
-    break;
-    case P_TYPE::TEXT_PLACE: {
+        break;
+    case P_TYPE::TEXT_PLACE:
         if (value == "auto") {
             return PropertyValue(int(PlaceText::AUTO));
         } else if (value == "above") {
@@ -590,8 +581,7 @@ PropertyValue propertyFromString(mu::engraving::P_TYPE type, QString value)
         } else if (value == "left") {
             return PropertyValue(int(PlaceText::LEFT));
         }
-    }
-    break;
+        break;
     case P_TYPE::BARLINE_TYPE: {
         bool ok;
         const int ct = value.toInt(&ok);
@@ -601,11 +591,10 @@ PropertyValue propertyFromString(mu::engraving::P_TYPE type, QString value)
             BarLineType t = BarLine::barLineType(value);
             return PropertyValue::fromValue(t);
         }
+        break;
     }
-    break;
     case P_TYPE::BEAM_MODE:
         return PropertyValue(int(0));
-
     case P_TYPE::GROUPS:
         // unsupported
         return PropertyValue();
@@ -713,12 +702,9 @@ PropertyValue readProperty(Pid id, XmlReader& e)
     case P_TYPE::ALIGN:
     case P_TYPE::ORIENTATION:
         return propertyFromString(id, e.readElementText());
-
     case P_TYPE::BEAM_MODE:
         return PropertyValue(int(0));
-
-    case P_TYPE::GROUPS:
-    {
+    case P_TYPE::GROUPS: {
         Groups g;
         g.read(e);
         return PropertyValue::fromValue(g);
@@ -945,7 +931,6 @@ QString propertyToString(Pid id, const PropertyValue& value, bool mscx)
         qFatal("unknown: GROUPS");
     case P_TYPE::INT_LIST:
         qFatal("unknown: INT_LIST");
-
     default: {
         switch (value.type()) {
         case P_TYPE::BOOL:

--- a/src/engraving/libmscore/tie.cpp
+++ b/src/engraving/libmscore/tie.cpp
@@ -803,7 +803,6 @@ void Tie::slurPos(SlurPos* sp)
     const StaffType* stt = useTablature ? staff()->staffType(tick()) : 0;
     qreal _spatium    = spatium();
     qreal hw          = startNote()->tabHeadWidth(stt) * mag();     // if stt == 0, defaults to headWidth()
-    qreal __up        = _up ? -1.0 : 1.0;
     /* Inside-style and Outside-style ties
      Outside ties connect above the notehead, in the middle. Ideally, we'd use opticalcenter for this, but
      that Smufl anchor is not available for noteheads yet. For this reason, we rely on Note::outsideTieAttachX()

--- a/src/engraving/property/propertyvalue.h
+++ b/src/engraving/property/propertyvalue.h
@@ -181,9 +181,9 @@ public:
         //! HACK Temporary hack for int to enum
         if constexpr (std::is_enum<T>::value) {
             if (P_TYPE::INT == m_type) {
-                const int* pi = std::get_if<int>(&m_val);
-                assert(pi);
-                return pi ? static_cast<T>(*pi) : T();
+                const int* p2i = std::get_if<int>(&m_val);
+                assert(p2i);
+                return p2i ? static_cast<T>(*p2i) : T();
             }
         }
 
@@ -216,9 +216,9 @@ public:
 
         //! HACK Temporary hack for int to bool
         if constexpr (std::is_same<T, bool>::value) {
-            const int* pi = std::get_if<int>(&m_val);
-            assert(pi);
-            return pi ? static_cast<T>(*pi) : T();
+            const int* p2i = std::get_if<int>(&m_val);
+            assert(p2i);
+            return p2i ? static_cast<T>(*p2i) : T();
         }
 
         //! HACK Temporary hack for real to Spatium

--- a/src/framework/mpe/mpetypes.h
+++ b/src/framework/mpe/mpetypes.h
@@ -310,7 +310,7 @@ struct PitchPattern
     PitchPattern(size_t size, percentage_t step, pitch_level_t defaultValue)
     {
         for (size_t i = 0; i < size; ++i) {
-            pitchOffsetMap.emplace(step * i, defaultValue);
+            pitchOffsetMap.emplace(step * static_cast<int>(i), defaultValue);
         }
     }
 
@@ -328,7 +328,7 @@ struct ExpressionPattern
     ExpressionPattern(size_t size, percentage_t step, dynamic_level_t defaultValue)
     {
         for (size_t i = 0; i < size; ++i) {
-            dynamicOffsetMap.emplace(step * i, defaultValue);
+            dynamicOffsetMap.emplace(step * static_cast<int>(i), defaultValue);
         }
     }
 
@@ -499,7 +499,7 @@ struct ArticulationMap : public std::map<ArticulationType, ArticulationData>
             result += pair.second.patternSegment.arrangementPattern.durationFactor;
         }
 
-        result /= size();
+        result /= static_cast<int>(size());
 
         return result;
     }
@@ -554,7 +554,7 @@ struct ArticulationMap : public std::map<ArticulationType, ArticulationData>
         }
 
         for (auto& pair : result) {
-            pair.second /= size();
+            pair.second /= static_cast<int>(size());
         }
 
         return result;
@@ -661,7 +661,7 @@ struct ArticulationMap : public std::map<ArticulationType, ArticulationData>
         }
 
         for (auto& pair : result) {
-            pair.second /= size();
+            pair.second /= static_cast<int>(size());
         }
 
         return result;

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -1458,7 +1458,7 @@ PropertyValue EditStyle::getValue(StyleId idx)
         return as->align();
     } break;
     default: {
-        qFatal("EditStyle::getValue: unhandled type <%d>", type);
+        qFatal("EditStyle::getValue: unhandled type <%d>", static_cast<int>(type));
     } break;
     }
 


### PR DESCRIPTION
Still a few left, one of which shows up 29 (!) times, "unreachable code" in [src/engraving/property/propertyvalue.h, line 270](https://github.com/musescore/MuseScore/blob/35270e4a7f839eb6831a90e465d3b063314c2c1d/src/engraving/property/propertyvalue.h#L270), not sure how to fix that one?
Another is "not all control paths return a value" in [src/notation/view/widgets/etditstyle.cpp, line 1906](https://github.com/musescore/MuseScore/blob/35270e4a7f839eb6831a90e465d3b063314c2c1d/src/notation/view/widgets/editstyle.cpp#L1906), here too I'm unsure how to fix.