### PR TITLE
Fix #9845: Fixed Non-MuseScore files not saved

### DIFF
--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -258,6 +258,8 @@ mu::Ret NotationProject::doImport(const io::path& path, const io::path& stylePat
     m_masterNotation = std::shared_ptr<MasterNotation>(new MasterNotation());
     m_masterNotation->setMasterScore(project->masterScore());
 
+    m_masterNotation->score()->setCreated(true);
+
     m_projectAudioSettings = audioSettings;
     m_viewSettings = viewSettings;
 


### PR DESCRIPTION
Resolves: #9845 

*(short description of the changes and the motivation to make the changes)*

Prior to this commit, you would not be able to save edits in
non-MuseScore Files as a MuseScore file. But, with this commit, you can
save Files like MIDI opened in MuseScore as a MuseScore file like mscz.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
