### PR TITLE
Fix panning score during playback and note input and when selecting elements

### DIFF
--- a/src/notation/view/notationnavigator.cpp
+++ b/src/notation/view/notationnavigator.cpp
@@ -86,7 +86,7 @@ void NotationNavigator::rescale()
         return;
     }
 
-    setScaling(scaling, QPointF());
+    setScaling(scaling, PointF());
 }
 
 void NotationNavigator::wheelEvent(QWheelEvent*)

--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -716,7 +716,7 @@ qreal NotationPaintView::currentScaling() const
     return m_matrix.m11();
 }
 
-void NotationPaintView::setScaling(qreal scaling, const QPointF& pos)
+void NotationPaintView::setScaling(qreal scaling, const PointF& pos)
 {
     TRACEFUNC;
     qreal currentScaling = this->currentScaling();
@@ -737,7 +737,7 @@ void NotationPaintView::setScaling(qreal scaling, const QPointF& pos)
     scale(deltaScaling, pos);
 }
 
-void NotationPaintView::scale(qreal factor, const QPointF& pos)
+void NotationPaintView::scale(qreal factor, const PointF& pos)
 {
     TRACEFUNC;
     if (qFuzzyCompare(factor, 1.0)) {
@@ -758,6 +758,11 @@ void NotationPaintView::scale(qreal factor, const QPointF& pos)
     if (!moveCanvas(dx, dy)) {
         update();
     }
+}
+
+void NotationPaintView::scale(qreal factor, const QPointF& pos)
+{
+    scale(factor, PointF::fromQPointF(pos));
 }
 
 void NotationPaintView::wheelEvent(QWheelEvent* event)
@@ -911,7 +916,7 @@ qreal NotationPaintView::height() const
 
 PointF NotationPaintView::canvasPos() const
 {
-    return PointF(m_matrix.dx(), m_matrix.dy());
+    return toLogical(PointF(0.0, 0.0));
 }
 
 PointF NotationPaintView::toLogical(const PointF& point) const

--- a/src/notation/view/notationpaintview.h
+++ b/src/notation/view/notationpaintview.h
@@ -93,7 +93,8 @@ public:
     void moveCanvasHorizontal(qreal dx) override;
 
     qreal currentScaling() const override;
-    void setScaling(qreal scaling, const QPointF& pos) override;
+    void setScaling(qreal scaling, const PointF& pos) override;
+    void scale(qreal factor, const PointF& pos);
     Q_INVOKABLE void scale(qreal factor, const QPointF& pos);
 
     bool isNoteEnterMode() const override;

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -28,6 +28,7 @@
 #include "notationpaintview.h"
 #include "commonscene/commonscenetypes.h"
 
+using namespace mu;
 using namespace mu::notation;
 using namespace mu::actions;
 using namespace mu::commonscene;
@@ -140,18 +141,18 @@ void NotationViewInputController::zoomOut()
     setZoom(zoom, findZoomFocusPoint());
 }
 
-QPointF NotationViewInputController::findZoomFocusPoint() const
+PointF NotationViewInputController::findZoomFocusPoint() const
 {
     INotationSelectionPtr selection = m_view->notationInteraction()->selection();
 
     // No selection: zoom at the center of the view
     if (selection->isNone()) {
-        return QPointF(m_view->width() / 2, m_view->height() / 2);
+        return PointF(m_view->width() / 2, m_view->height() / 2);
     }
 
     // Selection: zoom at the center of the selection
-    return ((selection->canvasBoundingRect().center() * m_view->currentScaling())
-            + m_view->canvasPos()).toQPointF();
+    return (selection->canvasBoundingRect().center() * m_view->currentScaling())
+           + m_view->canvasPos();
 }
 
 void NotationViewInputController::zoomToPageWidth()
@@ -163,7 +164,7 @@ void NotationViewInputController::zoomToPageWidth()
     qreal pageWidth = notationStyle()->styleValue(Ms::Sid::pageWidth).toDouble() * Ms::DPI;
     qreal scale = m_view->width() / pageWidth / configuration()->notationScaling();
 
-    setZoom(scale * 100, QPointF());
+    setZoom(scale * 100, PointF());
     m_isZoomInited = true;
 }
 
@@ -181,7 +182,7 @@ void NotationViewInputController::zoomToWholePage()
 
     qreal scale = std::min(pageWidthScale, pageHeightScale) / configuration()->notationScaling();
 
-    setZoom(scale * 100, QPointF());
+    setZoom(scale * 100, PointF());
     m_isZoomInited = true;
 }
 
@@ -211,7 +212,7 @@ void NotationViewInputController::zoomToTwoPages()
 
     qreal scale = std::min(pageHeightScale, pageWidthScale) / configuration()->notationScaling();
 
-    setZoom(scale * 100, QPointF());
+    setZoom(scale * 100, PointF());
     m_isZoomInited = true;
 }
 
@@ -231,7 +232,7 @@ int NotationViewInputController::currentZoomPercentage() const
     return qRound(m_view->currentScaling() * 100.0 / configuration()->notationScaling());
 }
 
-void NotationViewInputController::setZoom(int zoomPercentage, const QPointF& pos)
+void NotationViewInputController::setZoom(int zoomPercentage, const PointF& pos)
 {
     int minZoom = m_possibleZoomsPercentage.first();
     int maxZoom = m_possibleZoomsPercentage.last();
@@ -284,7 +285,7 @@ void NotationViewInputController::wheelEvent(QWheelEvent* event)
         double zoomSpeed = qPow(2.0, 1.0 / configuration()->mouseZoomPrecision());
         qreal absSteps = sqrt(stepsX * stepsX + stepsY * stepsY) * (stepsY > -stepsX ? 1 : -1);
         double zoomAmount = m_view->currentScaling() * qPow(zoomSpeed, absSteps);
-        m_view->setScaling(zoomAmount, event->position());
+        m_view->setScaling(zoomAmount, PointF::fromQPointF(event->position()));
     } else {
         qreal correction = 1.0 / m_view->currentScaling();
         if (keyState & Qt::ShiftModifier) {

--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -53,7 +53,7 @@ public:
     virtual void moveCanvasVertical(qreal dy) = 0;
 
     virtual qreal currentScaling() const = 0;
-    virtual void setScaling(qreal scaling, const QPointF& pos) = 0;
+    virtual void setScaling(qreal scaling, const PointF& pos) = 0;
 
     virtual PointF toLogical(const PointF& p) const = 0;
     virtual PointF toLogical(const QPointF& p) const = 0;
@@ -101,7 +101,7 @@ public:
     void dropEvent(QDropEvent* event);
 
     ElementType selectionType() const;
-    mu::PointF hitElementPos() const;
+    PointF hitElementPos() const;
 
 private:
     INotationPtr currentNotation() const;
@@ -115,8 +115,8 @@ private:
 
     int currentZoomIndex() const;
     int currentZoomPercentage() const;
-    QPointF findZoomFocusPoint() const;
-    void setZoom(int zoomPercentage, const QPointF& pos = QPointF());
+    PointF findZoomFocusPoint() const;
+    void setZoom(int zoomPercentage, const PointF& pos = PointF());
 
     void setViewMode(const ViewMode& viewMode);
 

--- a/src/project/view/templatepaintview.cpp
+++ b/src/project/view/templatepaintview.cpp
@@ -68,7 +68,7 @@ void TemplatePaintView::adjustCanvas()
         return;
     }
 
-    setScaling(scaling, QPointF());
+    setScaling(scaling, PointF());
     moveCanvasToCenter();
 }
 


### PR DESCRIPTION
Resolves: #9775

By fixing NotationPaintView::canvasPos, which fixes in turn NotationPaintView::adjustCanvasPosition.

Also replaced some QPointF to PointF.