### PR TITLE
Fixed issue #9076 - The "Open other..." button now opens the file explorer in the MuseScore/Scores Directory 

### DIFF
--- a/src/project/internal/projectfilescontroller.cpp
+++ b/src/project/internal/projectfilescontroller.cpp
@@ -486,7 +486,7 @@ io::path ProjectFilesController::selectScoreOpeningFile()
            << QObject::tr("MuseScore Dev Files") + " (*.mscs)"
            << QObject::tr("MuseScore Backup Files") + " (*.mscz~)";
 
-    return interactive()->selectOpeningFile(qtrc("project", "Score"), "", filter.join(";;"));
+    return interactive()->selectOpeningFile(qtrc("project", "Score"), configuration()->userProjectsPath(), filter.join(";;"));
 }
 
 io::path ProjectFilesController::selectScoreSavingFile(const io::path& defaultFilePath, const QString& saveTitle)


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9076

Created a constant function in the ProjectFilesController class named default defaultOpenFileDir() which returns the path to the desired directory(As of now the "Documents/MuseScore/Scores" part is hardcoded , it shouldn't be difficult to set it to any value)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [ ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
