### PR TITLE
fix whole note tremolo positions

### DIFF
--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -1334,8 +1334,8 @@ int Chord::calcMinStemLength()
         // so we need to multiply it by 2 to get the actual height
         int buzzRollMultiplier = _tremolo->isBuzzRoll() ? 2 : 1;
         minStemLength += ceil(_tremolo->minHeight() * 4.0 * buzzRollMultiplier);
-        static const int outSidePadding = 2;
-        static const int noteSidePadding = 6;
+        static const int outSidePadding = score()->styleMM(Sid::tremoloOutSidePadding).val() / _spatium * 4.0;
+        static const int noteSidePadding = score()->styleMM(Sid::tremoloNoteSidePadding).val() / _spatium * 4.0;
         int line = _up ? upNote()->line() : downNote()->line();
         line *= 2; // convert to quarter spaces
         int outsideStaffOffset = 0;

--- a/src/engraving/libmscore/tremolo.cpp
+++ b/src/engraving/libmscore/tremolo.cpp
@@ -282,7 +282,7 @@ void Tremolo::layoutOneNoteTremolo(qreal x, qreal y, qreal h, qreal spatium)
     bool up = chord()->up();
     int upValue = up ? -1 : 1;
 
-    qreal yOffset = h - 0.5 * spatium;
+    qreal yOffset = h - score()->styleMM(Sid::tremoloOutSidePadding).val();
 
     int beams = chord()->beams();
     if (chord()->hook()) {
@@ -501,7 +501,7 @@ void Tremolo::layout()
         return;
     }
 
-    Note* anchor1 = _chord1->upNote();
+    Note* anchor1 = _chord1->up() ? _chord1->upNote() : _chord1->downNote();
     Stem* stem    = _chord1->stem();
     qreal x, y, h;
     if (stem) {
@@ -510,12 +510,21 @@ void Tremolo::layout()
         h = stem->length();
     } else {
         // center tremolo above note
-        x = anchor1->x() + anchor1->headWidth() * .5;
-        y = anchor1->y();
-        h = 2.0 * spatium() + bbox().height();
-        if (anchor1->line() > 4) {
-            h *= -1;
+        x = anchor1->x() + anchor1->headWidth() * 0.5;
+        if (!twoNotes()) {
+            bool hasMirroredNote = false;
+            for (Note* n : _chord1->notes()) {
+                if (n->mirror()) {
+                    hasMirroredNote = true;
+                    break;
+                }
+            }
+            if (hasMirroredNote) {
+                x = _chord1->stemPosX();
+            }
         }
+        y = anchor1->y();
+        h = score()->styleMM(Sid::tremoloNoteSidePadding).val() + bbox().height();
     }
 
     if (twoNotes()) {

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -570,6 +570,8 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::tremoloDistance,         "tremoloDistance",         Spatium(0.8) },
     { Sid::tremoloStyle,            "tremoloStrokeStyle",      int(TremoloStyle::DEFAULT) },
     { Sid::tremoloStrokeLengthMultiplier, "tremoloStrokeLengthMultiplier", 0.62 },
+    { Sid::tremoloNoteSidePadding,  "tremoloNoteSidePadding",  Spatium(1.25) },
+    { Sid::tremoloOutSidePadding,   "tremoloOutSidePadding",   Spatium(0.5) },
 
     { Sid::linearStretch,           "linearStretch",           PropertyValue(qreal(1.5)) },
     { Sid::crossMeasureValues,      "crossMeasureValues",      false },

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -578,6 +578,8 @@ enum class Sid {
     tremoloDistance,
     tremoloStyle,
     tremoloStrokeLengthMultiplier,
+    tremoloNoteSidePadding,
+    tremoloOutSidePadding,
     // TODO tremoloMaxBeamLength,
 
     linearStretch,


### PR DESCRIPTION
Positions one-note tremolos on whole notes identically to those on stemmed notes. I also removed the magic numbers by creating two new style parameters. That way there's a single source of truth for the position for the tremolos.