### PR TITLE
Fix #9538: Fixed no language selected by default

### DIFF
--- a/src/appshell/qml/Preferences/GeneralPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/GeneralPreferencesPage.qml
@@ -57,6 +57,10 @@ PreferencesPage {
                 root.hideRequested()
                 preferencesModel.openUpdateTranslationsPage()
             }
+
+            onChangeCurrentLanguage: function(newLanguage) {
+                preferencesModel.currentLanguageCode(newLanguage);
+            }
         }
 
         SeparatorLine { }

--- a/src/appshell/qml/Preferences/internal/LanguagesSection.qml
+++ b/src/appshell/qml/Preferences/internal/LanguagesSection.qml
@@ -37,6 +37,9 @@ BaseSection {
 
     signal languageSelected(string languageCode)
     signal updateTranslationsRequested()
+    signal changeCurrentLanguage(string newLanguage)
+
+    property string fallbackLanguage: "en_US";
 
     Row {
         spacing: 12
@@ -50,7 +53,7 @@ BaseSection {
             textRole: "name"
             valueRole: "code"
 
-            currentIndex: dropdown.indexOfValue(root.currentLanguageCode)
+            currentIndex: findIndexOfValue(root.currentLanguageCode)
 
             navigation.name: "LanguagesBox"
             navigation.panel: root.navigation
@@ -58,6 +61,15 @@ BaseSection {
 
             onCurrentValueChanged: {
                 root.languageSelected(dropdown.currentValue)
+            }
+
+            function findIndexOfValue(languageCode) {
+                var index = dropdown.indexOfValue(languageCode)
+                if (index < 0) {
+                    changeCurrentLanguage(root.fallbackLanguage)
+                    index = dropdown.indexOfValue(root.fallbackLanguage)
+                }
+                return index
             }
         }
 


### PR DESCRIPTION
Resolves: #9538 

*(short description of the changes and the motivation to make the changes)*

This commit fix no language selected by default. The problem was that if
your system language was not part of the existing list of languages,
there would be no default language. Therefore, I have introduced
a fallback language which is English (US) which would be used as the
default language in the specified case

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
