### PR TITLE
Fix #9343 ensure selected items are always drawn over non-selected ones

### DIFF
--- a/src/engraving/paint/paint.cpp
+++ b/src/engraving/paint/paint.cpp
@@ -52,11 +52,11 @@ void Paint::paintElements(mu::draw::Painter& painter, const QList<EngravingItem*
         if (e1->z() == e2->z()) {
             if (e1->selected()) {
                 return false;
-            } else if (e1->visible()) {
-                return false;
             } else if (e2->selected()) {
                 return true;
             } else if (e1->visible()) {
+                return false;
+            } else if (e2->visible()) {
                 return true;
             }
 


### PR DESCRIPTION
Resolves: [*(direct link to the issue)*](https://github.com/musescore/MuseScore/issues/9343)

Slight bug in painting logic that could cause selected elements to be drawn under non-selected elements

- [x ] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
