### PR TITLE
Fix floating VST windows on Windows

### DIFF
--- a/src/framework/vst/view/abstractvsteditorview.h
+++ b/src/framework/vst/view/abstractvsteditorview.h
@@ -27,9 +27,10 @@
 #include <QWidget>
 
 #include "async/asyncable.h"
-#include "modularity/ioc.h"
 
+#include "modularity/ioc.h"
 #include "ivstpluginsregister.h"
+#include "ui/imainwindow.h"
 
 namespace mu::vst {
 class AbstractVstEditorView : public QDialog, public Steinberg::IPlugFrame, public async::Asyncable
@@ -40,6 +41,7 @@ class AbstractVstEditorView : public QDialog, public Steinberg::IPlugFrame, publ
     Q_PROPERTY(QString resourceId READ resourceId WRITE setResourceId NOTIFY resourceIdChanged)
 
     INJECT(vst, IVstPluginsRegister, pluginsRegister)
+    INJECT(vst, ui::IMainWindow, mainWindow)
 
 public:
     AbstractVstEditorView(QWidget* parent = nullptr);
@@ -64,8 +66,6 @@ protected:
 
 private:
     void attachView(VstPluginPtr pluginPtr);
-
-    void updateStayOnTopness();
 
     FIDString currentPlatformUiType() const;
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/pull/9830#issuecomment-979959093

The "hack" did not work well on Windows, but there appears to be a much more graceful solution. Unfortunately, that solution does not work on macOS, so on macOS we still use the old solution.

I must say that I have no idea about the situation on Linux. Maybe it works on Linux the same as on Windows, maybe the same as on macOS, or even different. Currently, I let Linux use the Windows solution.