### PR TITLE
Small staff beams

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -1027,8 +1027,7 @@ void Beam::layout2(std::vector<ChordRest*> chordRests, SpannerSegmentType, int f
     startAnchor.setY(quarterSpace * (isStartDictator ? dictator : pointer));
     endAnchor.setY(quarterSpace * (isStartDictator ? pointer : dictator));
 
-    qreal beamWidth = score()->styleMM(Sid::beamWidth).val() * mag();
-    _beamDist = beamWidth + 0.25 * spatium();
+    _beamDist = 0.75 * spatium();
 
     add8thSpaceSlant(isStartDictator ? startAnchor : endAnchor, dictator, pointer, beamCount, interval, middleLine, isFlat);
 

--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -592,7 +592,7 @@ PointF Beam::chordBeamAnchor(Chord* chord) const
     PointF position = note->pos() + chord->segment()->pos() + chord->measure()->pos();
 
     int upValue = _up ? -1 : 1;
-    qreal beamWidth = score()->styleMM(Sid::beamWidth).val() * mag();
+    qreal beamWidth = score()->styleMM(Sid::beamWidth).val() * chord->mag();
     qreal beamOffset = beamWidth / 2 * upValue;
 
     qreal x = chord->stemPosX() + chord->pagePos().x() - pagePos().x();
@@ -608,7 +608,7 @@ void Beam::createBeamSegment(Chord* startChord, Chord* endChord, int level)
 
     int upValue = _up ? -1 : 1;
     qreal verticalOffset = _beamDist * level * upValue;
-    qreal stemWidth = score()->styleMM(Sid::stemWidth).val();
+    qreal stemWidth = score()->styleMM(Sid::stemWidth).val() * startChord->mag();
 
     qreal startOffsetX = _up ? -stemWidth : 0.0;
     qreal endOffsetX = _up ? 0.0 : stemWidth;
@@ -709,7 +709,7 @@ void Beam::createBeamletSegment(Chord* chord, bool isBefore, int level)
 
     int upValue = _up ? -1 : 1;
     qreal verticalOffset = _beamDist * level * upValue;
-    qreal stemWidth = score()->styleMM(Sid::stemWidth).val();
+    qreal stemWidth = score()->styleMM(Sid::stemWidth).val() * chord->mag();
     qreal startOffsetX = 0;
     if (isBefore && !_up) {
         startOffsetX = stemWidth;


### PR DESCRIPTION
Previously, beams were not placed correctly on smaller staves:

![image](https://user-images.githubusercontent.com/5659171/144141736-4f673857-76c9-4900-ad50-3d5426475166.png)

Now, they are:

<img width="545" alt="Screen Shot 2021-11-30 at 3 00 17 PM" src="https://user-images.githubusercontent.com/5659171/144141782-999e6049-bd5f-43f0-9d3d-f2ac7ef5477f.png">

