### PR TITLE
fix build issues on main branch

### DIFF
--- a/src/engraving/utests/playbackeventsrendering_tests.cpp
+++ b/src/engraving/utests/playbackeventsrendering_tests.cpp
@@ -360,9 +360,9 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_Turn_Regular)
     int expectedSubNotesCount = 4;
     duration_t expectedDuration = QUARTER_NOTE_DURATION / expectedSubNotesCount;
     pitch_level_t nominalPitchLevel = pitchLevel(PitchClass::F, 4);
-    std::vector<pitch_level_t> expectedPitches = { nominalPitchLevel + PITCH_LEVEL_STEP,
+    std::vector<pitch_level_t> expectedPitches = { static_cast<short>(nominalPitchLevel + PITCH_LEVEL_STEP),
                                                    nominalPitchLevel,
-                                                   nominalPitchLevel - PITCH_LEVEL_STEP,
+                                                   static_cast<short>(nominalPitchLevel - PITCH_LEVEL_STEP),
                                                    nominalPitchLevel };
 
     // [GIVEN] Fulfill articulations profile with dummy patterns
@@ -414,9 +414,9 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_Turn_Inverted)
     int expectedSubNotesCount = 4;
     duration_t expectedDuration = QUARTER_NOTE_DURATION / expectedSubNotesCount;
     pitch_level_t nominalPitchLevel = pitchLevel(PitchClass::F, 4);
-    std::vector<pitch_level_t> expectedPitches = { nominalPitchLevel - PITCH_LEVEL_STEP,
+    std::vector<pitch_level_t> expectedPitches = { static_cast<short>(nominalPitchLevel - PITCH_LEVEL_STEP),
                                                    nominalPitchLevel,
-                                                   nominalPitchLevel + PITCH_LEVEL_STEP,
+                                                   static_cast<short>(nominalPitchLevel + PITCH_LEVEL_STEP),
                                                    nominalPitchLevel };
 
     // [GIVEN] Fulfill articulations profile with dummy patterns
@@ -470,9 +470,9 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_Turn_Inverted_Slash_Variation)
     int expectedSubNotesCount = 4;
     duration_t expectedDuration = QUARTER_NOTE_DURATION / expectedSubNotesCount;
     pitch_level_t nominalPitchLevel = pitchLevel(PitchClass::F, 4);
-    std::vector<pitch_level_t> expectedPitches = { nominalPitchLevel - PITCH_LEVEL_STEP,
+    std::vector<pitch_level_t> expectedPitches = { static_cast<short>(nominalPitchLevel - PITCH_LEVEL_STEP),
                                                    nominalPitchLevel,
-                                                   nominalPitchLevel + PITCH_LEVEL_STEP,
+                                                   static_cast<short>(nominalPitchLevel + PITCH_LEVEL_STEP),
                                                    nominalPitchLevel };
 
     // [GIVEN] Fulfill articulations profile with dummy patterns
@@ -539,7 +539,7 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_Upper_Mordent)
 
     std::vector<pitch_level_t> expectedPitches = {
         nominalPitchLevel,
-        nominalPitchLevel + PITCH_LEVEL_STEP,
+        static_cast<short>(nominalPitchLevel + PITCH_LEVEL_STEP),
         nominalPitchLevel
     };
 
@@ -607,7 +607,7 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_Lower_Mordent)
 
     std::vector<pitch_level_t> expectedPitches = {
         nominalPitchLevel,
-        nominalPitchLevel - PITCH_LEVEL_STEP,
+        static_cast<short>(nominalPitchLevel - PITCH_LEVEL_STEP),
         nominalPitchLevel
     };
 


### PR DESCRIPTION
The main branch currently has many build errors. This PR fixes them by adding the required static casts:

```
/src/engraving/utests/playbackeventsrendering_tests.cpp:610:9: error: non-constant-expression cannot be narrowed from type 'int' to 'short' in initializer list [-Wc++11-narrowing]
        nominalPitchLevel - PITCH_LEVEL_STEP,
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/src/engraving/utests/playbackeventsrendering_tests.cpp:610:9: note: insert an explicit cast to silence this issue
        nominalPitchLevel - PITCH_LEVEL_STEP,
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        static_cast<short>(                 )
```