### PR TITLE
disable stem direction flipping based on context

### DIFF
--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -187,7 +187,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::shortestStem,            "shortestStem",            PropertyValue(2.5) },
     { Sid::minStaffSizeForAutoStems, "minStaffSizeForAutoStems", 4 },
     { Sid::smallStaffStemDirection, "smallStaffStemDirection", DirectionV::UP },
-    { Sid::preferStemDirectionMatchContext, "preferStemDirectionMatchContext", true },
+    { Sid::preferStemDirectionMatchContext, "preferStemDirectionMatchContext", false },
     { Sid::beginRepeatLeftMargin,   "beginRepeatLeftMargin",   Spatium(1.0) },
     { Sid::minNoteDistance,         "minNoteDistance",         Spatium(0.2) },
     { Sid::barNoteDistance,         "barNoteDistance",         Spatium(1.3) },     // was 1.2


### PR DESCRIPTION
Resolves https://github.com/musescore/MuseScore/issues/9959

Part of the new beams code involved letting notes on the middle line flip their stem direction to match context. However, this is proving to be confusing and unintuitive for several people. This PR disables this feature, though it can be reenabled in the future if we choose to do so.