### PR TITLE
update musicxml.xsd and xlink.xsd to MusicXML 4.0

### DIFF
--- a/src/importexport/musicxml/schema/musicxml.xsd
+++ b/src/importexport/musicxml/schema/musicxml.xsd
@@ -3,9 +3,9 @@
 	<xs:annotation>
 		<xs:documentation>MusicXML W3C XML schema (XSD)
 
-Version 3.1
+Version 4.0
 
-Copyright © 2004-2017 the Contributors to the MusicXML Specification, published by the W3C Music Notation Community Group under the W3C Community Final Specification Agreement (FSA):
+Copyright © 2004-2021 the Contributors to the MusicXML Specification, published by the W3C Music Notation Community Group under the W3C Community Final Specification Agreement (FSA):
 
 	https://www.w3.org/community/about/agreements/final/
 
@@ -13,13 +13,15 @@ A human-readable summary is available:
 
 	https://www.w3.org/community/about/agreements/fsa-deed/
 
-This is the W3C XML Schema (XSD) version of the MusicXML 3.1 language. Validation is tightened by moving MusicXML definitions from comments into schema data types and definitions. Character entities and other entity usages that are not supported in W3C XML Schema have been removed. The features of W3C XML Schema make it easier to define variations of the MusicXML format, either via extension or restriction.
+This is the W3C XML Schema (XSD) version of the MusicXML 4.0 format. Validation is tightened by moving MusicXML definitions from comments into schema data types and definitions. Character entities and other entity usages that are not supported in W3C XML Schema have been removed. The features of W3C XML Schema make it easier to define variations of the MusicXML format, either via extension or restriction.
 
-This file defines the MusicXML 3.1 XSD, including the score-partwise and score-timewise document elements.</xs:documentation>
+This file defines the MusicXML 4.0 XSD, including the score-partwise and score-timewise document elements.
+
+The XML catalog at catalog.xml supports validating against a local copy of this XSD rather than the networked version. Software often has trouble using system IDs due to factors such as restrictions on network access, or resources having moved from the original specified location. To validate with the MusicXML XSD, use a schema URI of "http://www.musicxml.org/xsd/musicxml.xsd".</xs:documentation>
 	</xs:annotation>
 
 	<xs:annotation>
-		<xs:documentation>The MusicXML 3.1 DTD has no namespace, so for compatibility the MusicXML 3.1 XSD has no namespace either. Those who need to import the MusicXML XSD into another schema are advised to create a new version that uses "http://www.musicxml.org/xsd/MusicXML" as the namespace.</xs:documentation>
+		<xs:documentation>The MusicXML 4.0 DTD has no namespace, so for compatibility the MusicXML 4.0 XSD has no namespace either. Those who need to import the MusicXML XSD into another schema are advised to create a new version that uses "http://www.musicxml.org/xsd/MusicXML" as the namespace.</xs:documentation>
 	</xs:annotation>
 	<xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.musicxml.org/xsd/xml.xsd"/>
 	<xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.musicxml.org/xsd/xlink.xsd"/>
@@ -92,7 +94,7 @@ As in SVG 1.1, colors are defined in terms of the sRGB color space (IEC 61966).<
 
 	<xs:simpleType name="enclosure-shape">
 		<xs:annotation>
-			<xs:documentation>The enclosure-shape type describes the shape and presence / absence of an enclosure around text or symbols. A bracket enclosure is similar to a rectangle with the bottom line missing, as is common in jazz notation.</xs:documentation>
+			<xs:documentation>The enclosure-shape type describes the shape and presence / absence of an enclosure around text or symbols. A bracket enclosure is similar to a rectangle with the bottom line missing, as is common in jazz notation. An inverted-bracket enclosure is similar to a rectangle with the top line missing.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:token">
 			<xs:enumeration value="rectangle"/>
@@ -100,6 +102,7 @@ As in SVG 1.1, colors are defined in terms of the sRGB color space (IEC 61966).<
 			<xs:enumeration value="oval"/>
 			<xs:enumeration value="circle"/>
 			<xs:enumeration value="bracket"/>
+			<xs:enumeration value="inverted-bracket"/>
 			<xs:enumeration value="triangle"/>
 			<xs:enumeration value="diamond"/>
 			<xs:enumeration value="pentagon"/>
@@ -129,9 +132,16 @@ As in SVG 1.1, colors are defined in terms of the sRGB color space (IEC 61966).<
 		</xs:restriction>
 	</xs:simpleType>
 
+	<xs:simpleType name="font-family">
+		<xs:annotation>
+			<xs:documentation>The font-family is a comma-separated list of font names. These can be specific font styles such as Maestro or Opus, or one of several generic font styles: music, engraved, handwritten, text, serif, sans-serif, handwritten, cursive, fantasy, and monospace. The music, engraved, and handwritten values refer to music fonts; the rest refer to text fonts. The fantasy style refers to decorative text such as found in older German-style printing.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="comma-separated-text"/>
+	</xs:simpleType>
+	
 	<xs:simpleType name="font-size">
 		<xs:annotation>
-			<xs:documentation>The font-size can be one of the CSS font sizes or a numeric point size.</xs:documentation>
+			<xs:documentation>The font-size can be one of the CSS font sizes (xx-small, x-small, small, medium, large, x-large, xx-large) or a numeric point size.</xs:documentation>
 		</xs:annotation>
 		<xs:union memberTypes="xs:decimal css-font-size"/>
 	</xs:simpleType>
@@ -222,7 +232,7 @@ As in SVG 1.1, colors are defined in terms of the sRGB color space (IEC 61966).<
 
 	<xs:simpleType name="midi-128">
 		<xs:annotation>
-			<xs:documentation>The midi-16 type is used to express MIDI 1.0 values that range from 1 to 128.</xs:documentation>
+			<xs:documentation>The midi-128 type is used to express MIDI 1.0 values that range from 1 to 128.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:positiveInteger">
 			<xs:minInclusive value="1"/>
@@ -232,7 +242,7 @@ As in SVG 1.1, colors are defined in terms of the sRGB color space (IEC 61966).<
 
 	<xs:simpleType name="midi-16384">
 		<xs:annotation>
-			<xs:documentation>The midi-16 type is used to express MIDI 1.0 values that range from 1 to 16,384.</xs:documentation>
+			<xs:documentation>The midi-16384 type is used to express MIDI 1.0 values that range from 1 to 16,384.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:positiveInteger">
 			<xs:minInclusive value="1"/>
@@ -274,11 +284,19 @@ As in SVG 1.1, colors are defined in terms of the sRGB color space (IEC 61966).<
 
 	<xs:simpleType name="number-level">
 		<xs:annotation>
-			<xs:documentation>Slurs, tuplets, and many other features can be concurrent and overlapping within a single musical part. The number-level type distinguishes up to six concurrent objects of the same type. A reading program should be prepared to handle cases where the number-levels stop in an arbitrary order. Different numbers are needed when the features overlap in MusicXML document order. When a number-level value is optional, the value is 1 by default.</xs:documentation>
+			<xs:documentation>Slurs, tuplets, and many other features can be concurrent and overlap within a single musical part. The number-level entity distinguishes up to 16 concurrent objects of the same type when the objects overlap in MusicXML document order. Values greater than 6 are usually only needed for music with a large number of divisi staves in a single part, or if there are more than 6 cross-staff arpeggios in a single measure. When a number-level value is implied, the value is 1 by default.
+
+When polyphonic parts are involved, the ordering within a MusicXML document can differ from musical score order. As an example, say we have a piano part in 4/4 where within a single measure, all the notes on the top staff are followed by all the notes on the bottom staff. In this example, each staff has a slur that starts on beat 2 and stops on beat 3, and there is a third slur that goes from beat 1 of one staff to beat 4 of the other staff.
+
+In this situation, the two mid-measure slurs can use the same number because they do not overlap in MusicXML document order, even though they do overlap in musical score order. Within the MusicXML document, the top staff slur will both start and stop before the bottom staff slur starts and stops.
+
+If the cross-staff slur starts in the top staff and stops in the bottom staff, it will need a separate number from the mid-measure slurs because it overlaps those slurs in MusicXML document order. However, if the cross-staff slur starts in the bottom staff and stops in the top staff, all three slurs can use the same number. None of them overlap within the MusicXML document, even though they all overlap each other in the musical score order. Within the MusicXML document, the start and stop of the top-staff slur will be followed by the stop and start of the cross-staff slur, followed by the start and stop of the bottom-staff slur.
+
+As this example demonstrates, a reading program should be prepared to handle cases where the number-levels start and stop in an arbitrary order. Because the start and stop values refer to musical score order, a program may find the stopping point of an object earlier in the MusicXML document than it will find its starting point.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:positiveInteger">
 			<xs:minInclusive value="1"/>
-			<xs:maxInclusive value="6"/>
+			<xs:maxInclusive value="16"/>
 		</xs:restriction>
 	</xs:simpleType>
 
@@ -305,6 +323,16 @@ As in SVG 1.1, colors are defined in terms of the sRGB color space (IEC 61966).<
 		</xs:union>
 	</xs:simpleType>
 
+	<xs:simpleType name="numeral-value">
+		<xs:annotation>
+			<xs:documentation>The numeral-value type represents a Roman numeral or Nashville number value as a positive integer from 1 to 7.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:positiveInteger">
+			<xs:minInclusive value="1"/>
+			<xs:maxInclusive value="7"/>
+		</xs:restriction>
+	</xs:simpleType>
+	
 	<xs:simpleType name="over-under">
 		<xs:annotation>
 			<xs:documentation>The over-under type is used to indicate whether the tips of curved lines such as slurs and ties are overhand (tips down) or underhand (tips up).</xs:documentation>
@@ -389,10 +417,10 @@ As in SVG 1.1, colors are defined in terms of the sRGB color space (IEC 61966).<
 
 	<xs:simpleType name="smufl-accidental-glyph-name">
 		<xs:annotation>
-			<xs:documentation>The smufl-accidental-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) accidental character. The value is a SMuFL canonical glyph name that starts with acc.</xs:documentation>
+			<xs:documentation>The smufl-accidental-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) accidental character. The value is a SMuFL canonical glyph name that starts with one of the strings used at the start of glyph names for SMuFL accidentals.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="smufl-glyph-name">
-			<xs:pattern value="acc\c+"/>
+			<xs:pattern value="(acc|medRenFla|medRenNatura|medRenShar|kievanAccidental)(\c+)"/>
 		</xs:restriction>
 	</xs:simpleType>
 
@@ -432,6 +460,15 @@ As in SVG 1.1, colors are defined in terms of the sRGB color space (IEC 61966).<
 		</xs:restriction>
 	</xs:simpleType>
 
+	<xs:simpleType name="smufl-wavy-line-glyph-name">
+		<xs:annotation>
+			<xs:documentation>The smufl-wavy-line-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) wavy line character. The value is a SMuFL canonical glyph name that either starts with wiggle, or begins with guitar and ends with VibratoStroke. This includes all the glyphs in the Multi-segment lines range, excluding the beam glyphs.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="smufl-glyph-name">
+			<xs:pattern value="(wiggle\c+)|(guitar\c*VibratoStroke)"/>
+		</xs:restriction>
+	</xs:simpleType>
+	
 	<xs:simpleType name="start-note">
 		<xs:annotation>
 			<xs:documentation>The start-note type describes the starting note of trills and mordents for playback, relative to the current note.</xs:documentation>
@@ -447,7 +484,9 @@ As in SVG 1.1, colors are defined in terms of the sRGB color space (IEC 61966).<
 		<xs:annotation>
 			<xs:documentation>The start-stop type is used for an attribute of musical elements that can either start or stop, such as tuplets.
 
-The values of start and stop refer to how an element appears in musical score order, not in MusicXML document order. An element with a stop attribute may precede the corresponding element with a start attribute within a MusicXML document. This is particularly common in multi-staff music. For example, the stopping point for a tuplet may appear in staff 1 before the starting point for the tuplet appears in staff 2 later in the document.</xs:documentation>
+The values of start and stop refer to how an element appears in musical score order, not in MusicXML document order. An element with a stop attribute may precede the corresponding element with a start attribute within a MusicXML document. This is particularly common in multi-staff music. For example, the stopping point for a tuplet may appear in staff 1 before the starting point for the tuplet appears in staff 2 later in the document.
+
+When multiple elements with the same tag are used within the same note, their order within the MusicXML document should match the musical score order.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:token">
 			<xs:enumeration value="start"/>
@@ -459,7 +498,9 @@ The values of start and stop refer to how an element appears in musical score or
 		<xs:annotation>
 			<xs:documentation>The start-stop-continue type is used for an attribute of musical elements that can either start or stop, but also need to refer to an intermediate point in the symbol, as for complex slurs or for formatting of symbols across system breaks.
 
-The values of start, stop, and continue refer to how an element appears in musical score order, not in MusicXML document order. An element with a stop attribute may precede the corresponding element with a start attribute within a MusicXML document. This is particularly common in multi-staff music. For example, the stopping point for a slur may appear in staff 1 before the starting point for the slur appears in staff 2 later in the document.</xs:documentation>
+The values of start, stop, and continue refer to how an element appears in musical score order, not in MusicXML document order. An element with a stop attribute may precede the corresponding element with a start attribute within a MusicXML document. This is particularly common in multi-staff music. For example, the stopping point for a slur may appear in staff 1 before the starting point for the slur appears in staff 2 later in the document.
+
+When multiple elements with the same tag are used within the same note, their order within the MusicXML document should match the musical score order. For example, a note that marks both the end of one slur and the start of a new slur should have the incoming slur element with a type of stop precede the outgoing slur element with a type of start.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:token">
 			<xs:enumeration value="start"/>
@@ -470,7 +511,9 @@ The values of start, stop, and continue refer to how an element appears in music
 
 	<xs:simpleType name="start-stop-single">
 		<xs:annotation>
-			<xs:documentation>The start-stop-single type is used for an attribute of musical elements that can be used for either multi-note or single-note musical elements, as for groupings.</xs:documentation>
+			<xs:documentation>The start-stop-single type is used for an attribute of musical elements that can be used for either multi-note or single-note musical elements, as for groupings.
+
+When multiple elements with the same tag are used within the same note, their order within the MusicXML document should match the musical score order.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:token">
 			<xs:enumeration value="start"/>
@@ -509,7 +552,7 @@ Distances in a MusicXML file are measured in tenths of staff space. Tenths are t
 
 	<xs:simpleType name="text-direction">
 		<xs:annotation>
-			<xs:documentation>The text-direction type is used to adjust and override the Unicode bidirectional text algorithm, similar to the W3C Internationalization Tag Set recommendation. Values are ltr (left-to-right embed), rtl (right-to-left embed), lro (left-to-right bidi-override), and rlo (right-to-left bidi-override). The default value is ltr. This type is typically used by applications that store text in left-to-right visual order rather than logical order. Such applications can use the lro value to better communicate with other applications that more fully support bidirectional text.</xs:documentation>
+			<xs:documentation>The text-direction type is used to adjust and override the Unicode bidirectional text algorithm, similar to the Directionality data category in the W3C Internationalization Tag Set recommendation. Values are ltr (left-to-right embed), rtl (right-to-left embed), lro (left-to-right bidi-override), and rlo (right-to-left bidi-override). The default value is ltr. This type is typically used by applications that store text in left-to-right visual order rather than logical order. Such applications can use the lro value to better communicate with other applications that more fully support bidirectional text.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:token">
 			<xs:enumeration value="ltr"/>
@@ -523,7 +566,9 @@ Distances in a MusicXML file are measured in tenths of staff space. Tenths are t
 		<xs:annotation>
 			<xs:documentation>The tied-type type is used as an attribute of the tied element to specify where the visual representation of a tie begins and ends. A tied element which joins two notes of the same pitch can be specified with tied-type start on the first note and tied-type stop on the second note. To indicate a note should be undamped, use a single tied element with tied-type let-ring. For other ties that are visually attached to a single note, such as a tie leading into or out of a repeated section or coda, use two tied elements on the same note, one start and one stop.
 
-In start-stop cases, ties can add more elements using a continue type. This is typically used to specify the formatting of cross-system ties.</xs:documentation>
+In start-stop cases, ties can add more elements using a continue type. This is typically used to specify the formatting of cross-system ties.
+
+When multiple elements with the same tag are used within the same note, their order within the MusicXML document should match the musical score order. For example, a note with a tie at the end of a first ending should have the tied element with a type of start precede the tied element with a type of stop.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:token">
 			<xs:enumeration value="start"/>
@@ -535,7 +580,7 @@ In start-stop cases, ties can add more elements using a continue type. This is t
 
 	<xs:simpleType name="time-only">
 		<xs:annotation>
-			<xs:documentation>The time-only type is used to indicate that a particular playback-related element only applies particular times through a repeated section. The value is a comma-separated list of positive integers arranged in ascending order, indicating which times through the repeated section that the element applies.</xs:documentation>
+			<xs:documentation>The time-only type is used to indicate that a particular playback- or listening-related element only applies particular times through a repeated section. The value is a comma-separated list of positive integers arranged in ascending order, indicating which times through the repeated section that the element applies.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:token">
 			<xs:pattern value="[1-9][0-9]*(, ?[1-9][0-9]*)*"/>
@@ -554,7 +599,7 @@ In start-stop cases, ties can add more elements using a continue type. This is t
 
 	<xs:simpleType name="tremolo-type">
 		<xs:annotation>
-			<xs:documentation>The tremolo-type is used to distinguish multi-note, single-note, and unmeasured tremolos.</xs:documentation>
+			<xs:documentation>The tremolo-type is used to distinguish double-note, single-note, and unmeasured tremolos.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:token">
 			<xs:enumeration value="start"/>
@@ -617,7 +662,7 @@ In start-stop cases, ties can add more elements using a continue type. This is t
 
 	<xs:simpleType name="valign">
 		<xs:annotation>
-			<xs:documentation>The valign type is used to indicate vertical alignment to the top, middle, bottom, or baseline of the text. Defaults are implementation-dependent.</xs:documentation>
+			<xs:documentation>The valign type is used to indicate vertical alignment to the top, middle, bottom, or baseline of the text. If the text is on multiple lines, baseline alignment refers to the baseline of the lowest line of text. Defaults are implementation-dependent.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:token">
 			<xs:enumeration value="top"/>
@@ -679,7 +724,9 @@ In start-stop cases, ties can add more elements using a continue type. This is t
 
 	<xs:simpleType name="clef-sign">
 		<xs:annotation>
-			<xs:documentation>The clef-sign element represents the different clef symbols. The jianpu sign indicates that the music that follows should be in jianpu numbered notation, just as the TAB sign indicates that the music that follows should be in tablature notation. Unlike TAB, a jianpu sign does not correspond to a visual clef notation.</xs:documentation>
+			<xs:documentation>The clef-sign type represents the different clef symbols. The jianpu sign indicates that the music that follows should be in jianpu numbered notation, just as the TAB sign indicates that the music that follows should be in tablature notation. Unlike TAB, a jianpu sign does not correspond to a visual clef notation.
+
+The none sign is deprecated as of MusicXML 4.0. Use the clef element's print-object attribute instead. When the none sign is used, notes should be displayed as if in treble clef.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="G"/>
@@ -718,7 +765,14 @@ In start-stop cases, ties can add more elements using a continue type. This is t
 
 	<xs:simpleType name="staff-line">
 		<xs:annotation>
-			<xs:documentation>The staff-line type indicates the line on a given staff. Staff lines are numbered from bottom to top, with 1 being the bottom line on a staff. Staff line values can be used to specify positions outside the staff, such as a C clef positioned in the middle of a grand staff.</xs:documentation>
+			<xs:documentation>The staff-line type indicates the line on a given staff. Staff lines are numbered from bottom to top, with 1 being the bottom line on a staff.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:positiveInteger"/>
+	</xs:simpleType>
+	
+	<xs:simpleType name="staff-line-position">
+		<xs:annotation>
+			<xs:documentation>The staff-line-position type indicates the line position on a given staff. Staff lines are numbered from bottom to top, with 1 being the bottom line on a staff. A staff-line-position value can extend beyond the range of the lines on the current staff.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:integer"/>
 	</xs:simpleType>
@@ -732,14 +786,14 @@ In start-stop cases, ties can add more elements using a continue type. This is t
 
 	<xs:simpleType name="staff-type">
 		<xs:annotation>
-			<xs:documentation>The staff-type value can be ossia, cue, editorial, regular, or alternate. An alternate staff indicates one that shares the same musical data as the prior staff, but displayed differently (e.g., treble and bass clef, standard notation and tab).</xs:documentation>
+			<xs:documentation>The staff-type value can be ossia, editorial, cue, alternate, or regular. An ossia staff represents music that can be played instead of what appears on the regular staff. An editorial staff also represents musical alternatives, but is created by an editor rather than the composer. It can be used for suggested interpretations or alternatives from other sources. A cue staff represents music from another part. An alternate staff shares the same music as the prior staff, but displayed differently (e.g., treble and bass clef, standard notation and tablature). It is not included in playback. An alternate staff provides more information to an application reading a file than encoding the same music in separate parts, so its use is preferred in this situation if feasible. A regular staff is the standard default staff-type.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="ossia"/>
-			<xs:enumeration value="cue"/>
 			<xs:enumeration value="editorial"/>
-			<xs:enumeration value="regular"/>
+			<xs:enumeration value="cue"/>
 			<xs:enumeration value="alternate"/>
+			<xs:enumeration value="regular"/>
 		</xs:restriction>
 	</xs:simpleType>
 
@@ -859,7 +913,7 @@ In start-stop cases, ties can add more elements using a continue type. This is t
 		</xs:restriction>
 	</xs:simpleType>
 
-<!-- Simple types derived from direction.mod elements -->
+	<!-- Simple types derived from direction.mod elements -->
 
 	<xs:simpleType name="accordion-middle">
 		<xs:annotation>
@@ -901,7 +955,7 @@ In start-stop cases, ties can add more elements using a continue type. This is t
 
 	<xs:simpleType name="degree-symbol-value">
 		<xs:annotation>
-			<xs:documentation>The degree-symbol-value type indicates indicates that a symbol should be used in specifying the degree.</xs:documentation>
+			<xs:documentation>The degree-symbol-value type indicates which symbol should be used in specifying a degree.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:token">
 			<xs:enumeration value="major"/>
@@ -923,9 +977,9 @@ In start-stop cases, ties can add more elements using a continue type. This is t
 		</xs:restriction>
 	</xs:simpleType>
 
-	<xs:simpleType name="effect">
+	<xs:simpleType name="effect-value">
 		<xs:annotation>
-			<xs:documentation>The effect type represents pictograms for sound effect percussion instruments. The cannon, lotus flute, and megaphone values are in addition to Stone's list.</xs:documentation>
+			<xs:documentation>The effect-value type represents pictograms for sound effect percussion instruments. The cannon, lotus flute, and megaphone values are in addition to Stone's list.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="anvil"/>
@@ -958,6 +1012,17 @@ In start-stop cases, ties can add more elements using a continue type. This is t
 		</xs:restriction>
 	</xs:simpleType>
 
+	<xs:simpleType name="harmony-arrangement">
+		<xs:annotation>
+			<xs:documentation>The harmony-arrangement type indicates how stacked chords and bass notes are displayed within a harmony element. The vertical value specifies that the second element appears below the first. The horizontal value specifies that the second element appears to the right of the first. The diagonal value specifies that the second element appears both below and to the right of the first.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:token">
+			<xs:enumeration value="vertical"/>
+			<xs:enumeration value="horizontal"/>
+			<xs:enumeration value="diagonal"/>
+		</xs:restriction>
+	</xs:simpleType>
+	
 	<xs:simpleType name="harmony-type">
 		<xs:annotation>
 			<xs:documentation>The harmony-type type differentiates different types of harmonies when alternate harmonies are possible. Explicit harmonies have all note present in the music; implied have some notes missing but implied; alternate represents alternate analyses.</xs:documentation>
@@ -1014,7 +1079,9 @@ Other:
 	power (perfect fifth)
 	Tristan
 
-The "other" kind is used when the harmony is entirely composed of add elements. The "none" kind is used to explicitly encode absence of chords or functional harmony.</xs:documentation>
+The "other" kind is used when the harmony is entirely composed of add elements.
+
+The "none" kind is used to explicitly encode absence of chords or functional harmony. In this case, the root, numeral, or function element has no meaning. When using the root or numeral element, the root-step or numeral-step text attribute should be set to the empty string to keep the root or numeral from being displayed.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="major"/>
@@ -1070,16 +1137,16 @@ The "other" kind is used when the harmony is entirely composed of add elements. 
 		<xs:annotation>
 			<xs:documentation>The measure-numbering-value type describes how measure numbers are displayed on this part: no numbers, numbers every measure, or numbers every system.</xs:documentation>
 		</xs:annotation>
-		<xs:restriction base="xs:string">
+		<xs:restriction base="xs:token">
 			<xs:enumeration value="none"/>
 			<xs:enumeration value="measure"/>
 			<xs:enumeration value="system"/>
 		</xs:restriction>
 	</xs:simpleType>
 
-	<xs:simpleType name="membrane">
+	<xs:simpleType name="membrane-value">
 		<xs:annotation>
-			<xs:documentation>The membrane type represents pictograms for membrane percussion instruments.</xs:documentation>
+			<xs:documentation>The membrane-value type represents pictograms for membrane percussion instruments.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="bass drum"/>
@@ -1102,9 +1169,9 @@ The "other" kind is used when the harmony is entirely composed of add elements. 
 		</xs:restriction>
 	</xs:simpleType>
 
-	<xs:simpleType name="metal">
+	<xs:simpleType name="metal-value">
 		<xs:annotation>
-			<xs:documentation>The metal type represents pictograms for metal percussion instruments. The hi-hat value refers to a pictogram like Stone's high-hat cymbals but without the long vertical line at the bottom.</xs:documentation>
+			<xs:documentation>The metal-value type represents pictograms for metal percussion instruments. The hi-hat value refers to a pictogram like Stone's high-hat cymbals but without the long vertical line at the bottom.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="agogo"/>
@@ -1142,6 +1209,26 @@ The "other" kind is used when the harmony is entirely composed of add elements. 
 		</xs:restriction>
 	</xs:simpleType>
 
+	<xs:simpleType name="milliseconds">
+		<xs:annotation>
+			<xs:documentation>The milliseconds type represents an integral number of milliseconds.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:nonNegativeInteger"/>
+	</xs:simpleType>
+	
+	<xs:simpleType name="numeral-mode">
+		<xs:annotation>
+			<xs:documentation>The numeral-mode type specifies the mode similar to the mode type, but with a restricted set of values. The different minor values are used to interpret numeral-root values of 6 and 7 when present in a minor key. The harmonic minor value sharpens the 7 and the melodic minor value sharpens both 6 and 7. If a minor mode is used without qualification, either in the mode or numeral-mode elements, natural minor is used.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="major"/>
+			<xs:enumeration value="minor"/>
+			<xs:enumeration value="natural minor"/>
+			<xs:enumeration value="melodic minor"/>
+			<xs:enumeration value="harmonic minor"/>
+		</xs:restriction>
+	</xs:simpleType>
+	
 	<xs:simpleType name="on-off">
 		<xs:annotation>
 			<xs:documentation>The on-off type is used for notation elements such as string mutes.</xs:documentation>
@@ -1154,7 +1241,9 @@ The "other" kind is used when the harmony is entirely composed of add elements. 
 
 	<xs:simpleType name="pedal-type">
 		<xs:annotation>
-			<xs:documentation>The pedal-type simple type is used to distinguish types of pedal directions. The start value indicates the start of a damper pedal, while the sostenuto value indicates the start of a sostenuto pedal. The change, continue, and stop values can be used with either the damper or sostenuto pedal. The soft pedal is not included here because there is no special symbol or graphic used for it beyond what can be specified with words and bracket elements.</xs:documentation>
+			<xs:documentation>The pedal-type simple type is used to distinguish types of pedal directions. The start value indicates the start of a damper pedal, while the sostenuto value indicates the start of a sostenuto pedal. The other values can be used with either the damper or sostenuto pedal. The soft pedal is not included here because there is no special symbol or graphic used for it beyond what can be specified with words and bracket elements.
+
+The change, continue, discontinue, and resume types are used when the line attribute is yes. The change type indicates a pedal lift and retake indicated with an inverted V marking. The continue type allows more precise formatting across system breaks and for more complex pedaling lines. The discontinue type indicates the end of a pedal line that does not include the explicit lift represented by the stop type. The resume type indicates the start of a pedal line that does not include the downstroke represented by the start type. It can be used when a line resumes after being discontinued, or to start a pedal line that is preceded by a text or symbol representation of the pedal.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:token">
 			<xs:enumeration value="start"/>
@@ -1162,6 +1251,8 @@ The "other" kind is used when the harmony is entirely composed of add elements. 
 			<xs:enumeration value="sostenuto"/>
 			<xs:enumeration value="change"/>
 			<xs:enumeration value="continue"/>
+			<xs:enumeration value="discontinue"/>
+			<xs:enumeration value="resume"/>
 		</xs:restriction>
 	</xs:simpleType>
 	
@@ -1186,7 +1277,7 @@ The "other" kind is used when the harmony is entirely composed of add elements. 
 
 	<xs:simpleType name="principal-voice-symbol">
 		<xs:annotation>
-			<xs:documentation>The principal-voice-symbol type represents the type of symbol used to indicate the start of a principal or secondary voice. The "plain" value represents a plain square bracket. The value of "none" is used for analysis markup when the principal-voice element does not have a corresponding appearance in the score.</xs:documentation>
+			<xs:documentation>The principal-voice-symbol type represents the type of symbol used to indicate a principal or secondary voice. The "plain" value represents a plain square bracket. The value of "none" is used for analysis markup when the principal-voice element does not have a corresponding appearance in the score.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Hauptstimme"/>
@@ -1219,6 +1310,44 @@ The "other" kind is used when the harmony is entirely composed of add elements. 
 		</xs:restriction>
 	</xs:simpleType>
 
+	<xs:simpleType name="sync-type">
+		<xs:annotation>
+			<xs:documentation>The sync-type type specifies the style that a score following application should use to synchronize an accompaniment with a performer. The none type indicates no synchronization to the performer. The tempo type indicates synchronization based on the performer tempo rather than individual events in the score. The event type indicates synchronization by following the performance of individual events in the score rather than the performer tempo. The mostly-tempo and mostly-event types combine these two approaches, with mostly-tempo giving more weight to tempo and mostly-event giving more weight to performed events. The always-event type provides the strictest synchronization by not being forgiving of missing performed events.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:token">
+			<xs:enumeration value="none"/>
+			<xs:enumeration value="tempo"/>
+			<xs:enumeration value="mostly-tempo"/>
+			<xs:enumeration value="mostly-event"/>
+			<xs:enumeration value="event"/>
+			<xs:enumeration value="always-event"/>
+		</xs:restriction>
+	</xs:simpleType>
+	
+	<xs:simpleType name="system-relation-number">
+		<xs:annotation>
+			<xs:documentation>The system-relation-number type distinguishes measure numbers that are associated with a system rather than the particular part where the element appears. A value of only-top or only-bottom indicates that the number should appear only on the top or bottom part of the current system, respectively. A value of also-top or also-bottom indicates that the number should appear on both the current part and the top or bottom part of the current system, respectively. If these values appear in a score, when parts are created the number should only appear once in this part, not twice. A value of none indicates that the number is associated only with the current part, not with the system.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="only-top"/>
+			<xs:enumeration value="only-bottom"/>
+			<xs:enumeration value="also-top"/>
+			<xs:enumeration value="also-bottom"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	
+	<xs:simpleType name="system-relation">
+		<xs:annotation>
+			<xs:documentation>The system-relation type distinguishes elements that are associated with a system rather than the particular part where the element appears. A value of only-top indicates that the element should appear only on the top part of the current system. A value of also-top indicates that the element should appear on both the current part and the top part of the current system. If this value appears in a score, when parts are created the element should only appear once in this part, not twice. A value of none indicates that the element is associated only with the current part, not with the system.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="system-relation-number">
+			<xs:enumeration value="only-top"/>
+			<xs:enumeration value="also-top"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>	
+	
 	<xs:simpleType name="tip-direction">
 		<xs:annotation>
 			<xs:documentation>The tip-direction type represents the direction in which the tip of a stick or beater points, using Unicode arrow terminology.</xs:documentation>
@@ -1262,8 +1391,7 @@ The "other" kind is used when the harmony is entirely composed of add elements. 
 
 	<xs:simpleType name="stick-type">
 		<xs:annotation>
-			<xs:documentation>The stick-type type represents the shape of pictograms where the material
-	in the stick, mallet, or beater is represented in the pictogram.</xs:documentation>
+			<xs:documentation>The stick-type type represents the shape of pictograms where the material in the stick, mallet, or beater is represented in the pictogram.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="bass drum"/>
@@ -1303,9 +1431,9 @@ The "other" kind is used when the harmony is entirely composed of add elements. 
 		</xs:restriction>
 	</xs:simpleType>
 
-	<xs:simpleType name="wood">
+	<xs:simpleType name="wood-value">
 		<xs:annotation>
-			<xs:documentation>The wood type represents pictograms for wood percussion instruments. The maraca and maracas values distinguish the one- and two-maraca versions of the pictogram.</xs:documentation>
+			<xs:documentation>The wood-value type represents pictograms for wood percussion instruments. The maraca and maracas values distinguish the one- and two-maraca versions of the pictogram.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="bamboo scraper"/>
@@ -1487,6 +1615,16 @@ A quarter-rest type specifies the glyph to use when a note has a rest element an
 		</xs:restriction>
 	</xs:simpleType>
 
+	<xs:simpleType name="bend-shape">
+		<xs:annotation>
+			<xs:documentation>The bend-shape type distinguishes between the angled bend symbols commonly used in standard notation and the curved bend symbols commonly used in both tablature and standard notation.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="angled"/>
+			<xs:enumeration value="curved"/>
+		</xs:restriction>
+	</xs:simpleType>
+
 	<xs:simpleType name="breath-mark-value">
 		<xs:annotation>
 			<xs:documentation>The breath-mark-value type represents the symbol used for a breath mark.</xs:documentation>
@@ -1603,7 +1741,7 @@ A quarter-rest type specifies the glyph to use when a note has a rest element an
 
 	<xs:simpleType name="note-type-value">
 		<xs:annotation>
-			<xs:documentation>The note-type type is used for the MusicXML type element and represents the graphic note type, from 1024th (shortest) to maxima (longest).</xs:documentation>
+			<xs:documentation>The note-type-value type is used for the MusicXML type element and represents the graphic note type, from 1024th (shortest) to maxima (longest).</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="1024th"/>
@@ -1632,7 +1770,7 @@ The values do, re, mi, fa, fa up, so, la, and ti correspond to Aikin's 7-shape s
 
 The arrow shapes differ from triangle and inverted triangle by being centered on the stem. Slashed and back slashed notes include both the normal notehead and a slash. The triangle shape has the tip of the triangle pointing up; the inverted triangle shape has the tip of the triangle pointing down. The left triangle shape is a right triangle with the hypotenuse facing up and to the left.
 
-The other notehead covers noteheads other than those listed here. It is usually used in combination with the smufl attribute to specify a particular SMuFL notehead. The smufl attribute may be used with any notehead value to help specify the appearance of symbols that share the same MusicXML semantics. Noteheads in the SMuFL "Note name noteheads" range (U+E150–U+E1AF) should not use the smufl attribute or the "other" value, but instead use the notehead-text element.</xs:documentation>
+The other notehead covers noteheads other than those listed here. It is usually used in combination with the smufl attribute to specify a particular SMuFL notehead. The smufl attribute may be used with any notehead value to help specify the appearance of symbols that share the same MusicXML semantics. Noteheads in the SMuFL Note name noteheads and Note name noteheads supplement ranges (U+E150–U+E1AF and U+EEE0–U+EEFF) should not use the smufl attribute or the "other" value, but instead use the notehead-text element.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="slash"/>
@@ -1696,7 +1834,7 @@ The other notehead covers noteheads other than those listed here. It is usually 
 
 	<xs:simpleType name="stem-value">
 		<xs:annotation>
-			<xs:documentation>The stem type represents the notated stem direction.</xs:documentation>
+			<xs:documentation>The stem-value type represents the notated stem direction.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="down"/>
@@ -1768,7 +1906,7 @@ The other notehead covers noteheads other than those listed here. It is usually 
 
 	<xs:simpleType name="group-symbol-value">
 		<xs:annotation>
-			<xs:documentation>The group-symbol-value type indicates how the symbol for a group is indicated in the score. The default value is none.</xs:documentation>
+			<xs:documentation>The group-symbol-value type indicates how the symbol for a group or multi-staff part is indicated in the score.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="none"/>
@@ -1792,7 +1930,7 @@ The other notehead covers noteheads other than those listed here. It is usually 
 
 	<xs:attributeGroup name="bend-sound">
 		<xs:annotation>
-			<xs:documentation>The bend-sound type is used for bend and slide elements, and is similar to the trill-sound attribute group. Here the beats element refers to the number of discrete elements (like MIDI pitch bends) used to represent a continuous bend or slide. The first-beat indicates the percentage of the direction for starting a bend; the last-beat the percentage for ending it. The default choices are:
+			<xs:documentation>The bend-sound type is used for bend and slide elements, and is similar to the trill-sound attribute group. Here the beats element refers to the number of discrete elements (like MIDI pitch bends) used to represent a continuous bend or slide. The first-beat indicates the percentage of the duration for starting a bend; the last-beat the percentage for ending it. The default choices are:
 
 	accelerate = "no"
 	beats = "4"
@@ -1865,9 +2003,9 @@ The version attribute was added in Version 1.1 for the score-partwise and score-
 
 	<xs:attributeGroup name="font">
 		<xs:annotation>
-			<xs:documentation>The font attribute group gathers together attributes for determining the font within a credit or direction. They are based on the text styles for Cascading Style Sheets. The font-family is a comma-separated list of font names. These can be specific font styles such as Maestro or Opus, or one of several generic font styles: music, engraved, handwritten, text, serif, sans-serif, handwritten, cursive, fantasy, and monospace. The music, engraved, and handwritten values refer to music fonts; the rest refer to text fonts. The fantasy style refers to decorative text such as found in older German-style printing. The font-style can be normal or italic. The font-size can be one of the CSS sizes (xx-small, x-small, small, medium, large, x-large, xx-large) or a numeric point size. The font-weight can be normal or bold. The default is application-dependent, but is a text font vs. a music font.</xs:documentation>
+			<xs:documentation>The font attribute group gathers together attributes for determining the font within a credit or direction. They are based on the text styles for Cascading Style Sheets. The font-family is a comma-separated list of font names.The font-style can be normal or italic. The font-size can be one of the CSS sizes or a numeric point size. The font-weight can be normal or bold. The default is application-dependent, but is a text font vs. a music font.</xs:documentation>
 		</xs:annotation>
-		<xs:attribute name="font-family" type="comma-separated-text"/>
+		<xs:attribute name="font-family" type="font-family"/>
 		<xs:attribute name="font-style" type="font-style"/>
 		<xs:attribute name="font-size" type="font-size"/>
 		<xs:attribute name="font-weight" type="font-weight"/>
@@ -1882,7 +2020,7 @@ The version attribute was added in Version 1.1 for the score-partwise and score-
 
 Typically this type of credit is aligned to the right, so that the position information refers to the right-most part of the text. But in this example, the text is center-justified, not right-justified.
 
-The halign attribute is used in these situations. If it is not present, its value is the same as for the justify attribute.</xs:documentation>
+The halign attribute is used in these situations. If it is not present, its value is the same as for the justify attribute. For elements where a justify attribute is not allowed, the default is implementation-dependent.</xs:documentation>
 		</xs:annotation>
 		<xs:attribute name="halign" type="left-center-right"/>
 	</xs:attributeGroup>
@@ -1961,7 +2099,7 @@ The halign attribute is used in these situations. If it is not present, its valu
 
 	<xs:attributeGroup name="position">
 		<xs:annotation>
-			<xs:documentation>The position attributes are based on MuseData print suggestions. For most elements, any program will compute a default x and y position. The position attributes let this be changed two ways.
+			<xs:documentation>For most elements, any program will compute a default x and y position. The position attributes let this be changed two ways.
 
 The default-x and default-y attributes change the computation of the default position. For most elements, the origin is changed relative to the left-hand side of the note or the musical position within the bar (x) and the top line of the staff (y).
 
@@ -2049,6 +2187,23 @@ By default, all these attributes are set to yes. If print-object is set to no, t
 		<xs:attribute name="smufl" type="smufl-glyph-name"/>
 	</xs:attributeGroup>
 
+	<xs:attributeGroup name="system-relation">
+		<xs:annotation>
+			<xs:documentation>The system-relation attribute group distinguishes elements that are associated with a system rather than the particular part where the element appears.</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="system" type="system-relation"/>
+	</xs:attributeGroup>
+	
+	<xs:simpleType name="swing-type-value">
+		<xs:annotation>
+			<xs:documentation>The swing-type-value type specifies the note type, either eighth or 16th, to which the ratio defined in the swing element is applied.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="note-type-value">
+			<xs:enumeration value="16th"/>
+			<xs:enumeration value="eighth"/>
+		</xs:restriction>
+	</xs:simpleType>
+	
 	<xs:attributeGroup name="symbol-formatting">
 		<xs:annotation>
 			<xs:documentation>The symbol-formatting attribute group collects the common formatting attributes for musical symbols. Default values may differ across the elements that use this group.</xs:documentation>
@@ -2074,7 +2229,7 @@ By default, all these attributes are set to yes. If print-object is set to no, t
 
 	<xs:attributeGroup name="text-direction">
 		<xs:annotation>
-			<xs:documentation>The text-direction attribute is used to adjust and override the Unicode bidirectional text algorithm, similar to the W3C Internationalization Tag Set recommendation.</xs:documentation>
+			<xs:documentation>The text-direction attribute is used to adjust and override the Unicode bidirectional text algorithm, similar to the Directionality data category in the W3C Internationalization Tag Set recommendation.</xs:documentation>
 		</xs:annotation>
 		<xs:attribute name="dir" type="text-direction"/>
 	</xs:attributeGroup>
@@ -2104,7 +2259,7 @@ By default, all these attributes are set to yes. If print-object is set to no, t
 
 	<xs:attributeGroup name="trill-sound">
 		<xs:annotation>
-			<xs:documentation>The trill-sound attribute group includes attributes used to guide the sound of trills, mordents, turns, shakes, and wavy lines, based on MuseData sound suggestions. The default choices are:
+			<xs:documentation>The trill-sound attribute group includes attributes used to guide the sound of trills, mordents, turns, shakes, and wavy lines. The default choices are:
 
 	start-note = "upper"
 	trill-step = "whole"
@@ -2204,7 +2359,7 @@ The staff-spacing attribute specifies spacing between multiple staves in tenths 
 
 	<xs:attributeGroup name="link-attributes">
 		<xs:annotation>
-			<xs:documentation>The link-attributes group includes all the simple XLink attributes supported in the MusicXML format.</xs:documentation>
+			<xs:documentation>The link-attributes group includes all the simple XLink attributes supported in the MusicXML format. It is also used to connect a MusicXML score with MusicXML parts or a MusicXML opus.</xs:documentation>
 		</xs:annotation>
 		<!--<xs:attribute ref="xmnls:xlink" fixed="http://www.w3.org/1999/xlink"/>-->
 		<xs:attribute ref="xlink:href" use="required"/>
@@ -2288,9 +2443,11 @@ Measure width is specified in tenths. These are the global tenths specified in t
 
 	<xs:complexType name="dynamics">
 		<xs:annotation>
-			<xs:documentation>Dynamics can be associated either with a note or a general musical direction. To avoid inconsistencies between and amongst the letter abbreviations for dynamics (what is sf vs. sfz, standing alone or with a trailing dynamic that is not always piano), we use the actual letters as the names of these dynamic elements. The other-dynamics element allows other dynamic marks that are not covered here, but many of those should perhaps be included in a more general musical direction element. Dynamics elements may also be combined to create marks not covered by a single element, such as sfmp.
+			<xs:documentation>Dynamics can be associated either with a note or a general musical direction. To avoid inconsistencies between and amongst the letter abbreviations for dynamics (what is sf vs. sfz, standing alone or with a trailing dynamic that is not always piano), we use the actual letters as the names of these dynamic elements. The other-dynamics element allows other dynamic marks that are not covered here. Dynamics elements may also be combined to create marks not covered by a single element, such as sfmp.
 
-These letter dynamic symbols are separated from crescendo, decrescendo, and wedge indications. Dynamic representation is inconsistent in scores. Many things are assumed by the composer and left out, such as returns to original dynamics. Systematic representations are quite complex: for example, Humdrum has at least 3 representation formats related to dynamics. The MusicXML format captures what is in the score, but does not try to be optimal for analysis or synthesis of dynamics.</xs:documentation>
+These letter dynamic symbols are separated from crescendo, decrescendo, and wedge indications. Dynamic representation is inconsistent in scores. Many things are assumed by the composer and left out, such as returns to original dynamics. The MusicXML format captures what is in the score, but does not try to be optimal for analysis or synthesis of dynamics.
+
+The placement attribute is used when the dynamics are associated with a note. It is ignored when the dynamics are associated with a direction. In that case the direction element's placement attribute is used instead.</xs:documentation>
 		</xs:annotation>
 		<xs:choice minOccurs="0" maxOccurs="unbounded">
 			<xs:element name="p" type="empty"/>
@@ -2392,7 +2549,7 @@ These letter dynamic symbols are separated from crescendo, decrescendo, and wedg
 
 	<xs:complexType name="horizontal-turn">
 		<xs:annotation>
-			<xs:documentation>The horizontal-turn type represents turn elements that are horizontal rather than vertical. These are empty elements with print-style, placement, trill-sound, and slash attributes. If the slash attribute is yes, then a vertical line is used to slash the turn; it is no by default.</xs:documentation>
+			<xs:documentation>The horizontal-turn type represents turn elements that are horizontal rather than vertical. These are empty elements with print-style, placement, trill-sound, and slash attributes. If the slash attribute is yes, then a vertical line is used to slash the turn. It is no if not specified.</xs:documentation>
 		</xs:annotation>
 		<xs:attributeGroup ref="print-style"/>
 		<xs:attributeGroup ref="placement"/>
@@ -2487,11 +2644,16 @@ These letter dynamic symbols are separated from crescendo, decrescendo, and wedg
 
 	<xs:complexType name="level">
 		<xs:annotation>
-			<xs:documentation>The level type is used to specify editorial information for different MusicXML elements. If the reference attribute for the level element is yes, this indicates editorial information that is for display only and should not affect playback. For instance, a modern edition of older music may set reference="yes" on the attributes containing the music's original clef, key, and time signature. It is no by default.</xs:documentation>
+			<xs:documentation>The level type is used to specify editorial information for different MusicXML elements. The content contains identifying and/or descriptive text about the editorial status of the parent element.
+
+If the reference attribute is yes, this indicates editorial information that is for display only and should not affect playback. For instance, a modern edition of older music may set reference="yes" on the attributes containing the music's original clef, key, and time signature. It is no if not specified.
+
+The type attribute indicates whether the editorial information applies to the start of a series of symbols, the end of a series of symbols, or a single symbol. It is single if not specified for compatibility with earlier MusicXML versions.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="xs:string">
 				<xs:attribute name="reference" type="yes-no"/>
+				<xs:attribute name="type" type="start-stop-single"/>
 				<xs:attributeGroup ref="level-display"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -2499,7 +2661,7 @@ These letter dynamic symbols are separated from crescendo, decrescendo, and wedg
 
 	<xs:complexType name="midi-device">
 		<xs:annotation>
-			<xs:documentation>The midi-device type corresponds to the DeviceName meta event in Standard MIDI Files. The optional port attribute is a number from 1 to 16 that can be used with the unofficial MIDI port (or cable) meta event. Unlike the DeviceName meta event, there can be multiple midi-device elements per MusicXML part starting in MusicXML 3.0. The optional id attribute refers to the score-instrument assigned to this device. If missing, the device assignment affects all score-instrument elements in the score-part.</xs:documentation>
+			<xs:documentation>The midi-device type corresponds to the DeviceName meta event in Standard MIDI Files. The optional port attribute is a number from 1 to 16 that can be used with the unofficial MIDI 1.0 port (or cable) meta event. Unlike the DeviceName meta event, there can be multiple midi-device elements per MusicXML part. The optional id attribute refers to the score-instrument assigned to this device. If missing, the device assignment affects all score-instrument elements in the score-part.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="xs:string">
@@ -2526,7 +2688,7 @@ These letter dynamic symbols are separated from crescendo, decrescendo, and wedg
 			</xs:element>
 			<xs:element name="midi-bank" type="midi-16384" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>The midi-bank element specified a MIDI 1.0 bank number ranging from 1 to 16,384.</xs:documentation>
+					<xs:documentation>The midi-bank element specifies a MIDI 1.0 bank number ranging from 1 to 16,384.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="midi-program" type="midi-128" minOccurs="0">
@@ -2584,13 +2746,13 @@ These letter dynamic symbols are separated from crescendo, decrescendo, and wedg
 
 	<xs:complexType name="play">
 		<xs:annotation>
-			<xs:documentation>The play type, new in Version 3.0, specifies playback techniques to be used in conjunction with the instrument-sound element. When used as part of a sound element, it applies to all notes going forward in score order. In multi-instrument parts, the affected instrument should be specified using the id attribute. When used as part of a note element, it applies to the current note only.</xs:documentation>
+			<xs:documentation>The play type specifies playback techniques to be used in conjunction with the instrument-sound element. When used as part of a sound element, it applies to all notes going forward in score order. In multi-instrument parts, the affected instrument should be specified using the id attribute. When used as part of a note element, it applies to the current note only.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:choice minOccurs="0" maxOccurs="unbounded">
 				<xs:element name="ipa" type="xs:string">
 					<xs:annotation>
-						<xs:documentation>The ipa element represents International Phonetic Alphabet (IPA) sounds for vocal music. String content is limited to IPA 2005 symbols represented in Unicode 6.0.</xs:documentation>
+						<xs:documentation>The ipa element represents International Phonetic Alphabet (IPA) sounds for vocal music. String content is limited to IPA 2015 symbols represented in Unicode 13.0.</xs:documentation>
 					</xs:annotation>
 				</xs:element>
 				<xs:element name="mute" type="mute"/>
@@ -2624,7 +2786,7 @@ These letter dynamic symbols are separated from crescendo, decrescendo, and wedg
 
 	<xs:complexType name="typed-text">
 		<xs:annotation>
-			<xs:documentation>The typed-text type represents a text element with a type attributes.</xs:documentation>
+			<xs:documentation>The typed-text type represents a text element with a type attribute.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="xs:string">
@@ -2635,10 +2797,11 @@ These letter dynamic symbols are separated from crescendo, decrescendo, and wedg
 
 	<xs:complexType name="wavy-line">
 		<xs:annotation>
-			<xs:documentation>Wavy lines are one way to indicate trills. When used with a barline element, they should always have type="continue" set.</xs:documentation>
+			<xs:documentation>Wavy lines are one way to indicate trills and vibrato. When used with a barline element, they should always have type="continue" set. The smufl attribute specifies a particular wavy line glyph from the SMuFL Multi-segment lines range.</xs:documentation>
 		</xs:annotation>
 		<xs:attribute name="type" type="start-stop-continue" use="required"/>
 		<xs:attribute name="number" type="number-level"/>
+		<xs:attribute name="smufl" type="smufl-wavy-line-glyph-name"/>
 		<xs:attributeGroup ref="position"/>
 		<xs:attributeGroup ref="placement"/>
 		<xs:attributeGroup ref="color"/>
@@ -2702,15 +2865,23 @@ These letter dynamic symbols are separated from crescendo, decrescendo, and wedg
 				</xs:annotation>
 			</xs:element>
 
-			<xs:element name="transpose" type="transpose" minOccurs="0" maxOccurs="unbounded">
-				<xs:annotation>
-					<xs:documentation>If the part is being encoded for a transposing instrument in written vs. concert pitch, the transposition must be encoded in the transpose element using the transpose type.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-
+			<xs:choice>
+				<xs:element name="transpose" type="transpose" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>If the part is being encoded for a transposing instrument in written vs. concert pitch, the transposition must be encoded in the transpose element using the transpose type.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+	
+				<xs:element name="for-part" type="for-part" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>The for-part element is used in a concert score to indicate the transposition for a transposed part created from that score. It is only used in score files that contain a concert-score element in the defaults. This allows concert scores with transposed parts to be represented in a single uncompressed MusicXML file.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+			
 			<xs:element name="directive" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>Directives are like directions, but can be grouped together with attributes for convenience. This is typically used for tempo markings at the beginning of a piece of music. This element has been deprecated in Version 2.0 in favor of the directive attribute for direction elements. Language names come from ISO 639, with optional country subcodes from ISO 3166.</xs:documentation>
+					<xs:documentation>Directives are like directions, but can be grouped together with attributes for convenience. This is typically used for tempo markings at the beginning of a piece of music. This element was deprecated in Version 2.0 in favor of the direction element's directive attribute. Language names come from ISO 639, with optional country subcodes from ISO 3166.</xs:documentation>
 				</xs:annotation>
 				<xs:complexType>
 					<xs:simpleContent>
@@ -2733,7 +2904,9 @@ These letter dynamic symbols are separated from crescendo, decrescendo, and wedg
 
 	<xs:complexType name="beat-repeat">
 		<xs:annotation>
-			<xs:documentation>The beat-repeat type is used to indicate that a single beat (but possibly many notes) is repeated. Both the start and stop of the beat being repeated should be specified. The slashes attribute specifies the number of slashes to use in the symbol. The use-dots attribute indicates whether or not to use dots as well (for instance, with mixed rhythm patterns). By default, the value for slashes is 1 and the value for use-dots is no.
+			<xs:documentation>The beat-repeat type is used to indicate that a single beat (but possibly many notes) is repeated. The slashes attribute specifies the number of slashes to use in the symbol. The use-dots attribute indicates whether or not to use dots as well (for instance, with mixed rhythm patterns). The value for slashes is 1 and the value for use-dots is no if not specified.
+
+The stop type indicates the first beat where the repeats are no longer displayed. Both the start and stop of the beat being repeated should be specified unless the repeats are displayed through the end of the part.
 
 The beat-repeat element specifies a notation style for repetitions. The actual music being repeated needs to be repeated within the MusicXML file. This element specifies the notation that indicates the repeat.</xs:documentation>
 		</xs:annotation>
@@ -2764,23 +2937,7 @@ Sometimes clefs at the start of a measure need to appear after the barline rathe
 
 Clefs appear at the start of each system unless the print-object attribute has been set to "no" or the additional attribute has been set to "yes".</xs:documentation>
 		</xs:annotation>
-		<xs:sequence>
-			<xs:element name="sign" type="clef-sign">
-				<xs:annotation>
-					<xs:documentation>The sign element represents the clef symbol.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-			<xs:element name="line" type="staff-line" minOccurs="0">
-				<xs:annotation>
-					<xs:documentation>Line numbers are counted from the bottom of the staff. Standard values are 2 for the G sign (treble clef), 4 for the F sign (bass clef), 3 for the C sign (alto clef) and 5 for TAB (on a 6-line staff).</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-			<xs:element name="clef-octave-change" type="xs:integer" minOccurs="0">
-				<xs:annotation>
-					<xs:documentation>The clef-octave-change element is used for transposing clefs. A treble clef for tenors would have a value of -1.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-		</xs:sequence>
+		<xs:group ref="clef"/>
 		<xs:attribute name="number" type="staff-number"/>
 		<xs:attribute name="additional" type="yes-no"/>
 		<xs:attribute name="size" type="symbol-size"/>
@@ -2790,6 +2947,35 @@ Clefs appear at the start of each system unless the print-object attribute has b
 		<xs:attributeGroup ref="optional-unique-id"/>
 	</xs:complexType>
 
+	<xs:complexType name="double">
+		<xs:annotation>
+			<xs:documentation>The double type indicates that the music is doubled one octave from what is currently written. If the above attribute is set to yes, the doubling is one octave above what is written, as for mixed flute / piccolo parts in band literature. Otherwise the doubling is one octave below what is written, as for mixed cello / bass parts in orchestral literature.</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="above" type="yes-no"/>
+	</xs:complexType>
+
+	<xs:complexType name="for-part">
+		<xs:annotation>
+			<xs:documentation>The for-part type is used in a concert score to indicate the transposition for a transposed part created from that score. It is only used in score files that contain a concert-score element in the defaults. This allows concert scores with transposed parts to be represented in a single uncompressed MusicXML file.
+
+The optional number attribute refers to staff numbers, from top to bottom on the system. If absent, the child elements apply to all staves in the created part.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="part-clef" type="part-clef" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The part-clef element is used for transpositions that also include a change of clef, as for instruments such as bass clarinet.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="part-transpose" type="part-transpose">
+				<xs:annotation>
+					<xs:documentation>The chromatic element in a part-transpose element will usually have a non-zero value, since octave transpositions can be represented in concert scores using the transpose element.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>	
+		<xs:attribute name="number" type="staff-number"/>
+		<xs:attributeGroup ref="optional-unique-id"/>
+	</xs:complexType>
+	
 	<xs:complexType name="interchangeable">
 		<xs:annotation>
 			<xs:documentation>The interchangeable type is used to represent the second in a pair of interchangeable dual time signatures, such as the 6/8 in 3/4 (6/8). A separate symbol attribute value is available compared to the time element's symbol attribute, which applies to the first of the dual time signatures.</xs:documentation>
@@ -2836,7 +3022,7 @@ Clefs appear at the start of each system unless the print-object attribute has b
 
 	<xs:complexType name="key-octave">
 		<xs:annotation>
-			<xs:documentation>The key-octave element specifies in which octave an element of a key signature appears. The content specifies the octave value using the same values as the display-octave element. The number attribute is a positive integer that refers to the key signature element in left-to-right order. If the cancel attribute is set to yes, then this number refers to the canceling key signature specified by the cancel element in the parent key element. The cancel attribute cannot be set to yes if there is no corresponding cancel element within the parent key element. It is no by default.</xs:documentation>
+			<xs:documentation>The key-octave type specifies in which octave an element of a key signature appears. The content specifies the octave value using the same values as the display-octave element. The number attribute is a positive integer that refers to the key signature element in left-to-right order. If the cancel attribute is set to yes, then this number refers to the canceling key signature specified by the cancel element in the parent key element. The cancel attribute cannot be set to yes if there is no corresponding cancel element within the parent key element. It is no by default.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="octave">
@@ -2846,11 +3032,24 @@ Clefs appear at the start of each system unless the print-object attribute has b
 		</xs:simpleContent>
 	</xs:complexType>
 
+	<xs:complexType name="line-detail">
+		<xs:annotation>
+			<xs:documentation>If the staff-lines element is present, the appearance of each line may be individually specified with a line-detail type. Staff lines are numbered from bottom to top. The print-object attribute allows lines to be hidden within a staff. This is used in special situations such as a widely-spaced percussion staff where a note placed below the higher line is distinct from a note placed above the lower line. Hidden staff lines are included when specifying clef lines and determining display-step / display-octave values, but are not counted as lines for the purposes of the system-layout and staff-layout elements.</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="line" type="staff-line" use="required"/>
+		<xs:attribute name="width" type="tenths"/>
+		<xs:attributeGroup ref="color"/>
+		<xs:attributeGroup ref="line-type"/>
+		<xs:attributeGroup ref="print-object"/>
+	</xs:complexType>
+	
 	<xs:complexType name="measure-repeat">
 		<xs:annotation>
-			<xs:documentation>The measure-repeat type is used for both single and multiple measure repeats. The text of the element indicates the number of measures to be repeated in a single pattern. The slashes attribute specifies the number of slashes to use in the repeat sign. It is 1 if not specified. Both the start and the stop of the measure-repeat must be specified. The text of the element is ignored when the type is stop.
+			<xs:documentation>The measure-repeat type is used for both single and multiple measure repeats. The text of the element indicates the number of measures to be repeated in a single pattern. The slashes attribute specifies the number of slashes to use in the repeat sign. It is 1 if not specified. The text of the element is ignored when the type is stop.
 
-The measure-repeat element specifies a notation style for repetitions. The actual music being repeated needs to be repeated within the MusicXML file. This element specifies the notation that indicates the repeat.</xs:documentation>
+The stop type indicates the first measure where the repeats are no longer displayed. Both the start and the stop of the measure-repeat should be specified unless the repeats are displayed through the end of the part.
+
+The measure-repeat element specifies a notation style for repetitions. The actual music being repeated needs to be repeated within each measure of the MusicXML file. This element specifies the notation that indicates the repeat.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="positive-integer-or-empty">
@@ -2864,7 +3063,7 @@ The measure-repeat element specifies a notation style for repetitions. The actua
 		<xs:annotation>
 			<xs:documentation>A measure-style indicates a special way to print partial to multiple measures within a part. This includes multiple rests over several measures, repeats of beats, single, or multiple measures, and use of slash notation.
 
-The multiple-rest and measure-repeat symbols indicate the number of measures covered in the element content. The beat-repeat and slash elements can cover partial measures. All but the multiple-rest element use a type attribute to indicate starting and stopping the use of the style. The optional number attribute specifies the staff number from top to bottom on the system, as with clef.</xs:documentation>
+The multiple-rest and measure-repeat elements indicate the number of measures covered in the element content. The beat-repeat and slash elements can cover partial measures. All but the multiple-rest element use a type attribute to indicate starting and stopping the use of the style. The optional number attribute specifies the staff number from top to bottom on the system, as with clef.</xs:documentation>
 		</xs:annotation>
 		<xs:choice>
 			<xs:element name="multiple-rest" type="multiple-rest"/>
@@ -2883,15 +3082,22 @@ The multiple-rest and measure-repeat symbols indicate the number of measures cov
 			<xs:documentation>The text of the multiple-rest type indicates the number of measures in the multiple rest. Multiple rests may use the 1-bar / 2-bar / 4-bar rest symbols, or a single shape. The use-symbols attribute indicates which to use; it is no if not specified.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
-			<xs:extension base="positive-integer-or-empty">
+			<xs:extension base="xs:positiveInteger">
 				<xs:attribute name="use-symbols" type="yes-no"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
 
+	<xs:complexType name="part-clef">
+		<xs:annotation>
+			<xs:documentation>The child elements of the part-clef type have the same meaning as for the clef type. However that meaning applies to a transposed part created from the existing score file.</xs:documentation>
+		</xs:annotation>
+		<xs:group ref="clef"/>
+	</xs:complexType>
+
 	<xs:complexType name="part-symbol">
 		<xs:annotation>
-			<xs:documentation>The part-symbol type indicates how a symbol for a multi-staff part is indicated in the score; brace is the default value. The top-staff and bottom-staff elements are used when the brace does not extend across the entire part. For example, in a 3-staff organ part, the top-staff will typically be 1 for the right hand, while the bottom-staff will typically be 2 for the left hand. Staff 3 for the pedals is usually outside the brace.</xs:documentation>
+			<xs:documentation>The part-symbol type indicates how a symbol for a multi-staff part is indicated in the score; brace is the default value. The top-staff and bottom-staff attributes are used when the brace does not extend across the entire part. For example, in a 3-staff organ part, the top-staff will typically be 1 for the right hand, while the bottom-staff will typically be 2 for the left hand. Staff 3 for the pedals is usually outside the brace. By default, the presence of a part-symbol element that does not extend across the entire part also indicates a corresponding change in the common barlines within a part.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="group-symbol-value">
@@ -2901,6 +3107,13 @@ The multiple-rest and measure-repeat symbols indicate the number of measures cov
 				<xs:attributeGroup ref="color"/>
 			</xs:extension>
 		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:complexType name="part-transpose">
+		<xs:annotation>
+			<xs:documentation>The child elements of the part-transpose type have the same meaning as for the transpose type. However that meaning applies to a transposed part created from the existing score file.</xs:documentation>
+		</xs:annotation>
+		<xs:group ref="transpose"/>
 	</xs:complexType>
 
 	<xs:complexType name="slash">
@@ -2919,22 +3132,21 @@ The multiple-rest and measure-repeat symbols indicate the number of measures cov
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="staff-type" type="staff-type" minOccurs="0"/>
-			<xs:element name="staff-lines" type="xs:nonNegativeInteger" minOccurs="0">
-				<xs:annotation>
-					<xs:documentation>The staff-lines element specifies the number of lines for a non 5-line staff.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
+			<xs:sequence minOccurs="0">
+				<xs:element name="staff-lines" type="xs:nonNegativeInteger">
+					<xs:annotation>
+						<xs:documentation>The staff-lines element specifies the number of lines and is usually used for a non 5-line staff. If the staff-lines element is present, the appearance of each line may be individually specified with a line-detail element. </xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="line-detail" type="line-detail" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
 			<xs:element name="staff-tuning" type="staff-tuning" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="capo" type="xs:nonNegativeInteger" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>The capo element indicates at which fret a capo should be placed on a fretted instrument. This changes the open tuning of the strings specified by staff-tuning by the specified number of half-steps.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="staff-size" type="non-negative-decimal" minOccurs="0">
-				<xs:annotation>
-					<xs:documentation>The staff-size element indicates how large a staff space is on this staff, expressed as a percentage of the work's default scaling. Values less than 100 make the staff space smaller while values over 100 make the staff space larger. A staff-type of cue, ossia, or editorial implies a staff-size of less than 100, but the exact value is implementation-dependent unless specified here. Staff size affects staff height only, not the relationship of the staff to the left and right margins.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
+			<xs:element name="staff-size" type="staff-size" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="number" type="staff-number"/>
 		<xs:attribute name="show-frets" type="show-frets"/>
@@ -2942,17 +3154,30 @@ The multiple-rest and measure-repeat symbols indicate the number of measures cov
 		<xs:attributeGroup ref="print-spacing"/>
 	</xs:complexType>
 
+	<xs:complexType name="staff-size">
+		<xs:annotation>
+			<xs:documentation>The staff-size element indicates how large a staff space is on this staff, expressed as a percentage of the work's default scaling. Values less than 100 make the staff space smaller while values over 100 make the staff space larger. A staff-type of cue, ossia, or editorial implies a staff-size of less than 100, but the exact value is implementation-dependent unless specified here. Staff size affects staff height only, not the relationship of the staff to the left and right margins.
+
+In some cases, a staff-size different than 100 also scales the notation on the staff, such as with a cue staff. In other cases, such as percussion staves, the lines may be more widely spaced without scaling the notation on the staff. The scaling attribute allows these two cases to be distinguished. It specifies the percentage scaling that applies to the notation. Values less that 100 make the notation smaller while values over 100 make the notation larger. The staff-size content and scaling attribute are both non-negative decimal values.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="non-negative-decimal">
+				<xs:attribute name="scaling" type="non-negative-decimal"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
 	<xs:complexType name="staff-tuning">
 		<xs:annotation>
 			<xs:documentation>The staff-tuning type specifies the open, non-capo tuning of the lines on a tablature staff.</xs:documentation>
 		</xs:annotation>
 		<xs:group ref="tuning"/>
-		<xs:attribute name="line" type="staff-line"/>
+		<xs:attribute name="line" type="staff-line" use="required"/>
 	</xs:complexType>
 
 	<xs:complexType name="time">
 		<xs:annotation>
-			<xs:documentation>Time signatures are represented by the beats element for the numerator and the beat-type element for the denominator. The symbol attribute is used indicate common and cut time symbols as well as a single number display. Multiple pairs of beat and beat-type elements are used for composite time signatures with multiple denominators, such as 2/4 + 3/8. A composite such as 3+2/8 requires only one beat/beat-type pair.
+			<xs:documentation>Time signatures are represented by the beats element for the numerator and the beat-type element for the denominator. The symbol attribute is used to indicate common and cut time symbols as well as a single number display. Multiple pairs of beat and beat-type elements are used for composite time signatures with multiple denominators, such as 2/4 + 3/8. A composite such as 3+2/8 requires only one beat/beat-type pair.
 
 The print-object attribute allows a time signature to be specified but not printed, as is the case for excerpts from the middle of a score. The value is "yes" if not present. The optional number attribute refers to staff numbers within the part. If absent, the time signature applies to all staves in the part.</xs:documentation>
 		</xs:annotation>
@@ -2979,28 +3204,7 @@ The print-object attribute allows a time signature to be specified but not print
 		<xs:annotation>
 			<xs:documentation>The transpose type represents what must be added to a written pitch to get a correct sounding pitch. The optional number attribute refers to staff numbers, from top to bottom on the system. If absent, the transposition applies to all staves in the part. Per-staff transposition is most often used in parts that represent multiple instruments.</xs:documentation>
 		</xs:annotation>
-		<xs:sequence>
-			<xs:element name="diatonic" type="xs:integer" minOccurs="0">
-				<xs:annotation>
-					<xs:documentation>The diatonic element specifies the number of pitch steps needed to go from written to sounding pitch. This allows for correct spelling of enharmonic transpositions.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-			<xs:element name="chromatic" type="semitones">
-				<xs:annotation>
-					<xs:documentation>The chromatic element represents the number of semitones needed to get from written to sounding pitch. This value does not include octave-change values; the values for both elements need to be added to the written pitch to get the correct sounding pitch.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-			<xs:element name="octave-change" type="xs:integer" minOccurs="0">
-				<xs:annotation>
-					<xs:documentation>The octave-change element indicates how many octaves to add to get from written pitch to sounding pitch.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-			<xs:element name="double" type="empty" minOccurs="0">
-				<xs:annotation>
-					<xs:documentation>If the double element is present, it indicates that the music is doubled one octave down from what is currently written (as is the case for mixed cello / bass parts in orchestral literature).</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-		</xs:sequence>
+		<xs:group ref="transpose"/>
 		<xs:attribute name="number" type="staff-number"/>
 		<xs:attributeGroup ref="optional-unique-id"/>
 	</xs:complexType>
@@ -3045,7 +3249,7 @@ Barlines have a location attribute to make it easier to process barlines indepen
 		<xs:annotation>
 			<xs:documentation>The ending type represents multiple (e.g. first and second) endings. Typically, the start type is associated with the left barline of the first measure in an ending. The stop and discontinue types are associated with the right barline of the last measure in an ending. Stop is used when the ending mark concludes with a downward jog, as is typical for first endings. Discontinue is used when there is no downward jog, as is typical for second endings that do not conclude a piece. The length of the jog can be specified using the end-length attribute. The text-x and text-y attributes are offsets that specify where the baseline of the start of the ending text appears, relative to the start of the ending line.
 
-The number attribute reflects the numeric values of what is under the ending line. Single endings such as "1" or comma-separated multiple endings such as "1,2" may be used. The ending element text is used when the text displayed in the ending is different than what appears in the number attribute. The print-object element is used to indicate when an ending is present but not printed, as is often the case for many parts in a full score.</xs:documentation>
+The number attribute indicates which times the ending is played, similar to the time-only attribute used by other elements. While this often represents the numeric values for what is under the ending line, it can also indicate whether an ending is played during a larger dal segno or da capo repeat. Single endings such as "1" or comma-separated multiple endings such as "1,2" may be used. The ending element text is used when the text displayed in the ending is different than what appears in the number attribute. The print-object attribute is used to indicate when an ending is present but not printed, as is often the case for many parts in a full score.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="xs:string">
@@ -3053,6 +3257,7 @@ The number attribute reflects the numeric values of what is under the ending lin
 				<xs:attribute name="type" type="start-stop-discontinue" use="required"/>
 				<xs:attributeGroup ref="print-object"/>
 				<xs:attributeGroup ref="print-style"/>
+				<xs:attributeGroup ref="system-relation"/>
 				<xs:attribute name="end-length" type="tenths"/>
 				<xs:attribute name="text-x" type="tenths"/>
 				<xs:attribute name="text-y" type="tenths"/>
@@ -3062,10 +3267,11 @@ The number attribute reflects the numeric values of what is under the ending lin
 
 	<xs:complexType name="repeat">
 		<xs:annotation>
-			<xs:documentation>The repeat type represents repeat marks. The start of the repeat has a forward direction while the end of the repeat has a backward direction. Backward repeats that are not part of an ending can use the times attribute to indicate the number of times the repeated section is played.</xs:documentation>
+			<xs:documentation>The repeat type represents repeat marks. The start of the repeat has a forward direction while the end of the repeat has a backward direction. The times and after-jump attributes are only used with backward repeats that are not part of an ending. The times attribute indicates the number of times the repeated section is played. The after-jump attribute indicates if the repeats are played after a jump due to a da capo or dal segno.</xs:documentation>
 		</xs:annotation>
 		<xs:attribute name="direction" type="backward-forward" use="required"/>
 		<xs:attribute name="times" type="xs:nonNegativeInteger"/>
+		<xs:attribute name="after-jump" type="yes-no"/>
 		<xs:attribute name="winged" type="winged"/>
 	</xs:complexType>
 
@@ -3081,7 +3287,7 @@ The number attribute reflects the numeric values of what is under the ending lin
 
 	<xs:complexType name="accordion-registration">
 		<xs:annotation>
-			<xs:documentation>The accordion-registration type is use for accordion registration symbols. These are circular symbols divided horizontally into high, middle, and low sections that correspond to 4', 8', and 16' pipes. Each accordion-high, accordion-middle, and accordion-low element represents the presence of one or more dots in the registration diagram. An accordion-registration element needs to have at least one of the child elements present.</xs:documentation>
+			<xs:documentation>The accordion-registration type is used for accordion registration symbols. These are circular symbols divided horizontally into high, middle, and low sections that correspond to 4', 8', and 16' pipes. Each accordion-high, accordion-middle, and accordion-low element represents the presence of one or more dots in the registration diagram. An accordion-registration element needs to have at least one of the child elements present.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="accordion-high" type="empty" minOccurs="0">
@@ -3114,17 +3320,27 @@ The number attribute reflects the numeric values of what is under the ending lin
 
 	<xs:complexType name="bass">
 		<xs:annotation>
-			<xs:documentation>The bass type is used to indicate a bass note in popular music chord symbols, e.g. G/C. It is generally not used in functional harmony, as inversion is generally not used in pop chord symbols. As with root, it is divided into step and alter elements, similar to pitches.</xs:documentation>
+			<xs:documentation>The bass type is used to indicate a bass note in popular music chord symbols, e.g. G/C. It is generally not used in functional harmony, as inversion is generally not used in pop chord symbols. As with root, it is divided into step and alter elements, similar to pitches. The arrangement attribute specifies where the bass is displayed relative to what precedes it.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
+			<xs:element name="bass-separator" type="style-text" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The optional bass-separator element indicates that text, rather than a line or slash, separates the bass from what precedes it.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="bass-step" type="bass-step"/>
-			<xs:element name="bass-alter" type="bass-alter" minOccurs="0"/>
+			<xs:element name="bass-alter" type="harmony-alter" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The bass-alter element represents the chromatic alteration of the bass of the current chord within the harmony element. In some chord styles, the text for the bass-step element may include bass-alter information. In that case, the print-object attribute of the bass-alter element can be set to no. The location attribute indicates whether the alteration should appear to the left or the right of the bass-step; it is right if not specified.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 		</xs:sequence>
+		<xs:attribute name="arrangement" type="harmony-arrangement"/>
 	</xs:complexType>
 
-	<xs:complexType name="bass-alter">
+	<xs:complexType name="harmony-alter">
 		<xs:annotation>
-			<xs:documentation>The bass-alter type represents the chromatic alteration of the bass of the current chord within the harmony element. In some chord styles, the text for the bass-step element may include bass-alter information. In that case, the print-object attribute of the bass-alter element can be set to no. The location attribute indicates whether the alteration should appear to the left or the right of the bass-step; it is right by default.</xs:documentation>
+			<xs:documentation>The harmony-alter type represents the chromatic alteration of the root, numeral, or bass of the current harmony-chord group within the harmony element. In some chord styles, the text of the preceding element may include alteration information. In that case, the print-object attribute of this type can be set to no. The location attribute indicates whether the alteration should appear to the left or the right of the preceding element. Its default value varies by element.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="semitones">
@@ -3160,14 +3376,14 @@ The number attribute reflects the numeric values of what is under the ending lin
 
 	<xs:complexType name="beat-unit-tied">
 		<xs:annotation>
-			<xs:documentation>The beat-unit-tied type indicates a beat-unit within a metronome mark that is tied to the preceding beat-unit. This allows or two or more tied notes to be associated with a per-minute value in a metronome mark, whereas the metronome-tied element is restricted to metric relationship marks.</xs:documentation>
+			<xs:documentation>The beat-unit-tied type indicates a beat-unit within a metronome mark that is tied to the preceding beat-unit. This allows two or more tied notes to be associated with a per-minute value in a metronome mark, whereas the metronome-tied element is restricted to metric relationship marks.</xs:documentation>
 		</xs:annotation>
 		<xs:group ref="beat-unit"/>
 	</xs:complexType>
 
 	<xs:complexType name="bracket">
 		<xs:annotation>
-			<xs:documentation>Brackets are combined with words in a variety of modern directions. The line-end attribute specifies if there is a jog up or down (or both), an arrow, or nothing at the start or end of the bracket. If the line-end is up or down, the length of the jog can be specified using the end-length attribute. The line-type is solid by default.</xs:documentation>
+			<xs:documentation>Brackets are combined with words in a variety of modern directions. The line-end attribute specifies if there is a jog up or down (or both), an arrow, or nothing at the start or end of the bracket. If the line-end is up or down, the length of the jog can be specified using the end-length attribute. The line-type is solid if not specified.</xs:documentation>
 		</xs:annotation>
 		<xs:attribute name="type" type="start-stop-continue" use="required"/>
 		<xs:attribute name="number" type="number-level"/>
@@ -3208,7 +3424,7 @@ A harmony of kind "other" can be spelled explicitly by using a series of degree 
 
 	<xs:complexType name="degree-alter">
 		<xs:annotation>
-			<xs:documentation>The degree-alter type represents the chromatic alteration for the current degree. If the degree-type value is alter or subtract, the degree-alter value is relative to the degree already in the chord based on its kind element. If the degree-type value is add, the degree-alter is relative to a dominant chord (major and perfect intervals except for a minor seventh). The plus-minus attribute is used to indicate if plus and minus symbols should be used instead of sharp and flat symbols to display the degree alteration; it is no by default.</xs:documentation>
+			<xs:documentation>The degree-alter type represents the chromatic alteration for the current degree. If the degree-type value is alter or subtract, the degree-alter value is relative to the degree already in the chord based on its kind element. If the degree-type value is add, the degree-alter is relative to a dominant chord (major and perfect intervals except for a minor seventh). The plus-minus attribute is used to indicate if plus and minus symbols should be used instead of sharp and flat symbols to display the degree alteration. It is no if not specified.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="semitones">
@@ -3220,7 +3436,7 @@ A harmony of kind "other" can be spelled explicitly by using a series of degree 
 
 	<xs:complexType name="degree-type">
 		<xs:annotation>
-			<xs:documentation>The degree-type type indicates if this degree is an addition, alteration, or subtraction relative to the kind of the current chord. The value of the degree-type element affects the interpretation of the value of the degree-alter element. The text attribute specifies how the type of the degree should be displayed in a score.</xs:documentation>
+			<xs:documentation>The degree-type type indicates if this degree is an addition, alteration, or subtraction relative to the kind of the current chord. The value of the degree-type element affects the interpretation of the value of the degree-alter element. The text attribute specifies how the type of the degree should be displayed.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="degree-type-value">
@@ -3232,7 +3448,7 @@ A harmony of kind "other" can be spelled explicitly by using a series of degree 
 
 	<xs:complexType name="degree-value">
 		<xs:annotation>
-			<xs:documentation>The content of the degree-value type is a number indicating the degree of the chord (1 for the root, 3 for third, etc). The text attribute specifies how the type of the degree should be displayed in a score. The degree-value symbol attribute indicates that a symbol should be used in specifying the degree. If the symbol attribute is present, the value of the text attribute follows the symbol.</xs:documentation>
+			<xs:documentation>The content of the degree-value type is a number indicating the degree of the chord (1 for the root, 3 for third, etc). The text attribute specifies how the value of the degree should be displayed. The symbol attribute indicates that a symbol should be used in specifying the degree. If the symbol attribute is present, the value of the text attribute follows the symbol.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="xs:positiveInteger">
@@ -3245,7 +3461,7 @@ A harmony of kind "other" can be spelled explicitly by using a series of degree 
 
 	<xs:complexType name="direction">
 		<xs:annotation>
-			<xs:documentation>A direction is a musical indication that is not necessarily attached to a specific note. Two or more may be combined to indicate starts and stops of wedges, dashes, etc. For applications where a specific direction is indeed attached to a specific note, the direction element can be associated with the note element that follows it in score order that is not in a different voice.
+			<xs:documentation>A direction is a musical indication that is not necessarily attached to a specific note. Two or more may be combined to indicate words followed by the start of a dashed line, the end of a wedge followed by dynamics, etc. For applications where a specific direction is indeed attached to a specific note, the direction element can be associated with the first note element that follows it in score order that is not in a different voice.
 
 By default, a series of direction-type elements and a series of child elements of a direction-type within a single direction element follow one another in sequence visually. For a series of direction-type children, non-positional formatting attributes are carried over from the previous element by default.</xs:documentation>
 		</xs:annotation>
@@ -3255,9 +3471,11 @@ By default, a series of direction-type elements and a series of child elements o
 			<xs:group ref="editorial-voice-direction"/>
 			<xs:group ref="staff" minOccurs="0"/>
 			<xs:element name="sound" type="sound" minOccurs="0"/>
+			<xs:element name="listening" type="listening" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attributeGroup ref="placement"/>
 		<xs:attributeGroup ref="directive"/>
+		<xs:attributeGroup ref="system-relation"/>
 		<xs:attributeGroup ref="optional-unique-id"/>
 	</xs:complexType>
 
@@ -3268,7 +3486,7 @@ By default, a series of direction-type elements and a series of child elements o
 		<xs:choice>
 			<xs:element name="rehearsal" type="formatted-text-id" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>The rehearsal type specifies a rehearsal mark. Language is Italian ("it") by default. Enclosure is square by default. Left justification is assumed if not specified.</xs:documentation>
+					<xs:documentation>The rehearsal element specifies letters, numbers, and section names that are notated in the score for reference during rehearsal. The enclosure is square if not specified. The language is Italian ("it") if not specified. Left justification is used if not specified.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="segno" type="segno" maxOccurs="unbounded"/>
@@ -3276,12 +3494,12 @@ By default, a series of direction-type elements and a series of child elements o
 			<xs:choice maxOccurs="unbounded">
 				<xs:element name="words" type="formatted-text-id">
 					<xs:annotation>
-						<xs:documentation>The words element specifies a standard text direction. Left justification is assumed if not specified. Language is Italian ("it") by default. Enclosure is none by default.</xs:documentation>
+						<xs:documentation>The words element specifies a standard text direction. The enclosure is none if not specified. The language is Italian ("it") if not specified. Left justification is used if not specified.</xs:documentation>
 					</xs:annotation>
 				</xs:element>
 				<xs:element name="symbol" type="formatted-symbol-id">
 					<xs:annotation>
-						<xs:documentation>The symbol element specifies a musical symbol using a canonical SMuFL glyph name. It is used when an occasional musical symbol is interspersed into text. It should not be used in place of semantic markup, such as metronome marks that mix text and symbols. Left justification is assumed if not specified. Enclosure is none by default.</xs:documentation>
+						<xs:documentation>The symbol element specifies a musical symbol using a canonical SMuFL glyph name. It is used when an occasional musical symbol is interspersed into text. It should not be used in place of semantic markup, such as metronome marks that mix text and symbols. Left justification is used if not specified. Enclosure is none if not specified.</xs:documentation>
 					</xs:annotation>
 				</xs:element>
 			</xs:choice>
@@ -3305,7 +3523,7 @@ By default, a series of direction-type elements and a series of child elements o
 			</xs:element>
 			<xs:element name="eyeglasses" type="empty-print-style-align-id">
 				<xs:annotation>
-					<xs:documentation>The eyeglasses element specifies the eyeglasses symbol, common in commercial music.</xs:documentation>
+					<xs:documentation>The eyeglasses element represents the eyeglasses symbol, common in commercial music.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="string-mute" type="string-mute"/>
@@ -3320,6 +3538,17 @@ By default, a series of direction-type elements and a series of child elements o
 		<xs:attributeGroup ref="optional-unique-id"/>
 	</xs:complexType>
 
+	<xs:complexType name="effect">
+		<xs:annotation>
+			<xs:documentation>The effect type represents pictograms for sound effect percussion instruments. The smufl attribute is used to distinguish different SMuFL stylistic alternates.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="effect-value">
+				<xs:attribute name="smufl" type="smufl-pictogram-glyph-name"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
 	<xs:complexType name="feature">
 		<xs:annotation>
 			<xs:documentation>The feature type is a part of the grouping element used for musical analysis. The type attribute represents the type of the feature and the element content represents its value. This type is flexible to allow for different analyses.</xs:documentation>
@@ -3385,7 +3614,7 @@ By default, a series of direction-type elements and a series of child elements o
 
 	<xs:complexType name="glass">
 		<xs:annotation>
-			<xs:documentation>The glass type represents pictograms for glass percussion instruments. The smufl attribute is used to distinguish different SMuFL glyphs for wind chimes in the chimes pictograms range, including those made of materials other than glass.</xs:documentation>
+			<xs:documentation>The glass type represents pictograms for glass percussion instruments. The smufl attribute is used to distinguish different SMuFL glyphs for wind chimes in the Chimes pictograms range, including those made of materials other than glass.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="glass-value">
@@ -3411,11 +3640,11 @@ This element is flexible to allow for different types of analyses. Future versio
 
 	<xs:complexType name="harmony">
 		<xs:annotation>
-			<xs:documentation>The harmony type is based on Humdrum's **harm encoding, extended to support chord symbols in popular music as well as functional harmony analysis in classical music.
+			<xs:documentation>The harmony type represents harmony analysis, including chord symbols in popular music as well as functional harmony analysis in classical music.
 
 If there are alternate harmonies possible, this can be specified using multiple harmony elements differentiated by type. Explicit harmonies have all note present in the music; implied have some notes missing but implied; alternate represents alternate analyses.
 
-The harmony object may be used for analysis or for chord symbols. The print-object attribute controls whether or not anything is printed due to the harmony element. The print-frame attribute controls printing of a frame or fretboard diagram. The print-style attribute group sets the default for the harmony, but individual elements can override this with their own print-style values.</xs:documentation>
+The print-object attribute controls whether or not anything is printed due to the harmony element. The print-frame attribute controls printing of a frame or fretboard diagram. The print-style attribute group sets the default for the harmony, but individual elements can override this with their own print-style values. The arrangement attribute specifies how multiple harmony-chord groups are arranged relative to each other. Harmony-chords with vertical arrangement are separated by horizontal lines. Harmony-chords with diagonal or horizontal arrangement are separated by diagonal lines or slashes.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:group ref="harmony-chord" maxOccurs="unbounded"/>
@@ -3427,8 +3656,10 @@ The harmony object may be used for analysis or for chord symbols. The print-obje
 		<xs:attribute name="type" type="harmony-type"/>
 		<xs:attributeGroup ref="print-object"/>
 		<xs:attribute name="print-frame" type="yes-no"/>
+		<xs:attribute name="arrangement" type="harmony-arrangement"/>
 		<xs:attributeGroup ref="print-style"/>
 		<xs:attributeGroup ref="placement"/>
+		<xs:attributeGroup ref="system-relation"/>
 		<xs:attributeGroup ref="optional-unique-id"/>
 	</xs:complexType>
 
@@ -3450,13 +3681,22 @@ The harmony object may be used for analysis or for chord symbols. The print-obje
 		<xs:attributeGroup ref="image-attributes"/>
 		<xs:attributeGroup ref="optional-unique-id"/>
 	</xs:complexType>
+	
+	<xs:complexType name="instrument-change">
+		<xs:annotation>
+			<xs:documentation>The instrument-change element type represents a change to the virtual instrument sound for a given score-instrument. The id attribute refers to the score-instrument affected by the change. All instrument-change child elements can also be initially specified within the score-instrument element.</xs:documentation>
+		</xs:annotation>
+		<xs:group ref="virtual-instrument-data"/>
+		<xs:attribute name="id" type="xs:IDREF" use="required"/>
+	</xs:complexType>
 
 	<xs:complexType name="inversion">
 		<xs:annotation>
-			<xs:documentation>The inversion type represents harmony inversions. The value is a number indicating which inversion is used: 0 for root position, 1 for first inversion, etc.</xs:documentation>
+			<xs:documentation>The inversion type represents harmony inversions. The value is a number indicating which inversion is used: 0 for root position, 1 for first inversion, etc.  The text attribute indicates how the inversion should be displayed in a score.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="xs:nonNegativeInteger">
+				<xs:attribute name="text" type="xs:token"/>
 				<xs:attributeGroup ref="print-style"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -3478,7 +3718,9 @@ The use-symbols attribute is yes if the kind should be represented when possible
 
 For the major-minor kind, only the minor symbol is used when use-symbols is yes. The major symbol is set using the symbol attribute in the degree-value element. The corresponding degree-alter value will usually be 0 in this case.
 
-The text attribute describes how the kind should be spelled in a score. If use-symbols is yes, the value of the text attribute follows the symbol. The stack-degrees attribute is yes if the degree elements should be stacked above each other. The parentheses-degrees attribute is yes if all the degrees should be in parentheses. The bracket-degrees attribute is yes if all the degrees should be in a bracket. If not specified, these values are implementation-specific. The alignment attributes are for the entire harmony-chord group of which this kind element is a part.</xs:documentation>
+The text attribute describes how the kind should be spelled in a score. If use-symbols is yes, the value of the text attribute follows the symbol. The stack-degrees attribute is yes if the degree elements should be stacked above each other. The parentheses-degrees attribute is yes if all the degrees should be in parentheses. The bracket-degrees attribute is yes if all the degrees should be in a bracket. If not specified, these values are implementation-specific. The alignment attributes are for the entire harmony-chord group of which this kind element is a part.
+
+The text attribute may use strings such as "13sus" that refer to both the kind and one or more degree elements. In this case, the corresponding degree elements should have the print-object attribute set to "no" to keep redundant alterations from being displayed.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="kind-value">
@@ -3494,20 +3736,65 @@ The text attribute describes how the kind should be spelled in a score. If use-s
 		</xs:simpleContent>
 	</xs:complexType>
 
+	<xs:complexType name="listening">
+		<xs:annotation>
+			<xs:documentation>The listen and listening types, new in Version 4.0, specify different ways that a score following or machine listening application can interact with a performer. The listening type handles interactions that change the state of the listening application from the specified point in the performance onward. If multiple child elements of the same type are present, they should have distinct player and/or time-only attributes.
+
+The offset element is used to indicate that the listening change takes place offset from the current score position. If the listening element is a child of a direction element, the listening offset element overrides the direction offset element if both elements are present. Note that the offset reflects the intended musical position for the change in state. It should not be used to compensate for latency issues in particular hardware configurations.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:choice maxOccurs="unbounded">
+				<xs:element name="sync" type="sync"/>
+				<xs:element name="other-listening" type="other-listening"/>
+			</xs:choice>
+			<xs:element name="offset" type="offset" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	
 	<xs:complexType name="measure-numbering">
 		<xs:annotation>
-			<xs:documentation>The measure-numbering type describes how frequently measure numbers are displayed on this part. The number attribute from the measure element is used for printing. Measures with an implicit attribute set to "yes" never display a measure number, regardless of the measure-numbering setting.</xs:documentation>
+			<xs:documentation>The measure-numbering type describes how frequently measure numbers are displayed on this part. The text attribute from the measure element is used for display, or the number attribute if the text attribute is not present. Measures with an implicit attribute set to "yes" never display a measure number, regardless of the measure-numbering setting.
+
+The optional staff attribute refers to staff numbers within the part, from top to bottom on the system. It indicates which staff is used as the reference point for vertical positioning. A value of 1 is assumed if not present.
+
+The optional multiple-rest-always and multiple-rest-range attributes describe how measure numbers are shown on multiple rests when the measure-numbering value is not set to none. The multiple-rest-always attribute is set to yes when the measure number should always be shown, even if the multiple rest starts midway through a system when measure numbering is set to system level. The multiple-rest-range attribute is set to yes when measure numbers on multiple rests display the range of numbers for the first and last measure, rather than just the number of the first measure.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="measure-numbering-value">
+				<xs:attribute name="system" type="system-relation-number"/>
+				<xs:attribute name="staff" type="staff-number"/>
+				<xs:attribute name="multiple-rest-always" type="yes-no"/>
+				<xs:attribute name="multiple-rest-range" type="yes-no"/>
 				<xs:attributeGroup ref="print-style-align"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
 
+	<xs:complexType name="membrane">
+		<xs:annotation>
+			<xs:documentation>The membrane type represents pictograms for membrane percussion instruments. The smufl attribute is used to distinguish different SMuFL stylistic alternates.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="membrane-value">
+				<xs:attribute name="smufl" type="smufl-pictogram-glyph-name"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
+	<xs:complexType name="metal">
+		<xs:annotation>
+			<xs:documentation>The metal type represents pictograms for metal percussion instruments. The smufl attribute is used to distinguish different SMuFL stylistic alternates.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="metal-value">
+				<xs:attribute name="smufl" type="smufl-pictogram-glyph-name"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
 	<xs:complexType name="metronome">
 		<xs:annotation>
-			<xs:documentation>The metronome type represents metronome marks and other metric relationships. The beat-unit group and per-minute element specify regular metronome marks. The metronome-note and metronome-relation elements allow for the specification of metric modulations and other metric relationships, such as swing tempo marks where two eighths are equated to a quarter note / eighth note triplet. Tied notes can be represented in both types of metronome marks by using the beat-unit-tied and metronome-tied elements. The parentheses attribute indicates whether or not to put the metronome mark in parentheses; its value is no if not specified.</xs:documentation>
+			<xs:documentation>The metronome type represents metronome marks and other metric relationships. The beat-unit group and per-minute element specify regular metronome marks. The metronome-note and metronome-relation elements allow for the specification of metric modulations and other metric relationships, such as swing tempo marks where two eighths are equated to a quarter note / eighth note triplet. Tied notes can be represented in both types of metronome marks by using the beat-unit-tied and metronome-tied elements. The parentheses attribute indicates whether or not to put the metronome mark in parentheses; its value is no if not specified. The print-object attribute is set to no in cases where the metronome element represents a relationship or range that is not displayed in the music notation.</xs:documentation>
 		</xs:annotation>
 		<xs:choice>
 			<xs:sequence>
@@ -3539,6 +3826,7 @@ The text attribute describes how the kind should be spelled in a score. If use-s
 			</xs:sequence>
 		</xs:choice>
 		<xs:attributeGroup ref="print-style-align"/>
+		<xs:attributeGroup ref="print-object"/>
 		<xs:attributeGroup ref="justify"/>
 		<xs:attribute name="parentheses" type="yes-no"/>
 		<xs:attributeGroup ref="optional-unique-id"/>
@@ -3596,6 +3884,44 @@ The text attribute describes how the kind should be spelled in a score. If use-s
 		</xs:complexContent>
 	</xs:complexType>
 
+	<xs:complexType name="numeral">
+		<xs:annotation>
+			<xs:documentation>The numeral type represents the Roman numeral or Nashville number part of a harmony. It requires that the key be specified in the encoding, either with a key or numeral-key element.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="numeral-root" type="numeral-root"/>
+			<xs:element name="numeral-alter" type="harmony-alter" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The numeral-alter element represents an alteration to the numeral-root, similar to the alter element for a pitch. The print-object attribute can be used to hide an alteration in cases such as when the MusicXML encoding of a 6 or 7 numeral-root in a minor key requires an alteration that is not displayed. The location attribute indicates whether the alteration should appear to the left or the right of the numeral-root. It is left by default.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="numeral-key" type="numeral-key" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	
+	<xs:complexType name="numeral-key">
+		<xs:annotation>
+			<xs:documentation>The numeral-key type is used when the key for the numeral is different than the key specified by the key signature. The numeral-fifths element specifies the key in the same way as the fifths element. The numeral-mode element specifies the mode similar to the mode element, but with a restricted set of values</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="numeral-fifths" type="fifths"/>
+			<xs:element name="numeral-mode" type="numeral-mode"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="print-object"/>
+	</xs:complexType>
+	
+	<xs:complexType name="numeral-root">
+		<xs:annotation>
+			<xs:documentation>The numeral-root type represents the Roman numeral or Nashville number as a positive integer from 1 to 7. The text attribute indicates how the numeral should appear in the score. A numeral-root value of 5 with a kind of major would have a text attribute of "V" if displayed as a Roman numeral, and "5" if displayed as a Nashville number. If the text attribute is not specified, the display is application-dependent.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="numeral-value">
+				<xs:attribute name="text" type="xs:token"/>
+				<xs:attributeGroup ref="print-style"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
 	<xs:complexType name="octave-shift">
 		<xs:annotation>
 			<xs:documentation>The octave shift type indicates where notes are shifted up or down from their true pitched values because of printing difficulty. Thus a treble clef line noted with 8va will be indicated with an octave-shift down from the pitch data indicated in the notes. A size of 8 indicates one octave; a size of 15 indicates two octaves.</xs:documentation>
@@ -3610,7 +3936,9 @@ The text attribute describes how the kind should be spelled in a score. If use-s
 
 	<xs:complexType name="offset">
 		<xs:annotation>
-			<xs:documentation>An offset is represented in terms of divisions, and indicates where the direction will appear relative to the current musical location. This affects the visual appearance of the direction. If the sound attribute is "yes", then the offset affects playback too. If the sound attribute is "no", then any sound associated with the direction takes effect at the current location. The sound attribute is "no" by default for compatibility with earlier versions of the MusicXML format. If an element within a direction includes a default-x attribute, the offset value will be ignored when determining the appearance of that element.</xs:documentation>
+			<xs:documentation>An offset is represented in terms of divisions, and indicates where the direction will appear relative to the current musical location. The current musical location is always within the current measure, even at the end of a measure.
+
+The offset affects the visual appearance of the direction. If the sound attribute is "yes", then the offset affects playback and listening too. If the sound attribute is "no", then any sound or listening associated with the direction takes effect at the current location. The sound attribute is "no" by default for compatibility with earlier versions of the MusicXML format. If an element within a direction includes a default-x attribute, the offset value will be ignored when determining the appearance of that element.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="divisions">
@@ -3633,11 +3961,22 @@ The text attribute describes how the kind should be spelled in a score. If use-s
 		</xs:simpleContent>
 	</xs:complexType>
 
+	<xs:complexType name="other-listening">
+		<xs:annotation>
+			<xs:documentation>The other-listening type represents other types of listening control and interaction. The required type attribute indicates the type of listening to which the element content applies. The optional player and time-only attributes restrict the element to apply to a single player or set of times through a repeated section, respectively.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="type" type="xs:token" use="required"/>
+				<xs:attribute name="player" type="xs:IDREF"/>
+				<xs:attribute name="time-only" type="time-only"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
 	<xs:complexType name="pedal">
 		<xs:annotation>
-			<xs:documentation>The pedal type represents piano pedal marks. In MusicXML 3.1 this includes sostenuto as well as damper pedal marks. The line attribute is yes if pedal lines are used. The sign attribute is yes if Ped, Sost, and * signs are used. For MusicXML 2.0 compatibility, the sign attribute is yes by default if the line attribute is no, and is no by default if the line attribute is yes. If the sign attribute is set to yes and the type is start or sostenuto, the abbreviated attribute is yes if the short P and S signs are used, and no if the full Ped and Sost signs are used. It is no by default. Otherwise the abbreviated attribute is ignored.
-
-The change and continue types are used when the line attribute is yes. The change type indicates a pedal lift and retake indicated with an inverted V marking. The continue type allows more precise formatting across system breaks and for more complex pedaling lines. The alignment attributes are ignored if the line attribute is yes.</xs:documentation>
+			<xs:documentation>The pedal type represents piano pedal marks, including damper and sostenuto pedal marks. The line attribute is yes if pedal lines are used. The sign attribute is yes if Ped, Sost, and * signs are used. For compatibility with older versions, the sign attribute is yes by default if the line attribute is no, and is no by default if the line attribute is yes. If the sign attribute is set to yes and the type is start or sostenuto, the abbreviated attribute is yes if the short P and S signs are used, and no if the full Ped and Sost signs are used. It is no by default. Otherwise the abbreviated attribute is ignored. The alignment attributes are ignored if the sign attribute is no.</xs:documentation>
 		</xs:annotation>
 		<xs:attribute name="type" type="pedal-type" use="required"/>
 		<xs:attribute name="number" type="number-level"/>
@@ -3688,11 +4027,15 @@ The change and continue types are used when the line attribute is yes. The chang
 			<xs:element name="pitched" type="pitched"/>
 			<xs:element name="membrane" type="membrane"/>
 			<xs:element name="effect" type="effect"/>
-			<xs:element name="timpani" type="empty"/>
+			<xs:element name="timpani" type="timpani"/>
 			<xs:element name="beater" type="beater"/>
 			<xs:element name="stick" type="stick"/>
 			<xs:element name="stick-location" type="stick-location"/>
-			<xs:element name="other-percussion" type="other-text"/>
+			<xs:element name="other-percussion" type="other-text">
+				<xs:annotation>
+					<xs:documentation>The other-percussion element represents percussion pictograms not defined elsewhere.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 		</xs:choice>
 		<xs:attributeGroup ref="print-style-align"/>
 		<xs:attributeGroup ref="enclosure"/>
@@ -3701,7 +4044,7 @@ The change and continue types are used when the line attribute is yes. The chang
 
 	<xs:complexType name="pitched">
 		<xs:annotation>
-			<xs:documentation>The pitched-value type represents pictograms for pitched percussion instruments. The smufl attribute is used to distinguish different SMuFL glyphs for a particular pictogram within the tuned mallet percussion pictograms range.</xs:documentation>
+			<xs:documentation>The pitched-value type represents pictograms for pitched percussion instruments. The smufl attribute is used to distinguish different SMuFL glyphs for a particular pictogram within the Tuned mallet percussion pictograms range.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="pitched-value">
@@ -3712,7 +4055,7 @@ The change and continue types are used when the line attribute is yes. The chang
 
 	<xs:complexType name="principal-voice">
 		<xs:annotation>
-			<xs:documentation>The principal-voice element represents principal and secondary voices in a score, either for analysis or for square bracket symbols that appear in a score. The symbol attribute indicates the type of symbol used at the start of the principal-voice. The content of the principal-voice element is used for analysis and may be any text value. When used for analysis separate from any printed score markings, the symbol attribute should be set to "none".</xs:documentation>
+			<xs:documentation>The principal-voice type represents principal and secondary voices in a score, either for analysis or for square bracket symbols that appear in a score. The element content is used for analysis and may be any text value. The symbol attribute indicates the type of symbol used. When used for analysis separate from any printed score markings, it should be set to none. Otherwise if the type is stop it should be set to plain.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="xs:string">
@@ -3726,9 +4069,9 @@ The change and continue types are used when the line attribute is yes. The chang
 
 	<xs:complexType name="print">
 		<xs:annotation>
-			<xs:documentation>The print type contains general printing parameters, including the layout elements defined in the layout.mod file. The part-name-display and part-abbreviation-display elements used in the score.mod file may also be used here to change how a part name or abbreviation is displayed over the course of a piece. They take effect when the current measure or a succeeding measure starts a new system.
+			<xs:documentation>The print type contains general printing parameters, including layout elements. The part-name-display and part-abbreviation-display elements may also be used here to change how a part name or abbreviation is displayed over the course of a piece. They take effect when the current measure or a succeeding measure starts a new system.
 
-Layout elements in a print statement only apply to the current page, system, staff, or measure. Music that follows continues to take the default values from the layout included in the defaults element.</xs:documentation>
+Layout group elements in a print element only apply to the current page, system, or staff. Music that follows continues to take the default values from the layout determined by the defaults element.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:group ref="layout"/>
@@ -3743,25 +4086,16 @@ Layout elements in a print statement only apply to the current page, system, sta
 
 	<xs:complexType name="root">
 		<xs:annotation>
-			<xs:documentation>The root type indicates a pitch like C, D, E vs. a function indication like I, II, III. It is used with chord symbols in popular music. The root element has a root-step and optional root-alter element similar to the step and alter elements, but renamed to distinguish the different musical meanings.</xs:documentation>
+			<xs:documentation>The root type indicates a pitch like C, D, E vs. a scale degree like 1, 2, 3. It is used with chord symbols in popular music. The root element has a root-step and optional root-alter element similar to the step and alter elements, but renamed to distinguish the different musical meanings.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="root-step" type="root-step"/>
-			<xs:element name="root-alter" type="root-alter" minOccurs="0"/>
+			<xs:element name="root-alter" type="harmony-alter" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The root-alter element represents the chromatic alteration of the root of the current chord within the harmony element. In some chord styles, the text for the root-step element may include root-alter information. In that case, the print-object attribute of the root-alter element can be set to no. The location attribute indicates whether the alteration should appear to the left or the right of the root-step; it is right by default.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 		</xs:sequence>
-	</xs:complexType>
-
-	<xs:complexType name="root-alter">
-		<xs:annotation>
-			<xs:documentation>The root-alter type represents the chromatic alteration of the root of the current chord within the harmony element. In some chord styles, the text for the root-step element may include root-alter information. In that case, the print-object attribute of the root-alter element can be set to no. The location attribute indicates whether the alteration should appear to the left or the right of the root-step; it is right by default.</xs:documentation>
-		</xs:annotation>
-		<xs:simpleContent>
-			<xs:extension base="semitones">
-				<xs:attributeGroup ref="print-object"/>
-				<xs:attributeGroup ref="print-style"/>
-				<xs:attribute name="location" type="left-right"/>
-			</xs:extension>
-		</xs:simpleContent>
 	</xs:complexType>
 
 	<xs:complexType name="root-step">
@@ -3800,7 +4134,7 @@ Segno and dalsegno are used for backwards jumps to a segno sign; coda and tocoda
 
 By default, a dalsegno or dacapo attribute indicates that the jump should occur the first time through, while a tocoda attribute indicates the jump should occur the second time through. The time that jumps occur can be changed by using the time-only attribute.
 
-Forward-repeat is used when a forward repeat sign is implied, and usually follows a bar line. When used it always has the value of "yes".
+The forward-repeat attribute indicates that a forward repeat sign is implied but not displayed. It is used for example in two-part forms with repeats, such as a minuet and trio where no repeat is displayed at the start of the trio. This usually occurs after a barline. When used it always has the value of "yes".
 
 The fine attribute follows the final note or rest in a movement with a da capo or dal segno direction. If numeric, the value represents the actual duration of the final note or rest, which can be ambiguous in written notation and different among parts and voices. The value may also be "yes" to indicate no change to the final duration.
 
@@ -3812,16 +4146,18 @@ The pan and elevation attributes are deprecated in Version 2.0. The pan and elev
 
 The damper-pedal, soft-pedal, and sostenuto-pedal attributes effect playback of the three common piano pedals and their MIDI controller equivalents. The yes value indicates the pedal is depressed; no indicates the pedal is released. A numeric value from 0 to 100 may also be used for half pedaling. This value is the percentage that the pedal is depressed. A value of 0 is equivalent to no, and a value of 100 is equivalent to yes.
 
-MIDI devices, MIDI instruments, and playback techniques are changed using the midi-device, midi-instrument, and play elements. When there are multiple instances of these elements, they should be grouped together by instrument using the id attribute values.
+Instrument changes, MIDI devices, MIDI instruments, and playback techniques are changed using the instrument-change, midi-device, midi-instrument, and play elements. When there are multiple instances of these elements, they should be grouped together by instrument using the id attribute values.
 
 The offset element is used to indicate that the sound takes place offset from the current score position. If the sound element is a child of a direction element, the sound offset element overrides the direction offset element if both elements are present. Note that the offset reflects the intended musical position for the change in sound. It should not be used to compensate for latency issues in particular hardware configurations.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:sequence minOccurs="0" maxOccurs="unbounded">
+				<xs:element name="instrument-change" type="instrument-change" minOccurs="0"/>
 				<xs:element name="midi-device" type="midi-device" minOccurs="0"/>
 				<xs:element name="midi-instrument" type="midi-instrument" minOccurs="0"/>
 				<xs:element name="play" type="play" minOccurs="0"/>
 			</xs:sequence>
+			<xs:element name="swing" type="swing" minOccurs="0"/>
 			<xs:element name="offset" type="offset" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="tempo" type="non-negative-decimal"/>
@@ -3875,9 +4211,55 @@ The offset element is used to indicate that the sound takes place offset from th
 		<xs:attributeGroup ref="optional-unique-id"/>
 	</xs:complexType>
 
+	<xs:complexType name="swing">
+		<xs:annotation>
+			<xs:documentation>The swing element specifies whether or not to use swing playback, where consecutive on-beat / off-beat eighth or 16th notes are played with unequal nominal durations. 
+
+The straight element specifies that no swing is present, so consecutive notes have equal durations.
+
+The first and second elements are positive integers that specify the ratio between durations of consecutive notes. For example, a first element with a value of 2 and a second element with a value of 1 applied to eighth notes specifies a quarter note / eighth note tuplet playback, where the first note is twice as long as the second note. Ratios should be specified with the smallest integers possible. For example, a ratio of 6 to 4 should be specified as 3 to 2 instead.
+
+The optional swing-type element specifies the note type, either eighth or 16th, to which the ratio is applied. The value is eighth if this element is not present.
+
+The optional swing-style element is a string describing the style of swing used.
+
+The swing element has no effect for playback of grace notes, notes where a type element is not present, and notes where the specified duration is different than the nominal value associated with the specified type. If a swung note has attack and release attributes, those values modify the swung playback.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="straight" type="empty"/>
+				<xs:sequence>
+					<xs:element name="first" type="xs:positiveInteger"/>
+					<xs:element name="second" type="xs:positiveInteger"/>
+					<xs:element name="swing-type" type="swing-type-value" minOccurs="0"/>
+				</xs:sequence>
+			</xs:choice>
+			<xs:element name="swing-style" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	
+	<xs:complexType name="sync">
+		<xs:annotation>
+			<xs:documentation>The sync type specifies the style that a score following application should use the synchronize an accompaniment with a performer. If this type is not included in a score, default synchronization depends on the application.
+
+The optional latency attribute specifies a time in milliseconds that the listening application should expect from the performer. The optional player and time-only attributes restrict the element to apply to a single player or set of times through a repeated section, respectively.</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="type" type="sync-type" use="required"/>
+		<xs:attribute name="latency" type="milliseconds"/>
+		<xs:attribute name="player" type="xs:IDREF"/>
+		<xs:attribute name="time-only" type="time-only"/>
+	</xs:complexType>
+	
+	<xs:complexType name="timpani">
+		<xs:annotation>
+			<xs:documentation>The timpani type represents the timpani pictogram. The smufl attribute is used to distinguish different SMuFL stylistic alternates.</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="smufl" type="smufl-pictogram-glyph-name"/>
+	</xs:complexType>
+	
 	<xs:complexType name="wedge">
 		<xs:annotation>
-			<xs:documentation>The wedge type represents crescendo and diminuendo wedge symbols. The type attribute is crescendo for the start of a wedge that is closed at the left side, and diminuendo for the start of a wedge that is closed on the right side. Spread values are measured in tenths; those at the start of a crescendo wedge or end of a diminuendo wedge are ignored. The niente attribute is yes if a circle appears at the point of the wedge, indicating a crescendo from nothing or diminuendo to nothing. It is no by default, and used only when the type is crescendo, or the type is stop for a wedge that began with a diminuendo type. The line-type is solid by default.</xs:documentation>
+			<xs:documentation>The wedge type represents crescendo and diminuendo wedge symbols. The type attribute is crescendo for the start of a wedge that is closed at the left side, and diminuendo for the start of a wedge that is closed on the right side. Spread values are measured in tenths; those at the start of a crescendo wedge or end of a diminuendo wedge are ignored. The niente attribute is yes if a circle appears at the point of the wedge, indicating a crescendo from nothing or diminuendo to nothing. It is no by default, and used only when the type is crescendo, or the type is stop for a wedge that began with a diminuendo type. The line-type is solid if not specified.</xs:documentation>
 		</xs:annotation>
 		<xs:attribute name="type" type="wedge-type" use="required"/>
 		<xs:attribute name="number" type="number-level"/>
@@ -3890,6 +4272,17 @@ The offset element is used to indicate that the sound takes place offset from th
 		<xs:attributeGroup ref="optional-unique-id"/>
 	</xs:complexType>
 
+	<xs:complexType name="wood">
+		<xs:annotation>
+			<xs:documentation>The wood type represents pictograms for wood percussion instruments. The smufl attribute is used to distinguish different SMuFL stylistic alternates.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="wood-value">
+				<xs:attribute name="smufl" type="smufl-pictogram-glyph-name"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
 	<!-- Complex types derived from identity.mod elements -->
 
 	<xs:complexType name="encoding">
@@ -3907,7 +4300,7 @@ The offset element is used to indicate that the sound takes place offset from th
 
 	<xs:complexType name="identification">
 		<xs:annotation>
-			<xs:documentation>Identification contains basic metadata about the score. It includes the information in MuseData headers that may apply at a score-wide, movement-wide, or part-wide level. The creator, rights, source, and relation elements are based on Dublin Core.</xs:documentation>
+			<xs:documentation>Identification contains basic metadata about the score. It includes information that may apply at a score-wide, movement-wide, or part-wide level. The creator, rights, source, and relation elements are based on Dublin Core.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="creator" type="typed-text" minOccurs="0" maxOccurs="unbounded">
@@ -3917,7 +4310,7 @@ The offset element is used to indicate that the sound takes place offset from th
 			</xs:element>
 			<xs:element name="rights" type="typed-text" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>The rights element is borrowed from Dublin Core. It contains copyright and other intellectual property notices. Words, music, and derivatives can have different types, so multiple rights tags with different type attributes are supported. Standard type values are music, words, and arrangement, but other types may be used. The type attribute is only needed when there are multiple rights elements.</xs:documentation>
+					<xs:documentation>The rights element is borrowed from Dublin Core. It contains copyright and other intellectual property notices. Words, music, and derivatives can have different types, so multiple rights elements with different type attributes are supported. Standard type values are music, words, and arrangement, but other types may be used. The type attribute is only needed when there are multiple rights elements.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="encoding" type="encoding" minOccurs="0"/>
@@ -4015,7 +4408,7 @@ The offset element is used to indicate that the sound takes place offset from th
 
 	<xs:complexType name="measure-layout">
 		<xs:annotation>
-			<xs:documentation>The measure-layout type includes the horizontal distance from the previous measure.</xs:documentation>
+			<xs:documentation>The measure-layout type includes the horizontal distance from the previous measure. It applies to the current measure only.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="measure-distance" type="tenths" minOccurs="0">
@@ -4050,7 +4443,11 @@ The offset element is used to indicate that the sound takes place offset from th
 
 	<xs:complexType name="page-layout">
 		<xs:annotation>
-			<xs:documentation>Page layout can be defined both in score-wide defaults and in the print element. Page margins are specified either for both even and odd pages, or via separate odd and even page number values. The type is not needed when used as part of a print element. If omitted when used in the defaults element, "both" is the default.</xs:documentation>
+			<xs:documentation>Page layout can be defined both in score-wide defaults and in the print element. Page margins are specified either for both even and odd pages, or via separate odd and even page number values. The type is not needed when used as part of a print element. If omitted when used in the defaults element, "both" is the default.
+
+If no page-layout element is present in the defaults element, default page layout values are chosen by the application.
+
+When used in the print element, the page-layout element affects the appearance of the current page only. All other pages use the default values as determined by the defaults element. If any child elements are missing from the page-layout element in a print element, the values determined by the defaults element are used there as well.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:sequence minOccurs="0">
@@ -4081,7 +4478,9 @@ The offset element is used to indicate that the sound takes place offset from th
 
 	<xs:complexType name="staff-layout">
 		<xs:annotation>
-			<xs:documentation>Staff layout includes the vertical distance from the bottom line of the previous staff in this system to the top line of the staff specified by the number attribute. The optional number attribute refers to staff numbers within the part, from top to bottom on the system. A value of 1 is assumed if not present. When used in the defaults element, the values apply to all parts. This value is ignored for the first staff in a system.</xs:documentation>
+			<xs:documentation>Staff layout includes the vertical distance from the bottom line of the previous staff in this system to the top line of the staff specified by the number attribute. The optional number attribute refers to staff numbers within the part, from top to bottom on the system. A value of 1 is used if not present.
+
+When used in the defaults element, the values apply to all systems in all parts. When used in the print element, the values apply to the current system only. This value is ignored for the first staff in a system.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="staff-distance" type="tenths" minOccurs="0"/>
@@ -4105,7 +4504,11 @@ When used in the print element, the system-dividers element affects the dividers
 		<xs:annotation>
 			<xs:documentation>A system is a group of staves that are read and played simultaneously. System layout includes left and right margins and the vertical distance from the previous system. The system distance is measured from the bottom line of the previous system to the top line of the current system. It is ignored for the first system on a page. The top system distance is measured from the page's top margin to the top line of the first system. It is ignored for all but the first system on a page.
 
-Sometimes the sum of measure widths in a system may not equal the system width specified by the layout elements due to roundoff or other errors. The behavior when reading MusicXML files in these cases is application-dependent. For instance, applications may find that the system layout data is more reliable than the sum of the measure widths, and adjust the measure widths accordingly.</xs:documentation>
+Sometimes the sum of measure widths in a system may not equal the system width specified by the layout elements due to roundoff or other errors. The behavior when reading MusicXML files in these cases is application-dependent. For instance, applications may find that the system layout data is more reliable than the sum of the measure widths, and adjust the measure widths accordingly.
+
+When used in the defaults element, the system-layout element defines a default appearance for all systems in the score. If no system-layout element is present in the defaults element, default system layout values are chosen by the application.
+
+When used in the print element, the system-layout element affects the appearance of the current system only. All other systems use the default values as determined by the defaults element. If any child elements are missing from the system-layout element in a print element, the values determined by the defaults element are used there as well. This type of system-layout element need only be read from or written to the first visible part in the score.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="system-margins" type="system-margins" minOccurs="0"/>
@@ -4135,7 +4538,7 @@ Sometimes the sum of measure widths in a system may not equal the system width s
 
 	<xs:complexType name="link">
 		<xs:annotation>
-			<xs:documentation>The link type serves as an outgoing simple XLink. It is also used to connect a MusicXML score with a MusicXML opus. If a relative link is used within a document that is part of a compressed MusicXML file, the link is relative to the  root folder of the zip file.</xs:documentation>
+			<xs:documentation>The link type serves as an outgoing simple XLink. If a relative link is used within a document that is part of a compressed MusicXML file, the link is relative to the root folder of the zip file.</xs:documentation>
 		</xs:annotation>
 		<xs:attributeGroup ref="link-attributes"/>
 		<xs:attribute name="name" type="xs:token"/>
@@ -4177,10 +4580,11 @@ Sometimes the sum of measure widths in a system may not equal the system width s
 
 	<xs:complexType name="arpeggiate">
 		<xs:annotation>
-			<xs:documentation>The arpeggiate type indicates that this note is part of an arpeggiated chord. The number attribute can be used to distinguish between two simultaneous chords arpeggiated separately (different numbers) or together (same number). The up-down attribute is used if there is an arrow on the arpeggio sign. By default, arpeggios go from the lowest to highest note.</xs:documentation>
+			<xs:documentation>The arpeggiate type indicates that this note is part of an arpeggiated chord. The number attribute can be used to distinguish between two simultaneous chords arpeggiated separately (different numbers) or together (same number). The direction attribute is used if there is an arrow on the arpeggio sign. By default, arpeggios go from the lowest to highest note.  The length of the sign can be determined from the position attributes for the arpeggiate elements used with the top and bottom notes of the arpeggiated chord. If the unbroken attribute is set to yes, it indicates that the arpeggio continues onto another staff within the part. This serves as a hint to applications and is not required for cross-staff arpeggios.</xs:documentation>
 		</xs:annotation>
 		<xs:attribute name="number" type="number-level"/>
 		<xs:attribute name="direction" type="up-down"/>
+		<xs:attribute name="unbroken" type="yes-no"/>
 		<xs:attributeGroup ref="position"/>
 		<xs:attributeGroup ref="placement"/>
 		<xs:attributeGroup ref="color"/>
@@ -4229,22 +4633,22 @@ Sometimes the sum of measure widths in a system may not equal the system width s
 			</xs:element>
 			<xs:element name="scoop" type="empty-line">
 				<xs:annotation>
-					<xs:documentation>The scoop element is an indeterminate slide attached to a single note. The scoop element appears before the main note and comes from below the main pitch.</xs:documentation>
+					<xs:documentation>The scoop element is an indeterminate slide attached to a single note. The scoop appears before the main note and comes from below the main pitch.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="plop" type="empty-line">
 				<xs:annotation>
-					<xs:documentation>The plop element is an indeterminate slide attached to a single note. The plop element appears before the main note and comes from above the main pitch.</xs:documentation>
+					<xs:documentation>The plop element is an indeterminate slide attached to a single note. The plop appears before the main note and comes from above the main pitch.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="doit" type="empty-line">
 				<xs:annotation>
-					<xs:documentation>The doit element is an indeterminate slide attached to a single note. The doit element appears after the main note and goes above the main pitch.</xs:documentation>
+					<xs:documentation>The doit element is an indeterminate slide attached to a single note. The doit appears after the main note and goes above the main pitch.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="falloff" type="empty-line">
 				<xs:annotation>
-					<xs:documentation>The falloff element is an indeterminate slide attached to a single note. The falloff element appears after the main note and goes below the main pitch.</xs:documentation>
+					<xs:documentation>The falloff element is an indeterminate slide attached to a single note. The falloff appears after the main note and goes below the main pitch.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="breath-mark" type="breath-mark"/>
@@ -4261,7 +4665,7 @@ Sometimes the sum of measure widths in a system may not equal the system width s
 			</xs:element>
 			<xs:element name="soft-accent" type="empty-placement">
 				<xs:annotation>
-					<xs:documentation>The soft-accent element indicates a soft accent that is not as heavy as a normal accent. It is often notated as &lt;&gt;. It can be combined with other articulations to implement the entire SMuFL Articulation Supplement range.</xs:documentation>
+					<xs:documentation>The soft-accent element indicates a soft accent that is not as heavy as a normal accent. It is often notated as &lt;&gt;. It can be combined with other articulations to implement the first eight symbols in the SMuFL Articulation supplement range.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="other-articulation" type="other-placement-text">
@@ -4290,6 +4694,15 @@ Sometimes the sum of measure widths in a system may not equal the system width s
 		<xs:attributeGroup ref="smufl"/>
 	</xs:complexType>
 
+	<xs:complexType name="assess">
+		<xs:annotation>
+			<xs:documentation>By default, an assessment application should assess all notes without a cue child element, and not assess any note with a cue child element. The assess type allows this default assessment to be overridden for individual notes. The optional player and time-only attributes restrict the type to apply to a single player or set of times through a repeated section, respectively. If missing, the type applies to all players or all times through the repeated section, respectively. The player attribute references the id attribute of a player element defined within the matching score-part.</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="type" type="yes-no" use="required"/>
+		<xs:attribute name="player" type="xs:IDREF"/>
+		<xs:attribute name="time-only" type="time-only"/>
+	</xs:complexType>
+	
 	<xs:complexType name="backup">
 		<xs:annotation>
 			<xs:documentation>The backup and forward elements are required to coordinate multiple voices in one part, including music on multiple staves. The backup type is generally used to move between voices and staves. Thus the backup element does not include voice or staff elements. Duration values should always be positive, and should not cross measure boundaries or mid-measure changes in the divisions value.</xs:documentation>
@@ -4323,25 +4736,21 @@ The repeater attribute has been deprecated in MusicXML 3.0. Formerly used for tr
 
 	<xs:complexType name="bend">
 		<xs:annotation>
-			<xs:documentation>The bend type is used in guitar and tablature. The bend-alter element indicates the number of steps in the bend, similar to the alter element. As with the alter element, numbers like 0.5 can be used to indicate microtones. Negative numbers indicate pre-bends or releases; the pre-bend and release elements are used to distinguish what is intended. A with-bar element indicates that the bend is to be done at the bridge with a whammy or vibrato bar. The content of the element indicates how this should be notated.</xs:documentation>
+			<xs:documentation>The bend type is used in guitar notation and tablature. A single note with a bend and release will contain two bend elements: the first to represent the bend and the second to represent the release. The shape attribute distinguishes between the angled bend symbols commonly used in standard notation and the curved bend symbols commonly used in both tablature and standard notation.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="bend-alter" type="semitones">
 				<xs:annotation>
-					<xs:documentation>The bend-alter element indicates the number of steps in the bend, similar to the alter element. As with the alter element, numbers like 0.5 can be used to indicate microtones. Negative numbers indicate pre-bends or releases; the pre-bend and release elements are used to distinguish what is intended.</xs:documentation>
+					<xs:documentation>The bend-alter element indicates the number of semitones in the bend, similar to the alter element. As with the alter element, numbers like 0.5 can be used to indicate microtones. Negative values indicate pre-bends or releases. The pre-bend and release elements are used to distinguish what is intended. Because the bend-alter element represents the number of steps in the bend, a release after a bend has a negative bend-alter value, not a zero value.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:choice minOccurs="0">
 				<xs:element name="pre-bend" type="empty">
 					<xs:annotation>
-						<xs:documentation>The pre-bend element indicates that this is a pre-bend rather than a normal bend or a release.</xs:documentation>
+						<xs:documentation>The pre-bend element indicates that a bend is a pre-bend rather than a normal bend or a release.</xs:documentation>
 					</xs:annotation>
 				</xs:element>
-				<xs:element name="release" type="empty">
-					<xs:annotation>
-						<xs:documentation>The release element indicates that this is a release rather than a normal bend or pre-bend.</xs:documentation>
-					</xs:annotation>
-				</xs:element>
+				<xs:element name="release" type="release"/>
 			</xs:choice>
 			<xs:element name="with-bar" type="placement-text" minOccurs="0">
 				<xs:annotation>
@@ -4349,6 +4758,7 @@ The repeater attribute has been deprecated in MusicXML 3.0. Formerly used for tr
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
+		<xs:attribute name="shape" type="bend-shape"/>
 		<xs:attributeGroup ref="print-style"/>
 		<xs:attributeGroup ref="bend-sound"/>
 	</xs:complexType>
@@ -4447,7 +4857,8 @@ Figures are ordered from top to bottom. The value of parentheses is "no" if not 
 			<xs:group ref="duration" minOccurs="0"/>
 			<xs:group ref="editorial"/>
 		</xs:sequence>
-		<xs:attributeGroup ref="print-style"/>
+		<xs:attributeGroup ref="print-style-align"/>
+		<xs:attributeGroup ref="placement"/>
 		<xs:attributeGroup ref="printout"/>
 		<xs:attribute name="parentheses" type="yes-no"/>
 		<xs:attributeGroup ref="optional-unique-id"/>
@@ -4466,7 +4877,7 @@ Figures are ordered from top to bottom. The value of parentheses is "no" if not 
 
 	<xs:complexType name="glissando">
 		<xs:annotation>
-			<xs:documentation>Glissando and slide types both indicate rapidly moving from one pitch to the other so that individual notes are not discerned. The distinction is similar to that between NIFF's glissando and portamento elements. A glissando sounds the half notes in between the slide and defaults to a wavy line. The optional text is printed alongside the line.</xs:documentation>
+			<xs:documentation>Glissando and slide types both indicate rapidly moving from one pitch to the other so that individual notes are not discerned. A glissando sounds the distinct notes in between the two pitches and defaults to a wavy line. The optional text is printed alongside the line.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="xs:string">
@@ -4482,7 +4893,7 @@ Figures are ordered from top to bottom. The value of parentheses is "no" if not 
 
 	<xs:complexType name="grace">
 		<xs:annotation>
-			<xs:documentation>The grace type indicates the presence of a grace note. The slash attribute for a grace note is yes for slashed eighth notes. The other grace note attributes come from MuseData sound suggestions. The steal-time-previous attribute indicates the percentage of time to steal from the previous note for the grace note. The steal-time-following attribute indicates the percentage of time to steal from the following note for the grace note, as for appoggiaturas. The make-time attribute indicates to make time, not steal time; the units are in real-time divisions for the grace note.</xs:documentation>
+			<xs:documentation>The grace type indicates the presence of a grace note. The slash attribute for a grace note is yes for slashed grace notes. The steal-time-previous attribute indicates the percentage of time to steal from the previous note for the grace note. The steal-time-following attribute indicates the percentage of time to steal from the following note for the grace note, as for appoggiaturas. The make-time attribute indicates to make time, not steal time; the units are in real-time divisions for the grace note.</xs:documentation>
 		</xs:annotation>
 		<xs:attribute name="steal-time-previous" type="percent"/>
 		<xs:attribute name="steal-time-following" type="percent"/>
@@ -4540,7 +4951,7 @@ Figures are ordered from top to bottom. The value of parentheses is "no" if not 
 
 	<xs:complexType name="harmonic">
 		<xs:annotation>
-			<xs:documentation>The harmonic type indicates natural and artificial harmonics. Allowing the type of pitch to be specified, combined with controls for appearance/playback differences, allows both the notation and the sound to be represented. Artificial harmonics can add a notated touching-pitch; artificial pinch harmonics will usually not notate a touching pitch. The attributes for the harmonic element refer to the use of the circular harmonic symbol, typically but not always used with natural harmonics.</xs:documentation>
+			<xs:documentation>The harmonic type indicates natural and artificial harmonics. Allowing the type of pitch to be specified, combined with controls for appearance/playback differences, allows both the notation and the sound to be represented. Artificial harmonics can add a notated touching pitch; artificial pinch harmonics will usually not notate a touching pitch. The attributes for the harmonic element refer to the use of the circular harmonic symbol, typically but not always used with natural harmonics.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:choice minOccurs="0">
@@ -4623,16 +5034,27 @@ Figures are ordered from top to bottom. The value of parentheses is "no" if not 
 
 	<xs:complexType name="instrument">
 		<xs:annotation>
-			<xs:documentation>The instrument type distinguishes between score-instrument elements in a score-part. The id attribute is an IDREF back to the score-instrument ID. If multiple score-instruments are specified on a score-part, there should be an instrument element for each note in the part.</xs:documentation>
+			<xs:documentation>The instrument type distinguishes between score-instrument elements in a score-part. The id attribute is an IDREF back to the score-instrument ID. If multiple score-instruments are specified in a score-part, there should be an instrument element for each note in the part. Notes that are shared between multiple score-instruments can have more than one instrument element.</xs:documentation>
 		</xs:annotation>
 		<xs:attribute name="id" type="xs:IDREF" use="required"/>
 	</xs:complexType>
 
+	<xs:complexType name="listen">
+		<xs:annotation>
+			<xs:documentation>The listen and listening types, new in Version 4.0, specify different ways that a score following or machine listening application can interact with a performer. The listen type handles interactions that are specific to a note. If multiple child elements of the same type are present, they should have distinct player and/or time-only attributes.</xs:documentation>
+		</xs:annotation>
+		<xs:choice maxOccurs="unbounded">
+			<xs:element name="assess" type="assess"/>
+			<xs:element name="wait" type="wait"/>
+			<xs:element name="other-listen" type="other-listening"/>
+		</xs:choice>
+	</xs:complexType>
+	
 	<xs:complexType name="lyric">
 		<xs:annotation>
-			<xs:documentation>The lyric type represents text underlays for lyrics, based on Humdrum with support for other formats. Two text elements that are not separated by an elision element are part of the same syllable, but may have different text formatting. The MusicXML XSD is more strict than the DTD in enforcing this by disallowing a second syllabic element unless preceded by an elision element. The lyric number indicates multiple lines, though a name can be used as well (as in Finale's verse / chorus / section specification). 
+			<xs:documentation>The lyric type represents text underlays for lyrics. Two text elements that are not separated by an elision element are part of the same syllable, but may have different text formatting. The MusicXML XSD is more strict than the DTD in enforcing this by disallowing a second syllabic element unless preceded by an elision element. The lyric number indicates multiple lines, though a name can be used as well. Common name examples are verse and chorus.
 
-Justification is center by default; placement is below by default. The print-object attribute can override a note's print-lyric attribute in cases where only some lyrics on a note are printed, as when lyrics for later verses are printed in a block of text rather than with each note. The time-only attribute precisely specifies which lyrics are to be sung which time through a repeated section.</xs:documentation>
+Justification is center by default; placement is below by default. Vertical alignment is to the baseline of the text and horizontal alignment matches justification. The print-object attribute can override a note's print-lyric attribute in cases where only some lyrics on a note are printed, as when lyrics for later verses are printed in a block of text rather than with each note. The time-only attribute precisely specifies which lyrics are to be sung which time through a repeated section.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:choice>
@@ -4651,12 +5073,12 @@ Justification is center by default; placement is below by default. The print-obj
 				<xs:element name="extend" type="extend"/>
 				<xs:element name="laughing" type="empty">
 					<xs:annotation>
-						<xs:documentation>The laughing element is taken from Humdrum.</xs:documentation>
+						<xs:documentation>The laughing element represents a laughing voice.</xs:documentation>
 					</xs:annotation>
 				</xs:element>
 				<xs:element name="humming" type="empty">
 					<xs:annotation>
-						<xs:documentation>The humming element is taken from Humdrum.</xs:documentation>
+						<xs:documentation>The humming element represents a humming voice.</xs:documentation>
 					</xs:annotation>
 				</xs:element>
 			</xs:choice>
@@ -4737,7 +5159,7 @@ Justification is center by default; placement is below by default. The print-obj
 
 	<xs:complexType name="note">
 		<xs:annotation>
-			<xs:documentation>Notes are the most common type of MusicXML data. The MusicXML format keeps the MuseData distinction between elements used for sound information and elements used for notation information (e.g., tie is used for sound, tied for notation). Thus grace notes do not have a duration element. Cue notes have a duration element, as do forward elements, but no tie elements. Having these two types of information available can make interchange considerably easier, as some programs handle one type of information much more readily than the other.
+			<xs:documentation>Notes are the most common type of MusicXML data. The MusicXML format distinguishes between elements used for sound information and elements used for notation information (e.g., tie is used for sound, tied for notation). Thus grace notes do not have a duration element. Cue notes have a duration element, as do forward elements, but no tie elements. Having these two types of information available can make interchange easier, as some programs handle one type of information more readily than the other.
 
 The print-leger attribute is used to indicate whether leger lines are printed. Notes without leger lines are used to indicate indeterminate high and low notes. By default, it is set to yes. If print-object is set to no, print-leger is interpreted to also be set to no if not present. This attribute is ignored for rests.
 
@@ -4779,12 +5201,12 @@ The pizzicato attribute is used when just this note is sounded pizzicato, vs. th
 					<xs:element name="tie" type="tie" minOccurs="0" maxOccurs="2"/>
 				</xs:sequence>
 			</xs:choice>
-			<xs:element name="instrument" type="instrument" minOccurs="0"/>
+			<xs:element name="instrument" type="instrument" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:group ref="editorial-voice"/>
 			<xs:element name="type" type="note-type" minOccurs="0"/>
 			<xs:element name="dot" type="empty-placement" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>One dot element is used for each dot of prolongation. The placement element is used to specify whether the dot should appear above or below the staff line. It is ignored for notes that appear on a staff space.</xs:documentation>
+					<xs:documentation>One dot element is used for each dot of prolongation. The placement attribute is used to specify whether the dot should appear above or below the staff line. It is ignored for notes that appear on a staff space.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="accidental" type="accidental" minOccurs="0"/>
@@ -4797,6 +5219,7 @@ The pizzicato attribute is used when just this note is sounded pizzicato, vs. th
 			<xs:element name="notations" type="notations" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="lyric" type="lyric" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="play" type="play" minOccurs="0"/>
+			<xs:element name="listen" type="listen" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attributeGroup ref="x-position"/>
 		<xs:attributeGroup ref="font"/>
@@ -4827,7 +5250,7 @@ The pizzicato attribute is used when just this note is sounded pizzicato, vs. th
 		<xs:annotation>
 			<xs:documentation>The notehead type indicates shapes other than the open and closed ovals associated with note durations. 
 
-The smufl attribute can be used to specify a particular notehead, allowing application interoperability without requiring every SMuFL glyph to have a MusicXML element equivalent. This attribute can be used either with the "other" value, or to refine a specific notehead value such as "cluster". Noteheads in the SMuFL "Note name noteheads" range (U+E150–U+E1AF) should not use the smufl attribute or the "other" value, but instead use the notehead-text element.
+The smufl attribute can be used to specify a particular notehead, allowing application interoperability without requiring every SMuFL glyph to have a MusicXML element equivalent. This attribute can be used either with the "other" value, or to refine a specific notehead value such as "cluster". Noteheads in the SMuFL Note name noteheads and Note name noteheads supplement ranges (U+E150–U+E1AF and U+EEE0–U+EEFF) should not use the smufl attribute or the "other" value, but instead use the notehead-text element.
 
 For the enclosed shapes, the default is to be hollow for half notes and longer, and filled otherwise. The filled attribute can be set to change this if needed.
 
@@ -4999,6 +5422,17 @@ If the parentheses attribute is set to yes, the notehead is parenthesized. It is
 		</xs:simpleContent>
 	</xs:complexType>
 
+	<xs:complexType name="release">
+		<xs:annotation>
+			<xs:documentation>The release type indicates that a bend is a release rather than a normal bend or pre-bend. The offset attribute specifies where the release starts in terms of divisions relative to the current note. The first-beat and last-beat attributes of the parent bend element are relative to the original note position, not this offset value.</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="empty">
+				<xs:attribute name="offset" type="divisions"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
 	<xs:complexType name="rest">
 		<xs:annotation>
 			<xs:documentation>The rest element indicates notated rests or silences. Rest elements are usually empty, but placement on the staff can be specified using display-step and display-octave elements. If the measure attribute is set to yes, this indicates this is a complete measure rest.</xs:documentation>
@@ -5011,7 +5445,7 @@ If the parentheses attribute is set to yes, the notehead is parenthesized. It is
 
 	<xs:complexType name="slide">
 		<xs:annotation>
-			<xs:documentation>Glissando and slide types both indicate rapidly moving from one pitch to the other so that individual notes are not discerned. The distinction is similar to that between NIFF's glissando and portamento elements. A slide is continuous between two notes and defaults to a solid line. The optional text for a is printed alongside the line.</xs:documentation>
+			<xs:documentation>Glissando and slide types both indicate rapidly moving from one pitch to the other so that individual notes are not discerned. A slide is continuous between the two pitches and defaults to a solid line. The optional text for a is printed alongside the line.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="xs:string">
@@ -5279,12 +5713,12 @@ Ties that are visually attached to only one note, other than undamped ties, shou
 	<xs:complexType name="tremolo">
 		<xs:annotation>
 			<xs:documentation>The tremolo ornament can be used to indicate single-note, double-note, or unmeasured tremolos. Single-note tremolos use the single type, double-note tremolos use the start and stop types, and unmeasured tremolos use the unmeasured type. The default is "single" for compatibility with Version 1.1. The text of the element indicates the number of tremolo marks and is an integer from 0 to 8. Note that the number of attached beams is not included in this value, but is represented separately using the beam element. The value should be 0 for unmeasured tremolos.
-	
-	When using double-note tremolos, the duration of each note in the tremolo should correspond to half of the notated type value. A time-modification element should also be added with an actual-notes value of 2 and a normal-notes value of 1. If used within a tuplet, this 2/1 ratio should be multiplied by the existing tuplet ratio.
-	
-	The smufl attribute specifies the glyph to use from the SMuFL tremolos range for an unmeasured tremolo. It is ignored for other tremolo types. The SMuFL buzzRoll glyph is used by default if the attribute is missing.
-	
-	Using repeater beams for indicating tremolos is deprecated as of MusicXML 3.0.</xs:documentation>
+
+When using double-note tremolos, the duration of each note in the tremolo should correspond to half of the notated type value. A time-modification element should also be added with an actual-notes value of 2 and a normal-notes value of 1. If used within a tuplet, this 2/1 ratio should be multiplied by the existing tuplet ratio.
+
+The smufl attribute specifies the glyph to use from the SMuFL Tremolos range for an unmeasured tremolo. It is ignored for other tremolo types. The SMuFL buzzRoll glyph is used by default if the attribute is missing.
+
+Using repeater beams for indicating tremolos is deprecated as of MusicXML 3.0.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="tremolo-marks">
@@ -5329,7 +5763,7 @@ The show-number attribute is used to display either the number of actual notes, 
 
 	<xs:complexType name="tuplet-dot">
 		<xs:annotation>
-			<xs:documentation>The tuplet-dot type is used to specify dotted normal tuplet types.</xs:documentation>
+			<xs:documentation>The tuplet-dot type is used to specify dotted tuplet types.</xs:documentation>
 		</xs:annotation>
 		<xs:attributeGroup ref="font"/>
 		<xs:attributeGroup ref="color"/>
@@ -5372,13 +5806,21 @@ The show-number attribute is used to display either the number of actual notes, 
 
 	<xs:complexType name="unpitched">
 		<xs:annotation>
-			<xs:documentation>The unpitched type represents musical elements that are notated on the staff but lack definite pitch, such as unpitched percussion and speaking voice.</xs:documentation>
+			<xs:documentation>The unpitched type represents musical elements that are notated on the staff but lack definite pitch, such as unpitched percussion and speaking voice. If the child elements are not present, the note is placed on the middle line of the staff. This is generally used with a one-line staff. Notes in percussion clef should always use an unpitched element rather than a pitch element.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:group ref="display-step-octave" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
 
+	<xs:complexType name="wait">
+		<xs:annotation>
+			<xs:documentation>The wait type specifies a point where the accompaniment should wait for a performer event before continuing. This typically happens at the start of new sections or after a held note or indeterminate music. These waiting points cannot always be inferred reliably from the contents of the displayed score. The optional player and time-only attributes restrict the type to apply to a single player or set of times through a repeated section, respectively.</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="player" type="xs:IDREF"/>
+		<xs:attribute name="time-only" type="time-only"/>
+	</xs:complexType>
+	
 	<!-- Complex types derived from score.mod elements -->
 
 	<xs:complexType name="credit">
@@ -5389,7 +5831,7 @@ By default, a series of credit-words and credit-symbol elements within a single 
 
 The page attribute for the credit element specifies the page number where the credit should appear. This is an integer value that starts with 1 for the first page. Its value is 1 by default. Since credits occur before the music, these page numbers do not refer to the page numbering specified by the print element's page-number attribute.
 
-The credit-type element indicates the purpose behind a credit. Multiple types of data may be combined in a single credit, so multiple elements may be used. Standard values include page number, title, subtitle, composer, arranger, lyricist, and rights.
+The credit-type element indicates the purpose behind a credit. Multiple types of data may be combined in a single credit, so multiple elements may be used. Standard values include page number, title, subtitle, composer, arranger, lyricist, rights, and part name.
 </xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
@@ -5420,10 +5862,17 @@ The credit-type element indicates the purpose behind a credit. Multiple types of
 
 	<xs:complexType name="defaults">
 		<xs:annotation>
-			<xs:documentation>The defaults type specifies score-wide defaults for scaling, layout, and appearance.</xs:documentation>
+			<xs:documentation>The defaults type specifies score-wide defaults for scaling; whether or not the file is a concert score; layout; and default values for the music font, word font, lyric font, and lyric language. Except for the concert-score element, if any defaults are missing, the choice of what to use is determined by the application.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="scaling" type="scaling" minOccurs="0"/>
+			<xs:element name="concert-score" type="empty" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The presence of a concert-score element indicates that a score is displayed in concert pitch. It is used for scores that contain parts for transposing instruments.
+
+A document with a concert-score element may not contain any transpose elements that have non-zero values for either the diatonic or chromatic elements. Concert scores may include octave transpositions, so transpose elements with a double element or a non-zero octave-change element value are permitted.</xs:documentation>
+				</xs:annotation>				
+			</xs:element>
 			<xs:group ref="layout"/>
 			<xs:element name="appearance" type="appearance" minOccurs="0"/>
 			<xs:element name="music-font" type="empty-font" minOccurs="0"/>
@@ -5464,7 +5913,7 @@ The credit-type element indicates the purpose behind a credit. Multiple types of
 
 	<xs:complexType name="group-symbol">
 		<xs:annotation>
-			<xs:documentation>The group-symbol type indicates how the symbol for a group is indicated in the score.</xs:documentation>
+			<xs:documentation>The group-symbol type indicates how the symbol for a group is indicated in the score. It is none if not specified.</xs:documentation>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="group-symbol-value">
@@ -5474,6 +5923,13 @@ The credit-type element indicates the purpose behind a credit. Multiple types of
 		</xs:simpleContent>
 	</xs:complexType>
 
+	<xs:complexType name="instrument-link">
+		<xs:annotation>
+			<xs:documentation>Multiple part-link elements can link a condensed part within a score file to multiple MusicXML parts files. For example, a "Clarinet 1 and 2" part in a score file could link to separate "Clarinet 1" and "Clarinet 2" part files. The instrument-link type distinguish which of the score-instruments within a score-part are in which part file. The instrument-link id attribute refers to a score-instrument id attribute.</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="id" type="xs:IDREF" use="required"/>
+	</xs:complexType>
+	
 	<xs:complexType name="lyric-font">
 		<xs:annotation>
 			<xs:documentation>The lyric-font type specifies the default font for a particular name and number of lyric.</xs:documentation>
@@ -5533,9 +5989,24 @@ A part-group element is not needed for a single multi-staff part. By default, mu
 		<xs:attribute name="number" type="xs:token" default="1"/>
 	</xs:complexType>
 
+	<xs:complexType name="part-link">
+		<xs:annotation>
+			<xs:documentation>The part-link type allows MusicXML data for both score and parts to be contained within a single compressed MusicXML file. It links a score-part from a score document to MusicXML documents that contain parts data. In the case of a single compressed MusicXML file, the link href values are paths that are relative to the root folder of the zip file.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="instrument-link" type="instrument-link" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="group-link" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Multiple part-link elements can reference different types of linked documents, such as parts and condensed score. The optional group-link elements identify the groups used in the linked document. The content of a group-link element should match the content of a group element in the linked document.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attributeGroup ref="link-attributes"/>
+	</xs:complexType>
+	
 	<xs:complexType name="part-list">
 		<xs:annotation>
-			<xs:documentation>The part-list identifies the different musical parts in this movement. Each part has an ID that is used later within the musical data. Since parts may be encoded separately and combined later, identification elements are present at both the score and score-part levels. There must be at least one score-part, combined as desired with part-group elements that indicate braces and brackets. Parts are ordered from top to bottom in a score based on the order in which they appear in the part-list.</xs:documentation>
+			<xs:documentation>The part-list identifies the different musical parts in this document. Each part has an ID that is used later within the musical data. Since parts may be encoded separately and combined later, identification elements are present at both the score and score-part levels. There must be at least one score-part, combined as desired with part-group elements that indicate braces and brackets. Parts are ordered from top to bottom in a score based on the order in which they appear in the part-list.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:group ref="part-group" minOccurs="0" maxOccurs="unbounded"/>
@@ -5558,11 +6029,27 @@ A part-group element is not needed for a single multi-staff part. By default, mu
 		</xs:simpleContent>
 	</xs:complexType>
 
+	<xs:complexType name="player">
+		<xs:annotation>
+			<xs:documentation>The player type allows for multiple players per score-part for use in listening applications. One player may play multiple instruments, while a single instrument may include multiple players in divisi sections.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="player-name" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>The player-name element is typically used within a software application, rather than appearing on the printed page of a score.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="id" type="xs:ID" use="required"/>
+	</xs:complexType>
+	
 	<xs:complexType name="score-instrument">
 		<xs:annotation>
 			<xs:documentation>The score-instrument type represents a single instrument within a score-part. As with the score-part type, each score-instrument has a required ID attribute, a name, and an optional abbreviation.
 
-A score-instrument type is also required if the score specifies MIDI 1.0 channels, banks, or programs. An initial midi-instrument assignment can also be made here. MusicXML software should be able to automatically assign reasonable channels and instruments without these elements in simple cases, such as where part names match General MIDI instrument names.</xs:documentation>
+A score-instrument type is also required if the score specifies MIDI 1.0 channels, banks, or programs. An initial midi-instrument assignment can also be made here. MusicXML software should be able to automatically assign reasonable channels and instruments without these elements in simple cases, such as where part names match General MIDI instrument names.
+
+The score-instrument element can also distinguish multiple instruments of the same type that are on the same part, such as Clarinet 1 and Clarinet 2 instruments within a Clarinets 1 and 2 part.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="instrument-name" type="xs:string">
@@ -5575,44 +6062,29 @@ A score-instrument type is also required if the score specifies MIDI 1.0 channel
 					<xs:documentation>The optional instrument-abbreviation element is typically used within a software application, rather than appearing on the printed page of a score.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="instrument-sound" type="xs:string" minOccurs="0">
-				<xs:annotation>
-					<xs:documentation>The instrument-sound element describes the default timbre of the score-instrument. This description is independent of a particular virtual or MIDI instrument specification and allows playback to be shared more easily between applications and libraries.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-			<xs:choice minOccurs="0">
-				<xs:element name="solo" type="empty">
-					<xs:annotation>
-						<xs:documentation>The solo element was added in Version 2.0. It is present if performance is intended by a solo instrument.</xs:documentation>
-					</xs:annotation>
-				</xs:element>
-				<xs:element name="ensemble" type="positive-integer-or-empty">
-					<xs:annotation>
-						<xs:documentation>The ensemble element was added in Version 2.0. It is present if performance is intended by an ensemble such as an orchestral section. The text of the ensemble element contains the size of the section, or is empty if the ensemble size is not specified.</xs:documentation>
-					</xs:annotation>
-				</xs:element>
-			</xs:choice>
-			<xs:element name="virtual-instrument" type="virtual-instrument" minOccurs="0"/>
-		</xs:sequence>
+			<xs:group ref="virtual-instrument-data"/>
+			</xs:sequence>
 		<xs:attribute name="id" type="xs:ID" use="required"/>
 	</xs:complexType>
 
 	<xs:complexType name="score-part">
 		<xs:annotation>
-			<xs:documentation>Each MusicXML part corresponds to a track in a Standard MIDI Format 1 file. The score-instrument elements are used when there are multiple instruments per track. The midi-device element is used to make a MIDI device or port assignment for the given track or specific MIDI instruments. Initial midi-instrument assignments may be made here as well.</xs:documentation>
+			<xs:documentation>The score-part type collects part-wide information for each part in a score. Often, each MusicXML part corresponds to a track in a Standard MIDI Format 1 file. In this case, the midi-device element is used to make a MIDI device or port assignment for the given track or specific MIDI instruments. Initial midi-instrument assignments may be made here as well. The score-instrument elements are used when there are multiple instruments per track.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="identification" type="identification" minOccurs="0"/>
+			<xs:element name="part-link" type="part-link" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="part-name" type="part-name"/>
 			<xs:element name="part-name-display" type="name-display" minOccurs="0"/>
 			<xs:element name="part-abbreviation" type="part-name" minOccurs="0"/>
 			<xs:element name="part-abbreviation-display" type="name-display" minOccurs="0"/>
 			<xs:element name="group" type="xs:string" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>The group element allows the use of different versions of the part for different purposes. Typical values include score, parts, sound, and data. Ordering information that is directly encoded in MuseData can be derived from the ordering within a MusicXML score or opus.</xs:documentation>
+					<xs:documentation>The group element allows the use of different versions of the part for different purposes. Typical values include score, parts, sound, and data. Ordering information can be derived from the ordering within a MusicXML score or opus.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="score-instrument" type="score-instrument" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="player" type="player" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:sequence minOccurs="0" maxOccurs="unbounded">
 				<xs:element name="midi-device" type="midi-device" minOccurs="0"/>
 				<xs:element name="midi-instrument" type="midi-instrument" minOccurs="0"/>
@@ -5730,25 +6202,51 @@ A score-instrument type is also required if the score specifies MIDI 1.0 channel
 		<xs:sequence>
 			<xs:element name="tuning-step" type="step">
 				<xs:annotation>
-					<xs:documentation>The tuning-step element is represented like the step element, with a different name to reflect is different function.</xs:documentation>
+					<xs:documentation>The tuning-step element is represented like the step element, with a different name to reflect its different function in string tuning.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="tuning-alter" type="semitones" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>The tuning-alter element is represented like the alter element, with a different name to reflect is different function.</xs:documentation>
+					<xs:documentation>The tuning-alter element is represented like the alter element, with a different name to reflect its different function in string tuning.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="tuning-octave" type="octave">
 				<xs:annotation>
-					<xs:documentation>The tuning-octave element is represented like the octave element, with a different name to reflect is different function.</xs:documentation>
+					<xs:documentation>The tuning-octave element is represented like the octave element, with a different name to reflect its different function in string tuning.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
 	</xs:group>
 
+	<xs:group name="virtual-instrument-data">
+		<xs:annotation>
+			<xs:documentation>Virtual instrument data can be part of either the score-instrument element at the start of a part, or an instrument-change element within a part.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="instrument-sound" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The instrument-sound element describes the default timbre of the score-instrument. This description is independent of a particular virtual or MIDI instrument specification and allows playback to be shared more easily between applications and libraries.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice minOccurs="0">
+				<xs:element name="solo" type="empty">
+					<xs:annotation>
+						<xs:documentation>The solo element is present if performance is intended by a solo instrument.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="ensemble" type="positive-integer-or-empty">
+					<xs:annotation>
+						<xs:documentation>The ensemble element is present if performance is intended by an ensemble such as an orchestral section. The text of the ensemble element contains the size of the section, or is empty if the ensemble size is not specified.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+			<xs:element name="virtual-instrument" type="virtual-instrument" minOccurs="0"/>
+		</xs:sequence>
+	</xs:group>
+	
 	<xs:group name="voice">
 		<xs:annotation>
-			<xs:documentation>The voice is used to distinguish between multiple voices (what MuseData calls tracks) in individual parts. It is defined within a group due to its multiple uses within the MusicXML schema.</xs:documentation>
+			<xs:documentation>A voice is a sequence of musical events (e.g. notes, chords, rests) that proceeds linearly in time. The voice element is used to distinguish between multiple voices in individual parts. It is defined within a group due to its multiple uses within the MusicXML schema.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="voice" type="xs:string"/>
@@ -5757,6 +6255,29 @@ A score-instrument type is also required if the score specifies MIDI 1.0 channel
 
 	<!-- Element groups derived from attributes.mod elements -->
 
+	<xs:group name="clef">
+		<xs:annotation>
+			<xs:documentation>Clefs are represented by a combination of sign, line, and clef-octave-change elements.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="sign" type="clef-sign">
+				<xs:annotation>
+					<xs:documentation>The sign element represents the clef symbol.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="line" type="staff-line-position" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Line numbers are counted from the bottom of the staff. They are only needed with the G, F, and C signs in order to position a pitch correctly on the staff. Standard values are 2 for the G sign (treble clef), 4 for the F sign (bass clef), and 3 for the C sign (alto clef). Line values can be used to specify positions outside the staff, such as a C clef positioned in the middle of a grand staff.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="clef-octave-change" type="xs:integer" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The clef-octave-change element is used for transposing clefs. A treble clef for tenors would have a value of -1.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:group>
+	
 	<xs:group name="non-traditional-key">
 		<xs:annotation>
 			<xs:documentation>The non-traditional-key group represents a single alteration within a non-traditional key signature. A sequence of these groups makes up a non-traditional key signature</xs:documentation>
@@ -5764,17 +6285,17 @@ A score-instrument type is also required if the score specifies MIDI 1.0 channel
 		<xs:sequence>
 			<xs:element name="key-step" type="step">
 				<xs:annotation>
-					<xs:documentation>Non-traditional key signatures can be represented using the Humdrum/Scot concept of a list of altered tones. The key-step element indicates the pitch step to be altered, represented using the same names as in the step element.</xs:documentation>
+					<xs:documentation>Non-traditional key signatures are represented using a list of altered tones. The key-step element indicates the pitch step to be altered, represented using the same names as in the step element.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="key-alter" type="semitones">
 				<xs:annotation>
-					<xs:documentation>Non-traditional key signatures can be represented using the Humdrum/Scot concept of a list of altered tones. The key-alter element represents the alteration for a given pitch step, represented with semitones in the same manner as the alter element.</xs:documentation>
+					<xs:documentation>Non-traditional key signatures are represented using a list of altered tones. The key-alter element represents the alteration for a given pitch step, represented with semitones in the same manner as the alter element.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="key-accidental" type="key-accidental" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Non-traditional key signatures can be represented using the Humdrum/Scot concept of a list of altered tones. The key-accidental element indicates the accidental to be displayed in the key signature, represented in the same manner as the accidental element. It is used for disambiguating microtonal accidentals.</xs:documentation>
+					<xs:documentation>Non-traditional key signatures are represented using a list of altered tones. The key-accidental element indicates the accidental to be displayed in the key signature, represented in the same manner as the accidental element. It is used for disambiguating microtonal accidentals.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
@@ -5834,6 +6355,34 @@ A score-instrument type is also required if the score specifies MIDI 1.0 channel
 		</xs:sequence>
 	</xs:group>
 
+	<xs:group name="transpose">
+		<xs:annotation>
+			<xs:documentation>The transpose group represents what must be added to a written pitch to get a correct sounding pitch.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="diatonic" type="xs:integer" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The diatonic element specifies the number of pitch steps needed to go from written to sounding pitch. This allows for correct spelling of enharmonic transpositions. This value does not include octave-change values; the values for both elements need to be added to the written pitch to get the correct sounding pitch.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="chromatic" type="semitones">
+				<xs:annotation>
+					<xs:documentation>The chromatic element represents the number of semitones needed to get from written to sounding pitch. This value does not include octave-change values; the values for both elements need to be added to the written pitch to get the correct sounding pitch.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="octave-change" type="xs:integer" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The octave-change element indicates how many octaves to add to get from written pitch to sounding pitch. The octave-change element should be included when using transposition intervals of an octave or more, and should not be present for intervals of less than an octave.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="double" type="double" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If the double element is present, it indicates that the music is doubled one octave from what is currently written.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:group>
+	
 	<!-- Element groups derived from direction.mod entities and elements -->
 
 	<xs:group name="beat-unit">
@@ -5856,16 +6405,17 @@ A score-instrument type is also required if the score specifies MIDI 1.0 channel
 
 	<xs:group name="harmony-chord">
 		<xs:annotation>
-			<xs:documentation>A harmony element can contain many stacked chords (e.g. V of II). A sequence of harmony-chord groups is used for this type of secondary function, where V of II would be represented by a harmony-chord with a V function followed by a harmony-chord with a II function.
+			<xs:documentation>A harmony element can contain many stacked chords (e.g. V of II). A sequence of harmony-chord groups is used for this type of secondary function, where V of II would be represented by a harmony-chord with a 5 numeral followed by a harmony-chord with a 2 numeral.
 
-A root is a pitch name like C, D, E, where a function is an indication like I, II, III. It is an either/or choice to avoid data inconsistency.</xs:documentation>
+A root is a pitch name like C, D, E, while a numeral is a scale degree like 1, 2, 3. The root element is generally used with pop chord symbols, while the numeral element is generally used with classical functional harmony and Nashville numbers. It is an either/or choice to avoid data inconsistency. The function element, which represents Roman numerals with roman numeral text, has been deprecated as of MusicXML 4.0.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:choice>
 				<xs:element name="root" type="root"/>
+				<xs:element name="numeral" type="numeral"/>
 				<xs:element name="function" type="style-text">
 					<xs:annotation>
-						<xs:documentation>The function element is used to represent classical functional harmony with an indication like I, II, III rather than C, D, E. It is relative to the key that is specified in the MusicXML encoding.</xs:documentation>
+						<xs:documentation>The function element represents classical functional harmony with an indication like I, II, III rather than C, D, E. It represents the Roman numeral part of a functional harmony rather than the complete function itself. It has been deprecated as of MusicXML 4.0 in favor of the numeral element.</xs:documentation>
 					</xs:annotation>
 				</xs:element>
 			</xs:choice>
@@ -5914,12 +6464,14 @@ A root is a pitch name like C, D, E, where a function is an indication like I, I
 
 	<xs:group name="duration">
 		<xs:annotation>
-			<xs:documentation>The duration element is defined within a group due to its uses within the note, figure-bass, backup, and forward elements.</xs:documentation>
+			<xs:documentation>The duration element is defined within a group due to its uses within the note, figured-bass, backup, and forward elements.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="duration" type="positive-divisions">
 				<xs:annotation>
-					<xs:documentation>Duration is a positive number specified in division units. This is the intended duration vs. notated duration (for instance, swing eighths vs. even eighths, or differences in dotted notes in Baroque-era music). Differences in duration specific to an interpretation or performance should use the note element's attack and release attributes.</xs:documentation>
+					<xs:documentation>Duration is a positive number specified in division units. This is the intended duration vs. notated duration (for instance, differences in dotted notes in Baroque-era music). Differences in duration specific to an interpretation or performance should be represented using the note element's attack and release attributes.
+
+The duration element moves the musical position when used in backup elements, forward elements, and note elements that do not contain a chord child element.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
@@ -5927,7 +6479,7 @@ A root is a pitch name like C, D, E, where a function is an indication like I, I
 
 	<xs:group name="display-step-octave">
 		<xs:annotation>
-			<xs:documentation>The display-step-octave group contains the sequence of elements used by both the rest and unpitched elements. This group is used to place rests and unpitched elements on the staff without implying that these elements have pitch. Positioning follows the current clef. If percussion clef is used, the display-step and display-octave elements are interpreted as if in treble clef, with a G in octave 4 on line 2. If not present, the note is placed on the middle line of the staff, generally used for a one-line staff.</xs:documentation>
+			<xs:documentation>The display-step-octave group contains the sequence of elements used by both the rest and unpitched elements. This group is used to place rests and unpitched elements on the staff without implying that these elements have pitch. Positioning follows the current clef. If percussion clef is used, the display-step and display-octave elements are interpreted as if in treble clef, with a G in octave 4 on line 2.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="display-step" type="step"/>
@@ -5942,7 +6494,11 @@ A root is a pitch name like C, D, E, where a function is an indication like I, I
 		<xs:sequence>
 			<xs:element name="chord" type="empty" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>The chord element indicates that this note is an additional chord tone with the preceding note. The duration of this note can be no longer than the preceding note. In MuseData, a missing duration indicates the same length as the previous note, but the MusicXML format requires a duration for chord notes too.</xs:documentation>
+					<xs:documentation>The chord element indicates that this note is an additional chord tone with the preceding note.
+
+The duration of a chord note does not move the musical position within a measure. That is done by the duration of the first preceding note without a chord element. Thus the duration of a chord note cannot be longer than the preceding note.
+							
+In most cases the duration will be the same as the preceding note. However it can be shorter in situations such as multiple stops for string instruments.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:choice>
@@ -5970,6 +6526,7 @@ A root is a pitch name like C, D, E, where a function is an indication like I, I
 				<xs:element name="figured-bass" type="figured-bass"/>
 				<xs:element name="print" type="print"/>
 				<xs:element name="sound" type="sound"/>
+				<xs:element name="listening" type="listening"/>
 				<xs:element name="barline" type="barline"/>
 				<xs:element name="grouping" type="grouping"/>
 				<xs:element name="link" type="link"/>
@@ -5983,8 +6540,7 @@ A root is a pitch name like C, D, E, where a function is an indication like I, I
 			<xs:documentation>The part-group element is defined within a group due to its multiple uses within the part-list element.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="part-group" type="part-group">
-			</xs:element>
+			<xs:element name="part-group" type="part-group"/>			
 		</xs:sequence>
 	</xs:group>
 

--- a/src/importexport/musicxml/schema/xlink.xsd
+++ b/src/importexport/musicxml/schema/xlink.xsd
@@ -3,9 +3,9 @@
 	<xs:annotation>
 		<xs:documentation>MusicXML XLink module
 
-Version 3.1
+Version 4.0
 
-Copyright © 2004-2017 the Contributors to the MusicXML Specification, published by the W3C Music Notation Community Group under the W3C Community Final Specification Agreement (FSA):
+Copyright © 2004-2021 the Contributors to the MusicXML Specification, published by the W3C Music Notation Community Group under the W3C Community Final Specification Agreement (FSA):
 
 	https://www.w3.org/community/about/agreements/final/
 
@@ -13,7 +13,7 @@ A human-readable summary is available:
 
 	https://www.w3.org/community/about/agreements/fsa-deed/
 
-This is the W3C XML Schema (XSD) version of the MusicXML 3.1 language. Validation is tightened by moving MusicXML definitions from comments into schema data types and definitions. Character entities and other entity usages that are not supported in W3C XML Schema have also been removed. However, the features of W3C XML Schema make it easier to define variations of the MusicXML format, either via extension or restriction.
+This is the W3C XML Schema (XSD) version of the MusicXML 4.0 language. Validation is tightened by moving MusicXML definitions from comments into schema data types and definitions. Character entities and other entity usages that are not supported in W3C XML Schema have also been removed. However, the features of W3C XML Schema make it easier to define variations of the MusicXML format, either via extension or restriction.
 	
 This schema module defines the subset of XLink attributes that are supported in the MusicXML schema. All definitions here are in the XLink namespace.</xs:documentation>
 	</xs:annotation>


### PR DESCRIPTION
Resolves: (part of) https://musescore.org/en/node/321095

Updated relevant MusicXML schema files to their 4.0 version. This allows import of MusicXML 4.0 files without unnecessary warnings. It does not yet support new MusicXML features on either import or export, nor does it change the MusicXML exported from version 3.1 to 4.0.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
