### PR TITLE
Fixed crash on edit text style

### DIFF
--- a/src/engraving/infrastructure/draw/geometry.h
+++ b/src/engraving/infrastructure/draw/geometry.h
@@ -227,7 +227,14 @@ inline SizeX<T> operator/(const SizeX<T>& s, T c) { Q_ASSERT(!isEqual(c, T())); 
 
 using Size = SizeX<int>;
 using SizeF = SizeX<qreal>;
-using ScaleF = SizeX<qreal>;
+
+class ScaleF : public SizeX<qreal>
+{
+public:
+    ScaleF() = default;
+    ScaleF(qreal w, qreal h)
+        : SizeX<qreal>(w, h) {}
+};
 
 // ====================================
 // Rect

--- a/src/engraving/libmscore/property.cpp
+++ b/src/engraving/libmscore/property.cpp
@@ -504,7 +504,7 @@ PropertyValue readProperty(Pid id, XmlReader& e)
     case P_TYPE::POINT:
         return PropertyValue::fromValue(e.readPoint());
     case P_TYPE::SCALE:
-        return PropertyValue::fromValue(ScaleF(e.readSize()));
+        return PropertyValue::fromValue(e.readScale());
     case P_TYPE::SIZE:
         return PropertyValue::fromValue(e.readSize());
     case P_TYPE::STRING:

--- a/src/engraving/libmscore/timesig.cpp
+++ b/src/engraving/libmscore/timesig.cpp
@@ -518,7 +518,7 @@ bool TimeSig::setProperty(Pid propertyId, const PropertyValue& v)
         _timeSigType = (TimeSigType)(v.toInt());
         break;
     case Pid::SCALE:
-        _scale = v.value<SizeF>();
+        _scale = v.value<ScaleF>();
         break;
     default:
         if (!EngravingItem::setProperty(propertyId, v)) {

--- a/src/engraving/libmscore/timesig.h
+++ b/src/engraving/libmscore/timesig.h
@@ -120,7 +120,7 @@ public:
 
     void setLargeParentheses(bool v) { _largeParentheses = v; }
 
-    void setScale(const mu::SizeF& s) { _scale = s; }
+    void setScale(const mu::ScaleF& s) { _scale = s; }
 
     void setFrom(const TimeSig*);
 

--- a/src/engraving/property/propertyvalue.cpp
+++ b/src/engraving/property/propertyvalue.cpp
@@ -213,7 +213,11 @@ PropertyValue PropertyValue::fromQVariant(const QVariant& v, P_TYPE type)
     case P_TYPE::KEY_MODE:         return PropertyValue(KeyMode(v.toInt()));
     case P_TYPE::TEXT_STYLE:       return PropertyValue(TextStyleType(v.toInt()));
 
+    // other
+    case P_TYPE::ACCIDENTAL_ROLE: return PropertyValue(Ms::AccidentalRole(v.toInt()));
+    case P_TYPE::SUB_STYLE:       return PropertyValue(v.toInt());
     default:
+        UNREACHABLE;
         break;
     }
 

--- a/src/engraving/property/propertyvalue.h
+++ b/src/engraving/property/propertyvalue.h
@@ -138,6 +138,9 @@ public:
     PropertyValue(const PainterPath& v)
         : m_type(P_TYPE::DRAW_PATH), m_data(make_data<PainterPath>(v)) {}
 
+    PropertyValue(const ScaleF& v)
+        : m_type(P_TYPE::SCALE), m_data(make_data<ScaleF>(v)) {}
+
     PropertyValue(const Spatium& v)
         : m_type(P_TYPE::SPATIUM), m_data(make_data<Spatium>(v)) {}
 

--- a/src/engraving/property/propertyvalue.h
+++ b/src/engraving/property/propertyvalue.h
@@ -318,6 +318,11 @@ public:
                 }
             }
         }
+
+        assert(at);
+        if (!at) {
+            return T();
+        }
         return at->v;
     }
 

--- a/src/engraving/rw/xml.h
+++ b/src/engraving/rw/xml.h
@@ -147,6 +147,7 @@ public:
     bool readBool();
     mu::PointF readPoint();
     mu::SizeF readSize();
+    mu::ScaleF readScale();
     mu::RectF readRect();
     mu::draw::Color readColor();
     Fraction readFraction();

--- a/src/engraving/rw/xmlreader.cpp
+++ b/src/engraving/rw/xmlreader.cpp
@@ -172,6 +172,16 @@ SizeF XmlReader::readSize()
     return p;
 }
 
+ScaleF XmlReader::readScale()
+{
+    Q_ASSERT(tokenType() == QXmlStreamReader::StartElement);
+    ScaleF p;
+    p.setWidth(doubleAttribute("w", 0.0));
+    p.setHeight(doubleAttribute("h", 0.0));
+    skipCurrentElement();
+    return p;
+}
+
 //---------------------------------------------------------
 //   readRect
 //---------------------------------------------------------

--- a/src/engraving/style/style.cpp
+++ b/src/engraving/style/style.cpp
@@ -148,6 +148,11 @@ bool MStyle::readProperties(XmlReader& e)
                 qreal y = e.doubleAttribute("h", 0.0);
                 set(idx, SizeF(x, y));
                 e.readElementText();
+            } else if (P_TYPE::SCALE == type) {
+                qreal sx = e.doubleAttribute("w", 0.0);
+                qreal sy = e.doubleAttribute("h", 0.0);
+                set(idx, ScaleF(sx, sy));
+                e.readElementText();
             } else if (P_TYPE::COLOR == type) {
                 mu::draw::Color c;
                 c.setRed(e.intAttribute("r"));


### PR DESCRIPTION
An attempt was made to compare a value of type string ("20") with a value of type int (20).
Previously, QVariant converted values implicitly if they are of different types and then compared them.
I do not want to add another conversion hack ... I hope we will identify all such situations of a data type mismatch.