### PR TITLE
Add shortcuts to navigate through notations

### DIFF
--- a/src/framework/shortcuts/data/shortcuts-Mac.xml
+++ b/src/framework/shortcuts/data/shortcuts-Mac.xml
@@ -43,14 +43,6 @@
         <seq>Shift+Tab</seq>
     </SC>
     <SC>
-        <key>nav-next-tab</key>
-        <seq>Ctrl+Tab</seq>
-    </SC>
-    <SC>
-        <key>nav-prev-tab</key>
-        <seq>Ctrl+Shift+Tab</seq>
-    </SC>
-    <SC>
         <key>nav-right</key>
         <seq>Right</seq>
     </SC>
@@ -117,7 +109,7 @@
     <std>63</std>
     </SC>
   <SC>
-    <key>file-close</key>
+    <key>notation-close</key>
     <std>4</std>
     </SC>
   <SC>
@@ -841,12 +833,48 @@
     <seq>P</seq>
     </SC>
   <SC>
-    <key>next-score</key>
+    <key>notation-next</key>
     <std>20</std>
     </SC>
   <SC>
-    <key>previous-score</key>
-    <std>21</std>
+    <key>notation-previous</key>
+    <seq>Meta+Shift+Tab</seq>
+    </SC>
+  <SC>
+    <key>notation-change-1</key>
+    <seq>Ctrl+Shift+1</seq>
+    </SC>
+  <SC>
+    <key>notation-change-2</key>
+    <seq>Ctrl+Shift+2</seq>
+    </SC>
+  <SC>
+    <key>notation-change-3</key>
+    <seq>Ctrl+Shift+3</seq>
+    </SC>
+  <SC>
+    <key>notation-change-4</key>
+    <seq>Ctrl+Shift+4</seq>
+    </SC>
+  <SC>
+    <key>notation-change-5</key>
+    <seq>Ctrl+Shift+5</seq>
+    </SC>
+  <SC>
+    <key>notation-change-6</key>
+    <seq>Ctrl+Shift+6</seq>
+    </SC>
+  <SC>
+    <key>notation-change-7</key>
+    <seq>Ctrl+Shift+7</seq>
+    </SC>
+  <SC>
+    <key>notation-change-8</key>
+    <seq>Ctrl+Shift+8</seq>
+    </SC>
+  <SC>
+    <key>notation-change-9</key>
+    <seq>Ctrl+Shift+9</seq>
     </SC>
   <SC>
     <key>inspector</key>

--- a/src/framework/shortcuts/data/shortcuts.xml
+++ b/src/framework/shortcuts/data/shortcuts.xml
@@ -43,14 +43,6 @@
         <seq>Shift+Tab</seq>
     </SC>
     <SC>
-        <key>nav-next-tab</key>
-        <seq>Ctrl+Tab</seq>
-    </SC>
-    <SC>
-        <key>nav-prev-tab</key>
-        <seq>Ctrl+Shift+Tab</seq>
-    </SC>
-    <SC>
         <key>nav-right</key>
         <seq>Right</seq>
     </SC>
@@ -117,7 +109,7 @@
     <seq>Ctrl+Shift+S</seq>
     </SC>
   <SC>
-    <key>file-close</key>
+    <key>notation-close</key>
     <std>4</std>
     </SC>
   <SC>
@@ -841,12 +833,48 @@
     <seq>P</seq>
     </SC>
   <SC>
-    <key>next-score</key>
+    <key>notation-next</key>
     <std>20</std>
     </SC>
   <SC>
-    <key>previous-score</key>
-    <std>21</std>
+    <key>notation-previous</key>
+    <seq>Ctrl+Shift+Tab</seq>
+    </SC>
+  <SC>
+    <key>notation-change-1</key>
+    <seq>Ctrl+Shift+1</seq>
+    </SC>
+  <SC>
+    <key>notation-change-2</key>
+    <seq>Ctrl+Shift+2</seq>
+    </SC>
+  <SC>
+    <key>notation-change-3</key>
+    <seq>Ctrl+Shift+3</seq>
+    </SC>
+  <SC>
+    <key>notation-change-4</key>
+    <seq>Ctrl+Shift+4</seq>
+    </SC>
+  <SC>
+    <key>notation-change-5</key>
+    <seq>Ctrl+Shift+5</seq>
+    </SC>
+  <SC>
+    <key>notation-change-6</key>
+    <seq>Ctrl+Shift+6</seq>
+    </SC>
+  <SC>
+    <key>notation-change-7</key>
+    <seq>Ctrl+Shift+7</seq>
+    </SC>
+  <SC>
+    <key>notation-change-8</key>
+    <seq>Ctrl+Shift+8</seq>
+    </SC>
+  <SC>
+    <key>notation-change-9</key>
+    <seq>Ctrl+Shift+9</seq>
     </SC>
   <SC>
     <key>inspector</key>

--- a/src/framework/shortcuts/data/shortcuts_AZERTY.xml
+++ b/src/framework/shortcuts/data/shortcuts_AZERTY.xml
@@ -43,14 +43,6 @@
         <seq>Shift+Tab</seq>
     </SC>
     <SC>
-        <key>nav-next-tab</key>
-        <seq>Ctrl+Tab</seq>
-    </SC>
-    <SC>
-        <key>nav-prev-tab</key>
-        <seq>Ctrl+Shift+Tab</seq>
-    </SC>
-    <SC>
         <key>nav-right</key>
         <seq>Right</seq>
     </SC>
@@ -116,7 +108,7 @@
     <seq>Ctrl+Shift+S</seq>
     </SC>
   <SC>
-    <key>file-close</key>
+    <key>notation-close</key>
     <std>4</std>
     </SC>
   <SC>
@@ -867,13 +859,49 @@
     <seq>P</seq>
     </SC>
   <SC>
-    <key>next-score</key>
+    <key>notation-next</key>
     <std>20</std>
     </SC>
   <SC>
-    <key>previous-score</key>
-    <std>21</std>
+    <key>notation-previous</key>
+    <seq>Ctrl+Shift+Tab</seq>
     </SC>
+  <SC>
+    <key>notation-change-1</key>
+    <seq>Ctrl+Shift+1</seq>
+    </SC>
+  <SC>
+    <key>notation-change-2</key>
+    <seq>Ctrl+Shift+2</seq>
+    </SC>
+  <SC>
+    <key>notation-change-3</key>
+    <seq>Ctrl+Shift+3</seq>
+    </SC>
+  <SC>
+    <key>notation-change-4</key>
+    <seq>Ctrl+Shift+4</seq>
+    </SC>
+  <SC>
+    <key>notation-change-5</key>
+    <seq>Ctrl+Shift+5</seq>
+    </SC>
+  <SC>
+    <key>notation-change-6</key>
+    <seq>Ctrl+Shift+6</seq>
+    </SC>
+  <SC>
+    <key>notation-change-7</key>
+    <seq>Ctrl+Shift+7</seq>
+    </SC>
+  <SC>
+    <key>notation-change-8</key>
+    <seq>Ctrl+Shift+8</seq>
+    </SC>
+  <SC>
+    <key>notation-change-9</key>
+    <seq>Ctrl+Shift+9</seq>
+    </SC>v
   <SC>
     <key>inspector</key>
     <seq>F8</seq>

--- a/src/notation/internal/notationactioncontroller.h
+++ b/src/notation/internal/notationactioncontroller.h
@@ -206,6 +206,15 @@ private:
 
     void startNoteInputIfNeed();
 
+    void setOpenNotations(QList<INotationPtr> notations);
+    bool isMasterNotation(const INotationPtr notation) const;
+    std::vector<INotationPtr> getOpenNotations();
+    int getNotationIndex(std::vector<INotationPtr> notations);
+    void closeCurrentNotation();
+    void openPreviousNotation();
+    void openNextNotation();
+    void changeCurrentNotation(int index);
+
     bool hasSelection() const;
     bool canUndo() const;
     bool canRedo() const;

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -1492,6 +1492,66 @@ const UiActionList NotationUiActions::m_scoreConfigActions = {
              QT_TRANSLATE_NOOP("action", "Strike-throuch"),
              QT_TRANSLATE_NOOP("action", "Strike-through"),
              Checkable::Yes
+             ),
+    UiAction("notation-close",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Close current notation"),
+             QT_TRANSLATE_NOOP("action", "Close current notation")
+             ),
+    UiAction("notation-previous",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Switch to previous notation"),
+             QT_TRANSLATE_NOOP("action", "Switch to previous notation")
+             ),
+    UiAction("notation-next",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Switch to next notation"),
+             QT_TRANSLATE_NOOP("action", "Switch to next notation")
+             ),
+    UiAction("notation-change-1",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Switch to first notation"),
+             QT_TRANSLATE_NOOP("action", "Switch to first notation")
+             ),
+    UiAction("notation-change-2",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Switch to second notation"),
+             QT_TRANSLATE_NOOP("action", "Switch to second notation")
+             ),
+    UiAction("notation-change-3",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Switch to third notation"),
+             QT_TRANSLATE_NOOP("action", "Switch to third notation")
+             ),
+    UiAction("notation-change-4",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Switch to fourth notation"),
+             QT_TRANSLATE_NOOP("action", "Switch to fourth notation")
+             ),
+    UiAction("notation-change-5",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Switch to fifth notation"),
+             QT_TRANSLATE_NOOP("action", "Switch to fifth notation")
+             ),
+    UiAction("notation-change-6",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Switch to sixth notation"),
+             QT_TRANSLATE_NOOP("action", "Switch to sixth notation")
+             ),
+    UiAction("notation-change-7",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Switch to seventh notation"),
+             QT_TRANSLATE_NOOP("action", "Switch to seventh notation")
+             ),
+    UiAction("notation-change-8",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Switch to eighth notation"),
+             QT_TRANSLATE_NOOP("action", "Switch to eighth notation")
+             ),
+    UiAction("notation-change-9",
+             mu::context::UiCtxNotationOpened,
+             QT_TRANSLATE_NOOP("action", "Switch to ninth notation"),
+             QT_TRANSLATE_NOOP("action", "Switch to ninth notation")
              )
 };
 


### PR DESCRIPTION
Resolves: No issue

*(short description of the changes and the motivation to make the changes)*
This commit has added shortcuts to navigate through notations. If you
use the Ctrl+W shortcut, you can close a notation. You can switch to the
next and previous notations by using Ctrl+Tab and Ctrl+Shift+Tab
shortcuts. You can also set the current notation by using
Ctrl+Shift+#Number#.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
