### PR TITLE
[MU4] runtime_permissions

### DIFF
--- a/build/macosx_entitlements.plist
+++ b/build/macosx_entitlements.plist
@@ -6,5 +6,9 @@
   <true/>
   <key>com.apple.security.cs.disable-library-validation</key>
   <true/>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
 </dict>
 </plist>


### PR DESCRIPTION
On some devices MAC OS prevents MU4 to launch itself or access runtime resources due to the lack of proper permissions

![image](https://user-images.githubusercontent.com/57620349/145994061-6f53249a-9ac0-4e02-8b00-b3d7dd759c30.png)