### PR TITLE
[MU4] Fixed resetting the focus of the search field when showing popups(tooltips of palette cell)

### DIFF
--- a/src/palette/qml/MuseScore/Palette/internal/PalettesPanelHeader.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PalettesPanelHeader.qml
@@ -130,11 +130,12 @@ Item {
             root.endSearch()
         }
 
-        onTextEditingFinished: {
-            root.endSearch()
-        }
-
         visible: root.isSearchOpened
+        onVisibleChanged: {
+            if (!searchField.visible) {
+                addPalettesButton.navigation.requestActive()
+            }
+        }
 
         onSearchTextChanged: resultsTimer.restart()
         onActiveFocusChanged: {


### PR DESCRIPTION
Reverted unnecessary fixes from #9994
