### PR TITLE
Mixer - Add separators, fine-tune spacing

### DIFF
--- a/src/framework/audio/qml/MuseScore/Audio/KnobControl.qml
+++ b/src/framework/audio/qml/MuseScore/Audio/KnobControl.qml
@@ -165,6 +165,7 @@ Dial {
     }
 
     MouseArea {
+        id: mouseArea
         anchors.fill: parent
         onDoubleClicked: {
             root.newValueRequested(0)
@@ -196,6 +197,14 @@ Dial {
             let newValue = initialValue + dist * sgn
             let bounded = Math.max(root.from, Math.min(newValue, root.to))
             root.newValueRequested(bounded)
+        }
+
+        // We also listen for wheel events here, but for a different reason:
+        // Qml Dial has a bug that it doesn't emit moved() when the value is changed through a wheel event.
+        // So when we see a wheel event, we let the dial handle it, but we will account for emitting the signal.
+        onWheel: function(wheel) {
+            wheel.accepted = false
+            Qt.callLater(function() { root.newValueRequested(Math.round(value)) })
         }
     }
 }

--- a/src/framework/audio/qml/MuseScore/Audio/KnobControl.qml
+++ b/src/framework/audio/qml/MuseScore/Audio/KnobControl.qml
@@ -19,7 +19,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
@@ -33,11 +32,11 @@ Dial {
 
     property alias navigation: navCtrl
 
-    width: prv.radius * 2
-    height: width
+    implicitWidth: prv.radius * 2
+    implicitHeight: implicitWidth
 
-    implicitHeight: height
-    implicitWidth: width
+    width: implicitWidth
+    height: width
 
     wheelEnabled: true
 
@@ -121,18 +120,18 @@ Dial {
 
             ctx.strokeStyle = prv.outerArcColor
             ctx.beginPath()
-            ctx.arc(width/2, height/2, prv.radius - prv.outerArcLineWidth, -140 * (Math.PI/180) - Math.PI/2, 140 * (Math.PI/180) - Math.PI/2, false)
+            ctx.arc(width/2, height/2, prv.radius - prv.outerArcLineWidth/2, -140 * (Math.PI/180) - Math.PI/2, 140 * (Math.PI/180) - Math.PI/2, false)
             ctx.stroke()
 
             ctx.strokeStyle = prv.valueArcColor
             ctx.beginPath()
-            ctx.arc(width/2, height/2, prv.radius - prv.outerArcLineWidth, -Math.PI/2, root.angle * (Math.PI/180) - Math.PI/2, prv.reversed)
+            ctx.arc(width/2, height/2, prv.radius - prv.outerArcLineWidth/2, -Math.PI/2, root.angle * (Math.PI/180) - Math.PI/2, prv.reversed)
             ctx.stroke()
 
             ctx.lineWidth = prv.innerArcLineWidth
             ctx.strokeStyle = prv.innerArcColor
             ctx.beginPath()
-            ctx.arc(width/2, height/2, prv.radius - (prv.outerArcLineWidth + prv.innerArcLineWidth), 0, Math.PI * 2, false)
+            ctx.arc(width/2, height/2, prv.radius - (prv.outerArcLineWidth + prv.innerArcLineWidth/2), 0, Math.PI * 2, false)
             ctx.stroke()
         }
     }

--- a/src/framework/audio/qml/MuseScore/Audio/VolumeSlider.qml
+++ b/src/framework/audio/qml/MuseScore/Audio/VolumeSlider.qml
@@ -252,6 +252,37 @@ Slider {
         implicitWidth: prv.handleWidth
         implicitHeight: prv.handleHeight
 
+        MouseArea {
+            anchors.fill: parent
+            onDoubleClicked: {
+                // Double click resets the volume
+                root.volumeLevelMoved(0.0)
+            }
+
+            // The MouseArea steals mouse press events from the slider.
+            // There is really no way to prevent that.
+            // (if you set mouse.accepted to false in the onPressed handler,
+            // the MouseArea won't receive doubleClick events).
+            // So we use this workaround.
+
+            preventStealing: true // Don't let a Flickable steal the mouse
+
+            property real dragStartOffset: 0.0
+
+            onPressed: function(mouse) {
+                dragStartOffset = mouse.y
+            }
+
+            onPositionChanged: function(mouse)  {
+                let mousePosInRoot = mapToItem(root, 0, mouse.y - dragStartOffset).y
+                let newPosZeroToOne = 1 - mousePosInRoot / prv.rulerLineHeight
+                let newPosClamped = Math.max(0.0, Math.min(newPosZeroToOne, 1.0))
+                let localNewValue = root.valueAt(newPosClamped)
+                let logicalNewValue = convertor.volumeLevelFromLocal(localNewValue)
+                root.volumeLevelMoved(logicalNewValue)
+            }
+        }
+
         StyledDropShadow {
             anchors.fill: handleRect
             source: handleRect

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/Border.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/Border.qml
@@ -19,9 +19,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.15
 
 QtObject {
-    property int width: 0
+    property real width: 0
     property color color: "#00000000"
 }

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/RoundedRectangle.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/RoundedRectangle.qml
@@ -19,53 +19,38 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.15
 
 Canvas {
     id: root
 
-    property int radius: 0
+    property real radius: 0
 
-    property int topLeftRadius: radius
-    property int topRightRadius: radius
-    property int bottomLeftRadius: radius
-    property int bottomRightRadius: radius
+    property real topLeftRadius: radius
+    property real topRightRadius: radius
+    property real bottomLeftRadius: radius
+    property real bottomRightRadius: radius
 
     property color color: "#FFFFFF"
 
     property Border border: Border {}
 
-    onColorChanged: {
-        requestPaint()
+    onColorChanged: { requestPaint() }
+    onBorderChanged: { requestPaint() }
+
+    Connections {
+        target: border
+        function onColorChanged() { requestPaint() }
+        function onWidthChanged() { requestPaint() }
     }
 
-    onBorderChanged: {
-        requestPaint()
-    }
+    onTopLeftRadiusChanged: { requestPaint() }
+    onTopRightRadiusChanged: { requestPaint() }
+    onBottomRightRadiusChanged: { requestPaint() }
+    onBottomLeftRadiusChanged: { requestPaint() }
 
-    onTopLeftRadiusChanged: {
-        requestPaint()
-    }
-
-    onTopRightRadiusChanged: {
-        requestPaint()
-    }
-
-    onBottomRightRadiusChanged: {
-        requestPaint()
-    }
-
-    onBottomLeftRadiusChanged: {
-        requestPaint()
-    }
-
-    onOpacityChanged: {
-        requestPaint()
-    }
-
-    onActiveFocusChanged: {
-        requestPaint()
-    }
+    onOpacityChanged: { requestPaint() }
+    onActiveFocusChanged: { requestPaint() }
 
     onPaint: {
         roundRect(0, 0, width, height)
@@ -83,6 +68,8 @@ Canvas {
         if (!needsFill && !needsStroke) {
             return
         }
+
+        context.clearRect(0, 0, width, height)
 
         context.beginPath()
         context.fillStyle = root.color

--- a/src/playback/qml/MuseScore/Playback/MixerPanel.qml
+++ b/src/playback/qml/MuseScore/Playback/MixerPanel.qml
@@ -120,16 +120,15 @@ Rectangle {
 
         Column {
             id: contentColumn
-
             width: childrenRect.width
-
-            spacing: 8
+            spacing: 0
 
             MixerSoundSection {
                 id: soundSection
 
                 visible: contextMenuModel.soundSectionVisible
                 headerVisible: contextMenuModel.labelsSectionVisible
+                spacingAbove: 8
                 rootPanel: root
 
                 model: mixerPanelModel
@@ -137,7 +136,7 @@ Rectangle {
                 navigationRowStart: 1
                 needReadChannelName: prv.isPanelActivated
 
-                onNavigateControlIndexChanged: {
+                onNavigateControlIndexChanged: function(index) {
                     prv.setNavigateControlIndex(index)
                 }
             }
@@ -147,6 +146,7 @@ Rectangle {
 
                 visible: contextMenuModel.audioFxSectionVisible
                 headerVisible: contextMenuModel.labelsSectionVisible
+                spacingAbove: 8
                 rootPanel: root
 
                 model: mixerPanelModel
@@ -154,7 +154,7 @@ Rectangle {
                 navigationRowStart: 100
                 needReadChannelName: prv.isPanelActivated
 
-                onNavigateControlIndexChanged: {
+                onNavigateControlIndexChanged: function(index) {
                     prv.setNavigateControlIndex(index)
                 }
             }
@@ -171,7 +171,7 @@ Rectangle {
                 navigationRowStart: 200
                 needReadChannelName: prv.isPanelActivated
 
-                onNavigateControlIndexChanged: {
+                onNavigateControlIndexChanged: function(index) {
                     prv.setNavigateControlIndex(index)
                 }
             }
@@ -188,7 +188,7 @@ Rectangle {
                 navigationRowStart: 300
                 needReadChannelName: prv.isPanelActivated
 
-                onNavigateControlIndexChanged: {
+                onNavigateControlIndexChanged: function(index) {
                     prv.setNavigateControlIndex(index)
                 }
             }
@@ -198,6 +198,8 @@ Rectangle {
 
                 visible: contextMenuModel.faderSectionVisible
                 headerVisible: contextMenuModel.labelsSectionVisible
+                spacingAbove: -3
+                spacingBelow: -2
                 rootPanel: root
 
                 model: mixerPanelModel
@@ -205,7 +207,7 @@ Rectangle {
                 navigationRowStart: 400
                 needReadChannelName: prv.isPanelActivated
 
-                onNavigateControlIndexChanged: {
+                onNavigateControlIndexChanged: function(index) {
                     prv.setNavigateControlIndex(index)
                 }
             }
@@ -222,7 +224,7 @@ Rectangle {
                 navigationRowStart: 500
                 needReadChannelName: prv.isPanelActivated
 
-                onNavigateControlIndexChanged: {
+                onNavigateControlIndexChanged: function(index) {
                     prv.setNavigateControlIndex(index)
                 }
             }
@@ -232,6 +234,8 @@ Rectangle {
 
                 visible: contextMenuModel.titleSectionVisible
                 headerVisible: contextMenuModel.labelsSectionVisible
+                spacingAbove: 2
+                spacingBelow: 0
                 rootPanel: root
 
                 model: mixerPanelModel
@@ -239,7 +243,7 @@ Rectangle {
                 navigationRowStart: 600
                 needReadChannelName: prv.isPanelActivated
 
-                onNavigateControlIndexChanged: {
+                onNavigateControlIndexChanged: function(index) {
                     prv.setNavigateControlIndex(index)
                 }
             }

--- a/src/playback/qml/MuseScore/Playback/MixerPanel.qml
+++ b/src/playback/qml/MuseScore/Playback/MixerPanel.qml
@@ -44,6 +44,9 @@ Rectangle {
         property var currentNavigateControlIndex: undefined
         property bool isPanelActivated: false
 
+        readonly property real headerWidth: 98
+        readonly property real channelItemWidth: 108
+
         function setNavigateControlIndex(index) {
             if (!Boolean(prv.currentNavigateControlIndex) ||
                     index.row !== prv.currentNavigateControlIndex.row ||
@@ -75,8 +78,8 @@ Rectangle {
         clip: true
         boundsBehavior: Flickable.StopAtBounds
 
-        contentWidth: contentColumn.width
-        contentHeight: contentColumn.height
+        contentWidth: contentColumn.width + 1 // for trailing separator
+        contentHeight: Math.max(contentColumn.height, height)
         interactive: height < contentHeight || width < contentWidth
 
         ScrollBar.vertical: StyledScrollBar { policy: ScrollBar.AlwaysOn }
@@ -96,7 +99,7 @@ Rectangle {
             function setupConnections() {
                 for (var i = 0; i < mixerPanelModel.rowCount(); i++) {
                     var item = mixerPanelModel.get(i)
-                    item.item.panel.navigationEvent.connect(function(event) {
+                    item.channelItem.panel.navigationEvent.connect(function(event) {
                         if (event.type === NavigationEvent.AboutActive) {
                             if (Boolean(prv.currentNavigateControlIndex)) {
                                 event.setData("controlIndex", [prv.currentNavigateControlIndex.row, prv.currentNavigateControlIndex.column])
@@ -118,8 +121,24 @@ Rectangle {
             }
         }
 
+        Row {
+            id: separators
+            anchors.fill: parent
+            anchors.leftMargin: contextMenuModel.labelsSectionVisible ? prv.headerWidth : prv.channelItemWidth
+            spacing: prv.channelItemWidth
+
+            Repeater {
+                model: contextMenuModel.labelsSectionVisible ? mixerPanelModel.count + 1 : mixerPanelModel.count
+
+                SeparatorLine {
+                    orientation: Qt.Vertical
+                }
+            }
+        }
+
         Column {
             id: contentColumn
+            anchors.bottom: parent.bottom
             width: childrenRect.width
             spacing: 0
 
@@ -128,6 +147,8 @@ Rectangle {
 
                 visible: contextMenuModel.soundSectionVisible
                 headerVisible: contextMenuModel.labelsSectionVisible
+                headerWidth: prv.headerWidth
+                channelItemWidth: prv.channelItemWidth
                 spacingAbove: 8
                 rootPanel: root
 
@@ -146,6 +167,8 @@ Rectangle {
 
                 visible: contextMenuModel.audioFxSectionVisible
                 headerVisible: contextMenuModel.labelsSectionVisible
+                headerWidth: prv.headerWidth
+                channelItemWidth: prv.channelItemWidth
                 spacingAbove: 8
                 rootPanel: root
 
@@ -164,6 +187,8 @@ Rectangle {
 
                 visible: contextMenuModel.balanceSectionVisible
                 headerVisible: contextMenuModel.labelsSectionVisible
+                headerWidth: prv.headerWidth
+                channelItemWidth: prv.channelItemWidth
                 rootPanel: root
 
                 model: mixerPanelModel
@@ -181,6 +206,8 @@ Rectangle {
 
                 visible: contextMenuModel.volumeSectionVisible
                 headerVisible: contextMenuModel.labelsSectionVisible
+                headerWidth: prv.headerWidth
+                channelItemWidth: prv.channelItemWidth
                 rootPanel: root
 
                 model: mixerPanelModel
@@ -198,6 +225,8 @@ Rectangle {
 
                 visible: contextMenuModel.faderSectionVisible
                 headerVisible: contextMenuModel.labelsSectionVisible
+                headerWidth: prv.headerWidth
+                channelItemWidth: prv.channelItemWidth
                 spacingAbove: -3
                 spacingBelow: -2
                 rootPanel: root
@@ -217,6 +246,8 @@ Rectangle {
 
                 visible: contextMenuModel.muteAndSoloSectionVisible
                 headerVisible: contextMenuModel.labelsSectionVisible
+                headerWidth: prv.headerWidth
+                channelItemWidth: prv.channelItemWidth
                 rootPanel: root
 
                 model: mixerPanelModel
@@ -234,6 +265,8 @@ Rectangle {
 
                 visible: contextMenuModel.titleSectionVisible
                 headerVisible: contextMenuModel.labelsSectionVisible
+                headerWidth: prv.headerWidth
+                channelItemWidth: prv.channelItemWidth
                 spacingAbove: 2
                 spacingBelow: 0
                 rootPanel: root

--- a/src/playback/qml/MuseScore/Playback/internal/AudioResourceControl.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/AudioResourceControl.qml
@@ -19,9 +19,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
+
 import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
 import MuseScore.Audio 1.0
@@ -92,16 +92,13 @@ Item {
                 backgroundItem: RoundedRectangle {
                     id: activityButtonBackground
 
-                    color: root.active ? ui.theme.accentColor : ui.theme.buttonColor
-                    opacity: ui.theme.buttonOpacityNormal
+                    property real backgroundOpacity: ui.theme.buttonOpacityNormal
+                    color: Utils.colorWithAlpha(root.active ? ui.theme.accentColor : ui.theme.buttonColor, backgroundOpacity)
 
                     topLeftRadius: 3
                     topRightRadius: 0
                     bottomLeftRadius: 3
                     bottomRightRadius: 0
-
-                    border.width: ui.theme.borderWidth
-                    border.color: ui.theme.strokeColor
 
                     NavigationFocusBorder {
                         navigationCtrl: activityButton.navigation
@@ -114,31 +111,24 @@ Item {
 
                             PropertyChanges {
                                 target: activityButtonBackground
-                                opacity: ui.theme.buttonOpacityHit
+                                backgroundOpacity: ui.theme.buttonOpacityHit
                             }
                         },
 
                         State {
                             name: "HOVERED"
-                            when: rootMouseArea.containsMouse
+                            when: (!activityButton.mouseArea.pressed && rootMouseArea.containsMouse) || root.resourcePickingActive
 
                             PropertyChanges {
                                 target: activityButtonBackground
-                                opacity: ui.theme.buttonOpacityHover
+                                backgroundOpacity: ui.theme.buttonOpacityHover
                             }
                         }
                     ]
 
-                    Rectangle {
-                        id: rightSeparator
-
+                    SeparatorLine {
                         anchors.right: parent.right
-
-                        height: root.height
-                        width: 1
-
-                        color: ui.theme.fontPrimaryColor
-                        opacity: 0.3
+                        orientation: Qt.Vertical
                     }
                 }
 
@@ -182,12 +172,9 @@ Item {
                 backgroundItem: RoundedRectangle {
                     id: titleButtonBackground
 
-                    color: root.active ? ui.theme.accentColor : ui.theme.buttonColor
-                    opacity: ui.theme.buttonOpacityNormal
+                    property real backgroundOpacity: ui.theme.buttonOpacityNormal
+                    color: Utils.colorWithAlpha(root.active ? ui.theme.accentColor : ui.theme.buttonColor, backgroundOpacity)
                     radius: 3
-
-                    border.width: ui.theme.borderWidth
-                    border.color: ui.theme.strokeColor
 
                     NavigationFocusBorder {
                         navigationCtrl: titleButton.navigation
@@ -200,21 +187,23 @@ Item {
 
                             PropertyChanges {
                                 target: titleButtonBackground
-                                opacity: ui.theme.buttonOpacityHit
+                                radius: 0
+                                topLeftRadius: root.supportsByPassing ? 0 : 3
+                                bottomLeftRadius: topLeftRadius
+                                backgroundOpacity: ui.theme.buttonOpacityHit
                             }
                         },
 
                         State {
                             name: "HOVERED"
-                            when: rootMouseArea.containsMouse || root.resourcePickingActive
+                            when: (!titleButton.mouseArea.pressed && rootMouseArea.containsMouse) || root.resourcePickingActive
 
                             PropertyChanges {
                                 target: titleButtonBackground
-                                topRightRadius: 0
-                                bottomRightRadius: topRightRadius
+                                radius: 0
                                 topLeftRadius: root.supportsByPassing ? 0 : 3
                                 bottomLeftRadius: topLeftRadius
-                                opacity: ui.theme.buttonOpacityHover
+                                backgroundOpacity: ui.theme.buttonOpacityHover
                             }
 
                             PropertyChanges {
@@ -265,16 +254,13 @@ Item {
                 backgroundItem: RoundedRectangle {
                     id: menuButtonBackground
 
-                    color: root.active ? ui.theme.accentColor : ui.theme.buttonColor
-                    opacity: ui.theme.buttonOpacityNormal
+                    property real backgroundOpacity: ui.theme.buttonOpacityNormal
+                    color: Utils.colorWithAlpha(root.active ? ui.theme.accentColor : ui.theme.buttonColor, backgroundOpacity)
 
                     topLeftRadius: 0
                     topRightRadius: 3
                     bottomLeftRadius: 0
                     bottomRightRadius: 3
-
-                    border.width: ui.theme.borderWidth
-                    border.color: ui.theme.strokeColor
 
                     NavigationFocusBorder {
                         navigationCtrl: menuButton.navigation
@@ -283,35 +269,28 @@ Item {
                     states: [
                         State {
                             name: "PRESSED"
-                            when: root.resourcePickingActive
+                            when: menuButton.mouseArea.pressed || root.resourcePickingActive
 
                             PropertyChanges {
                                 target: menuButtonBackground
-                                opacity: ui.theme.buttonOpacityHit
+                                backgroundOpacity: ui.theme.buttonOpacityHit
                             }
                         },
 
                         State {
                             name: "HOVERED"
-                            when: rootMouseArea.containsMouse && !root.resourcePickingActive
+                            when: (!menuButton.mouseArea.pressed && rootMouseArea.containsMouse) && !root.resourcePickingActive
 
                             PropertyChanges {
                                 target: menuButtonBackground
-                                opacity: ui.theme.buttonOpacityHover
+                                backgroundOpacity: ui.theme.buttonOpacityHover
                             }
                         }
                     ]
 
-                    Rectangle {
-                        id: leftSeparator
-
+                    SeparatorLine {
                         anchors.left: parent.left
-
-                        height: root.height
-                        width: 1
-
-                        color: ui.theme.fontPrimaryColor
-                        opacity: 0.3
+                        orientation: Qt.Vertical
                     }
                 }
 
@@ -352,18 +331,19 @@ Item {
         }
     }
 
+    Rectangle {
+        anchors.fill: parent
+        color: "transparent"
+        border.color: ui.theme.strokeColor
+        border.width: root.active ? ui.theme.borderWidth : 1
+        radius: 3
+    }
+
     MouseArea {
         id: rootMouseArea
 
         anchors.fill: parent
-        propagateComposedEvents: true
+        acceptedButtons: Qt.NoButton
         hoverEnabled: true
-
-        onClicked: mouse.accepted = false
-        onPressed: mouse.accepted = false
-        onReleased: mouse.accepted = false
-        onDoubleClicked: mouse.accepted = false
-        onPositionChanged: mouse.accepted = false
-        onPressAndHold: mouse.accepted = false
     }
 }

--- a/src/playback/qml/MuseScore/Playback/internal/AudioResourceControl.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/AudioResourceControl.qml
@@ -162,6 +162,10 @@ Item {
                 height: root.height
                 width: titleLoader.width
 
+                enabled: root.showAdditionalButtons
+                         ? (root.resourceItemModel ? root.resourceItemModel.hasNativeEditorSupport : false)
+                         : true
+
                 navigation.panel: root.navigationPanel
                 navigation.name: root.navigationName + "TitleButton"
                 navigation.row: root.navigationRowStart + 2
@@ -189,12 +193,16 @@ Item {
 
                     states: [
                         State {
+                            name: "DISABLED"
+                            when: !titleButton.enabled
+                        },
+
+                        State {
                             name: "PRESSED"
                             when: titleButton.mouseArea.pressed
 
                             PropertyChanges {
                                 target: titleButtonBackground
-                                radius: 0
                                 backgroundOpacity: ui.theme.buttonOpacityHit
                             }
                         },
@@ -205,13 +213,7 @@ Item {
 
                             PropertyChanges {
                                 target: titleButtonBackground
-                                radius: 0
                                 backgroundOpacity: ui.theme.buttonOpacityHover
-                            }
-
-                            PropertyChanges {
-                                target: titleButton
-                                enabled: root.resourceItemModel ? root.resourceItemModel.hasNativeEditorSupport : true
                             }
                         }
                     ]

--- a/src/playback/qml/MuseScore/Playback/internal/MixerBalanceSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerBalanceSection.qml
@@ -60,8 +60,8 @@ MixerPanelSection {
                     }
                 }
 
-                onMoved: {
-                    channelItem.balance = value
+                onNewValueRequested: function(newValue) {
+                    channelItem.balance = newValue
                 }
 
                 onIncreaseRequested: {

--- a/src/playback/qml/MuseScore/Playback/internal/MixerBalanceSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerBalanceSection.qml
@@ -34,9 +34,9 @@ MixerPanelSection {
         id: content
 
         height: contentRow.implicitHeight
-        width: root.delegateDefaultWidth
+        width: root.channelItemWidth
 
-        property string accessibleName: (Boolean(root.needReadChannelName) ? mixerItem.title + " " : "") + root.headerTitle
+        property string accessibleName: (Boolean(root.needReadChannelName) ? channelItem.title + " " : "") + root.headerTitle
 
         Row {
             id: contentRow
@@ -48,10 +48,10 @@ MixerPanelSection {
             KnobControl {
                 id: balanceKnob
 
-                value: mixerItem.balance
+                value: channelItem.balance
                 stepSize: 1
 
-                navigation.panel: mixerItem.panel
+                navigation.panel: channelItem.panel
                 navigation.row: root.navigationRowStart
                 navigation.accessible.name: content.accessibleName
                 navigation.onActiveChanged: {
@@ -61,15 +61,15 @@ MixerPanelSection {
                 }
 
                 onMoved: {
-                    mixerItem.balance = value
+                    channelItem.balance = value
                 }
 
                 onIncreaseRequested: {
-                    mixerItem.balance += stepSize
+                    channelItem.balance += stepSize
                 }
 
                 onDecreaseRequested: {
-                    mixerItem.balance -= stepSize
+                    channelItem.balance -= stepSize
                 }
             }
 
@@ -85,7 +85,7 @@ MixerPanelSection {
                 textSidePadding: 0
                 background.radius: 2
 
-                navigation.panel: mixerItem.panel
+                navigation.panel: channelItem.panel
                 navigation.row: root.navigationRowStart + 1
                 navigation.accessible.name: content.accessibleName + " " + currentText
                 navigation.onActiveChanged: {
@@ -100,11 +100,11 @@ MixerPanelSection {
                     bottom: -100
                 }
 
-                currentText: mixerItem.balance
+                currentText: channelItem.balance
 
                 onCurrentTextEdited: {
-                    if (mixerItem.balance !== Number(newTextValue)) {
-                        mixerItem.balance = Number(newTextValue)
+                    if (channelItem.balance !== Number(newTextValue)) {
+                        channelItem.balance = Number(newTextValue)
                     }
                 }
             }

--- a/src/playback/qml/MuseScore/Playback/internal/MixerBalanceSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerBalanceSection.qml
@@ -19,7 +19,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 import QtQuick 2.15
 
 import MuseScore.Ui 1.0
@@ -37,7 +36,7 @@ MixerPanelSection {
         height: contentRow.implicitHeight
         width: root.delegateDefaultWidth
 
-        property string accessibleName: (Boolean(root.needReadChannelName) ? item.title + " " : "") + root.headerTitle
+        property string accessibleName: (Boolean(root.needReadChannelName) ? mixerItem.title + " " : "") + root.headerTitle
 
         Row {
             id: contentRow
@@ -49,10 +48,10 @@ MixerPanelSection {
             KnobControl {
                 id: balanceKnob
 
-                value: item.balance
+                value: mixerItem.balance
                 stepSize: 1
 
-                navigation.panel: item.panel
+                navigation.panel: mixerItem.panel
                 navigation.row: root.navigationRowStart
                 navigation.accessible.name: content.accessibleName
                 navigation.onActiveChanged: {
@@ -62,15 +61,15 @@ MixerPanelSection {
                 }
 
                 onMoved: {
-                    item.balance = value
+                    mixerItem.balance = value
                 }
 
                 onIncreaseRequested: {
-                    item.balance += stepSize
+                    mixerItem.balance += stepSize
                 }
 
                 onDecreaseRequested: {
-                    item.balance -= stepSize
+                    mixerItem.balance -= stepSize
                 }
             }
 
@@ -86,7 +85,7 @@ MixerPanelSection {
                 textSidePadding: 0
                 background.radius: 2
 
-                navigation.panel: item.panel
+                navigation.panel: mixerItem.panel
                 navigation.row: root.navigationRowStart + 1
                 navigation.accessible.name: content.accessibleName + " " + currentText
                 navigation.onActiveChanged: {
@@ -101,11 +100,11 @@ MixerPanelSection {
                     bottom: -100
                 }
 
-                currentText: item.balance
+                currentText: mixerItem.balance
 
                 onCurrentTextEdited: {
-                    if (item.balance !== Number(newTextValue)) {
-                        item.balance = Number(newTextValue)
+                    if (mixerItem.balance !== Number(newTextValue)) {
+                        mixerItem.balance = Number(newTextValue)
                     }
                 }
             }

--- a/src/playback/qml/MuseScore/Playback/internal/MixerFaderSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerFaderSection.qml
@@ -19,7 +19,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 import QtQuick 2.15
 
 import MuseScore.Ui 1.0
@@ -35,7 +34,7 @@ MixerPanelSection {
         height: childrenRect.height
         width: root.delegateDefaultWidth
 
-        property string accessibleName: (Boolean(root.needReadChannelName) ? item.title + " " : "") + root.headerTitle
+        property string accessibleName: (Boolean(root.needReadChannelName) ? mixerItem.title + " " : "") + root.headerTitle
 
         Row {
             anchors.horizontalCenter: parent.horizontalCenter
@@ -43,10 +42,10 @@ MixerPanelSection {
             spacing: 8
 
             VolumeSlider {
-                volumeLevel: item.volumeLevel
+                volumeLevel: mixerItem.volumeLevel
                 stepSize: 1.0
 
-                navigation.panel: item.panel
+                navigation.panel: mixerItem.panel
                 navigation.row: root.navigationRowStart
                 navigation.accessible.name: content.accessibleName + " " + readableVolumeLevel
                 navigation.onActiveChanged: {
@@ -56,15 +55,15 @@ MixerPanelSection {
                 }
 
                 onVolumeLevelMoved: {
-                    item.volumeLevel = Math.round(level * 10) / 10
+                    mixerItem.volumeLevel = Math.round(level * 10) / 10
                 }
 
                 onIncreaseRequested: {
-                    item.volumeLevel += stepSize
+                    mixerItem.volumeLevel += stepSize
                 }
 
                 onDecreaseRequested: {
-                    item.volumeLevel -= stepSize
+                    mixerItem.volumeLevel -= stepSize
                 }
             }
 
@@ -75,12 +74,12 @@ MixerPanelSection {
 
                 VolumePressureMeter {
                     id: leftPressure
-                    currentVolumePressure: item.leftChannelPressure
+                    currentVolumePressure: mixerItem.leftChannelPressure
                 }
 
                 VolumePressureMeter {
                     id: rightPressure
-                    currentVolumePressure: item.rightChannelPressure
+                    currentVolumePressure: mixerItem.rightChannelPressure
                     showRuler: true
                 }
             }

--- a/src/playback/qml/MuseScore/Playback/internal/MixerFaderSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerFaderSection.qml
@@ -32,9 +32,9 @@ MixerPanelSection {
         id: content
 
         height: childrenRect.height
-        width: root.delegateDefaultWidth
+        width: root.channelItemWidth
 
-        property string accessibleName: (Boolean(root.needReadChannelName) ? mixerItem.title + " " : "") + root.headerTitle
+        property string accessibleName: (Boolean(root.needReadChannelName) ? channelItem.title + " " : "") + root.headerTitle
 
         Row {
             anchors.horizontalCenter: parent.horizontalCenter
@@ -42,10 +42,10 @@ MixerPanelSection {
             spacing: 8
 
             VolumeSlider {
-                volumeLevel: mixerItem.volumeLevel
+                volumeLevel: channelItem.volumeLevel
                 stepSize: 1.0
 
-                navigation.panel: mixerItem.panel
+                navigation.panel: channelItem.panel
                 navigation.row: root.navigationRowStart
                 navigation.accessible.name: content.accessibleName + " " + readableVolumeLevel
                 navigation.onActiveChanged: {
@@ -55,15 +55,15 @@ MixerPanelSection {
                 }
 
                 onVolumeLevelMoved: {
-                    mixerItem.volumeLevel = Math.round(level * 10) / 10
+                    channelItem.volumeLevel = Math.round(level * 10) / 10
                 }
 
                 onIncreaseRequested: {
-                    mixerItem.volumeLevel += stepSize
+                    channelItem.volumeLevel += stepSize
                 }
 
                 onDecreaseRequested: {
-                    mixerItem.volumeLevel -= stepSize
+                    channelItem.volumeLevel -= stepSize
                 }
             }
 
@@ -74,12 +74,12 @@ MixerPanelSection {
 
                 VolumePressureMeter {
                     id: leftPressure
-                    currentVolumePressure: mixerItem.leftChannelPressure
+                    currentVolumePressure: channelItem.leftChannelPressure
                 }
 
                 VolumePressureMeter {
                     id: rightPressure
-                    currentVolumePressure: mixerItem.rightChannelPressure
+                    currentVolumePressure: channelItem.rightChannelPressure
                     showRuler: true
                 }
             }

--- a/src/playback/qml/MuseScore/Playback/internal/MixerFxSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerFxSection.qml
@@ -55,7 +55,6 @@ MixerPanelSection {
 
                 menuAnchorItem: root.rootPanel
                 resourceItemModel: modelData
-                active: modelData.isActive
 
                 navigationPanel: channelItem.panel
                 navigationRowStart: root.navigationRowStart + (model.index * 3) // NOTE: 3 - because AudioResourceControl have 3 controls

--- a/src/playback/qml/MuseScore/Playback/internal/MixerFxSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerFxSection.qml
@@ -19,8 +19,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 import QtQuick 2.15
+
 import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
 import MuseScore.Audio 1.0
@@ -28,7 +28,7 @@ import MuseScore.Audio 1.0
 MixerPanelSection {
     id: root
 
-    headerTitle: qsTrc("playback", "Audio Fx")
+    headerTitle: qsTrc("playback", "Audio FX")
 
     Column {
         id: content
@@ -38,7 +38,7 @@ MixerPanelSection {
         height: childrenRect.height
         width: root.delegateDefaultWidth
 
-        property string accessibleName: (Boolean(root.needReadChannelName) ? item.title + " " : "") + root.headerTitle
+        property string accessibleName: (Boolean(root.needReadChannelName) ? mixerItem.title + " " : "") + root.headerTitle
 
         spacing: 4
 
@@ -46,7 +46,7 @@ MixerPanelSection {
             id: repeater
             anchors.horizontalCenter: parent.horizontalCenter
 
-            model: item.outputResourceItemList
+            model: mixerItem.outputResourceItemList
             delegate: AudioResourceControl {
                 id: inputResourceControl
 
@@ -56,7 +56,7 @@ MixerPanelSection {
                 resourceItemModel: modelData
                 active: modelData.isActive
 
-                navigationPanel: item.panel
+                navigationPanel: mixerItem.panel
                 navigationRowStart: root.navigationRowStart + (model.index * 3) // NOTE: 3 - because AudioResourceControl have 3 controls
                 navigationName: modelData.id
                 accessibleName: content.accessibleName

--- a/src/playback/qml/MuseScore/Playback/internal/MixerFxSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerFxSection.qml
@@ -29,6 +29,7 @@ MixerPanelSection {
     id: root
 
     headerTitle: qsTrc("playback", "Audio FX")
+    headerHeight: 24
 
     Column {
         id: content
@@ -36,9 +37,9 @@ MixerPanelSection {
         y: 0
 
         height: childrenRect.height
-        width: root.delegateDefaultWidth
+        width: root.channelItemWidth
 
-        property string accessibleName: (Boolean(root.needReadChannelName) ? mixerItem.title + " " : "") + root.headerTitle
+        property string accessibleName: (Boolean(root.needReadChannelName) ? channelItem.title + " " : "") + root.headerTitle
 
         spacing: 4
 
@@ -46,7 +47,7 @@ MixerPanelSection {
             id: repeater
             anchors.horizontalCenter: parent.horizontalCenter
 
-            model: mixerItem.outputResourceItemList
+            model: channelItem.outputResourceItemList
             delegate: AudioResourceControl {
                 id: inputResourceControl
 
@@ -56,7 +57,7 @@ MixerPanelSection {
                 resourceItemModel: modelData
                 active: modelData.isActive
 
-                navigationPanel: mixerItem.panel
+                navigationPanel: channelItem.panel
                 navigationRowStart: root.navigationRowStart + (model.index * 3) // NOTE: 3 - because AudioResourceControl have 3 controls
                 navigationName: modelData.id
                 accessibleName: content.accessibleName

--- a/src/playback/qml/MuseScore/Playback/internal/MixerMuteAndSoloSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerMuteAndSoloSection.qml
@@ -32,9 +32,9 @@ MixerPanelSection {
         id: content
 
         height: childrenRect.height
-        width: root.delegateDefaultWidth
+        width: root.channelItemWidth
 
-        property string accessibleName: (Boolean(root.needReadChannelName) ? mixerItem.title + " " : "") + root.headerTitle
+        property string accessibleName: (Boolean(root.needReadChannelName) ? channelItem.title + " " : "") + root.headerTitle
 
         Row {
             anchors.horizontalCenter: parent.horizontalCenter
@@ -48,10 +48,10 @@ MixerPanelSection {
                 width: 20
 
                 icon: IconCode.MUTE
-                checked: mixerItem.muted
+                checked: channelItem.muted
 
                 navigation.name: "MuteButton"
-                navigation.panel: mixerItem.panel
+                navigation.panel: channelItem.panel
                 navigation.row: root.navigationRowStart
                 navigation.accessible.name: content.accessibleName + " " + qsTrc("playback", "Mute")
                 navigation.onActiveChanged: {
@@ -61,7 +61,7 @@ MixerPanelSection {
                 }
 
                 onToggled: {
-                    mixerItem.muted = !mixerItem.muted
+                    channelItem.muted = !channelItem.muted
                 }
             }
 
@@ -72,10 +72,10 @@ MixerPanelSection {
                 width: 20
 
                 icon: IconCode.SOLO
-                checked: mixerItem.solo
+                checked: channelItem.solo
 
                 navigation.name: "SoloButton"
-                navigation.panel: mixerItem.panel
+                navigation.panel: channelItem.panel
                 navigation.row: root.navigationRowStart + 1
                 navigation.accessible.name: content.accessibleName + " " + qsTrc("payback", "Solo")
                 navigation.onActiveChanged: {
@@ -85,7 +85,7 @@ MixerPanelSection {
                 }
 
                 onToggled: {
-                    mixerItem.solo = !mixerItem.solo
+                    channelItem.solo = !channelItem.solo
                 }
             }
         }

--- a/src/playback/qml/MuseScore/Playback/internal/MixerMuteAndSoloSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerMuteAndSoloSection.qml
@@ -19,7 +19,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 import QtQuick 2.15
 
 import MuseScore.Ui 1.0
@@ -35,7 +34,7 @@ MixerPanelSection {
         height: childrenRect.height
         width: root.delegateDefaultWidth
 
-        property string accessibleName: (Boolean(root.needReadChannelName) ? item.title + " " : "") + root.headerTitle
+        property string accessibleName: (Boolean(root.needReadChannelName) ? mixerItem.title + " " : "") + root.headerTitle
 
         Row {
             anchors.horizontalCenter: parent.horizontalCenter
@@ -49,10 +48,10 @@ MixerPanelSection {
                 width: 20
 
                 icon: IconCode.MUTE
-                checked: item.muted
+                checked: mixerItem.muted
 
                 navigation.name: "MuteButton"
-                navigation.panel: item.panel
+                navigation.panel: mixerItem.panel
                 navigation.row: root.navigationRowStart
                 navigation.accessible.name: content.accessibleName + " " + qsTrc("playback", "Mute")
                 navigation.onActiveChanged: {
@@ -62,7 +61,7 @@ MixerPanelSection {
                 }
 
                 onToggled: {
-                    item.muted = !item.muted
+                    mixerItem.muted = !mixerItem.muted
                 }
             }
 
@@ -73,10 +72,10 @@ MixerPanelSection {
                 width: 20
 
                 icon: IconCode.SOLO
-                checked: item.solo
+                checked: mixerItem.solo
 
                 navigation.name: "SoloButton"
-                navigation.panel: item.panel
+                navigation.panel: mixerItem.panel
                 navigation.row: root.navigationRowStart + 1
                 navigation.accessible.name: content.accessibleName + " " + qsTrc("payback", "Solo")
                 navigation.onActiveChanged: {
@@ -86,7 +85,7 @@ MixerPanelSection {
                 }
 
                 onToggled: {
-                    item.solo = !item.solo
+                    mixerItem.solo = !mixerItem.solo
                 }
             }
         }

--- a/src/playback/qml/MuseScore/Playback/internal/MixerPanelSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerPanelSection.qml
@@ -32,8 +32,9 @@ Loader {
     property string headerTitle: ""
     property bool headerVisible: true
     property int headerWidth: 98
+    property int headerHeight: implicitHeight - spacingAbove - spacingBelow
 
-    property int delegateDefaultWidth: 108
+    property int channelItemWidth: 108
 
     property real spacingAbove: 4
     property real spacingBelow: 4
@@ -51,68 +52,42 @@ Loader {
 
     active: visible
 
-    sourceComponent: ListView {
-        id: sectionContentList
+    sourceComponent: Row {
+        width: implicitWidth
+        height: root.spacingAbove + sectionContentList.contentHeight + root.spacingBelow
+        spacing: 1 // for separator (will be rendered in MixerPanel.qml)
 
-        width: contentItem.childrenRect.width
-        height: contentHeight
-        contentHeight: contentItem.childrenRect.height
-
-        interactive: false
-        orientation: Qt.Horizontal
-        spacing: 0
-
-        model: root.model
-
-        header: Item {
-            width: visible ? root.headerWidth + 1 : 0 // +1 for separator
-            height: parent.height
+        StyledTextLabel {
             visible: root.headerVisible
 
-            StyledTextLabel {
-                anchors.top: parent.top
-                anchors.topMargin: root.spacingAbove
-                anchors.bottom: parent.bottom
-                anchors.bottomMargin: root.spacingBelow
-                anchors.right: separator.left
-                anchors.rightMargin: 12
-                anchors.left: parent.left
-                anchors.leftMargin: 12
+            anchors.top: parent.top
+            anchors.topMargin: root.spacingAbove
 
-                horizontalAlignment: Qt.AlignRight
-                text: root.headerTitle
-            }
+            width: root.headerWidth
+            height: root.headerHeight
 
-            SeparatorLine {
-                id: separator
-                anchors.right: parent.right
-                orientation: Qt.Vertical
-            }
+            leftPadding: 12
+            rightPadding: 12
+
+            horizontalAlignment: Qt.AlignRight
+            text: root.headerTitle
         }
 
-        delegate: Row {
-            id: delegateRow
+        ListView {
+            id: sectionContentList
 
-            width: root.delegateDefaultWidth + 1 // for separator
-            height: root.spacingAbove + delegateLoader.implicitHeight + root.spacingBelow
+            anchors.top: parent.top
+            anchors.topMargin: root.spacingAbove
+            width: contentItem.childrenRect.width
+            height: contentHeight
+            contentHeight: contentItem.childrenRect.height
 
-            topPadding: root.spacingAbove
-            bottomPadding: root.spacingBelow
-            spacing: 0
+            interactive: false
+            orientation: Qt.Horizontal
+            spacing: 1 // for separators (will be rendered in MixerPanel.qml)
 
-            Loader {
-                id: delegateLoader
-
-                width: root.delegateDefaultWidth
-
-                property var mixerItem: model.item
-                sourceComponent: root.delegateComponent
-            }
-
-            SeparatorLine {
-                orientation: Qt.Vertical
-                height: root.height
-            }
+            model: root.model
+            delegate: delegateComponent
         }
     }
 }

--- a/src/playback/qml/MuseScore/Playback/internal/MixerPanelSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerPanelSection.qml
@@ -19,8 +19,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 import QtQuick 2.15
+
 import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
 import MuseScore.Audio 1.0
@@ -31,9 +31,13 @@ Loader {
 
     property string headerTitle: ""
     property bool headerVisible: true
-    property int headerHeight: 22
-    property int headerWidth: headerVisible ? 98 : 0
+    property int headerWidth: 98
+
     property int delegateDefaultWidth: 108
+
+    property real spacingAbove: 4
+    property real spacingBelow: 4
+
     property var model: undefined
     property var rootPanel: undefined
 
@@ -56,27 +60,59 @@ Loader {
 
         interactive: false
         orientation: Qt.Horizontal
-        spacing: 4
+        spacing: 0
 
         model: root.model
 
         header: Item {
-            height: root.headerHeight
-            width: root.headerWidth
+            width: visible ? root.headerWidth + 1 : 0 // +1 for separator
+            height: parent.height
+            visible: root.headerVisible
 
             StyledTextLabel {
-                anchors {
-                    fill: parent
-                    rightMargin: 12
-                    leftMargin: 12
-                }
+                anchors.top: parent.top
+                anchors.topMargin: root.spacingAbove
+                anchors.bottom: parent.bottom
+                anchors.bottomMargin: root.spacingBelow
+                anchors.right: separator.left
+                anchors.rightMargin: 12
+                anchors.left: parent.left
+                anchors.leftMargin: 12
 
                 horizontalAlignment: Qt.AlignRight
                 text: root.headerTitle
-                visible: root.headerVisible
+            }
+
+            SeparatorLine {
+                id: separator
+                anchors.right: parent.right
+                orientation: Qt.Vertical
             }
         }
 
-        delegate: root.delegateComponent
+        delegate: Row {
+            id: delegateRow
+
+            width: root.delegateDefaultWidth + 1 // for separator
+            height: root.spacingAbove + delegateLoader.implicitHeight + root.spacingBelow
+
+            topPadding: root.spacingAbove
+            bottomPadding: root.spacingBelow
+            spacing: 0
+
+            Loader {
+                id: delegateLoader
+
+                width: root.delegateDefaultWidth
+
+                property var mixerItem: model.item
+                sourceComponent: root.delegateComponent
+            }
+
+            SeparatorLine {
+                orientation: Qt.Vertical
+                height: root.height
+            }
+        }
     }
 }

--- a/src/playback/qml/MuseScore/Playback/internal/MixerSoundSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerSoundSection.qml
@@ -44,6 +44,7 @@ MixerPanelSection {
             id: inputResourceControl
 
             anchors.horizontalCenter: parent.horizontalCenter
+            height: 26
 
             menuAnchorItem: root.rootPanel
             supportsByPassing: false

--- a/src/playback/qml/MuseScore/Playback/internal/MixerSoundSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerSoundSection.qml
@@ -34,11 +34,11 @@ MixerPanelSection {
         id: content
 
         height: inputResourceControl.height
-        width: root.delegateDefaultWidth
+        width: root.channelItemWidth
 
-        property string accessibleName: (Boolean(root.needReadChannelName) ? mixerItem.title + " " : "") + root.headerTitle
+        property string accessibleName: (Boolean(root.needReadChannelName) ? channelItem.title + " " : "") + root.headerTitle
 
-        visible: !mixerItem.outputOnly
+        visible: !channelItem.outputOnly
 
         AudioResourceControl {
             id: inputResourceControl
@@ -47,15 +47,15 @@ MixerPanelSection {
 
             menuAnchorItem: root.rootPanel
             supportsByPassing: false
-            resourceItemModel: mixerItem.inputResourceItem
+            resourceItemModel: channelItem.inputResourceItem
 
-            navigationPanel: mixerItem.panel
+            navigationPanel: channelItem.panel
             navigationRowStart: root.navigationRowStart
             accessibleName: content.accessibleName
 
             onTitleClicked: {
-                if (mixerItem.inputResourceItem) {
-                    mixerItem.inputResourceItem.requestToLaunchNativeEditorView()
+                if (channelItem.inputResourceItem) {
+                    channelItem.inputResourceItem.requestToLaunchNativeEditorView()
                 }
             }
 

--- a/src/playback/qml/MuseScore/Playback/internal/MixerSoundSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerSoundSection.qml
@@ -19,8 +19,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 import QtQuick 2.15
+
 import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
 import MuseScore.Audio 1.0
@@ -36,9 +36,9 @@ MixerPanelSection {
         height: inputResourceControl.height
         width: root.delegateDefaultWidth
 
-        property string accessibleName: (Boolean(root.needReadChannelName) ? item.title + " " : "") + root.headerTitle
+        property string accessibleName: (Boolean(root.needReadChannelName) ? mixerItem.title + " " : "") + root.headerTitle
 
-        visible: !item.outputOnly
+        visible: !mixerItem.outputOnly
 
         AudioResourceControl {
             id: inputResourceControl
@@ -47,15 +47,15 @@ MixerPanelSection {
 
             menuAnchorItem: root.rootPanel
             supportsByPassing: false
-            resourceItemModel: item.inputResourceItem
+            resourceItemModel: mixerItem.inputResourceItem
 
-            navigationPanel: item.panel
+            navigationPanel: mixerItem.panel
             navigationRowStart: root.navigationRowStart
             accessibleName: content.accessibleName
 
             onTitleClicked: {
-                if (item.inputResourceItem) {
-                    item.inputResourceItem.requestToLaunchNativeEditorView()
+                if (mixerItem.inputResourceItem) {
+                    mixerItem.inputResourceItem.requestToLaunchNativeEditorView()
                 }
             }
 

--- a/src/playback/qml/MuseScore/Playback/internal/MixerTitleSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerTitleSection.qml
@@ -31,7 +31,7 @@ MixerPanelSection {
     headerTitle: qsTrc("playback", "Name")
 
     Rectangle {
-        width: root.delegateDefaultWidth
+        width: root.channelItemWidth
         height: 22
 
         color: Utils.colorWithAlpha(ui.theme.accentColor, 0.5)
@@ -46,7 +46,7 @@ MixerPanelSection {
             readonly property int margin: -8
             width: margin + parent.width + margin
 
-            text: mixerItem.title
+            text: channelItem.title
         }
     }
 }

--- a/src/playback/qml/MuseScore/Playback/internal/MixerTitleSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerTitleSection.qml
@@ -19,8 +19,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 import QtQuick 2.15
+
 import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
 import MuseScore.Audio 1.0
@@ -46,7 +46,7 @@ MixerPanelSection {
             readonly property int margin: -8
             width: margin + parent.width + margin
 
-            text: item.title
+            text: mixerItem.title
         }
     }
 }

--- a/src/playback/qml/MuseScore/Playback/internal/MixerVolumeSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerVolumeSection.qml
@@ -34,9 +34,9 @@ MixerPanelSection {
         id: content
 
         height: childrenRect.height
-        width: root.delegateDefaultWidth
+        width: root.channelItemWidth
 
-        property string accessibleName: (Boolean(root.needReadChannelName) ? mixerItem.title + " " : "") + root.headerTitle
+        property string accessibleName: (Boolean(root.needReadChannelName) ? channelItem.title + " " : "") + root.headerTitle
 
         TextInputField {
             id: volumeTextInputField
@@ -51,7 +51,7 @@ MixerPanelSection {
             background.radius: 2
 
             navigation.name: "VolumeInputField"
-            navigation.panel: mixerItem.panel
+            navigation.panel: channelItem.panel
             navigation.row: root.navigationRowStart
             navigation.accessible.name: content.accessibleName + " " + currentText
             navigation.onActiveChanged: {
@@ -67,11 +67,11 @@ MixerPanelSection {
                 decimal: 1
             }
 
-            currentText: Math.round(mixerItem.volumeLevel * 10) / 10
+            currentText: Math.round(channelItem.volumeLevel * 10) / 10
 
             onCurrentTextEdited: {
-                if (mixerItem.volumeLevel !== Number(newTextValue)) {
-                    mixerItem.volumeLevel = Number(newTextValue)
+                if (channelItem.volumeLevel !== Number(newTextValue)) {
+                    channelItem.volumeLevel = Number(newTextValue)
                 }
             }
         }

--- a/src/playback/qml/MuseScore/Playback/internal/MixerVolumeSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerVolumeSection.qml
@@ -19,7 +19,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 import QtQuick 2.15
 
 import MuseScore.Ui 1.0
@@ -37,7 +36,7 @@ MixerPanelSection {
         height: childrenRect.height
         width: root.delegateDefaultWidth
 
-        property string accessibleName: (Boolean(root.needReadChannelName) ? item.title + " " : "") + root.headerTitle
+        property string accessibleName: (Boolean(root.needReadChannelName) ? mixerItem.title + " " : "") + root.headerTitle
 
         TextInputField {
             id: volumeTextInputField
@@ -52,7 +51,7 @@ MixerPanelSection {
             background.radius: 2
 
             navigation.name: "VolumeInputField"
-            navigation.panel: item.panel
+            navigation.panel: mixerItem.panel
             navigation.row: root.navigationRowStart
             navigation.accessible.name: content.accessibleName + " " + currentText
             navigation.onActiveChanged: {
@@ -68,11 +67,11 @@ MixerPanelSection {
                 decimal: 1
             }
 
-            currentText: Math.round(item.volumeLevel * 10) / 10
+            currentText: Math.round(mixerItem.volumeLevel * 10) / 10
 
             onCurrentTextEdited: {
-                if (item.volumeLevel !== Number(newTextValue)) {
-                    item.volumeLevel = Number(newTextValue)
+                if (mixerItem.volumeLevel !== Number(newTextValue)) {
+                    mixerItem.volumeLevel = Number(newTextValue)
                 }
             }
         }

--- a/src/playback/view/internal/abstractaudioresourceitem.cpp
+++ b/src/playback/view/internal/abstractaudioresourceitem.cpp
@@ -31,6 +31,11 @@ bool AbstractAudioResourceItem::isBlank() const
     return true;
 }
 
+bool AbstractAudioResourceItem::isActive() const
+{
+    return true;
+}
+
 QVariantMap AbstractAudioResourceItem::buildMenuItem(const QString& itemId,
                                                      const QString& title,
                                                      const bool checked,

--- a/src/playback/view/internal/abstractaudioresourceitem.cpp
+++ b/src/playback/view/internal/abstractaudioresourceitem.cpp
@@ -33,7 +33,7 @@ bool AbstractAudioResourceItem::isBlank() const
 
 bool AbstractAudioResourceItem::isActive() const
 {
-    return true;
+    return false;
 }
 
 QVariantMap AbstractAudioResourceItem::buildMenuItem(const QString& itemId,

--- a/src/playback/view/internal/abstractaudioresourceitem.h
+++ b/src/playback/view/internal/abstractaudioresourceitem.h
@@ -32,6 +32,7 @@ class AbstractAudioResourceItem : public QObject
 
     Q_PROPERTY(QString title READ title NOTIFY titleChanged)
     Q_PROPERTY(bool isBlank READ isBlank NOTIFY isBlankChanged)
+    Q_PROPERTY(bool isActive READ isActive NOTIFY isActiveChanged)
     Q_PROPERTY(bool hasNativeEditorSupport READ hasNativeEditorSupport NOTIFY hasNativeEditorSupportChanged)
 
 public:
@@ -43,11 +44,13 @@ public:
 
     virtual QString title() const;
     virtual bool isBlank() const;
+    virtual bool isActive() const;
     virtual bool hasNativeEditorSupport() const;
 
 signals:
     void titleChanged();
     void isBlankChanged();
+    void isActiveChanged();
     void hasNativeEditorSupportChanged();
 
     void nativeEditorViewLaunchRequested();

--- a/src/playback/view/internal/inputresourceitem.cpp
+++ b/src/playback/view/internal/inputresourceitem.cpp
@@ -82,6 +82,7 @@ void InputResourceItem::setParams(const audio::AudioInputParams& newParams)
 
     emit titleChanged();
     emit isBlankChanged();
+    emit isActiveChanged();
 }
 
 QString InputResourceItem::title() const
@@ -92,6 +93,11 @@ QString InputResourceItem::title() const
 bool InputResourceItem::isBlank() const
 {
     return !m_currentInputParams.isValid();
+}
+
+bool InputResourceItem::isActive() const
+{
+    return m_currentInputParams.isValid();
 }
 
 bool InputResourceItem::hasNativeEditorSupport() const
@@ -153,6 +159,7 @@ void InputResourceItem::updateCurrentParams(const AudioResourceMeta& newMeta)
 
     emit titleChanged();
     emit isBlankChanged();
+    emit isActiveChanged();
     emit inputParamsChanged();
 
     requestToLaunchNativeEditorView();

--- a/src/playback/view/internal/inputresourceitem.h
+++ b/src/playback/view/internal/inputresourceitem.h
@@ -53,6 +53,7 @@ public:
 
     QString title() const override;
     bool isBlank() const override;
+    bool isActive() const override;
     bool hasNativeEditorSupport() const override;
 
 signals:

--- a/src/playback/view/internal/outputresourceitem.h
+++ b/src/playback/view/internal/outputresourceitem.h
@@ -55,8 +55,8 @@ public:
 
     QString title() const override;
     bool isBlank() const override;
+    bool isActive() const override;
     bool hasNativeEditorSupport() const override;
-    bool isActive() const;
 
     QString id() const;
 
@@ -64,8 +64,6 @@ public slots:
     void setIsActive(bool newIsActive);
 
 signals:
-    void isActiveChanged();
-
     void fxParamsChanged();
 
 private:

--- a/src/playback/view/mixerpanelmodel.cpp
+++ b/src/playback/view/mixerpanelmodel.cpp
@@ -34,6 +34,10 @@ MixerPanelModel::MixerPanelModel(QObject* parent)
     controller()->currentTrackSequenceIdChanged().onNotify(this, [this]() {
         load(QVariant::fromValue(m_itemsNavigationSection));
     });
+
+    connect(this, &QAbstractItemModel::modelReset, this, &MixerPanelModel::rowCountChanged);
+    connect(this, &QAbstractItemModel::rowsInserted, this, &MixerPanelModel::rowCountChanged);
+    connect(this, &QAbstractItemModel::rowsRemoved, this, &MixerPanelModel::rowCountChanged);
 }
 
 void MixerPanelModel::load(const QVariant& navigationSection)
@@ -75,7 +79,7 @@ QVariantMap MixerPanelModel::get(int index)
 
 QVariant MixerPanelModel::data(const QModelIndex& index, int role) const
 {
-    if (!index.isValid() || index.row() >= rowCount() || role != ItemRole) {
+    if (!index.isValid() || index.row() >= rowCount() || role != ChannelItemRole) {
         return QVariant();
     }
 
@@ -90,7 +94,7 @@ int MixerPanelModel::rowCount(const QModelIndex&) const
 QHash<int, QByteArray> MixerPanelModel::roleNames() const
 {
     static QHash<int, QByteArray> roles = {
-        { ItemRole, "item" }
+        { ChannelItemRole, "channelItem" }
     };
 
     return roles;

--- a/src/playback/view/mixerpanelmodel.cpp
+++ b/src/playback/view/mixerpanelmodel.cpp
@@ -34,10 +34,6 @@ MixerPanelModel::MixerPanelModel(QObject* parent)
     controller()->currentTrackSequenceIdChanged().onNotify(this, [this]() {
         load(QVariant::fromValue(m_itemsNavigationSection));
     });
-
-    connect(this, &QAbstractItemModel::modelReset, this, &MixerPanelModel::rowCountChanged);
-    connect(this, &QAbstractItemModel::rowsInserted, this, &MixerPanelModel::rowCountChanged);
-    connect(this, &QAbstractItemModel::rowsRemoved, this, &MixerPanelModel::rowCountChanged);
 }
 
 void MixerPanelModel::load(const QVariant& navigationSection)
@@ -114,6 +110,7 @@ void MixerPanelModel::loadItems(const TrackSequenceId sequenceId, const TrackIdL
     sortItems();
 
     endResetModel();
+    emit rowCountChanged();
 
     playback()->tracks()->trackAdded().onReceive(this, [this](const TrackSequenceId sequenceId, const TrackId trackId) {
         addItem(sequenceId, trackId);
@@ -132,6 +129,7 @@ void MixerPanelModel::addItem(const audio::TrackSequenceId sequenceId, const aud
     sortItems();
 
     endResetModel();
+    emit rowCountChanged();
 }
 
 void MixerPanelModel::removeItem(const audio::TrackId trackId)
@@ -145,6 +143,7 @@ void MixerPanelModel::removeItem(const audio::TrackId trackId)
     sortItems();
 
     endResetModel();
+    emit rowCountChanged();
 }
 
 void MixerPanelModel::sortItems()

--- a/src/playback/view/mixerpanelmodel.h
+++ b/src/playback/view/mixerpanelmodel.h
@@ -43,6 +43,8 @@ class MixerPanelModel : public QAbstractListModel, public async::Asyncable
     INJECT(playback, audio::IPlayback, playback)
     INJECT(playback, IPlaybackController, controller)
 
+    Q_PROPERTY(int count READ rowCount NOTIFY rowCountChanged)
+
 public:
     explicit MixerPanelModel(QObject* parent = nullptr);
 
@@ -53,9 +55,12 @@ public:
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     QHash<int, QByteArray> roleNames() const override;
 
+signals:
+    void rowCountChanged();
+
 private:
     enum Roles {
-        ItemRole = Qt::UserRole + 1
+        ChannelItemRole = Qt::UserRole + 1
     };
 
     void loadItems(const audio::TrackSequenceId sequenceId, const audio::TrackIdList& trackIdList);


### PR DESCRIPTION
Resolves: #9149
Resolves: #9634
Resolves: #9246

- Added separator lines between channel strips in Mixer
- Fine-tuned the spacing
- You can now also double-click the handle of the volume slider to reset the volume
- To change the value of the pan knob, you now need to drag up and down instead of drawing circles with the mouse