### PR TITLE
Corrects the value the "bracket" member for "unsorted" sections.

### DIFF
--- a/src/engraving/libmscore/scoreorder.cpp
+++ b/src/engraving/libmscore/scoreorder.cpp
@@ -140,7 +140,7 @@ void ScoreOrder::readSection(Ms::XmlReader& reader)
             sg.family = QString(UNSORTED_ID);
             sg.section = sectionId;
             sg.unsorted = group;
-            sg.bracket = false;
+            sg.bracket = true;
             sg.showSystemMarkings = readBoolAttribute(reader, "showSystemMarkings", false);
             sg.barLineSpan = readBoolAttribute(reader, "barLineSpan", true);
             sg.thinBracket = readBoolAttribute(reader, "thinBrackets", true);
@@ -362,7 +362,7 @@ void ScoreOrder::read(Ms::XmlReader& reader)
             sg.family = QString(UNSORTED_ID);
             sg.section = sectionId;
             sg.unsorted = group;
-            sg.bracket = true;
+            sg.bracket = false;
             sg.showSystemMarkings = false;
             sg.barLineSpan = false;
             sg.thinBracket = false;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9940

Instruments within a group are grouped by a bracket. Therefor the `bracket` member the `unsorted` `ScoreGroup` inside a section must be `true` and `false` if it is outside a section.
However, this `bracket` member had the wrong value. The result was that `unsorted` instruments where grouped by a bracket if the `unsorted` was outside a section.

This PR now corrects the value of these `bracket` members. 

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
