### PR TITLE
Make panel tabs scrollable in case of overflow

### DIFF
--- a/src/appshell/qml/dockwindow/DockFrame.qml
+++ b/src/appshell/qml/dockwindow/DockFrame.qml
@@ -142,10 +142,11 @@ Rectangle {
             anchors.bottom: parent.bottom
             anchors.left: parent.left
 
-            width: contentWidth
+            // NOTE: + 1, because we don't need to see the separator of the rightmost tab
+            width: Math.min(contentWidth, parent.width + 1)
 
             orientation: Qt.Horizontal
-            interactive: false
+            boundsBehavior: Flickable.StopAtBounds
             spacing: 0
 
             currentIndex: tabsPanel.currentIndex
@@ -166,6 +167,10 @@ Rectangle {
 
                 onClicked: {
                     tabsPanel.currentIndex = model.index
+                }
+
+                onNavigationActivated: {
+                    tabs.positionViewAtIndex(model.index, ListView.Contain)
                 }
 
                 onHandleContextMenuItemRequested: function(itemId) {

--- a/src/appshell/qml/dockwindow/DockPanelTab.qml
+++ b/src/appshell/qml/dockwindow/DockPanelTab.qml
@@ -31,6 +31,7 @@ StyledTabButton {
 
     property alias contextMenuModel: contextMenuButton.menuModel
 
+    signal navigationActivated()
     signal handleContextMenuItemRequested(string itemId)
 
     readonly property real actualHeight: 34
@@ -44,6 +45,12 @@ StyledTabButton {
     rightPadding: (contextMenuButton.visible ? buttonPadding : textPadding) + 1 // For separator
     topPadding: 0
     bottomPadding: 1 // For separator
+
+    navigation.onActiveChanged: {
+        if (navigation.active) {
+            root.navigationActivated()
+        }
+    }
 
     contentItem: Row {
         spacing: root.buttonPadding
@@ -87,6 +94,11 @@ StyledTabButton {
 
             navigation.panel: root.navigation.panel
             navigation.order: root.navigation.order + 1
+            navigation.onActiveChanged: {
+                if (navigation.active) {
+                    root.navigationActivated()
+                }
+            }
 
             onHandleMenuItem: function(itemId) {
                 root.handleContextMenuItemRequested(itemId)

--- a/src/notation/qml/MuseScore/NotationScene/SelectionFilterPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/SelectionFilterPanel.qml
@@ -47,7 +47,11 @@ Item {
 
     StyledListView {
         anchors.fill: parent
-        anchors.margins: 12
+
+        topMargin: 12
+        leftMargin: topMargin
+        rightMargin: topMargin
+        bottomMargin: topMargin
 
         spacing: 12
 

--- a/thirdparty/KDDockWidgets/src/private/quick/TabBarQuick.cpp
+++ b/thirdparty/KDDockWidgets/src/private/quick/TabBarQuick.cpp
@@ -41,9 +41,10 @@ int TabBarQuick::tabAt(QPoint p) const
     }
 
     if (QQuickItem *internalListView = listView()) {
+        double x = internalListView->property("contentX").toDouble() + p.x();
         int index = -1;
         QMetaObject::invokeMethod(internalListView, "indexAt", Q_RETURN_ARG(int, index),
-                                  Q_ARG(double, p.x()), Q_ARG(double, p.y()));
+                                  Q_ARG(double, x), Q_ARG(double, p.y()));
 
         return index;
     } else {


### PR DESCRIPTION
Resolves: #9262

Note: this is different from the originally planned design. I looked into ways to implement that design, and got the logic for it correctly, but then I got stuck with binding loops, not-working bindings, polish loops, non-informative warnings, and hangs and crashes... 

So I decided to go for a slightly simpler solution, which appears to work well. (I also made sure it works well with keyboard navigation.)

I had to make changes to the KDDockWidgets library to make clicking at a tab panel work when the tabs are scrolled. Maybe we should offer this change to KDAB, since I think it may make sense for other projects too.

In case anyone is interested in seeing what I tried for the original design, it's here: https://github.com/cbjeukendrup/MuseScore/commit/e54032190e1d32ca02796c396568b86cae3c269e
You'll find that it kind of works, but especially when you just launch the app, it sometimes behaves very strangely.