### PR TITLE
Fix #10192, #9096: Fixed zoom in not working with Ctrl++

### DIFF
--- a/src/framework/shortcuts/data/shortcuts.xml
+++ b/src/framework/shortcuts/data/shortcuts.xml
@@ -834,7 +834,7 @@
     </SC>
   <SC>
     <key>zoomin</key>
-    <seq>Ctrl++</seq>
+    <seq>Ctrl+=</seq>
     </SC>
   <SC>
     <key>zoomout</key>


### PR DESCRIPTION
Resolves: #9096
Resolves: #10192

*(short description of the changes and the motivation to make the changes)*

The problem was the shortcut was just Ctrl + +. This meant I had to use
shift + = to get the + similar to how you type in + (By holding shift +
=). So, I changed the shortcut sequence to Ctrl+=

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
