### PR TITLE
fix #10223: Save selection now works

### DIFF
--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -774,6 +774,7 @@ public:
     void setPlayNote(bool v) { _updateState._playNote = v; }
     bool playChord() const { return _updateState._playChord; }
     void setPlayChord(bool v) { _updateState._playChord = v; }
+    bool selectionEmpty() const { return _selection.staffStart() == _selection.staffEnd(); }
     bool selectionChanged() const { return _updateState._selectionChanged; }
     void setSelectionChanged(bool val) { _updateState._selectionChanged = val; }
     void deleteLater(EngravingObject* e) { _updateState._deleteList.push_back(e); }

--- a/src/engraving/libmscore/scorefile.cpp
+++ b/src/engraving/libmscore/scorefile.cpp
@@ -82,10 +82,6 @@ void Score::write(XmlWriter& xml, bool selectionOnly, compat::WriteScoreHook& ho
     // then some layout information is missing:
     // relayout with all parts set visible
 
-    if (selectionOnly && _selection.staffStart() == _selection.staffEnd()) {
-        return;
-    }
-
     QList<Part*> hiddenParts;
     bool unhide = false;
     if (styleB(Sid::createMultiMeasureRests)) {

--- a/src/engraving/libmscore/scorefile.cpp
+++ b/src/engraving/libmscore/scorefile.cpp
@@ -82,6 +82,10 @@ void Score::write(XmlWriter& xml, bool selectionOnly, compat::WriteScoreHook& ho
     // then some layout information is missing:
     // relayout with all parts set visible
 
+    if (selectionOnly && _selection.staffStart() == _selection.staffEnd()) {
+        return;
+    }
+
     QList<Part*> hiddenParts;
     bool unhide = false;
     if (styleB(Sid::createMultiMeasureRests)) {

--- a/src/notation/notationerrors.h
+++ b/src/notation/notationerrors.h
@@ -60,8 +60,11 @@ enum class Err {
     // notation
     NoScore = 1030,
 
-    //playback
+    // playback
     UnableToPlaybackElement = 1040,
+
+    // selection
+    EmptySelection = 1050,
 };
 
 inline Ret make_ret(Err err, const io::path& filePath = "")

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -522,12 +522,9 @@ mu::Ret NotationProject::saveSelectionOnScore(const mu::io::path& path)
     // Write project
     std::string suffix = io::suffix(info.fileName());
     MscWriter::Params params;
-    QString org_path = m_engravingProject->path();
-    m_engravingProject->setPath(path.toQString());
-    params.filePath = m_engravingProject->path();
+    params.filePath = path.toQString();
     params.mode = mcsIoModeBySuffix(suffix);
     IF_ASSERT_FAILED(params.mode != MscIoMode::Unknown) {
-        m_engravingProject->setPath(org_path);
         return make_ret(Ret::Code::InternalError);
     }
 
@@ -539,7 +536,6 @@ mu::Ret NotationProject::saveSelectionOnScore(const mu::io::path& path)
                               QFile::ReadOwner | QFile::WriteOwner | QFile::ReadUser | QFile::ReadGroup | QFile::ReadOther);
     }
     LOGI() << "success save file: " << info.filePath();
-    m_engravingProject->setPath(org_path);
     return ret;
 }
 

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -512,6 +512,10 @@ mu::Ret NotationProject::saveSelectionOnScore(const mu::io::path& path)
         return make_ret(notation::Err::UnknownError);
     }
 
+    if (m_engravingProject->masterScore()->selectionEmpty()) {
+        LOGE() << "failed save, empty selection";
+        return make_ret(notation::Err::EmptySelection);
+    }
     // Check writable
     QFileInfo info(path.toQString());
     if (info.exists() && !info.isWritable()) {

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -522,20 +522,24 @@ mu::Ret NotationProject::saveSelectionOnScore(const mu::io::path& path)
     // Write project
     std::string suffix = io::suffix(info.fileName());
     MscWriter::Params params;
+    QString org_path = m_engravingProject->path();
+    m_engravingProject->setPath(path.toQString());
     params.filePath = m_engravingProject->path();
     params.mode = mcsIoModeBySuffix(suffix);
     IF_ASSERT_FAILED(params.mode != MscIoMode::Unknown) {
+        m_engravingProject->setPath(org_path);
         return make_ret(Ret::Code::InternalError);
     }
 
     MscWriter msczWriter(params);
-    Ret ret = writeProject(msczWriter, false);
+    Ret ret = writeProject(msczWriter, true);
 
     if (ret) {
         QFile::setPermissions(info.filePath(),
                               QFile::ReadOwner | QFile::WriteOwner | QFile::ReadUser | QFile::ReadGroup | QFile::ReadOther);
     }
     LOGI() << "success save file: " << info.filePath();
+    m_engravingProject->setPath(org_path);
     return ret;
 }
 


### PR DESCRIPTION
Resolves: #10223 
The save selection feature now works
There was a crash when nothing was selected, and I have also implemented a check for that in `src/engraving/libmscore/scorefile.cpp`
```cpp
// outdated, this check has been moved outside now
if (selectionOnly && _selection.staffStart() == _selection.staffEnd()) {
        return;
}
```
Please do verify that the changes made are correct and do not break anything, though I have tested the changes (on Windows) and will continue to test further and report back (if any issues) after creating the PR

Edit: It is quite late here right now but I feel like just returning might not be a very good solution, will have to look more into that

Edit_2: The check has been moved outside before the file is created. A new error code has been created for the same and a new function has been created which checks if the selection is empty.
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
