### PR TITLE
fix GH#9448: 'Offset' parameter not editable in MS4

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/common/OffsetSection.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/common/OffsetSection.qml
@@ -35,8 +35,11 @@ InspectorPropertyView {
     property alias horizontalOffsetControl: horizontalOffsetControl
     property alias verticalOffsetControl: verticalOffsetControl
 
+    property var onlyOne: (Boolean(horizontalOffset) && !Boolean(verticalOffset))
+                          || (Boolean(verticalOffset) && !Boolean(horizontalOffset))
+
     titleText: qsTrc("inspector", "Offset")
-    propertyItem: root.horizontalOffset
+    propertyItem: Boolean(horizontalOffset) ? horizontalOffset : verticalOffset
 
     navigationName: "OffsetSection"
     navigationRowEnd: verticalOffsetControl.navigation.row
@@ -54,7 +57,7 @@ InspectorPropertyView {
         IncrementalPropertyControl {
             id: horizontalOffsetControl
 
-            Layout.preferredWidth: parent.width / 2 - row.spacing / 2
+            Layout.preferredWidth: onlyOne ? parent.width : parent.width / 2 - row.spacing / 2
 
             navigation.name: "HorizontalOffsetControl"
             navigation.panel: root.navigationPanel
@@ -77,7 +80,7 @@ InspectorPropertyView {
         IncrementalPropertyControl {
             id: verticalOffsetControl
 
-            Layout.preferredWidth: parent.width / 2 - row.spacing / 2
+            Layout.preferredWidth: onlyOne ? parent.width : parent.width / 2 - row.spacing / 2
 
             navigation.name: "VerticalOffsetControl"
             navigation.panel: root.navigationPanel

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/stafftype/StaffTypeSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/stafftype/StaffTypeSettings.qml
@@ -65,10 +65,9 @@ Column {
 
             verticalOffset: root.model ? root.model.verticalOffset : null
 
-            verticalOffsetControl.step: 0.1
-            verticalOffsetControl.decimals: 2
-            verticalOffsetControl.minValue: 0.1
-            verticalOffsetControl.maxValue: 5
+            verticalOffsetControl.decimals: 1
+            verticalOffsetControl.maxValue: 20
+            verticalOffsetControl.minValue: -20
 
             navigationPanel: root.navigationPanel
             navigationRowStart: root.navigationRowStart + 1


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/46259489/146391015-f74008b0-4f0f-425b-9f0a-00b3a9ad6507.png)
Fixes #9448. I also fixed the width of the input box and adjusted the properties of it to be the same as in MuseScore 3. If some of the property changes are not desirable, please tell me.