### PR TITLE
Enhance sizing in StandardDialogs

### DIFF
--- a/src/framework/ui/qml/MuseScore/Ui/internal/StandardDialog.qml
+++ b/src/framework/ui/qml/MuseScore/Ui/internal/StandardDialog.qml
@@ -41,6 +41,9 @@ StyledDialogView {
     property var buttons: [ { "buttonId": 1, "title": qsTrc("global", "OK") } ]
     property alias defaultButtonId: content.defaultButtonId
 
+    contentWidth: content.implicitWidth
+    contentHeight: content.implicitHeight
+
     margins: 16
 
     onOpened: {
@@ -49,20 +52,10 @@ StyledDialogView {
 
     StandardDialogPanel {
         id: content
-
         anchors.fill: parent
 
         navigation.section: root.navigationSection
-
         buttons: root.buttons
-
-        onContentWidthChanged: {
-            root.contentWidth = Math.max(Math.min(491, content.contentWidth), 306)
-        }
-
-        onContentHeightChanged: {
-            root.contentHeight = Math.max(104, content.contentHeight)
-        }
 
         onClicked: function(buttonId, showAgain) {
             root.ret = { "errcode": 0, "value": { "buttonId": buttonId, "showAgain": showAgain}}

--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -103,6 +103,10 @@ void PopupView::componentComplete()
     m_window->setOnHidden([this]() { onHidden(); });
     m_window->setContent(m_contentItem);
 
+    if (isDialog()) {
+        connect(m_window, &IPopupWindow::sizeChanged, this, &PopupView::updateSize);
+    }
+
     // TODO: Can't use new `connect` syntax because the IPopupWindow::aboutToClose
     // has a parameter of type QQuickCloseEvent, which is not public, so we
     // can't include any header for it and it will always be an incomplete
@@ -175,11 +179,7 @@ void PopupView::open()
         qWindow->setModality(Qt::NonModal);
 #endif
 
-        QRect winRect = m_window->geometry();
-        qWindow->setMinimumSize(winRect.size());
-        if (!m_resizable) {
-            qWindow->setMaximumSize(winRect.size());
-        }
+        updateSize();
     }
 
     m_window->show(m_globalPos.toPoint());
@@ -572,6 +572,24 @@ QRect PopupView::currentScreenGeometry() const
     }
 
     return currentScreen->availableGeometry();
+}
+
+void PopupView::updateSize()
+{
+    if (!isDialog()) {
+        return;
+    }
+
+    QWindow* qWindow = this->qWindow();
+    if (!qWindow) {
+        return;
+    }
+
+    QSize size = qWindow->size();
+    qWindow->setMinimumSize(size);
+    if (!m_resizable) {
+        qWindow->setMaximumSize(size);
+    }
 }
 
 void PopupView::updatePosition()

--- a/src/framework/uicomponents/view/popupview.h
+++ b/src/framework/uicomponents/view/popupview.h
@@ -198,6 +198,7 @@ protected:
     void setErrCode(Ret::Code code);
 
     QRect currentScreenGeometry() const;
+    void updateSize();
     void updatePosition();
     void updateContentPosition();
 

--- a/src/framework/uicomponents/view/popupview.h
+++ b/src/framework/uicomponents/view/popupview.h
@@ -198,7 +198,6 @@ protected:
     void setErrCode(Ret::Code code);
 
     QRect currentScreenGeometry() const;
-    void updateSize();
     void updatePosition();
     void updateContentPosition();
 

--- a/src/framework/uicomponents/view/popupwindow/ipopupwindow.h
+++ b/src/framework/uicomponents/view/popupwindow/ipopupwindow.h
@@ -61,6 +61,7 @@ public:
     virtual void setOnHidden(const std::function<void()>& callback) = 0;
 
 signals:
+    void sizeChanged();
     void aboutToClose(QQuickCloseEvent* event);
 };
 }

--- a/src/framework/uicomponents/view/popupwindow/ipopupwindow.h
+++ b/src/framework/uicomponents/view/popupwindow/ipopupwindow.h
@@ -54,6 +54,9 @@ public:
     virtual QWindow* parentWindow() const = 0;
     virtual void setParentWindow(QWindow* window) = 0;
 
+    virtual bool resizable() const = 0;
+    virtual void setResizable(bool resizable) = 0;
+
     virtual void setPosition(const QPoint& position) const = 0;
 
     virtual void forceActiveFocus() = 0;
@@ -61,7 +64,6 @@ public:
     virtual void setOnHidden(const std::function<void()>& callback) = 0;
 
 signals:
-    void sizeChanged();
     void aboutToClose(QQuickCloseEvent* event);
 };
 }

--- a/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
+++ b/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
@@ -91,6 +91,7 @@ void PopupWindow_QQuickView::setContent(QQuickItem* item)
         }
         if (item->implicitWidth() != m_view->width()) {
             m_view->resize(item->implicitWidth(), item->implicitHeight());
+            emit sizeChanged();
         }
     });
 
@@ -100,6 +101,7 @@ void PopupWindow_QQuickView::setContent(QQuickItem* item)
         }
         if (item->implicitHeight() != m_view->height()) {
             m_view->resize(item->implicitWidth(), item->implicitHeight());
+            emit sizeChanged();
         }
     });
 }

--- a/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
+++ b/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
@@ -90,8 +90,7 @@ void PopupWindow_QQuickView::setContent(QQuickItem* item)
             return;
         }
         if (item->implicitWidth() != m_view->width()) {
-            m_view->resize(item->implicitWidth(), item->implicitHeight());
-            emit sizeChanged();
+            updateSize(QSize(item->implicitWidth(), item->implicitHeight()));
         }
     });
 
@@ -100,8 +99,7 @@ void PopupWindow_QQuickView::setContent(QQuickItem* item)
             return;
         }
         if (item->implicitHeight() != m_view->height()) {
-            m_view->resize(item->implicitWidth(), item->implicitHeight());
-            emit sizeChanged();
+            updateSize(QSize(item->implicitWidth(), item->implicitHeight()));
         }
     });
 }
@@ -125,7 +123,7 @@ void PopupWindow_QQuickView::show(QPoint p)
 
     m_view->requestActivate();
     QQuickItem* item = m_view->rootObject();
-    m_view->resize(item->implicitWidth(), item->implicitHeight());
+    updateSize(QSize(item->implicitWidth(), item->implicitHeight()));
 
     QTimer::singleShot(0, [this]() {
         forceActiveFocus();
@@ -172,6 +170,23 @@ void PopupWindow_QQuickView::setParentWindow(QWindow* window)
     m_parentWindow = window;
 }
 
+bool PopupWindow_QQuickView::resizable() const
+{
+    return m_resizable;
+}
+
+void PopupWindow_QQuickView::setResizable(bool resizable)
+{
+    if (m_resizable == resizable) {
+        return;
+    }
+
+    m_resizable = resizable;
+    if (m_view) {
+        updateSize(m_view->size());
+    }
+}
+
 void PopupWindow_QQuickView::setPosition(const QPoint& position) const
 {
     m_view->setPosition(position);
@@ -212,4 +227,21 @@ bool PopupWindow_QQuickView::eventFilter(QObject* watched, QEvent* event)
     }
 
     return QObject::eventFilter(watched, event);
+}
+
+void PopupWindow_QQuickView::updateSize(const QSize& newSize)
+{
+    if (!m_view) {
+        return;
+    }
+
+    if (m_resizable) {
+        m_view->setMinimumSize(newSize);
+        m_view->setMaximumSize(QSize(16777215, 16777215));
+        m_view->resize(m_view->size().expandedTo(newSize));
+    } else {
+        m_view->setMinimumSize(newSize);
+        m_view->setMaximumSize(newSize);
+        m_view->resize(newSize);
+    }
 }

--- a/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.h
+++ b/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.h
@@ -58,6 +58,9 @@ public:
     QWindow* parentWindow() const override;
     void setParentWindow(QWindow* window) override;
 
+    bool resizable() const override;
+    void setResizable(bool resizable) override;
+
     void setPosition(const QPoint& position) const override;
 
     void forceActiveFocus() override;
@@ -68,7 +71,10 @@ private:
 
     bool eventFilter(QObject* watched, QEvent* event) override;
 
+    void updateSize(const QSize& newSize);
+
     QQuickView* m_view = nullptr;
+    bool m_resizable = false;
     std::function<void()> m_onHidden;
 
     QWindow* m_parentWindow = nullptr;


### PR DESCRIPTION
Resolves: #8443

It's quite smart now, and will look beautiful in (hopefully, or at least almost) all possible cases.

Also implemented updating size of PopupView in dialog mode when content size changed. This was necessary to make the StandardDialogs work.