### PR TITLE
Fix #10019: set min height/width for dock panels

### DIFF
--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -91,8 +91,10 @@ DockPage {
     }
 
     readonly property int verticalPanelDefaultWidth: 300
-    readonly property int verticalPanelMinimumHeight: 200
-    readonly property int horizontalPanelMinimumWidth: 300
+    readonly property int verticalPanelMinimumHeightFloating: 200
+    readonly property int verticalPanelMinimumHeightDocked: 50
+    readonly property int horizontalPanelMinimumWidthFloating: 300
+    readonly property int horizontalPanelMinimumWidthDocked: 100
 
     readonly property int horizontalPanelMinHeight: 100
     readonly property int horizontalPanelMaxHeight: 520
@@ -223,7 +225,7 @@ DockPage {
             width: root.verticalPanelDefaultWidth
             minimumWidth: root.verticalPanelDefaultWidth
             maximumWidth: root.verticalPanelDefaultWidth
-            minimumHeight: root.verticalPanelMinimumHeight
+            minimumHeight: floating ? root.verticalPanelMinimumHeightFloating : root.verticalPanelMinimumHeightDocked
 
             groupName: root.verticalPanelsGroup
 
@@ -249,7 +251,7 @@ DockPage {
             width: root.verticalPanelDefaultWidth
             minimumWidth: root.verticalPanelDefaultWidth
             maximumWidth: root.verticalPanelDefaultWidth
-            minimumHeight: root.verticalPanelMinimumHeight
+            minimumHeight: floating ? root.verticalPanelMinimumHeightFloating : root.verticalPanelMinimumHeightDocked
 
             groupName: root.verticalPanelsGroup
 
@@ -277,7 +279,7 @@ DockPage {
             maximumWidth: root.verticalPanelDefaultWidth
 
             groupName: root.verticalPanelsGroup
-            minimumHeight: root.verticalPanelMinimumHeight
+            minimumHeight: floating ? root.verticalPanelMinimumHeightFloating : root.verticalPanelMinimumHeightDocked
             
             dropDestinations: root.verticalPanelDropDestinations
 
@@ -298,7 +300,7 @@ DockPage {
             width: root.verticalPanelDefaultWidth
             minimumWidth: root.verticalPanelDefaultWidth
             maximumWidth: root.verticalPanelDefaultWidth
-            minimumHeight: root.verticalPanelMinimumHeight
+            minimumHeight: floating ? root.verticalPanelMinimumHeightFloating : root.verticalPanelMinimumHeightDocked
 
             groupName: root.verticalPanelsGroup
 
@@ -325,7 +327,8 @@ DockPage {
             height: 368
             minimumHeight: root.horizontalPanelMinHeight
             maximumHeight: root.horizontalPanelMaxHeight
-            minimumWidth: root.horizontalPanelMinimumWidth
+
+            minimumWidth: floating ? root.horizontalPanelMinimumWidthFloating : root.horizontalPanelMinimumWidthDocked
 
             groupName: root.horizontalPanelsGroup
 
@@ -360,7 +363,7 @@ DockPage {
             height: 200
             minimumHeight: root.horizontalPanelMinHeight
             maximumHeight: root.horizontalPanelMaxHeight
-            minimumWidth: root.horizontalPanelMinimumWidth
+            minimumWidth: floating ? root.horizontalPanelMinimumWidthFloating : root.horizontalPanelMinimumWidthDocked
 
             groupName: root.horizontalPanelsGroup
 
@@ -387,9 +390,9 @@ DockPage {
             height: 200
             minimumHeight: root.horizontalPanelMinHeight
             maximumHeight: root.horizontalPanelMaxHeight
+            minimumWidth: floating ? root.horizontalPanelMinimumWidthFloating : root.horizontalPanelMinimumWidthDocked
 
             groupName: root.horizontalPanelsGroup
-            minimumWidth: root.horizontalPanelMinimumWidth
 
             //! NOTE: hidden by default
             visible: false
@@ -416,7 +419,7 @@ DockPage {
 
             floatable: false
             closable: false
-            minimumWidth: root.horizontalPanelMinimumWidth
+            minimumWidth: floating ? root.horizontalPanelMinimumWidthFloating : root.horizontalPanelMinimumWidthDocked
 
             location: Location.Bottom
 

--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -91,6 +91,8 @@ DockPage {
     }
 
     readonly property int verticalPanelDefaultWidth: 300
+    readonly property int verticalPanelMinimumHeight: 200
+    readonly property int horizontalPanelMinimumWidth: 300
 
     readonly property int horizontalPanelMinHeight: 100
     readonly property int horizontalPanelMaxHeight: 520
@@ -221,6 +223,7 @@ DockPage {
             width: root.verticalPanelDefaultWidth
             minimumWidth: root.verticalPanelDefaultWidth
             maximumWidth: root.verticalPanelDefaultWidth
+            minimumHeight: root.verticalPanelMinimumHeight
 
             groupName: root.verticalPanelsGroup
 
@@ -246,6 +249,7 @@ DockPage {
             width: root.verticalPanelDefaultWidth
             minimumWidth: root.verticalPanelDefaultWidth
             maximumWidth: root.verticalPanelDefaultWidth
+            minimumHeight: root.verticalPanelMinimumHeight
 
             groupName: root.verticalPanelsGroup
 
@@ -273,7 +277,8 @@ DockPage {
             maximumWidth: root.verticalPanelDefaultWidth
 
             groupName: root.verticalPanelsGroup
-
+            minimumHeight: root.verticalPanelMinimumHeight
+            
             dropDestinations: root.verticalPanelDropDestinations
 
             InspectorForm {
@@ -293,6 +298,7 @@ DockPage {
             width: root.verticalPanelDefaultWidth
             minimumWidth: root.verticalPanelDefaultWidth
             maximumWidth: root.verticalPanelDefaultWidth
+            minimumHeight: root.verticalPanelMinimumHeight
 
             groupName: root.verticalPanelsGroup
 
@@ -319,6 +325,7 @@ DockPage {
             height: 368
             minimumHeight: root.horizontalPanelMinHeight
             maximumHeight: root.horizontalPanelMaxHeight
+            minimumWidth: root.horizontalPanelMinimumWidth
 
             groupName: root.horizontalPanelsGroup
 
@@ -353,6 +360,7 @@ DockPage {
             height: 200
             minimumHeight: root.horizontalPanelMinHeight
             maximumHeight: root.horizontalPanelMaxHeight
+            minimumWidth: root.horizontalPanelMinimumWidth
 
             groupName: root.horizontalPanelsGroup
 
@@ -381,6 +389,7 @@ DockPage {
             maximumHeight: root.horizontalPanelMaxHeight
 
             groupName: root.horizontalPanelsGroup
+            minimumWidth: root.horizontalPanelMinimumWidth
 
             //! NOTE: hidden by default
             visible: false
@@ -407,6 +416,7 @@ DockPage {
 
             floatable: false
             closable: false
+            minimumWidth: root.horizontalPanelMinimumWidth
 
             location: Location.Bottom
 


### PR DESCRIPTION
Resolves: #10019

Added minimum height of 200px to vertical dock panels and minimum width of 300px to horizontal dock panels, as suggested in the issue.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
