### PR TITLE
[MU4] fix #10222: Text items from + menu don't recognise keystrokes; causes crash after repeated attempts

### DIFF
--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -384,10 +384,6 @@ DockPage {
         name: "MainNotationView"
 
         isNavigatorVisible: pageModel.isNavigatorVisible
-
-        onTextEdittingStarted: {
-            notationView.forceActiveFocus()
-        }
     }
 
     statusBar: DockStatusBar {

--- a/src/engraving/accessibility/accessibleroot.cpp
+++ b/src/engraving/accessibility/accessibleroot.cpp
@@ -89,7 +89,7 @@ QString AccessibleRoot::accessibleName() const
     return element()->score()->title();
 }
 
-void AccessibleRoot::setMapToScreenFunc(const notation::AccessibleMapToScreenFunc& func)
+void AccessibleRoot::setMapToScreenFunc(const AccessibleMapToScreenFunc& func)
 {
     m_accessibleMapToScreenFunc = func;
 }

--- a/src/engraving/accessibility/accessibleroot.cpp
+++ b/src/engraving/accessibility/accessibleroot.cpp
@@ -49,14 +49,6 @@ void AccessibleRoot::setFocusedElement(AccessibleItem* e)
 
 AccessibleItem* AccessibleRoot::focusedElement() const
 {
-    if (!m_focusedElement) {
-        return nullptr;
-    }
-
-    if (uicontextResolver()->currentUiContext() != mu::context::UiCtxNotationFocused) {
-        return nullptr;
-    }
-
     return m_focusedElement;
 }
 

--- a/src/engraving/accessibility/accessibleroot.h
+++ b/src/engraving/accessibility/accessibleroot.h
@@ -26,9 +26,10 @@
 #include "../libmscore/rootitem.h"
 #include "modularity/ioc.h"
 #include "context/iuicontextresolver.h"
-#include "notation/notationtypes.h"
 
 namespace mu::engraving {
+using AccessibleMapToScreenFunc = std::function<RectF(const RectF&)>;
+
 class AccessibleRoot : public AccessibleItem
 {
     INJECT(engraving, context::IUiContextResolver, uicontextResolver)
@@ -38,7 +39,7 @@ public:
     void setFocusedElement(AccessibleItem* e);
     AccessibleItem* focusedElement() const;
 
-    void setMapToScreenFunc(const notation::AccessibleMapToScreenFunc& func);
+    void setMapToScreenFunc(const AccessibleMapToScreenFunc& func);
     RectF toScreenRect(const RectF& rect, bool* ok = nullptr) const;
 
     const accessibility::IAccessible* accessibleParent() const override;
@@ -48,7 +49,7 @@ public:
 private:
     AccessibleItem* m_focusedElement = nullptr;
 
-    notation::AccessibleMapToScreenFunc m_accessibleMapToScreenFunc;
+    AccessibleMapToScreenFunc m_accessibleMapToScreenFunc;
 };
 }
 

--- a/src/engraving/accessibility/accessibleroot.h
+++ b/src/engraving/accessibility/accessibleroot.h
@@ -24,15 +24,12 @@
 
 #include "accessibleitem.h"
 #include "../libmscore/rootitem.h"
-#include "modularity/ioc.h"
-#include "context/iuicontextresolver.h"
 
 namespace mu::engraving {
 using AccessibleMapToScreenFunc = std::function<RectF(const RectF&)>;
 
 class AccessibleRoot : public AccessibleItem
 {
-    INJECT(engraving, context::IUiContextResolver, uicontextResolver)
 public:
     AccessibleRoot(RootItem* e);
 

--- a/src/notation/inotationaccessibility.h
+++ b/src/notation/inotationaccessibility.h
@@ -26,6 +26,8 @@
 #include "retval.h"
 #include "notationtypes.h"
 
+#include "engraving/accessibility/accessibleroot.h"
+
 namespace mu::notation {
 class INotationAccessibility
 {
@@ -34,7 +36,7 @@ public:
 
     virtual ValCh<std::string> accessibilityInfo() const = 0;
 
-    virtual void setMapToScreenFunc(const AccessibleMapToScreenFunc& func) = 0;
+    virtual void setMapToScreenFunc(const mu::engraving::AccessibleMapToScreenFunc& func) = 0;
 };
 
 using INotationAccessibilityPtr = std::shared_ptr<INotationAccessibility>;

--- a/src/notation/internal/notationaccessibility.cpp
+++ b/src/notation/internal/notationaccessibility.cpp
@@ -38,6 +38,7 @@
 
 using namespace mu::notation;
 using namespace mu::async;
+using namespace mu::engraving;
 
 NotationAccessibility::NotationAccessibility(const IGetScore* getScore, Notification selectionChangedNotification)
     : m_getScore(getScore)

--- a/src/notation/internal/notationaccessibility.h
+++ b/src/notation/internal/notationaccessibility.h
@@ -44,7 +44,7 @@ public:
 
     ValCh<std::string> accessibilityInfo() const override;
 
-    void setMapToScreenFunc(const AccessibleMapToScreenFunc& func) override;
+    void setMapToScreenFunc(const mu::engraving::AccessibleMapToScreenFunc& func) override;
 
 private:
     const Ms::Score* score() const;

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -140,8 +140,6 @@ using ScoreOrderList = QList<ScoreOrder>;
 using InstrumentGroupList = QList<const InstrumentGroup*>;
 using MidiArticulationList = QList<MidiArticulation>;
 
-using AccessibleMapToScreenFunc = std::function<RectF(const RectF&)>;
-
 static const QString COMMON_GENRE_ID("common");
 
 enum class DragMode

--- a/src/notation/qml/MuseScore/NotationScene/NotationView.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NotationView.qml
@@ -37,8 +37,6 @@ FocusScope {
 
     property alias isNavigatorVisible: notationNavigator.visible
 
-    signal textEdittingStarted()
-
     NavigationSection {
         id: navSec
         name: "NotationView"
@@ -120,10 +118,6 @@ FocusScope {
 
                     onActiveFocusRequested: {
                         fakeNavCtrl.requestActive()
-                    }
-
-                    onTextEdittingStarted: {
-                        root.textEdittingStarted()
                     }
 
                     onShowContextMenuRequested: function (elementType, viewPos) {

--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -219,12 +219,13 @@ void NotationPaintView::onCurrentNotationChanged()
 
     interaction->textEditingStarted().onNotify(this, [this]() {
         if (!hasActiveFocus()) {
-            emit textEdittingStarted();
+            forceFocusIn();
         }
     });
+
     interaction->dropChanged().onNotify(this, [this]() {
         if (!hasActiveFocus()) {
-            emit textEdittingStarted(); // grab keyboard focus after element added from palette
+            forceFocusIn(); // grab keyboard focus after element added from palette
         }
     });
 

--- a/src/notation/view/notationpaintview.h
+++ b/src/notation/view/notationpaintview.h
@@ -124,8 +124,6 @@ signals:
     void showContextMenuRequested(int elementType, const QPointF& viewPos);
     void hideContextMenuRequested();
 
-    void textEdittingStarted();
-
     void horizontalScrollChanged();
     void verticalScrollChanged();
 

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -64,6 +64,7 @@ void NotationViewInputController::init()
         dispatcher()->reg(this, "view-mode-single", [this]() {
             setViewMode(ViewMode::SYSTEM);
         });
+
         dispatcher()->reg(this, "scr-next", this, &NotationViewInputController::nextScreen);
         dispatcher()->reg(this, "scr-prev", this, &NotationViewInputController::previousScreen);
         dispatcher()->reg(this, "page-next", this, &NotationViewInputController::nextPage);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10222