### PR TITLE
[MU4] Enables reset button when values is not equal to the default value.

### DIFF
--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -1477,7 +1477,7 @@ void EditStyle::setValues()
         }
         PropertyValue val = styleValue(sw.idx);
         if (sw.reset) {
-            sw.reset->setEnabled(hasDefaultStyleValue(sw.idx));
+            sw.reset->setEnabled(!hasDefaultStyleValue(sw.idx));
         }
 
         switch (val.type()) {
@@ -1803,7 +1803,7 @@ void EditStyle::enableStyleWidget(const StyleId idx, bool enable)
     const StyleWidget& sw { styleWidget(idx) };
     static_cast<QWidget*>(sw.widget)->setEnabled(enable);
     if (sw.reset) {
-        sw.reset->setEnabled(enable && hasDefaultStyleValue(idx));
+        sw.reset->setEnabled(enable && !hasDefaultStyleValue(idx));
     }
 }
 


### PR DESCRIPTION
In the current `master` the reset button of a style parameter in the style editor is **enabled** when the current value is **equal** to the default value, which doesn't make much sense.
This PR now **disables** the reset button when the current value equals the default value and enables it otherwise.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
