### PR TITLE
[MU4] Turn `enum : char` into `enum : signed char` if it contains negative values

### DIFF
--- a/src/engraving/libmscore/textbase.h
+++ b/src/engraving/libmscore/textbase.h
@@ -46,7 +46,7 @@ enum class FrameType : char {
 //   VerticalAlignment
 //---------------------------------------------------------
 
-enum class VerticalAlignment : char {
+enum class VerticalAlignment : signed char {
     AlignUndefined = -1, AlignNormal, AlignSuperScript, AlignSubScript
 };
 

--- a/src/engraving/libmscore/types.h
+++ b/src/engraving/libmscore/types.h
@@ -469,7 +469,7 @@ constexpr bool operator&(const SegmentType t1, const SegmentType t2)
 //   FontStyle
 //---------------------------------------------------------
 
-enum class FontStyle : char {
+enum class FontStyle : signed char {
     Undefined = -1,
     Normal = 0,
     Bold = 1 << 0,

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -395,7 +395,7 @@ enum class HookType : char {
 };
 
 // P_TYPE::KEY_MODE
-enum class KeyMode : char {
+enum class KeyMode : signed char {
     UNKNOWN = -1,
     NONE,
     MAJOR,


### PR DESCRIPTION
Needed for all platforms/compilers/implementations where `char` is `unsigned char` by default, like e.g. ARM