### PR TITLE
Fixed set UiCtxNotationFocused context

### DIFF
--- a/src/context/internal/uicontextresolver.cpp
+++ b/src/context/internal/uicontextresolver.cpp
@@ -97,10 +97,6 @@ UiContext UiContextResolver::currentUiContext() const
             if (activePanel->name() == NOTATION_NAVIGATION_PANEL) {
                 return context::UiCtxNotationFocused;
             }
-        } else {
-            if (m_notationViewFocusedCounter > 0) {
-                return context::UiCtxNotationFocused;
-            }
         }
 
         return context::UiCtxNotationOpened;
@@ -136,17 +132,6 @@ bool UiContextResolver::matchWithCurrent(const UiContext& ctx) const
 mu::async::Notification UiContextResolver::currentUiContextChanged() const
 {
     return m_currentUiContextChanged;
-}
-
-void UiContextResolver::onNotationViewFocuseChanged(bool focused)
-{
-    if (focused) {
-        m_notationViewFocusedCounter++;
-    } else {
-        m_notationViewFocusedCounter--;
-    }
-
-    notifyAboutContextChanged();
 }
 
 bool UiContextResolver::isShortcutContextAllowed(const std::string& scContext) const

--- a/src/context/internal/uicontextresolver.cpp
+++ b/src/context/internal/uicontextresolver.cpp
@@ -148,11 +148,14 @@ bool UiContextResolver::isShortcutContextAllowed(const std::string& scContext) c
 
     static const std::string CTX_ANY("any");
     static const std::string CTX_NOTATION_OPENED("notation-opened");
+    static const std::string CTX_NOT_NOTATION_FOCUSED("not-notation-focused");
     static const std::string CTX_NOTATION_STAFF_STANDARD("notation-staff-standard");
     static const std::string CTX_NOTATION_STAFF_TAB("notation-staff-tab");
 
     if (CTX_NOTATION_OPENED == scContext) {
         return matchWithCurrent(context::UiCtxNotationOpened);
+    } else if (CTX_NOT_NOTATION_FOCUSED == scContext) {
+        return !matchWithCurrent(context::UiCtxNotationFocused);
     } else if (CTX_NOTATION_STAFF_STANDARD == scContext) {
         auto notation = globalContext()->currentNotation();
         if (!notation) {

--- a/src/context/internal/uicontextresolver.h
+++ b/src/context/internal/uicontextresolver.h
@@ -49,15 +49,12 @@ public:
     bool match(const ui::UiContext& currentCtx, const ui::UiContext& actCtx) const override;
     bool matchWithCurrent(const ui::UiContext& ctx) const override;
 
-    void onNotationViewFocuseChanged(bool focused) override;
-
     bool isShortcutContextAllowed(const std::string& scContext) const override;
 
 private:
     void notifyAboutContextChanged();
 
     async::Notification m_currentUiContextChanged;
-    int m_notationViewFocusedCounter = 0;
 };
 }
 

--- a/src/framework/shortcuts/data/shortcuts-Mac.xml
+++ b/src/framework/shortcuts/data/shortcuts-Mac.xml
@@ -85,10 +85,8 @@
     <SC>
       <key>nav-trigger-control</key>
       <seq>Return</seq>
-    </SC>
-    <SC>
-      <key>nav-trigger-control</key>
       <seq>Space</seq>
+      <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-escape</key>

--- a/src/framework/shortcuts/data/shortcuts.xml
+++ b/src/framework/shortcuts/data/shortcuts.xml
@@ -85,10 +85,8 @@
     <SC>
       <key>nav-trigger-control</key>
       <seq>Return</seq>
-    </SC>
-    <SC>
-      <key>nav-trigger-control</key>
       <seq>Space</seq>
+      <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-escape</key>

--- a/src/framework/shortcuts/data/shortcuts_AZERTY.xml
+++ b/src/framework/shortcuts/data/shortcuts_AZERTY.xml
@@ -85,10 +85,8 @@
     <SC>
       <key>nav-trigger-control</key>
       <seq>Return</seq>
-    </SC>
-    <SC>
-      <key>nav-trigger-control</key>
       <seq>Space</seq>
+      <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-escape</key>

--- a/src/framework/ui/internal/navigationcontroller.cpp
+++ b/src/framework/ui/internal/navigationcontroller.cpp
@@ -278,7 +278,7 @@ void NavigationController::init()
     dispatcher()->reg(this, "nav-next-tab", [this]() { navigateTo(NavigationType::NextPanel); });
     dispatcher()->reg(this, "nav-prev-tab", [this]() { navigateTo(NavigationType::PrevPanel); });
 
-    dispatcher()->reg(this, "nav-trigger-control", [this]() { navigateTo(NavigationType::TriggerControl); });
+    dispatcher()->reg(this, "nav-trigger-control", [this]() { doTriggerControl(); });
 
     dispatcher()->reg(this, "nav-right", [this]() { navigateTo(NavigationType::Right); });
     dispatcher()->reg(this, "nav-left", [this]() { navigateTo(NavigationType::Left); });
@@ -389,9 +389,6 @@ void NavigationController::navigateTo(NavigationController::NavigationType type)
         break;
     case NavigationType::Down:
         onDown();
-        break;
-    case NavigationType::TriggerControl:
-        doTriggerControl();
         break;
     case NavigationType::FirstControl:
         goToFirstControl();

--- a/src/framework/ui/internal/navigationcontroller.h
+++ b/src/framework/ui/internal/navigationcontroller.h
@@ -83,7 +83,6 @@ private:
         Right,
         Up,
         Down,
-        TriggerControl,
         FirstControl,
         LastControl,
         NextRowControl,

--- a/src/framework/ui/iuicontextresolver.h
+++ b/src/framework/ui/iuicontextresolver.h
@@ -41,8 +41,6 @@ public:
     virtual bool match(const ui::UiContext& currentCtx, const ui::UiContext& actCtx) const = 0;
     virtual bool matchWithCurrent(const ui::UiContext& ctx) const = 0;
 
-    virtual void onNotationViewFocuseChanged(bool focused) = 0;
-
     virtual bool isShortcutContextAllowed(const std::string& scContext) const = 0;
 };
 

--- a/src/notation/qml/MuseScore/NotationScene/NotationView.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NotationView.qml
@@ -118,6 +118,10 @@ FocusScope {
                         }
                     }
 
+                    onActiveFocusRequested: {
+                        fakeNavCtrl.requestActive()
+                    }
+
                     onTextEdittingStarted: {
                         root.textEdittingStarted()
                     }

--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -861,12 +861,6 @@ bool NotationPaintView::event(QEvent* ev)
         shortcutOverride(dynamic_cast<QKeyEvent*>(ev));
     }
 
-    if (ev->type() == QEvent::Type::FocusIn || ev->type() == QEvent::Type::FocusOut) {
-        bool ok = QQuickPaintedItem::event(ev);
-        uiContextResolver()->onNotationViewFocuseChanged(hasFocus());
-        return ok;
-    }
-
     return QQuickPaintedItem::event(ev);
 }
 


### PR DESCRIPTION
Now the navigation system always works (but the focus is not always highlighted), so it can be used to determine where we are now