### PR TITLE
[MU4] Fix (MSVC) compiler warnings

### DIFF
--- a/src/engraving/property/propertyvalue.h
+++ b/src/engraving/property/propertyvalue.h
@@ -357,8 +357,9 @@ private:
         {
             if constexpr (std::is_enum<T>::value) {
                 return static_cast<int>(v);
+            } else {
+                return -1;
             }
-            return -1;
         }
     };
 

--- a/src/framework/telemetry/CMakeLists.txt
+++ b/src/framework/telemetry/CMakeLists.txt
@@ -30,7 +30,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/devtools/telemetrydevtools.h
     )
 
-set(MODULE_QRC telemetry.qrc)
+#set(MODULE_QRC telemetry.qrc)
 
 set(MODULE_QML_IMPORT ${CMAKE_CURRENT_LIST_DIR}/qml )
 

--- a/src/framework/telemetry/telemetrymodule.cpp
+++ b/src/framework/telemetry/telemetrymodule.cpp
@@ -46,7 +46,7 @@ static std::shared_ptr<TelemetryConfiguration> s_configuration = std::make_share
 
 static void telemetry_init_qrc()
 {
-    Q_INIT_RESOURCE(telemetry);
+    //Q_INIT_RESOURCE(telemetry);
 }
 
 std::string TelemetryModule::moduleName() const


### PR DESCRIPTION
* 70 warnings about "unreachable code" at the very same line (the `return -1;`)
* 1 warning about empty (telemetry.)qrc file