### PR TITLE
Fix #10137: Fixed note/rest duration shortcut

### DIFF
--- a/src/context/internal/uicontextresolver.cpp
+++ b/src/context/internal/uicontextresolver.cpp
@@ -163,7 +163,7 @@ bool UiContextResolver::isShortcutContextAllowed(const std::string& scContext) c
     } else if (CTX_NOT_NOTATION_FOCUSED == scContext) {
         return !matchWithCurrent(context::UiCtxNotationFocused);
     } else if (CTX_NOTATION_STAFF_STANDARD == scContext) {
-        if (matchWithCurrent(context::UiCtxNotationFocused)) {
+        if (!matchWithCurrent(context::UiCtxNotationFocused)) {
             return false;
         }
         auto notation = globalContext()->currentNotation();

--- a/src/framework/shortcuts/data/shortcuts-Mac.xml
+++ b/src/framework/shortcuts/data/shortcuts-Mac.xml
@@ -61,10 +61,12 @@
     <SC>
         <key>nav-up</key>
         <seq>Up</seq>
+        <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
         <key>nav-down</key>
         <seq>Down</seq>
+        <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-first-control</key>

--- a/src/framework/shortcuts/data/shortcuts.xml
+++ b/src/framework/shortcuts/data/shortcuts.xml
@@ -61,10 +61,12 @@
     <SC>
         <key>nav-up</key>
         <seq>Up</seq>
+        <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
         <key>nav-down</key>
         <seq>Down</seq>
+        <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-first-control</key>
@@ -399,7 +401,7 @@
   <SC>
     <key>move-up</key>
     <seq>Ctrl+Shift+Up</seq>
-    <ctx>notation-focused</ctx>
+    <ctx>notation-staff-standard</ctx>
     </SC>
   <SC>
     <key>pitch-down</key>

--- a/src/framework/shortcuts/data/shortcuts_AZERTY.xml
+++ b/src/framework/shortcuts/data/shortcuts_AZERTY.xml
@@ -61,10 +61,12 @@
     <SC>
         <key>nav-up</key>
         <seq>Up</seq>
+        <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
         <key>nav-down</key>
         <seq>Down</seq>
+        <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-first-control</key>


### PR DESCRIPTION
Resolves: #10137 

*(short description of the changes and the motivation to make the changes)*

Though, initially changing uicontextresolver.cpp fixed the original
issue, I came across another bug in which up and down shortcuts were not working
for changing pitch. This new bug maybe related to the original fix. I
fixed the second bug by adding a context for nav-up and nav-down

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
