### PR TITLE
Fix #9745: Changed instrument connection to instrument title and instrument name

### DIFF
--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsTreeItemDelegate.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsTreeItemDelegate.qml
@@ -389,7 +389,6 @@ Item {
                     popup = popupLoader.createPopup(instrumentSettingsComp, this)
 
                     item["partId"] = model.itemRole.id
-                    item["partName"] = model.itemRole.title
                     item["instrumentId"] = model.itemRole.instrumentId()
 
                 } else if (root.type === InstrumentsTreeItemType.STAFF) {

--- a/src/instrumentsscene/view/instrumentsettingsmodel.cpp
+++ b/src/instrumentsscene/view/instrumentsettingsmodel.cpp
@@ -42,13 +42,13 @@ void InstrumentSettingsModel::load(const QVariant& instrument)
     QVariantMap map = instrument.toMap();
     m_instrumentKey.partId = ID(map["partId"]);
     m_instrumentKey.instrumentId = map["instrumentId"].toString();
-    m_partName = map["partName"].toString();
 
     const Part* part = notationParts()->part(m_instrumentKey.partId);
     if (!part) {
         return;
     }
 
+    m_partName = part->partName();
     m_instrumentName = part->instrument()->name();
     m_instrumentAbbreviature = part->instrument()->abbreviature();
 

--- a/src/instrumentsscene/view/parttreeitem.cpp
+++ b/src/instrumentsscene/view/parttreeitem.cpp
@@ -48,7 +48,7 @@ void PartTreeItem::init(const notation::Part* masterPart)
     }
 
     setId(part->id());
-    setTitle(part->partName().isEmpty() ? part->instrument()->name() : part->partName());
+    setTitle(part->instrument()->name());
     setIsVisible(visible);
     setIsEditable(partExists);
     setIsExpandable(partExists);


### PR DESCRIPTION
Resolves: #9745

*(short description of the changes and the motivation to make the changes)*

Prior to this commit, if you were to change the part name in the
instruments dialog, it would automatically get updated in the instrument
title (the text for the corresponding instrument button). However, with
this commit, this "connection" is changed to instrument name and the
instrument title, that is, if you now change the instrument name, the
same would be the instrument title. Also, this commit does not fix the
entire issue. Another problem mentioned in this issue had been fixed
earlier in a separate pull request #10014

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
