### PR TITLE
Fix #7654: Added ability to hide multiple instruments at once

### DIFF
--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/InstrumentsPanel.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/InstrumentsPanel.qml
@@ -276,6 +276,10 @@ Item {
                                 onPopupClosed: {
                                     flickable.contentY = contentYBackup
                                 }
+
+                                onVisibilityChanged: function(visible) {
+                                    instrumentsTreeModel.toggleVisibilityOfSelectedRows(visible);
+                                }
                             }
                         }
 

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsTreeItemDelegate.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsTreeItemDelegate.qml
@@ -49,6 +49,8 @@ FocusableControl {
     signal popupOpened(var popupX, var popupY, var popupHeight)
     signal popupClosed()
 
+    signal visibilityChanged(bool visible)
+
     QtObject {
         id: prv
 
@@ -199,7 +201,11 @@ FocusableControl {
                     return
                 }
 
-                model.itemRole.isVisible = !isVisible
+                if (root.isSelected) {
+                    root.visibilityChanged(!isVisible)
+                } else {
+                    model.itemRole.isVisible = !isVisible
+                }
             }
         }
 

--- a/src/instrumentsscene/view/instrumentspaneltreemodel.cpp
+++ b/src/instrumentsscene/view/instrumentspaneltreemodel.cpp
@@ -414,6 +414,21 @@ bool InstrumentsPanelTreeModel::moveRows(const QModelIndex& sourceParent, int so
     return true;
 }
 
+void InstrumentsPanelTreeModel::toggleVisibilityOfSelectedRows(bool visible)
+{
+    if (!m_selectionModel || !m_selectionModel->hasSelection()) {
+        return;
+    }
+
+    QModelIndexList selectedIndexes = m_selectionModel->selectedIndexes();
+
+    for (QModelIndex index : selectedIndexes) {
+        AbstractInstrumentsPanelTreeItem* item = modelIndexToItem(index);
+
+        item->setIsVisible(visible);
+    }
+}
+
 QItemSelectionModel* InstrumentsPanelTreeModel::selectionModel() const
 {
     return m_selectionModel;

--- a/src/instrumentsscene/view/instrumentspaneltreemodel.h
+++ b/src/instrumentsscene/view/instrumentspaneltreemodel.h
@@ -78,6 +78,7 @@ public:
     Q_INVOKABLE void moveSelectedRowsUp();
     Q_INVOKABLE void moveSelectedRowsDown();
     Q_INVOKABLE void removeSelectedRows();
+    Q_INVOKABLE void toggleVisibilityOfSelectedRows(bool visible);
 
     Q_INVOKABLE bool moveRows(const QModelIndex& sourceParent, int sourceRow, int count, const QModelIndex& destinationParent,
                               int destinationChild) override;


### PR DESCRIPTION
Resolves: #7654
Closes: #7940

This PR solved #7654 and also adds the ability to select multiple instruments using Ctrl

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
