### PR TITLE
add support for tab staff beams

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -604,8 +604,9 @@ PointF Beam::chordBeamAnchor(Chord* chord) const
     qreal x = chord->stemPosX() + chord->pagePos().x() - pagePos().x();
     qreal y = position.y() + chord->defaultStemLength() * upValue - beamOffset;
     if (_isBesideTabStaff) {
-        y = _tab->chordRestStemPosY(chord) + (_up ? -STAFFTYPE_TAB_DEFAULTSTEMLEN_UP : STAFFTYPE_TAB_DEFAULTSTEMLEN_DN) * chord->mag()
-            / chord->staff()->staffMag(chord);
+        StaffType const* staffType = chord->staff()->staffType(chord->tick());
+        qreal stemLength = staffType->chordStemLength(chord);
+        y = _tab->chordRestStemPosY(chord) + stemLength;
         y *= spatium();
         y -= beamOffset;
     }
@@ -1480,7 +1481,7 @@ void Beam::setUserModified(bool val)
 PropertyValue Beam::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
-    case Pid::STEM_DIRECTION: return beamDirection();
+    case Pid::STEM_DIRECTION : return beamDirection();
     case Pid::DISTRIBUTE:     return distribute();
     case Pid::GROW_LEFT:      return growLeft();
     case Pid::GROW_RIGHT:     return growRight();

--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -604,7 +604,8 @@ PointF Beam::chordBeamAnchor(Chord* chord) const
     qreal x = chord->stemPosX() + chord->pagePos().x() - pagePos().x();
     qreal y = position.y() + chord->defaultStemLength() * upValue - beamOffset;
     if (_isBesideTabStaff) {
-        y = _tab->chordRestStemPosY(chord) + (_up ? -STAFFTYPE_TAB_DEFAULTSTEMLEN_UP : STAFFTYPE_TAB_DEFAULTSTEMLEN_DN);
+        y = _tab->chordRestStemPosY(chord) + (_up ? -STAFFTYPE_TAB_DEFAULTSTEMLEN_UP : STAFFTYPE_TAB_DEFAULTSTEMLEN_DN) * chord->mag()
+            / chord->staff()->staffMag(chord);
         y *= spatium();
         y -= beamOffset;
     }
@@ -1016,6 +1017,7 @@ void Beam::layout2(std::vector<ChordRest*> chordRests, SpannerSegmentType, int f
     }
 
     _beamSpacing = score()->styleB(Sid::useWideBeams) ? 4 : 3;
+    _beamDist = (_beamSpacing / 4.0) * spatium() * mag();
 
     if (!chordRests.front()->isChord() || !chordRests.back()->isChord()) {
         NOT_IMPL_RETURN;
@@ -1063,7 +1065,6 @@ void Beam::layout2(std::vector<ChordRest*> chordRests, SpannerSegmentType, int f
             addMiddleLineSlant(dictator, pointer, beamCount, middleLine, interval);
         }
 
-        _beamDist = (_beamSpacing / 4.0) * spatium() * mag();
         startAnchor.setY(quarterSpace * (isStartDictator ? dictator : pointer));
         endAnchor.setY(quarterSpace * (isStartDictator ? pointer : dictator));
 

--- a/src/engraving/libmscore/beam.h
+++ b/src/engraving/libmscore/beam.h
@@ -65,6 +65,10 @@ class Beam final : public EngravingItem
     qreal _beamDist         { 0.0f };
     int _beamSpacing        { 3 }; // how far apart beams are spaced in quarter spaces
 
+    // for tabs
+    bool _isBesideTabStaff  { false };
+    StaffType const* _tab         { nullptr };
+
     QVector<BeamFragment*> fragments;       // beam splits across systems
 
     mutable int _id         { 0 };          // used in read()/write()

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -1496,6 +1496,8 @@ qreal Chord::calcDefaultStemLength()
     bool isBesideTabStaff = tab && !tab->stemless() && !tab->stemThrough();
     if (isBesideTabStaff) {
         return tab->chordStemLength(this) * _spatium;
+    } else if (tab) {
+        defaultStemLength *= 1.5;
     }
 
     int minStemLengthQuarterSpaces = calcMinStemLength();
@@ -1514,6 +1516,9 @@ qreal Chord::calcDefaultStemLength()
 
         if (stemEndPosition <= -shortStemStart) {
             int reduction = maxReduction(qAbs(stemEndPosition + shortStemStart));
+            if (tab) {
+                reduction *= 2;
+            }
             if (_hook) {
                 reduction = reduction / 2 * 2; // transforms to only half steps positions
             }
@@ -1531,6 +1536,9 @@ qreal Chord::calcDefaultStemLength()
         int downShortStemStart = (staffLineCount - 1) * 4 + shortStemStart;
         if (stemEndPosition >= downShortStemStart) {
             int reduction = maxReduction(stemEndPosition - downShortStemStart);
+            if (tab) {
+                reduction *= 2;
+            }
             idealStemLength = qMax(idealStemLength - reduction, shortestStem);
         } else if (stemEndPosition < middleLine) {
             idealStemLength += middleLine - stemEndPosition;

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -242,14 +242,10 @@ std::vector<int> Chord::noteDistances() const
     Q_ASSERT(staffType);
     bool isTabStaff = staffType->isTabStaff();
     int staffMiddleLine = staffType->middleLine();
-    int upStringAmount = 0;
-    if (isTabStaff) {
-        upStringAmount = upString() * 2;
-    }
 
     std::vector<int> distances;
     for (Note* note : _notes) {
-        int noteLine = isTabStaff ? upStringAmount : note->line();
+        int noteLine = isTabStaff ? note->string() : note->line();
         distances.push_back(noteLine - staffMiddleLine);
     }
     return distances;

--- a/src/engraving/libmscore/stafftype.cpp
+++ b/src/engraving/libmscore/stafftype.cpp
@@ -681,7 +681,7 @@ qreal StaffType::chordStemLength(const Chord* chord) const
     else {
         bool shrt = (minimStyle() == TablatureMinimStyle::SHORTER) && (chord->durationType().type() == DurationType::V_HALF);
         stemLen = (stemsDown() ? STAFFTYPE_TAB_DEFAULTSTEMLEN_DN : STAFFTYPE_TAB_DEFAULTSTEMLEN_UP)
-                  * (shrt ? STAFFTYPE_TAB_SHORTSTEMRATIO : 1.0);
+                  * (shrt ? STAFFTYPE_TAB_SHORTSTEMRATIO : 1.0) * (chord->score()->styleB(Sid::useWideBeams) ? 1.25 : 1.0);
     }
     // scale length by scale of parent chord, but relative to scale of context staff
     return stemLen * chord->mag() / chord->staff()->staffMag(chord->tick());


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10023

After the beam refactoring in #9792, beams on tablature staves got really messed up. This PR fixes those issues for both "common" and "full" staves.