### PR TITLE
fix grace note ledger line lengths

### DIFF
--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -855,8 +855,8 @@ void Chord::addLedgerLines()
 
             //ledger lines need the leftmost point of the notehead with a respect of bbox
             x = note->pos().x() + note->bboxXShift();
-            if (x - extraLen < minX) {
-                minX  = x - extraLen;
+            if (x - extraLen * note->mag() < minX) {
+                minX  = x - extraLen * note->mag();
                 // increase width of all lines between this one and the staff
                 for (auto& d : vecLines) {
                     if (!d.accidental && ((l < 0 && d.line >= l) || (l > 0 && d.line <= l))) {
@@ -865,8 +865,8 @@ void Chord::addLedgerLines()
                 }
             }
             // same for left side
-            if (x + hw + extraLen > maxX) {
-                maxX = x + hw + extraLen;
+            if (x + hw + extraLen * note->mag() > maxX) {
+                maxX = x + hw + extraLen * note->mag();
                 for (auto& d : vecLines) {
                     if ((l < 0 && d.line >= l) || (l > 0 && d.line <= l)) {
                         d.maxX = maxX;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9987

This PR multiplies a note's ledger line extension by the note's size. This way, grace notes have ledger lines that are appropriately wide.