### PR TITLE
Changed Additional Score Info default values

### DIFF
--- a/src/project/qml/MuseScore/Project/internal/GeneralInfoItem.qml
+++ b/src/project/qml/MuseScore/Project/internal/GeneralInfoItem.qml
@@ -28,7 +28,7 @@ Column {
     id: root
 
     property string title: ""
-    property alias info: textField.currentText
+    property alias info: textField.hint
 
     property alias navigation: textField.navigation
 
@@ -45,7 +45,6 @@ Column {
 
     TextInputField {
         id: textField
-        hint: qsTrc("project", "Optional")
 
         navigation.accessible.name: root.title + " " + currentText
 


### PR DESCRIPTION
Resolves: #10076 

*(short description of the changes and the motivation to make the changes)*

This commit changes default values of Additonal Score Info. With this
commit, the default values have been "hinted", that is greyed out.
Also, the default value of all five fields except Title has been
removed since they didn't seem to be adding any meaningful information.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
