### PR TITLE
System objects now appear on template-specified tracks

### DIFF
--- a/share/instruments/orders.xml
+++ b/share/instruments/orders.xml
@@ -2,7 +2,7 @@
 <museScore>
     <Order id="orchestral">
         <name>Orchestral</name>
-        <section id="woodwind" showSystemMarkings="true">
+        <section id="woodwind">
             <family>flutes</family>
             <family>oboes</family>
             <family>clarinets</family>

--- a/share/templates/02-Choral/02-SATB_+_Organ/02-SATB_+_Organ.mscx
+++ b/share/templates/02-Choral/02-SATB_+_Organ/02-SATB_+_Organ.mscx
@@ -44,6 +44,9 @@
       <family>organs</family>
       <unsorted/>
       </Order>
+    <SystemObjects>
+      <Instance staffId="5" barNumbers="false"/>
+      </SystemObjects>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/share/templates/02-Choral/03-SATB_+_Piano/03-SATB_+_Piano.mscx
+++ b/share/templates/02-Choral/03-SATB_+_Piano/03-SATB_+_Piano.mscx
@@ -44,6 +44,9 @@
       <family>organs</family>
       <unsorted/>
       </Order>
+    <SystemObjects>
+      <Instance staffId="5" barNumbers="false"/>
+      </SystemObjects>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/share/templates/02-Choral/05-SATB_Closed_Score_+_Organ/05-SATB_Closed_Score_+_Organ.mscx
+++ b/share/templates/02-Choral/05-SATB_Closed_Score_+_Organ/05-SATB_Closed_Score_+_Organ.mscx
@@ -38,6 +38,9 @@
       <family>organs</family>
       <unsorted/>
       </Order>
+    <SystemObjects>
+      <Instance staffId="3" barNumbers="false"/>
+      </SystemObjects>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/share/templates/02-Choral/06-SATB_Closed_Score_+_Piano/06-SATB_Closed_Score_+_Piano.mscx
+++ b/share/templates/02-Choral/06-SATB_Closed_Score_+_Piano/06-SATB_Closed_Score_+_Piano.mscx
@@ -38,6 +38,9 @@
       <family>organs</family>
       <unsorted/>
       </Order>
+    <SystemObjects>
+      <Instance staffId="3" barNumbers="false"/>
+      </SystemObjects>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/share/templates/08-Orchestral/01-Classical_Orchestra/01-Classical_Orchestra.mscx
+++ b/share/templates/08-Orchestral/01-Classical_Orchestra/01-Classical_Orchestra.mscx
@@ -47,7 +47,7 @@
       <instrument id="timpani">
         <family id="timpani">Timpani</family>
         </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
+      <section id="woodwind" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
         <family>flutes</family>
         <family>oboes</family>
         <family>clarinets</family>
@@ -89,6 +89,9 @@
         </section>
       <unsorted/>
       </Order>
+    <SystemObjects>
+      <Instance staffId="9" barNumbers="false"/>
+      </SystemObjects>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/share/templates/08-Orchestral/02-Symphony_Orchestra/02-Symphony_Orchestra.mscx
+++ b/share/templates/08-Orchestral/02-Symphony_Orchestra/02-Symphony_Orchestra.mscx
@@ -77,7 +77,7 @@
       <instrument id="violoncellos">
         <family id="orchestral-strings">Orchestral Strings</family>
         </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
+      <section id="woodwind" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
         <family>flutes</family>
         <family>oboes</family>
         <family>clarinets</family>
@@ -119,6 +119,9 @@
         </section>
       <unsorted/>
       </Order>
+    <SystemObjects>
+      <Instance staffId="22" barNumbers="false"/>
+      </SystemObjects>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/share/templates/08-Orchestral/03-String_Orchestra/03-String_Orchestra.mscx
+++ b/share/templates/08-Orchestral/03-String_Orchestra/03-String_Orchestra.mscx
@@ -35,7 +35,7 @@
       <instrument id="violoncellos">
         <family id="orchestral-strings">Orchestral Strings</family>
         </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
+      <section id="woodwind" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
         <family>flutes</family>
         <family>oboes</family>
         <family>clarinets</family>

--- a/src/engraving/libmscore/chordrest.cpp
+++ b/src/engraving/libmscore/chordrest.cpp
@@ -1415,7 +1415,7 @@ void ChordRest::undoAddAnnotation(EngravingItem* a)
         seg = m->mmRestFirst()->findSegmentR(SegmentType::ChordRest, Fraction(0, 1));
     }
 
-    a->setTrack(a->systemFlag() ? 0 : track());
+    a->setTrack(/*a->systemFlag() ? 0 : */ track());
     a->setParent(seg);
     score()->undoAddElement(a);
 }

--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -412,12 +412,12 @@ void Score::deletePostponed()
 //        HAIRPIN, LET_RING, VIBRATO and TEXTLINE
 //---------------------------------------------------------
 
-void Score::cmdAddSpanner(Spanner* spanner, const PointF& pos, bool firstStaffOnly)
+void Score::cmdAddSpanner(Spanner* spanner, const PointF& pos, bool systemStavesOnly)
 {
-    int staffIdx;
+    int staffIdx = spanner->staffIdx();
     Segment* segment;
     MeasureBase* mb = pos2measure(pos, &staffIdx, 0, &segment, 0);
-    if (firstStaffOnly) {
+    if (systemStavesOnly) {
         staffIdx = 0;
     }
     // ignore if we do not have a measure
@@ -450,7 +450,9 @@ void Score::cmdAddSpanner(Spanner* spanner, const PointF& pos, bool firstStaffOn
     }
     spanner->eraseSpannerSegments();
 
-    undoAddElement(spanner);
+    ElementType et = spanner->type();
+    bool ctrlModifier = (et == ElementType::VOLTA || et == ElementType::TEXTLINE) && spanner->systemFlag() && !systemStavesOnly;
+    undoAddElement(spanner, ctrlModifier);
     spanner->setParent(mb);
     select(spanner, SelectType::SINGLE, 0);
 }

--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -5122,8 +5122,8 @@ void Score::undoAddElement(EngravingItem* element, bool ctrlModifier)
             element->setSystemFlag(false);
             staffList.append(element->staff());
         } else {
-            staffList.append(staff(0)); // system objects always appear on the top staff
             for (Score* s : scoreList()) {
+                staffList.append(s->staff(0)); // system objects always appear on the top staff
                 for (Staff* staff : s->getSystemObjectStaves()) {
                     staffList.append(staff);
                 }

--- a/src/engraving/libmscore/engravingitem.cpp
+++ b/src/engraving/libmscore/engravingitem.cpp
@@ -456,8 +456,8 @@ int EngravingItem::staffIdxOrNextVisible() const
         return si;
     }
     int firstVis = m->system()->firstVisibleStaff();
-    if (!isLinked()) {
-        // original, put on the top of the score
+    if (track() == 0) {
+        // original OR first system object in excerpt, put on the top of the score
         return firstVis;
     }
     if (si <= firstVis) {

--- a/src/engraving/libmscore/engravingitem.h
+++ b/src/engraving/libmscore/engravingitem.h
@@ -212,6 +212,7 @@ class EngravingItem : public EngravingObject
 protected:
     mutable int _z;
     mu::draw::Color _color;                ///< element color attribute
+    bool _skipDraw{ false };
 
     friend class mu::engraving::Factory;
     EngravingItem(const ElementType& type, EngravingObject* se = 0, ElementFlags = ElementFlag::NOTHING);
@@ -310,6 +311,7 @@ public:
     qreal& rxpos() { return _pos.rx(); }
     qreal& rypos() { return _pos.ry(); }
     virtual void move(const mu::PointF& s) { _pos += s; }
+    bool skipDraw() const { return _skipDraw; }
 
     virtual mu::PointF pagePos() const;            ///< position in page coordinates
     virtual mu::PointF canvasPos() const;          ///< position in canvas coordinates
@@ -421,6 +423,7 @@ public:
 
     int staffIdx() const;
     void setStaffIdx(int val);
+    int staffIdxOrNextVisible() const; // for system objects migrating
     virtual int vStaffIdx() const;
     int voice() const;
     void setVoice(int v);

--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -520,7 +520,7 @@ void MasterScore::initEmptyExcerpt(Excerpt* excerpt)
 static void cloneSpanner(Spanner* s, Score* score, int dstTrack, int dstTrack2)
 {
     // don’t clone voltas for track != 0
-    if ((s->isVolta() || (s->isTextLine() && toTextLine(s)->systemFlag())) && s->track() != 0) {
+    if (((s->isVolta() || s->isTextLine()) && s->systemFlag()) && s->track() != 0) {
         return;
     }
 
@@ -994,7 +994,7 @@ void Excerpt::cloneStaves(Score* oscore, Score* score, const QList<int>& sourceS
         int dstTrack  = -1;
         int dstTrack2 = -1;
 
-        if (s->isVolta() || (s->isTextLine() && toTextLine(s)->systemFlag())) {
+        if ((s->isVolta() || s->isTextLine()) && s->systemFlag()) {
             //always export voltas to first staff in part
             dstTrack  = 0;
             dstTrack2 = 0;
@@ -1234,7 +1234,7 @@ void Excerpt::cloneStaff(Staff* srcStaff, Staff* dstStaff)
         int staffIdx = s->staffIdx();
         int dstTrack = -1;
         int dstTrack2 = -1;
-        if (!(s->isVolta() || (s->isTextLine() && toTextLine(s)->systemFlag()))) {
+        if (!((s->isVolta() || s->isTextLine()) && s->systemFlag())) {
             //export other spanner if staffidx matches
             if (srcStaffIdx == staffIdx) {
                 dstTrack = dstStaffIdx * VOICES + s->voice();
@@ -1435,7 +1435,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
         int staffIdx = s->staffIdx();
         int dstTrack = -1;
         int dstTrack2 = -1;
-        if (!(s->isVolta() || (s->isTextLine() && s->systemFlag()))) {
+        if (!((s->isVolta() || s->isTextLine()) && s->systemFlag())) {
             //export other spanner if staffidx matches
             if (srcStaffIdx == staffIdx) {
                 dstTrack  = dstStaffIdx * VOICES + s->voice();

--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -899,7 +899,7 @@ static Ms::MeasureBase* cloneMeasure(Ms::MeasureBase* mb, Ms::Score* score, cons
             track = trackList.value(e->track(), -1);
             if (track == -1) {
                 // even if track not in excerpt, we need to clone system elements
-                if (e->systemFlag()) {
+                if (e->systemFlag() && e->track() == 0) {
                     track = 0;
                 } else {
                     continue;

--- a/src/engraving/libmscore/jump.cpp
+++ b/src/engraving/libmscore/jump.cpp
@@ -64,7 +64,7 @@ int jumpTypeTableSize()
 //---------------------------------------------------------
 
 Jump::Jump(Measure* parent)
-    : TextBase(ElementType::JUMP, parent, TextStyleType::REPEAT_RIGHT, ElementFlag::MOVABLE | ElementFlag::SYSTEM)
+    : TextBase(ElementType::JUMP, parent, TextStyleType::REPEAT_RIGHT, ElementFlag::MOVABLE | ElementFlag::SYSTEM | ElementFlag::ON_STAFF)
 {
     initElementStyle(&jumpStyle);
     setLayoutToParentWidth(true);

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -1546,9 +1546,6 @@ EngravingItem* Measure::drop(EditData& data)
     Segment* seg;
     score()->pos2measure(data.pos, &staffIdx, 0, &seg, 0);
 
-    if (e->systemFlag()) {
-        staffIdx = 0;
-    }
     if (staffIdx < 0) {
         return 0;
     }
@@ -2232,7 +2229,7 @@ void Measure::sortStaves(QList<int>& dst)
     }
 
     for (EngravingItem* e : el()) {
-        if (e->track() == -1 || e->systemFlag()) {
+        if (e->track() == -1 /* || e->systemFlag()*/) {
             continue;
         }
         int voice    = e->voice();

--- a/src/engraving/libmscore/rehearsalmark.cpp
+++ b/src/engraving/libmscore/rehearsalmark.cpp
@@ -42,7 +42,7 @@ static const ElementStyle rehearsalMarkStyle {
 //---------------------------------------------------------
 
 RehearsalMark::RehearsalMark(Segment* parent)
-    : TextBase(ElementType::REHEARSAL_MARK, parent, TextStyleType::REHEARSAL_MARK)
+    : TextBase(ElementType::REHEARSAL_MARK, parent, TextStyleType::REHEARSAL_MARK, ElementFlag::ON_STAFF)
 {
     initElementStyle(&rehearsalMarkStyle);
     setSystemFlag(true);

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -420,6 +420,7 @@ private:
     MeasureBaseList _measures;            // here are the notes
     QList<Part*> _parts;
     QList<Staff*> _staves;
+    QList<Staff*> systemObjectStaves;
 
     SpannerMap _spanner;
     std::set<Spanner*> _unmanagedSpanner;
@@ -645,10 +646,14 @@ public:
     Staff* staffById(const ID& staffId) const;
     Part* partById(const ID& partId) const;
 
+    void clearSystemObjectStaves() { systemObjectStaves.clear(); }
+    void addSystemObjectStaff(Staff* staff) { systemObjectStaves.push_back(staff); }
+    QList<Staff*> getSystemObjectStaves() { return systemObjectStaves; }
+
     Measure* pos2measure(const mu::PointF&, int* staffIdx, int* pitch, Segment**, mu::PointF* offset) const;
     void dragPosition(const mu::PointF&, int* staffIdx, Segment**, qreal spacingFactor = 0.5) const;
 
-    void undoAddElement(EngravingItem* element);
+    void undoAddElement(EngravingItem* element, bool ctrlModifier = false);
     void undoAddCR(ChordRest* element, Measure*, const Fraction& tick);
     void undoRemoveElement(EngravingItem* element);
     void undoChangeSpannerElements(Spanner* spanner, EngravingItem* startElement, EngravingItem* endElement);
@@ -785,6 +790,7 @@ public:
 
     void appendPart(const InstrumentTemplate*);
     void updateStaffIndex();
+    void sortSystemObjects(QList<int>& dst);
     void sortStaves(QList<int>& dst);
     void mapExcerptTracks(QList<int>& l);
 
@@ -971,6 +977,7 @@ public:
     ScoreOrder scoreOrder() const;
     void setScoreOrder(ScoreOrder order);
     void setBracketsAndBarlines();
+    void setSystemObjectStaves();
 
     void lassoSelect(const mu::RectF&);
     void lassoSelectEnd(bool);
@@ -1147,7 +1154,7 @@ public:
     bool isSpannerStartEnd(const Fraction& tick, int track) const;
     void removeSpanner(Spanner*);
     void addSpanner(Spanner*);
-    void cmdAddSpanner(Spanner* spanner, const mu::PointF& pos, bool firstStaffOnly = false);
+    void cmdAddSpanner(Spanner* spanner, const mu::PointF& pos, bool systemStavesOnly = false);
     void cmdAddSpanner(Spanner* spanner, int staffIdx, Segment* startSegment, Segment* endSegment);
     void checkSpanner(const Fraction& startTick, const Fraction& lastTick);
     const std::set<Spanner*> unmanagedSpanners() { return _unmanagedSpanner; }

--- a/src/engraving/libmscore/scoreorder.cpp
+++ b/src/engraving/libmscore/scoreorder.cpp
@@ -325,6 +325,36 @@ void ScoreOrder::setBracketsAndBarlines(Score* score)
 }
 
 //---------------------------------------------------------
+//   setSystemObjectStaves
+//---------------------------------------------------------
+
+void ScoreOrder::setSystemObjectStaves(Score* score)
+{
+    // the cool thing is that the template is populated by both the full template used
+    // and also orders.xml. If we want to do some jiggery-pokery with adding system object
+    // staves in the situation where the user has added the instruments manually, orders.xml
+    // is the place to go, and will likely need special handling here.
+    if (!score->getSystemObjectStaves().isEmpty()) {
+        return;
+    }
+    score->clearSystemObjectStaves();
+
+    QString prvSection = "";
+    for (Part* part : score->parts()) {
+        InstrumentIndex ii = searchTemplateIndexForId(part->instrument()->id());
+        if (!ii.instrTemplate) {
+            continue;
+        }
+        QString family{ getFamilyName(ii.instrTemplate, part->soloist()) };
+        const ScoreGroup sg = getGroup(family, instrumentGroups[ii.groupIndex]->id);
+        if (sg.section != prvSection && sg.showSystemMarkings) {
+            score->addSystemObjectStaff(part->staff(0));
+        }
+        prvSection = sg.section;
+    }
+}
+
+//---------------------------------------------------------
 //   read
 //---------------------------------------------------------
 

--- a/src/engraving/libmscore/scoreorder.h
+++ b/src/engraving/libmscore/scoreorder.h
@@ -80,6 +80,7 @@ struct ScoreOrder
     ScoreGroup getGroup(const QString family, const QString instrumentGroup) const;
 
     void setBracketsAndBarlines(Score* score);
+    void setSystemObjectStaves(Score* score);
 
     void read(Ms::XmlReader& reader);
     void write(Ms::XmlWriter& xml) const;

--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -496,7 +496,7 @@ void Segment::insertStaff(int staff)
 
     for (EngravingItem* e : _annotations) {
         int staffIdx = e->staffIdx();
-        if (staffIdx >= staff && !e->systemFlag()) {
+        if (staffIdx >= staff) {
             e->setTrack(e->track() + VOICES);
         }
     }
@@ -856,7 +856,15 @@ void Segment::sortStaves(QList<int>& dst)
         map.insert(dst[k], k);
     }
     for (EngravingItem* e : _annotations) {
-        if (!e->systemFlag()) {
+        ElementType et = e->type();
+        if (!e->systemFlag()
+            || (et == ElementType::REHEARSAL_MARK)
+            || (et == ElementType::SYSTEM_TEXT)
+            || (et == ElementType::JUMP)
+            || (et == ElementType::MARKER)
+            || (et == ElementType::TEMPO_TEXT)
+            || (et == ElementType::VOLTA)
+            || (et == ElementType::TEXTLINE && e->systemFlag())) {
             e->setTrack(map[e->staffIdx()] * VOICES + e->voice());
         }
     }

--- a/src/engraving/libmscore/staff.cpp
+++ b/src/engraving/libmscore/staff.cpp
@@ -89,6 +89,11 @@ Staff::Staff(const Staff& staff)
 Staff::~Staff()
 {
     qDeleteAll(brackets());
+    QList<Staff*> sysStaves = m_score->getSystemObjectStaves();
+    for (Staff* s : sysStaves) {
+        if (s == this) {
+        }
+    }
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/tempotext.cpp
+++ b/src/engraving/libmscore/tempotext.cpp
@@ -60,7 +60,7 @@ static const ElementStyle tempoStyle {
 //---------------------------------------------------------
 
 TempoText::TempoText(Segment* parent)
-    : TextBase(ElementType::TEMPO_TEXT, parent, TextStyleType::TEMPO, ElementFlags(ElementFlag::SYSTEM))
+    : TextBase(ElementType::TEMPO_TEXT, parent, TextStyleType::TEMPO, ElementFlag::SYSTEM | ElementFlag::ON_STAFF)
 {
     initElementStyle(&tempoStyle);
     _tempo      = 2.0;        // propertyDefault(P_TEMPO).toDouble();

--- a/src/engraving/paint/paint.cpp
+++ b/src/engraving/paint/paint.cpp
@@ -36,6 +36,9 @@ using namespace Ms;
 
 void Paint::paintElement(mu::draw::Painter& painter, const Ms::EngravingItem* element)
 {
+    if (element->skipDraw()) {
+        return;
+    }
     element->itemDiscovered = false;
     PointF elementPosition(element->pagePos());
 

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -85,6 +85,7 @@ void MasterNotation::setMasterScore(Ms::MasterScore* score)
     TRACEFUNC;
 
     setScore(score);
+    score->setSystemObjectStaves();
     initExcerptNotations(masterScore()->excerpts());
     m_notationMidiData->init(m_parts);
 }
@@ -271,6 +272,7 @@ void MasterNotation::applyOptions(Ms::MasterScore* score, const ScoreCreateOptio
             nvb->setRightMargin(tvb->rightMargin());
             nvb->setAutoSizeEnabled(tvb->isAutoSizeEnabled());
         }
+        score->setSystemObjectStaves(); // use the template to determine where system objects go
     }
 
     score->setName(qtrc("notation", "Untitled"));

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1031,19 +1031,19 @@ bool NotationInteraction::drop(const PointF& pos, Qt::KeyboardModifiers modifier
     m_dropData.ed.modifiers = modifiers;
     m_dropData.ed.dropElement->styleChanged();
 
-    bool firstStaffOnly = false;
+    bool systemStavesOnly = false;
     bool applyUserOffset = false;
 
     startEdit();
     score()->addRefresh(m_dropData.ed.dropElement->canvasBoundingRect());
-
-    switch (m_dropData.ed.dropElement->type()) {
+    ElementType et = m_dropData.ed.dropElement->type();
+    switch (et) {
     case ElementType::TEXTLINE:
-        firstStaffOnly = m_dropData.ed.dropElement->systemFlag();
+        systemStavesOnly = m_dropData.ed.dropElement->systemFlag();
     // fall-thru
     case ElementType::VOLTA:
-        // voltas drop to first staff by default, or closest staff if Control is held
-        firstStaffOnly = firstStaffOnly || !(m_dropData.ed.modifiers & Qt::ControlModifier);
+        // voltas drop to system staves by default, or closest staff if Control is held
+        systemStavesOnly = systemStavesOnly || !(m_dropData.ed.modifiers & Qt::ControlModifier);
     // fall-thru
     case ElementType::OTTAVA:
     case ElementType::TRILL:
@@ -1054,7 +1054,7 @@ bool NotationInteraction::drop(const PointF& pos, Qt::KeyboardModifiers modifier
     case ElementType::HAIRPIN:
     {
         Ms::Spanner* spanner = ptr::checked_cast<Ms::Spanner>(m_dropData.ed.dropElement);
-        score()->cmdAddSpanner(spanner, pos, firstStaffOnly);
+        score()->cmdAddSpanner(spanner, pos, systemStavesOnly);
         score()->setUpdateAll();
         accepted = true;
     }
@@ -1081,6 +1081,7 @@ bool NotationInteraction::drop(const PointF& pos, Qt::KeyboardModifiers modifier
                 if (applyUserOffset) {
                     m_dropData.ed.dropElement->setOffset(offset);
                 }
+
                 score()->undoAddElement(m_dropData.ed.dropElement);
             } else {
                 qDebug("cannot drop here");

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -1033,9 +1033,9 @@ void NotationParts::sortParts(const PartInstrumentList& parts, const QList<Ms::S
         ++partIndex;
     }
 
-    if (sortingNeeded) {
-        score()->undo(new Ms::SortStaves(score(), staffMapping));
-    }
+    //if (sortingNeeded) {
+    score()->undo(new Ms::SortStaves(score(), staffMapping));
+    //}
 
     score()->undo(new Ms::MapExcerptTracks(score(), trackMapping));
 }


### PR DESCRIPTION
Templates include information about which staves have system objects above them (i.e. tempo text, voltas, jump markers, system text, etc.), and this PR enforces those objects on the appropriate staves.
![image](https://user-images.githubusercontent.com/89263931/145921945-2c109274-eeee-4865-861b-ad1cd2293da1.png)

There is also pre-existing functionality where you can hold ctrl when dragging a volta to a staff and it shows on that staff instead of the preset system staves:
![image](https://user-images.githubusercontent.com/89263931/145922196-108b3280-e8fe-4e90-bb41-68e5a269f136.png)

This PR also deals with saving and loading of all system objects, regardless of staff.