### PR TITLE
Fixed Notation Page not updating to Home Page when closing project and first launch setup

### DIFF
--- a/src/appshell/view/firstlaunchsetup/firstlaunchsetupmodel.cpp
+++ b/src/appshell/view/firstlaunchsetup/firstlaunchsetupmodel.cpp
@@ -27,8 +27,8 @@ FirstLaunchSetupModel::FirstLaunchSetupModel(QObject* parent)
     : QObject(parent)
 {
     m_pages = {
-        Page { "ThemesPage.qml", "musescore://notation" },
-        Page { "PlaybackPage.qml", "musescore://notation", /*canSkip*/ true },
+        Page { "ThemesPage.qml", "musescore://home" },
+        Page { "PlaybackPage.qml", "musescore://home", /*canSkip*/ true },
         Page { "TutorialsPage.qml", "musescore://home?section=learn" }
     };
 }

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -39,6 +39,7 @@ using namespace mu::framework;
 using namespace mu::actions;
 
 static mu::Uri NOTATION_PAGE_URI("musescore://notation");
+static mu::Uri HOME_PAGE_URI("musescore://home");
 static mu::Uri NEW_SCORE_URI("musescore://project/newscore");
 
 void ProjectActionsController::init()
@@ -153,7 +154,7 @@ Ret ProjectActionsController::openProject(const io::path& projectPath_)
 
     //! Step 2. If the project is already open in the current window, then just switch to showing the notation
     if (isProjectOpened(projectPath)) {
-        return openNotationPageIfNeed();
+        return openPageIfNeed(NOTATION_PAGE_URI);
     }
 
     //! Step 3. Check, if the project already opened in another window, then activate the window with the project
@@ -200,16 +201,16 @@ Ret ProjectActionsController::doOpenProject(const io::path& filePath)
 
     prependToRecentScoreList(filePath);
 
-    return openNotationPageIfNeed();
+    return openPageIfNeed(NOTATION_PAGE_URI);
 }
 
-mu::Ret ProjectActionsController::openNotationPageIfNeed()
+Ret ProjectActionsController::openPageIfNeed(Uri pageUri)
 {
-    if (interactive()->isOpened(NOTATION_PAGE_URI).val) {
+    if (interactive()->isOpened(pageUri).val) {
         return make_ret(Ret::Code::Ok);
     }
 
-    return interactive()->open(NOTATION_PAGE_URI).ret;
+    return interactive()->open(pageUri).ret;
 }
 
 bool ProjectActionsController::isProjectOpened(const io::path& scorePath) const
@@ -271,7 +272,7 @@ void ProjectActionsController::newProject()
     Ret ret = interactive()->open(NEW_SCORE_URI).ret;
 
     if (ret) {
-        ret = openNotationPageIfNeed();
+        ret = openPageIfNeed(NOTATION_PAGE_URI);
     }
 
     if (!ret) {
@@ -309,6 +310,11 @@ bool ProjectActionsController::closeOpenedProject(bool quitApp)
 
         if (quitApp) {
             dispatcher()->dispatch("quit", actions::ActionData::make_arg1<bool>(false));
+        } else {
+            Ret ret = openPageIfNeed(HOME_PAGE_URI);
+            if (!ret) {
+                LOGE() << ret.toString();
+            }
         }
     }
 

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -103,7 +103,7 @@ private:
     Ret doOpenProject(const io::path& filePath);
     bool doSaveScore(const io::path& filePath = io::path(), project::SaveMode saveMode = project::SaveMode::Save);
 
-    Ret openNotationPageIfNeed();
+    Ret openPageIfNeed(Uri pageUri);
 
     void exportScore();
     void printScore();


### PR DESCRIPTION
Resolves: #10172 

Closing the project and first launch set up now changes the current page from notation page to home page. 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
