### PR TITLE
fix #10202: Added a check on whether zoom has already been initialized

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -76,6 +76,11 @@ void NotationViewInputController::init()
         if (!m_isZoomInited) {
             initZoom();
         }
+
+        auto masterNotation = globalContext()->currentMasterNotation();
+        if (!masterNotation) {
+            m_isZoomInited = false;
+        }
     });
 }
 

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -73,7 +73,7 @@ void NotationViewInputController::init()
     }
 
     globalContext()->currentMasterNotationChanged().onNotify(this, [this]() {
-        if (m_isZoomInited == false) {
+        if (!m_isZoomInited) {
             initZoom();
         }
     });

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -73,8 +73,9 @@ void NotationViewInputController::init()
     }
 
     globalContext()->currentMasterNotationChanged().onNotify(this, [this]() {
-        m_isZoomInited = false;
-        initZoom();
+        if (m_isZoomInited == false) {
+            initZoom();
+        }
     });
 }
 


### PR DESCRIPTION
Resolves: #10202 

I added a check on whether zoom has already been initiated instead of setting it to false everytime, as this is what is called upon save. Another solution is to just remove this call on the save function, please let me know if that alternative seems better.
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
