### PR TITLE
Fix #328003 score property crash

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,7 +102,7 @@ endif()
 add_subdirectory(stubs)
 
 if (BUILD_UNIT_TESTS)
-#    add_subdirectory(notation/tests) no tests at moment
+    add_subdirectory(notation/tests)
     add_subdirectory(project/tests)
 
     add_subdirectory(engraving/tests)

--- a/src/framework/testing/gmain.cpp
+++ b/src/framework/testing/gmain.cpp
@@ -20,7 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <QGuiApplication>
+#include <QApplication>
 #include <gmock/gmock.h>
 
 #include "framework/global/runtime.h"
@@ -28,7 +28,7 @@
 
 GTEST_API_ int main(int argc, char** argv)
 {
-    QGuiApplication app(argc, argv);
+    QApplication app(argc, argv);
 
     qputenv("QML_DISABLE_DISK_CACHE", "true");
 

--- a/src/notation/CMakeLists.txt
+++ b/src/notation/CMakeLists.txt
@@ -100,6 +100,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/masternotationparts.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/searchcommandsparser.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/searchcommandsparser.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/scorepropertiesitem.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/scorepropertiesitem.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/inotationselectionrange.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/masternotationmididata.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/masternotationmididata.h

--- a/src/notation/internal/scorepropertiesitem.cpp
+++ b/src/notation/internal/scorepropertiesitem.cpp
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "scorepropertiesitem.h"
+#include <QLabel>
+
+using namespace mu::notation;
+
+ScorePropertiesItem::ScorePropertiesItem(QWidget* label, QWidget* value)
+{
+	this->label = label;
+	this->value = value;
+}
+
+QString ScorePropertiesItem::Label()
+{
+    QLineEdit* tag = static_cast<QLineEdit*>(this->label);
+    return tag->text();
+}
+
+QString ScorePropertiesItem::Value()
+{
+    QLineEdit* val = static_cast<QLineEdit*>(this->value);
+    return val->text();
+}
+
+void ScorePropertiesItem::SetFocus()
+{
+    QLineEdit* tag = static_cast<QLineEdit*>(this->label);
+    tag->setFocus();
+}

--- a/src/notation/internal/scorepropertiesitem.cpp
+++ b/src/notation/internal/scorepropertiesitem.cpp
@@ -25,26 +25,53 @@
 
 using namespace mu::notation;
 
+/// <summary>
+/// Create a new instance of a ScorePropertiesItem using a label and value widget from the ScoreProperty screen
+/// </summary>
+/// <param name="label">The label widget</param>
+/// <param name="value">The value widget</param>
 ScorePropertiesItem::ScorePropertiesItem(QWidget* label, QWidget* value)
 {
 	this->label = label;
 	this->value = value;
 }
 
+/// <summary>
+/// Get the string value of the label
+/// </summary>
+/// <returns>The name of property</returns>
 QString ScorePropertiesItem::Label()
 {
-    QLineEdit* tag = static_cast<QLineEdit*>(this->label);
-    return tag->text();
+    // Label could be a line edit (for none standard properties) or a label widget (for standard properties)
+    QLineEdit* lineEditItem = dynamic_cast<QLineEdit*>(this->label);
+    if (lineEditItem)
+    {
+        return lineEditItem->text();
+    }
+    
+    QLabel* labelItem = dynamic_cast<QLabel*>(this->label);
+    if (labelItem)
+    {
+        return labelItem->text();
+    }
+
+    return "";
 }
 
+/// <summary>
+/// Get the value of the property
+/// </summary>
+/// <returns>Value</returns>
 QString ScorePropertiesItem::Value()
 {
     QLineEdit* val = static_cast<QLineEdit*>(this->value);
     return val->text();
 }
 
+/// <summary>
+/// Set focus to the widget
+/// </summary>
 void ScorePropertiesItem::SetFocus()
 {
-    QLineEdit* tag = static_cast<QLineEdit*>(this->label);
-    tag->setFocus();
+    this->label->setFocus();
 }

--- a/src/notation/internal/scorepropertiesitem.cpp
+++ b/src/notation/internal/scorepropertiesitem.cpp
@@ -44,14 +44,12 @@ QString ScorePropertiesItem::Label()
 {
     // Label could be a line edit (for none standard properties) or a label widget (for standard properties)
     QLineEdit* lineEditItem = dynamic_cast<QLineEdit*>(this->label);
-    if (lineEditItem)
-    {
+    if (lineEditItem) {
         return lineEditItem->text();
     }
     
     QLabel* labelItem = dynamic_cast<QLabel*>(this->label);
-    if (labelItem)
-    {
+    if (labelItem) {
         return labelItem->text();
     }
 

--- a/src/notation/internal/scorepropertiesitem.h
+++ b/src/notation/internal/scorepropertiesitem.h
@@ -36,9 +36,9 @@ namespace mu::notation {
     {
     public:
         ScorePropertiesItem(QWidget* label = nullptr, QWidget* value = nullptr);
-        QString ScorePropertiesItem::Label();
-        QString ScorePropertiesItem::Value();
-        void ScorePropertiesItem::SetFocus();
+        QString Label();
+        QString Value();
+        void SetFocus();
 
     private:
         QWidget* label;

--- a/src/notation/internal/scorepropertiesitem.h
+++ b/src/notation/internal/scorepropertiesitem.h
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_NOTATION_SCOREPROPERTIESITEM_H
+#define MU_NOTATION_SCOREPROPERTIESITEM_H
+
+#include <QLineEdit>
+#include <QLayoutItem>
+
+namespace mu::notation {
+    //---------------------------------------------------------
+    //  Model class for Score Property Items
+    //  Used in the Score Properties UI to get name value pairs 
+    //---------------------------------------------------------
+
+    class ScorePropertiesItem
+    {
+    public:
+        ScorePropertiesItem(QWidget* label = nullptr, QWidget* value = nullptr);
+        QString ScorePropertiesItem::Label();
+        QString ScorePropertiesItem::Value();
+        void ScorePropertiesItem::SetFocus();
+
+    private:
+        QWidget* label;
+        QWidget* value;
+    };
+}
+
+#endif // MU_NOTATION_SCOREPROPERTIESITEM_H

--- a/src/notation/internal/scorepropertiesitem.h
+++ b/src/notation/internal/scorepropertiesitem.h
@@ -27,11 +27,11 @@
 #include <QLayoutItem>
 
 namespace mu::notation {
+
     //---------------------------------------------------------
-    //  Model class for Score Property Items
+    //  Class for Score Property Items
     //  Used in the Score Properties UI to get name value pairs 
     //---------------------------------------------------------
-
     class ScorePropertiesItem
     {
     public:

--- a/src/notation/tests/CMakeLists.txt
+++ b/src/notation/tests/CMakeLists.txt
@@ -21,10 +21,13 @@
 set(MODULE_TEST notation_test)
 
 set(MODULE_TEST_SRC
-    ${CMAKE_CURRENT_LIST_DIR}/mocks/msczreadermock.h
+    ${CMAKE_CURRENT_LIST_DIR}/environment.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/scorepropertiesitem_tests.cpp
 )
 
 set(MODULE_TEST_LINK notation)
 
-include(${PROJECT_SOURCE_DIR}/framework/utests_base/utests_base.cmake)
+set(MODULE_TEST_DATA_ROOT ${CMAKE_CURRENT_LIST_DIR})
+
+include(${PROJECT_SOURCE_DIR}/src/framework/testing/gtest.cmake)
 

--- a/src/notation/tests/environment.cpp
+++ b/src/notation/tests/environment.cpp
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "testing/environment.h"
+#include "log.h"
+
+static mu::testing::SuiteEnvironment notation_se(
+    {},
+    []() 
+    {
+        LOGI() << "notation tests suite post init";
+        //Ms::MScore::noGui = true;
+        //new Ms::MuseScoreCore();
+    }
+);

--- a/src/notation/tests/scorepropertiesitem_tests.cpp
+++ b/src/notation/tests/scorepropertiesitem_tests.cpp
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "notation/internal/scorepropertiesitem.h"
+#include <QLabel>
+#include <QApplication>
+//#include <QTest>
+
+using namespace mu;
+using namespace mu::notation;
+
+class ScorePropertiesItemTests : public ::testing::Test
+{
+public:
+
+};
+
+TEST_F(ScorePropertiesItemTests, StandardProperty)
+{
+    //! CASE When assembling a property item with a non editable label
+    QLabel label("MyLabel");
+
+    ScorePropertiesItem item(&label, nullptr);
+
+    //! GIVEN I get the label name
+    QString labelName = item.Label();
+
+    //! CHECK It is what I expect it to be
+    EXPECT_TRUE(labelName == "MyLabel");
+}
+
+TEST_F(ScorePropertiesItemTests, NonStandardProperty)
+{
+    //! CASE When assembling a property item with a editable label
+    QLineEdit label("MyLabel");
+
+    ScorePropertiesItem item(&label, nullptr);
+ 
+    //! GIVEN I get the label name
+    QString labelName = item.Label();
+
+
+    //! CHECK It is what I expect it to be
+    EXPECT_TRUE(labelName == "MyLabel");
+}

--- a/src/notation/tests/scorepropertiesitem_tests.cpp
+++ b/src/notation/tests/scorepropertiesitem_tests.cpp
@@ -39,23 +39,24 @@ public:
 TEST_F(ScorePropertiesItemTests, StandardProperty)
 {
     //! CASE When assembling a property item with a non editable label
-    QLabel label("MyLabel");
+    QLabel *label = new QLabel("MyLabel");
 
-    ScorePropertiesItem item(&label, nullptr);
+    ScorePropertiesItem item(label, nullptr);
 
     //! GIVEN I get the label name
     QString labelName = item.Label();
 
     //! CHECK It is what I expect it to be
     EXPECT_TRUE(labelName == "MyLabel");
+    delete label;
 }
 
 TEST_F(ScorePropertiesItemTests, NonStandardProperty)
 {
     //! CASE When assembling a property item with a editable label
-    QLineEdit label("MyLabel");
+    QLineEdit *label = new QLineEdit("MyLabel");
 
-    ScorePropertiesItem item(&label, nullptr);
+    ScorePropertiesItem item(label, nullptr);
  
     //! GIVEN I get the label name
     QString labelName = item.Label();
@@ -63,4 +64,5 @@ TEST_F(ScorePropertiesItemTests, NonStandardProperty)
 
     //! CHECK It is what I expect it to be
     EXPECT_TRUE(labelName == "MyLabel");
+    delete label;
 }

--- a/src/notation/view/widgets/scoreproperties.cpp
+++ b/src/notation/view/widgets/scoreproperties.cpp
@@ -28,6 +28,7 @@
 #include "ui/view/widgetutils.h"
 
 #include "translation.h"
+#include "notation/internal/scorepropertiesitem.h"
 
 using namespace mu::notation;
 using namespace mu::project;
@@ -248,14 +249,14 @@ bool ScorePropertiesDialog::save()
         QLayoutItem* tagItem   = scrollAreaLayout->itemAtPosition(i, 0);
         QLayoutItem* valueItem = scrollAreaLayout->itemAtPosition(i, 1);
         if (tagItem && valueItem) {
-            QLineEdit* tag   = static_cast<QLineEdit*>(tagItem->widget());
-            QLineEdit* value = static_cast<QLineEdit*>(valueItem->widget());
 
-            QString tagText = tag->text();
+            ScorePropertiesItem item(tagItem->widget(), valueItem->widget());
+
+            QString tagText = item.Label();
             if (tagText.isEmpty()) {
                 interactive()->warning(trc("notation", "MuseScore"),
                                        trc("notation", "Tags can't have empty names."));
-                tag->setFocus();
+                item.SetFocus();
                 return false;
             }
             if (map.contains(tagText)) {
@@ -263,16 +264,16 @@ bool ScorePropertiesDialog::save()
                     interactive()->warning(trc("notation", "MuseScore"),
                                            qtrc("notation",
                                                 "%1 is a reserved builtin tag.\n It can't be used.").arg(tagText).toStdString());
-                    tag->setFocus();
+                    item.SetFocus();
                     return false;
                 }
 
                 interactive()->warning(trc("notation", "MuseScore"),
                                        trc("notation", "You have multiple tags with the same name."));
-                tag->setFocus();
+                item.SetFocus();
                 return false;
             }
-            map.insert(tagText, value->text());
+            map.insert(tagText, item.Value());
         } else {
             qDebug("MetaEditDialog: abnormal configuration: %i", i);
         }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/328003

Following accessibility changes saving score properties causes MuseScore to crash

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://musescore.org/en/cla)
- [ x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x] I made sure the code compiles on my machine
- [ x] I made sure there are no unnecessary changes in the code
- [ x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ x] I created the test (mtest, vtest, script test) to verify the changes I made
