### PR TITLE
Manual beams

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -820,8 +820,6 @@ void Beam::offsetBeamToRemoveCollisions(std::vector<ChordRest*> chordRests, int&
 
 void Beam::extendStems(std::vector<ChordRest*> chordRests)
 {
-    ChordRest* startChordRest = chordRests[0];
-    ChordRest* endChordRest = chordRests[chordRests.size() - 1];
     for (ChordRest* chordRest : chordRests) {
         if (!chordRest->isChord()) {
             continue;
@@ -1025,8 +1023,15 @@ void Beam::layout2(std::vector<ChordRest*> chordRests, SpannerSegmentType, int f
 
     int fragmentIndex = (_direction == DirectionV::AUTO || _direction == DirectionV::DOWN) ? 0 : 1;
     if (_userModified[fragmentIndex]) {
-        _startAnchor.setY(fragments[frag]->py1[fragmentIndex]);
-        _endAnchor.setY(fragments[frag]->py2[fragmentIndex]);
+        qreal startY = fragments[frag]->py1[fragmentIndex];
+        qreal endY = fragments[frag]->py2[fragmentIndex];
+        if (score()->styleB(Sid::snapCustomBeamsToGrid)) {
+            const qreal quarterSpace = spatium() / 4;
+            startY = round(startY / quarterSpace) * quarterSpace;
+            endY = round(endY / quarterSpace) * quarterSpace;
+        }
+        _startAnchor.setY(startY);
+        _endAnchor.setY(endY);
         _slope = (_endAnchor.y() - _startAnchor.y()) / (_endAnchor.x() - _startAnchor.x());
         extendStems(chordRests);
         createBeamSegments(chordRests);

--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -1007,8 +1007,6 @@ void Beam::layout2(std::vector<ChordRest*> chordRests, SpannerSegmentType, int f
         LayoutBeams::respace(&chordRests);
     }
 
-    _beamSpacing = score()->styleB(Sid::useWideBeams) ? 4 : 3;
-
     if (!chordRests.front()->isChord() || !chordRests.back()->isChord()) {
         NOT_IMPL_RETURN;
     }
@@ -1020,6 +1018,8 @@ void Beam::layout2(std::vector<ChordRest*> chordRests, SpannerSegmentType, int f
     // anchor represents the middle of the beam, not the tip of the stem
     _startAnchor = chordBeamAnchor(startChord);
     _endAnchor = chordBeamAnchor(endChord);
+    _beamSpacing = score()->styleB(Sid::useWideBeams) ? 4 : 3;
+    _beamDist = (_beamSpacing / 4.0) * spatium() * mag();
 
     int fragmentIndex = (_direction == DirectionV::AUTO || _direction == DirectionV::DOWN) ? 0 : 1;
     if (_userModified[fragmentIndex]) {
@@ -1061,8 +1061,6 @@ void Beam::layout2(std::vector<ChordRest*> chordRests, SpannerSegmentType, int f
 
     _startAnchor.setY(quarterSpace * (isStartDictator ? dictator : pointer));
     _endAnchor.setY(quarterSpace * (isStartDictator ? pointer : dictator));
-
-    _beamDist = (_beamSpacing / 4.0) * spatium() * mag();
 
     add8thSpaceSlant(isStartDictator ? _startAnchor : _endAnchor, dictator, pointer, beamCount, interval, middleLine, isFlat);
 

--- a/src/engraving/libmscore/beam.h
+++ b/src/engraving/libmscore/beam.h
@@ -64,6 +64,8 @@ class Beam final : public EngravingItem
     qreal _grow2            { 1.0f };
     qreal _beamDist         { 0.0f };
     int _beamSpacing        { 3 }; // how far apart beams are spaced in quarter spaces
+    mu::PointF _startAnchor;
+    mu::PointF _endAnchor;
 
     QVector<BeamFragment*> fragments;       // beam splits across systems
 
@@ -93,7 +95,7 @@ class Beam final : public EngravingItem
                                bool isAscending);
     void addMiddleLineSlant(int& dictator, int& pointer, int beamCount, int middleLine, int interval);
     void add8thSpaceSlant(mu::PointF& dictatorAnchor, int dictator, int pointer, int beamCount, int interval, int middleLine, bool isFlat);
-    void extendStems(std::vector<ChordRest*> chordRests, mu::PointF start, mu::PointF end);
+    void extendStems(std::vector<ChordRest*> chordRests);
     mu::PointF chordBeamAnchor(Chord* chord) const;
     bool calcIsBeamletBefore(Chord* chord, int i, int level) const;
     void createBeamSegment(Chord* startChord, Chord* endChord, int level);
@@ -180,6 +182,9 @@ public:
     void setBeamPos(const mu::engraving::PairF& bp);
 
     qreal beamDist() const { return _beamDist; }
+
+    inline const mu::PointF startAnchor() const { return _startAnchor; }
+    inline const mu::PointF endAnchor() const { return _endAnchor; }
 
     mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -932,12 +932,13 @@ void Chord::computeUp()
     }
 
     if (_beam) {
-        if (_beam->userModified()) {
-            double noteY = (upNote()->pos() + segment()->pos() + measure()->pos()).y();
+        if (_beam->userModified() || _beam->cross()) {
+            double noteY = upNote()->pagePos().y();
             PointF startAnchor = _beam->startAnchor();
             PointF endAnchor = _beam->endAnchor();
             if (this == _beam->elements().first()) {
                 _up = noteY > startAnchor.y();
+                // std::cout << "noteY: " << noteY << " startAnchor: " << startAnchor.y() << " up: " << _up << std::endl;
             } else if (this == _beam->elements().last()) {
                 _up = noteY > endAnchor.y();
             } else {

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -926,13 +926,29 @@ void Chord::computeUp()
 
     _usesAutoUp = false;
 
-    if (_beam) {
-        _up = _beam->up();
+    if (_isUiItem) {
+        _up = true;
         return;
     }
 
-    if (_isUiItem) {
-        _up = true;
+    if (_beam) {
+        if (_beam->userModified()) {
+            double noteY = (upNote()->pos() + segment()->pos() + measure()->pos()).y();
+            PointF startAnchor = _beam->startAnchor();
+            PointF endAnchor = _beam->endAnchor();
+            if (this == _beam->elements().first()) {
+                _up = noteY > startAnchor.y();
+            } else if (this == _beam->elements().last()) {
+                _up = noteY > endAnchor.y();
+            } else {
+                double noteX = stemPosX() + pagePos().x() + _beam->pagePos().x() + measure()->pos().x();
+                qreal proportionAlongX = (noteX - startAnchor.x()) / (endAnchor.x() - startAnchor.x());
+                qreal desiredY = proportionAlongX * (endAnchor.y() - startAnchor.y()) + startAnchor.y();
+                _up = noteY > desiredY;
+            }
+        } else {
+            _up = _beam->up();
+        }
         return;
     }
 

--- a/src/engraving/libmscore/stem.cpp
+++ b/src/engraving/libmscore/stem.cpp
@@ -111,6 +111,10 @@ void Stem::layout()
         if (chord()->hook() && !chord()->beam()) {
             y2 += chord()->hook()->smuflAnchor().y();
         }
+
+        if (chord()->beam()) {
+            y2 -= _up * point(score()->styleS(Sid::beamWidth)) * .5 * chord()->beam()->mag();
+        }
     }
 
     double lineWidthCorrection = lineWidthMag() * 0.5;

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -215,7 +215,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::useWideBeams,            "useWideBeams",            false },
     { Sid::beamMinLen,              "beamMinLen",              Spatium(1.3) },     // 1.316178 exactly notehead widthen beams
     { Sid::beamNoSlope,             "beamNoSlope",             false },
-    { Sid::snapCustomBeamsToGrid,   "snapCustomBeamsToGrid",   false },
+    { Sid::snapCustomBeamsToGrid,   "snapCustomBeamsToGrid",   true },
 
     { Sid::dotMag,                  "dotMag",                  PropertyValue(1.0) },
     { Sid::dotNoteDistance,         "dotNoteDistance",         Spatium(0.5) },

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -215,6 +215,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::useWideBeams,            "useWideBeams",            false },
     { Sid::beamMinLen,              "beamMinLen",              Spatium(1.3) },     // 1.316178 exactly notehead widthen beams
     { Sid::beamNoSlope,             "beamNoSlope",             false },
+    { Sid::snapCustomBeamsToGrid,   "snapCustomBeamsToGrid",   false },
 
     { Sid::dotMag,                  "dotMag",                  PropertyValue(1.0) },
     { Sid::dotNoteDistance,         "dotNoteDistance",         Spatium(0.5) },

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -226,6 +226,7 @@ enum class Sid {
     useWideBeams,
     beamMinLen,
     beamNoSlope,
+    snapCustomBeamsToGrid,
 
     dotMag,
     dotNoteDistance,


### PR DESCRIPTION
Allows for manual adjustment for beams.

- Can use your mouse to adjust beam endpoints
- Adds style parameter for snapping beams to the quarter-space grid (https://github.com/musescore/MuseScore/issues/10114)
- Accounts for custom stem widths

> Note: this is still draft because there are a few known edge cases to fix, tests to add, and will need to be refactored once https://github.com/musescore/MuseScore/pull/10039 is merged