### PR TITLE
[MU4] Fix GH#10081: Dynamics show broken 'underline' and 'strikethrough' visuals.

### DIFF
--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -956,8 +956,6 @@ mu::draw::Font TextFragment::font(const TextBase* t) const
     if (format.valign() != VerticalAlignment::AlignNormal) {
         m *= subScriptSize;
     }
-    font.setUnderline(format.underline());
-    font.setStrike(format.strike());
 
     QString family;
     if (format.fontFamily() == "ScoreText") {
@@ -1004,6 +1002,8 @@ mu::draw::Font TextFragment::font(const TextBase* t) const
         family = format.fontFamily();
         font.setBold(format.bold());
         font.setItalic(format.italic());
+        font.setUnderline(format.underline());
+        font.setStrike(format.strike());
     }
 
     font.setFamily(family);


### PR DESCRIPTION
Resolves: #10081

Fixed by preventing it from happening, same way bold and italic are prevented already