### PR TITLE
Fix #299741 and #289446 - Improved horizontal spacing algorithm 

### DIFF
--- a/src/engraving/layout/layout.cpp
+++ b/src/engraving/layout/layout.cpp
@@ -386,9 +386,9 @@ void Layout::collectLinearSystem(const LayoutOptions& options, LayoutContext& ct
                     m->stretchMeasureInPracticeMode(ww);
                 } else {
                     m->createEndBarLines(false);
-                    m->computeMinWidth(Fraction(1, 16));
+                    m->computeMinWidth(Fraction(1, 16), 1);
                     ww = m->width();
-                    m->stretchMeasure(ww);
+                    m->stretchMeasure(ww, Fraction(1, 16));
                 }
             } else {
                 // for measures not in range, use existing layout

--- a/src/engraving/layout/layout.cpp
+++ b/src/engraving/layout/layout.cpp
@@ -386,9 +386,9 @@ void Layout::collectLinearSystem(const LayoutOptions& options, LayoutContext& ct
                     m->stretchMeasureInPracticeMode(ww);
                 } else {
                     m->createEndBarLines(false);
-                    m->computeMinWidth(Fraction(1, 16), 1);
+                    m->computeWidth(Fraction(1, 16), 1);
                     ww = m->width();
-                    m->stretchMeasure(ww, Fraction(1, 16));
+                    m->layoutMeasureElements();
                 }
             } else {
                 // for measures not in range, use existing layout

--- a/src/engraving/layout/layout.cpp
+++ b/src/engraving/layout/layout.cpp
@@ -386,7 +386,7 @@ void Layout::collectLinearSystem(const LayoutOptions& options, LayoutContext& ct
                     m->stretchMeasureInPracticeMode(ww);
                 } else {
                     m->createEndBarLines(false);
-                    m->computeMinWidth();
+                    m->computeMinWidth(Fraction(1, 16));
                     ww = m->width();
                     m->stretchMeasure(ww);
                 }

--- a/src/engraving/layout/layout.cpp
+++ b/src/engraving/layout/layout.cpp
@@ -347,6 +347,10 @@ void Layout::collectLinearSystem(const LayoutOptions& options, LayoutContext& ct
     ctx.tick = Fraction(0, 1);
     LayoutMeasure::getNextMeasure(options, ctx);
 
+    static constexpr Fraction minTicks = Fraction(1, 16); // In continuous view, we cannot look fot the shortest note
+    // of the system (as we do in page view), because the whole music is a single big system. Therefore,
+    // we simply assume a shortest note of 1/16. This ensures perfect spacing consistency.
+
     while (ctx.curMeasure) {
         qreal ww = 0.0;
         if (ctx.curMeasure->isVBox() || ctx.curMeasure->isTBox()) {
@@ -386,7 +390,7 @@ void Layout::collectLinearSystem(const LayoutOptions& options, LayoutContext& ct
                     m->stretchMeasureInPracticeMode(ww);
                 } else {
                     m->createEndBarLines(false);
-                    m->computeWidth(Fraction(1, 16), 1);
+                    m->computeWidth(minTicks, 1);
                     ww = m->width();
                     m->layoutMeasureElements();
                 }

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -324,7 +324,7 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
                     } else {
                         m->removeSystemTrailer();
                     }
-                    m->computeWidth(m->minSysTicks(), oldStretch);
+                    m->computeWidth(m->system()->minSysTicks(), oldStretch);
                     m->layoutMeasureElements();
                     LayoutBeams::restoreBeams(m);
                     if (m == nm || !m->noBreak()) {

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -378,8 +378,6 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
             } else if (mb->isMeasure()) {
                 Measure* m  = toMeasure(mb);
                 mw          += m->width();                       // measures are stretched already with basicStretch()
-                //int weight   = m->layoutWeight();
-                //totalWeight += weight * m->basicStretch();
                 qreal weight = m->stretchWeight(); // The stretch is now assigned proportionally to the width
                 totalWeight += weight; // No need now to multiply again by m->basicStretch()
             }
@@ -417,8 +415,6 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
             mb->setPos(pos);
             Measure* m = toMeasure(mb);
             qreal stretch = m->basicStretch();
-            //int weight = m->layoutWeight();
-            //ww  += rest * weight * stretch;
             qreal weight = m->stretchWeight(); // Updated stretching formula
             ww += rest * weight;
             m->stretchMeasure(ww);

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -169,7 +169,10 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
         // check if lc.curMeasure fits, remove if not
         // collect at least one measure and the break
 
-        bool doBreak = (system->measures().size() > 1) && ((curSysWidth + ww) > systemWidth * 1.025);
+        static constexpr acceptanceRange = 1.025; // We allow the initial width of the system to be slightly
+        // larger than the target system width. This avoids having to put a measure in the next system just because
+        // it overshoots the width by a tiny amount.
+        bool doBreak = (system->measures().size() > 1) && ((curSysWidth + ww) > systemWidth * acceptanceRange);
         if (doBreak) {
             breakMeasure = ctx.curMeasure;
             system->removeLastMeasure();

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -112,8 +112,7 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
                         minWidth += newWidth - prevWidth;
                     }
                 }
-            }
-            else {
+            } else {
                 changeMinSysTicks = false;
             }
         }

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -90,7 +90,6 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
     bool changeMinSysTicks = false;
 
     while (ctx.curMeasure) {      // collect measure for system
-
         System* oldSystem = ctx.curMeasure->system();
         system->appendMeasure(ctx.curMeasure);
 
@@ -99,11 +98,13 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
         // After appending a new measure, the shortest note in the system may change, in which case
         // we need to recompute the layout of the previous measures. By updating the width of these
         // measures, minWidth must be updated accordingly.
-        if (ctx.curMeasure->isMeasure())
+        if (ctx.curMeasure->isMeasure()) {
             if (toMeasure(ctx.curMeasure)->computeTicks() < minSysTicks) {
                 changeMinSysTicks = true;
                 for (MeasureBase* mb : system->measures()) {
-                    if (mb == ctx.curMeasure) break; // Cause I want to change only previous measures, not current one
+                    if (mb == ctx.curMeasure) {
+                        break; // Cause I want to change only previous measures, not current one
+                    }
                     if (mb->isMeasure()) {
                         qreal prevWidth = toMeasure(mb)->width();
                         toMeasure(mb)->computeMinWidth();
@@ -112,7 +113,10 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
                     }
                 }
             }
-            else changeMinSysTicks = false;
+            else {
+                changeMinSysTicks = false;
+            }
+        }
 
         if (ctx.curMeasure->isMeasure()) {
             Measure* m = toMeasure(ctx.curMeasure);

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -188,7 +188,7 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
                 ctx.curMeasure->setParent(oldSystem);
             }
             // If the last appended measure caused a re-layout of the previous measures, now that we are
-            // removing it we need to re-layout the previous measures again. 
+            // removing it we need to re-layout the previous measures again.
             if (changeMinSysTicks) {
                 minTicks = prevMinTicks; // If the last measure caused it to change, now we need to restore it!
                 for (MeasureBase* mb : system->measures()) {
@@ -421,7 +421,6 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
             }
             mb->setPos(pos);
             Measure* m = toMeasure(mb);
-            qreal stretch = m->basicStretch();
             qreal weight = m->stretchWeight(); // Updated stretching formula
             ww += rest * weight;
             m->stretchMeasure(ww);

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -86,7 +86,7 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
     bool curTrailer = ctx.curMeasure->trailer();
     MeasureBase* breakMeasure = nullptr;
 
-    Fraction minTicks = Fraction(10000, 1); // Initializing this variable at a random high value.
+    Fraction minTicks = Fraction::max(); // Initializing this variable at an arbitrary high value.
     // In principle, it just needs to be longer than any possible note.
     Fraction prevMinTicks = Fraction(1, 1);
     bool changeMinSysTicks = false;

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -86,8 +86,8 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
     bool curTrailer = ctx.curMeasure->trailer();
     MeasureBase* breakMeasure = nullptr;
 
-    Fraction minTicks = Fraction(1, 8); // Inizialize variable which stores the shortest note of the system
-    Fraction prevMinTicks = Fraction(1, 1);
+    Fraction minTicks = Fraction(4, 1); // Inizialize variable which stores the shortest note of the system
+    Fraction prevMinTicks = Fraction(4, 1);
     bool changeMinSysTicks = false;
 
     while (ctx.curMeasure) {      // collect measure for system

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -169,7 +169,7 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
         // check if lc.curMeasure fits, remove if not
         // collect at least one measure and the break
 
-        static constexpr acceptanceRange = 1.025; // We allow the initial width of the system to be slightly
+        static constexpr double acceptanceRange = 1.025; // We allow the initial width of the system to be slightly
         // larger than the target system width. This avoids having to put a measure in the next system just because
         // it overshoots the width by a tiny amount.
         bool doBreak = (system->measures().size() > 1) && ((curSysWidth + ww) > systemWidth * acceptanceRange);

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -3149,8 +3149,6 @@ QString Measure::accessibleInfo() const
 
 void Measure::layoutMeasureElements()
 {
-    //bbox().setWidth(targetWidth); // Doesn't seem to be needed but I keep it here just to be safe
-
     //---------------------------------------------------
     //    layout individual elements
     //---------------------------------------------------
@@ -4008,7 +4006,7 @@ static bool hasAccidental(Segment* s)
 }
 
 //---------------------------------------------------------
-//      Stretch formula
+//      durationStretch
 //      Computes the stretch for a given segment depending
 //      on its duration with respect to the shortest one.
 //      Three different options proposed (see documentation).
@@ -4019,7 +4017,7 @@ float Measure::durationStretch(Fraction curTicks, const Fraction minTicks) const
     static constexpr qreal baseSlope = 0.647;
     qreal slope = userSlope * baseSlope;
     // The slope of the spacing formula is determined by the multiplication of user-defined settings and baseSlope.
-    // The value of baseSlope is chosen such that, for the default user settings, the curve matches the Gould.
+    // The value of baseSlope is chosen such that the curve matches the "ideal" one when user settings are at default.
     // See documentation PDF for more detail.
 
     static constexpr int maxMMRestWidth = 20; // At most, MM rests will be spaced "as if" they were 20 bars long.
@@ -4046,7 +4044,7 @@ float Measure::durationStretch(Fraction curTicks, const Fraction minTicks) const
     //qreal str = 1 - 0.112 * slope +  0.112 * slope * qreal(curTicks.ticks()) / qreal(minTicks.ticks());
     // Logarithmic spacing (MS 3.6)
     //qreal str = 1.0 + 0.721 * slope * log(qreal(curTicks.ticks()) / qreal(minTicks.ticks()));
-    // Quadratic spacing (Gould)
+    // Quadratic spacing
     qreal str = 1 - slope + slope * sqrt(qreal(curTicks.ticks()) / qreal(minTicks.ticks()));
 
     if (minTicks > longNoteThreshold) {
@@ -4077,8 +4075,10 @@ void Measure::computeWidth(Segment* s, qreal x, bool isSystemHeader, Fraction mi
     bool first  = isFirstInSystem();
     const Shape ls(first ? RectF(0.0, -1000000.0, 0.0, 2000000.0) : RectF(0.0, 0.0, 0.0, spatium() * 4));
 
-    qreal minNoteSpace = score()->noteHeadWidth() * 1.05;
-    qreal usrStretch = qMax(userStretch() * score()->styleD(Sid::measureSpacing), qreal(0.1)); // The qMax avoids stretch going to zero
+    qreal minNoteSpace = score()->noteHeadWidth() * 1.05; // This used to be minNoteSpace = noteHeadWidth() + minNoteDistance().
+    // I have removed minNoteDistance() because it was causing an unintuitive behaviour in the spacing,
+    // and I've substituted it with a purely empirical factor (*1.05) which obtains a similar default distance.
+    qreal usrStretch = std::max(userStretch() * score()->styleD(Sid::measureSpacing), qreal(0.1)); // The max() avoids stretch going to zero
 
     while (s) {
         s->rxpos() = x;
@@ -4119,7 +4119,7 @@ void Measure::computeWidth(Segment* s, qreal x, bool isSystemHeader, Fraction mi
                     // NOTE: durStretch is the spacing factor purely determined by the duration of the note.
                     // usrStretch is the spacing factor determined by user settings.
                     // stretchCoeff is the spacing factor used to justify the systems, i.e. getting the systems to fill the page.
-                    w = qMax(w, minStretchedWidth);
+                    w = std::max(w, minStretchedWidth);
                 }
             }
             // look back for collisions with previous segments

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -3663,11 +3663,10 @@ qreal Measure::basicWidth() const
 
 //---------------------------------------------------------
 //   stretchWeight
-//   Used for distributing the space remaining at the end of
-//   a system. Returns a weight parameter proportional to the
+//   Returns a weight parameter proportional to the
 //   current with of the measure.
 //---------------------------------------------------------
-qreal Measure::stretchWeight() 
+qreal Measure::stretchWeight()
 {
     if (isMMRest()) {
         return width();
@@ -4153,7 +4152,7 @@ static bool hasAccidental(Segment* s)
 //      returns the shortest note/rest in the system
 //---------------------------------------------------------
 
-Fraction Measure::minSysTicks() 
+Fraction Measure::minSysTicks()
 {
     Fraction minTicks = ticks();
     //System* sys = system();
@@ -4168,8 +4167,7 @@ Fraction Measure::minSysTicks()
     }
     if (minTicks > Fraction(1, 8)) {
         return Fraction(1, 8);
-    }
-    else {
+    } else {
         return minTicks;
     }
 }
@@ -4180,7 +4178,7 @@ Fraction Measure::minSysTicks()
 //      on its duration with respect to the shortest one.
 //      Three different options proposed (see documentation).
 //---------------------------------------------------------
-qreal Measure::stretchFormula(Fraction curTicks, Fraction minTicks) 
+qreal Measure::stretchFormula(Fraction curTicks, Fraction minTicks)
 {
     qreal uStretch = userStretch();
     qreal genLayoutStretch = score()->styleD(Sid::measureSpacing);

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -4080,8 +4080,7 @@ static bool hasAccidental(Segment* s)
 
 Fraction Measure::minSysTicks()
 {
-    Fraction minTicks = Fraction(1, 8);
-    //System* sys = system();
+    Fraction minTicks = Fraction(10, 1);
     for (MeasureBase* mb : system()->measures()) {
         if (mb->isMeasure()) {
             Measure* m = toMeasure(mb);
@@ -4155,7 +4154,7 @@ void Measure::computeWidth(Segment* s, qreal x, bool isSystemHeader, Fraction mi
     const Shape ls(first ? RectF(0.0, -1000000.0, 0.0, 2000000.0) : RectF(0.0, 0.0, 0.0, spatium() * 4));
 
     qreal minNoteSpace = score()->noteHeadWidth() * 1.05;
-    qreal stretch = userStretch() * score()->styleD(Sid::measureSpacing);
+    qreal stretch = qMax(userStretch() * score()->styleD(Sid::measureSpacing), qreal(1));
 
     while (s) {
         s->rxpos() = x;

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -3674,8 +3674,7 @@ qreal Measure::stretchWeight()
     qreal w = 0;
     qreal W = 0;
     qreal weight = 0;
-    qreal minNoteSpace = (score()->noteHeadWidth() + score()->styleMM(Sid::minNoteDistance));
-    qreal minNoteDistance = score()->styleMM(Sid::minNoteDistance);
+    qreal minNoteSpace = score()->noteHeadWidth();
     Fraction minTicks = minSysTicks();
     for (Segment* s = first(); s; s = s->next()) {
         if (s->enabled() && s->visible() && !s->allElementsInvisible() && s->isChordRestType()) {
@@ -4180,11 +4179,15 @@ qreal Measure::stretchFormula(Fraction curTicks, Fraction minTicks)
     qreal genLayoutStretch = score()->styleD(Sid::measureSpacing);
     qreal stretch = uStretch * genLayoutStretch;
     // Linear spacing
-    //qreal str = 1 - 0.945 * stretch +  0.945 * stretch * qreal(curTicks.ticks()) / qreal(minTicks.ticks());
+    //qreal str = 1 - 0.112 * stretch +  0.112 * stretch * qreal(curTicks.ticks()) / qreal(minTicks.ticks());
     // Logarithmic spacing (MS 3.6)
     //qreal str = 1.0 + 0.721 * stretch * log(qreal(curTicks.ticks()) / qreal(minTicks.ticks()));
     // Quadratic spacing (Gould)
     qreal str = 1 - 0.647 * stretch + 0.647 * stretch * sqrt(qreal(curTicks.ticks()) / qreal(minTicks.ticks()));
+    if (minTicks > Fraction(1, 16)) {
+        // This additional stretch avoids long notes being too narrow in the absense of shorter notes.
+        str = str * (1 - 0.5 + 0.5 * sqrt(qreal(minTicks.ticks()) / qreal(Fraction(1, 16).ticks())));
+    }
     return str;
     //TODO: choose formula in style settings
 }
@@ -4204,8 +4207,8 @@ void Measure::computeMinWidth(Segment* s, qreal x, bool isSystemHeader, Fraction
     bool first  = isFirstInSystem();
     const Shape ls(first ? RectF(0.0, -1000000.0, 0.0, 2000000.0) : RectF(0.0, 0.0, 0.0, spatium() * 4));
 
-    //Fraction minTicks = minSysTicks(); // New spacing algorithm: we get the shortest note duration in the system.
-    qreal minNoteSpace = (score()->noteHeadWidth() + score()->styleMM(Sid::minNoteDistance));
+    qreal minNoteSpace = score()->noteHeadWidth();
+    qreal stretch = userStretch() * score()->styleD(Sid::measureSpacing);
 
     if (isMMRest()) {
         // Reset MM rest to initial size and position
@@ -4258,7 +4261,7 @@ void Measure::computeMinWidth(Segment* s, qreal x, bool isSystemHeader, Fraction
                 qreal str = stretchFormula(t, minTicks);
                 // Simply doing w * str would be wrong at this point cause you would stretch also the additional
                 // space taken by accidentals.
-                qreal minStretchedWidth = minNoteSpace * str * basicStretch();
+                qreal minStretchedWidth = minNoteSpace * str * stretch;
                 w = qMax(w, minStretchedWidth);
             }
             // look back for collisions with previous segments

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -3148,17 +3148,13 @@ void Measure::stretchMeasure(qreal targetWidth)
 {
     bbox().setWidth(targetWidth);
 
-    Fraction minTick = computeTicks();
-
     //---------------------------------------------------
     //    compute stretch
     //---------------------------------------------------
 
     std::multimap<qreal, Segment*> springs;
 
-    //Fraction minTicks = computeTicks();
     Fraction minTicks = minSysTicks(); // The stretching must be done according to the shortest note *of the system*!
-    qreal minNoteSpace = (score()->noteHeadWidth() + score()->styleMM(Sid::minNoteDistance));
 
     Segment* seg = first();
     while (seg && (!seg->enabled() || seg->allElementsInvisible())) {

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -4113,7 +4113,8 @@ void Measure::setStretchedWidth(qreal w)
     // applied within computeMinWidth(). This function was the main responsible for measures 
     // with many accidentals being too wide.
 
-    /*qreal stretchableWidth = 0.0;
+#if 0
+    qreal stretchableWidth = 0.0;
     for (Segment* s = first(SegmentType::ChordRest); s; s = s->next(SegmentType::ChordRest)) {
         if (!s->enabled()) {
             continue;
@@ -4122,8 +4123,8 @@ void Measure::setStretchedWidth(qreal w)
     }
     const int maxMMRestLength = 32;       // TODO: style
     int weight = layoutWeight(maxMMRestLength);
-    w += stretchableWidth * (basicStretch() - 1.0) * weight / 1920.0;*/
-
+    w += stretchableWidth * (basicStretch() - 1.0) * weight / 1920.0;
+#endif
     setWidth(w);
 }
 

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -3156,6 +3156,10 @@ void Measure::stretchMeasure(qreal targetWidth)
 
     std::multimap<qreal, Segment*> springs;
 
+    //Fraction minTicks = computeTicks();
+    Fraction minTicks = minSysTicks(); // The stretching must be done according to the shortest note *of the system*!
+    qreal minNoteSpace = (score()->noteHeadWidth() + score()->styleMM(Sid::minNoteDistance));
+
     Segment* seg = first();
     while (seg && (!seg->enabled() || seg->allElementsInvisible())) {
         seg = seg->next();
@@ -3167,7 +3171,7 @@ void Measure::stretchMeasure(qreal targetWidth)
         }
         Fraction t = s.ticks();
         if (t.isNotZero()) {
-            qreal str = 1.0 + 0.865617 * log(qreal(t.ticks()) / qreal(minTick.ticks()));       // .6 * log(t / minTick.ticks()) / log(2);
+            qreal str = stretchFormula(t, minTicks); // Moved the formula to a dedicated method
             qreal d   = s.width() / str;
             s.setStretch(str);
             springs.insert(std::pair<qreal, Segment*>(d, &s));
@@ -3658,6 +3662,40 @@ qreal Measure::basicWidth() const
 }
 
 //---------------------------------------------------------
+//   stretchWeight
+//   Used for distributing the space remaining at the end of
+//   a system. Returns a weight parameter proportional to the
+//   current with of the measure. You cannot simply get it 
+//   by multiplying measure->width() becase measures containing 
+//   additional elements such as clefs, tempo, etc would be 
+//   stretched more than the others.
+//---------------------------------------------------------
+qreal Measure::stretchWeight() {
+    if (isMMRest())
+        return width();
+    qreal w = 0;
+    qreal W = 0;
+    qreal weight = 0;
+    qreal minNoteSpace = (score()->noteHeadWidth() + score()->styleMM(Sid::minNoteDistance));
+    qreal minNoteDistance = score()->styleMM(Sid::minNoteDistance);
+    Fraction minTicks = minSysTicks();
+ 
+    for (Segment* s = first(); s; s = s->next()) {
+        if (s->enabled() && s->visible() && !s->allElementsInvisible() && s->isChordRestType()) {
+            qreal str = stretchFormula(s->ticks(), minTicks);
+            w += minNoteSpace * str * basicStretch();
+            W += s->width();
+            // You cannot simply do weight += s->width(), because the s->width() also includes
+            // the space for accidentals, and it would cause measures with many accidentals to be 
+            // given more weight than the others, resulting in inconsistent spacing.
+        }
+        continue;
+    }
+    weight = w * (w / W); // Empirical correction factor (see documentation)
+    return weight;
+}
+
+//---------------------------------------------------------
 //   layoutWeight
 //---------------------------------------------------------
 
@@ -4071,7 +4109,11 @@ void Measure::setStretchedWidth(qreal w)
         w = minWidth;
     }
 
-    qreal stretchableWidth = 0.0;
+    // New spacing algorithm: this stretching is not necessary anymore, as it's already
+    // applied within computeMinWidth(). This function was the main responsible for measures 
+    // with many accidentals being too wide.
+
+    /*qreal stretchableWidth = 0.0;
     for (Segment* s = first(SegmentType::ChordRest); s; s = s->next(SegmentType::ChordRest)) {
         if (!s->enabled()) {
             continue;
@@ -4080,7 +4122,7 @@ void Measure::setStretchedWidth(qreal w)
     }
     const int maxMMRestLength = 32;       // TODO: style
     int weight = layoutWeight(maxMMRestLength);
-    w += stretchableWidth * (basicStretch() - 1.0) * weight / 1920.0;
+    w += stretchableWidth * (basicStretch() - 1.0) * weight / 1920.0;*/
 
     setWidth(w);
 }
@@ -4112,6 +4154,56 @@ static bool hasAccidental(Segment* s)
 }
 
 //---------------------------------------------------------
+//      minSysTicks
+//      returns the shortest note/rest in the system
+//---------------------------------------------------------
+
+Fraction Measure::minSysTicks() {
+    Fraction minTicks = ticks();
+    //System* sys = system();
+    for (MeasureBase* mb : system()->measures()) {
+        if (mb->isMeasure()) {
+            Measure* m = toMeasure(mb);
+            Fraction curMinTicks = m->computeTicks();
+            if (curMinTicks < minTicks)
+                minTicks = curMinTicks;
+        }
+    }
+    if (minTicks > Fraction(1, 8))
+        return Fraction(1, 8);
+    else
+        return minTicks;
+}
+
+//---------------------------------------------------------
+//      Stretch formula
+//      Computes the stretch for a given segment depending
+//      on its duration with respect to the shortest one.
+//      The spacing formula is customizable. Three options
+//      proposed: linear spacing, quadratic spacing (Gould),
+//      or logarithmic spacing (Musescore 3.6). 
+//      These formulas takes into account also user stretch and style
+//      settings. This produces a finer, more natural response 
+//      to the } and { commands. The numeric coefficients are 
+//      optimized to give the best results for userStretch = 1
+//      and measureSpacing = 1.2, i.e. the program defaults (see
+//      documentation). 
+//      TODO: choice of formula in style settings!
+//---------------------------------------------------------
+qreal Measure::stretchFormula(Fraction curTicks, Fraction minTicks) {
+    qreal uStretch = userStretch();
+    qreal genLayoutStretch = score()->styleD(Sid::measureSpacing);
+    qreal stretch = uStretch * genLayoutStretch;
+    // Linear spacing
+    //qreal str = 1 - 0.945 * stretch +  0.945 * stretch * qreal(curTicks.ticks()) / qreal(minTicks.ticks());
+    // Logarithmic spacing (MS 3.6)
+    //qreal str = 1.0 + 0.721 * stretch * log(qreal(curTicks.ticks()) / qreal(minTicks.ticks()));
+    // Quadratic spacing (Gould)
+    qreal str = 1 - 0.647 * stretch + 0.647 * stretch * sqrt(qreal(curTicks.ticks()) / qreal(minTicks.ticks()));
+    return str;
+}
+
+//---------------------------------------------------------
 //   computeMinWidth
 //    sets the minimum stretched width of segment list s
 //    set the width and x position for all segments
@@ -4125,6 +4217,9 @@ void Measure::computeMinWidth(Segment* s, qreal x, bool isSystemHeader)
     }
     bool first  = isFirstInSystem();
     const Shape ls(first ? RectF(0.0, -1000000.0, 0.0, 2000000.0) : RectF(0.0, 0.0, 0.0, spatium() * 4));
+
+    Fraction minTicks = minSysTicks(); // New spacing algorithm: we get the shortest note duration in the system.
+    qreal minNoteSpace = (score()->noteHeadWidth() + score()->styleMM(Sid::minNoteDistance));
 
     if (isMMRest()) {
         // Reset MM rest to initial size and position
@@ -4170,6 +4265,15 @@ void Measure::computeMinWidth(Segment* s, qreal x, bool isSystemHeader)
                 isSystemHeader = false;
             } else {
                 w = s->minHorizontalDistance(ns, false);
+                // New spacing algorithm: we apply an additional spacing which depends on the duration of
+                // the note with respect to the shortest note *of the system*. This is done
+                // according to the stretch formula, which can be customized.
+                Fraction t = s->ticks();
+                qreal str = stretchFormula(t, minTicks);
+                // Simply doing w * str would be wrong at this point cause you would stretch also the additional
+                // space taken by accidentals.
+                qreal minStretchedWidth = minNoteSpace * str * basicStretch();
+                w = qMax(w, minStretchedWidth);
             }
             // look back for collisions with previous segments
             // this is time consuming (ca. +5%) and probably requires more optimization

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -3665,29 +3665,25 @@ qreal Measure::basicWidth() const
 //   stretchWeight
 //   Used for distributing the space remaining at the end of
 //   a system. Returns a weight parameter proportional to the
-//   current with of the measure. You cannot simply get it 
-//   by multiplying measure->width() becase measures containing 
-//   additional elements such as clefs, tempo, etc would be 
-//   stretched more than the others.
+//   current with of the measure.
 //---------------------------------------------------------
-qreal Measure::stretchWeight() {
-    if (isMMRest())
+qreal Measure::stretchWeight() 
+{
+    if (isMMRest()) {
         return width();
+    }
     qreal w = 0;
     qreal W = 0;
     qreal weight = 0;
     qreal minNoteSpace = (score()->noteHeadWidth() + score()->styleMM(Sid::minNoteDistance));
     qreal minNoteDistance = score()->styleMM(Sid::minNoteDistance);
     Fraction minTicks = minSysTicks();
- 
     for (Segment* s = first(); s; s = s->next()) {
         if (s->enabled() && s->visible() && !s->allElementsInvisible() && s->isChordRestType()) {
             qreal str = stretchFormula(s->ticks(), minTicks);
             w += minNoteSpace * str * basicStretch();
             W += s->width();
-            // You cannot simply do weight += s->width(), because the s->width() also includes
-            // the space for accidentals, and it would cause measures with many accidentals to be 
-            // given more weight than the others, resulting in inconsistent spacing.
+            // You cannot simply do weight += s->width(), because the s->width() also includes accidentals
         }
         continue;
     }
@@ -4109,9 +4105,7 @@ void Measure::setStretchedWidth(qreal w)
         w = minWidth;
     }
 
-    // New spacing algorithm: this stretching is not necessary anymore, as it's already
-    // applied within computeMinWidth(). This function was the main responsible for measures 
-    // with many accidentals being too wide.
+    // New spacing algorithm: this stretching is not necessary anymore.
 
 #if 0
     qreal stretchableWidth = 0.0;
@@ -4159,39 +4153,35 @@ static bool hasAccidental(Segment* s)
 //      returns the shortest note/rest in the system
 //---------------------------------------------------------
 
-Fraction Measure::minSysTicks() {
+Fraction Measure::minSysTicks() 
+{
     Fraction minTicks = ticks();
     //System* sys = system();
     for (MeasureBase* mb : system()->measures()) {
         if (mb->isMeasure()) {
             Measure* m = toMeasure(mb);
             Fraction curMinTicks = m->computeTicks();
-            if (curMinTicks < minTicks)
+            if (curMinTicks < minTicks) {
                 minTicks = curMinTicks;
+            }
         }
     }
-    if (minTicks > Fraction(1, 8))
+    if (minTicks > Fraction(1, 8)) {
         return Fraction(1, 8);
-    else
+    }
+    else {
         return minTicks;
+    }
 }
 
 //---------------------------------------------------------
 //      Stretch formula
 //      Computes the stretch for a given segment depending
 //      on its duration with respect to the shortest one.
-//      The spacing formula is customizable. Three options
-//      proposed: linear spacing, quadratic spacing (Gould),
-//      or logarithmic spacing (Musescore 3.6). 
-//      These formulas takes into account also user stretch and style
-//      settings. This produces a finer, more natural response 
-//      to the } and { commands. The numeric coefficients are 
-//      optimized to give the best results for userStretch = 1
-//      and measureSpacing = 1.2, i.e. the program defaults (see
-//      documentation). 
-//      TODO: choice of formula in style settings!
+//      Three different options proposed (see documentation).
 //---------------------------------------------------------
-qreal Measure::stretchFormula(Fraction curTicks, Fraction minTicks) {
+qreal Measure::stretchFormula(Fraction curTicks, Fraction minTicks) 
+{
     qreal uStretch = userStretch();
     qreal genLayoutStretch = score()->styleD(Sid::measureSpacing);
     qreal stretch = uStretch * genLayoutStretch;
@@ -4202,6 +4192,7 @@ qreal Measure::stretchFormula(Fraction curTicks, Fraction minTicks) {
     // Quadratic spacing (Gould)
     qreal str = 1 - 0.647 * stretch + 0.647 * stretch * sqrt(qreal(curTicks.ticks()) / qreal(minTicks.ticks()));
     return str;
+    //TODO: choose formula in style settings
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/measure.h
+++ b/src/engraving/libmscore/measure.h
@@ -210,7 +210,10 @@ public:
     qreal userStretch() const;
     void setUserStretch(qreal v) { m_userStretch = v; }
 
-    void stretchMeasure(qreal stretch, Fraction minTicks);
+    void setLayoutStretch(qreal stretchCoeff) { m_layoutStretch = stretchCoeff; }
+    qreal layoutStretch() { return m_layoutStretch; }
+
+    void layoutMeasureElements();
     Fraction computeTicks();
     void layout2();
 
@@ -339,7 +342,7 @@ public:
     qreal stretchWeight();
     qreal stretchFormula(Fraction curTicks, Fraction minTicks, qreal stretchCoeff);
     Fraction minSysTicks();
-    void computeMinWidth(Fraction minTicks, qreal stretchCoeff);
+    void computeWidth(Fraction minTicks, qreal stretchCoeff);
     void checkHeader();
     void checkTrailer();
     void setStretchedWidth(qreal);
@@ -370,7 +373,7 @@ private:
     void push_front(Segment* e);
 
     void fillGap(const Fraction& pos, const Fraction& len, int track, const Fraction& stretch, bool useGapRests = true);
-    void computeMinWidth(Segment* s, qreal x, bool isSystemHeader, Fraction minTicks, qreal stretchCoeff);
+    void computeWidth(Segment* s, qreal x, bool isSystemHeader, Fraction minTicks, qreal stretchCoeff);
 
     MStaff* mstaff(int staffIndex) const;
 
@@ -395,6 +398,8 @@ private:
     bool m_breakMultiMeasureRest;
 
     Fraction m_quantumOfSegmentCell = { 1, 16 };
+
+    qreal m_layoutStretch = 1;
 };
 }     // namespace Ms
 #endif

--- a/src/engraving/libmscore/measure.h
+++ b/src/engraving/libmscore/measure.h
@@ -336,6 +336,9 @@ public:
     qreal basicStretch() const;
     qreal basicWidth() const;
     int layoutWeight(int maxMMRestLength = 0) const;
+    qreal stretchWeight();
+    qreal stretchFormula(Fraction curTicks, Fraction minTicks);
+    Fraction minSysTicks();
     void computeMinWidth() override;
     void checkHeader();
     void checkTrailer();

--- a/src/engraving/libmscore/measure.h
+++ b/src/engraving/libmscore/measure.h
@@ -210,7 +210,7 @@ public:
     qreal userStretch() const;
     void setUserStretch(qreal v) { m_userStretch = v; }
 
-    void stretchMeasure(qreal stretch);
+    void stretchMeasure(qreal stretch, Fraction minTicks);
     Fraction computeTicks();
     void layout2();
 
@@ -337,9 +337,9 @@ public:
     qreal basicWidth() const;
     int layoutWeight(int maxMMRestLength = 0) const;
     qreal stretchWeight();
-    qreal stretchFormula(Fraction curTicks, Fraction minTicks);
+    qreal stretchFormula(Fraction curTicks, Fraction minTicks, qreal stretchCoeff);
     Fraction minSysTicks();
-    void computeMinWidth(Fraction minTicks);
+    void computeMinWidth(Fraction minTicks, qreal stretchCoeff);
     void checkHeader();
     void checkTrailer();
     void setStretchedWidth(qreal);
@@ -370,7 +370,7 @@ private:
     void push_front(Segment* e);
 
     void fillGap(const Fraction& pos, const Fraction& len, int track, const Fraction& stretch, bool useGapRests = true);
-    void computeMinWidth(Segment* s, qreal x, bool isSystemHeader, Fraction minTicks);
+    void computeMinWidth(Segment* s, qreal x, bool isSystemHeader, Fraction minTicks, qreal stretchCoeff);
 
     MStaff* mstaff(int staffIndex) const;
 

--- a/src/engraving/libmscore/measure.h
+++ b/src/engraving/libmscore/measure.h
@@ -338,10 +338,7 @@ public:
     void triggerLayout() const override;
     qreal basicStretch() const;
     qreal basicWidth() const;
-    int layoutWeight(int maxMMRestLength = 0) const;
-    qreal stretchWeight();
-    qreal stretchFormula(Fraction curTicks, Fraction minTicks, qreal stretchCoeff);
-    Fraction minSysTicks();
+    float durationStretch(Fraction curTicks, const Fraction minTicks) const;
     void computeWidth(Fraction minTicks, qreal stretchCoeff);
     void checkHeader();
     void checkTrailer();
@@ -399,7 +396,7 @@ private:
 
     Fraction m_quantumOfSegmentCell = { 1, 16 };
 
-    qreal m_layoutStretch = 1;
+    double m_layoutStretch = 1.0;
 };
 }     // namespace Ms
 #endif

--- a/src/engraving/libmscore/measure.h
+++ b/src/engraving/libmscore/measure.h
@@ -339,7 +339,7 @@ public:
     qreal stretchWeight();
     qreal stretchFormula(Fraction curTicks, Fraction minTicks);
     Fraction minSysTicks();
-    void computeMinWidth() override;
+    void computeMinWidth(Fraction minTicks);
     void checkHeader();
     void checkTrailer();
     void setStretchedWidth(qreal);
@@ -370,7 +370,7 @@ private:
     void push_front(Segment* e);
 
     void fillGap(const Fraction& pos, const Fraction& len, int track, const Fraction& stretch, bool useGapRests = true);
-    void computeMinWidth(Segment* s, qreal x, bool isSystemHeader);
+    void computeMinWidth(Segment* s, qreal x, bool isSystemHeader, Fraction minTicks);
 
     MStaff* mstaff(int staffIndex) const;
 

--- a/src/engraving/libmscore/system.cpp
+++ b/src/engraving/libmscore/system.cpp
@@ -1832,14 +1832,13 @@ int System::lastVisibleSysStaffOfPart(const Part* part) const
 
 Fraction System::minSysTicks() const
 {
-    Fraction minTicks = Fraction(10, 1); // Initializing the variable at a random high value.
+    Fraction minTicks = Fraction (10000, 1); // Initializing the variable at a random high value.
+    // In principle, it just needs to be longer than any possible note, such that the following loop
+    // always correctly returns the shortest note/rest of the system.
     for (MeasureBase* mb : measures()) {
         if (mb->isMeasure()) {
             Measure* m = toMeasure(mb);
-            Fraction curMinTicks = m->computeTicks();
-            if (curMinTicks < minTicks) {
-                minTicks = curMinTicks;
-            }
+            minTicks = std::min(m->computeTicks(), minTicks);
         }
     }
     return minTicks;

--- a/src/engraving/libmscore/system.cpp
+++ b/src/engraving/libmscore/system.cpp
@@ -1832,7 +1832,7 @@ int System::lastVisibleSysStaffOfPart(const Part* part) const
 
 Fraction System::minSysTicks() const
 {
-    Fraction minTicks = Fraction (10000, 1); // Initializing the variable at a random high value.
+    Fraction minTicks = Fraction::max(); // Initializing the variable at an arbitrary high value.
     // In principle, it just needs to be longer than any possible note, such that the following loop
     // always correctly returns the shortest note/rest of the system.
     for (MeasureBase* mb : measures()) {

--- a/src/engraving/libmscore/system.cpp
+++ b/src/engraving/libmscore/system.cpp
@@ -1824,4 +1824,24 @@ int System::lastVisibleSysStaffOfPart(const Part* part) const
     }
     return -1;   // No visible staves on this part.
 }
+
+//---------------------------------------------------------
+//      minSysTicks
+//      returns the shortest note/rest in the system
+//---------------------------------------------------------
+
+Fraction System::minSysTicks() const
+{
+    Fraction minTicks = Fraction(10, 1); // Initializing the variable at a random high value.
+    for (MeasureBase* mb : measures()) {
+        if (mb->isMeasure()) {
+            Measure* m = toMeasure(mb);
+            Fraction curMinTicks = m->computeTicks();
+            if (curMinTicks < minTicks) {
+                minTicks = curMinTicks;
+            }
+        }
+    }
+    return minTicks;
+}
 }

--- a/src/engraving/libmscore/system.h
+++ b/src/engraving/libmscore/system.h
@@ -233,6 +233,8 @@ public:
     int firstVisibleSysStaffOfPart(const Part* part) const;
     int lastSysStaffOfPart(const Part* part) const;
     int lastVisibleSysStaffOfPart(const Part* part) const;
+
+    Fraction minSysTicks() const;
 };
 
 typedef QList<System*>::iterator iSystem;

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -189,7 +189,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::smallStaffStemDirection, "smallStaffStemDirection", DirectionV::UP },
     { Sid::preferStemDirectionMatchContext, "preferStemDirectionMatchContext", false },
     { Sid::beginRepeatLeftMargin,   "beginRepeatLeftMargin",   Spatium(1.0) },
-    { Sid::minNoteDistance,         "minNoteDistance",         Spatium(0.4) }, // was 0.2
+    { Sid::minNoteDistance,         "minNoteDistance",         Spatium(0.2) },
     { Sid::barNoteDistance,         "barNoteDistance",         Spatium(1.3) },     // was 1.2
 
     { Sid::barAccidentalDistance,   "barAccidentalDistance",   Spatium(0.65) },

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -189,7 +189,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::smallStaffStemDirection, "smallStaffStemDirection", DirectionV::UP },
     { Sid::preferStemDirectionMatchContext, "preferStemDirectionMatchContext", false },
     { Sid::beginRepeatLeftMargin,   "beginRepeatLeftMargin",   Spatium(1.0) },
-    { Sid::minNoteDistance,         "minNoteDistance",         Spatium(0.2) },
+    { Sid::minNoteDistance,         "minNoteDistance",         Spatium(0.4) }, // was 0.2
     { Sid::barNoteDistance,         "barNoteDistance",         Spatium(1.3) },     // was 1.2
 
     { Sid::barAccidentalDistance,   "barAccidentalDistance",   Spatium(0.65) },

--- a/src/engraving/types/fraction.h
+++ b/src/engraving/types/fraction.h
@@ -71,6 +71,9 @@ public:
     int numerator() const { return m_numerator; }
     int denominator() const { return m_denominator; }
 
+    static constexpr Fraction max() { return Fraction(10000, 1); }
+    // Use this when you need to initialize a Fraction to an arbitrary high value
+
     void setNumerator(int v) { m_numerator = v; }
     void setDenominator(int v)
     {

--- a/src/engraving/utests/beam_data/Beam-A.mscx
+++ b/src/engraving/utests/beam_data/Beam-A.mscx
@@ -712,8 +712,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>38</l1>
-            <l2>40</l2>
+            <l1>32</l1>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>

--- a/src/engraving/utests/beam_data/Beam-B.mscx
+++ b/src/engraving/utests/beam_data/Beam-B.mscx
@@ -297,8 +297,8 @@
             </Chord>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>-6</l1>
-            <l2>-8</l2>
+            <l1>0</l1>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -1123,8 +1123,8 @@
             </Chord>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>38</l1>
-            <l2>40</l2>
+            <l1>32</l1>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/beam_data/Beam-C.mscx
+++ b/src/engraving/utests/beam_data/Beam-C.mscx
@@ -255,8 +255,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-6</l1>
-            <l2>-8</l2>
+            <l1>0</l1>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>

--- a/src/engraving/utests/beam_data/Beam-D.mscx
+++ b/src/engraving/utests/beam_data/Beam-D.mscx
@@ -751,8 +751,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>38</l1>
-            <l2>40</l2>
+            <l1>32</l1>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -790,7 +790,7 @@
             </Chord>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>40</l1>
+            <l1>38</l1>
             <l2>44</l2>
             </Beam>
           <Chord>

--- a/src/engraving/utests/beam_data/Beam-D.mscx
+++ b/src/engraving/utests/beam_data/Beam-D.mscx
@@ -814,7 +814,7 @@
         <voice>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>44</l1>
+            <l1>42</l1>
             <l2>48</l2>
             </Beam>
           <Chord>

--- a/src/engraving/utests/beam_data/Beam-E.mscx
+++ b/src/engraving/utests/beam_data/Beam-E.mscx
@@ -990,7 +990,7 @@
         <voice>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>52</l1>
+            <l1>46</l1>
             <l2>48</l2>
             </Beam>
           <Chord>
@@ -1010,7 +1010,7 @@
           <Beam>
             <StemDirection>down</StemDirection>
             <l1>52</l1>
-            <l2>48</l2>
+            <l2>46</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -1030,7 +1030,7 @@
           <Beam>
             <StemDirection>down</StemDirection>
             <l1>52</l1>
-            <l2>48</l2>
+            <l2>46</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/beam_data/Beam-E.mscx
+++ b/src/engraving/utests/beam_data/Beam-E.mscx
@@ -990,8 +990,8 @@
         <voice>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>46</l1>
-            <l2>48</l2>
+            <l1>52</l1>
+            <l2>46</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/beam_data/Beam-F.mscx
+++ b/src/engraving/utests/beam_data/Beam-F.mscx
@@ -992,7 +992,7 @@
           <Beam>
             <StemDirection>down</StemDirection>
             <l1>48</l1>
-            <l2>44</l2>
+            <l2>42</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -1011,7 +1011,7 @@
           <Beam>
             <StemDirection>down</StemDirection>
             <l1>48</l1>
-            <l2>44</l2>
+            <l2>42</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -1031,7 +1031,7 @@
           <Beam>
             <StemDirection>down</StemDirection>
             <l1>48</l1>
-            <l2>44</l2>
+            <l2>42</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/beam_data/Beam-G.mscx
+++ b/src/engraving/utests/beam_data/Beam-G.mscx
@@ -902,7 +902,7 @@
           <Beam>
             <StemDirection>down</StemDirection>
             <l1>44</l1>
-            <l2>40</l2>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -922,7 +922,7 @@
           <Beam>
             <StemDirection>down</StemDirection>
             <l1>44</l1>
-            <l2>40</l2>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -941,7 +941,7 @@
           <Beam>
             <StemDirection>down</StemDirection>
             <l1>44</l1>
-            <l2>40</l2>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>

--- a/src/engraving/utests/copypastesymbollist_data/copypastesymbollist-lyrics-ref.mscx
+++ b/src/engraving/utests/copypastesymbollist_data/copypastesymbollist-lyrics-ref.mscx
@@ -287,7 +287,7 @@
       <Measure>
         <voice>
           <Beam>
-            <l1>24</l1>
+            <l1>30</l1>
             <l2>32</l2>
             </Beam>
           <Chord>

--- a/src/importexport/capella/tests/data/test7.cap-ref.mscx
+++ b/src/importexport/capella/tests/data/test7.cap-ref.mscx
@@ -808,7 +808,7 @@
             <accidental>-7</accidental>
             </KeySig>
           <Beam>
-            <l1>8</l1>
+            <l1>2</l1>
             <l2>0</l2>
             </Beam>
           <Chord>


### PR DESCRIPTION
Fix #299741 and #289446

Ensures consistent spacing of same-duration notes within the same system.
Behaves much better with measures containing many accidentals.
Has customizable spacing formula (possibly to be chosen in Style settings). 
The default spacing formula now perfectly replicates the spacing suggested by Gould.
Provides smoother behaviour to the } and { stretch commands.

Please see attached PDF for full documentation.

- [x] I signed [CLA]
- [x] I made sure the code in the PR follows [the coding rules]
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
 
[An improved horizontal spacing algorithm for Musescore.pdf](https://github.com/musescore/MuseScore/files/7625701/An.improved.horizontal.spacing.algorithm.for.Musescore.pdf)

