### PR TITLE
Fix dynamic optical center for custom font sizes

### DIFF
--- a/src/engraving/libmscore/dynamic.cpp
+++ b/src/engraving/libmscore/dynamic.cpp
@@ -352,8 +352,8 @@ void Dynamic::layout()
                     qreal fontScaling = size() / DEFAULT_DYNAMIC_FONT_SIZE;
                     qreal left = symBbox(symId).bottomLeft().x() * dynamicMag; // this is negative per SMuFL spec
 
-                    opticalCenter += fontScaling;
-                    left += fontScaling;
+                    opticalCenter *= fontScaling;
+                    left *= fontScaling;
 
                     qreal offset = opticalCenter - left - bbox().width() * 0.5;
                     rxpos() -= offset;


### PR DESCRIPTION
Dynamics use the SMuFL opticalCenter anchor if available to horizontally center them (instead of their bounding box).

Currently, if dynamics use a custom font size, the optical center is not scaled correctly. This PR fixes that behavior.