### PR TITLE
Fix #9908- Clicking cancel closes project

### DIFF
--- a/src/project/internal/projectfilescontroller.cpp
+++ b/src/project/internal/projectfilescontroller.cpp
@@ -239,6 +239,7 @@ void ProjectFilesController::newProject()
 bool ProjectFilesController::closeOpenedProject()
 {
     INotationProjectPtr project = currentNotationProject();
+    bool result = false;
     if (!project) {
         return true;
     }
@@ -253,12 +254,16 @@ bool ProjectFilesController::closeOpenedProject()
         if (btn == IInteractive::Button::Cancel) {
             return false;
         } else if (btn == IInteractive::Button::Save) {
-            saveProject();
+            result = saveProject();
+        } else if (btn == IInteractive::Button::DontSave) {
+            result = true;
         }
     }
-
-    globalContext()->setCurrentProject(nullptr);
-    return true;
+    if (result) {
+        globalContext()->setCurrentProject(nullptr);
+        return true;
+    }
+    return false;
 }
 
 IInteractive::Button ProjectFilesController::askAboutSavingScore(const io::path& filePath)
@@ -285,16 +290,15 @@ IInteractive::Button ProjectFilesController::askAboutSavingScore(const io::path&
     return result.standardButton();
 }
 
-void ProjectFilesController::saveProject(const io::path& path)
+bool ProjectFilesController::saveProject(const io::path& path)
 {
     if (!currentNotationProject()) {
         LOGW() << "no current project";
-        return;
+        return false;
     }
 
     if (!currentNotationProject()->created().val) {
-        doSaveScore();
-        return;
+        return doSaveScore();
     }
 
     io::path filePath;
@@ -306,7 +310,7 @@ void ProjectFilesController::saveProject(const io::path& path)
     }
 
     if (filePath.empty()) {
-        return;
+        return false;
     }
 
     if (io::suffix(filePath).empty()) {
@@ -314,6 +318,7 @@ void ProjectFilesController::saveProject(const io::path& path)
     }
 
     doSaveScore(filePath);
+    return true;
 }
 
 void ProjectFilesController::saveProjectAs()
@@ -497,14 +502,14 @@ io::path ProjectFilesController::selectScoreSavingFile(const io::path& defaultFi
     return filePath;
 }
 
-void ProjectFilesController::doSaveScore(const io::path& filePath, project::SaveMode saveMode)
+bool ProjectFilesController::doSaveScore(const io::path& filePath, project::SaveMode saveMode)
 {
     io::path oldPath = currentNotationProject()->metaInfo().filePath;
 
     Ret ret = currentNotationProject()->save(filePath, saveMode);
     if (!ret) {
         LOGE() << ret.toString();
-        return;
+        return false;
     }
 
     if (saveMode == SaveMode::SaveAs && oldPath != filePath) {
@@ -512,6 +517,7 @@ void ProjectFilesController::doSaveScore(const io::path& filePath, project::Save
     }
 
     prependToRecentScoreList(filePath);
+    return true;
 }
 
 io::path ProjectFilesController::defaultSavingFilePath() const

--- a/src/project/internal/projectfilescontroller.h
+++ b/src/project/internal/projectfilescontroller.h
@@ -61,7 +61,7 @@ public:
     bool closeOpenedProject() override;
     bool isProjectOpened(const io::path& scorePath) const override;
     bool isAnyProjectOpened() const override;
-    void saveProject(const io::path& path = io::path()) override;
+    bool saveProject(const io::path& path = io::path()) override;
 
 private:
     void setupConnections();
@@ -95,7 +95,7 @@ private:
     io::path selectScoreSavingFile(const io::path& defaultFilePath, const QString& saveTitle);
 
     Ret doOpenProject(const io::path& filePath);
-    void doSaveScore(const io::path& filePath = io::path(), project::SaveMode saveMode = project::SaveMode::Save);
+    bool doSaveScore(const io::path& filePath = io::path(), project::SaveMode saveMode = project::SaveMode::Save);
 
     void exportScore();
 

--- a/src/project/iprojectfilescontroller.h
+++ b/src/project/iprojectfilescontroller.h
@@ -38,7 +38,7 @@ public:
     virtual bool closeOpenedProject() = 0;
     virtual bool isProjectOpened(const io::path& path) const = 0;
     virtual bool isAnyProjectOpened() const = 0;
-    virtual void saveProject(const io::path& path = io::path()) = 0;
+    virtual bool saveProject(const io::path& path = io::path()) = 0;
 };
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9908

This commit fixes the bug that whenever a user clicks cancel in the save dialog, it causes the project to be closed. So, whenever you close a project by clicking on the cross in the project notation tab or use Ctrl+W on the main project notation (Ctrl+W shortcut will be added soon), and then subsequently click cancel in the save dialog, it will not close the project and lets you return to it. This bug would also be present if you use Alt+F4 shortcut or close the entire app. Now this commit ensures that the app will not quit when the user clicks cancel in save dialog and lets you return to your project.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
