### PR TITLE
[MU4] fix #9186 Set a default title, subtitle and composer for new scores.

### DIFF
--- a/src/project/qml/MuseScore/Project/internal/GeneralInfoView.qml
+++ b/src/project/qml/MuseScore/Project/internal/GeneralInfoView.qml
@@ -67,6 +67,8 @@ Column {
 
             title: qsTrc("project", "Title")
 
+            info: qsTrc("project", "Untitled Score")
+
             navigation.panel: root.navigationPanel
             navigation.column: 0
         }
@@ -78,6 +80,8 @@ Column {
             width: parent.childWidth
 
             title: qsTrc("project", "Composer")
+
+            info: qsTrc("project", "Composer / arranger")
 
             navigation.panel: root.navigationPanel
             navigation.column: 1
@@ -102,6 +106,8 @@ Column {
             width: parent.childWidth
 
             title: qsTrc("project", "Subtitle")
+
+            info: qsTrc("project", "Subtitle")
 
             navigation.panel: root.navigationPanel
             navigation.column: 2


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9186

Defines a default value for the items `titleInfo`, `composerInfo` and `subtitleInfo` on the `Additional Score Information` form.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
