### PR TITLE
[MU4] Fix (MinGW/gcc) compiler warnings

### DIFF
--- a/src/framework/mpe/tests/multinotearticulationstest.cpp
+++ b/src/framework/mpe/tests/multinotearticulationstest.cpp
@@ -241,21 +241,21 @@ TEST_F(MultiNoteArticulationsTest, CrescendoPattern)
 
     ArticulationPattern crescendoScope;
 
-    for (int i = 0; i <= dynamicSegmentsCount; ++i) {
+    for (size_t i = 0; i <= dynamicSegmentsCount; ++i) {
         ArticulationPatternSegment crescendoPattern;
         crescendoPattern.arrangementPattern = createArrangementPattern(HUNDRED_PERCENTS /*duration_factor*/, 0 /*timestamp_offset*/);
         crescendoPattern.pitchPattern = createSimplePitchPattern(0 /*increment_pitch_diff*/);
         crescendoPattern.expressionPattern = createSimpleExpressionPattern(dynamicLevelFromType(
-                                                                               DynamicType::Natural) + i * DYNAMIC_LEVEL_STEP
+                                                                               DynamicType::Natural) + static_cast<int>(i) * DYNAMIC_LEVEL_STEP
                                                                            / static_cast<dynamic_level_t>(dynamicSegmentsCount));
 
-        crescendoScope.emplace(25 * ONE_PERCENT * i, std::move(crescendoPattern));
+        crescendoScope.emplace(25 * ONE_PERCENT * static_cast<int>(i), std::move(crescendoPattern));
     }
 
-    for (int i = 0; i < noteCount; ++i) {
+    for (size_t i = 0; i < noteCount; ++i) {
         // [GIVEN] Crescendo articulation applied on the note
-        ArticulationData crescendoApplied(ArticulationType::Crescendo, crescendoScope, 25 * ONE_PERCENT * i,
-                                          25 * ONE_PERCENT * (i + 1), 0, dynamicLevelDiff);
+        ArticulationData crescendoApplied(ArticulationType::Crescendo, crescendoScope, 25 * ONE_PERCENT * static_cast<int>(i),
+                                          25 * ONE_PERCENT * (static_cast<int>(i) + 1), 0, dynamicLevelDiff);
         appliedArticulations[i].emplace(ArticulationType::Crescendo, crescendoApplied);
     }
 

--- a/src/framework/mpe/tests/utils/articulationutils.h
+++ b/src/framework/mpe/tests/utils/articulationutils.h
@@ -40,8 +40,8 @@ inline PitchPattern createSimplePitchPattern(const pitch_level_t incrementDiff =
 {
     PitchPattern result;
 
-    for (int i = 0; i < EXPECTED_SIZE; ++i) {
-        result.pitchOffsetMap.insert_or_assign(i * TEN_PERCENTS, i * incrementDiff);
+    for (size_t i = 0; i < EXPECTED_SIZE; ++i) {
+        result.pitchOffsetMap.insert_or_assign(static_cast<int>(i) * TEN_PERCENTS, static_cast<int>(i) * incrementDiff);
     }
 
     return result;
@@ -53,8 +53,8 @@ inline ExpressionPattern createSimpleExpressionPattern(const dynamic_level_t amp
 
     float amplitudeSqrt = std::sqrt(amplitudeLevel);
 
-    for (int i = 0; i < EXPECTED_SIZE; ++i) {
-        duration_percentage_t currentPos = i * TEN_PERCENTS;
+    for (size_t i = 0; i < EXPECTED_SIZE; ++i) {
+        duration_percentage_t currentPos = static_cast<int>(i) * TEN_PERCENTS;
         dynamic_level_t value = amplitudeLevel - std::pow(
             (2 * (amplitudeSqrt / static_cast<float>(HUNDRED_PERCENTS)) * currentPos) - amplitudeSqrt, 2);
 


### PR DESCRIPTION
Introduced with #10074, to fix warnings for MSVC apparently jumping too short there.
Usually I do test such changes with MSVC **and** MinGW, seems I skiped the MinGW check for #10074