### PR TITLE
Fixed crash on getting shortcut

### DIFF
--- a/src/framework/shortcuts/internal/shortcutsregister.cpp
+++ b/src/framework/shortcuts/internal/shortcutsregister.cpp
@@ -270,15 +270,9 @@ Notification ShortcutsRegister::shortcutsChanged() const
     return m_shortcutsChanged;
 }
 
-const Shortcut& ShortcutsRegister::shortcut(const std::string& actionCode)
+const Shortcut& ShortcutsRegister::shortcut(const std::string& actionCode) const
 {
-    const auto& shortCut = findShortcut(m_shortcuts, actionCode);
-    if (shortCut.action.empty()) {
-        Shortcut sc = { actionCode, 0 };
-        m_shortcuts.push_back(sc);
-        return findShortcut(m_shortcuts, actionCode);
-    }
-    return shortCut;
+    return findShortcut(m_shortcuts, actionCode);
 }
 
 const Shortcut& ShortcutsRegister::defaultShortcut(const std::string& actionCode) const

--- a/src/framework/shortcuts/internal/shortcutsregister.h
+++ b/src/framework/shortcuts/internal/shortcutsregister.h
@@ -50,7 +50,7 @@ public:
     Ret setShortcuts(const ShortcutList& shortcuts) override;
     async::Notification shortcutsChanged() const override;
 
-    const Shortcut& shortcut(const std::string& actionCode) override;
+    const Shortcut& shortcut(const std::string& actionCode) const override;
     const Shortcut& defaultShortcut(const std::string& actionCode) const override;
 
     bool isRegistered(const std::string& sequence) const override;

--- a/src/framework/shortcuts/ishortcutsregister.h
+++ b/src/framework/shortcuts/ishortcutsregister.h
@@ -41,7 +41,7 @@ public:
     virtual Ret setShortcuts(const ShortcutList& shortcuts) = 0;
     virtual async::Notification shortcutsChanged() const = 0;
 
-    virtual const Shortcut& shortcut(const std::string& actionCode) = 0;
+    virtual const Shortcut& shortcut(const std::string& actionCode) const = 0;
     virtual const Shortcut& defaultShortcut(const std::string& actionCode) const = 0;
 
     virtual bool isRegistered(const std::string& sequence) const = 0;

--- a/src/framework/shortcuts/shortcutstypes.h
+++ b/src/framework/shortcuts/shortcutstypes.h
@@ -35,6 +35,10 @@ struct Shortcut
     std::string sequence;
     QKeySequence::StandardKey standardKey = QKeySequence::UnknownKey;
 
+    Shortcut() = default;
+    Shortcut(const std::string& a)
+        : action(a) {}
+
     bool isValid() const
     {
         return !action.empty() && (!sequence.empty() || standardKey != QKeySequence::UnknownKey);


### PR DESCRIPTION
The crash itself was added by this PR
https://github.com/musescore/MuseScore/pull/9973

But I also paid attention to the implementation of the `hortcutsRegister::shortcut` method.
I read the explanation from @wizofaus (https://github.com/musescore/MuseScore/pull/8908/files#r694720397), I think that the problem indicated in the explanation needs to be solved differently, we can, for example, add a separate method to create shortcuts that are absent in  `shortcuts.xml` or, as @wizofaus suggests, use the ui action resistor as source for build the form of shortcuts. While this is not meant to be, not all actions need to have shortcuts. I believe that we, as developers, must explicitly prescribe which actions can have shortcuts and which cannot (for example, we can explicitly prescribe these actions in `shortcuts.xml`, but not assign sequences to them). Because the actions themselves can be our technical internal implementation, not public, they can be added, removed, changed ... If we grant access to all actions indiscriminately, then this will restrain us in the future, we will have to invest additional efforts to maintain backward compatibility.

In any case, it is not worth solving this problem by imposing a side effect on a method that is not intended for this, and the fact that it is now called for all actions is just an implementation detail that can be changed, and accordingly it will stop fulfilling the additional responsibility imposed on it ...