### PR TITLE
[MU4] Fix (MinGW) compiler warnings and MinGW build

### DIFF
--- a/src/appshell/internal/platform/win/winframelesswindowcontroller.cpp
+++ b/src/appshell/internal/platform/win/winframelesswindowcontroller.cpp
@@ -22,6 +22,10 @@
 
 #include "winframelesswindowcontroller.h"
 
+#if defined(_WIN32_WINNT) && (_WIN32_WINNT < 0x600)
+#undef _WIN32_WINNT // like defined to `0x502` in _mingw.h for Qt 5.15
+#define _WIN32_WINNT 0x0600 // Vista or later, needed for `iPaddedBorderWidth`
+#endif
 #include <Windows.h>
 #include <windowsx.h>
 #include <dwmapi.h>

--- a/src/engraving/libmscore/barline.cpp
+++ b/src/engraving/libmscore/barline.cpp
@@ -1059,7 +1059,7 @@ void BarLine::startEdit(EditData& ed)
 bool BarLine::edit(EditData& ed)
 {
     bool local = ed.control() || segment()->isBarLineType() || spanStaff() != score()->staff(staffIdx())->barLineSpan();
-    if (ed.key == Qt::Key_Up && spanStaff() || ed.key == Qt::Key_Down && !spanStaff()) {
+    if ((ed.key == Qt::Key_Up && spanStaff()) || (ed.key == Qt::Key_Down && !spanStaff())) {
         if (local) {
             BarLine* b = toBarLine(segment()->element(staffIdx() * VOICES));
             if (b) {

--- a/src/framework/shortcuts/internal/shortcutsregister.cpp
+++ b/src/framework/shortcuts/internal/shortcutsregister.cpp
@@ -274,7 +274,7 @@ const Shortcut& ShortcutsRegister::shortcut(const std::string& actionCode)
 {
     const auto& shortCut = findShortcut(m_shortcuts, actionCode);
     if (shortCut.action.empty()) {
-        Shortcut sc = { actionCode };
+        Shortcut sc = { actionCode, 0 };
         m_shortcuts.push_back(sc);
         return findShortcut(m_shortcuts, actionCode);
     }

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -713,6 +713,8 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
             interaction->moveSelection(direction, quickly ? MoveSelectionType::Measure : MoveSelectionType::Chord);
         }
         break;
+    case MoveDirection::Undefined:
+        break;
     }
     playSelectedElement(false);
 }

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2021,6 +2021,11 @@ void NotationInteraction::addToSelection(MoveDirection d, MoveSelectionType type
         } else {
             el = score()->downStaff(cr);
         }
+    case MoveSelectionType::EngravingItem:
+    case MoveSelectionType::Frame:
+    case MoveSelectionType::System:
+    case MoveSelectionType::Undefined:
+        break;
     }
     if (el) {
         score()->select(el, SelectType::RANGE, el->staffIdx());
@@ -2591,7 +2596,6 @@ void NotationInteraction::updateAnchorLines()
     Ms::Grip anchorLinesGrip = m_editData.curGrip == Ms::Grip::NO_GRIP ? m_editData.element->defaultGrip() : m_editData.curGrip;
     QVector<LineF> anchorLines = m_editData.element->gripAnchorLines(anchorLinesGrip);
 
-    EngravingItem* page = m_editData.element->findAncestor(ElementType::PAGE);
     if (!anchorLines.isEmpty()) {
         for (LineF& line : anchorLines) {
             if (line.p1() != line.p2()) {

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -624,6 +624,7 @@ void NotationViewInputController::mouseReleaseEvent(QMouseEvent* event)
 
 void NotationViewInputController::mouseDoubleClickEvent(QMouseEvent* event)
 {
+    UNUSED(event);
     EngravingItem* element = viewInteraction()->selection()->element();
 
     if (!viewInteraction()->textEditingAllowed(element)) {


### PR DESCRIPTION
* Fix (MinGW) compiler warnings
* Fix MinGW build 
    Needed for `iPaddedBorderWidth`. Means we won't support Windows Server 2003 and Windows XP/2000 anymore, which we don't (plan to) anyway (and can't with MSVC).
    `0x600` is Windows Vista (and later), maybe we can even go higher. MSVC needs Windows 7 or higher, that'd be `0x601`.
    See https://docs.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-nonclientmetricsa#remarks for furter details.