### PR TITLE
fix #10189: Autosave dedicated file

### DIFF
--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -373,12 +373,16 @@ mu::Ret NotationProject::saveScore(const io::path& path, SaveMode saveMode)
         m_engravingProject->setPath(path.toQString());
     }
 
+    std::string auto_path = m_engravingProject->path().toStdString();
+    std::string name = m_engravingProject->title();
+    auto_path.erase(auto_path.end() - name.length() - 5, auto_path.end());
+    auto_path += ("autosave_" + name + ".mscz");
+
     if (saveMode == SaveMode::Autosave) {
-        std::string original_path = m_engravingProject->path().toStdString();
-        std::string name = m_engravingProject->title();
-        original_path.erase(original_path.end() - name.length() - 5, original_path.end());
-        original_path += ("autosave_" + name + ".mscz");
-        m_engravingProject->setPath(QString::fromStdString(original_path));
+        m_engravingProject->setPath(QString::fromStdString(auto_path));
+    }
+    else {
+        remove(auto_path.c_str());
     }
     Ret ret = doSave(true);
     if (!ret) {

--- a/src/project/internal/projectautosaver.cpp
+++ b/src/project/internal/projectautosaver.cpp
@@ -69,7 +69,7 @@ void ProjectAutoSaver::onTrySave()
         return;
     }
 
-    Ret ret = project->save();
+    Ret ret = project->save(mu::io::path(), SaveMode::Autosave);
     if (!ret) {
         LOGE() << "[autosave] failed to save project, err: " << ret.toString();
         return;

--- a/src/project/projecttypes.h
+++ b/src/project/projecttypes.h
@@ -61,7 +61,8 @@ enum class SaveMode
     Save,
     SaveAs,
     SaveCopy,
-    SaveSelection
+    SaveSelection,
+    Autosave
 };
 
 struct ProjectMeta


### PR DESCRIPTION
Resolves: #10189 

Instead of overwriting the same file, the program now makes a new file and does not modify the original file on its own
I added another save type called autosave, which I felt would help distinguish this save later on if someone wants to work on this feature later on (I tried using Savecopy before, but it felt stranger hence made another type)

Note this requires that the user should NEVER have two files of the name \<name\>.mscz and autosave_\<name\>.mscz as the program would OVERWRITE the latter treating it as an autosave file without warnings
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
