### PR TITLE
Always update _magx after changing the height of bracket.

### DIFF
--- a/src/engraving/libmscore/bracket.cpp
+++ b/src/engraving/libmscore/bracket.cpp
@@ -144,10 +144,10 @@ void Bracket::setStaffSpan(int a, int b)
         if (score()->styleSt(Sid::MusicalSymbolFont) == "Leland") {
             v = qMin(4, v);
         }
-        // total default height of a system of n staves / height of a 5 line staff
-        qreal dist = score()->enableVerticalSpread() ? score()->styleS(Sid::maxAkkoladeDistance).val() : score()->styleS(
-            Sid::akkoladeDistance).val();
-        _magx = v + ((v - 1) * dist / 4.0);
+
+        // 1.625 is a "magic" number based on akkoladeDistance/4.0 (default value 6.5).
+        _magx = v + ((v - 1) * 1.625);
+
         if (v == 1) {
             _braceSymbol = SymId::braceSmall;
         } else if (v <= 2) {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9041

This PR updates the `_magx`  of a bracket when the height of a bracket is changed. 

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
