### PR TITLE
[MU4] Fix #9837: Settings in Styles dialog override changes to individual text objects

### DIFF
--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -3665,7 +3665,7 @@ void TextBase::undoChangeProperty(Pid id, const PropertyValue& v, PropertyFlags 
     }
     if (id == Pid::FONT_STYLE || id == Pid::FONT_FACE || id == Pid::FONT_SIZE || id == Pid::TEXT_SCRIPT_ALIGN) {
         // can't use standard change property as Undo might set to "undefined"
-        score()->undo(new ChangeTextProperties(_cursor, id, v));
+        score()->undo(new ChangeTextProperties(_cursor, id, v, ps));
     } else {
         EngravingItem::undoChangeProperty(id, v, ps);
     }

--- a/src/engraving/libmscore/textedit.cpp
+++ b/src/engraving/libmscore/textedit.cpp
@@ -845,11 +845,12 @@ void ChangeTextProperties::restoreSelection()
     tc.text()->cursor()->setColumn(tc.column());
 }
 
-ChangeTextProperties::ChangeTextProperties(const TextCursor* tc, Ms::Pid propId, const PropertyValue& propVal)
+ChangeTextProperties::ChangeTextProperties(const TextCursor* tc, Ms::Pid propId, const PropertyValue& propVal, PropertyFlags flags_)
     : TextEditUndoCommand(*tc)
 {
     propertyId = propId;
     propertyVal = propVal;
+    flags = flags_;
     if (propertyId == Pid::FONT_STYLE) {
         existingStyle = static_cast<FontStyle>(cursor().text()->getProperty(propId).toInt());
     }
@@ -867,6 +868,8 @@ void ChangeTextProperties::redo(EditData*)
 {
     xmlText = cursor().text()->xmlText();
     restoreSelection();
+    cursor().text()->setPropertyFlags(propertyId, flags);
+
     if (propertyId == Pid::FONT_STYLE) {
         FontStyle setStyle = static_cast<FontStyle>(propertyVal.toInt());
         TextCursor* tc = cursor().text()->cursor();

--- a/src/engraving/libmscore/textedit.h
+++ b/src/engraving/libmscore/textedit.h
@@ -82,11 +82,12 @@ class ChangeTextProperties : public TextEditUndoCommand
     Pid propertyId;
     mu::engraving::PropertyValue propertyVal;
     FontStyle existingStyle;
+    PropertyFlags flags;
 
     void restoreSelection();
 
 public:
-    ChangeTextProperties(const TextCursor* tc, Ms::Pid propId, const mu::engraving::PropertyValue& propVal);
+    ChangeTextProperties(const TextCursor* tc, Ms::Pid propId, const mu::engraving::PropertyValue& propVal, PropertyFlags flags);
     void undo(EditData*) override;
     void redo(EditData*) override;
 };


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9837